### PR TITLE
Fix logs for changeDir

### DIFF
--- a/cmd/autobumper/main.go
+++ b/cmd/autobumper/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	gc := github.NewClient(sa.GetTokenGenerator(o.githubToken), sa.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 
-	logrus.Infof("Changing working directory to %s...", o.targetDir)
+	logrus.Infof("Changing working directory to '%s' ...", o.targetDir)
 	if err := os.Chdir(o.targetDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to change to root dir")
 	}

--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -389,7 +389,7 @@ func main() {
 	}
 	gc = github.NewClient(secretAgent.GetTokenGenerator(o.githubToken), secretAgent.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
 
-	logrus.Infof("Changing working directory to %s...", o.targetDir)
+	logrus.Infof("Changing working directory to '%s' ...", o.targetDir)
 	if err := os.Chdir(o.targetDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to change to root dir")
 	}


### PR DESCRIPTION
When the targetDir is ".", the log shows, for example,
```
time="2019-09-18T13:35:51Z" level=info msg="Changing working directory to '.' ..."
```
instead of
```
time="2019-09-18T13:35:51Z" level=info msg="Changing working directory to ...."
```

/cc @openshift/openshift-team-developer-productivity-test-platform 