### PR TITLE
WIP Allow non ci-operator jobs to be rehearsed.

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -172,16 +172,14 @@ func filterJobSpec(spec *v1.PodSpec, allowVolumes bool) error {
 	// there will always be exactly one container.
 	container := spec.Containers[0]
 
-	if len(container.Command) != 1 || container.Command[0] != "ci-operator" {
-		return fmt.Errorf("cannot rehearse jobs that have Command different from simple 'ci-operator'")
-	}
-
-	for _, arg := range container.Args {
-		if strings.HasPrefix(arg, "--git-ref") || strings.HasPrefix(arg, "-git-ref") {
-			return fmt.Errorf("cannot rehearse jobs that call ci-operator with '--git-ref' arg")
-		}
-		if arg == "--promote" {
-			return fmt.Errorf("cannot rehearse jobs that call ci-operator with '--promote' arg")
+	if len(container.Command) > 0 && container.Command[0] == "ci-operator" {
+		for _, arg := range container.Args {
+			if strings.HasPrefix(arg, "--git-ref") || strings.HasPrefix(arg, "-git-ref") {
+				return fmt.Errorf("cannot rehearse jobs that call ci-operator with '--git-ref' arg")
+			}
+			if arg == "--promote" {
+				return fmt.Errorf("cannot rehearse jobs that call ci-operator with '--promote' arg")
+			}
 		}
 	}
 	if len(spec.Volumes) > 0 && !allowVolumes {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -823,16 +823,6 @@ func TestFilterPresubmits(t *testing.T) {
 		expected       func(*prowconfig.Presubmit) config.Presubmits
 	}{
 		{
-			description: "job where command is not `ci-operator`",
-			crippleFunc: func(j *prowconfig.Presubmit) map[string][]prowconfig.Presubmit {
-				j.Spec.Containers[0].Command[0] = "not-ci-operator"
-				return map[string][]prowconfig.Presubmit{"org/repo": {*j}}
-			},
-			expected: func(j *prowconfig.Presubmit) config.Presubmits {
-				return config.Presubmits{}
-			},
-		},
-		{
 			description: "ci-operator job already using --git-ref",
 			crippleFunc: func(j *prowconfig.Presubmit) map[string][]prowconfig.Presubmit {
 				j.Spec.Containers[0].Args = append(j.Spec.Containers[0].Args, "--git-ref=organization/repo@master")

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -258,6 +258,90 @@
   kind: ProwJob
   metadata:
     annotations:
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-no-ciop
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse: "1234"
+      created-by-prow: "true"
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-no-ciop
+      prow.k8s.io/type: periodic
+    name: 8a50d0b5-b77a-11e9-9411-54e1ad07d68a
+    namespace: test-namespace
+  spec:
+    agent: kubernetes
+    cluster: default
+    decoration_config:
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15s
+      timeout: 4h0m0s
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    extra_refs:
+    - base_ref: master
+      org: super
+      repo: duper
+    job: rehearse-1234-periodic-ci-super-duper-no-ciop
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --no-ci-op-args
+        - --CHANGED
+        command:
+        - no-ci-op
+        env:
+        - name: CONFIG_SPEC
+          value: |
+            base_images:
+              base:
+                cluster: https://api.ci.openshift.org
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                cluster: https://api.ci.openshift.org
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            images:
+            - from: base
+              to: test-image
+            - from: base
+              to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+      serviceAccountName: ci-operator
+    type: periodic
+  status:
+    startTime: "2019-06-18T09:30:17Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
     creationTimestamp: null
     labels:


### PR DESCRIPTION
After in some changes in upstream and multiple changes to `ci-operator` we are now able to manipulate the working directory of the job. That allows us to rehearse also non ci-operator jobs.

WIP -> 

Enable opt-in mechanism for the non ci-operator jobs to be rehearsed.