### PR TITLE
Import initial release into test namespace correctly

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -226,7 +226,7 @@ func (s *assembleReleaseStep) importFromReleaseImage(ctx context.Context, dry bo
 	// retry importing the image a few times because we might race against establishing credentials/roles
 	// and be unable to import images on the same cluster
 	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Duration: 1 * time.Second, Factor: 2}, func() (bool, error) {
-		result, err := s.imageClient.ImageStreamImports(s.config.Namespace).Create(&imageapi.ImageStreamImport{
+		result, err := s.imageClient.ImageStreamImports(s.jobSpec.Namespace).Create(&imageapi.ImageStreamImport{
 			ObjectMeta: meta.ObjectMeta{
 				Name: "release",
 			},


### PR DESCRIPTION
We were importing into (frequently) the release configuration namespace, so ocp/release:latest and ocp/release:initial and were getting set by the PR.  Instead we should create those in the job namespace.  Did not fail the run because we don't use the reference in the namespace (we use the exact value provided to the test).

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>