### PR TITLE
ci-operator-configresolver: improve metrics buckets

### DIFF
--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -40,7 +40,7 @@ var reloadTimeMetric = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Name:    "configresolver_config_reload_duration_seconds",
 		Help:    "config reload duration in seconds",
-		Buckets: []float64{0.0005, 0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1},
+		Buckets: []float64{0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3},
 	},
 )
 


### PR DESCRIPTION
This PR improves some of the metrics based on some initial findings when running  the configresolver on the CI cluster.

Request Duration: It seems that most if not all requests were finishing under 0.005 seconds in some initial testing, so I've shrunk the duration sizes by 10x.

Request Size: The request size can be anywhere from a couple of bytes for errors up to ~7.5KB for the largest ci-operator config. The request size metric has been updated to better reflect that.

Config Reload Duration: In the cluster with the configs from master and 4.1-4.4, this seemed to range between ~750ms and 2.5s. The metrics buckets now reflect that.

I've also added a generic handler, so if we get 404s triggered by incorrect paths, those get logged as well.