### PR TITLE
ci-operator: use lease step for templates

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,5 +1,7 @@
 package api
 
+import "fmt"
+
 // ReleaseBuildConfiguration describes how release
 // artifacts are built from a repository of source
 // code. The configuration is made up of two parts:
@@ -567,6 +569,16 @@ func (p ClusterProfile) LeaseType() string {
 		return "vsphere-quota-slice"
 	default:
 		return ""
+	}
+}
+
+// LeaseTypeFromClusterType maps cluster types to lease types
+func LeaseTypeFromClusterType(t string) (string, error) {
+	switch t {
+	case "aws", "azure", "gcp", "openstack", "vsphere":
+		return t + "-quota-slice", nil
+	default:
+		return "", fmt.Errorf("invalid cluster type %q", t)
 	}
 }
 


### PR DESCRIPTION
Use the same mechanism as multi-stage tests to acquire a lease for the cluster
type (if one is provided).

To enable a gradual migration, ignore templates without a specific parameter.
This allows the code to be merged without changes to existing jobs.  Each
template can be migrated by adding the special parameter and removing the lease
container.  When all are migrated, the parameter and the code that checks for
it can be removed.

Successfully tested locally with one of the `openshift/origin` jobs.