### PR TITLE
Allow users to generate periodic jobs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -325,6 +325,11 @@ type TestStepConfiguration struct {
 	// will be mounted inside the test container.
 	Secret *Secret `json:"secret,omitempty"`
 
+	// Cron is how often the test is expected to run outside
+	// of pull request workflows. Setting this field will
+	// create a periodic job instead of a presubmit
+	Cron *string `json:"cron,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
 	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
@@ -43,3 +43,13 @@ tests:
 - as: e2e-random
   commands: make e2e
   openshift_installer_random: {}
+- as: e2e-nightly
+  commands: make e2e
+  openshift_ansible:
+    cluster_profile: gcp
+  cron: '@yearly'
+- as: e2e-aws-nightly
+  commands: make e2e
+  openshift_ansible:
+    cluster_profile: aws
+  cron: '@yearly'

--- a/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-periodics.yaml
@@ -1,0 +1,133 @@
+periodics:
+- agent: kubernetes
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  cron: '@yearly'
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  name: periodic-ci-super-duper-master-e2e-aws-nightly
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  spec:
+    containers:
+    - args:
+      - --give-pr-author-access-to-namespace=true
+      - --artifact-dir=$(ARTIFACTS)
+      - --target=e2e-aws-nightly
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --secret-dir=/usr/local/e2e-aws-nightly-cluster-profile
+      - --template=/usr/local/e2e-aws-nightly
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: JOB_NAME_SAFE
+        value: e2e-aws-nightly
+      - name: TEST_COMMAND
+        value: make e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      volumeMounts:
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-nightly-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws-nightly
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator
+    volumes:
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+- agent: kubernetes
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  cron: '@yearly'
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  name: periodic-ci-super-duper-master-e2e-azure-nightly
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  spec:
+    containers:
+    - args:
+      - --give-pr-author-access-to-namespace=true
+      - --artifact-dir=$(ARTIFACTS)
+      - --target=e2e-azure-nightly
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --secret-dir=/usr/local/e2e-azure-nightly-cluster-profile
+      - --template=/usr/local/e2e-azure-nightly
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
+      - name: CLUSTER_TYPE
+        value: azure
+      - name: JOB_NAME_SAFE
+        value: e2e-azure-nightly
+      - name: TEST_COMMAND
+        value: make e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      volumeMounts:
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+      - mountPath: /usr/local/e2e-azure-nightly-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-azure-nightly
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+      resources:
+        requests:
+          cpu: 10m
+    serviceAccountName: ci-operator
+    volumes:
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-azure

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -1,0 +1,135 @@
+periodics:
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-duper-master-e2e-nightly
+  spec:
+    containers:
+    - args:
+      - --give-pr-author-access-to-namespace=true
+      - --artifact-dir=$(ARTIFACTS)
+      - --target=e2e-nightly
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --secret-dir=/usr/local/e2e-nightly-cluster-profile
+      - --template=/usr/local/e2e-nightly
+      command:
+      - ci-operator
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: JOB_NAME_SAFE
+        value: e2e-nightly
+      - name: TEST_COMMAND
+        value: make e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+      - mountPath: /usr/local/e2e-nightly-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-nightly
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+    serviceAccountName: ci-operator
+    volumes:
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-duper-master-e2e-aws-nightly
+  spec:
+    containers:
+    - args:
+      - --give-pr-author-access-to-namespace=true
+      - --artifact-dir=$(ARTIFACTS)
+      - --target=e2e-aws-nightly
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --secret-dir=/usr/local/e2e-aws-nightly-cluster-profile
+      - --template=/usr/local/e2e-aws-nightly
+      command:
+      - ci-operator
+      env:
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: JOB_NAME_SAFE
+        value: e2e-aws-nightly
+      - name: TEST_COMMAND
+        value: make e2e
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-nightly-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws-nightly
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+    serviceAccountName: ci-operator
+    volumes:
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws


### PR DESCRIPTION
In addition to generating presubmits and postsubmits, a new field on the
test type allows users to generate periodic jobs. In order to support
generating periodic jobs that require the `src-build` step, we add the
repo under test as the first `extra_ref`. Jobs that do not need to clone
anything will no-op.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>