### PR TITLE
Fix an example of destination_dir in ONBOARD.md

### DIFF
--- a/ONBOARD.md
+++ b/ONBOARD.md
@@ -147,7 +147,7 @@ images:
   inputs:
     bin:
       paths:
-      - destination_dir: /usr/bin/binary
+      - destination_dir: usr/bin/binary
         source_path: path/to/binary
   to: product
 build_root:


### PR DESCRIPTION
`destination_dir` has to be a relative path. Otherwise [1]
error: could not run steps: step ipi-deprovision failed: could not create build ipi-deprovision: Build.build.openshift.io "ipi-deprovision" is invalid: spec.source.images[0].paths[0].destinationDir: Invalid value: "/usr/bin": must be a relative path

[1]. https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/4531/rehearse-4531-pull-ci-openshift-ci-tools-master-images/1#0:build-log.txt%3A53