### PR TITLE
ci-operator multi-stage: use appropriate names

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -297,15 +297,15 @@ func validateTestSteps(fieldRoot string, steps []TestStep) (ret []error) {
 	seen := sets.NewString()
 	for i, s := range steps {
 		fieldRootI := fmt.Sprintf("%s[%d]", fieldRoot, i)
-		if len(s.Name) == 0 {
-			ret = append(ret, fmt.Errorf("%s: `name` is required", fieldRootI))
-		} else if seen.Has(s.Name) {
-			ret = append(ret, fmt.Errorf("%s: duplicated name %q", fieldRootI, s.Name))
+		if len(s.As) == 0 {
+			ret = append(ret, fmt.Errorf("%s: `as` is required", fieldRootI))
+		} else if seen.Has(s.As) {
+			ret = append(ret, fmt.Errorf("%s: duplicated name %q", fieldRootI, s.As))
 		} else {
-			seen.Insert(s.Name)
+			seen.Insert(s.As)
 		}
-		if len(s.Image) == 0 {
-			ret = append(ret, fmt.Errorf("%s: `image` is required", fieldRootI))
+		if len(s.From) == 0 {
+			ret = append(ret, fmt.Errorf("%s: `from` is required", fieldRootI))
 		}
 		if len(s.Commands) == 0 {
 			ret = append(ret, fmt.Errorf("%s: `commands` is required", fieldRootI))

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -396,8 +396,8 @@ func TestValidateTestSteps(t *testing.T) {
 	}{{
 		name: "valid step",
 		steps: []TestStep{{
-			Name:     "name",
-			Image:    "image",
+			As:       "as",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
@@ -407,35 +407,35 @@ func TestValidateTestSteps(t *testing.T) {
 	}, {
 		name: "no name",
 		steps: []TestStep{{
-			Image:    "image",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
 				Limits:   ResourceList{"memory": "1m"},
 			},
 		}},
-		errs: []error{errors.New("test[0]: `name` is required")},
+		errs: []error{errors.New("test[0]: `as` is required")},
 	}, {
 		name: "duplicated names",
 		steps: []TestStep{{
-			Name:     "s0",
-			Image:    "image",
+			As:       "s0",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
 				Limits:   ResourceList{"memory": "1m"},
 			},
 		}, {
-			Name:     "s1",
-			Image:    "image",
+			As:       "s1",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
 				Limits:   ResourceList{"memory": "1m"},
 			},
 		}, {
-			Name:     "s0",
-			Image:    "image",
+			As:       "s0",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
@@ -446,19 +446,19 @@ func TestValidateTestSteps(t *testing.T) {
 	}, {
 		name: "no image",
 		steps: []TestStep{{
-			Name:     "no_image",
+			As:       "no_image",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
 				Limits:   ResourceList{"memory": "1m"},
 			},
 		}},
-		errs: []error{errors.New("test[0]: `image` is required")},
+		errs: []error{errors.New("test[0]: `from` is required")},
 	}, {
 		name: "no commands",
 		steps: []TestStep{{
-			Name:  "no_commands",
-			Image: "image",
+			As:   "no_commands",
+			From: "from",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "1"},
 				Limits:   ResourceList{"memory": "1m"},
@@ -468,8 +468,8 @@ func TestValidateTestSteps(t *testing.T) {
 	}, {
 		name: "invalid resources",
 		steps: []TestStep{{
-			Name:     "bad_resources",
-			Image:    "image",
+			As:       "bad_resources",
+			From:     "from",
 			Commands: "commands",
 			Resources: ResourceRequirements{
 				Requests: ResourceList{"cpu": "yes"},

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -312,9 +312,9 @@ type TestStepConfiguration struct {
 // write less verbose test configs. It gets converted to an internal TestStep
 // struct that represents the full configuration that ci-operator can use.
 type TestStep struct {
-	Name          string               `json:"name,omitempty"`
+	As            string               `json:"as,omitempty"`
 	Documentation string               `json:"documentation,omitempty"`
-	Image         string               `json:"image,omitempty"`
+	From          string               `json:"from,omitempty"`
 	Commands      string               `json:"commands,omitempty"`
 	ArtifactDir   string               `json:"artifact_dir,omitempty"`
 	Resources     ResourceRequirements `json:"resources,omitempty"`

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -46,8 +46,8 @@ func (r *registry) Resolve(config api.MultiStageTestConfiguration) (types.TestFl
 
 func toInternal(input api.TestStep) types.TestStep {
 	return types.TestStep{
-		Name:        input.Name,
-		Image:       input.Image,
+		As:          input.As,
+		From:        input.From,
 		Commands:    input.Commands,
 		ArtifactDir: input.ArtifactDir,
 		Resources:   input.Resources,

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -21,8 +21,8 @@ func TestResolve(t *testing.T) {
 		config: api.MultiStageTestConfiguration{
 			ClusterProfile: api.ClusterProfileAWS,
 			Pre: []api.TestStep{{
-				Name:     "ipi-install",
-				Image:    "installer",
+				As:       "ipi-install",
+				From:     "installer",
 				Commands: "openshift-cluster install",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},
@@ -30,8 +30,8 @@ func TestResolve(t *testing.T) {
 				},
 			}},
 			Test: []api.TestStep{{
-				Name:     "e2e",
-				Image:    "my-image",
+				As:       "e2e",
+				From:     "my-image",
 				Commands: "make custom-e2e",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},
@@ -39,8 +39,8 @@ func TestResolve(t *testing.T) {
 				},
 			}},
 			Post: []api.TestStep{{
-				Name:     "ipi-teardown",
-				Image:    "installer",
+				As:       "ipi-teardown",
+				From:     "installer",
 				Commands: "openshift-cluster destroy",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},
@@ -51,8 +51,8 @@ func TestResolve(t *testing.T) {
 		expectedRes: types.TestFlow{
 			ClusterProfile: api.ClusterProfileAWS,
 			Pre: []types.TestStep{{
-				Name:     "ipi-install",
-				Image:    "installer",
+				As:       "ipi-install",
+				From:     "installer",
 				Commands: "openshift-cluster install",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},
@@ -60,8 +60,8 @@ func TestResolve(t *testing.T) {
 				},
 			}},
 			Test: []types.TestStep{{
-				Name:     "e2e",
-				Image:    "my-image",
+				As:       "e2e",
+				From:     "my-image",
 				Commands: "make custom-e2e",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},
@@ -69,8 +69,8 @@ func TestResolve(t *testing.T) {
 				},
 			}},
 			Post: []types.TestStep{{
-				Name:     "ipi-teardown",
-				Image:    "installer",
+				As:       "ipi-teardown",
+				From:     "installer",
 				Commands: "openshift-cluster destroy",
 				Resources: api.ResourceRequirements{
 					Requests: api.ResourceList{"cpu": "1000m"},

--- a/pkg/steps/types/types.go
+++ b/pkg/steps/types/types.go
@@ -6,8 +6,8 @@ import (
 
 // TestStep contains a full definition of a test step from a MultiStageTestConfiguration
 type TestStep struct {
-	Name        string
-	Image       string
+	As          string
+	From        string
 	Commands    string
 	ArtifactDir string
 	Resources   api.ResourceRequirements


### PR DESCRIPTION
Change field names to conform to the design document.

@AlexNPavel: FYI