### PR TITLE
Don't change refs at runtime unless running locally 

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -474,10 +474,6 @@ type SourceStepConfiguration struct {
 	From PipelineImageStreamTagReference `json:"from"`
 	To   PipelineImageStreamTagReference `json:"to,omitempty"`
 
-	// PathAlias is the location within the source repository
-	// to place source contents. It defaults to
-	// github.com/ORG/REPO.
-	PathAlias string `json:"source_path"`
 	// ClonerefsImage is the image where we get the clonerefs tool
 	ClonerefsImage ImageStreamTagReference `json:"clonerefs_image"`
 	// ClonerefsPath is the path in the above image where the

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -320,9 +320,6 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			},
 			ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
 		}}
-		if config.CanonicalGoRepository != nil {
-			step.SourceStepConfiguration.PathAlias = *config.CanonicalGoRepository
-		}
 		buildSteps = append(buildSteps, step)
 	}
 

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -113,7 +113,316 @@ RUN git submodule update --init
 								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
 								ForcePull:               true,
 								NoCache:                 true,
-								Env:                     []coreapi.EnvVar{{Name: "CLONEREFS_OPTIONS", Value: `{"git_user_email":"ci-robot@openshift.io","git_user_name":"ci-robot","log":"/dev/null","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"src_root":"/go"}`}},
+								Env:                     []coreapi.EnvVar{{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}]}`}},
+								ImageOptimizationPolicy: &layer,
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &coreapi.ObjectReference{
+								Kind:      "ImageStreamTag",
+								Namespace: "namespace",
+								Name:      "pipeline:src",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with a path alias",
+			config: api.SourceStepConfiguration{
+				From: api.PipelineImageStreamTagReferenceRoot,
+				To:   api.PipelineImageStreamTagReferenceSource,
+				ClonerefsImage: api.ImageStreamTagReference{
+					Cluster:   "https://api.ci.openshift.org",
+					Namespace: "ci",
+					Name:      "clonerefs",
+					Tag:       "latest",
+				},
+				ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+					Refs: &v1.Refs{
+						Org:       "org",
+						Repo:      "repo",
+						BaseRef:   "master",
+						BaseSHA:   "masterSHA",
+						PathAlias: "somewhere/else",
+						Pulls: []v1.Pull{{
+							Number: 1,
+							SHA:    "pullSHA",
+						}},
+					},
+				},
+				Namespace: "namespace",
+			},
+			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
+
+			expected: &buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "src",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"persists-between-builds": "false",
+						"job":                     "job",
+						"build-id":                "buildId",
+						"prow.k8s.io/id":          "prowJobId",
+						"creates":                 "src",
+						"created-by-ci":           "true",
+					},
+					Annotations: map[string]string{
+						"ci.openshift.io/job-spec": ``, // set via unexported fields so will be empty
+					},
+				},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Resources:      coreapi.ResourceRequirements{Requests: map[coreapi.ResourceName]resource.Quantity{"cpu": resource.MustParse("200m")}},
+						ServiceAccount: "builder",
+						Source: buildapi.BuildSource{
+							Type: buildapi.BuildSourceDockerfile,
+							Dockerfile: strP(`
+FROM pipeline:root
+ADD ./app.binary /clonerefs
+RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
+WORKDIR /go/src/somewhere/else/
+ENV GOPATH=/go
+RUN git submodule update --init
+`),
+							Images: []buildapi.ImageSource{
+								{
+									From: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+									Paths: []buildapi.ImageSourcePath{
+										{
+											SourcePath:     "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+											DestinationDir: ".",
+										},
+									},
+								},
+							},
+						},
+						Strategy: buildapi.BuildStrategy{
+							Type: buildapi.DockerBuildStrategyType,
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								DockerfilePath:          "",
+								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
+								ForcePull:               true,
+								NoCache:                 true,
+								Env:                     []coreapi.EnvVar{{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"path_alias":"somewhere/else"}]}`}},
+								ImageOptimizationPolicy: &layer,
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &coreapi.ObjectReference{
+								Kind:      "ImageStreamTag",
+								Namespace: "namespace",
+								Name:      "pipeline:src",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with extra refs",
+			config: api.SourceStepConfiguration{
+				From: api.PipelineImageStreamTagReferenceRoot,
+				To:   api.PipelineImageStreamTagReferenceSource,
+				ClonerefsImage: api.ImageStreamTagReference{
+					Cluster:   "https://api.ci.openshift.org",
+					Namespace: "ci",
+					Name:      "clonerefs",
+					Tag:       "latest",
+				},
+				ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+					Refs: &v1.Refs{
+						Org:     "org",
+						Repo:    "repo",
+						BaseRef: "master",
+						BaseSHA: "masterSHA",
+						Pulls: []v1.Pull{{
+							Number: 1,
+							SHA:    "pullSHA",
+						}},
+					},
+					ExtraRefs: []v1.Refs{{
+						Org:     "org",
+						Repo:    "other",
+						BaseRef: "master",
+						BaseSHA: "masterSHA",
+					}},
+				},
+				Namespace: "namespace",
+			},
+			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
+
+			expected: &buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "src",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"persists-between-builds": "false",
+						"job":                     "job",
+						"build-id":                "buildId",
+						"prow.k8s.io/id":          "prowJobId",
+						"creates":                 "src",
+						"created-by-ci":           "true",
+					},
+					Annotations: map[string]string{
+						"ci.openshift.io/job-spec": ``, // set via unexported fields so will be empty
+					},
+				},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Resources:      coreapi.ResourceRequirements{Requests: map[coreapi.ResourceName]resource.Quantity{"cpu": resource.MustParse("200m")}},
+						ServiceAccount: "builder",
+						Source: buildapi.BuildSource{
+							Type: buildapi.BuildSourceDockerfile,
+							Dockerfile: strP(`
+FROM pipeline:root
+ADD ./app.binary /clonerefs
+RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
+WORKDIR /go/src/github.com/org/repo/
+ENV GOPATH=/go
+RUN git submodule update --init
+`),
+							Images: []buildapi.ImageSource{
+								{
+									From: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+									Paths: []buildapi.ImageSourcePath{
+										{
+											SourcePath:     "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+											DestinationDir: ".",
+										},
+									},
+								},
+							},
+						},
+						Strategy: buildapi.BuildStrategy{
+							Type: buildapi.DockerBuildStrategyType,
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								DockerfilePath:          "",
+								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
+								ForcePull:               true,
+								NoCache:                 true,
+								Env:                     []coreapi.EnvVar{{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA"}]}`}},
+								ImageOptimizationPolicy: &layer,
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &coreapi.ObjectReference{
+								Kind:      "ImageStreamTag",
+								Namespace: "namespace",
+								Name:      "pipeline:src",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with extra refs setting workdir and path alias",
+			config: api.SourceStepConfiguration{
+				From: api.PipelineImageStreamTagReferenceRoot,
+				To:   api.PipelineImageStreamTagReferenceSource,
+				ClonerefsImage: api.ImageStreamTagReference{
+					Cluster:   "https://api.ci.openshift.org",
+					Namespace: "ci",
+					Name:      "clonerefs",
+					Tag:       "latest",
+				},
+				ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+					Refs: &v1.Refs{
+						Org:     "org",
+						Repo:    "repo",
+						BaseRef: "master",
+						BaseSHA: "masterSHA",
+						Pulls: []v1.Pull{{
+							Number: 1,
+							SHA:    "pullSHA",
+						}},
+					},
+					ExtraRefs: []v1.Refs{{
+						Org:       "org",
+						Repo:      "other",
+						BaseRef:   "master",
+						BaseSHA:   "masterSHA",
+						WorkDir:   true,
+						PathAlias: "this/is/nuts",
+					}},
+				},
+				Namespace: "namespace",
+			},
+			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
+
+			expected: &buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "src",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"persists-between-builds": "false",
+						"job":                     "job",
+						"build-id":                "buildId",
+						"prow.k8s.io/id":          "prowJobId",
+						"creates":                 "src",
+						"created-by-ci":           "true",
+					},
+					Annotations: map[string]string{
+						"ci.openshift.io/job-spec": ``, // set via unexported fields so will be empty
+					},
+				},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Resources:      coreapi.ResourceRequirements{Requests: map[coreapi.ResourceName]resource.Quantity{"cpu": resource.MustParse("200m")}},
+						ServiceAccount: "builder",
+						Source: buildapi.BuildSource{
+							Type: buildapi.BuildSourceDockerfile,
+							Dockerfile: strP(`
+FROM pipeline:root
+ADD ./app.binary /clonerefs
+RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
+WORKDIR /go/src/this/is/nuts/
+ENV GOPATH=/go
+RUN git submodule update --init
+`),
+							Images: []buildapi.ImageSource{
+								{
+									From: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+									Paths: []buildapi.ImageSourcePath{
+										{
+											SourcePath:     "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+											DestinationDir: ".",
+										},
+									},
+								},
+							},
+						},
+						Strategy: buildapi.BuildStrategy{
+							Type: buildapi.DockerBuildStrategyType,
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								DockerfilePath:          "",
+								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
+								ForcePull:               true,
+								NoCache:                 true,
+								Env:                     []coreapi.EnvVar{{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA","path_alias":"this/is/nuts","workdir":true}]}`}},
 								ImageOptimizationPolicy: &layer,
 							},
 						},

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master__variant.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master__variant.yaml
@@ -32,3 +32,4 @@ tests:
   commands: make test-unit
   container:
     from: src
+canonical_go_repository: whoa.com/super/duper

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -56,6 +56,7 @@ postsubmits:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: variant
     name: branch-ci-super-duper-master-variant-images
+    path_alias: whoa.com/super/duper
     spec:
       containers:
       - args:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -332,6 +332,7 @@ presubmits:
       ci-operator.openshift.io/variant: variant
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-variant-images
+    path_alias: whoa.com/super/duper
     rerun_command: /test variant-images
     spec:
       containers:
@@ -378,6 +379,7 @@ presubmits:
       ci-operator.openshift.io/variant: variant
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-variant-unit
+    path_alias: whoa.com/super/duper
     rerun_command: /test variant-unit
     spec:
       containers:


### PR DESCRIPTION

Use `canonical_go_repository` to generate `path_alias`

These settings are identical, so we should use the CI Operator
configuration to generate an appropriate set of jobs.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Don't change refs at runtime unless running locally

When running with a Prow-provided set of Refs, we should honor those and
not attempt to change them in CI Operator. If a user is passing
`--git-ref` manually, though, we have to construct a set of refs
dynamically at runtime.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

depends on #66 
/assign @petr-muller @droslean 