### PR TITLE
pkg/registry: add support for test references

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -389,6 +389,9 @@ func TestValidateBaseRpmImages(t *testing.T) {
 }
 
 func TestValidateTestSteps(t *testing.T) {
+	// string pointers in golang are annoying
+	myReference := "my-reference"
+	asReference := "as"
 	for _, tc := range []struct {
 		name  string
 		steps []TestStep
@@ -396,89 +399,130 @@ func TestValidateTestSteps(t *testing.T) {
 	}{{
 		name: "valid step",
 		steps: []TestStep{{
-			As:       "as",
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "as",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}},
 	}, {
 		name: "no name",
 		steps: []TestStep{{
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}},
 		errs: []error{errors.New("test[0]: `as` is required")},
 	}, {
 		name: "duplicated names",
 		steps: []TestStep{{
-			As:       "s0",
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "s0",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}, {
-			As:       "s1",
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "s1",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}, {
-			As:       "s0",
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "s0",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}},
 		errs: []error{errors.New(`test[2]: duplicated name "s0"`)},
 	}, {
 		name: "no image",
 		steps: []TestStep{{
-			As:       "no_image",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "no_image",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}},
 		errs: []error{errors.New("test[0]: `from` is required")},
 	}, {
 		name: "no commands",
 		steps: []TestStep{{
-			As:   "no_commands",
-			From: "from",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "1"},
-				Limits:   ResourceList{"memory": "1m"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:   "no_commands",
+				From: "from",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
 		}},
 		errs: []error{errors.New("test[0]: `commands` is required")},
 	}, {
 		name: "invalid resources",
 		steps: []TestStep{{
-			As:       "bad_resources",
-			From:     "from",
-			Commands: "commands",
-			Resources: ResourceRequirements{
-				Requests: ResourceList{"cpu": "yes"},
-				Limits:   ResourceList{"piña_colada": "10dL"},
-			},
+			LiteralTestStep: &LiteralTestStep{
+				As:       "bad_resources",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "yes"},
+					Limits:   ResourceList{"piña_colada": "10dL"},
+				}},
 		}},
 		errs: []error{
 			errors.New("'test[0].resources.limits' specifies an invalid key piña_colada"),
 			errors.New("test[0].resources.requests.cpu: invalid quantity: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"),
+		},
+	}, {
+		name: "Reference and TestStep set",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:       "as",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
+			Reference: &myReference,
+		}},
+		errs: []error{
+			errors.New("test[0]: `ref` cannot be set along with other test step fields"),
+		},
+	}, {
+		name: "Step with same name as reference",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:       "as",
+				From:     "from",
+				Commands: "commands",
+				Resources: ResourceRequirements{
+					Requests: ResourceList{"cpu": "1"},
+					Limits:   ResourceList{"memory": "1m"},
+				}},
+		}, {
+			Reference: &asReference,
+		}},
+		errs: []error{
+			errors.New("test[1].ref: duplicated name \"as\""),
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -341,16 +341,24 @@ type TestStepConfiguration struct {
 	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
 }
 
-// TestStep is the external representation of a test step that allows users to
-// write less verbose test configs. It gets converted to an internal TestStep
+// LiteralTestStep is the external representation of a test step allowing users
+// to define new test steps. It gets converted to an internal LiteralTestStep
 // struct that represents the full configuration that ci-operator can use.
-type TestStep struct {
+type LiteralTestStep struct {
 	As            string               `json:"as,omitempty"`
 	Documentation string               `json:"documentation,omitempty"`
 	From          string               `json:"from,omitempty"`
 	Commands      string               `json:"commands,omitempty"`
 	ArtifactDir   string               `json:"artifact_dir,omitempty"`
 	Resources     ResourceRequirements `json:"resources,omitempty"`
+}
+
+// TestStep is the struct that a user's configuration gets unmarshalled into.
+// It can contain either a LiteralTestStep or a Reference. If both are filled in an
+// the same time, config validation will fail.
+type TestStep struct {
+	*LiteralTestStep `json:",inline,omitempty"`
+	Reference        *string `json:"ref,omitempty"`
 }
 
 // MultiStageTestConfiguration is a flexible configuration mode that allows tighter control over

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"fmt"
+
 	api "github.com/openshift/ci-tools/pkg/api"
 	types "github.com/openshift/ci-tools/pkg/steps/types"
 	"k8s.io/apimachinery/pkg/util/errors"
@@ -10,13 +12,17 @@ type Resolver interface {
 	Resolve(config api.MultiStageTestConfiguration) (types.TestFlow, error)
 }
 
-// Registry will hold all the registry information needed to convert between the
+// registry will hold all the registry information needed to convert between the
 // user provided configs referencing the registry and the internal, complete
 // representation
-type registry struct{}
+type registry struct {
+	stepsByName map[string]api.LiteralTestStep
+}
 
-func NewResolver() Resolver {
-	return &registry{}
+func NewResolver(stepsByName map[string]api.LiteralTestStep) Resolver {
+	return &registry{
+		stepsByName: stepsByName,
+	}
 }
 
 func (r *registry) Resolve(config api.MultiStageTestConfiguration) (types.TestFlow, error) {
@@ -24,27 +30,54 @@ func (r *registry) Resolve(config api.MultiStageTestConfiguration) (types.TestFl
 	expandedFlow := types.TestFlow{
 		ClusterProfile: config.ClusterProfile,
 	}
-	for _, external := range config.Pre {
-		newStep := toInternal(external)
-		expandedFlow.Pre = append(expandedFlow.Pre, newStep)
-	}
-	for _, external := range config.Test {
-		newStep := toInternal(external)
-		expandedFlow.Test = append(expandedFlow.Test, newStep)
-	}
-	for _, external := range config.Post {
-		newStep := toInternal(external)
-		expandedFlow.Post = append(expandedFlow.Post, newStep)
-	}
-	// This currently never gets run as we don't have any situations that can result in errors yet.
-	// This will become used as we add more functionality.
+	pre, errs := r.process(config.Pre)
+	expandedFlow.Pre = append(expandedFlow.Pre, pre...)
+	resolveErrors = append(resolveErrors, errs...)
+
+	test, errs := r.process(config.Test)
+	expandedFlow.Test = append(expandedFlow.Test, test...)
+	resolveErrors = append(resolveErrors, errs...)
+
+	post, errs := r.process(config.Post)
+	expandedFlow.Post = append(expandedFlow.Post, post...)
+	resolveErrors = append(resolveErrors, errs...)
+
 	if resolveErrors != nil {
 		return types.TestFlow{}, errors.NewAggregate(resolveErrors)
 	}
 	return expandedFlow, nil
 }
 
-func toInternal(input api.TestStep) types.TestStep {
+func (r *registry) process(steps []api.TestStep) (internalSteps []types.TestStep, errs []error) {
+	for _, external := range steps {
+		var step api.LiteralTestStep
+		if external.Reference != nil {
+			var err error
+			step, err = r.dereference(external)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		} else if external.LiteralTestStep != nil {
+			step = *external.LiteralTestStep
+		} else {
+			errs = append(errs, fmt.Errorf("Encountered TestStep where both `Reference` and `LiteralTestStep` are nil"))
+			continue
+		}
+		internalStep := toInternal(step)
+		internalSteps = append(internalSteps, internalStep)
+	}
+	return
+}
+
+func (r *registry) dereference(input api.TestStep) (api.LiteralTestStep, error) {
+	step, ok := r.stepsByName[*input.Reference]
+	if !ok {
+		return api.LiteralTestStep{}, fmt.Errorf("invalid step reference: %s", *input.Reference)
+	}
+	return step, nil
+}
+
+func toInternal(input api.LiteralTestStep) types.TestStep {
 	return types.TestStep{
 		As:          input.As,
 		From:        input.From,

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -26,7 +26,7 @@ func TestRequires(t *testing.T) {
 		req    []api.StepLink
 	}{{
 		name:  "step needs release images, should have ReleaseImagesLink",
-		steps: []api.TestStep{{From: "from-release"}},
+		steps: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{From: "from-release"}}},
 		req:   []api.StepLink{api.ReleaseImagesLink()},
 	}, {
 		name: "step needs images, should have ImagesReadyLink",
@@ -35,11 +35,11 @@ func TestRequires(t *testing.T) {
 				{To: "from-images"},
 			},
 		},
-		steps: []api.TestStep{{From: "from-images"}},
+		steps: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{From: "from-images"}}},
 		req:   []api.StepLink{api.ImagesReadyLink()},
 	}, {
 		name:  "step needs pipeline image, should have InternalImageLink",
-		steps: []api.TestStep{{From: "src"}},
+		steps: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{From: "src"}}},
 		req: []api.StepLink{
 			api.InternalImageLink(
 				api.PipelineImageStreamTagReference(
@@ -72,8 +72,8 @@ func TestGeneratePods(t *testing.T) {
 			As: "test",
 			MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
 				Test: []api.TestStep{
-					{As: "step0", From: "image0", Commands: "command0"},
-					{As: "step1", From: "image1", Commands: "command1"},
+					{LiteralTestStep: &api.LiteralTestStep{As: "step0", From: "image0", Commands: "command0"}},
+					{LiteralTestStep: &api.LiteralTestStep{As: "step1", From: "image1", Commands: "command1"}},
 				},
 			},
 		}},
@@ -181,9 +181,9 @@ func TestRun(t *testing.T) {
 				Type:      prowapi.PeriodicJob,
 			},
 		},
-		pre:  []api.TestStep{{As: "pre0"}, {As: "pre1"}},
-		test: []api.TestStep{{As: "test0"}, {As: "test1"}},
-		post: []api.TestStep{{As: "post0"}, {As: "post1"}},
+		pre:  []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{As: "pre0"}}, {LiteralTestStep: &api.LiteralTestStep{As: "pre1"}}},
+		test: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{As: "test0"}}, {LiteralTestStep: &api.LiteralTestStep{As: "test1"}}},
+		post: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{As: "post0"}}, {LiteralTestStep: &api.LiteralTestStep{As: "post1"}}},
 	}
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
Adds support for test references via a step map that is passed to the registry in the `NewResolver` function.