### PR TITLE
Use HideSecretsWriter as stderr for git-status command

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -343,9 +343,10 @@ func (w *OutputWriter) Write(content []byte) (n int, err error) {
 	return len(content), nil
 }
 
-func listUpdatedDirectories() ([]string, error) {
+func listUpdatedDirectories(sa *secret.Agent) ([]string, error) {
 	w := &OutputWriter{}
-	if err := bumper.Call(w, os.Stderr, "git", []string{"status", "--porcelain"}...); err != nil {
+	e := bumper.HideSecretsWriter{Delegate: os.Stderr, Censor: sa}
+	if err := bumper.Call(w, e, "git", []string{"status", "--porcelain"}...); err != nil {
 		return nil, err
 	}
 	return listUpdatedDirectoriesFromGitStatusOutput(string(w.output))
@@ -389,7 +390,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error occurred when walking through the target dir.")
 	}
 
-	directories, err := listUpdatedDirectories()
+	directories, err := listUpdatedDirectories(secretAgent)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error occurred when listing updated directories.")
 	}

--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -386,6 +386,11 @@ func main() {
 	}
 	gc = github.NewClient(secretAgent.GetTokenGenerator(o.githubToken), secretAgent.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 
+	logrus.Infof("Changing working directory to %s...", o.targetDir)
+	if err := os.Chdir(o.targetDir); err != nil {
+		logrus.WithError(err).Fatal("Failed to change to root dir")
+	}
+
 	if err := pullOwners(o.targetDir, sets.NewString(o.blacklist.Strings()...)); err != nil {
 		logrus.WithError(err).Fatal("Error occurred when walking through the target dir.")
 	}


### PR DESCRIPTION
Although it is unlikely that `git-status` exposes sensitive
information, it is better to avoid surprises.

/cc @openshift/openshift-team-developer-productivity-test-platform 