### PR TITLE
Don't serialize `upgrade: false`

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -412,7 +412,7 @@ type OpenshiftInstallerClusterTestConfiguration struct {
 	// the initial payload and the installer image from that
 	// will be upgraded. The `run-upgrade-tests` function will be
 	// available for the commands.
-	Upgrade bool `json:"upgrade"`
+	Upgrade bool `json:"upgrade,omitempty"`
 }
 
 // OpenshiftInstallerSrcClusterTestConfiguration describes a


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

This will be useful in the cases we determinize or auto-generate ci-operator fields.

/assign @petr-muller @droslean @bbguimaraes 