### PR TITLE
Fix failures when no update of image is made

### DIFF
--- a/cmd/autobumper/main.go
+++ b/cmd/autobumper/main.go
@@ -90,6 +90,11 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to update references.")
 	}
 
+	if len(images) == 0 {
+		logrus.Info("no images updated, exiting ...")
+		return
+	}
+
 	stdout := bumper.HideSecretsWriter{Delegate: os.Stdout, Censor: sa}
 	stderr := bumper.HideSecretsWriter{Delegate: os.Stderr, Censor: sa}
 


### PR DESCRIPTION
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-prow-image-autobump/64

/cc @openshift/openshift-team-developer-productivity-test-platform 