### PR TITLE
Ignore the changes on modules.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ validate-vendor:
 	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod tidy
 	GO111MODULE=on GOPROXY=https://proxy.golang.org go mod vendor
 	git status -s ./vendor/ go.mod go.sum
-	test -z "$$(git status -s ./vendor/ go.mod go.sum)"
+	test -z "$$(git status -s ./vendor/ go.mod go.sum | grep -v vendor/modules.txt)"
 .PHONY: validate-vendor
 
 lint:


### PR DESCRIPTION
./vendor/modules.txt can be modified (reordering the lines in it)
even if the dependencies are not changed. This forces us to run
`make validate-vendor` for each commit.

We ingore the changes on that file in the check.

https://github.com/openshift/ci-tools/pull/161#issuecomment-533296228