### PR TITLE
configresolver: improve metrics buckets and change logging

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -70,7 +70,7 @@ var (
 			prometheus.HistogramOpts{
 				Name:    "configresolver_http_response_size_bytes",
 				Help:    "http response size in bytes",
-				Buckets: []float64{256, 512, 1024, 2048, 4096, 6144, 8192},
+				Buckets: []float64{256, 512, 1024, 2048, 4096, 6144, 8192, 10240, 12288},
 			},
 			[]string{"status", "path"},
 		),

--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -40,7 +40,7 @@ var reloadTimeMetric = prometheus.NewHistogram(
 	prometheus.HistogramOpts{
 		Name:    "configresolver_config_reload_duration_seconds",
 		Help:    "config reload duration in seconds",
-		Buckets: []float64{0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3},
+		Buckets: []float64{0.5, 0.75, 1, 1.25, 1.5, 2, 2.5, 3, 4, 5, 6},
 	},
 )
 
@@ -121,7 +121,7 @@ func (a *agent) loadFilenameToConfig() error {
 				a.recordError("invalid ci-operator config")
 				return fmt.Errorf("invalid ci-operator config: %v", err)
 			}
-			//log.Debugf("Adding %s to filenameToConfig", filepath.Base(path))
+			log.Tracef("Adding %s to filenameToConfig", filepath.Base(path))
 			configs[filepath.Base(path)] = *configSpec
 		}
 		return nil
@@ -144,7 +144,7 @@ func populateWatcher(watcher *fsnotify.Watcher, root string) error {
 		// We only need to watch directories as creation, deletion, and writes
 		// for files in a directory trigger events for the directory
 		if info != nil && info.IsDir() {
-			//log.Debugf("Adding %s to watch list", path)
+			log.Tracef("Adding %s to watch list", path)
 			err = watcher.Add(path)
 			if err != nil {
 				return fmt.Errorf("Failed to add watch on directory %s: %v", path, err)
@@ -163,7 +163,7 @@ func reloadWatcher(ctx context.Context, w *fsnotify.Watcher, a *agent, c coalesc
 			}
 			return
 		case event := <-w.Events:
-			log.Debugf("Received %v event for %s", event.Op, event.Name)
+			log.Tracef("Received %v event for %s", event.Op, event.Name)
 			go c.Run()
 			// add new files to be watched; if a watch already exists on a file, the
 			// watch is simply updated


### PR DESCRIPTION
This expands the bucket sizes for response size (previous buckets were based off of YAML config sizes, not JSON which is larger; the largest JSON response with current configs is 10471 bytes) and adds more levels for configresolver reload times, as the 0.95 and 0.99 quantile times pushed up against the upper 3 second bucket quite a lot.

This also changes some debug statements that could generate 100s of MB per hour to trace statements instead, as they are overly verbose for most debugging purposes.