### PR TITLE
ci-operator multi-stage: gather artifacts

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -155,7 +155,7 @@ func FromConfig(
 
 		} else if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if testStep.MultiStageTestConfiguration != nil {
-				step = steps.MultiStageTestStep(*testStep, config, podClient, jobSpec)
+				step = steps.MultiStageTestStep(*testStep, config, podClient, artifactDir, jobSpec)
 			} else if testStep.OpenshiftInstallerClusterTestConfiguration != nil {
 				if testStep.OpenshiftInstallerClusterTestConfiguration.Upgrade {
 					var err error


### PR DESCRIPTION
When given an output artifact directory, for each step that declares an
artifact directory, copy files from the container to
`$artifact_dir/$test_name/$step_name/`.

---

Tests involving `pkg/steps/artifacts.go` are impractical and it would be a lot
of work to invent a separate test infrastructure, so tests are limited to pod
generation. I am open for ideas, though, and to working on that in a separate
PR.