### PR TITLE
Fix config-brancher path in auto-config-brancher image

### DIFF
--- a/images/autoconfigbrancher/Dockerfile
+++ b/images/autoconfigbrancher/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 ADD determinize-ci-operator /usr/bin/determinize-ci-operator
-ADD config-brancher /usr/bin//go/bin/config-brancher
+ADD config-brancher /usr/bin/config-brancher
 ADD ci-operator-prowgen /usr/bin/ci-operator-prowgen
 ADD autoconfigbrancher /usr/bin/autoconfigbrancher
 


### PR DESCRIPTION
Fix
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-prow-auto-config-brancher/2#0:build-log.txt%3A5

/cc @openshift/openshift-team-developer-productivity-test-platform 