### PR TITLE
Install oc cli in ipi-deprovision image

### DIFF
--- a/images/ipi-deprovision/Dockerfile
+++ b/images/ipi-deprovision/Dockerfile
@@ -14,6 +14,10 @@ RUN chmod +x /usr/bin/ipi-deprovision.sh && \
       curl -L -o jq "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" && \
       chmod +x ./jq && \
       mv ./jq /usr/bin && \
+      curl -L -O https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz && \
+      tar -xzf openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz && \
+      mv openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/{oc,kubectl} /usr/bin/ && \
+      rm -rfv ./openshift-origin-client-tools* && \
       yum install -y less && \
       yum clean all && \
       rm -rf /var/cache/yum


### PR DESCRIPTION
We need to collect information that help us debug why deprovision
procedure cannot be run on its own. To this end, oc binary is used
to communicate with the cluster.