### PR TITLE
pj-rehearse: Add periodic jobs to the rehearsals 

### DIFF
--- a/pkg/rehearse/metrics.go
+++ b/pkg/rehearse/metrics.go
@@ -27,6 +27,7 @@ type Metrics struct {
 
 	ChangedCiopConfigs     []string `json:"changed_ciop_configs"`
 	ChangedPresubmits      []string `json:"changed_presubmits"`
+	ChangedPeriodics       []string `json:"changed_periodics"`
 	ChangedTemplates       []string `json:"changed_templates"`
 	ChangedClusterProfiles []string `json:"changed_cluster_profiles"`
 
@@ -49,6 +50,7 @@ func NewMetrics(file string) *Metrics {
 	return &Metrics{
 		ChangedCiopConfigs: []string{},
 		ChangedPresubmits:  []string{},
+		ChangedPeriodics:   []string{},
 		ChangedTemplates:   []string{},
 
 		Opportunities: map[string][]string{},
@@ -84,8 +86,14 @@ func (m *Metrics) RecordChangedPresubmits(presubmits config.Presubmits) {
 	}
 }
 
-func (m *Metrics) RecordOpportunity(toRehearse config.Presubmits, reason string) {
-	for _, jobs := range toRehearse {
+func (m *Metrics) RecordChangedPeriodics(periodics []prowconfig.Periodic) {
+	for _, job := range periodics {
+		m.ChangedPeriodics = append(m.ChangedPeriodics, job.Name)
+	}
+}
+
+func (m *Metrics) RecordPresubmitsOpportunity(presubmits config.Presubmits, reason string) {
+	for _, jobs := range presubmits {
 		for _, job := range jobs {
 			if _, ok := m.Opportunities[job.Name]; !ok {
 				m.Opportunities[job.Name] = []string{reason}
@@ -96,8 +104,18 @@ func (m *Metrics) RecordOpportunity(toRehearse config.Presubmits, reason string)
 	}
 }
 
-func (m *Metrics) RecordActual(rehearsals []*prowconfig.Presubmit) {
-	for _, job := range rehearsals {
+func (m *Metrics) RecordPeriodicsOpportunity(periodics []prowconfig.Periodic, reason string) {
+	for _, job := range periodics {
+		m.Opportunities[job.Name] = append(m.Opportunities[job.Name], reason)
+	}
+}
+
+func (m *Metrics) RecordActual(presubmits []*prowconfig.Presubmit, periodics []prowconfig.Periodic) {
+	for _, job := range presubmits {
+		m.Actual = append(m.Actual, job.Name)
+	}
+
+	for _, job := range periodics {
 		m.Actual = append(m.Actual, job.Name)
 	}
 }

--- a/pkg/rehearse/metrics_test.go
+++ b/pkg/rehearse/metrics_test.go
@@ -121,7 +121,7 @@ func TestRecordChangedPresubmits(t *testing.T) {
 	}
 }
 
-func TestRecordOpportunity(t *testing.T) {
+func TestRecordPresubmitsOpportunity(t *testing.T) {
 	testFilename := ""
 
 	var testCases = []struct {
@@ -178,7 +178,7 @@ func TestRecordOpportunity(t *testing.T) {
 
 			}
 			metrics.Opportunities = tc.existing
-			metrics.RecordOpportunity(testPresubmits, tc.reason)
+			metrics.RecordPresubmitsOpportunity(testPresubmits, tc.reason)
 			if !reflect.DeepEqual(tc.expected, metrics.Opportunities) {
 				t.Errorf("Recorded rehearsal opportunities differ from expected:\n%s", diff.ObjectReflectDiff(tc.expected, metrics.Opportunities))
 			}
@@ -208,7 +208,7 @@ func TestRecordActual(t *testing.T) {
 			for _, name := range tc.jobs {
 				presubmits = append(presubmits, &prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: name}})
 			}
-			metrics.RecordActual(presubmits)
+			metrics.RecordActual(presubmits, nil)
 			sort.Strings(metrics.Actual)
 			if !reflect.DeepEqual(tc.expected, metrics.Actual) {
 				t.Errorf("Recorded rehearsals differ from expected:\n%s", diff.ObjectReflectDiff(tc.expected, metrics.Actual))

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -1,0 +1,89 @@
+periodics:
+- agent: kubernetes
+  cron: ""
+  decorate: true
+  interval: 24h
+  name: periodic-ci-super-duper-e2e
+  skip_cloning: true
+  extra_refs:
+  - org: super
+    repo: duper
+    base_ref: master
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --secret-dir=/usr/local/e2e-cluster-profile
+      - --target=CHANGED
+      - --template=/usr/local/e2e
+      command:
+      - ci-operator
+      env:
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-ciop-cfg-change.yaml
+            name: ci-operator-misc-configs
+      - name: JOB_NAME_SAFE
+        value: e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
+      - name: TEST_COMMAND
+        value: make test-e2e
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e
+        name: job-definition
+        subPath: cluster-launch-src.yaml
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - configMap:
+        name: prow-job-cluster-launch-src
+      name: job-definition
+- agent: kubernetes
+  cron: ""
+  decorate: true
+  interval: 24h
+  name: periodic-ci-super-duper-no-ciop
+  skip_cloning: true
+  extra_refs:
+  - org: super
+    repo: duper
+    base_ref: master
+  spec:
+    containers:
+    - args:
+      - --no-ci-op-args
+      - --CHANGED
+      command:
+      - no-ci-op
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-ciop-cfg-change.yaml
+            name: ci-operator-misc-configs
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator
+    

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -147,6 +147,123 @@
   kind: ProwJob
   metadata:
     annotations:
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-e2e
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse: "1234"
+      created-by-prow: "true"
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-e2e
+      prow.k8s.io/type: periodic
+    name: aeed2bfa-91ab-11e9-ae38-54e1ad07d68a
+    namespace: test-namespace
+  spec:
+    agent: kubernetes
+    cluster: default
+    decoration_config:
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15s
+      timeout: 4h0m0s
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    extra_refs:
+    - base_ref: master
+      base_sha: dd5da2efc6582980ae671362e119d884e4c1cd6c
+      org: openshift
+      pulls:
+      - author: petr-muller
+        number: 1234
+        sha: 4e01b0829216b589d4e2a5a3d91b08fb0443bf62
+      repo: release
+    job: rehearse-1234-periodic-ci-super-duper-e2e
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --secret-dir=/usr/local/e2e-cluster-profile
+        - --target=CHANGED
+        - --template=/usr/local/e2e
+        - --git-ref=super/duper@master
+        command:
+        - ci-operator
+        env:
+        - name: CLUSTER_TYPE
+          value: gcp
+        - name: CONFIG_SPEC
+          value: |
+            base_images:
+              base:
+                cluster: https://api.ci.openshift.org
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                cluster: https://api.ci.openshift.org
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            images:
+            - from: base
+              to: test-image
+            - from: base
+              to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
+        - name: JOB_NAME_SAFE
+          value: e2e
+        - name: RPM_REPO_OPENSHIFT_ORIGIN
+          value: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
+        - name: TEST_COMMAND
+          value: make test-e2e
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/e2e-cluster-profile
+          name: cluster-profile
+        - mountPath: /usr/local/e2e
+          name: job-definition
+          subPath: cluster-launch-src.yaml
+      serviceAccountName: ci-operator
+      volumes:
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-gcp
+          - configMap:
+              name: cluster-profile-gcp
+      - configMap:
+          name: prow-job-cluster-launch-src
+        name: job-definition
+    type: periodic
+  status:
+    startTime: "2019-06-18T09:30:17Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
     creationTimestamp: null
     labels:

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -1,0 +1,81 @@
+periodics:
+- agent: kubernetes
+  cron: ""
+  decorate: true
+  interval: 24h
+  name: periodic-ci-super-duper-e2e
+  skip_cloning: true
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --git-ref=super/duper@master
+      - --secret-dir=/usr/local/e2e-cluster-profile
+      - --target=e2e
+      - --template=/usr/local/e2e
+      command:
+      - ci-operator
+      env:
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-ciop-cfg-change.yaml
+            name: ci-operator-misc-configs
+      - name: JOB_NAME_SAFE
+        value: e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
+      - name: TEST_COMMAND
+        value: make test-e2e
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e
+        name: job-definition
+        subPath: cluster-launch-src.yaml
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - configMap:
+        name: prow-job-cluster-launch-src
+      name: job-definition
+- agent: kubernetes
+  cron: ""
+  decorate: true
+  interval: 24h
+  name: periodic-ci-super-duper-no-ciop
+  skip_cloning: true
+  spec:
+    containers:
+    - args:
+      - --no-ci-op-args
+      command:
+      - no-ci-op
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-ciop-cfg-change.yaml
+            name: ci-operator-misc-configs
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator
+    


### PR DESCRIPTION
In this PR we enable the periodic jobs to the rehearse tool.

- [X] Adding periodic jobs to the job configuration.
- [X] Include periodic jobs to the execution
- [X] Update tests
- [X] Include periodic jobs to metrics
- [X] Update integration tests
