### PR TITLE
Introduce a dry run logger to ci-operator

### DIFF
--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -42,6 +42,7 @@ func E2ETestStep(
 	secretClient coreclientset.SecretsGetter,
 	artifactDir string,
 	jobSpec *api.JobSpec,
+	dryLogger *steps.DryLogger,
 ) (api.Step, error) {
 	var template *templateapi.Template
 	if err := yaml.Unmarshal([]byte(installTemplateE2E), &template); err != nil {
@@ -94,7 +95,7 @@ func E2ETestStep(
 		params = api.NewOverrideParameters(params, overrides)
 	}
 
-	step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec)
+	step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, dryLogger)
 	subTests, ok := step.(nestedSubTests)
 	if !ok {
 		return nil, fmt.Errorf("unexpected %T", step)

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -19,6 +19,7 @@ type gitSourceStep struct {
 	buildClient BuildClient
 	artifactDir string
 	jobSpec     *api.JobSpec
+	dryLogger   *DryLogger
 }
 
 func (s *gitSourceStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -34,7 +35,7 @@ func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
 				URI: fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo),
 				Ref: refs.BaseRef,
 			},
-		}, s.config.DockerfilePath, s.resources), dry, s.artifactDir)
+		}, s.config.DockerfilePath, s.resources), dry, s.artifactDir, s.dryLogger)
 	}
 
 	return fmt.Errorf("Nothing to build source image from, no refs")
@@ -82,7 +83,7 @@ func determineRefsWorkdir(refs *prowapi.Refs, extraRefs []prowapi.Refs) *prowapi
 }
 
 // GitSourceStep returns gitSourceStep that holds all the required information to create a build from a git source.
-func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
 	return &gitSourceStep{
 		config:      config,
 		resources:   resources,
@@ -90,5 +91,6 @@ func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.Re
 		imageClient: imageClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
 	}
 }

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -51,7 +51,8 @@ func TestInputImageTagStep(t *testing.T) {
 
 	// Make a step instance
 	jobspec := &api.JobSpec{Namespace: "target-namespace"}
-	iits := InputImageTagStep(config, srcClient, dstClient, jobspec)
+	dryLogger := &DryLogger{}
+	iits := InputImageTagStep(config, srcClient, dstClient, jobspec, dryLogger)
 
 	// Set up expectations for the step methods
 	specification := stepExpectation{

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -134,7 +134,8 @@ func TestOutputImageStep(t *testing.T) {
 				}
 			}
 
-			oits := OutputImageTagStep(config, client, client, jobspec)
+			dryLogger := &DryLogger{}
+			oits := OutputImageTagStep(config, client, client, jobspec, dryLogger)
 
 			examineStep(t, oits, stepSpec)
 			executeStep(t, oits, tt.execSpecification, nil)

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -24,6 +24,7 @@ type pipelineImageCacheStep struct {
 	imageClient imageclientset.ImageV1Interface
 	artifactDir string
 	jobSpec     *api.JobSpec
+	dryLogger   *DryLogger
 }
 
 func (s *pipelineImageCacheStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -40,7 +41,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
-	), dry, s.artifactDir)
+	), dry, s.artifactDir, s.dryLogger)
 }
 
 func (s *pipelineImageCacheStep) Done() (bool, error) {
@@ -84,7 +85,7 @@ func (s *pipelineImageCacheStep) Description() string {
 	return fmt.Sprintf("Store build results into a layer on top of %s and save as %s", s.config.From, s.config.To)
 }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
 		resources:   resources,
@@ -92,5 +93,6 @@ func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, reso
 		imageClient: imageClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
 	}
 }

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -3,7 +3,7 @@ package steps
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,8 +61,8 @@ func preparePodStep(t *testing.T, namespace string) (*podStep, stepExpectation, 
 		t:       t,
 	}
 	client := NewPodClient(fakecs.Core(), nil, nil)
-
-	ps := PodStep(stepName, config, resources, client, artifactDir, jobSpec)
+	dryLogger := &DryLogger{}
+	ps := PodStep(stepName, config, resources, client, artifactDir, jobSpec, dryLogger)
 
 	specification := stepExpectation{
 		name:     podName,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -22,6 +22,7 @@ type projectDirectoryImageBuildStep struct {
 	istClient   imageclientset.ImageStreamTagsGetter
 	jobSpec     *api.JobSpec
 	artifactDir string
+	dryLogger   *DryLogger
 }
 
 func (s *projectDirectoryImageBuildStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -109,7 +110,7 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 			Value: v,
 		})
 	}
-	return handleBuild(s.buildClient, build, dry, s.artifactDir)
+	return handleBuild(s.buildClient, build, dry, s.artifactDir, s.dryLogger)
 }
 
 func (s *projectDirectoryImageBuildStep) Done() (bool, error) {
@@ -162,7 +163,7 @@ func (s *projectDirectoryImageBuildStep) Description() string {
 	return fmt.Sprintf("Build image %s from the repository", s.config.To)
 }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
 	return &projectDirectoryImageBuildStep{
 		config:      config,
 		resources:   resources,
@@ -171,5 +172,6 @@ func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepCon
 		istClient:   istClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
 	}
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -25,6 +25,7 @@ type rpmImageInjectionStep struct {
 	istClient   imageclientset.ImageStreamTagsGetter
 	artifactDir string
 	jobSpec     *api.JobSpec
+	dryLogger   *DryLogger
 }
 
 func (s *rpmImageInjectionStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -51,7 +52,7 @@ func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
-	), dry, s.artifactDir)
+	), dry, s.artifactDir, s.dryLogger)
 }
 
 func (s *rpmImageInjectionStep) Done() (bool, error) {
@@ -76,7 +77,7 @@ func (s *rpmImageInjectionStep) Description() string {
 	return "Inject an RPM repository that will point at the RPM server"
 }
 
-func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
 	return &rpmImageInjectionStep{
 		config:      config,
 		resources:   resources,
@@ -85,5 +86,6 @@ func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resour
 		istClient:   istClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
 	}
 }

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -60,6 +60,7 @@ type templateExecutionStep struct {
 	podClient      PodClient
 	artifactDir    string
 	jobSpec        *api.JobSpec
+	dryLogger      *DryLogger
 
 	subTests []*junit.TestCase
 }
@@ -118,8 +119,7 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		j, _ := json.MarshalIndent(s.template, "", "  ")
-		log.Printf("template:\n%s", j)
+		s.dryLogger.AddObject(s.template.DeepCopyObject())
 		return nil
 	}
 
@@ -276,7 +276,7 @@ func (s *templateExecutionStep) Description() string {
 	return fmt.Sprintf("Run template %s", s.template.Name)
 }
 
-func TemplateExecutionStep(template *templateapi.Template, params api.Parameters, podClient PodClient, templateClient TemplateClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func TemplateExecutionStep(template *templateapi.Template, params api.Parameters, podClient PodClient, templateClient TemplateClient, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
 	return &templateExecutionStep{
 		template:       template,
 		params:         params,
@@ -284,6 +284,7 @@ func TemplateExecutionStep(template *templateapi.Template, params api.Parameters
 		templateClient: templateClient,
 		artifactDir:    artifactDir,
 		jobSpec:        jobSpec,
+		dryLogger:      dryLogger,
 	}
 }
 

--- a/pkg/steps/testing.go
+++ b/pkg/steps/testing.go
@@ -5,6 +5,7 @@ package steps
 import (
 	"context"
 	"reflect"
+	"sync"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -25,16 +26,21 @@ import (
 
 // DryLogger holds the information of all objects that have been created from a dry run.
 type DryLogger struct {
+	sync.RWMutex
 	objects []runtime.Object
 }
 
 // AddObject is adding an object to the list.
 func (dl *DryLogger) AddObject(o runtime.Object) {
+	dl.Lock()
+	defer dl.Unlock()
 	dl.objects = append(dl.objects, o)
 }
 
 // GetObjects returns the list of objects.
 func (dl *DryLogger) GetObjects() []runtime.Object {
+	dl.RLock()
+	defer dl.RUnlock()
 	return dl.objects
 }
 

--- a/pkg/steps/testing.go
+++ b/pkg/steps/testing.go
@@ -7,18 +7,36 @@ import (
 	"reflect"
 	"testing"
 
-	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
-	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	fakeimagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1/fake"
-
 	v1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
+
 	"k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	fakecorev1 "k8s.io/client-go/kubernetes/typed/core/v1/fake"
 
+	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
+	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	fakeimagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1/fake"
+
 	"github.com/openshift/ci-tools/pkg/api"
 )
+
+// DryLogger holds the information of all objects that have been created from a dry run.
+type DryLogger struct {
+	objects []runtime.Object
+}
+
+// AddObject is adding an object to the list.
+func (dl *DryLogger) AddObject(o runtime.Object) {
+	dl.objects = append(dl.objects, o)
+}
+
+// GetObjects returns the list of objects.
+func (dl *DryLogger) GetObjects() []runtime.Object {
+	return dl.objects
+}
 
 // Fake Clientset, created so we can override its `Core()` method
 // and return our fake CoreV1 API (=ciopTestingCore)

--- a/pkg/steps/testing_test.go
+++ b/pkg/steps/testing_test.go
@@ -1,0 +1,36 @@
+package steps
+
+import (
+	"sync"
+	"testing"
+
+	coreapi "k8s.io/api/core/v1"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDryLogger(t *testing.T) {
+	var wg sync.WaitGroup
+	dryLogger := &DryLogger{}
+	pod := &coreapi.Pod{
+		TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+		Spec:       coreapi.PodSpec{Containers: []coreapi.Container{{Name: "test"}}},
+	}
+
+	addObjectFn := func() {
+		defer wg.Done()
+		dryLogger.AddObject(pod.DeepCopyObject())
+	}
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go addObjectFn()
+	}
+
+	wg.Wait()
+	objectList := dryLogger.GetObjects()
+	if len(objectList) != 10 {
+		t.Fatalf("ten objects expected to be in the list. got %d: %#v", len(objectList), objectList)
+	}
+}


### PR DESCRIPTION
DryLogger holds the generated object from each step. This can be used to JSON Marshal only once the whole array and generate a valid JSON output to be used for tests etc...