### PR TITLE
Collapse job configuration configmaps for master branch

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -53,10 +53,6 @@ func (i *Info) ConfigMapName() string {
 	if i.Type == "periodics" && i.Branch == "" {
 		return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(""))
 	}
-	// job-config shards for master are already too big, shard them further by type
-	if i.Branch == "master" {
-		return fmt.Sprintf("job-config-%s-%s", promotion.FlavorForBranch(i.Branch), i.Type)
-	}
 	return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(i.Branch))
 }
 

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -644,16 +644,16 @@ func TestInfo_ConfigMapName(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "master branch goes to master configmap further sharded by type: presubmits",
+			name:     "master branch goes to master configmap",
 			branch:   "master",
 			jobType:  "presubmits",
-			expected: "job-config-master-presubmits",
+			expected: "job-config-master",
 		},
 		{
-			name:     "master branch goes to master configmap further sharded by type: postsubmits",
+			name:     "master branch goes to master configmap",
 			branch:   "master",
 			jobType:  "postsubmits",
-			expected: "job-config-master-postsubmits",
+			expected: "job-config-master",
 		},
 		{
 			name:     "periodic without relationship to a repo goes to misc",
@@ -662,10 +662,10 @@ func TestInfo_ConfigMapName(t *testing.T) {
 			expected: "job-config-misc",
 		},
 		{
-			name:     "periodic with relationship to a repo master branch goes to type shard",
+			name:     "periodic with relationship to a repo master branch goes to branch shard",
 			branch:   "master",
 			jobType:  "periodics",
-			expected: "job-config-master-periodics",
+			expected: "job-config-master",
 		},
 		{
 			name:     "periodic with relationship to a repo branch goes to branch shard",


### PR DESCRIPTION
Now that we zip all of our files, space constraints are not relevant any
longer and we can just shard simply by branch.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @hongkailiu 