### PR TITLE
prowgen: Generate private jobs as `hidden: true`

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -468,6 +468,9 @@ func generateJobBase(name, prefix string, info *prowgenInfo, label jc.ProwgenLab
 	if pathAlias != nil {
 		base.PathAlias = *pathAlias
 	}
+	if info.config.Private {
+		base.Hidden = true
+	}
 	return base
 }
 

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -1799,6 +1799,27 @@ func TestGenerateJobBase(t *testing.T) {
 				UtilityConfig: prowconfig.UtilityConfig{Decorate: true, DecorationConfig: &v1.DecorationConfig{SkipCloning: &yes}, PathAlias: "/some/where"},
 			},
 		},
+		{
+			testName: "hidden job for private repos",
+			name:     "test",
+			prefix:   "pull",
+			info: &prowgenInfo{
+				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
+				config: Config{Private: true},
+			},
+			label:   jobconfig.Generated,
+			podSpec: &kubeapi.PodSpec{Containers: []kubeapi.Container{{Name: "test"}}},
+			expected: prowconfig.JobBase{
+				Name:  "pull-ci-org-repo-branch-test",
+				Agent: "kubernetes",
+				Labels: map[string]string{
+					"ci-operator.openshift.io/prowgen-controlled": "true",
+				},
+				Spec:          &kubeapi.PodSpec{Containers: []kubeapi.Container{{Name: "test"}}},
+				UtilityConfig: prowconfig.UtilityConfig{Decorate: true, DecorationConfig: &v1.DecorationConfig{SkipCloning: &yes}},
+				Hidden:        true,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+    hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -8,6 +8,7 @@ periodics:
   - base_ref: master
     org: private
     repo: duper
+  hidden: true
   labels:
     ci-operator.openshift.io/prowgen-controlled: "true"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -6,6 +6,7 @@ postsubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+    hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
     name: branch-ci-private-duper-master-images

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -8,6 +8,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+    hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -88,6 +89,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+    hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -144,6 +146,7 @@ presubmits:
     decorate: true
     decoration_config:
       skip_cloning: true
+    hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
This is a low-cost way how to make sure private and public jobs are shown in the correct Deck instance. This way we do not need to sync repos to the `hidden_repos` config for deck, or implement `hidden_orgs` yet.

We may eventually decide to implement `hidden_orgs` anyway, as it's the most clean solution, but this saves us from it being urgent.

/cc @droslean @openshift/openshift-team-developer-productivity-test-platform 
