### PR TITLE
Add UPI-src template to prowgen.

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -235,6 +235,9 @@ func generatePodSpecTemplate(info *config.Info, secret *cioperatorapi.Secret, re
 	} else if conf := test.OpenshiftInstallerUPIClusterTestConfiguration; conf != nil {
 		template = "cluster-launch-installer-upi-e2e"
 		clusterProfile = conf.ClusterProfile
+	} else if conf := test.OpenshiftInstallerUPISrcClusterTestConfiguration; conf != nil {
+		template = "cluster-launch-installer-upi-src"
+		clusterProfile = conf.ClusterProfile
 	} else if conf := test.OpenshiftInstallerConsoleClusterTestConfiguration; conf != nil {
 		template = "cluster-launch-installer-console"
 		clusterProfile = conf.ClusterProfile

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -265,6 +265,10 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
 	}
+	if testConfig := test.OpenshiftInstallerUPISrcClusterTestConfiguration; testConfig != nil {
+		typeCount++
+		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
+	}
 	if testConfig := test.OpenshiftInstallerConsoleClusterTestConfiguration; testConfig != nil {
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -341,6 +341,7 @@ type TestStepConfiguration struct {
 	OpenshiftInstallerClusterTestConfiguration                *OpenshiftInstallerClusterTestConfiguration                `json:"openshift_installer,omitempty"`
 	OpenshiftInstallerSrcClusterTestConfiguration             *OpenshiftInstallerSrcClusterTestConfiguration             `json:"openshift_installer_src,omitempty"`
 	OpenshiftInstallerUPIClusterTestConfiguration             *OpenshiftInstallerUPIClusterTestConfiguration             `json:"openshift_installer_upi,omitempty"`
+	OpenshiftInstallerUPISrcClusterTestConfiguration          *OpenshiftInstallerUPISrcClusterTestConfiguration          `json:"openshift_installer_upi_src,omitempty"`
 	OpenshiftInstallerConsoleClusterTestConfiguration         *OpenshiftInstallerConsoleClusterTestConfiguration         `json:"openshift_installer_console,omitempty"`
 	OpenshiftInstallerRandomClusterTestConfiguration          *OpenshiftInstallerRandomClusterTestConfiguration          `json:"openshift_installer_random,omitempty"`
 	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
@@ -593,6 +594,14 @@ type OpenshiftInstallerConsoleClusterTestConfiguration struct {
 // test that provisions machines using installer-upi image and
 // installs the cluster using UPI flow.
 type OpenshiftInstallerUPIClusterTestConfiguration struct {
+	ClusterTestConfiguration `json:",inline"`
+}
+
+// OpenshiftInstallerUPISrcClusterTestConfiguration describes a
+// test that provisions machines using installer-upi image and
+// installs the cluster using UPI flow. Tests will be run
+// akin to the OpenshiftInstallerSrcClusterTestConfiguration.
+type OpenshiftInstallerUPISrcClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
 

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -256,6 +256,10 @@ tests:
   commands: TEST_SUITE=openshift/conformance/serial run-tests
   openshift_installer_upi:
     cluster_profile: aws
+- as: e2e-upi-src-vsphere
+  commands: make tests
+  openshift_installer_upi_src:
+    cluster_profile: vsphere
 `
 
 func strP(str string) *string {
@@ -506,6 +510,12 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 		Commands: `TEST_SUITE=openshift/conformance/serial run-tests`,
 		OpenshiftInstallerUPIClusterTestConfiguration: &api.OpenshiftInstallerUPIClusterTestConfiguration{
 			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "aws"},
+		},
+	}, {
+		As:       "e2e-upi-src-vsphere",
+		Commands: `make tests`,
+		OpenshiftInstallerUPISrcClusterTestConfiguration: &api.OpenshiftInstallerUPISrcClusterTestConfiguration{
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "vsphere"},
 		},
 	}},
 }


### PR DESCRIPTION
This template has been added in https://github.com/openshift/release/pull/5388.

This lines up the needed steps in prowgen for this to be correctly picked up and usable in CI configs.