### PR TITLE
pkg/load/configAgent: make some functions more generic

### DIFF
--- a/pkg/load/agent_utils.go
+++ b/pkg/load/agent_utils.go
@@ -1,0 +1,52 @@
+package load
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openshift/ci-tools/pkg/coalescer"
+)
+
+func populateWatcher(watcher *fsnotify.Watcher, root string) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		// We only need to watch directories as creation, deletion, and writes
+		// for files in a directory trigger events for the directory
+		if info != nil && info.IsDir() {
+			log.Tracef("Adding %s to watch list", path)
+			err = watcher.Add(path)
+			if err != nil {
+				return fmt.Errorf("Failed to add watch on directory %s: %v", path, err)
+			}
+		}
+		return nil
+	})
+}
+
+func reloadWatcher(ctx context.Context, w *fsnotify.Watcher, root string, errFunc func(string), c coalescer.Coalescer) {
+	for {
+		select {
+		case <-ctx.Done():
+			if err := w.Close(); err != nil {
+				log.WithError(err).Error("Failed to close fsnotify watcher")
+			}
+			return
+		case event := <-w.Events:
+			log.Tracef("Received %v event for %s", event.Op, event.Name)
+			go c.Run()
+			// add new files to be watched; if a watch already exists on a file, the
+			// watch is simply updated
+			if err := populateWatcher(w, root); err != nil {
+				errFunc("failed to update watcher")
+				log.WithError(err).Error("Failed to update fsnotify watchlist")
+			}
+		case err := <-w.Errors:
+			errFunc("received fsnotify error")
+			log.WithError(err).Errorf("Received fsnotify error")
+		}
+	}
+}


### PR DESCRIPTION
This PR refactors `pkg/load/configAgent.go` to make it more generic and make implementing a similar `registryAgent.go` cleaner.

- Renames `agent` to `configAgent`
- Renames `reloadTimeMetric` to `configReloadTimeMetric`
- Makes `reloadWatcher` more generic by not requiring a `configAgent` in the function signature
- Move generic agent helpers to their own file