### PR TITLE
Make sure injected RPM repos are enabled

### DIFF
--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -14,7 +14,7 @@ import (
 
 func rpmInjectionDockerfile(from api.PipelineImageStreamTagReference, repo string) string {
 	return fmt.Sprintf(`FROM %s:%s
-RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 0\n\n[origin-local-release]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 0' > /etc/yum.repos.d/built.repo`, api.PipelineImageStream, from, repo, repo)
+RUN echo $'[built]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 1\n\n[origin-local-release]\nname = Built RPMs\nbaseurl = http://%s/\ngpgcheck = 0\nenabled = 1' > /etc/yum.repos.d/built.repo`, api.PipelineImageStream, from, repo, repo)
 }
 
 type rpmImageInjectionStep struct {

--- a/test/ci-operator-integration/base/expected_files/expected.json
+++ b/test/ci-operator-integration/base/expected_files/expected.json
@@ -170,7 +170,7 @@
       },
       "serviceAccount": "builder",
       "source": {
-        "dockerfile": "FROM pipeline:base-machine\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0' > /etc/yum.repos.d/built.repo",
+        "dockerfile": "FROM pipeline:base-machine\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1' > /etc/yum.repos.d/built.repo",
         "type": "Dockerfile"
       },
       "strategy": {
@@ -235,7 +235,7 @@
       },
       "serviceAccount": "builder",
       "source": {
-        "dockerfile": "FROM pipeline:base\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0' > /etc/yum.repos.d/built.repo",
+        "dockerfile": "FROM pipeline:base\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1' > /etc/yum.repos.d/built.repo",
         "type": "Dockerfile"
       },
       "strategy": {

--- a/test/ci-operator-integration/base/expected_files/expected_with_template.json
+++ b/test/ci-operator-integration/base/expected_files/expected_with_template.json
@@ -41,7 +41,7 @@
       },
       "serviceAccount": "builder",
       "source": {
-        "dockerfile": "FROM pipeline:base-machine\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0' > /etc/yum.repos.d/built.repo",
+        "dockerfile": "FROM pipeline:base-machine\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 1' > /etc/yum.repos.d/built.repo",
         "type": "Dockerfile"
       },
       "strategy": {


### PR DESCRIPTION
For some reason the repos injected after RPMs are built in the build
process are not enabled. Moreover, on those images yum-config-manager is
disabled as well. In order to enable the repos hacks like those need to
be used:

```
RUN sed -i -e 's/enabled \?= \?0/enabled = 1/' /etc/yum.repos.d/*
```
(See openshift/kuryr-kubernetes@eee5fe3 for reference)

This commit solves that by making sure those injected repos have
`enabled = 1` set.