### PR TITLE
config-brancher: Only bump the fields actually present in the config

### DIFF
--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -132,8 +132,12 @@ func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases 
 // updateRelease updates the release that is promoted to and that
 // which is used to source the release payload for testing
 func updateRelease(config *api.ReleaseBuildConfiguration, futureRelease string) {
-	config.PromotionConfiguration.Name = futureRelease
-	config.ReleaseTagConfiguration.Name = futureRelease
+	if config.PromotionConfiguration != nil {
+		config.PromotionConfiguration.Name = futureRelease
+	}
+	if config.ReleaseTagConfiguration != nil {
+		config.ReleaseTagConfiguration.Name = futureRelease
+	}
 }
 
 // updateImages updates the release that is used for input images


### PR DESCRIPTION
This fixes a segfault when we attempted to branch a config with a
`promotion` stanza but not `tag_specification` stanza. That config only
defined container tests and built no images, so not having
`tag_specification` is fine and we should not segfault on it.

/cc @openshift/openshift-team-developer-productivity-test-platform 