### PR TITLE
ci-operator: add TestStep type

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -385,10 +385,6 @@ func TestValidateBaseRpmImages(t *testing.T) {
 	}
 }
 
-func parseError(id string, err error) error {
-	return fmt.Errorf("%q expected to be valid, got 'Error(%v)' instead", id, err)
-}
-
 func parseValidError(id string) error {
 	return fmt.Errorf("%q expected to be invalid, but returned valid", id)
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -307,6 +307,14 @@ type TestStepConfiguration struct {
 	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
 }
 
+type TestStep struct {
+	Name        string               `json:"name,omitempty"`
+	Image       string               `json:"image,omitempty"`
+	Commands    string               `json:"commands,omitempty"`
+	ArtifactDir string               `json:"artifact_dir,omitempty"`
+	Resources   ResourceRequirements `json:"resources,omitempty"`
+}
+
 // Secret describes a secret to be mounted inside a test
 // container.
 type Secret struct {


### PR DESCRIPTION
Slightly modified subset of https://github.com/openshift/ci-tools/pull/85.

Open questions:

- Is a step with just a `name` the best way to reference a pre-defined step?  See the original PR for details and https://github.com/bbguimaraes/release/tree/steps for an example.
- Is `resources` required? That is the case for other ci-operator tests, but not for templates.
- `TestStep` is a terrible name.