### PR TITLE
ci-operator: make the artifact worker testable

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -422,7 +422,7 @@ func (w *ArtifactWorker) downloadArtifacts(podName string, hasArtifacts bool) er
 	return nil
 }
 
-func (w *ArtifactWorker) CollectFromPod(podName string, hasArtifactsContainer bool, hasArtifacts []string, waitForContainers []string) {
+func (w *ArtifactWorker) CollectFromPod(podName string, hasArtifacts []string, waitForContainers []string) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 
@@ -541,11 +541,7 @@ func (w *ArtifactWorker) Done(podName string) bool {
 
 func addArtifactContainersFromPod(pod *coreapi.Pod, worker *ArtifactWorker) {
 	var containers []string
-	var hasArtifactsContainer bool
 	for _, container := range append(append([]coreapi.Container{}, pod.Spec.InitContainers...), pod.Spec.Containers...) {
-		if container.Name == "artifacts" {
-			hasArtifactsContainer = true
-		}
 		if !containerHasVolumeName(container, "artifacts") {
 			continue
 		}
@@ -555,7 +551,7 @@ func addArtifactContainersFromPod(pod *coreapi.Pod, worker *ArtifactWorker) {
 	if names := pod.Annotations[annotationWaitForContainerArtifacts]; len(names) > 0 {
 		waitForContainers = strings.Split(names, ",")
 	}
-	worker.CollectFromPod(pod.Name, hasArtifactsContainer, containers, waitForContainers)
+	worker.CollectFromPod(pod.Name, containers, waitForContainers)
 }
 
 func containerHasVolumeName(container coreapi.Container, name string) bool {

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -159,10 +159,22 @@ type podCmdExecutor interface {
 	Exec(namespace, pod string, opts *coreapi.PodExecOptions) (remotecommand.Executor, error)
 }
 
+type fakePodExec struct{}
+
+func (fakePodExec) Stream(remotecommand.StreamOptions) error { return nil }
+
 type podClient struct {
 	coreclientset.PodsGetter
 	config *rest.Config
 	client rest.Interface
+}
+
+type fakePodClient struct {
+	coreclientset.PodsGetter
+}
+
+func (c *fakePodClient) Exec(namespace, name string, opts *coreapi.PodExecOptions) (remotecommand.Executor, error) {
+	return &fakePodExec{}, nil
 }
 
 func NewPodClient(podsClient coreclientset.PodsGetter, config *rest.Config, client rest.Interface) PodClient {

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -509,7 +509,7 @@ func TestArtifactWorker(t *testing.T) {
 		name:       pod,
 	}
 	w := NewArtifactWorker(podClient, tmp, podClient.namespace)
-	w.CollectFromPod(pod, true, []string{"container"}, nil)
+	w.CollectFromPod(pod, []string{"container"}, nil)
 	w.Complete(pod)
 	for !w.Done(pod) {
 	}

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -511,7 +511,10 @@ func TestArtifactWorker(t *testing.T) {
 	w := NewArtifactWorker(podClient, tmp, podClient.namespace)
 	w.CollectFromPod(pod, []string{"container"}, nil)
 	w.Complete(pod)
-	for !w.Done(pod) {
+	select {
+	case <-w.Done(pod):
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for artifact worker to finish")
 	}
 	files, err := ioutil.ReadDir(tmp)
 	if err != nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -184,7 +184,7 @@ func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, sh
 			if c.Name == "artifacts" {
 				container := pod.Spec.Containers[0].Name
 				artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, container), s.jobSpec.Namespace)
-				artifacts.CollectFromPod(pod.Name, true, []string{container}, nil)
+				artifacts.CollectFromPod(pod.Name, []string{container}, nil)
 				notifier = artifacts
 				break
 			}

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -85,7 +85,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 			MountPath: s.config.ArtifactDir,
 		})
 		addArtifactsContainer(pod)
-		artifacts.CollectFromPod(pod.Name, true, []string{s.name}, nil)
+		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
 		notifier = artifacts
 	}
 	testCaseNotifier := NewTestCaseNotifier(notifier)


### PR DESCRIPTION
Not for the faint-hearted.  As promised (and since regretted) in
https://github.com/openshift/ci-tools/pull/110, test artifact gathering in
multi-stage tests, making internal APIs more generic where required.

`waitForPodCompletion` and friends are very complex and messy functions, but
changes are as small as possible and tests are added as soon as it's practical.
This also makes it possible to add test to those functions.

Additionally, I've verified multiple executions of container, template, and
multi-stage tests using the new binary.

Each commit is independent.