### PR TITLE
Disallow redundant path aliases

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -3,13 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-
-	"github.com/ghodss/yaml"
-
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"os"
 )
 
 func main() {
@@ -22,37 +18,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := filepath.Walk(configDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			fmt.Printf("prevent panic by handling failure accessing a path %q: %v\n", configDir, err)
-			return err
-		}
-		if filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".json" {
-			// we assume any JSON or YAML in the config dir is a CI Operator config
-			name, err := filepath.Rel(configDir, path)
-			if err != nil {
-				return fmt.Errorf("could not determine relative path name for %s: %v", path, err)
-			}
-
-			data, err := ioutil.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("failed to load config from %s: %v", name, err)
-			}
-
-			var config api.ReleaseBuildConfiguration
-			if err := yaml.Unmarshal(data, &config); err != nil {
-				return fmt.Errorf("invalid configuration from %s: %v\nvalue:%s", name, err, string(data))
-			}
-
-			if err := config.Validate(); err != nil {
-				return fmt.Errorf("invalid configuration from %s: %v", name, err)
-
-			}
-			fmt.Printf("validated configuration at %s\n", name)
-		}
+	if err := config.OperateOnCIOperatorConfigDir(configDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+		// validation is implicit, so we don't need to do anything
 		return nil
 	}); err != nil {
-		fmt.Printf("error loading configuration files: %v\n", err)
+		fmt.Printf("error validating configuration files: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -269,7 +269,7 @@ func (o *options) Complete() error {
 	}
 	o.configSpec = config
 
-	if err := o.configSpec.Validate(); err != nil {
+	if err := o.configSpec.ValidateAtRuntime(); err != nil {
 		return err
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -36,7 +36,7 @@ type ReleaseBuildConfiguration struct {
 	// the desired location of the contents of this repository in
 	// Go. If specified the location of the repository we are
 	// cloning from is ignored.
-	CanonicalGoRepository string `json:"canonical_go_repository,omitempty"`
+	CanonicalGoRepository *string `json:"canonical_go_repository,omitempty"`
 
 	// Images describes the images that are built
 	// baseImage the project as part of the release

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -309,10 +309,9 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 	}
 
 	if jobSpec.Refs != nil || len(jobSpec.ExtraRefs) > 0 {
-		buildSteps = append(buildSteps, api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
-			From:      api.PipelineImageStreamTagReferenceRoot,
-			To:        api.PipelineImageStreamTagReferenceSource,
-			PathAlias: config.CanonicalGoRepository,
+		step := api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
+			From: api.PipelineImageStreamTagReferenceRoot,
+			To:   api.PipelineImageStreamTagReferenceSource,
 			ClonerefsImage: api.ImageStreamTagReference{
 				Cluster:   "https://api.ci.openshift.org",
 				Namespace: "ci",
@@ -320,7 +319,11 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 				Tag:       "latest",
 			},
 			ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
-		}})
+		}}
+		if config.CanonicalGoRepository != nil {
+			step.SourceStepConfiguration.PathAlias = *config.CanonicalGoRepository
+		}
+		buildSteps = append(buildSteps, step)
 	}
 
 	if len(config.BinaryBuildCommands) > 0 {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -255,6 +255,10 @@ tests:
     cluster_profile: aws
 `
 
+func strP(str string) *string {
+	return &str
+}
+
 var parsedConfig = &api.ReleaseBuildConfiguration{
 	InputConfiguration: api.InputConfiguration{
 		BaseImages: map[string]api.ImageStreamTagReference{
@@ -292,7 +296,7 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 	TestBinaryBuildCommands: "",
 	RpmBuildCommands:        "make build-rpms",
 	RpmBuildLocation:        "",
-	CanonicalGoRepository:   "github.com/openshift/origin",
+	CanonicalGoRepository:   strP("github.com/openshift/origin"),
 	Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
 		From: "base",
 		To:   "template-service-broker",


### PR DESCRIPTION
The default clone location for a repository is
`${GOPATH}/src/github.com/<org>/<repo>`. There is no need to allow
people to add an alias that points at the same location.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @droslean 