### PR TITLE
Add options of github endpoints to auto-tools

### DIFF
--- a/cmd/autobumper/main.go
+++ b/cmd/autobumper/main.go
@@ -9,7 +9,7 @@ import (
 
 	"k8s.io/test-infra/experiment/autobumper/bumper"
 	"k8s.io/test-infra/prow/config/secret"
-	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/flagutil"
 )
 
 const (
@@ -24,32 +24,34 @@ var extraFiles = map[string]bool{
 }
 
 type options struct {
+	dryRun      bool
 	githubLogin string
-	githubToken string
 	gitName     string
 	gitEmail    string
 	targetDir   string
 	assign      string
+	flagutil.GitHubOptions
 }
 
 func parseOptions() options {
 	var o options
-	flag.StringVar(&o.githubLogin, "github-login", githubLogin, "The GitHub username to use.")
-	flag.StringVar(&o.githubToken, "github-token", "", "The path to the GitHub token file.")
-	flag.StringVar(&o.gitName, "git-name", "", "The name to use on the git commit. Requires --git-email. If not specified, uses the system default.")
-	flag.StringVar(&o.gitEmail, "git-email", "", "The email to use on the git commit. Requires --git-name. If not specified, uses the system default.")
-	flag.StringVar(&o.targetDir, "target-dir", "", "The directory containing the target repo.")
-	flag.StringVar(&o.assign, "assign", githubTeam, "The github username or group name to assign the created pull request to.")
-	flag.Parse()
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to actually create the pull request with github client")
+	fs.StringVar(&o.githubLogin, "github-login", githubLogin, "The GitHub username to use.")
+	fs.StringVar(&o.gitName, "git-name", "", "The name to use on the git commit. Requires --git-email. If not specified, uses the system default.")
+	fs.StringVar(&o.gitEmail, "git-email", "", "The email to use on the git commit. Requires --git-name. If not specified, uses the system default.")
+	fs.StringVar(&o.targetDir, "target-dir", "", "The directory containing the target repo.")
+	fs.StringVar(&o.assign, "assign", githubTeam, "The github username or group name to assign the created pull request to.")
+	o.AddFlagsWithoutDefaultGitHubTokenPath(fs)
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Errorf("cannot parse args: '%s'", os.Args[1:])
+	}
 	return o
 }
 
 func validateOptions(o options) error {
 	if o.githubLogin == "" {
 		return fmt.Errorf("--github-login cannot be empty string")
-	}
-	if o.githubToken == "" {
-		return fmt.Errorf("--github-token is mandatory")
 	}
 	if (o.gitEmail == "") != (o.gitName == "") {
 		return fmt.Errorf("--git-name and --git-email must be specified together")
@@ -60,7 +62,7 @@ func validateOptions(o options) error {
 	if o.assign == "" {
 		return fmt.Errorf("--assign is mandatory")
 	}
-	return nil
+	return o.GitHubOptions.Validate(o.dryRun)
 }
 
 func main() {
@@ -70,11 +72,14 @@ func main() {
 	}
 
 	sa := &secret.Agent{}
-	if err := sa.Start([]string{o.githubToken}); err != nil {
+	if err := sa.Start([]string{o.GitHubOptions.TokenPath}); err != nil {
 		logrus.WithError(err).Fatal("Failed to start secrets agent")
 	}
 
-	gc := github.NewClient(sa.GetTokenGenerator(o.githubToken), sa.Censor, github.DefaultGraphQLEndpoint, github.DefaultAPIEndpoint)
+	gc, err := o.GitHubOptions.GitHubClient(sa, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("error getting GitHub client")
+	}
 
 	logrus.Infof("Changing working directory to '%s' ...", o.targetDir)
 	if err := os.Chdir(o.targetDir); err != nil {
@@ -90,7 +95,7 @@ func main() {
 
 	remoteBranch := "autobump"
 	if err := bumper.MakeGitCommit(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin,
-		string(sa.GetTokenGenerator(o.githubToken)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, images, stdout, stderr); err != nil {
+		string(sa.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, images, stdout, stderr); err != nil {
 		logrus.WithError(err).Fatal("Failed to push changes.")
 	}
 

--- a/cmd/autoowners/README.md
+++ b/cmd/autoowners/README.md
@@ -7,14 +7,24 @@ $ ./autoowners -h
 Usage of ./autoowners:
   -assign string
         The github username or group name to assign the created pull request to. (default "openshift/openshift-team-developer-productivity-test-platform")
+  -debug-mode
+        Enable the DEBUG level of logs if true.
+  -dry-run
+        Whether to actually create the pull request with github client (default true)
   -git-email string
         The email to use on the git commit. Requires --git-name. If not specified, uses the system default.
   -git-name string
         The name to use on the git commit. Requires --git-email. If not specified, uses the system default.
+  -github-endpoint value
+        GitHub's API endpoint (may differ for enterprise). (default https://api.github.com)
+  -github-graphql-endpoint string
+        GitHub GraphQL API endpoint (may differ for enterprise). (default "https://api.github.com/graphql")
   -github-login string
         The GitHub username to use. (default "openshift-bot")
-  -github-token string
-        The path to the GitHub token file.
+  -github-token-file string
+        DEPRECATED: use -github-token-path instead.  -github-token-file may be removed anytime after 2019-01-01.
+  -github-token-path string
+        Path to the file containing the GitHub OAuth secret.
   -ignore-repo value
         The repo for which syncing OWNERS file is disabled.
   -target-dir string


### PR DESCRIPTION
Add options of github endpoints to auto-tools
    
With the option we can use ghproxy service and get metrics.
    
For the existing prwo jobs using those tools, we need to update the args accordingly.


/cc @openshift/openshift-team-developer-productivity-test-platform 