### PR TITLE
ci-operator: check for permission to create events

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -23,11 +23,13 @@ import (
 
 	"github.com/golang/glog"
 
+	authapi "k8s.io/api/authorization/v1"
 	coreapi "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	authclientset "k8s.io/client-go/kubernetes/typed/authorization/v1"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacclientset "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
@@ -453,7 +455,17 @@ func (o *options) Run() error {
 		if err != nil {
 			return fmt.Errorf("could not get core client for cluster config: %v", err)
 		}
-		eventRecorder := eventRecorder(client, o.namespace, o.dry)
+		var authClient *authclientset.AuthorizationV1Client
+		if !o.dry {
+			authClient, err = authclientset.NewForConfig(o.clusterConfig)
+			if err != nil {
+				return fmt.Errorf("could not get auth client for cluster config: %v", err)
+			}
+		}
+		eventRecorder, err := eventRecorder(client, authClient, o.namespace, o.dry)
+		if err != nil {
+			return fmt.Errorf("could not create event recorder: %v", err)
+		}
 		runtimeObject := &coreapi.ObjectReference{Namespace: o.namespace}
 		eventRecorder.Event(runtimeObject, coreapi.EventTypeNormal, "CiJobStarted", eventJobDescription(o.jobSpec, o.namespace))
 		// execute the graph
@@ -1194,15 +1206,31 @@ func summarizeRef(refs prowapi.Refs) string {
 	return fmt.Sprintf("Resolved source https://github.com/%s/%s to %s@%s", refs.Org, refs.Repo, refs.BaseRef, shorten(refs.BaseSHA, 8))
 }
 
-func eventRecorder(kubeClient *coreclientset.CoreV1Client, namespace string, dry bool) record.EventRecorder {
+func eventRecorder(kubeClient *coreclientset.CoreV1Client, authClient *authclientset.AuthorizationV1Client, namespace string, dry bool) (record.EventRecorder, error) {
 	if dry {
+		return &record.FakeRecorder{}, nil
+	}
+	res, err := authClient.SelfSubjectAccessReviews().Create(&authapi.SelfSubjectAccessReview{
+		Spec: authapi.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authapi.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "create",
+				Resource:  "events",
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not check permission to create events: %v", err)
+	}
+	if !res.Status.Allowed {
+		log.Println("warning: Events will not be created because of lack of permission")
 		return &record.FakeRecorder{}, nil
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&coreclientset.EventSinkImpl{
 		Interface: coreclientset.New(kubeClient.RESTClient()).Events("")})
 	return eventBroadcaster.NewRecorder(
-		templatescheme.Scheme, coreapi.EventSource{Component: namespace})
+		templatescheme.Scheme, coreapi.EventSource{Component: namespace}), nil
 }
 
 func getSSHSecretFromPath(sshKeyPath string) (*coreapi.Secret, error) {


### PR DESCRIPTION
A minor change, but it annoys me deeply (and I remember at least one case where
users were confused because of it).

When creating an EventRecorder, first check if we have permission to create
events and use a FakeRecorder if we don't.  An added benefit is being able to
use the FakeRecorder in dry-run mode and removing some code from conditionals.

<details>
  <summary>before (much worse with line wrapping)</summary>

```
2019/10/01 16:44:34 Resolved source https://github.com/openshift/ci-tools to master@1b0baff4
2019/10/01 16:44:35 Resolved openshift/release:golang-1.11 to sha256:580a279c3f0e29cded68868db9a2bdb9abe86227537cfea8d26f237386053f49
2019/10/01 16:44:35 Resolved openshift/release:golang-1.11 to sha256:580a279c3f0e29cded68868db9a2bdb9abe86227537cfea8d26f237386053f49
2019/10/01 16:44:35 Resolved openshift/hive-v4.0:hive to sha256:00670a701d717309722468f930f641ca3044b47347c62075181ce1219b3074d8
2019/10/01 16:44:36 Resolved openshift/centos:7 to sha256:a36b9e68613d07eec4ef553da84d0012a5ca5ae4a830cf825bb68b929475c869
2019/10/01 16:44:36 Using namespace bbguimaraes
2019/10/01 16:44:36 Running [input:root], src, bin, unit
2019/10/01 16:44:36 Creating namespace bbguimaraes
2019/10/01 16:44:36 Setting a soft TTL of 1h0m0s for the namespace
2019/10/01 16:44:36 Setting a hard TTL of 12h0m0s for the namespace
2019/10/01 16:44:36 warning: Could not add annotations because you do not have permission to update the namespace (details: namespaces "bbguimaraes" is forbidden: User "bbguimaraes" cannot update namespaces in the namespace "bbguimaraes": no RBAC policy matched)
2019/10/01 16:44:36 Setting up pipeline imagestream for the test
2019/10/01 16:44:37 Tagging openshift/release:golang-1.11 into pipeline:root
E1001 16:44:37.563728    3986 event.go:191] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:".15c993a3eb0cb62a", GenerateName:"", Namespace:"bbguimaraes", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"", Namespace:"bbguimaraes", Name:"", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}, Reason:"CiJobStarted", Message: "Running job branch-ci-openshift-ci-tools-master-e2e for PRs () in namespace bbguimaraes from authors ()", Source:v1.EventSource{Component:"bbguimaraes", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbf5cfe7d54ba642a, ext:2958871408, loc:(*time.Location)(0x2a07080)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbf5cfe7d54ba642a, ext:2958871408, loc:(*time.Location)(0x2a07080)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "bbguimaraes" cannot create events in the namespace "bbguimaraes": no RBAC policy matched' (will not retry!)
2019/10/01 16:44:37 Building src
2019/10/01 16:44:38 Build src already succeeded in 1m26s
2019/10/01 16:44:38 Building bin
2019/10/01 16:44:39 Build bin already succeeded in 1m9s
2019/10/01 16:44:39 Creating multi-stage test secret "unit"
2019/10/01 16:44:40 Executing "unit-pre"
2019/10/01 16:44:46 Container cp-secret-wrapper in pod unit-pre completed successfully
2019/10/01 16:45:30 Container pre in pod unit-pre completed successfully
2019/10/01 16:45:30 Pod unit-pre succeeded after 47s
2019/10/01 16:45:34 Executing "unit-unit"
2019/10/01 16:45:38 Container cp-secret-wrapper in pod unit-unit completed successfully
2019/10/01 16:46:00 Container unit in pod unit-unit completed successfully
2019/10/01 16:46:00 Pod unit-unit succeeded after 24s
E1001 16:46:04.379229    3986 event.go:191] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:".15c993b827413f31", GenerateName:"", Namespace:"bbguimaraes", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"", Namespace:"bbguimaraes", Name:"", UID:"", APIVersion:"", ResourceVersion:"", FieldPath:""}, Reason:"CiJobSucceeded", Message:"Running job branch-ci-openshift-ci-tools-master-e2e for PRs () in namespace bbguimaraes from authors ()", Source:v1.EventSource{Component:"bbguimaraes", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0xbf5cfe930f544731, ext:89868293234, loc:(*time.Location)(0x2a07080)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xbf5cfe930f544731, ext:89868293234, loc:(*time.Location)(0x2a07080)}}, Count:1, Type:"Normal", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events is forbidden: User "bbguimaraes" cannot create events in the namespace "bbguimaraes": no RBAC policy matched' (will not retry!)
2019/10/01 16:46:05 Ran for 1m30s
```

</details>

<details>
  <summary>after</summary>

```
2019/10/01 16:39:34 Resolved source https://github.com/openshift/ci-tools to master@1b0baff4
2019/10/01 16:39:35 Resolved openshift/release:golang-1.11 to sha256:580a279c3f0e29cded68868db9a2bdb9abe86227537cfea8d26f237386053f49
2019/10/01 16:39:35 Resolved openshift/centos:7 to sha256:a36b9e68613d07eec4ef553da84d0012a5ca5ae4a830cf825bb68b929475c869
2019/10/01 16:39:36 Resolved openshift/release:golang-1.11 to sha256:580a279c3f0e29cded68868db9a2bdb9abe86227537cfea8d26f237386053f49
2019/10/01 16:39:36 Resolved openshift/hive-v4.0:hive to sha256:00670a701d717309722468f930f641ca3044b47347c62075181ce1219b3074d8
2019/10/01 16:39:36 Using namespace bbguimaraes
2019/10/01 16:39:36 Running [input:root], src, bin, unit
2019/10/01 16:39:36 Creating namespace bbguimaraes
2019/10/01 16:39:36 Setting a soft TTL of 1h0m0s for the namespace
2019/10/01 16:39:36 Setting a hard TTL of 12h0m0s for the namespace
2019/10/01 16:39:36 warning: Could not add annotations because you do not have permission to update the namespace (details: namespaces "bbguimaraes" is forbidden: User "bbguimaraes" cannot update namespaces in the namespace "bbguimaraes": no RBAC policy matched)
2019/10/01 16:39:36 Setting up pipeline imagestream for the test
2019/10/01 16:39:37 warning: Events will not be created because of lack of permission
2019/10/01 16:39:37 Tagging openshift/release:golang-1.11 into pipeline:root
2019/10/01 16:39:37 Building src
2019/10/01 16:39:38 Build src already succeeded in 1m26s
2019/10/01 16:39:38 Building bin
2019/10/01 16:39:39 Build bin already succeeded in 1m9s
2019/10/01 16:39:39 Creating multi-stage test secret "unit"
2019/10/01 16:39:40 Executing "unit-pre"
2019/10/01 16:39:47 Container cp-secret-wrapper in pod unit-pre completed successfully
2019/10/01 16:41:02 Container pre in pod unit-pre completed successfully
2019/10/01 16:41:02 Pod unit-pre succeeded after 1m20s
2019/10/01 16:41:06 Executing "unit-unit"
2019/10/01 16:41:12 Container cp-secret-wrapper in pod unit-unit completed successfully
2019/10/01 16:41:41 Container unit in pod unit-unit completed successfully
2019/10/01 16:41:41 Pod unit-unit succeeded after 34s
2019/10/01 16:41:45 Ran for 2m11s
```

</details>