### PR TITLE
pj-rehearse: remove configresolver flags from rehearsals

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -61,6 +61,8 @@ func Config(path string, info *ResolverInfo) (*api.ReleaseBuildConfiguration, er
 			return configSpec, nil
 		}
 		log.Print("Config from configresolver matches standard config")
+	} else {
+		log.Print("Config resolver info not provided; using env var or file instead")
 	}
 	return configSpec, nil
 }


### PR DESCRIPTION
~~Add a flag to `ci-operator` to enable a "rehearse" mode, which simply disables use of the configresolver by preventing the creation of the `load.ResolverInfo` that `load.Config()` uses for the configresolver.~~

~~`pj-rehearse` has been updated to make use of this as well, adding the `--rehearse` flag to all rehearsal jobs that use the `ci-operator` command.~~

The way this is handled has been redone. Now `pj-rehearse` looks at the `Args` for all rehearsal jobs that use the `ci-operator` commands and removes all configresolver configuration args.