### PR TITLE
testgrid-config-generator: Support more informing jobs

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "k8s.io/test-infra/prow/config"
 )

--- a/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
+++ b/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
@@ -1,0 +1,18 @@
+periodics:
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    ci.openshift.io/release-type: informing
+    job-release: "4.2"
+  name: job-with-labels
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    ci.openshift.io/release-type: informing
+  name: job-without-release
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: job-without-informing

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -11,6 +11,25 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
+    name: job-with-labels
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: job-with-labels
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
     name: release-openshift-ocp-installer-e2e-aws-optional-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -21,5 +40,7 @@ dashboards:
     test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
   name: redhat-openshift-ocp-release-4.2-informing
 test_groups:
+- gcs_prefix: origin-ci-test/logs/job-with-labels
+  name: job-with-labels
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
   name: release-openshift-ocp-installer-e2e-aws-optional-4.2

--- a/test/testgrid-config-generator/expected/redhat-openshift-okd-release-4.2-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-okd-release-4.2-informing.yaml
@@ -11,6 +11,25 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
+    name: job-with-labels
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: job-with-labels
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
     name: release-openshift-origin-installer-e2e-aws-optional-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -21,5 +40,7 @@ dashboards:
     test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.2
   name: redhat-openshift-okd-release-4.2-informing
 test_groups:
+- gcs_prefix: origin-ci-test/logs/job-with-labels
+  name: job-with-labels
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
   name: release-openshift-origin-installer-e2e-aws-optional-4.2

--- a/test/testgrid-config-generator/run.sh
+++ b/test/testgrid-config-generator/run.sh
@@ -8,9 +8,11 @@ set -o nounset
 set -o pipefail
 
 workdir="$( mktemp -d )"
-trap 'rm -rf "${workdir}"' EXIT
+echo $workdir
+#trap 'rm -rf "${workdir}"' EXIT
 
 data_dir="$( dirname "${BASH_SOURCE[0]}" )"
+input_jobs_dir="${data_dir}/config/jobs"
 input_release_dir="${data_dir}/config/release"
 input_testgrid_dir="${data_dir}/config/testgrid"
 generated_output_config_dir="${workdir}/testgrid"
@@ -19,7 +21,7 @@ expected_output_config_dir="${data_dir}/expected"
 cp -r "${input_testgrid_dir}" "${workdir}"
 
 echo "[INFO] Generating TestGrid config..."
-testgrid-config-generator --release-config "${input_release_dir}" --testgrid-config "${generated_output_config_dir}"
+testgrid-config-generator --release-config "${input_release_dir}" --testgrid-config "${generated_output_config_dir}" --prow-jobs-dir "${input_jobs_dir}"
 
 echo "[INFO] Validating generated TestGrid config..."
 if ! diff -Naupr "${expected_output_config_dir}" "${generated_output_config_dir}"> "${workdir}/diff"; then


### PR DESCRIPTION
The doc for release informing jobs didn't make it clear that
we allow jobs from periodics that aren't part of release config.

Add support to the generator to read periodics that have the label
`ci.openshift.io/release-type=informing` and add them to dashboards
based on the existing `job-release` label (already in use by other
components like ci-chat-bot and release-controller). These become
part of the appropriate informing dashboard.