### PR TITLE
testgrid-config-generator: Filter the monitor cluster test from testgrid

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -87,7 +87,7 @@ func dashboardTabFor(name string) *config.DashboardTab {
 	return &config.DashboardTab{
 		Name:             name,
 		TestGroupName:    name,
-		BaseOptions:      "width=10",
+		BaseOptions:      "width=10&exclude-filter-by-regex=Monitor%5Cscluster",
 		OpenTestTemplate: &config.LinkTemplate{Url: "https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>"},
 		FileBugTemplate: &config.LinkTemplate{
 			Url: "https://github.com/openshift/origin/issues/new",

--- a/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-blocking-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-blocking-ci.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.1
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-informing-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.1-informing-ci.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ci.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.2
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ocp.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-blocking-ocp.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ci.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ci.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ocp.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-release-4.2-informing-ocp.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-job
-  - base_options: width=10
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>


### PR DESCRIPTION
This better reflects actual health and the summarizer will take it into
account.