### PR TITLE
pkg/load/configAgent.go: don't call fsnotify.Remove on REMOVE event

### DIFF
--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -164,14 +164,6 @@ func reloadWatcher(ctx context.Context, w *fsnotify.Watcher, a *agent, c coalesc
 			return
 		case event := <-w.Events:
 			log.Debugf("Received %v event for %s", event.Op, event.Name)
-			// Remove deleted files from watches
-			if event.Op == fsnotify.Remove {
-				log.Debugf("Removing %s from watches", event.Name)
-				if err := w.Remove(event.Name); err != nil {
-					a.recordError("failed to remove item from watcher")
-					log.WithError(err).Errorf("Failed to remove %s from watches", event.Name)
-				}
-			}
 			go c.Run()
 			// add new files to be watched; if a watch already exists on a file, the
 			// watch is simply updated


### PR DESCRIPTION
This piece of code was intended to keep internal state for fsnotify clean/consistent, but it looks like that is automatically handled by fsnotify when a REMOVE event is received, and this just triggers a lot of errors.