### PR TITLE
ci-operator multi-stage: add cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -486,6 +486,36 @@ const (
 	ClusterProfileVSphere                           = "vsphere"
 )
 
+func (p ClusterProfile) ClusterType() string {
+	switch p {
+	case
+		ClusterProfileAWS,
+		ClusterProfileAWSAtomic,
+		ClusterProfileAWSCentos,
+		ClusterProfileAWSCentos40,
+		ClusterProfileAWSGluster:
+		return "aws"
+	case ClusterProfileAzure4:
+		return "azure"
+	case
+		ClusterProfileGCP,
+		ClusterProfileGCP40,
+		ClusterProfileGCPHA,
+		ClusterProfileGCPCRIO,
+		ClusterProfileGCPLogging,
+		ClusterProfileGCPLoggingJournald,
+		ClusterProfileGCPLoggingJSONFile,
+		ClusterProfileGCPLoggingCRIO:
+		return "gcp"
+	case ClusterProfileOpenStack:
+		return "openstack"
+	case ClusterProfileVSphere:
+		return "vsphere"
+	default:
+		return ""
+	}
+}
+
 // ClusterTestConfiguration describes a test that provisions
 // a cluster and runs a command in it.
 type ClusterTestConfiguration struct {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -268,7 +268,7 @@ func addProfile(name string, profile api.ClusterProfile, pod *coreapi.Pod) {
 	})
 	container.Env = append(container.Env, coreapi.EnvVar{
 		Name:  "CLUSTER_TYPE",
-		Value: strings.Split(string(profile), "-")[0],
+		Value: profile.ClusterType(),
 	})
 }
 

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -73,6 +73,7 @@ func TestGeneratePods(t *testing.T) {
 		Tests: []api.TestStepConfiguration{{
 			As: "test",
 			MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
+				ClusterProfile: api.ClusterProfileAWS,
 				Test: []api.TestStep{{
 					LiteralTestStep: &api.LiteralTestStep{As: "step0", From: "image0", Commands: "command0"},
 				}, {
@@ -110,6 +111,8 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "NAMESPACE", Value: "namespace"},
 		{Name: "JOB_NAME_SAFE", Value: "test"},
 		{Name: "JOB_NAME_HASH", Value: "5e8c9"},
+		{Name: "CLUSTER_TYPE", Value: "aws"},
+		{Name: "KUBECONFIG", Value: "/var/run/secrets/ci.openshift.io/multi-stage/kubeconfig"},
 	}
 	jobSpec := api.JobSpec{
 		JobSpec: prowdapi.JobSpec{
@@ -168,6 +171,9 @@ func TestGeneratePods(t *testing.T) {
 					Name:      "secret-wrapper",
 					MountPath: "/tmp/secret-wrapper",
 				}, {
+					Name:      "cluster-profile",
+					MountPath: "/var/run/secrets/ci.openshift.io/cluster-profile",
+				}, {
 					Name:      "test",
 					MountPath: "/var/run/secrets/ci.openshift.io/multi-stage",
 				}},
@@ -176,6 +182,13 @@ func TestGeneratePods(t *testing.T) {
 				Name: "secret-wrapper",
 				VolumeSource: coreapi.VolumeSource{
 					EmptyDir: &coreapi.EmptyDirVolumeSource{},
+				},
+			}, {
+				Name: "cluster-profile",
+				VolumeSource: coreapi.VolumeSource{
+					Secret: &coreapi.SecretVolumeSource{
+						SecretName: "test-cluster-profile",
+					},
 				},
 			}, {
 				Name: "test",
@@ -223,6 +236,9 @@ func TestGeneratePods(t *testing.T) {
 					Name:      "secret-wrapper",
 					MountPath: "/tmp/secret-wrapper",
 				}, {
+					Name:      "cluster-profile",
+					MountPath: "/var/run/secrets/ci.openshift.io/cluster-profile",
+				}, {
 					Name:      "artifacts",
 					MountPath: "/artifact/dir",
 				}, {
@@ -258,6 +274,13 @@ done
 				Name: "secret-wrapper",
 				VolumeSource: coreapi.VolumeSource{
 					EmptyDir: &coreapi.EmptyDirVolumeSource{},
+				},
+			}, {
+				Name: "cluster-profile",
+				VolumeSource: coreapi.VolumeSource{
+					Secret: &coreapi.SecretVolumeSource{
+						SecretName: "test-cluster-profile",
+					},
 				},
 			}, {
 				Name: "artifacts",


### PR DESCRIPTION
When the test has a non-empty profile:
- check that a secret with a pre-defined name exists
- mount the contents of that secret in every pod
- assume a `kubeconfig` key will be added to the test's secret and set
  `$KUBECONFIG` to point to it in every pod