### PR TITLE
ci-operator: implement multi stage test workflows

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -275,7 +275,7 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 	}
 	if testConfig := test.MultiStageTestConfiguration; testConfig != nil {
 		typeCount++
-		if testConfig.ClusterProfile != "" {
+		if testConfig.ClusterProfile != "" && testConfig.Workflow == nil {
 			validationErrors = append(validationErrors, validateClusterProfile(fmt.Sprintf("%s", fieldRoot), testConfig.ClusterProfile)...)
 		}
 		seen := sets.NewString()

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -369,6 +369,7 @@ type MultiStageTestConfiguration struct {
 	Pre            []TestStep     `json:"pre,omitempty"`
 	Test           []TestStep     `json:"test,omitempty"`
 	Post           []TestStep     `json:"post,omitempty"`
+	Workflow       *string        `json:"workflow,omitempty"`
 }
 
 // Secret describes a secret to be mounted inside a test


### PR DESCRIPTION
Implement workflows in the registry resolver. If a user specifies the same field as a field the workflow specifies, the user's config takes priority and overrides the workflow.