### PR TITLE
testgrid-config-generator: Update naming and dashboard ordering

### DIFF
--- a/test/testgrid-config-generator/expected/groups.yaml
+++ b/test/testgrid-config-generator/expected/groups.yaml
@@ -1,10 +1,11 @@
 dashboard_groups:
 - dashboard_names:
   - other
-  - redhat-openshift-ocp-release-4.2-blocking
-  - redhat-openshift-ocp-release-4.2-informing
-  - redhat-openshift-okd-release-4.1-blocking
-  - redhat-openshift-okd-release-4.1-informing
-  - redhat-openshift-okd-release-4.2-blocking
-  - redhat-openshift-okd-release-4.2-informing
+  - redhat-openshift-informing
+  - redhat-openshift-release-4.1-blocking-ci
+  - redhat-openshift-release-4.1-informing-ci
+  - redhat-openshift-release-4.2-blocking-ci
+  - redhat-openshift-release-4.2-blocking-ocp
+  - redhat-openshift-release-4.2-informing-ci
+  - redhat-openshift-release-4.2-informing-ocp
   name: redhat

--- a/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
@@ -11,15 +11,15 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-optional-4.1
+    name: release-openshift-origin-installer-e2e-aws-upgrade
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.1
-  name: redhat-openshift-okd-release-4.1-informing
+    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade
+  name: redhat-openshift-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.1
-  name: release-openshift-origin-installer-e2e-aws-optional-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade
+  name: release-openshift-origin-installer-e2e-aws-upgrade

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-blocking-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-blocking-ci.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+    name: release-openshift-origin-installer-e2e-aws-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.1
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-job
+    name: release-openshift-origin-installer-e2e-aws-serial-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-job
-  name: redhat-openshift-ocp-release-4.2-informing
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
+  name: redhat-openshift-release-4.1-blocking-ci
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
-  name: release-openshift-ocp-installer-e2e-aws-optional-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
-  name: release-openshift-ocp-job
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
+  name: release-openshift-origin-installer-e2e-aws-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
+  name: release-openshift-origin-installer-e2e-aws-serial-4.1

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-informing-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-informing-ci.yaml
@@ -1,0 +1,25 @@
+dashboards:
+- dashboard_tab:
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-origin-installer-e2e-aws-optional-4.1
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.1
+  name: redhat-openshift-release-4.1-informing-ci
+test_groups:
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.1
+  name: release-openshift-origin-installer-e2e-aws-optional-4.1

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ci.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-4.2
+    name: release-openshift-origin-installer-e2e-aws-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+    name: release-openshift-origin-installer-e2e-aws-serial-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-  name: redhat-openshift-ocp-release-4.2-blocking
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
+  name: redhat-openshift-release-4.2-blocking-ci
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
-  name: release-openshift-ocp-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
-  name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
+  name: release-openshift-origin-installer-e2e-aws-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
+  name: release-openshift-origin-installer-e2e-aws-serial-4.2

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ocp.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ocp.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-4.1
+    name: release-openshift-ocp-installer-e2e-aws-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-4.1
+    test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-serial-4.1
+    name: release-openshift-ocp-installer-e2e-aws-serial-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
-  name: redhat-openshift-okd-release-4.1-blocking
+    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+  name: redhat-openshift-release-4.2-blocking-ocp
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
-  name: release-openshift-origin-installer-e2e-aws-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
-  name: release-openshift-origin-installer-e2e-aws-serial-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
+  name: release-openshift-ocp-installer-e2e-aws-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
+  name: release-openshift-ocp-installer-e2e-aws-serial-4.2

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ci.yaml
@@ -19,28 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.2
-  - base_options: width=10
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-job
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-job
-  name: redhat-openshift-okd-release-4.2-informing
+  name: redhat-openshift-release-4.2-informing-ci
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
   name: release-openshift-origin-installer-e2e-aws-optional-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
-  name: release-openshift-origin-job

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ocp.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ocp.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-4.2
+    name: release-openshift-ocp-installer-e2e-aws-optional-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-4.2
+    test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,38 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-serial-4.2
+    name: release-openshift-ocp-job
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
-  name: redhat-openshift-okd-release-4.2-blocking
+    test_group_name: release-openshift-ocp-job
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-origin-job
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-job
+  name: redhat-openshift-release-4.2-informing-ocp
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
-  name: release-openshift-origin-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
-  name: release-openshift-origin-installer-e2e-aws-serial-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
+  name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
+  name: release-openshift-ocp-job
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
+  name: release-openshift-origin-job


### PR DESCRIPTION
Add a new generic informing dashboard for openshift to cover jobs
that fall outside the release spectrum but are still relevant.

Restructure the naming so that we use 'ci' instead of 'okd' (which
was not accurate), and also leave fixes for when we correct the
job naming in prow.

Finally, order the naming so that it is product-release-type-source
and so that the OCP and CI tabs are next to each other - CI is a
leading indicator for OCP, not a separate product.