### PR TITLE
Rely on 'gather bootstrap' for CI templates > 4.1

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -442,7 +442,8 @@ objects:
           mkdir -p /tmp/artifacts/pods /tmp/artifacts/nodes /tmp/artifacts/metrics /tmp/artifacts/bootstrap /tmp/artifacts/network
 
 
-          if [ -f /tmp/artifacts/installer/terraform.tfstate ]
+          # NOTE: OpenShift 4.2 and greater have native 'gather bootstrap' support
+          if [ -f /tmp/artifacts/installer/terraform.tfstate ] && openshift-install version | grep v4.1 &>/dev/null
           then
               # we don't have jq, so the python equivalent of
               # jq '.modules[].resources."aws_instance.bootstrap".primary.attributes."public_ip" | select(.)'


### PR DESCRIPTION
Update the clusterinstall CI template so that it skips the
inline bootstrap_ip code if the installer version matches 4.1.
All other CI versions supported (4.2, and greater) would have
'gather bootstrap' to replace this functionality.