### PR TITLE
Revert "Collapse job configuration configmaps for master branch"

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -53,6 +53,10 @@ func (i *Info) ConfigMapName() string {
 	if i.Type == "periodics" && i.Branch == "" {
 		return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(""))
 	}
+	// job-config shards for master are already too big, shard them further by type
+	if i.Branch == "master" {
+		return fmt.Sprintf("job-config-%s-%s", promotion.FlavorForBranch(i.Branch), i.Type)
+	}
 	return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(i.Branch))
 }
 

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -644,16 +644,16 @@ func TestInfo_ConfigMapName(t *testing.T) {
 		expected string
 	}{
 		{
-			name:     "master branch goes to master configmap",
+			name:     "master branch goes to master configmap further sharded by type: presubmits",
 			branch:   "master",
 			jobType:  "presubmits",
-			expected: "job-config-master",
+			expected: "job-config-master-presubmits",
 		},
 		{
-			name:     "master branch goes to master configmap",
+			name:     "master branch goes to master configmap further sharded by type: postsubmits",
 			branch:   "master",
 			jobType:  "postsubmits",
-			expected: "job-config-master",
+			expected: "job-config-master-postsubmits",
 		},
 		{
 			name:     "periodic without relationship to a repo goes to misc",
@@ -662,10 +662,10 @@ func TestInfo_ConfigMapName(t *testing.T) {
 			expected: "job-config-misc",
 		},
 		{
-			name:     "periodic with relationship to a repo master branch goes to branch shard",
+			name:     "periodic with relationship to a repo master branch goes to type shard",
 			branch:   "master",
 			jobType:  "periodics",
-			expected: "job-config-master",
+			expected: "job-config-master-periodics",
 		},
 		{
 			name:     "periodic with relationship to a repo branch goes to branch shard",


### PR DESCRIPTION
Reverts openshift/ci-tools#192

The collapsed shard does not exist so the Prow components cannot use it yet. We need to do some preparation before we can merge this PR.