### PR TITLE
prowgen: add configresolver flags to ci-tools repo

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
@@ -189,6 +189,18 @@ func generateCiOperatorPodSpec(info *config.Info, secret *cioperatorapi.Secret, 
 	}, additionalArgs...)
 	if secret != nil {
 		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--secret-dir=%s", secret.MountPath))
+	}
+	// temporary hack until we are 100% sure the flags won't break anything
+	// TODO: add these flags to all ci-operator podspecs
+	if info.Repo == "ci-tools" {
+		ret.Containers[0].Args = append(ret.Containers[0].Args,
+			"--resolver-address=http://ci-operator-configresolver",
+			fmt.Sprintf("--org=%s", info.Org),
+			fmt.Sprintf("--repo=%s", info.Repo),
+			fmt.Sprintf("--branch=%s", info.Branch))
+		if len(info.Variant) > 0 {
+			ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--variant=%s", info.Variant))
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
This PR adds the `ci-operator-configresolver` flags to `prowgen` job generation. Before rolling out the new configresolver flags to all jobs, we will only add the flags to this repo's jobs to make sure we don't break everything.