### PR TITLE
Grab base config from one commit back

### DIFF
--- a/cmd/config-change-trigger/main.go
+++ b/cmd/config-change-trigger/main.go
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	prConfig := config.GetAllConfigs(o.releaseRepoPath, logger)
-	masterConfig, err := config.GetAllConfigsFromSHA(o.releaseRepoPath, jobSpec.Refs.BaseSHA, logger)
+	masterConfig, err := config.GetAllConfigsFromSHA(o.releaseRepoPath, fmt.Sprintf("%s^1", jobSpec.Refs.BaseSHA), logger)
 	if err != nil {
 		logger.WithError(err).Fatal("could not load configuration from base revision of release repo")
 	}


### PR DESCRIPTION
When a postsubmit is triggered from a merge, `SHA^1` will refer to the
previous state of the branch before the merge, regardless of how many
commits have been merged in one action. Therefore, this is a safe way
to grab the previous state of the repository. This will work unless
someone manually pushes commits to the repository, which shouldn't
happen, so this is a reasonably resilient, albeit best-effort approach.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @dros