### PR TITLE
add rehearse label to generated presubmits

### DIFF
--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -523,7 +523,9 @@ func TestGeneratePodSpecRandom(t *testing.T) {
 
 func TestGeneratePresubmitForTest(t *testing.T) {
 	newTrue := true
-	standardJobLabels := map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"}
+	standardJobLabels := map[string]string{
+		"ci-operator.openshift.io/prowgen-controlled": "true",
+		"pj-rehearse.openshift.io/can-be-rehearsed":   "true"}
 
 	tests := []struct {
 		name     string
@@ -553,7 +555,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		},
 	}}
 	for _, tc := range tests {
-		presubmit := generatePresubmitForTest(tc.name, tc.repoInfo, jobconfig.Generated, nil) // podSpec tested in generatePodSpec
+		presubmit := generatePresubmitForTest(tc.name, tc.repoInfo, jobconfig.Generated, nil, true) // podSpec tested in generatePodSpec
 		if !equality.Semantic.DeepEqual(presubmit, tc.expected) {
 			t.Errorf("expected presubmit diff:\n%s", diff.ObjectDiff(tc.expected, presubmit))
 		}
@@ -641,7 +643,11 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 }
 
 func TestGenerateJobs(t *testing.T) {
-	standardJobLabels := map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"}
+	standardPresubmitJobLabels := map[string]string{
+		"ci-operator.openshift.io/prowgen-controlled": "true",
+		"pj-rehearse.openshift.io/can-be-rehearsed":   "true"}
+	standardPostsubmitJobLabels := map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"}
+
 	tests := []struct {
 		id       string
 		config   *ciop.ReleaseBuildConfiguration
@@ -667,11 +673,11 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-derTest",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}}, {
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-leTest",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{},
@@ -694,21 +700,21 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-derTest",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}}, {
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-leTest",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}}, {
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: standardJobLabels,
+						Labels: standardPostsubmitJobLabels,
 					}},
 				}},
 			},
@@ -735,7 +741,7 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-oTeste",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 			},
@@ -758,7 +764,7 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-oTeste",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 			},
@@ -778,13 +784,13 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 				Postsubmits: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: standardJobLabels,
+						Labels: standardPostsubmitJobLabels,
 					}},
 				}},
 			},
@@ -806,7 +812,7 @@ func TestGenerateJobs(t *testing.T) {
 				Presubmits: map[string][]prowconfig.Presubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
 						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardJobLabels,
+						Labels: standardPresubmitJobLabels,
 					}},
 				}},
 			},
@@ -957,6 +963,7 @@ tests:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
     spec:
@@ -1000,6 +1007,7 @@ tests:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit
     spec:
@@ -1119,6 +1127,7 @@ tests:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: rhel
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-rhel-images
     rerun_command: /test rhel-images
     spec:
@@ -1163,6 +1172,7 @@ tests:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: rhel
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-rhel-unit
     rerun_command: /test rhel-unit
     spec:
@@ -1351,6 +1361,7 @@ tests:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
     spec:
@@ -1394,6 +1405,7 @@ tests:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit
     spec:

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -22,6 +22,7 @@ type ProwgenLabel string
 
 const (
 	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
+	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
 	Generated             ProwgenLabel = "true"
 	New                   ProwgenLabel = "newly-generated"
 )

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-subdir-repo-master-test
     rerun_command: /test test
     spec:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-e2e
     rerun_command: /test e2e
     spec:
@@ -78,6 +79,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-e2e-random
     rerun_command: /test e2e-random
     spec:
@@ -180,6 +182,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     max_concurrency: 100
     name: pull-ci-super-duper-master-images
     optional: true
@@ -238,6 +241,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-lint
     rerun_command: /test lint
     spec:
@@ -281,6 +285,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-unit
     rerun_command: /test unit
     spec:
@@ -325,6 +330,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: variant
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-variant-images
     rerun_command: /test variant-images
     spec:
@@ -370,6 +376,7 @@ presubmits:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: variant
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-variant-unit
     rerun_command: /test variant-unit
     spec:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-removed-promotion-images
     rerun_command: /test images
     spec:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -10,6 +10,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-release-3.11-images
     rerun_command: /test images
     spec:
@@ -63,6 +64,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-release-3.11-lint
     rerun_command: /test lint
     spec:
@@ -106,6 +108,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-release-3.11-unit
     rerun_command: /test unit
     spec:


### PR DESCRIPTION
We are about to add an opt-in mechanism for the rehearsals that will be allowed to be executed only if they hold the `pj-rehearse.openshift.io/can-be-rehearsed: "true"` label. 
With this PR, we include this label to all generated ci-operator presubmits.