### PR TITLE
ci-operator multi-stage: MultiStageTestStep

### DIFF
--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 
@@ -48,6 +49,10 @@ func (s *JobSpec) Inputs() InputDefinition {
 		panic(err)
 	}
 	return InputDefinition{string(raw)}
+}
+
+func (s JobSpec) JobNameHash() string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s.Job)))[:5]
 }
 
 // ResolveSpecFromEnv will determine the Refs being

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -27,8 +27,8 @@ type ReleaseBuildConfiguration struct {
 	// command. The created RPMs will then be served via HTTP to the "base" image
 	// via an injected rpm.repo in the standard location at /etc/yum.repos.d.
 	RpmBuildCommands string `json:"rpm_build_commands,omitempty"`
-	// RpmBuildLocation is where RPms are deposited/ after being built. If
-	// unset, this will default/ under the repository root to
+	// RpmBuildLocation is where RPms are deposited after being built. If
+	// unset, this will default under the repository root to
 	// _output/local/releases/rpms/.
 	RpmBuildLocation string `json:"rpm_build_location,omitempty"`
 
@@ -64,6 +64,39 @@ type ReleaseBuildConfiguration struct {
 	// input types. The special name '*' may be used to set default
 	// requests and limits.
 	Resources ResourceConfiguration `json:"resources,omitempty"`
+}
+
+// BuildsImage checks if an image is built by the release configuration.
+func (c ReleaseBuildConfiguration) BuildsImage(name string) bool {
+	for _, i := range c.Images {
+		if string(i.To) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// IsPipelineImage checks if `name` will be a tag in the pipeline image stream.
+func (c ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
+	for i := range c.BaseImages {
+		if i == name {
+			return true
+		}
+	}
+	for i := range c.BaseRPMImages {
+		if i == name {
+			return true
+		}
+	}
+	switch name {
+	case string(PipelineImageStreamTagReferenceRoot),
+		string(PipelineImageStreamTagReferenceSource),
+		string(PipelineImageStreamTagReferenceBinaries),
+		string(PipelineImageStreamTagReferenceTestBinaries),
+		string(PipelineImageStreamTagReferenceRPMs):
+		return true
+	}
+	return false
 }
 
 // ResourceConfiguration defines resource overrides for jobs run

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -1,0 +1,192 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/junit"
+)
+
+const (
+	multiStageTestLabel = "ci.openshift.io/multi-stage-test"
+)
+
+type multiStageTestStep struct {
+	name            string
+	config          *api.ReleaseBuildConfiguration
+	podClient       PodClient
+	jobSpec         *api.JobSpec
+	pre, test, post []api.TestStep
+}
+
+func MultiStageTestStep(
+	testConfig api.TestStepConfiguration,
+	config *api.ReleaseBuildConfiguration,
+	podClient PodClient,
+	jobSpec *api.JobSpec,
+) api.Step {
+	return newMultiStageTestStep(testConfig, config, podClient, jobSpec)
+}
+
+func newMultiStageTestStep(
+	testConfig api.TestStepConfiguration,
+	config *api.ReleaseBuildConfiguration,
+	podClient PodClient,
+	jobSpec *api.JobSpec,
+) *multiStageTestStep {
+	return &multiStageTestStep{
+		name:      testConfig.As,
+		config:    config,
+		podClient: podClient,
+		jobSpec:   jobSpec,
+		pre:       testConfig.MultiStageTestConfiguration.Pre,
+		test:      testConfig.MultiStageTestConfiguration.Test,
+		post:      testConfig.MultiStageTestConfiguration.Post,
+	}
+}
+
+func (s *multiStageTestStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *multiStageTestStep) Run(ctx context.Context, dry bool) error {
+	if dry {
+		return nil
+	}
+	var errs []error
+	if err := s.runSteps(ctx, s.pre, true); err != nil {
+		errs = append(errs, fmt.Errorf("%q pre steps failed: %v", s.name, err))
+	} else if err := s.runSteps(ctx, s.test, true); err != nil {
+		errs = append(errs, fmt.Errorf("%q test steps failed: %v", s.name, err))
+	}
+	if err := s.runSteps(ctx, s.post, false); err != nil {
+		errs = append(errs, fmt.Errorf("%q post steps failed: %v", s.name, err))
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func (s *multiStageTestStep) Done() (bool, error) { return false, nil }
+func (s *multiStageTestStep) Name() string        { return s.name }
+func (s *multiStageTestStep) Description() string {
+	return fmt.Sprintf("Run multi-stage test %s", s.name)
+}
+
+func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
+	var needsImages, needsRelease bool
+	for _, step := range append(append(s.pre, s.test...), s.post...) {
+		if s.config.IsPipelineImage(step.From) {
+			ret = append(ret, api.InternalImageLink(api.PipelineImageStreamTagReference(step.From)))
+		} else if s.config.BuildsImage(step.From) {
+			needsImages = true
+		} else {
+			needsRelease = true
+		}
+	}
+	if needsImages {
+		ret = append(ret, api.ImagesReadyLink())
+	}
+	if needsRelease {
+		ret = append(ret, api.ReleaseImagesLink())
+	}
+	return
+}
+
+func (s *multiStageTestStep) Creates() []api.StepLink { return nil }
+func (s *multiStageTestStep) Provides() (api.ParameterMap, api.StepLink) {
+	return nil, nil
+}
+func (s *multiStageTestStep) SubTests() []*junit.TestCase { return nil }
+
+func (s *multiStageTestStep) runSteps(ctx context.Context, steps []api.TestStep, shortCircuit bool) error {
+	pods, err := s.generatePods(steps)
+	if err != nil {
+		return err
+	}
+	return s.runPods(ctx, pods, shortCircuit)
+}
+
+func (s *multiStageTestStep) generatePods(steps []api.TestStep) ([]coreapi.Pod, error) {
+	var ret []coreapi.Pod
+	var errs []error
+	for _, step := range steps {
+		image := step.From
+		if s.config.IsPipelineImage(image) {
+			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
+		}
+		resources, err := resourcesFor(step.Resources)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		name := fmt.Sprintf("%s-%s", s.name, step.As)
+		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		pod.Labels[multiStageTestLabel] = s.name
+		container := &pod.Spec.Containers[0]
+		container.Env = append(container.Env, []coreapi.EnvVar{
+			{Name: "NAMESPACE", Value: s.jobSpec.Namespace},
+			{Name: "JOB_NAME_SAFE", Value: strings.Replace(s.name, "_", "-", -1)},
+			{Name: "JOB_NAME_HASH", Value: s.jobSpec.JobNameHash()},
+		}...)
+		if owner := s.jobSpec.Owner(); owner != nil {
+			pod.OwnerReferences = append(pod.OwnerReferences, *owner)
+		}
+		ret = append(ret, *pod)
+	}
+	return ret, utilerrors.NewAggregate(errs)
+}
+
+func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, shortCircuit bool) error {
+	go func() {
+		<-ctx.Done()
+		log.Printf("cleanup: Deleting pods with label %s=%s", multiStageTestLabel, s.name)
+		if err := deletePods(s.podClient.Pods(s.jobSpec.Namespace), s.name); err != nil {
+			log.Printf("failed to delete pods with label %s=%s: %v", multiStageTestLabel, s.name, err)
+		}
+	}()
+	var errs []error
+	for _, pod := range pods {
+		log.Printf("Executing %q", pod.Name)
+		if _, err := createOrRestartPod(s.podClient.Pods(s.jobSpec.Namespace), &pod); err != nil {
+			errs = append(errs, fmt.Errorf("failed to create or restart %q pod: %v", pod.Name, err))
+			if shortCircuit {
+				break
+			}
+		}
+		if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, nil, false); err != nil {
+			errs = append(errs, fmt.Errorf("%q pod %q failed: %v", s.name, pod.Name, err))
+			if shortCircuit {
+				break
+			}
+		}
+	}
+	return utilerrors.NewAggregate(errs)
+}
+
+func deletePods(client coreclientset.PodInterface, test string) error {
+	err := client.DeleteCollection(
+		&meta.DeleteOptions{},
+		meta.ListOptions{
+			LabelSelector: fields.Set{
+				multiStageTestLabel: test,
+			}.AsSelector().String(),
+		},
+	)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -1,0 +1,259 @@
+package steps
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgo_testing "k8s.io/client-go/testing"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowdapi "k8s.io/test-infra/prow/pod-utils/downwardapi"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestRequires(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		config api.ReleaseBuildConfiguration
+		steps  []api.TestStep
+		req    []api.StepLink
+	}{{
+		name:  "step needs release images, should have ReleaseImagesLink",
+		steps: []api.TestStep{{From: "from-release"}},
+		req:   []api.StepLink{api.ReleaseImagesLink()},
+	}, {
+		name: "step needs images, should have ImagesReadyLink",
+		config: api.ReleaseBuildConfiguration{
+			Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: "from-images"},
+			},
+		},
+		steps: []api.TestStep{{From: "from-images"}},
+		req:   []api.StepLink{api.ImagesReadyLink()},
+	}, {
+		name:  "step needs pipeline image, should have InternalImageLink",
+		steps: []api.TestStep{{From: "src"}},
+		req: []api.StepLink{
+			api.InternalImageLink(
+				api.PipelineImageStreamTagReference(
+					api.PipelineImageStreamTagReferenceSource)),
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			step := multiStageTestStep{config: &tc.config, test: tc.steps}
+			ret := step.Requires()
+			if len(ret) == len(tc.req) {
+				matches := true
+				for i := range ret {
+					if !ret[i].Matches(tc.req[i]) {
+						matches = false
+						break
+					}
+				}
+				if matches {
+					return
+				}
+			}
+			t.Errorf("incorrect requirements: %s", diff.ObjectReflectDiff(ret, tc.req))
+		})
+	}
+}
+
+func TestGeneratePods(t *testing.T) {
+	config := api.ReleaseBuildConfiguration{
+		Tests: []api.TestStepConfiguration{{
+			As: "test",
+			MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
+				Test: []api.TestStep{
+					{As: "step0", From: "image0", Commands: "command0"},
+					{As: "step1", From: "image1", Commands: "command1"},
+				},
+			},
+		}},
+	}
+	labels := map[string]string{
+		"job":                              "job",
+		"build-id":                         "build id",
+		"prow.k8s.io/id":                   "prow job id",
+		"created-by-ci":                    "true",
+		"ci.openshift.io/refs.branch":      "base ref",
+		"ci.openshift.io/refs.org":         "org",
+		"ci.openshift.io/refs.repo":        "repo",
+		"ci.openshift.io/multi-stage-test": "test",
+	}
+	env := []coreapi.EnvVar{
+		{Name: "BUILD_ID", Value: "build id"},
+		{Name: "JOB_NAME", Value: "job"},
+		{Name: "JOB_SPEC", Value: `{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}`},
+		{Name: "JOB_TYPE", Value: "postsubmit"},
+		{Name: "PROW_JOB_ID", Value: "prow job id"},
+		{Name: "PULL_BASE_REF", Value: "base ref"},
+		{Name: "PULL_BASE_SHA", Value: "base sha"},
+		{Name: "PULL_REFS", Value: "base ref:base sha"},
+		{Name: "REPO_NAME", Value: "repo"},
+		{Name: "REPO_OWNER", Value: "org"},
+		{Name: "NAMESPACE", Value: "namespace"},
+		{Name: "JOB_NAME_SAFE", Value: "test"},
+		{Name: "JOB_NAME_HASH", Value: "5e8c9"},
+	}
+	jobSpec := api.JobSpec{
+		JobSpec: prowdapi.JobSpec{
+			Job:       "job",
+			BuildID:   "build id",
+			ProwJobID: "prow job id",
+			Refs: &prowapi.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "base ref",
+				BaseSHA: "base sha",
+			},
+			Type: "postsubmit",
+		},
+		Namespace: "namespace",
+	}
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, &jobSpec)
+	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfiguration.Test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []coreapi.Pod{{
+		ObjectMeta: meta.ObjectMeta{
+			Name:   "test-step0",
+			Labels: labels,
+			Annotations: map[string]string{
+				"ci.openshift.io/job-spec":                     "",
+				"ci-operator.openshift.io/container-sub-tests": "step0",
+			},
+		},
+		Spec: coreapi.PodSpec{
+			RestartPolicy: "Never",
+			Containers: []coreapi.Container{{
+				Name:                     "step0",
+				Image:                    "image0",
+				Command:                  []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
+				Env:                      env,
+				Resources:                coreapi.ResourceRequirements{},
+				TerminationMessagePolicy: "FallbackToLogsOnError",
+			}},
+		},
+	}, {
+		ObjectMeta: meta.ObjectMeta{
+			Name:   "test-step1",
+			Labels: labels,
+			Annotations: map[string]string{
+				"ci.openshift.io/job-spec":                     "",
+				"ci-operator.openshift.io/container-sub-tests": "step1",
+			},
+		},
+		Spec: coreapi.PodSpec{
+			RestartPolicy: "Never",
+			Containers: []coreapi.Container{{
+				Name:                     "step1",
+				Image:                    "image1",
+				Command:                  []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
+				Env:                      env,
+				Resources:                coreapi.ResourceRequirements{},
+				TerminationMessagePolicy: "FallbackToLogsOnError",
+			}},
+		},
+	}}
+	if !reflect.DeepEqual(expected, ret) {
+		t.Fatalf("did not generate expected pods: %s", diff.ObjectReflectDiff(expected, ret))
+	}
+}
+
+func TestRun(t *testing.T) {
+	step := multiStageTestStep{
+		name:   "test",
+		config: &api.ReleaseBuildConfiguration{},
+		jobSpec: &api.JobSpec{
+			JobSpec: prowdapi.JobSpec{
+				Job:       "job",
+				BuildID:   "build_id",
+				ProwJobID: "prow_job_id",
+				Type:      prowapi.PeriodicJob,
+			},
+		},
+		pre:  []api.TestStep{{As: "pre0"}, {As: "pre1"}},
+		test: []api.TestStep{{As: "test0"}, {As: "test1"}},
+		post: []api.TestStep{{As: "post0"}, {As: "post1"}},
+	}
+	for _, tc := range []struct {
+		name     string
+		failures []string
+		expected []string
+	}{{
+		name: "no step fails, no error",
+		expected: []string{
+			"test-pre0", "test-pre1",
+			"test-test0", "test-test1",
+			"test-post0", "test-post1",
+		},
+	}, {
+		name:     "failure in a pre step, test should not run, post should",
+		failures: []string{"test-pre0"},
+		expected: []string{
+			"test-pre0",
+			"test-post0", "test-post1",
+		},
+	}, {
+		name:     "failure in a test step, post should run",
+		failures: []string{"test-test0"},
+		expected: []string{
+			"test-pre0", "test-pre1",
+			"test-test0",
+			"test-post0", "test-post1",
+		},
+	}, {
+		name:     "failure in a post step, other post steps should still run",
+		failures: []string{"test-post0"},
+		expected: []string{
+			"test-pre0", "test-pre1",
+			"test-test0", "test-test1",
+			"test-post0", "test-post1",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			fakecs := fake.NewSimpleClientset()
+			var pods []*coreapi.Pod
+			fakecs.PrependReactor("create", "pods", func(action clientgo_testing.Action) (bool, runtime.Object, error) {
+				pod := action.(clientgo_testing.CreateAction).GetObject().(*coreapi.Pod)
+				for _, failure := range tc.failures {
+					if pod.Name == failure {
+						pod.Status.Phase = coreapi.PodFailed
+					}
+				}
+				pods = append(pods, pod)
+				return false, nil, nil
+			})
+			fakecs.PrependReactor("list", "pods", func(action clientgo_testing.Action) (bool, runtime.Object, error) {
+				fieldRestrictions := action.(clientgo_testing.ListAction).GetListRestrictions().Fields
+				for _, pods := range pods {
+					if fieldRestrictions.Matches(fields.Set{"metadata.name": pods.Name}) {
+						return true, &coreapi.PodList{Items: []coreapi.Pod{*pods}}, nil
+					}
+				}
+				return false, nil, nil
+			})
+			step.podClient = NewPodClient(fakecs.CoreV1(), nil, nil)
+			if err := step.Run(context.Background(), false); tc.failures == nil && err != nil {
+				t.Error(err)
+				return
+			}
+			var names []string
+			for _, pods := range pods {
+				names = append(names, pods.ObjectMeta.Name)
+			}
+			if !reflect.DeepEqual(names, tc.expected) {
+				t.Errorf("did not execute correct pods: %s", diff.ObjectReflectDiff(names, tc.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Basic implementation of the multi-stage test type. Subset of
https://github.com/openshift/ci-tools/pull/85, based on
https://github.com/openshift/ci-tools/pull/98. Design document:
https://docs.google.com/document/d/1md-1BMf4_7mtKgGVoeZ3jOh4zSIBSjwl6vTTAYESwIM.

Fully-functional but lacking management of artifacts, the test secret, cluster
profile, and release image(s).