### PR TITLE
[prowgen] Introduce prowgen configuration files.

### DIFF
--- a/test/prowgen-integration/data/input/config/private/duper/.config.prowgen
+++ b/test/prowgen-integration/data/input/config/private/duper/.config.prowgen
@@ -1,0 +1,1 @@
+private: true

--- a/test/prowgen-integration/data/input/config/private/duper/private-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/private/duper/private-duper-master.yaml
@@ -1,0 +1,43 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+- as: e2e
+  commands: make e2e
+  openshift_ansible:
+    cluster_profile: gcp
+- as: e2e-nightly
+  commands: make e2e
+  openshift_ansible:
+    cluster_profile: gcp
+  cron: '@yearly'

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -1,0 +1,80 @@
+periodics:
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: private
+    repo: duper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-private-duper-master-e2e-nightly
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --branch=master
+      - --give-pr-author-access-to-namespace=true
+      - --org=private
+      - --repo=duper
+      - --resolver-address=http://ci-operator-configresolver
+      - --secret-dir=/usr/local/e2e-nightly-cluster-profile
+      - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+      - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
+      - --target=e2e-nightly
+      - --template=/usr/local/e2e-nightly
+      command:
+      - ci-operator
+      env:
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: private-duper-master.yaml
+            name: ci-operator-master-configs
+      - name: JOB_NAME_SAFE
+        value: e2e-nightly
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      - name: TEST_COMMAND
+        value: make e2e
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-nightly-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/github-ssh-credentials-openshift-bot
+        name: github-ssh-credentials-openshift-bot
+        readOnly: true
+      - mountPath: /usr/local/e2e-nightly
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+      - mountPath: /etc/sentry-dsn
+        name: sentry-dsn
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: github-ssh-credentials-openshift-bot
+      secret:
+        secretName: github-ssh-credentials-openshift-bot
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: sentry-dsn
+      secret:
+        secretName: sentry-dsn

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -1,0 +1,53 @@
+postsubmits:
+  private/duper:
+  - agent: kubernetes
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    name: branch-ci-private-duper-master-images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=private
+        - --promote
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
+          name: github-ssh-credentials-openshift-bot
+          readOnly: true
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-ssh-credentials-openshift-bot
+        secret:
+          secretName: github-ssh-credentials-openshift-bot
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -1,0 +1,193 @@
+presubmits:
+  private/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-private-duper-master-e2e
+    rerun_command: /test e2e
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=private
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
+        - --secret-dir=/usr/local/e2e-cluster-profile
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
+        - --target=e2e
+        - --template=/usr/local/e2e
+        command:
+        - ci-operator
+        env:
+        - name: CLUSTER_TYPE
+          value: gcp
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
+        - name: JOB_NAME_SAFE
+          value: e2e
+        - name: RPM_REPO_OPENSHIFT_ORIGIN
+          value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+        - name: TEST_COMMAND
+          value: make e2e
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/e2e-cluster-profile
+          name: cluster-profile
+        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
+          name: github-ssh-credentials-openshift-bot
+          readOnly: true
+        - mountPath: /usr/local/e2e
+          name: job-definition
+          subPath: cluster-launch-e2e.yaml
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-gcp
+          - configMap:
+              name: cluster-profile-gcp
+      - name: github-ssh-credentials-openshift-bot
+        secret:
+          secretName: github-ssh-credentials-openshift-bot
+      - configMap:
+          name: prow-job-cluster-launch-e2e
+        name: job-definition
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-private-duper-master-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=private
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
+        - --target=[images]
+        - --target=[release:latest]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
+          name: github-ssh-credentials-openshift-bot
+          readOnly: true
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-ssh-credentials-openshift-bot
+        secret:
+          secretName: github-ssh-credentials-openshift-bot
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-private-duper-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=private
+        - --repo=duper
+        - --resolver-address=http://ci-operator-configresolver
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
+          name: github-ssh-credentials-openshift-bot
+          readOnly: true
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: github-ssh-credentials-openshift-bot
+        secret:
+          secretName: github-ssh-credentials-openshift-bot
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
Now the config contains only one field `private: bool`.
When we detect this in any repo's ci-op config folder, we generate jobs with the bot's secret mounted and add the `ssh-key-path` argument to ci-operator's command. 