### PR TITLE
determinize all ci-operator configs

### DIFF
--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -33,9 +33,6 @@ func main() {
 		if (o.Org != "" && o.Org != info.Org) || (o.Repo != "" && o.Repo != info.Repo) {
 			return nil
 		}
-		if !(promotion.PromotesOfficialImages(configuration) && configuration.PromotionConfiguration.Name == o.CurrentRelease) {
-			return nil
-		}
 		output := config.DataWithInfo{Configuration: *configuration, Info: *info}
 		if !o.Confirm {
 			output.Logger().Info("Would re-format file.")


### PR DESCRIPTION
I don't think there's a good reason for determinizing only the configs that would be branched. @stevekuznetsov WDYT?

/cc @openshift/openshift-team-developer-productivity-test-platform 