### PR TITLE
prowgen: use default GOPATH

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -495,11 +496,7 @@ func generateJobsToDir(dir string, label jc.ProwgenLabel) func(configSpec *ciope
 }
 
 func getReleaseRepoDir(directory string) (string, error) {
-	var gopath string
-	if gopath = os.Getenv("GOPATH"); len(gopath) == 0 {
-		return "", fmt.Errorf("GOPATH not set, cannot infer openshift/release repo location")
-	}
-	tentative := filepath.Join(gopath, "src/github.com/openshift/release", directory)
+	tentative := filepath.Join(build.Default.GOPATH, "src/github.com/openshift/release", directory)
 	if stat, err := os.Stat(tentative); err == nil && stat.IsDir() {
 		return tentative, nil
 	}


### PR DESCRIPTION
I tried `--{from,to}-release-repo` for the first time (sue me) and they did not
work because `GOPATH` was not set.  go 1.8 (two years old now and beyond the
two-major-versions support policy) has a way to resolve the value, see
https://golang.org/pkg/go/build.