### PR TITLE
cmd/blocking-issue-creator: Use "Failed to ..." for all failing errors

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -75,7 +75,7 @@ func main() {
 		for _, futureRelease := range o.FutureReleases.Strings() {
 			futureBranch, err := promotion.DetermineReleaseBranch(o.CurrentRelease, futureRelease, repoInfo.Branch)
 			if err != nil {
-				logger.WithError(err).Error("could not determine release branch")
+				logger.WithError(err).Error("Failed to determine release branch.")
 				failed = true
 				return nil
 			}
@@ -218,7 +218,7 @@ func main() {
 				return nil
 			}
 			if labelQuery.Repository.Label.ID == nil {
-				logger.Error("Could not find a merge blocker label.")
+				logger.Error("Failed to find a merge blocker label.")
 				failed = true
 				return nil
 			}


### PR DESCRIPTION
This makes it easier to grep for things which might eventually cause an terminal failure [like][1]:

```
level=fatal msg="Could not publish merge blocking issues." error="<nil>"
```

You can already find those by grepping for `level=error`, since we only use error logging before setting `failed=true`, which you can confirm with:

```console
$ git grep -1 'logger.*Error\|failed = true' cmd/blocking-issue-creator/
```

But "there's already some consistency" shouldn't block us from adding the additional consistency I'm adding here ;).

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-openshift-release-merge-blockers/692