### PR TITLE
cmd/ipi-deprovision: Shuffle cluster IDs

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -56,7 +56,7 @@ for r in "${regions[@]}"
 do
   echo "doing region ${r} ..."
   json_output=$(aws ec2 describe-vpcs --output json --region "${r}")
-  for cluster in $(echo ${json_output} | jq --arg date "${cluster_age_cutoff}" -r -S '.Vpcs[] | select (.Tags[]? | (.Key == "expirationDate" and .Value < $date)) | .Tags[] | select (.Value == "owned") | .Key')
+  for cluster in $(echo ${json_output} | jq --arg date "${cluster_age_cutoff}" -r -S '.Vpcs[] | select (.Tags[]? | (.Key == "expirationDate" and .Value < $date)) | .Tags[] | select (.Value == "owned") | .Key' | shuf)
   do
     expirationDateValue=$(echo ${json_output} | jq --arg cl "${cluster}" -r -S '.Vpcs[] | select (.Tags[]? | (.Key == $cl and .Value == "owned")) | .Tags[] | select (.Key == "expirationDate") | .Value')
     handle_cluster "${cluster}" "${expirationDateValue}" "${r}"


### PR DESCRIPTION
Sometimes we get stuck on one cluster, for example because [AWS fumbled a load balancer deletion][1].  By shuffling the results, we'll gradually nip off any deletable clusters instead of having them pile up while we're blocking on the same hung-up cluster with each run.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1760616