### PR TITLE
promotion: handle "master*" branch same as master

### DIFF
--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -130,12 +130,13 @@ func (o *Options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.Repo, "repo", "", "Limit repos affected to this repo.")
 }
 
+var masterBranches = regexp.MustCompile(`^master.*$`)
 var threeXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-3\.[0-9]+$`)
 var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9]+)$`)
 
 func FlavorForBranch(branch string) string {
 	var flavor string
-	if branch == "master" {
+	if masterBranches.MatchString(branch) {
 		flavor = "master"
 	} else if threeXBranches.MatchString(branch) {
 		flavor = "3.x"

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -131,6 +131,16 @@ func TestFlavorForBranch(t *testing.T) {
 			expected: "master",
 		},
 		{
+			name:     "master-fcos branch goes to master configmap",
+			branch:   "master-fcos",
+			expected: "master",
+		},
+		{
+			name:     "branch containing master goes to misc configmap",
+			branch:   "not-really-master-branch",
+			expected: "misc",
+		},
+		{
 			name:     "enterprise 3.6 branch goes to 3.x configmap",
 			branch:   "enterprise-3.6",
 			expected: "3.x",

--- a/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-ciop-config-postsubmits.yaml
+++ b/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-ciop-config-postsubmits.yaml
@@ -26,7 +26,7 @@ postsubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-promotion-postsubmits.yaml
+++ b/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-promotion-postsubmits.yaml
@@ -24,7 +24,7 @@ postsubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/input/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
           valueFrom:
             configMapKeyRef:
               key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
OKD-on-FCOS testing requires some projects to have master temporarily 
forked in "master-fcos" branches. This uses correct promotion flavor for 
those.

Fixes sharded config tests in https://github.com/openshift/release/pull/5557 and https://github.com/openshift/release/pull/5589