### PR TITLE
ci-op-configresolver: add fsnotify and periodic reloaders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ install:
 .PHONY: install
 
 test:
-	go test ./...
+	go test -race ./...
 .PHONY: test
 
 validate-vendor:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
 	github.com/elazarl/goproxy v0.0.0-20190711103511-473e67f1d7d2 // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2 // indirect
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getlantern/deepcopy v0.0.0-20160317154340-7f45deb8130a
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/pkg/coalescer/coalescer.go
+++ b/pkg/coalescer/coalescer.go
@@ -1,0 +1,46 @@
+package coalescer
+
+import (
+	"sync"
+)
+
+// Coalescer contains a Run function that will run a specified function.
+// If the function is already being run in a separate thread, the Coalescer
+// will simply wait until the function finishes and return nil
+type Coalescer interface {
+	Run() error
+}
+
+// NewCoalescer returns a new Coalescer with the given function set as the runFunc.
+func NewCoalescer(f func() error) Coalescer {
+	return &coalescer{runFunc: f, once: &sync.Once{}}
+}
+
+type coalescer struct {
+	sync.Mutex
+	once    *sync.Once
+	runFunc func() error
+}
+
+// Run the runFunc. If the runFunc is currently being run in another thread, wait
+// and return nil when the the other thread finishes.
+func (c *coalescer) Run() error {
+	var err error
+	var once *sync.Once
+
+	c.Lock()
+	once = c.once
+	c.Unlock()
+	once.Do(func() {
+		defer func() {
+			c.Lock()
+			c.once = &sync.Once{}
+			c.Unlock()
+		}()
+		err = c.runFunc()
+		if err != nil {
+			return
+		}
+	})
+	return err
+}

--- a/pkg/coalescer/coalescer_test.go
+++ b/pkg/coalescer/coalescer_test.go
@@ -1,0 +1,30 @@
+package coalescer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRun(t *testing.T) {
+	sharedVar := 0
+	wg := &sync.WaitGroup{}
+	c := NewCoalescer(func() error {
+		fmt.Printf("Hello\n")
+		time.Sleep(time.Millisecond * 250)
+		sharedVar++
+		return nil
+	})
+	for n := 0; n < 10; n++ {
+		wg.Add(1)
+		go func() {
+			c.Run()
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if sharedVar != 1 {
+		t.Errorf("Shared var should equal 1, but instead equals %d", sharedVar)
+	}
+}

--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -1,0 +1,161 @@
+package load
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/coalescer"
+	"github.com/openshift/ci-tools/pkg/config"
+)
+
+// ConfigAgent is an interface that can load configs from disk into
+// memory and retrieve them when provided with a config.Info.
+type ConfigAgent interface {
+	GetConfig(config.Info) (api.ReleaseBuildConfiguration, error)
+	GetGeneration() int
+}
+
+type filenameToConfig map[string]api.ReleaseBuildConfiguration
+
+type agent struct {
+	lock       *sync.RWMutex
+	configs    filenameToConfig
+	configPath string
+	cycle      time.Duration
+	generation int
+}
+
+// NewConfigAgent returns a ConfigAgent interface that automatically reloads when
+// configs are changed on disk as well as on a period specified with a time.Duration.
+func NewConfigAgent(configPath string, cycle time.Duration) (ConfigAgent, error) {
+	a := &agent{configPath: configPath, cycle: cycle, lock: &sync.RWMutex{}}
+	configCoalescer := coalescer.NewCoalescer(a.loadFilenameToConfig)
+	err := configCoalescer.Run()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load configs: %v", err)
+	}
+
+	// periodic reload
+	interrupts.TickLiteral(func() {
+		if err := configCoalescer.Run(); err != nil {
+			log.WithError(err).Error("Failed to reload configs")
+		}
+	}, a.cycle)
+
+	// fsnotify reload
+	configWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create new watcher: %v", err)
+	}
+	err = populateWatcher(configWatcher, a.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to populate watcher: %v", err)
+	}
+	interrupts.Run(func(ctx context.Context) {
+		reloadWatcher(ctx, configWatcher, configCoalescer, a.configPath)
+	})
+	return a, nil
+}
+
+func (a *agent) GetConfig(info config.Info) (api.ReleaseBuildConfiguration, error) {
+	a.lock.RLock()
+	config, ok := a.configs[info.Basename()]
+	a.lock.RUnlock()
+	if !ok {
+		return api.ReleaseBuildConfiguration{}, fmt.Errorf("Could not find config %s", info.Basename())
+	}
+	return config, nil
+}
+
+func (a *agent) GetGeneration() int {
+	var gen int
+	a.lock.RLock()
+	gen = a.generation
+	a.lock.RUnlock()
+	return gen
+}
+
+// loadFilenameToConfig generates a new filenameToConfig map.
+func (a *agent) loadFilenameToConfig() error {
+	log.Debug("Reloading configs")
+	startTime := time.Now()
+	configs := filenameToConfig{}
+	err := filepath.Walk(a.configPath, func(path string, info os.FileInfo, err error) error {
+		ext := filepath.Ext(path)
+		if info != nil && !info.IsDir() && (ext == ".yml" || ext == ".yaml") {
+			configSpec, err := Config(path)
+			if err != nil {
+				return fmt.Errorf("failed to load ci-operator config (%v)", err)
+			}
+
+			if err := configSpec.ValidateAtRuntime(); err != nil {
+				return fmt.Errorf("invalid ci-operator config: %v", err)
+			}
+			log.Debugf("Adding %s to filenameToConfig", filepath.Base(path))
+			configs[filepath.Base(path)] = *configSpec
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	a.lock.Lock()
+	a.configs = configs
+	a.generation++
+	a.lock.Unlock()
+	log.WithField("duration", time.Since(startTime)).Info("Configs reloaded")
+	return nil
+}
+
+func populateWatcher(watcher *fsnotify.Watcher, root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		// We only need to watch directories as creation, deletion, and writes
+		// for files in a directory trigger events for the directory
+		if info != nil && info.IsDir() {
+			log.Debugf("Adding %s to watch list", path)
+			err = watcher.Add(path)
+			if err != nil {
+				return fmt.Errorf("Failed to add watch on directory %s: %v", path, err)
+			}
+		}
+		return nil
+	})
+}
+
+func reloadWatcher(ctx context.Context, w *fsnotify.Watcher, c coalescer.Coalescer, path string) {
+	for {
+		select {
+		case <-ctx.Done():
+			if err := w.Close(); err != nil {
+				log.WithError(err).Error("Failed to close fsnotify watcher")
+			}
+			return
+		case event := <-w.Events:
+			log.Debugf("Received %v event for %s", event.Op, event.Name)
+			// Remove deleted files from watches
+			if event.Op == fsnotify.Remove {
+				log.Debugf("Removing %s from watches", event.Name)
+				if err := w.Remove(event.Name); err != nil {
+					log.WithError(err).Errorf("Failed to remove %s from watches", event.Name)
+				}
+			}
+			go c.Run()
+			// add new files to be watched; if a watch already exists on a file, the
+			// watch is simply updated
+			if err := populateWatcher(w, path); err != nil {
+				log.WithError(err).Error("Failed to update fsnotify watchlist")
+			}
+		case err := <-w.Errors:
+			log.WithError(err).Errorf("Received fsnotify error")
+		}
+	}
+}

--- a/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
+++ b/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    name: "4.2"
+    namespace: ocp
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.11
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: unit
+  commands: go test ./pkg/...
+  container:
+    from: src
+- as: e2e-aws
+  commands: TEST_SUITE=openshift/conformance/parallel run-tests
+  openshift_installer:
+    cluster_profile: aws

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
@@ -1,0 +1,44 @@
+{
+  "base_images": {
+    "base": {
+      "namespace": "ocp",
+      "name": "4.2",
+      "tag": "base"
+    }
+  },
+  "build_root": {
+    "image_stream_tag": {
+      "cluster": "https://api.ci.openshift.org",
+      "namespace": "openshift",
+      "name": "release",
+      "tag": "golang-1.11"
+    }
+  },
+  "tests": [
+    {
+      "as": "unit",
+      "commands": "go test ./pkg/...",
+      "container": {
+        "from": "src"
+      }
+    },
+    {
+      "as": "e2e-aws",
+      "commands": "TEST_SUITE=openshift/conformance/parallel run-tests",
+      "openshift_installer": {
+        "cluster_profile": "aws"
+      }
+    }
+  ],
+  "resources": {
+    "*": {
+      "requests": {
+        "cpu": "100m",
+        "memory": "200Mi"
+      },
+      "limits": {
+        "memory": "4Gi"
+      }
+    }
+  }
+}

--- a/test/ci-operator-configresolver-integration/run.sh
+++ b/test/ci-operator-configresolver-integration/run.sh
@@ -9,16 +9,54 @@ set -o pipefail
 
 ROOTDIR=$(pwd)
 WORKDIR="$( mktemp -d )"
-trap "rm -rf ${WORKDIR}" EXIT
+trap 'rm -rf ${WORKDIR}' EXIT
 
-cd $WORKDIR
+cd "$WORKDIR"
 # copy registry to tmpdir to allow tester to modify registry
-cp -a $ROOTDIR/test/ci-operator-configresolver-integration/ tests
-ci-operator-configresolver -config tests/configs -log-level debug &
+cp -a "$ROOTDIR"/test/ci-operator-configresolver-integration/ tests
+ci-operator-configresolver -config tests/configs -log-level debug -cycle 2m &
 PID=$!
-if ! timeout 10s bash -c 2>/dev/null -- "until diff tests/expected/openshift-installer-release-4.2.json <(curl 'http://127.0.0.1:8080/config?org=openshift&repo=installer&branch=release-4.2'); do sleep 1; done" &>/dev/null; then
-    echo "diff: $(diff -ru tests/expected/openshift-installer-release-4.2.json <(curl 'http://127.0.0.1:8080/config?org=openshift&repo=installer&branch=release-4.2'))"
+# generation should be >= 1. 0 or an error means the config function has not run yet
+for (( i = 0; i < 10; i++ )); do
+    if [[ "$(curl http://127.0.0.1:8080/generation 2>/dev/null)" -ne 0 ]]; then
+        break
+    fi
+    if [[ "${i}" -eq 10 ]]; then
+        echo "[ERROR] Timed out waiting for ci-operator-configresolver to load configuration for the first time"
+        kill $PID
+        wait $PID
+        exit 1
+    fi
+    sleep 0.5
+done
+if ! diff -Naupr tests/expected/openshift-installer-release-4.2.json <(curl 'http://127.0.0.1:8080/config?org=openshift&repo=installer&branch=release-4.2' 2>/dev/null)> "$WORKDIR/diff"; then
+    echo "diff:"
+    cat "$WORKDIR/diff"
     kill $PID
+    wait $PID
+    exit 1
+fi
+currGen=$(curl 'http://127.0.0.1:8080/generation')
+export currGen
+cp tests/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml tests/configs/release-4.2/openshift-installer-release-4.2.yaml
+for (( i = 0; i < 10; i++ )); do
+    if [[ "$(curl http://127.0.0.1:8080/generation 2>/dev/null)" -gt $currGen+1 ]]; then
+        break
+    fi
+    if [[ "${i}" -eq 10 ]]; then
+        echo "[ERROR] Timed out waiting for ci-operator-configresolver to reload configuration after file change"
+        kill $PID
+        wait $PID
+        exit 1
+    fi
+    sleep 0.5
+done
+if ! diff -Naupr tests/expected/openshift-installer-release-4.2-golang111.json <(curl 'http://127.0.0.1:8080/config?org=openshift&repo=installer&branch=release-4.2' 2>/dev/null)> "$WORKDIR/diff"; then
+    echo "diff:"
+    cat "$WORKDIR/diff"
+    kill $PID
+    wait $PID
     exit 1
 fi
 kill $PID
+wait $PID


### PR DESCRIPTION
This adds both a periodic reloader and an fs event based reloader for the ci-operator-configresolver. The fsnotify reloader uses a new `Coalescer` type that only allows one instance of the reload to run at a time. Any other instance that is started while the reload is still occuring simply waits for the existing instance to finish and then returns. This is useful because if we mount configs via a configmap, changing a single file can result in 10s of events due to the way configmap mounts work, which would result in the reloader running many times. The periodic reloader is included in case the fsnotify reloader manages to run before all the configmap mount changes are finished and makes sure that the configs being served by the resolver are eventually consistent.