### PR TITLE
testgrid-config-generator: Correct some faulty assumptions

### DIFF
--- a/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
+++ b/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
@@ -5,14 +5,21 @@ periodics:
   labels:
     ci.openshift.io/release-type: informing
     job-release: "4.2"
-  name: job-with-labels
+  name: release-openshift-origin-job
 - agent: kubernetes
   decorate: true
   interval: 12h
   labels:
     ci.openshift.io/release-type: informing
-  name: job-without-release
+  name: release-openshift-origin-job-without-release-label
 - agent: kubernetes
   decorate: true
   interval: 12h
-  name: job-without-informing
+  name: release-openshift-origin-job-without-informing
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    ci.openshift.io/release-type: informing
+    job-release: "4.2"
+  name: release-openshift-ocp-job

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: job-with-labels
+    name: release-openshift-ocp-installer-e2e-aws-optional-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: job-with-labels
+    test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+    name: release-openshift-ocp-job
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+    test_group_name: release-openshift-ocp-job
   name: redhat-openshift-ocp-release-4.2-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/job-with-labels
-  name: job-with-labels
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
   name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
+  name: release-openshift-ocp-job

--- a/test/testgrid-config-generator/expected/redhat-openshift-okd-release-4.2-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-okd-release-4.2-informing.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: job-with-labels
+    name: release-openshift-origin-installer-e2e-aws-optional-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: job-with-labels
+    test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-optional-4.2
+    name: release-openshift-origin-job
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.2
+    test_group_name: release-openshift-origin-job
   name: redhat-openshift-okd-release-4.2-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/job-with-labels
-  name: job-with-labels
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
   name: release-openshift-origin-installer-e2e-aws-optional-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
+  name: release-openshift-origin-job

--- a/test/testgrid-config-generator/run.sh
+++ b/test/testgrid-config-generator/run.sh
@@ -8,8 +8,7 @@ set -o nounset
 set -o pipefail
 
 workdir="$( mktemp -d )"
-echo $workdir
-#trap 'rm -rf "${workdir}"' EXIT
+trap 'rm -rf "${workdir}"' EXIT
 
 data_dir="$( dirname "${BASH_SOURCE[0]}" )"
 input_jobs_dir="${data_dir}/config/jobs"
@@ -22,6 +21,12 @@ cp -r "${input_testgrid_dir}" "${workdir}"
 
 echo "[INFO] Generating TestGrid config..."
 testgrid-config-generator --release-config "${input_release_dir}" --testgrid-config "${generated_output_config_dir}" --prow-jobs-dir "${input_jobs_dir}"
+
+if [[ -n "${UPDATE_EXPECTED-}" ]]; then
+  cp "${generated_output_config_dir}"/* "${expected_output_config_dir}"
+  echo "[INFO] Updated"
+  exit 0
+fi
 
 echo "[INFO] Validating generated TestGrid config..."
 if ! diff -Naupr "${expected_output_config_dir}" "${generated_output_config_dir}"> "${workdir}/diff"; then


### PR DESCRIPTION
The publish steps inside the release config are not good indicators of ocp or okd. Instead, the naming conventions chosen by the release should be used.  `-openshift-origin-` means `okd` in a job, and `X.Y.Z-0.ci` for release name also means `okd`.  The okd release streams are downstream of CI and can be ignored for now.

Fix a bug where the periodics were added to both dashboards by checking for the correct convention. Also revert the run.sh script to be correct and add a generate mode.

/assign @stevekuznetsov