### PR TITLE
Define a pull_request_policy that allows gen of always_run:false

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestValidateTests(t *testing.T) {
+	testInterval := "0 0 0 0 0"
 	var validationErrors []error
 	var testTestsCases = []struct {
 		id            string
@@ -203,6 +204,131 @@ func TestValidateTests(t *testing.T) {
 			},
 			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
 			expectedValid: true,
+		},
+		{
+			id: "with invalid policy",
+			tests: []TestStepConfiguration{
+				{
+					As:                "test",
+					Commands:          "commands",
+					PullRequestPolicy: "Unknown",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: false,
+		},
+		{
+			id: "with valid Always policy",
+			tests: []TestStepConfiguration{
+				{
+					As:                "test",
+					Commands:          "commands",
+					PullRequestPolicy: "Always",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: true,
+		},
+		{
+			id: "with valid OnRequest policy",
+			tests: []TestStepConfiguration{
+				{
+					As:                "test",
+					Commands:          "commands",
+					PullRequestPolicy: "OnRequest",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: true,
+		},
+		{
+			id: "with valid RunIfChanged policy",
+			tests: []TestStepConfiguration{
+				{
+					As:                      "test",
+					Commands:                "commands",
+					PullRequestPolicy:       "RunIfChanged",
+					PullRequestRunIfChanged: ".*",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: true,
+		},
+		{
+			id: "with invalid RunIfChanged policy",
+			tests: []TestStepConfiguration{
+				{
+					As:                      "test",
+					Commands:                "commands",
+					PullRequestPolicy:       "RunIfChanged",
+					PullRequestRunIfChanged: "",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: false,
+		},
+		{
+			id: "with invalid regex run_if_changed",
+			tests: []TestStepConfiguration{
+				{
+					As:                      "test",
+					Commands:                "commands",
+					PullRequestPolicy:       "RunIfChanged",
+					PullRequestRunIfChanged: "*",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: false,
+		},
+		{
+			id: "pull request policy should conflict with cron",
+			tests: []TestStepConfiguration{
+				{
+					As:                "test",
+					Commands:          "commands",
+					PullRequestPolicy: "OnRequest",
+					Cron:              &testInterval,
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: false,
+		},
+		{
+			id: "pull request policy should conflict with run_if_changed",
+			tests: []TestStepConfiguration{
+				{
+					As:                      "test",
+					Commands:                "commands",
+					PullRequestPolicy:       "OnRequest",
+					PullRequestRunIfChanged: ".*",
+					OpenshiftAnsibleClusterTestConfiguration: &OpenshiftAnsibleClusterTestConfiguration{
+						ClusterTestConfiguration: ClusterTestConfiguration{ClusterProfile: ClusterProfileGCP},
+					},
+				},
+			},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			expectedValid: false,
 		},
 		{
 			id: "invalid secret mountPath",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -330,6 +330,27 @@ type TestStepConfiguration struct {
 	// create a periodic job instead of a presubmit
 	Cron *string `json:"cron,omitempty"`
 
+	// PullRequestPolicy defines when this test is run as
+	// part of pull requests. It is a validation error to
+	// set this field when Cron is also set. Policies:
+	//
+	// * Always: this test is run on every pull request
+	// * OnRequest: this test will not be run until a user
+	//     explicitly requests it via /test NAME, at which
+	//     point it will be required for merge.
+	// * RunIfChanged: this test will be run if the regex
+	//     in pull_request_run_if_changed matches a change
+	//     in the PR.
+	//
+	// The default value is Always
+	PullRequestPolicy string `json:"pull_request_policy"`
+	// PullRequestRunIfChanged is an optional regex that
+	// will run this test if a filename in the repository
+	// matching the regex is changed. If this regex is
+	// set the PullRequestPolicy must be RunIfChanged or
+	// empty (in which case it is defaulted).
+	PullRequestRunIfChanged string `json:"pull_request_run_if_changed"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
 	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -1366,6 +1366,8 @@
               commands: make unit CHANGED
               container:
                 from: src
+              pull_request_policy: ""
+              pull_request_run_if_changed: ""
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1479,6 +1481,8 @@
               commands: make unit CHANGED
               container:
                 from: src
+              pull_request_policy: ""
+              pull_request_run_if_changed: ""
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -1607,6 +1611,8 @@
               commands: make unit CHANGED
               container:
                 from: src
+              pull_request_policy: ""
+              pull_request_run_if_changed: ""
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1714,6 +1720,8 @@
               commands: make unit CHANGED
               container:
                 from: src
+              pull_request_policy: ""
+              pull_request_run_if_changed: ""
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
always_run is hard to maintain across a thousand jobs, so we should
bring it into the config. Use a policy rather than a boolean so we
can evolve over time (and prevent configs we don't really want to be
frequently used, like optional: true, always_run: false).

Plumb into generation.