### PR TITLE
ci-operator-prowgen: enable configresolver for all jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -186,21 +186,16 @@ func generateCiOperatorPodSpec(info *config.Info, secret *cioperatorapi.Secret, 
 		"--artifact-dir=$(ARTIFACTS)",
 		fmt.Sprintf("--target=%s", target),
 		fmt.Sprintf("--sentry-dsn-path=%s", sentryDsnSecretPath),
+		"--resolver-address=http://ci-operator-configresolver",
+		fmt.Sprintf("--org=%s", info.Org),
+		fmt.Sprintf("--repo=%s", info.Repo),
+		fmt.Sprintf("--branch=%s", info.Branch),
 	}, additionalArgs...)
 	if secret != nil {
 		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--secret-dir=%s", secret.MountPath))
 	}
-	// temporary hack until we are 100% sure the flags won't break anything
-	// TODO: add these flags to all ci-operator podspecs
-	if info.Repo == "ci-tools" {
-		ret.Containers[0].Args = append(ret.Containers[0].Args,
-			"--resolver-address=http://ci-operator-configresolver",
-			fmt.Sprintf("--org=%s", info.Org),
-			fmt.Sprintf("--repo=%s", info.Repo),
-			fmt.Sprintf("--branch=%s", info.Branch))
-		if len(info.Variant) > 0 {
-			ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--variant=%s", info.Variant))
-		}
+	if len(info.Variant) > 0 {
+		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--variant=%s", info.Variant))
 	}
 	return ret
 }

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -51,6 +51,10 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--artifact-dir=$(ARTIFACTS)",
 						"--target=target",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver",
+						"--org=org",
+						"--repo=repo",
+						"--branch=branch",
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
@@ -93,6 +97,10 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--artifact-dir=$(ARTIFACTS)",
 						"--target=target",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver",
+						"--org=org",
+						"--repo=repo",
+						"--branch=branch",
 						"--promote",
 						"--some=thing",
 					},
@@ -137,6 +145,10 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--artifact-dir=$(ARTIFACTS)",
 						"--target=target",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver",
+						"--org=org",
+						"--repo=repo",
+						"--branch=branch",
 						"--promote",
 						"--some=thing",
 						fmt.Sprintf("--secret-dir=%s", testSecret.MountPath),
@@ -262,6 +274,10 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--artifact-dir=$(ARTIFACTS)",
 						"--target=test",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver",
+						"--org=organization",
+						"--repo=repo",
+						"--branch=branch",
 						"--secret-dir=/usr/local/test-cluster-profile",
 						"--template=/usr/local/test"},
 					Resources: kubeapi.ResourceRequirements{
@@ -348,6 +364,10 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--artifact-dir=$(ARTIFACTS)",
 						"--target=test",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver",
+						"--org=organization",
+						"--repo=repo",
+						"--branch=branch",
 						"--secret-dir=/usr/local/test-cluster-profile",
 						"--template=/usr/local/test"},
 					Resources: kubeapi.ResourceRequirements{
@@ -919,8 +939,12 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -966,7 +990,11 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -1010,7 +1038,11 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -1130,9 +1162,14 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
+        - --variant=rhel
         command:
         - ci-operator
         env:
@@ -1175,9 +1212,14 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
+        - --variant=rhel
         command:
         - ci-operator
         env:
@@ -1247,10 +1289,15 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
+        - --variant=rhel
         command:
         - ci-operator
         env:
@@ -1364,7 +1411,11 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -1408,7 +1459,11 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -1477,8 +1532,12 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=branch
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -17,7 +17,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=subdir
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=test
         command:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -16,7 +16,11 @@ periodics:
     containers:
     - args:
       - --artifact-dir=$(ARTIFACTS)
+      - --branch=master
       - --give-pr-author-access-to-namespace=true
+      - --org=super
+      - --repo=duper
+      - --resolver-address=http://ci-operator-configresolver
       - --secret-dir=/usr/local/e2e-aws-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
       - --target=e2e-aws-nightly
@@ -82,7 +86,11 @@ periodics:
     containers:
     - args:
       - --artifact-dir=$(ARTIFACTS)
+      - --branch=master
       - --give-pr-author-access-to-namespace=true
+      - --org=super
+      - --repo=duper
+      - --resolver-address=http://ci-operator-configresolver
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
       - --target=e2e-nightly

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -13,8 +13,12 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -61,10 +65,15 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
+        - --variant=variant
         command:
         - ci-operator
         env:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -17,7 +17,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=e2e
@@ -193,7 +197,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -248,7 +256,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -292,7 +304,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -338,10 +354,15 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
+        - --variant=variant
         command:
         - ci-operator
         env:
@@ -385,9 +406,14 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
+        - --variant=variant
         command:
         - ci-operator
         env:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -17,7 +17,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=master-removed-promotion
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -13,8 +13,12 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
+        - --org=super
         - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=src

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -17,7 +17,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -71,7 +75,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -115,7 +123,11 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
+        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
+        - --org=super
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:


### PR DESCRIPTION
Make prowgen add `configresolver` flags to all `ci-operator` jobs (and update tests)