### PR TITLE
prowgen: DRY out JobBase generation

### DIFF
--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -505,8 +505,6 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 		name     string
 		repoInfo *config.Info
 
-		treatBranchesAsExplicit bool
-
 		expected *prowconfig.Postsubmit
 	}{
 		{
@@ -528,7 +526,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 					},
 				},
 
-				Brancher: prowconfig.Brancher{Branches: []string{"branch"}},
+				Brancher: prowconfig.Brancher{Branches: []string{"^branch$"}},
 			},
 		},
 		{
@@ -548,7 +546,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 						DecorationConfig: &v1.DecorationConfig{SkipCloning: &newTrue},
 						Decorate:         true,
 					}},
-				Brancher: prowconfig.Brancher{Branches: []string{"Branch"}},
+				Brancher: prowconfig.Brancher{Branches: []string{"^Branch$"}},
 			},
 		},
 		{
@@ -558,8 +556,6 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "Repository",
 				Branch: "Branch",
 			},
-
-			treatBranchesAsExplicit: true,
 
 			expected: &prowconfig.Postsubmit{
 				JobBase: prowconfig.JobBase{
@@ -573,32 +569,9 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Brancher: prowconfig.Brancher{Branches: []string{"^Branch$"}},
 			},
 		},
-
-		{
-			name: "name",
-			repoInfo: &config.Info{
-				Org:    "Organization",
-				Repo:   "Repository",
-				Branch: "Branch-.*",
-			},
-
-			treatBranchesAsExplicit: true,
-
-			expected: &prowconfig.Postsubmit{
-				JobBase: prowconfig.JobBase{
-					Agent:  "kubernetes",
-					Name:   "branch-ci-Organization-Repository-Branch-name",
-					Labels: map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"},
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &v1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         true,
-					}},
-				Brancher: prowconfig.Brancher{Branches: []string{"Branch-.*"}},
-			},
-		},
 	}
 	for _, tc := range tests {
-		postsubmit := generatePostsubmitForTest(tc.name, tc.repoInfo, tc.treatBranchesAsExplicit, nil) // podSpec tested in TestGeneratePodSpec
+		postsubmit := generatePostsubmitForTest(tc.name, tc.repoInfo, nil) // podSpec tested in TestGeneratePodSpec
 		if !equality.Semantic.DeepEqual(postsubmit, tc.expected) {
 			t.Errorf("expected postsubmit diff:\n%s", diff.ObjectDiff(tc.expected, postsubmit))
 		}

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -489,7 +489,7 @@ func writeToFile(path string, jobConfig *prowconfig.JobConfig) error {
 	return nil
 }
 
-var regexParts = regexp.MustCompile(`[^\w\-\.]+`)
+var regexParts = regexp.MustCompile(`[^\w\-.]+`)
 
 func MakeRegexFilenameLabel(possibleRegex string) string {
 	label := regexParts.ReplaceAllString(possibleRegex, "")


### PR DESCRIPTION
Generate the JobBase parts of both Presubmits and Postsubmit in a single
method.

Additionally, remove some of the regex-handling code for Postsubmits. We
never passed anything else than `true` to the `treatBranchesAsExplicit`
param, so I've removed the parameter and simplified the API. Also, we
took some measures to handle regex-y branches, but the branches come
from **ci-operator** config (not Prowjob config), so they are never
regexes, so we do not need to handle that.

/cc @stevekuznetsov @droslean @bbguimaraes @hongkailiu 