### PR TITLE
Update URL and build command

### DIFF
--- a/CI_OPERATOR.md
+++ b/CI_OPERATOR.md
@@ -24,9 +24,9 @@ software on top of Kubernetes easier.
 Currently, users must download the source and build it themselves:
 
 ```
-$ git clone https://github.com/openshift/ci-operator.git
-$ cd ci-operator
-$ make build
+$ git clone https://github.com/openshift/ci-tools.git
+$ cd ci-tools
+$ go build ./cmd/ci-operator
 ```
 
 ## Usage

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,8 +13,8 @@ Additionally, the PR needs to be approved by one of the core project members
 To obtain sources and build the `ci-operator` binary, use `go get` and `go build`:
 
 ```
-$ go get github.com/openshift/ci-operator
-$ cd ${GOPATH}/src/github.com/openshift/ci-operator
+$ go get github.com/openshift/ci-tools
+$ cd ${GOPATH}/src/github.com/openshift/ci-tools
 $ go build ./cmd/ci-operator
 ```
 
@@ -24,10 +24,10 @@ At the moment, ci-operator only has unit tests. You can run them with `go test`:
 
 ```
 $ go test ./...
-?   	github.com/openshift/ci-operator	[no test files]
-ok  	github.com/openshift/ci-operator/cmd/ci-operator	0.036s
-ok  	github.com/openshift/ci-operator/pkg/api	0.029s
-?   	github.com/openshift/ci-operator/pkg/interrupt	[no test files]
-?   	github.com/openshift/ci-operator/pkg/junit	[no test files]
-ok  	github.com/openshift/ci-operator/pkg/steps	0.044s
+?   	github.com/openshift/ci-tools	[no test files]
+ok  	github.com/openshift/ci-tools/cmd/ci-operator	0.036s
+ok  	github.com/openshift/ci-tools/pkg/api	0.029s
+?   	github.com/openshift/ci-tools/pkg/interrupt	[no test files]
+?   	github.com/openshift/ci-tools/pkg/junit	[no test files]
+ok  	github.com/openshift/ci-tools/pkg/steps	0.044s
 ```


### PR DESCRIPTION
ci-operator was recently merged into ci-tools. The ci-operator repo
and build command needed to be updated.