### PR TITLE
Use a data structure with more metadata for storing config

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -197,7 +197,9 @@ func rehearseMain() int {
 	changedCiopConfigs := config.CompoundCiopConfig{}
 	affectedJobs := make(map[string]sets.String)
 	if masterConfig.CiOperator != nil && prConfig.CiOperator != nil {
-		changedCiopConfigs, affectedJobs = diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+		data, jobs := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+		changedCiopConfigs = config.CompoundFrom(data)
+		affectedJobs = jobs
 		metrics.RecordChangedCiopConfigs(changedCiopConfigs)
 	}
 
@@ -285,7 +287,7 @@ func rehearseMain() int {
 	metrics.RecordPresubmitsOpportunity(toRehearseClusterProfiles, "cluster-profile-change")
 	toRehearse.AddAll(toRehearseClusterProfiles)
 
-	jobConfigurer := rehearse.NewJobConfigurer(prConfig.CiOperator, prNumber, loggers, o.allowVolumes, changedTemplates, changedClusterProfiles, jobSpec.Refs)
+	jobConfigurer := rehearse.NewJobConfigurer(config.CompoundFrom(prConfig.CiOperator), prNumber, loggers, o.allowVolumes, changedTemplates, changedClusterProfiles, jobSpec.Refs)
 
 	presubmitsToRehearse := jobConfigurer.ConfigurePresubmitRehearsals(toRehearse)
 	periodicsToRehearse := jobConfigurer.ConfigurePeriodicRehearsals(changedPeriodics)

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/openshift/ci-tools/pkg/api"
 	"reflect"
 	"testing"
 
@@ -197,6 +198,171 @@ func TestInfo_ConfigMapName(t *testing.T) {
 			// test that ConfigMapName() stays in sync with IsCiopConfigCM()
 			if !IsCiopConfigCM(actual) {
 				t.Errorf("%s: IsCiopConfigCM() returned false for %s", testCase.name, actual)
+			}
+		})
+	}
+}
+
+func TestCompoundFrom(t *testing.T) {
+	var testCases = []struct {
+		name string
+		in   ByFilename
+		out  CompoundCiopConfig
+	}{
+		{
+			name: "no input, no output",
+			in:   ByFilename{},
+			out:  CompoundCiopConfig{},
+		},
+		{
+			name: "input is faithfully copied",
+			in: ByFilename{
+				"foo": {
+					Configuration: api.ReleaseBuildConfiguration{
+						PromotionConfiguration: &api.PromotionConfiguration{
+							Name:      "foo",
+							Namespace: "ocp",
+						},
+						InputConfiguration: api.InputConfiguration{
+							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+								Name:      "foo",
+								Namespace: "ocp",
+							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "foo",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "foo",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "foo",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
+							},
+						},
+					},
+				},
+				"bar": {
+					Configuration: api.ReleaseBuildConfiguration{
+						PromotionConfiguration: &api.PromotionConfiguration{
+							Name:      "bar",
+							Namespace: "ocp",
+						},
+						InputConfiguration: api.InputConfiguration{
+							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+								Name:      "bar",
+								Namespace: "ocp",
+							},
+							BaseImages: map[string]api.ImageStreamTagReference{
+								"first": {
+									Name:      "bar",
+									Namespace: "ocp",
+									Tag:       "first",
+								},
+							},
+							BaseRPMImages: map[string]api.ImageStreamTagReference{
+								"second": {
+									Name:      "bar",
+									Namespace: "ocp",
+									Tag:       "second",
+								},
+							},
+							BuildRootImage: &api.BuildRootImageConfiguration{
+								ImageStreamTagReference: &api.ImageStreamTagReference{
+									Name:      "bar",
+									Namespace: "ocp",
+									Tag:       "third",
+								},
+							},
+						},
+					},
+				},
+			},
+			out: CompoundCiopConfig{
+				"foo": &api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Name:      "foo",
+						Namespace: "ocp",
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Name:      "foo",
+							Namespace: "ocp",
+						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"first": {
+								Name:      "foo",
+								Namespace: "ocp",
+								Tag:       "first",
+							},
+						},
+						BaseRPMImages: map[string]api.ImageStreamTagReference{
+							"second": {
+								Name:      "foo",
+								Namespace: "ocp",
+								Tag:       "second",
+							},
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Name:      "foo",
+								Namespace: "ocp",
+								Tag:       "third",
+							},
+						},
+					},
+				},
+				"bar": &api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Name:      "bar",
+						Namespace: "ocp",
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Name:      "bar",
+							Namespace: "ocp",
+						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"first": {
+								Name:      "bar",
+								Namespace: "ocp",
+								Tag:       "first",
+							},
+						},
+						BaseRPMImages: map[string]api.ImageStreamTagReference{
+							"second": {
+								Name:      "bar",
+								Namespace: "ocp",
+								Tag:       "second",
+							},
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Name:      "bar",
+								Namespace: "ocp",
+								Tag:       "third",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := CompoundFrom(testCase.in), testCase.out; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect output: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -35,7 +35,7 @@ const (
 // ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)
 type ReleaseRepoConfig struct {
 	Prow       *prowconfig.Config
-	CiOperator CompoundCiopConfig
+	CiOperator ByFilename
 }
 
 func git(repoPath string, args ...string) (string, error) {
@@ -98,7 +98,7 @@ func GetAllConfigs(releaseRepoPath string, logger *logrus.Entry) *ReleaseRepoCon
 	config := &ReleaseRepoConfig{}
 	var err error
 	ciopConfigPath := filepath.Join(releaseRepoPath, CiopConfigInRepoPath)
-	config.CiOperator, err = CompoundLoad(ciopConfigPath)
+	config.CiOperator, err = LoadConfigByFilename(ciopConfigPath)
 	if err != nil {
 		logger.WithError(err).Warn("failed to load ci-operator configuration from release repo")
 	}


### PR DESCRIPTION
When we load every CI Operator configuration, we have the ability to
record a lot of metadata about the files. We should do so and record it
so that it can be used downstream. This patch adds that change and a
conversion function so that the rollout of the change can be
incremental.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 
depends on #145 