### PR TITLE
cmd/ipi-deprovision/ipi-deprovision.sh: Debug logs for aws-tag-deprovision

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -26,7 +26,7 @@ handle_cluster () {
   local region
   region=$3
   echo "handling cluster: ${cluster_name} in region ${region} with expirationDate: ${expirationDateValue}"
-  timeout -v 10m ./bin/hiveutil aws-tag-deprovision "${cluster_name}=owned" --region "${region}"
+  timeout -v 10m ./bin/hiveutil aws-tag-deprovision --loglevel debug "${cluster_name}=owned" --region "${region}"
 }
 
 collect_metadata () {


### PR DESCRIPTION
The info-level logs don't give a lot of information about where we're stuck [when a cluster hangs][1]:

```
handling cluster: kubernetes.io/cluster/ci-op-cyzb4xyb-57a9f-29jcd in region us-east-1 with expirationDate: 2019-08-07T12:49+0000
{"component":"entrypoint","file":"prow/entrypoint/run.go:159","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 8h0m0s timeout","time":"2019-08-08T10:09:15Z"}
```

[1]: https://storage.googleapis.com/origin-ci-test/logs/periodic-ipi-deprovision/3630/build-log.txt