### PR TITLE
add job pathalias to the extraref with workdif

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -102,10 +102,11 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 		if len(repo) > 0 {
 			orgRepo := strings.Split(repo, "/")
 			rehearsal.ExtraRefs = append(rehearsal.ExtraRefs, pjapi.Refs{
-				Org:     orgRepo[0],
-				Repo:    orgRepo[1],
-				BaseRef: branch,
-				WorkDir: true,
+				Org:       orgRepo[0],
+				Repo:      orgRepo[1],
+				BaseRef:   branch,
+				WorkDir:   true,
+				PathAlias: rehearsal.PathAlias,
 			})
 			context += repo + "/"
 		}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -256,8 +256,9 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 	testRepo := "org/repo"
 	sourcePresubmit := &prowconfig.Presubmit{
 		JobBase: prowconfig.JobBase{
-			Agent: "kubernetes",
-			Name:  "pull-ci-org-repo-branch-test",
+			Agent:         "kubernetes",
+			Name:          "pull-ci-org-repo-branch-test",
+			UtilityConfig: prowconfig.UtilityConfig{PathAlias: "test/path.io"},
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Command: []string{"ci-operator"},
@@ -280,10 +281,11 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 	expectedPresubmit.Optional = true
 	expectedPresubmit.ExtraRefs = []pjapi.Refs{
 		{
-			Org:     "org",
-			Repo:    "repo",
-			BaseRef: "branch",
-			WorkDir: true,
+			Org:       "org",
+			Repo:      "repo",
+			BaseRef:   "branch",
+			PathAlias: "test/path.io",
+			WorkDir:   true,
 		},
 	}
 


### PR DESCRIPTION
Adds the job's config `path_alias` to the `extraRef`. With this, we assume that the `path_alias` in the extrarefs will override the `path_alias` in the Refs while cloning. 

A proper fix should be done upstream.