### PR TITLE
Inject resources in template pod's container named "test"

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -159,7 +159,7 @@ func FromConfig(
 			} else if testStep.OpenshiftInstallerClusterTestConfiguration != nil {
 				if testStep.OpenshiftInstallerClusterTestConfiguration.Upgrade {
 					var err error
-					step, err = clusterinstall.E2ETestStep(*testStep.OpenshiftInstallerClusterTestConfiguration, *testStep, params, podClient, templateClient, secretGetter, artifactDir, jobSpec, dryLogger)
+					step, err = clusterinstall.E2ETestStep(*testStep.OpenshiftInstallerClusterTestConfiguration, *testStep, params, podClient, templateClient, secretGetter, artifactDir, jobSpec, dryLogger, config.Resources)
 					if err != nil {
 						return nil, nil, fmt.Errorf("unable to create end to end test step: %v", err)
 					}
@@ -178,7 +178,7 @@ func FromConfig(
 	}
 
 	for _, template := range templates {
-		step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, dryLogger)
+		step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, dryLogger, config.Resources)
 		buildSteps = append(buildSteps, step)
 	}
 

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -43,6 +43,7 @@ func E2ETestStep(
 	artifactDir string,
 	jobSpec *api.JobSpec,
 	dryLogger *steps.DryLogger,
+	resources api.ResourceConfiguration,
 ) (api.Step, error) {
 	var template *templateapi.Template
 	if err := yaml.Unmarshal([]byte(installTemplateE2E), &template); err != nil {
@@ -95,7 +96,7 @@ func E2ETestStep(
 		params = api.NewOverrideParameters(params, overrides)
 	}
 
-	step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, dryLogger)
+	step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, dryLogger, resources)
 	subTests, ok := step.(nestedSubTests)
 	if !ok {
 		return nil, fmt.Errorf("unexpected %T", step)

--- a/pkg/steps/template_test.go
+++ b/pkg/steps/template_test.go
@@ -10,11 +10,13 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 
 	templateapi "github.com/openshift/api/template/v1"
+
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
@@ -83,6 +85,7 @@ func TestOperateOnTemplatePods(t *testing.T) {
 	testCases := []struct {
 		testID       string
 		artifactsDir string
+		resources    api.ResourceConfiguration
 		template     *templateapi.Template
 		expected     *templateapi.Template
 	}{
@@ -230,15 +233,334 @@ func TestOperateOnTemplatePods(t *testing.T) {
 				},
 			},
 		},
+		{
+			testID: "resources defined in the config but the test container has existing resources, no changes expected",
+			resources: api.ResourceConfiguration{
+				"*": {
+					Requests: api.ResourceList{"cpu": "1", "memory": "2Gi"},
+					Limits:   api.ResourceList{"memory": "3Gi"},
+				},
+				"test-template": {
+					Requests: api.ResourceList{"cpu": "5", "memory": "10Gi"},
+					Limits:   api.ResourceList{"memory": "16Gi"},
+				},
+			},
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{
+									{
+										Name: "test",
+										Resources: coreapi.ResourceRequirements{
+											Requests: coreapi.ResourceList{
+												"cpu":    *resource.NewQuantity(3, resource.DecimalSI),
+												"memory": *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI)},
+											Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)},
+										},
+									},
+								}},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{
+									{
+										Name: "test",
+										Resources: coreapi.ResourceRequirements{
+											Requests: coreapi.ResourceList{
+												"cpu":    *resource.NewQuantity(3, resource.DecimalSI),
+												"memory": *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI)},
+											Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)},
+										},
+									},
+								},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
+		{
+			testID: "resources defined in the config,no existing resources in the container, changes are expected",
+			resources: api.ResourceConfiguration{
+				"*": {
+					Requests: api.ResourceList{"cpu": "1", "memory": "2Gi"},
+					Limits:   api.ResourceList{"memory": "3Gi"},
+				},
+				"test-template": {
+					Requests: api.ResourceList{"cpu": "5", "memory": "10Gi"},
+					Limits:   api.ResourceList{"memory": "16Gi"},
+				},
+			},
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{{Name: "test"}}},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{
+									{
+										Name: "test",
+										Resources: coreapi.ResourceRequirements{
+											Requests: coreapi.ResourceList{
+												"cpu":    *resource.NewQuantity(5, resource.DecimalSI),
+												"memory": *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)},
+											Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(16*1024*1024*1024, resource.BinarySI)},
+										},
+									},
+								},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
+		{
+			testID: "only default resources defined in the config,no existing resources in the container, changes are expected",
+			resources: api.ResourceConfiguration{
+				"*": {
+					Requests: api.ResourceList{"cpu": "1", "memory": "2Gi"},
+					Limits:   api.ResourceList{"memory": "3Gi"},
+				},
+			},
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{{Name: "test"}}},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{
+									{
+										Name: "test",
+										Resources: coreapi.ResourceRequirements{
+											Requests: coreapi.ResourceList{
+												"cpu":    *resource.NewQuantity(1, resource.DecimalSI),
+												"memory": *resource.NewQuantity(2*1024*1024*1024, resource.BinarySI)},
+											Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(3*1024*1024*1024, resource.BinarySI)},
+										},
+									},
+								},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.testID, func(t *testing.T) {
-			operateOnTemplatePods(tc.template, tc.artifactsDir)
+			operateOnTemplatePods(tc.template, tc.artifactsDir, tc.resources)
 			if !equality.Semantic.DeepEqual(tc.template, tc.expected) {
 				t.Fatal(diff.ObjectReflectDiff(tc.template, tc.expected))
 			}
 
+		})
+	}
+}
+
+func TestInjectResourcesToPod(t *testing.T) {
+	testTemplateName := "test-template"
+	testCases := []struct {
+		testID    string
+		resources api.ResourceConfiguration
+		pod       *coreapi.Pod
+		expected  *coreapi.Pod
+	}{
+		{
+			testID: "no resource requests are defined, container named 'test' exists, expect no changes",
+			pod: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec:       coreapi.PodSpec{Containers: []coreapi.Container{{Name: "test"}}},
+			},
+			expected: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "test"}},
+				},
+			},
+		},
+		{
+			testID: "resource requests are defined, no container named 'test' exists, expect no changes",
+			resources: api.ResourceConfiguration{
+				testTemplateName: {
+					Requests: api.ResourceList{"cpu": "3", "memory": "8Gi"},
+					Limits:   api.ResourceList{"memory": "10Gi"},
+				},
+			},
+			pod: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "no-test"}},
+				},
+			},
+			expected: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "no-test"}},
+				},
+			},
+		},
+
+		{
+			testID: "both default and template's resource requests are defined, pod has container named 'test', and is changed",
+			resources: api.ResourceConfiguration{
+				"*": {
+					Requests: api.ResourceList{"cpu": "3", "memory": "8Gi"},
+					Limits:   api.ResourceList{"memory": "10Gi"},
+				},
+				"test-template": {
+					Requests: api.ResourceList{"cpu": "5", "memory": "10Gi"},
+					Limits:   api.ResourceList{"memory": "16Gi"},
+				},
+			},
+			pod: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "test"}},
+				},
+			},
+			expected: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{
+						{
+							Name: "test",
+							Resources: coreapi.ResourceRequirements{
+								Requests: coreapi.ResourceList{
+									"cpu":    *resource.NewQuantity(5, resource.DecimalSI),
+									"memory": *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)},
+								Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(16*1024*1024*1024, resource.BinarySI)},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			testID: "only the default resource requests are defined, pod has container named 'test', and is changed",
+			resources: api.ResourceConfiguration{
+				"*": {
+					Requests: api.ResourceList{"cpu": "3", "memory": "8Gi"},
+					Limits:   api.ResourceList{"memory": "10Gi"},
+				},
+			},
+			pod: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "test"}},
+				},
+			},
+			expected: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{
+						{
+							Name: "test",
+							Resources: coreapi.ResourceRequirements{
+								Requests: coreapi.ResourceList{
+									"cpu":    *resource.NewQuantity(3, resource.DecimalSI),
+									"memory": *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI)},
+								Limits: coreapi.ResourceList{"memory": *resource.NewQuantity(10*1024*1024*1024, resource.BinarySI)},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testID, func(t *testing.T) {
+			pod := tc.pod
+			expectedPod := tc.expected
+
+			injectResourcesToPod(pod, testTemplateName, tc.resources)
+			if !equality.Semantic.DeepEqual(expectedPod, pod) {
+				t.Fatal(diff.ObjectDiff(expectedPod, pod))
+			}
 		})
 	}
 }

--- a/test/ci-operator-integration/base/config/test-config.yaml
+++ b/test/ci-operator-integration/base/config/test-config.yaml
@@ -164,6 +164,12 @@ resources:
     requests:
       cpu: "3"
       memory: 8Gi
+  test-template:
+    limits:
+      memory: 20Gi
+    requests:
+      cpu: "10"
+      memory: 30Gi
 rpm_build_commands: make build-rpms
 tag_specification:
   name: "ci-operator-test"

--- a/test/ci-operator-integration/base/config/test-template.yaml
+++ b/test/ci-operator-integration/base/config/test-template.yaml
@@ -110,12 +110,6 @@ objects:
     - name: test
       image: ${LOCAL_IMAGE_SRC}
       terminationMessagePolicy: FallbackToLogsOnError
-      resources:
-        requests:
-          cpu: 10m
-          memory: 10Mi
-        limits:
-          memory: 200Mi      
       volumeMounts:
       - name: shared-tmp
         mountPath: /tmp/shared

--- a/test/ci-operator-integration/base/expected_files/expected_with_template.json
+++ b/test/ci-operator-integration/base/expected_files/expected_with_template.json
@@ -1250,11 +1250,11 @@
               "name": "test",
               "resources": {
                 "limits": {
-                  "memory": "200Mi"
+                  "memory": "20Gi"
                 },
                 "requests": {
-                  "cpu": "10m",
-                  "memory": "10Mi"
+                  "cpu": "10",
+                  "memory": "30Gi"
                 }
               },
               "terminationMessagePolicy": "FallbackToLogsOnError",


### PR DESCRIPTION
With this patch, we allow resources injection to the template pod's test container. 

The logic is the following:
* If the test container has already resources defined, use them.
* else If the ci-operator config has resources defined with the template's name, inject the resources to the test container.
* else If there are only the default resources defined in the ci-operator's config, use them instead.

Note: The resources will be injected only if the template has a pod and the pod has a container named "test"