### PR TITLE
ci-operator multi-stage: create secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,11 +51,12 @@ integration-ci-operator:
 
 integration-ci-operator-configresolver:
 	test/ci-operator-configresolver-integration/run.sh
-
-check-breaking-changes:
-	test/validate-prowgen-breaking-changes.sh
-.PHONY: check-breaking-changes
+.PHONY: integration-ci-operator-configresolver
 
 integration-testgrid-generator:
 	test/testgrid-config-generator/run.sh
+.PHONY: integration-testgrid-generator
+
+check-breaking-changes:
+	test/validate-prowgen-breaking-changes.sh
 .PHONY: check-breaking-changes

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ integration-ci-operator-configresolver:
 	test/ci-operator-configresolver-integration/run.sh
 .PHONY: integration-ci-operator-configresolver
 
+integration-secret-wrapper:
+	test/secret-wrapper-integration.sh
+.PHONY: integration-secret-wrapper
+
 integration-testgrid-generator:
 	test/testgrid-config-generator/run.sh
 .PHONY: integration-testgrid-generator

--- a/cmd/secret-wrapper/main.go
+++ b/cmd/secret-wrapper/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/ci-tools/pkg/util"
+)
+
+const (
+	DIR = "/tmp/secret"
+)
+
+func main() {
+	if err := run(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(argv []string) error {
+	if len(os.Args) == 1 {
+		return fmt.Errorf("Usage: %s cmd...\n", os.Args[0])
+	}
+	var ns, name string
+	if ns = os.Getenv("NAMESPACE"); ns == "" {
+		return fmt.Errorf("environment variable NAMESPACE is empty")
+	}
+	if name = os.Getenv("JOB_NAME_SAFE"); name == "" {
+		return fmt.Errorf("environment variable JOB_NAME_SAFE is empty")
+	}
+	client, err := loadClient(ns)
+	if err != nil {
+		return err
+	}
+	if err := execCmd(os.Args); err != nil {
+		return fmt.Errorf("failed to execute wrapped command: %v\n", err)
+	}
+	if _, err := os.Stat(DIR); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to stat directory %q: %v", DIR, err)
+	}
+	secret, err := util.SecretFromDir(DIR)
+	if err != nil {
+		return fmt.Errorf("failed to generate secret: %v\n", err)
+	}
+	secret.Name = name
+	if _, err := util.UpdateSecret(client, secret); err != nil {
+		return fmt.Errorf("failed to update secret: %v\n", err)
+	}
+	return nil
+}
+
+func loadClient(namespace string) (coreclientset.SecretInterface, error) {
+	config, err := util.LoadClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load cluster config: %v", err)
+	}
+	client, err := coreclientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create client: %v", err)
+	}
+	return client.Secrets(namespace), nil
+}
+
+func execCmd(argv []string) error {
+	proc := exec.Command(argv[1], argv[2:]...)
+	proc.Stdout = os.Stdout
+	proc.Stderr = os.Stderr
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				break
+			case s := <-sig:
+				fmt.Fprintf(os.Stderr, "received signal %d, forwarding\n", s)
+				proc.Process.Signal(s)
+			}
+		}
+	}()
+	return proc.Run()
+}

--- a/cmd/secret-wrapper/main.go
+++ b/cmd/secret-wrapper/main.go
@@ -14,10 +14,14 @@ import (
 )
 
 const (
-	DIR = "/tmp/secret"
+	dir = "/tmp/secret"
 )
 
 func main() {
+	if len(os.Args) == 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s cmd...\n", os.Args[0])
+		os.Exit(1)
+	}
 	if err := run(os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -25,9 +29,6 @@ func main() {
 }
 
 func run(argv []string) error {
-	if len(os.Args) == 1 {
-		return fmt.Errorf("Usage: %s cmd...\n", os.Args[0])
-	}
 	var ns, name string
 	if ns = os.Getenv("NAMESPACE"); ns == "" {
 		return fmt.Errorf("environment variable NAMESPACE is empty")
@@ -40,21 +41,21 @@ func run(argv []string) error {
 		return err
 	}
 	if err := execCmd(os.Args); err != nil {
-		return fmt.Errorf("failed to execute wrapped command: %v\n", err)
+		return fmt.Errorf("failed to execute wrapped command: %v", err)
 	}
-	if _, err := os.Stat(DIR); err != nil {
+	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to stat directory %q: %v", DIR, err)
+		return fmt.Errorf("failed to stat directory %q: %v", dir, err)
 	}
-	secret, err := util.SecretFromDir(DIR)
+	secret, err := util.SecretFromDir(dir)
 	if err != nil {
-		return fmt.Errorf("failed to generate secret: %v\n", err)
+		return fmt.Errorf("failed to generate secret: %v", err)
 	}
 	secret.Name = name
 	if _, err := util.UpdateSecret(client, secret); err != nil {
-		return fmt.Errorf("failed to update secret: %v\n", err)
+		return fmt.Errorf("failed to update secret: %v", err)
 	}
 	return nil
 }

--- a/images/secret-wrapper/Dockerfile
+++ b/images/secret-wrapper/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+LABEL maintainer="bbarcaro@redhat.com"
+
+ADD secret-wrapper /usr/bin/secret-wrapper
+ENTRYPOINT ["/usr/bin/secret-wrapper"]

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -155,7 +155,7 @@ func FromConfig(
 
 		} else if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if testStep.MultiStageTestConfiguration != nil {
-				step = steps.MultiStageTestStep(*testStep, config, podClient, artifactDir, jobSpec, dryLogger)
+				step = steps.MultiStageTestStep(*testStep, config, podClient, secretGetter, artifactDir, jobSpec, dryLogger)
 			} else if testStep.OpenshiftInstallerClusterTestConfiguration != nil {
 				if testStep.OpenshiftInstallerClusterTestConfiguration.Upgrade {
 					var err error

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	multiStageTestLabel = "ci.openshift.io/multi-stage-test"
+	secretMountPath     = "/var/run/secrets/ci.openshift.io/multi-stage"
 )
 
 type multiStageTestStep struct {
@@ -28,6 +29,7 @@ type multiStageTestStep struct {
 	name            string
 	config          *api.ReleaseBuildConfiguration
 	podClient       PodClient
+	secretClient    coreclientset.SecretsGetter
 	artifactDir     string
 	jobSpec         *api.JobSpec
 	pre, test, post []api.TestStep
@@ -38,17 +40,19 @@ func MultiStageTestStep(
 	testConfig api.TestStepConfiguration,
 	config *api.ReleaseBuildConfiguration,
 	podClient PodClient,
+	secretClient coreclientset.SecretsGetter,
 	artifactDir string,
 	jobSpec *api.JobSpec,
 	logger *DryLogger,
 ) api.Step {
-	return newMultiStageTestStep(testConfig, config, podClient, artifactDir, jobSpec, logger)
+	return newMultiStageTestStep(testConfig, config, podClient, secretClient, artifactDir, jobSpec, logger)
 }
 
 func newMultiStageTestStep(
 	testConfig api.TestStepConfiguration,
 	config *api.ReleaseBuildConfiguration,
 	podClient PodClient,
+	secretClient coreclientset.SecretsGetter,
 	artifactDir string,
 	jobSpec *api.JobSpec,
 	logger *DryLogger,
@@ -57,15 +61,16 @@ func newMultiStageTestStep(
 		artifactDir = filepath.Join(artifactDir, testConfig.As)
 	}
 	return &multiStageTestStep{
-		logger:      logger,
-		name:        testConfig.As,
-		config:      config,
-		podClient:   podClient,
-		artifactDir: artifactDir,
-		jobSpec:     jobSpec,
-		pre:         testConfig.MultiStageTestConfiguration.Pre,
-		test:        testConfig.MultiStageTestConfiguration.Test,
-		post:        testConfig.MultiStageTestConfiguration.Post,
+		logger:       logger,
+		name:         testConfig.As,
+		config:       config,
+		podClient:    podClient,
+		secretClient: secretClient,
+		artifactDir:  artifactDir,
+		jobSpec:      jobSpec,
+		pre:          testConfig.MultiStageTestConfiguration.Pre,
+		test:         testConfig.MultiStageTestConfiguration.Test,
+		post:         testConfig.MultiStageTestConfiguration.Post,
 	}
 }
 
@@ -75,6 +80,9 @@ func (s *multiStageTestStep) Inputs(ctx context.Context, dry bool) (api.InputDef
 
 func (s *multiStageTestStep) Run(ctx context.Context, dry bool) error {
 	s.dry = dry
+	if err := s.createSecret(); err != nil {
+		return fmt.Errorf("failed to create secret: %v", err)
+	}
 	var errs []error
 	if err := s.runSteps(ctx, s.pre, true); err != nil {
 		errs = append(errs, fmt.Errorf("%q pre steps failed: %v", s.name, err))
@@ -118,6 +126,21 @@ func (s *multiStageTestStep) Provides() (api.ParameterMap, api.StepLink) {
 	return nil, nil
 }
 func (s *multiStageTestStep) SubTests() []*junit.TestCase { return s.subTests }
+
+func (s *multiStageTestStep) createSecret() error {
+	log.Printf("Creating multi-stage test secret %q", s.name)
+	secret := coreapi.Secret{ObjectMeta: meta.ObjectMeta{Name: s.name}}
+	if s.dry {
+		s.logger.AddObject(secret.DeepCopyObject())
+		return nil
+	}
+	client := s.secretClient.Secrets(s.jobSpec.Namespace)
+	if err := client.Delete(s.name, &meta.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("cannot delete secret %q: %v", s.name, err)
+	}
+	_, err := client.Create(&secret)
+	return err
+}
 
 func (s *multiStageTestStep) runSteps(ctx context.Context, steps []api.TestStep, shortCircuit bool) error {
 	pods, err := s.generatePods(steps)
@@ -163,9 +186,23 @@ func (s *multiStageTestStep) generatePods(steps []api.TestStep) ([]coreapi.Pod, 
 			})
 			addArtifactsContainer(pod)
 		}
+		addSecret(s.name, pod)
 		ret = append(ret, *pod)
 	}
 	return ret, utilerrors.NewAggregate(errs)
+}
+
+func addSecret(secret string, pod *coreapi.Pod) {
+	pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
+		Name: secret,
+		VolumeSource: coreapi.VolumeSource{
+			Secret: &coreapi.SecretVolumeSource{SecretName: secret},
+		},
+	})
+	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, coreapi.VolumeMount{
+		Name:      secret,
+		MountPath: secretMountPath,
+	})
 }
 
 func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, shortCircuit bool) error {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -142,19 +142,42 @@ func TestGeneratePods(t *testing.T) {
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: "Never",
+			InitContainers: []coreapi.Container{{
+				Name:    "cp-secret-wrapper",
+				Image:   "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+				Command: []string{"cp"},
+				Args: []string{
+					"/bin/secret-wrapper",
+					"/tmp/secret-wrapper/secret-wrapper",
+				},
+				VolumeMounts: []coreapi.VolumeMount{{
+					Name:      "secret-wrapper",
+					MountPath: "/tmp/secret-wrapper",
+				}},
+				TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step0",
 				Image:                    "image0",
-				Command:                  []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
+				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
+				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
 				Env:                      env,
 				Resources:                coreapi.ResourceRequirements{},
 				TerminationMessagePolicy: "FallbackToLogsOnError",
 				VolumeMounts: []coreapi.VolumeMount{{
+					Name:      "secret-wrapper",
+					MountPath: "/tmp/secret-wrapper",
+				}, {
 					Name:      "test",
 					MountPath: "/var/run/secrets/ci.openshift.io/multi-stage",
 				}},
 			}},
 			Volumes: []coreapi.Volume{{
+				Name: "secret-wrapper",
+				VolumeSource: coreapi.VolumeSource{
+					EmptyDir: &coreapi.EmptyDirVolumeSource{},
+				},
+			}, {
 				Name: "test",
 				VolumeSource: coreapi.VolumeSource{
 					Secret: &coreapi.SecretVolumeSource{
@@ -174,14 +197,32 @@ func TestGeneratePods(t *testing.T) {
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: "Never",
+			InitContainers: []coreapi.Container{{
+				Name:    "cp-secret-wrapper",
+				Image:   "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+				Command: []string{"cp"},
+				Args: []string{
+					"/bin/secret-wrapper",
+					"/tmp/secret-wrapper/secret-wrapper",
+				},
+				VolumeMounts: []coreapi.VolumeMount{{
+					Name:      "secret-wrapper",
+					MountPath: "/tmp/secret-wrapper",
+				}},
+				TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step1",
 				Image:                    "image1",
-				Command:                  []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
+				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
+				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
 				Env:                      env,
 				Resources:                coreapi.ResourceRequirements{},
 				TerminationMessagePolicy: "FallbackToLogsOnError",
 				VolumeMounts: []coreapi.VolumeMount{{
+					Name:      "secret-wrapper",
+					MountPath: "/tmp/secret-wrapper",
+				}, {
 					Name:      "artifacts",
 					MountPath: "/artifact/dir",
 				}, {
@@ -214,6 +255,11 @@ done
 				}},
 			}},
 			Volumes: []coreapi.Volume{{
+				Name: "secret-wrapper",
+				VolumeSource: coreapi.VolumeSource{
+					EmptyDir: &coreapi.EmptyDirVolumeSource{},
+				},
+			}, {
 				Name: "artifacts",
 				VolumeSource: coreapi.VolumeSource{
 					EmptyDir: &coreapi.EmptyDirVolumeSource{},

--- a/pkg/util/secret.go
+++ b/pkg/util/secret.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	coreapi "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// SecretFromDir creates a secret with the contents of files in a directory.
+func SecretFromDir(path string) (*coreapi.Secret, error) {
+	ret := &coreapi.Secret{
+		Type: coreapi.SecretTypeOpaque,
+		Data: make(map[string][]byte),
+	}
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not read dir %s: %v", path, err)
+	}
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+		path := filepath.Join(path, f.Name())
+		// if the file is a broken symlink or a symlink to a dir, skip it
+		if fi, err := os.Stat(path); err != nil || fi.IsDir() {
+			continue
+		}
+		ret.Data[f.Name()], err = ioutil.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("could not read file %s: %v", path, err)
+		}
+	}
+	return ret, nil
+}
+
+// UpdateSecret adds new values to an existing secret.
+// New values are added, existing values are overwritten. The secret will be
+// created if it doesn't already exist.
+func UpdateSecret(client coreclientset.SecretInterface, secret *coreapi.Secret) (created bool, err error) {
+	_, err = client.Create(secret)
+	if err == nil {
+		return true, nil
+	}
+	if !kerrors.IsAlreadyExists(err) {
+		return false, err
+	}
+	existing, err := client.Get(secret.Name, meta.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	if l := len(secret.Data); l != 0 && existing.Data == nil {
+		existing.Data = make(map[string][]byte, l)
+	}
+	for k, v := range secret.Data {
+		existing.Data[k] = v
+	}
+	_, err = client.Update(existing)
+	return false, err
+}

--- a/test/ci-operator-integration/multi-stage/expected.json
+++ b/test/ci-operator-integration/multi-stage/expected.json
@@ -454,10 +454,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\npost0 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -534,14 +537,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -576,10 +608,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\npost1 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -656,14 +691,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -698,10 +762,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\npre0 command\n"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -778,14 +845,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -820,10 +916,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\npre1 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -900,14 +999,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -942,10 +1070,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\ntest0 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -1022,14 +1153,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -1064,10 +1224,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\ntest1 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -1144,14 +1307,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {
@@ -1186,10 +1378,13 @@
     "spec": {
       "containers": [
         {
-          "command": [
+          "args": [
             "/bin/bash",
             "-c",
             "#!/bin/bash\nset -eu\ntest2 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
           ],
           "env": [
             {
@@ -1266,14 +1461,43 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
               "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
               "name": "multi-stage"
             }
           ]
         }
       ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
         {
           "name": "multi-stage",
           "secret": {

--- a/test/ci-operator-integration/multi-stage/expected.json
+++ b/test/ci-operator-integration/multi-stage/expected.json
@@ -531,10 +531,24 @@
               "memory": "6"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -639,10 +653,24 @@
               "memory": "7"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -747,10 +775,24 @@
               "memory": "1"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -855,10 +897,24 @@
               "memory": "2"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -963,10 +1019,24 @@
               "memory": "3"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -1071,10 +1141,24 @@
               "memory": "4"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
   },
@@ -1179,11 +1263,33 @@
               "memory": "5"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
     },
     "status": {}
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "multi-stage"
+    }
   }
 ]

--- a/test/secret-wrapper-integration.sh
+++ b/test/secret-wrapper-integration.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -euo pipefail
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -r "${TMPDIR}"' EXIT
+export TMPDIR
+export NAMESPACE=test
+export JOB_NAME_SAFE=test
+SECRET='[
+  {
+    "kind": "Secret",
+    "apiVersion": "v1",
+    "metadata": {
+      "name": "test",
+      "creationTimestamp": null
+    },
+    "data": {
+      "test.txt": "dGVzdAo="
+    },
+    "type": "Opaque"
+  }
+]'
+
+test_output() {
+    local out
+    if ! out=$(diff /dev/fd/3 /dev/fd/4 3<<<"$1" 4<<<"$2"); then
+        echo "${out}"
+        echo '[ERROR] incorrect dry-run output'
+        return 1
+    fi
+}
+
+test_signal() {
+    local pid
+    secret-wrapper --dry-run sleep 1d &
+    pid=$!
+    if ! timeout 1s sh -c \
+        'until pgrep --count --parent "$1" sleep > /dev/null ; do :; done' \
+        sh "${pid}"
+    then
+        kill "${pid}"
+        echo '[ERROR] timeout while waiting for `sleep` to start.'
+        return 1
+    fi
+    kill -s "$1" "${pid}"
+    if wait "$pid"; then
+        echo "[ERROR] secret-wrapper did not fail as expected."
+        return 1
+    fi
+}
+
+mkdir "${TMPDIR}/secret"
+echo test > "${TMPDIR}/secret/test.txt"
+
+echo '[INFO] Running `secret-wrapper true`...'
+if ! out=$(secret-wrapper --dry-run true); then
+    echo "[ERROR] secret-wrapper failed."
+    exit 1
+fi
+test_output "${out}" "${SECRET}"
+echo '[INFO] Running `secret-wrapper false`...'
+if out=$(secret-wrapper --dry-run false); then
+    echo "[ERROR] secret-wrapper did not fail."
+    exit 1
+fi
+test_output "${out}" ""
+echo '[INFO] Running `secret-wrapper sleep 1d` and sending SIGINT...'
+out=$(test_signal INT)
+test_output "${out}" ""
+echo '[INFO] Running `secret-wrapper sleep 1d` and sending SIGTERM...'
+out=$(test_signal TERM)
+test_output "${out}" ""
+echo "[INFO] Success"


### PR DESCRIPTION
Each test is assigned a secret with a pre-defined name (already
accessible via the `$JOB_NAME_SAFE` environment variable) that will be
mounted at a specific path in all pods (from `pre` to `post`) and can be
used to pass a small amount of data to subsequent steps.