### PR TITLE
Install git for the postsubmit change trigger

### DIFF
--- a/images/config-change-trigger/Dockerfile
+++ b/images/config-change-trigger/Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:7
 LABEL maintainer="skuznets@redhat.com"
 
+RUN yum install -y git && yum clean all
 ADD config-change-trigger /usr/bin/config-change-trigger
 ENTRYPOINT ["/usr/bin/config-change-trigger"]

--- a/images/pj-rehearse/Dockerfile
+++ b/images/pj-rehearse/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 LABEL maintainer="nmoraiti@redhat.com"
 
-RUN yum install -y git
+RUN yum install -y git && yum clean all
 ADD pj-rehearse /usr/bin/pj-rehearse
 ENTRYPOINT ["/usr/bin/pj-rehearse"]


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes [this](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/branch-ci-openshift-release-master-config-change-trigger/268):

```
time="2019-09-23T17:09:04Z" level=fatal msg="could not load configuration from base revision of release repo" error="failed to get SHA of current HEAD: '[git rev-parse HEAD]' failed with error=exec: \"git\": executable file not found in $PATH, output:\n" org=openshift repo=release
```