### PR TITLE
ci-operator multistage: implement chains

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -505,7 +505,7 @@ func TestValidateTestSteps(t *testing.T) {
 			Reference: &myReference,
 		}},
 		errs: []error{
-			errors.New("test[0]: `ref` cannot be set along with other test step fields"),
+			errors.New("test[0]: only one of `ref`, `chain`, or a literal test step can be set"),
 		},
 	}, {
 		name: "Step with same name as reference",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -359,6 +359,7 @@ type LiteralTestStep struct {
 type TestStep struct {
 	*LiteralTestStep `json:",inline,omitempty"`
 	Reference        *string `json:"ref,omitempty"`
+	Chain            *string `json:"chain,omitempty"`
 }
 
 // MultiStageTestConfiguration is a flexible configuration mode that allows tighter control over


### PR DESCRIPTION
Add chains to the multistage registry. The registry first unrolls chains to form an unrolled `[]api.TestStep` and then continues to process as before.