### PR TITLE
ci-operator: add validation

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -278,9 +278,10 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		if testConfig.ClusterProfile != "" {
 			validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile)...)
 		}
-		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Pre", fieldRoot), testConfig.Pre)...)
-		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Test", fieldRoot), testConfig.Test)...)
-		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Post", fieldRoot), testConfig.Post)...)
+		seen := sets.NewString()
+		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Pre", fieldRoot), testConfig.Pre, seen)...)
+		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Test", fieldRoot), testConfig.Test, seen)...)
+		validationErrors = append(validationErrors, validateTestSteps(fmt.Sprintf("%s.Post", fieldRoot), testConfig.Post, seen)...)
 	}
 	if test.OpenshiftInstallerRandomClusterTestConfiguration != nil {
 		typeCount++
@@ -298,8 +299,7 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 	return validationErrors
 }
 
-func validateTestSteps(fieldRoot string, steps []TestStep) (ret []error) {
-	seen := sets.NewString()
+func validateTestSteps(fieldRoot string, steps []TestStep, seen sets.String) (ret []error) {
 	for i, s := range steps {
 		fieldRootI := fmt.Sprintf("%s[%d]", fieldRoot, i)
 		if s.LiteralTestStep != nil && s.Reference != nil {

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -115,10 +115,6 @@ func validateTestStepConfiguration(fieldRoot string, input []TestStepConfigurati
 			validationErrors = append(validationErrors, fmt.Errorf("%s: either `commands` or `steps` should be set", fieldRootN))
 		} else if hasCommands && hasSteps {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `commands` and `steps` are mutually exclusive", fieldRootN))
-		} else if hasSteps {
-			validationErrors = append(validationErrors, validateTestSteps(fieldRootN+".steps.pre", test.MultiStageTestConfiguration.Pre)...)
-			validationErrors = append(validationErrors, validateTestSteps(fieldRootN+".steps.test", test.MultiStageTestConfiguration.Test)...)
-			validationErrors = append(validationErrors, validateTestSteps(fieldRootN+".steps.post", test.MultiStageTestConfiguration.Post)...)
 		}
 
 		if test.Secret != nil {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -136,7 +136,8 @@ func TestValidateTests(t *testing.T) {
 			id: "test without `as`",
 			tests: []TestStepConfiguration{
 				{
-					Commands: "test",
+					Commands:                   "test",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
 				},
 			},
 			expectedValid: false,
@@ -266,11 +267,13 @@ func TestValidateTests(t *testing.T) {
 	}
 
 	for _, tc := range testTestsCases {
-		if errs := validateTestStepConfiguration("tests", tc.tests, tc.release); len(errs) > 0 && tc.expectedValid {
-			validationErrors = append(validationErrors, fmt.Errorf("%q expected to be valid, got: %v", tc.id, errs))
-		} else if !tc.expectedValid && len(errs) == 0 {
-			validationErrors = append(validationErrors, parseValidError(tc.id))
-		}
+		t.Run(tc.id, func(t *testing.T) {
+			if errs := validateTestStepConfiguration("tests", tc.tests, tc.release); len(errs) > 0 && tc.expectedValid {
+				validationErrors = append(validationErrors, fmt.Errorf("expected to be valid, got: %v", errs))
+			} else if !tc.expectedValid && len(errs) == 0 {
+				validationErrors = append(validationErrors, parseValidError(tc.id))
+			}
+		})
 	}
 
 	if validationErrors != nil {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -64,6 +64,17 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			id: "`commands` and `steps`",
+			tests: []TestStepConfiguration{
+				{
+					As:                          "test",
+					Commands:                    "commands",
+					MultiStageTestConfiguration: &MultiStageTestConfiguration{},
+				},
+			},
+			expectedValid: false,
+		},
+		{
 			id: "container test without `from`",
 			tests: []TestStepConfiguration{
 				{


### PR DESCRIPTION
edit: I'd used the lazy approach of commenting out code to determine if it is covered by tests and it turns out we had a bad test (a disadvantage of having a single boolean to determine success), not bad coverage. I fixed it and added the remaining validation code.together with the original content of this PR — validating duplicates across stages.

---

original:

Eventually, with all the indirections of references, chains, and workflows, we
may want error messages that state more clearly the origin of each conflicting
name.

We will still want a final validation, so this code will remain relevant.