### PR TITLE
determine working directory for the source image.

### DIFF
--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -54,6 +54,7 @@ type Refs struct {
 
 	BaseRef string `json:"base_ref,omitempty"`
 	BaseSHA string `json:"base_sha,omitempty"`
+	WorkDir bool   `json:"workdir,omitempty"`
 
 	Pulls []Pull `json:"pulls,omitempty"`
 


### PR DESCRIPTION
Get working directory from jobspec and use it in the source image.

reference: [apis/prowjobs/v1/types.go#L565](https://github.com/kubernetes/test-infra/blob/master/prow/apis/prowjobs/v1/types.go#L565)

Working directory will be overwritten if there is an `extra_refs` with `workdir:true` in the `$JOB_SPEC`