### PR TITLE
cmd/blocking-issue-creator: Log reason for skipping a config

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -67,7 +67,12 @@ func main() {
 		if (o.Org != "" && o.Org != repoInfo.Org) || (o.Repo != "" && o.Repo != repoInfo.Repo) {
 			return nil
 		}
-		if !(promotion.PromotesOfficialImages(configuration) && configuration.PromotionConfiguration.Name == o.CurrentRelease) {
+		if !promotion.PromotesOfficialImages(configuration) {
+			logger.Debugf("Skipping because no offical images are promoted from this configuration")
+			return nil
+		}
+		if configuration.PromotionConfiguration.Name != o.CurrentRelease {
+			logger.Debugf("Skipping because this configuration promotes %s, but the current release is %s", configuration.PromotionConfiguration.Name, o.CurrentRelease)
 			return nil
 		}
 


### PR DESCRIPTION
This may already seem pretty obvious, but folks like me who aren't as familiar with the registry configs for image promotion might appreciate the extra hand-holding.  And being a bit noisy in debug logs doesn't seem like a problem ;).