### PR TITLE
Refactor artifacts container injection to Template pods.

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"archive/tar"
 	"compress/gzip"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -18,18 +17,19 @@ import (
 	"github.com/golang/glog"
 
 	coreapi "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/client-go/kubernetes/scheme"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 
 	buildapi "github.com/openshift/api/build/v1"
-	templateapi "github.com/openshift/api/template/v1"
 
 	"github.com/openshift/ci-tools/pkg/junit"
 )
@@ -564,97 +564,39 @@ func containerHasVolumeName(container coreapi.Container, name string) bool {
 	return true
 }
 
-func addArtifactsToTemplate(template *templateapi.Template) {
-	for i := range template.Objects {
-		t := &template.Objects[i]
-		var pod map[string]interface{}
-		if err := json.Unmarshal(t.Raw, &pod); err != nil {
-			log.Printf("error: object can't be unmarshalled: %v", err)
-			continue
-		}
-		if jsonString(pod, "kind") != "Pod" || jsonString(pod, "apiVersion") != "v1" {
-			continue
-		}
-		if !arrayHasObjectString(jsonArray(pod, "spec", "volumes"), "name", "artifacts") {
-			continue
-		}
-		names := allPodContainerNamesWithArtifacts(pod)
-		if len(names) == 0 {
-			continue
-		}
-		data, err := json.Marshal(artifactsContainer())
-		if err != nil {
-			panic(err)
-		}
-		var container map[string]interface{}
-		if err := json.Unmarshal(data, &container); err != nil {
-			panic(err)
-		}
-		containers := append(jsonArray(pod, "spec", "containers"), container)
-		jsonMap(pod, "spec")["containers"] = containers
-		data, err = json.Marshal(pod)
-		if err != nil {
-			panic(err)
-		}
-		t.Object = nil
-		t.Raw = data
+func addArtifactsToPod(pod *coreapi.Pod) {
+	if hasArtifactsVolume(pod) && hasMountsArtifactsVolume(pod) {
+		pod.Spec.Containers = append(pod.Spec.Containers, artifactsContainer())
 	}
 }
 
-func jsonMap(obj map[string]interface{}, keys ...string) map[string]interface{} {
-	if len(keys) == 0 {
-		return obj
-	}
-	for _, key := range keys[:len(keys)-1] {
-		v, ok := obj[key]
-		if !ok {
-			return nil
-		}
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			return nil
-		}
-		obj = m
-	}
-	m, _ := obj[keys[len(keys)-1]].(map[string]interface{})
-	return m
-}
-
-func jsonArray(obj map[string]interface{}, keys ...string) []interface{} {
-	if len(keys) < 1 {
-		return nil
-	}
-	s, _ := jsonMap(obj, keys[:len(keys)-1]...)[keys[len(keys)-1]].([]interface{})
-	return s
-}
-
-func jsonString(obj map[string]interface{}, keys ...string) string {
-	if len(keys) < 1 {
-		return ""
-	}
-	s, _ := jsonMap(obj, keys[:len(keys)-1]...)[keys[len(keys)-1]].(string)
-	return s
-}
-
-func arrayHasObjectString(arr []interface{}, key, name string) bool {
-	for _, obj := range arr {
-		o, _ := obj.(map[string]interface{})
-		if jsonString(o, key) == name {
+func hasArtifactsVolume(pod *coreapi.Pod) bool {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == "artifacts" {
 			return true
 		}
 	}
 	return false
 }
 
-func allPodContainerNamesWithArtifacts(pod map[string]interface{}) map[string]struct{} {
-	names := make(map[string]struct{})
-	for _, obj := range append(append([]interface{}(nil), jsonArray(pod, "spec", "initContainers")...), jsonArray(pod, "spec", "containers")...) {
-		o, _ := obj.(map[string]interface{})
-		if arrayHasObjectString(jsonArray(o, "volumeMounts"), "name", "artifacts") {
-			names[jsonString(o, "name")] = struct{}{}
+func hasMountsArtifactsVolume(pod *coreapi.Pod) bool {
+	for _, initContainer := range pod.Spec.InitContainers {
+		for _, volumeMount := range initContainer.VolumeMounts {
+			if volumeMount.Name == "artifacts" {
+				return true
+			}
 		}
 	}
-	return names
+
+	for _, container := range pod.Spec.Containers {
+		for _, volumeMount := range container.VolumeMounts {
+			if volumeMount.Name == "artifacts" {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func gatherContainerLogsOutput(podClient PodClient, artifactDir, namespace, podName string) error {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -12,17 +12,18 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"k8s.io/client-go/rest"
-
 	coreapi "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 
 	templateapi "github.com/openshift/api/template/v1"
 	templateclientset "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
@@ -91,6 +92,8 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 		}
 	}
 
+	operateOnTemplatePods(s.template, s.artifactDir)
+
 	if refs := s.jobSpec.JobSpec.Refs; refs != nil {
 		if s.template.ObjectLabels == nil {
 			s.template.ObjectLabels = make(map[string]string)
@@ -98,10 +101,6 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 		s.template.ObjectLabels[RefsOrgLabel] = refs.Org
 		s.template.ObjectLabels[RefsRepoLabel] = refs.Repo
 		s.template.ObjectLabels[RefsBranchLabel] = refs.BaseRef
-	}
-
-	if len(s.artifactDir) > 0 {
-		addArtifactsToTemplate(s.template)
 	}
 
 	if dry {
@@ -184,6 +183,18 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 		}
 	}
 	return nil
+}
+
+func operateOnTemplatePods(template *templateapi.Template, artifactDir string) {
+	for index, object := range template.Objects {
+		if pod := getPodFromObject(object); pod != nil {
+			if len(artifactDir) > 0 {
+				addArtifactsToPod(pod)
+			}
+			template.Objects[index].Raw = []byte(runtime.EncodeOrDie(corev1Codec, pod))
+			template.Objects[index].Object = pod.DeepCopyObject()
+		}
+	}
 }
 
 func (s *templateExecutionStep) SubTests() []*junit.TestCase {
@@ -763,4 +774,14 @@ func podLogNewFailedContainers(podClient coreclientset.PodInterface, pod *coreap
 	if (pod.Status.Phase == coreapi.PodFailed || pod.Status.Phase == coreapi.PodSucceeded) && len(podRunningContainers(pod)) == 0 {
 		notifier.Complete(pod.Name)
 	}
+}
+
+func getPodFromObject(object runtime.RawExtension) *coreapi.Pod {
+	// We don't care for errors, because we accept that this func() will check also a non-pod objects.
+	requiredObj, _ := runtime.Decode(codecFactory.UniversalDecoder(coreapi.SchemeGroupVersion), object.Raw)
+	if pod, ok := requiredObj.(*coreapi.Pod); ok {
+		return pod
+	}
+
+	return nil
 }

--- a/pkg/steps/template_test.go
+++ b/pkg/steps/template_test.go
@@ -1,0 +1,240 @@
+package steps
+
+import (
+	"testing"
+
+	coreapi "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	templateapi "github.com/openshift/api/template/v1"
+)
+
+func TestGetPodFromObject(t *testing.T) {
+	testCases := []struct {
+		testID      string
+		object      runtime.RawExtension
+		expectedPod *coreapi.Pod
+	}{
+		{
+			testID: "empty object, expect nothing",
+			object: runtime.RawExtension{},
+		},
+		{
+			testID: "object different than pod, expect nothing",
+			object: func() runtime.RawExtension {
+				rolebinding := &rbacv1.RoleBinding{
+					ObjectMeta: meta.ObjectMeta{
+						Name:      "image-puller",
+						Namespace: "test-namespace",
+					},
+				}
+
+				return runtime.RawExtension{
+					Raw:    []byte(runtime.EncodeOrDie(rbacv1Codec, rolebinding)),
+					Object: rolebinding.DeepCopyObject(),
+				}
+			}(),
+		},
+		{
+			testID: "object is a Pod, expect to get a pod struct",
+			object: func() runtime.RawExtension {
+				pod := &coreapi.Pod{
+					TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+					ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+					Spec: coreapi.PodSpec{
+						Containers: []coreapi.Container{{Name: "test"}},
+					},
+				}
+				return runtime.RawExtension{
+					Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+					Object: pod.DeepCopyObject(),
+				}
+			}(),
+			expectedPod: &coreapi.Pod{
+				TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+				Spec: coreapi.PodSpec{
+					Containers: []coreapi.Container{{Name: "test"}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testID, func(t *testing.T) {
+			pod := getPodFromObject(tc.object)
+			if !equality.Semantic.DeepEqual(pod, tc.expectedPod) {
+				t.Fatal(diff.ObjectReflectDiff(pod, tc.expectedPod))
+			}
+		})
+	}
+}
+
+func TestOperateOnTemplatePods(t *testing.T) {
+	testCases := []struct {
+		testID       string
+		artifactsDir string
+		template     *templateapi.Template
+		expected     *templateapi.Template
+	}{
+		{
+			testID: "template with no pod, no changes expected",
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+			},
+		},
+		{
+			testID: "template with pod but with no artifacts Volume/VolumeMount, no changes expected",
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{{Name: "test"}},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Containers: []coreapi.Container{{Name: "test"}},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
+		{
+			testID: "template with pod with artifacts Volume/VolumeMount but not artifacts dir defined, no changes expected",
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Volumes:    []coreapi.Volume{{Name: "artifacts"}},
+								Containers: []coreapi.Container{{Name: "test", VolumeMounts: []coreapi.VolumeMount{{Name: "artifacts"}}}},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Volumes:    []coreapi.Volume{{Name: "artifacts"}},
+								Containers: []coreapi.Container{{Name: "test", VolumeMounts: []coreapi.VolumeMount{{Name: "artifacts"}}}},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
+		{
+			testID:       "template with pod with artifacts Volume/VolumeMount and artifacts dir defined, changes expected",
+			artifactsDir: "/path/to/artifacts",
+			template: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Volumes:    []coreapi.Volume{{Name: "artifacts"}},
+								Containers: []coreapi.Container{{Name: "test", VolumeMounts: []coreapi.VolumeMount{{Name: "artifacts"}}}},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+			expected: &templateapi.Template{
+				TypeMeta:   meta.TypeMeta{Kind: "Template", APIVersion: "template.openshift.io/v1"},
+				ObjectMeta: meta.ObjectMeta{Name: "test-template"},
+				Objects: []runtime.RawExtension{
+					func() runtime.RawExtension {
+						pod := &coreapi.Pod{
+							TypeMeta:   meta.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+							ObjectMeta: meta.ObjectMeta{Name: "test-pod"},
+							Spec: coreapi.PodSpec{
+								Volumes: []coreapi.Volume{{Name: "artifacts"}},
+								Containers: []coreapi.Container{
+									{
+										Name: "test", VolumeMounts: []coreapi.VolumeMount{{Name: "artifacts"}},
+									},
+									testArtifactsContainer,
+								},
+							},
+						}
+						return runtime.RawExtension{
+							Raw:    []byte(runtime.EncodeOrDie(corev1Codec, pod)),
+							Object: pod.DeepCopyObject(),
+						}
+					}(),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testID, func(t *testing.T) {
+			operateOnTemplatePods(tc.template, tc.artifactsDir)
+			if !equality.Semantic.DeepEqual(tc.template, tc.expected) {
+				t.Fatal(diff.ObjectReflectDiff(tc.template, tc.expected))
+			}
+
+		})
+	}
+}

--- a/test/ci-operator-integration/config/test-template.yaml
+++ b/test/ci-operator-integration/config/test-template.yaml
@@ -110,6 +110,12 @@ objects:
     - name: test
       image: ${LOCAL_IMAGE_SRC}
       terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          cpu: 10m
+          memory: 10Mi
+        limits:
+          memory: 200Mi      
       volumeMounts:
       - name: shared-tmp
         mountPath: /tmp/shared
@@ -139,6 +145,12 @@ objects:
     - name: setup
       image: ${IMAGE_INSTALLER}
       terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          cpu: 10m
+          memory: 10Mi
+        limits:
+          memory: 200Mi      
       volumeMounts:
       - name: shared-tmp
         mountPath: /tmp
@@ -200,6 +212,12 @@ objects:
     - name: teardown
       image: ${IMAGE_TESTS}
       terminationMessagePolicy: FallbackToLogsOnError
+      resources:
+        requests:
+          cpu: 10m
+          memory: 10Mi
+        limits:
+          memory: 200Mi      
       volumeMounts:
       - name: shared-tmp
         mountPath: /tmp/shared

--- a/test/ci-operator-integration/expected_files/expected_with_template.json
+++ b/test/ci-operator-integration/expected_files/expected_with_template.json
@@ -1164,6 +1164,7 @@
             "ci-operator.openshift.io/save-container-logs": "true",
             "ci-operator.openshift.io/wait-for-container-artifacts": "teardown"
           },
+          "creationTimestamp": null,
           "name": "${JOB_NAME_SAFE}",
           "namespace": "${NAMESPACE}"
         },
@@ -1247,6 +1248,15 @@
               ],
               "image": "${LOCAL_IMAGE_SRC}",
               "name": "test",
+              "resources": {
+                "limits": {
+                  "memory": "200Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "10Mi"
+                }
+              },
               "terminationMessagePolicy": "FallbackToLogsOnError",
               "volumeMounts": [
                 {
@@ -1363,6 +1373,15 @@
               ],
               "image": "${IMAGE_INSTALLER}",
               "name": "setup",
+              "resources": {
+                "limits": {
+                  "memory": "200Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "10Mi"
+                }
+              },
               "terminationMessagePolicy": "FallbackToLogsOnError",
               "volumeMounts": [
                 {
@@ -1419,6 +1438,15 @@
               ],
               "image": "${IMAGE_TESTS}",
               "name": "teardown",
+              "resources": {
+                "limits": {
+                  "memory": "200Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "10Mi"
+                }
+              },
               "terminationMessagePolicy": "FallbackToLogsOnError",
               "volumeMounts": [
                 {
@@ -1461,6 +1489,7 @@
               ],
               "image": "${IMAGE_CLI}",
               "name": "cli",
+              "resources": {},
               "volumeMounts": [
                 {
                   "mountPath": "/tmp/shared",
@@ -1487,7 +1516,8 @@
               }
             }
           ]
-        }
+        },
+        "status": {}
       }
     ],
     "parameters": [


### PR DESCRIPTION
Trying to land this kind of changes, we met a lot of complications. 
Another PR that removes the unnecessary variables in the template has to be merged in order for this PR to work.

The previous attempt was crashing to Decode the pod from the template because of [this](https://github.com/openshift/release/blob/master/ci-operator/templates/openshift/installer/cluster-launch-installer-src.yaml#L151) variable.

ref: [release/pull/4950](https://github.com/openshift/release/pull/4950)
