### PR TITLE
Add an interactive tool to bootstrap a repo's config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
 
-integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator
+integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init
 .PHONY: integration
 
 integration-prowgen:
@@ -60,6 +60,10 @@ integration-secret-wrapper:
 integration-testgrid-generator:
 	test/testgrid-config-generator/run.sh
 .PHONY: integration-testgrid-generator
+
+integration-repo-init:
+	test/repo-init-integration/run.sh
+.PHONY: integration-repo-init
 
 check-breaking-changes:
 	test/validate-prowgen-breaking-changes.sh

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -1,0 +1,582 @@
+// repo-init is an interactive command-line utility to bootstrap
+// configuration options for repositories, including config for
+// prow as well as ci-operator. It is not intended to replace
+// manual interaction with the configuration, especially for all
+// complicated scenarios, but to provide a good set of defaults.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/plugins"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	ciopconfig "github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/diffs"
+)
+
+type options struct {
+	releaseRepo string
+	config      string
+}
+
+func (o *options) Validate() error {
+	if o.releaseRepo == "" {
+		return errors.New("--release-repo is required")
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.releaseRepo, "release-repo", "", "Path to the root of the openshift/release repository.")
+	fs.StringVar(&o.config, "config", "", "JSON configuration to use instead of the interactive mode.")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Printf("ERROR: could not parse input: %v", err)
+		os.Exit(1)
+	}
+	return o
+}
+
+type initConfig struct {
+	Org                   string    `json:"org"`
+	Repo                  string    `json:"repo"`
+	Branch                string    `json:"branch"`
+	CanonicalGoRepository string    `json:"canonical_go_repository"`
+	Promotes              bool      `json:"promotes"`
+	PromotesWithOpenShift bool      `json:"promotes_with_openshift"`
+	NeedsBase             bool      `json:"needs_base"`
+	NeedsOS               bool      `json:"needs_os"`
+	GoVersion             string    `json:"go_version"`
+	BuildCommands         string    `json:"build_commands"`
+	TestBuildCommands     string    `json:"test_build_commands"`
+	Tests                 []test    `json:"tests"`
+	CustomE2E             []e2eTest `json:"custom_e2e"`
+}
+
+type test struct {
+	As      string                              `json:"as"`
+	From    api.PipelineImageStreamTagReference `json:"from"`
+	Command string                              `json:"command"`
+}
+
+type e2eTest struct {
+	As      string             `json:"as"`
+	Profile api.ClusterProfile `json:"profile"`
+	Command string             `json:"command"`
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		errorExit(fmt.Sprintf("invalid options: %v", err))
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	fmt.Println(`Welcome to the repository configuration initializer.
+In order to generate a new set of configurations, some information will be necessary.`)
+	var config initConfig
+	if o.config != "" {
+		fmt.Println("Loading configuration from flags ...")
+		if err := json.Unmarshal([]byte(o.config), &config); err != nil {
+			errorExit(fmt.Sprintf("could not unmarshal provided configuration: %v", err))
+		}
+	} else {
+		fmt.Println(`
+Let's start with general information about the repository...`)
+		config.Org = fetchWithPrompt("Enter the organization for the repository:")
+		config.Repo = fetchWithPrompt("Enter the repository to initialize:")
+		config.Branch = fetchOrDefaultWithPrompt("Enter the development branch for the repository:", "master")
+
+		configPath := path.Join(o.releaseRepo, "ci-operator", "config", config.Org, config.Repo)
+		if _, err := os.Stat(configPath); err == nil {
+			errorExit(fmt.Sprintf("configuration for %s/%s already exists at %s", config.Org, config.Repo, configPath))
+		}
+
+		fmt.Println(`
+Now, let's determine how the repository builds output artifacts...`)
+		config.Promotes = fetchBoolWithPrompt("Does the repository build and promote container images? ")
+		if config.Promotes {
+			config.PromotesWithOpenShift = fetchBoolWithPrompt("Does the repository promote images as part of the OpenShift release? ")
+			config.NeedsBase = fetchBoolWithPrompt("Do any images build on top of the OpenShift base image? ")
+			config.NeedsOS = fetchBoolWithPrompt("Do any images build on top of the CentOS base image? ")
+		}
+
+		fmt.Println(`
+Now, let's configure how the repository is compiled...`)
+		config.GoVersion = fetchOrDefaultWithPrompt("What version of Go does the repository build with?", "1.12")
+		config.CanonicalGoRepository = fetchOrDefaultWithPrompt("[OPTIONAL] Enter the Go import path for the repository if it uses a vanity URL (e.g. \"k8s.io/my-repo\"):", "")
+		config.BuildCommands = fetchOrDefaultWithPrompt("[OPTIONAL] What commands are used to build binaries in the repository? (e.g. \"go install ./cmd/...\")", "")
+		config.TestBuildCommands = fetchOrDefaultWithPrompt("[OPTIONAL] What commands are used to build test binaries? (e.g. \"go install -race ./cmd/...\" or \"go test -c ./test/...\")", "")
+
+		fmt.Println(`
+Now, let's configure test jobs for the repository...`)
+		names := sets.NewString()
+		var tests []test
+		for {
+			more := ""
+			detail := `
+First, we will configure simple test scripts. Test scripts
+execute unit or integration style tests by running a command
+from your repository inside of a test container. For example,
+a unit test may be executed by running "make test-unit" after
+checking out the code under test.
+
+`
+			if len(tests) > 0 {
+				more = "more "
+				detail = ""
+			}
+			if !fetchBoolWithPrompt(fmt.Sprintf("%sAre there any %stest scripts to configure? ", detail, more)) {
+				break
+			}
+			var test test
+			test.As = fetchWithPrompt("What is the name of this test (e.g. \"unit\")? ")
+			for {
+				if names.Has(test.As) {
+					fmt.Printf(`
+A test named %s already exists. Please choose a different name.\n`, test.As)
+					test.As = fetchWithPrompt("What is the name of this test (e.g. \"unit\")? ")
+				} else {
+					names.Insert(test.As)
+					break
+				}
+			}
+			var usesBinaries, usesTestBinaries bool
+			if config.BuildCommands != "" {
+				usesBinaries = fetchBoolWithPrompt("Does this test require built binaries? ")
+			}
+			if config.TestBuildCommands != "" && !usesBinaries {
+				usesTestBinaries = fetchBoolWithPrompt("Does this test require test binaries? ")
+			}
+			switch {
+			case !usesBinaries && !usesTestBinaries:
+				test.From = api.PipelineImageStreamTagReferenceSource
+			case usesBinaries:
+				test.From = api.PipelineImageStreamTagReferenceBinaries
+			case usesTestBinaries:
+				test.From = api.PipelineImageStreamTagReferenceTestBinaries
+			}
+			test.Command = fetchWithPrompt("What commands in the repository run the test (e.g. \"make test-unit\")? ")
+			tests = append(tests, test)
+		}
+		config.Tests = tests
+
+		var e2eTests []e2eTest
+		for {
+			more := ""
+			detail := `
+Next, we will configure end-to-end tests. An end-to-end test
+executes a command from your repository against an ephemeral
+OpenShift cluster. The test script will have "cluster:admin"
+credentials with which it can execute no other tests will
+share the cluster.
+
+`
+			if len(e2eTests) > 0 {
+				more = "more "
+				detail = ""
+			}
+			if !fetchBoolWithPrompt(fmt.Sprintf("%sAre there any %send-to-end test scripts to configure? ", detail, more)) {
+				break
+			}
+			var test e2eTest
+			test.As = fetchWithPrompt("What is the name of this test (e.g. \"e2e-operator\")? ")
+			for {
+				if names.Has(test.As) {
+					fmt.Printf(`
+A test named %s already exists. Please choose a different name.\n`, test.As)
+					test.As = fetchWithPrompt("What is the name of this test (e.g. \"e2e-operator\")? ")
+				} else {
+					names.Insert(test.As)
+					break
+				}
+			}
+			test.Profile = api.ClusterProfile(fetchOrDefaultWithPrompt("Which specific cloud provider does the test require, if any? ", string(api.ClusterProfileAWS)))
+			for {
+				if test.Profile.ClusterType() == "" {
+					fmt.Printf(`
+No cluster profile named %s exists. Please choose one from: %v.\n`, test.Profile, api.ClusterProfiles())
+					test.Profile = api.ClusterProfile(fetchOrDefaultWithPrompt("Which specific cloud provider does the test require, if any? ", string(api.ClusterProfileAWS)))
+				} else {
+					break
+				}
+			}
+			test.Command = fetchWithPrompt("What commands in the repository run the test (e.g. \"make test-e2e\")? ")
+			e2eTests = append(e2eTests, test)
+		}
+		config.CustomE2E = e2eTests
+	}
+
+	marshalled, err := json.Marshal(&config)
+	if err != nil {
+		errorExit(fmt.Sprintf("could not marshal configuration: %v", err))
+	}
+	fmt.Printf(`
+Repository configuration options loaded!
+In case of any errors, use the following command to re-
+create this run without using the interactive interface:
+
+%s --config=%q
+`, strings.Join(os.Args, " "), string(marshalled))
+
+	if err := updateProwConfig(config, o.releaseRepo); err != nil {
+		errorExit(fmt.Sprintf("could not update Prow configuration: %v", err))
+	}
+
+	if err := updatePluginConfig(config, o.releaseRepo); err != nil {
+		errorExit(fmt.Sprintf("could not update Prow plugin configuration: %v", err))
+	}
+
+	if err := createCIOperatorConfig(config, o.releaseRepo); err != nil {
+		errorExit(fmt.Sprintf("could not generate new CI Operator configuration: %v", err))
+	}
+
+	if err := generateProwJobs(o.releaseRepo); err != nil {
+		errorExit(fmt.Sprintf("could not generate Prow jobs: %v", err))
+	}
+}
+
+func errorExit(msg string) {
+	fmt.Printf("ERROR: %s\n", msg)
+	os.Exit(1)
+}
+
+func errorRetry(msg string) {
+	fmt.Printf("ERROR: %s\nPlease try again.\n", msg)
+}
+
+func fetchBoolWithPrompt(msg string) bool {
+	response := errorRetry
+	for i := 0; i < 5; i++ {
+		if i == 4 {
+			response = errorExit
+		}
+		out := fetchOrDefaultWithPrompt(msg, "no")
+		switch out {
+		case "t", "T", "true", "y", "Y", "yes", "Yes", "YES":
+			return true
+		case "f", "F", "false", "n", "N", "no", "No", "NO":
+			return false
+		default:
+			response(fmt.Sprintf("%q is not recognized, please respond \"yes\" or \"no\"", out))
+			continue
+		}
+	}
+	// dead code below
+	return false
+}
+
+func fetchWithPrompt(msg string) string {
+	response := errorRetry
+	for i := 0; i < 5; i++ {
+		if i == 4 {
+			response = errorExit
+		}
+		out := fetchOrDefaultWithPrompt(msg, "")
+		if out == "" {
+			response("a response is required")
+			continue
+		}
+		return out
+	}
+	// dead code below
+	return ""
+}
+
+// creating a reader from stdin consumes all of the content from the pipe,
+// so a shared reader must be used so that content put into the pipe in one
+// moment can be shared between multiple reads, as when we send all of the
+// responses to the binary in one moment in testing
+var reader = bufio.NewReader(os.Stdin)
+
+func fetchOrDefaultWithPrompt(msg, def string) string {
+	response := errorRetry
+	for i := 0; i < 5; i++ {
+		if i == 4 {
+			response = errorExit
+		}
+		formattedDefault := ""
+		if def != "" {
+			formattedDefault = fmt.Sprintf(" [default: %s]", def)
+		}
+		fmt.Printf("%s%s ", msg, formattedDefault)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			response(fmt.Sprintf("could not read the value: %v", err))
+			break
+		}
+		line = strings.TrimSuffix(line, "\n")
+		if line == "" {
+			return def
+		}
+		return line
+	}
+	// dead code below
+	return ""
+}
+
+func updateProwConfig(config initConfig, releaseRepo string) error {
+	configPath := path.Join(releaseRepo, diffs.ConfigInRepoPath)
+	agent := prowconfig.Agent{}
+	if err := agent.Start(configPath, ""); err != nil {
+		return fmt.Errorf("could not load Prow configuration: %v", err)
+	}
+
+	prowConfig := agent.Config()
+	editProwConfig(prowConfig, config)
+
+	data, err := yaml.Marshal(prowConfig)
+	if err != nil {
+		return fmt.Errorf("could not marshal Prow configuration: %v", err)
+	}
+
+	return ioutil.WriteFile(configPath, data, 0644)
+}
+
+func editProwConfig(prowConfig *prowconfig.Config, config initConfig) {
+	fmt.Println(`
+Updating Prow configuration ...`)
+	queries := prowConfig.Tide.Queries.QueryMap()
+	existing := queries.ForRepo(config.Org, config.Repo)
+	var existingStrings []string
+	for _, query := range existing {
+		existingStrings = append(existingStrings, query.Query())
+	}
+	if len(existing) > 0 {
+		fmt.Printf(`The following "tide" queries were found that already apply to %s/%s:
+
+%v
+
+No additional "tide" queries will be added.
+`, config.Org, config.Repo, strings.Join(existingStrings, "\n"))
+		return
+	}
+
+	// this is a bit hacky but simple -- we have a couple types of tide interactions
+	// and we can set defaults by piggy backing off of other repos we know that are
+	// doing it right
+	var copyCatQueries prowconfig.TideQueries
+	switch {
+	case config.Promotes && config.PromotesWithOpenShift:
+		copyCatQueries = queries.ForRepo("openshift", "origin")
+	case config.Promotes && !config.PromotesWithOpenShift:
+		copyCatQueries = queries.ForRepo("openshift", "ci-tools")
+	}
+
+	orgRepo := fmt.Sprintf("%s/%s", config.Org, config.Repo)
+	for i := range prowConfig.Tide.Queries {
+		for _, copyCat := range copyCatQueries {
+			if reflect.DeepEqual(prowConfig.Tide.Queries[i], copyCat) {
+				prowConfig.Tide.Queries[i].Repos = append(prowConfig.Tide.Queries[i].Repos, orgRepo)
+			}
+		}
+	}
+}
+
+func updatePluginConfig(config initConfig, releaseRepo string) error {
+	fmt.Println(`
+Updating Prow plugin configuration ...`)
+	configPath := path.Join(releaseRepo, diffs.PluginsInRepoPath)
+	agent := plugins.ConfigAgent{}
+	if err := agent.Load(configPath, false); err != nil {
+		return fmt.Errorf("could not load Prow plugin configuration: %v", err)
+	}
+
+	pluginConfig := agent.Config()
+	editPluginConfig(pluginConfig, config)
+
+	data, err := yaml.Marshal(pluginConfig)
+	if err != nil {
+		return fmt.Errorf("could not marshal Prow plugin configuration: %v", err)
+	}
+
+	return ioutil.WriteFile(configPath, data, 0644)
+}
+
+func editPluginConfig(pluginConfig *plugins.Configuration, config initConfig) {
+	orgRepo := fmt.Sprintf("%s/%s", config.Org, config.Repo)
+	_, orgRegistered := pluginConfig.Plugins[config.Org]
+	_, repoRegistered := pluginConfig.Plugins[orgRepo]
+	switch {
+	case !orgRegistered && !repoRegistered:
+		// the repo needs all plugins
+		fmt.Println(`
+No prior Prow plugin configuration was found for this organization or repository.
+Ensure that webhooks are set up for Prow to watch GitHub state.`)
+		pluginConfig.Plugins[orgRepo] = append(pluginConfig.Plugins["openshift"], pluginConfig.Plugins["openshift/origin"]...)
+	case orgRegistered && !repoRegistered:
+		// we just need the repo-specific bits
+		pluginConfig.Plugins[orgRepo] = pluginConfig.Plugins["openshift/origin"]
+	}
+
+	_, orgRegisteredExternal := pluginConfig.ExternalPlugins[config.Org]
+	_, repoRegisteredExternal := pluginConfig.ExternalPlugins[orgRepo]
+	if !orgRegisteredExternal && !repoRegisteredExternal {
+		// the repo needs all plugins
+		pluginConfig.ExternalPlugins[orgRepo] = pluginConfig.ExternalPlugins["openshift"]
+	}
+
+	// TODO: make PR to remove trigger config
+	// TODO: update bazel and make PR for exposing LGTM and Approval configs
+	no := false
+	pluginConfig.Approve = append(pluginConfig.Approve, plugins.Approve{
+		Repos:               []string{orgRepo},
+		RequireSelfApproval: &no,
+		LgtmActsAsApprove:   false,
+	})
+	pluginConfig.Lgtm = append(pluginConfig.Lgtm, plugins.Lgtm{
+		Repos:            []string{orgRepo},
+		ReviewActsAsLgtm: true,
+	})
+}
+
+func createCIOperatorConfig(config initConfig, releaseRepo string) error {
+	fmt.Println(`
+Generating CI Operator configuration ...`)
+	info := ciopconfig.Info{
+		Org:    "openshift",
+		Repo:   "origin",
+		Branch: "master",
+	}
+	originPath := path.Join(releaseRepo, diffs.CIOperatorConfigInRepoPath, info.RelativePath())
+	var originConfig *api.ReleaseBuildConfiguration
+	if err := ciopconfig.OperateOnCIOperatorConfig(originPath, func(configuration *api.ReleaseBuildConfiguration, _ *ciopconfig.Info) error {
+		originConfig = configuration
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to load configuration for openshift/origin: %v", err)
+	}
+
+	generated := generateCIOperatorConfig(config, originConfig.PromotionConfiguration)
+	return generated.CommitTo(path.Join(releaseRepo, diffs.CIOperatorConfigInRepoPath))
+}
+
+func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConfiguration) ciopconfig.DataWithInfo {
+	generated := ciopconfig.DataWithInfo{
+		Info: ciopconfig.Info{
+			Org:    config.Org,
+			Repo:   config.Repo,
+			Branch: config.Branch,
+		},
+		Configuration: api.ReleaseBuildConfiguration{
+			BinaryBuildCommands:     config.BuildCommands,
+			TestBinaryBuildCommands: config.TestBuildCommands,
+			Tests:                   []api.TestStepConfiguration{},
+			Resources: map[string]api.ResourceRequirements{"*": {
+				Limits:   map[string]string{"memory": "4Gi"},
+				Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+			}},
+		},
+	}
+
+	if config.CanonicalGoRepository != "" {
+		generated.Configuration.CanonicalGoRepository = &config.CanonicalGoRepository
+	}
+
+	if config.Promotes {
+		generated.Configuration.PromotionConfiguration = &api.PromotionConfiguration{
+			Namespace: originConfig.Namespace,
+			Name:      originConfig.Name,
+		}
+		generated.Configuration.ReleaseTagConfiguration = &api.ReleaseTagConfiguration{
+			Namespace: originConfig.Namespace,
+			Name:      originConfig.Name,
+		}
+		if config.PromotesWithOpenShift {
+			generated.Configuration.Tests = append(generated.Configuration.Tests, api.TestStepConfiguration{
+				As:       "e2e-aws",
+				Commands: "TEST_SUITE=openshift/conformance/parallel run-tests",
+				OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+					ClusterTestConfiguration: api.ClusterTestConfiguration{
+						ClusterProfile: api.ClusterProfileAWS,
+					},
+				},
+			})
+		}
+	}
+
+	if config.NeedsBase || config.NeedsOS {
+		if generated.Configuration.BaseImages == nil {
+			generated.Configuration.BaseImages = map[string]api.ImageStreamTagReference{}
+		}
+	}
+
+	if config.NeedsBase {
+		generated.Configuration.BaseImages["base"] = api.ImageStreamTagReference{
+			Namespace: "ocp",
+			Name:      "4.3",
+			Tag:       "base",
+		}
+	}
+
+	if config.NeedsOS {
+		generated.Configuration.BaseImages["os"] = api.ImageStreamTagReference{
+			Namespace: "openshift",
+			Name:      "centos",
+			Tag:       "7",
+		}
+	}
+
+	generated.Configuration.BuildRootImage = &api.BuildRootImageConfiguration{
+		ImageStreamTagReference: &api.ImageStreamTagReference{
+			Namespace: "openshift",
+			Name:      "release",
+			Tag:       fmt.Sprintf("golang-%s", config.GoVersion),
+		},
+	}
+
+	for _, test := range config.Tests {
+		generated.Configuration.Tests = append(generated.Configuration.Tests, api.TestStepConfiguration{
+			As:       test.As,
+			Commands: test.Command,
+			ContainerTestConfiguration: &api.ContainerTestConfiguration{
+				From: test.From,
+			},
+		})
+	}
+
+	for _, test := range config.CustomE2E {
+		generated.Configuration.Tests = append(generated.Configuration.Tests, api.TestStepConfiguration{
+			As:       test.As,
+			Commands: test.Command,
+			OpenshiftInstallerSrcClusterTestConfiguration: &api.OpenshiftInstallerSrcClusterTestConfiguration{
+				ClusterTestConfiguration: api.ClusterTestConfiguration{
+					ClusterProfile: test.Profile,
+				},
+			},
+		})
+	}
+	return generated
+}
+
+func generateProwJobs(releaseRepo string) error {
+	fmt.Println(`
+Generating new Prow jobs and checking formatting...`)
+	cmd := exec.Command("make", "jobs")
+	cmd.Dir = releaseRepo
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("could not run \"make jobs\": %v\n output: %v", err, string(out))
+	}
+	return nil
+}

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -1,0 +1,589 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/plugins"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	ciopconfig "github.com/openshift/ci-tools/pkg/config"
+)
+
+func TestEditProwConfig(t *testing.T) {
+	var testCases = []struct {
+		name       string
+		prowConfig *prowconfig.Config
+		config     initConfig
+		expected   *prowconfig.Config
+	}{
+		{
+			name: "queries already exist, nothing changes",
+			config: initConfig{
+				Org:  "org",
+				Repo: "repo",
+			},
+			prowConfig: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"org/repo"},
+						}},
+					},
+				},
+			},
+			expected: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"org/repo"},
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "repo does not need bugzilla",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Promotes:              true,
+				PromotesWithOpenShift: false,
+			},
+			prowConfig: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"openshift/ci-tools"},
+						}},
+					},
+				},
+			},
+			expected: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"openshift/ci-tools", "org/repo"},
+						}},
+					},
+				},
+			},
+		},
+		{
+			name: "repo needs bugzilla",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Promotes:              true,
+				PromotesWithOpenShift: true,
+			},
+			prowConfig: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"openshift/origin"},
+						}},
+					},
+				},
+			},
+			expected: &prowconfig.Config{
+				ProwConfig: prowconfig.ProwConfig{
+					Tide: prowconfig.Tide{
+						Queries: prowconfig.TideQueries{{
+							Repos: []string{"openshift/origin", "org/repo"},
+						}},
+					},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			editProwConfig(testCase.prowConfig, testCase.config)
+			if actual, expected := testCase.prowConfig, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect edited Prow config: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestEditPluginConfig(t *testing.T) {
+	no := false
+	var testCases = []struct {
+		name         string
+		pluginConfig *plugins.Configuration
+		config       initConfig
+		expected     *plugins.Configuration
+	}{
+		// TODO: actual approve and LGTM cases once the logic is worked out
+		{
+			name: "no prior records gets everything added",
+			config: initConfig{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			pluginConfig: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{},
+				Lgtm:    []plugins.Lgtm{},
+			},
+			expected: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org/repo":         {"foo", "bar"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+					"org/repo":  {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{{
+					Repos:               []string{"org/repo"},
+					RequireSelfApproval: &no,
+					LgtmActsAsApprove:   false,
+				}},
+				Lgtm: []plugins.Lgtm{{
+					Repos:            []string{"org/repo"},
+					ReviewActsAsLgtm: true,
+				}},
+			},
+		},
+		{
+			name: "org already has plugins configured",
+			config: initConfig{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			pluginConfig: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org":              {"other"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{},
+				Lgtm:    []plugins.Lgtm{},
+			},
+			expected: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org":              {"other"},
+					"org/repo":         {"bar"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+					"org/repo":  {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{{
+					Repos:               []string{"org/repo"},
+					RequireSelfApproval: &no,
+					LgtmActsAsApprove:   false,
+				}},
+				Lgtm: []plugins.Lgtm{{
+					Repos:            []string{"org/repo"},
+					ReviewActsAsLgtm: true,
+				}},
+			},
+		},
+		{
+			name: "org and repo already have plugins configured",
+			config: initConfig{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			pluginConfig: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org":              {"other"},
+					"org/repo":         {"something"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{},
+				Lgtm:    []plugins.Lgtm{},
+			},
+			expected: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org":              {"other"},
+					"org/repo":         {"something"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+					"org/repo":  {{Endpoint: "oops"}},
+				},
+				Approve: []plugins.Approve{{
+					Repos:               []string{"org/repo"},
+					RequireSelfApproval: &no,
+					LgtmActsAsApprove:   false,
+				}},
+				Lgtm: []plugins.Lgtm{{
+					Repos:            []string{"org/repo"},
+					ReviewActsAsLgtm: true,
+				}},
+			},
+		},
+		{
+			name: "org already has external plugins",
+			config: initConfig{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			pluginConfig: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+					"org":       {{Endpoint: "woops"}},
+				},
+				Approve: []plugins.Approve{},
+				Lgtm:    []plugins.Lgtm{},
+			},
+			expected: &plugins.Configuration{
+				Plugins: map[string][]string{
+					"openshift":        {"foo"},
+					"openshift/origin": {"bar"},
+					"org/repo":         {"foo", "bar"},
+				},
+				ExternalPlugins: map[string][]plugins.ExternalPlugin{
+					"openshift": {{Endpoint: "oops"}},
+					"org":       {{Endpoint: "woops"}},
+				},
+				Approve: []plugins.Approve{{
+					Repos:               []string{"org/repo"},
+					RequireSelfApproval: &no,
+					LgtmActsAsApprove:   false,
+				}},
+				Lgtm: []plugins.Lgtm{{
+					Repos:            []string{"org/repo"},
+					ReviewActsAsLgtm: true,
+				}},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			editPluginConfig(testCase.pluginConfig, testCase.config)
+			if actual, expected := testCase.pluginConfig, testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect edited Prow plugin config: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func strP(str string) *string {
+	return &str
+}
+
+func TestGenerateCIOperatorConfig(t *testing.T) {
+	var testCases = []struct {
+		name         string
+		originConfig *api.PromotionConfiguration
+		config       initConfig
+		expected     ciopconfig.DataWithInfo
+	}{
+		{
+			name: "minimal options",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				BuildCommands:         "make",
+				TestBuildCommands:     "make tests",
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					InputConfiguration: api.InputConfiguration{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+					},
+					BinaryBuildCommands:     "make",
+					TestBinaryBuildCommands: "make tests",
+					CanonicalGoRepository:   strP("sometimes.com"),
+					Tests:                   []api.TestStepConfiguration{},
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+				},
+				Info: ciopconfig.Info{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			name: "promoting into the ecosystem",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				Promotes:              true,
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Namespace: "promote",
+						Name:      "version",
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Namespace: "promote",
+							Name:      "version",
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Tests:                 []api.TestStepConfiguration{},
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+				},
+				Info: ciopconfig.Info{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			name: "releasing with openshift adds e2e",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				Promotes:              true,
+				PromotesWithOpenShift: true,
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Namespace: "promote",
+						Name:      "version",
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Namespace: "promote",
+							Name:      "version",
+						},
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Tests: []api.TestStepConfiguration{{
+						As:       "e2e-aws",
+						Commands: "TEST_SUITE=openshift/conformance/parallel run-tests",
+						OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+							ClusterTestConfiguration: api.ClusterTestConfiguration{
+								ClusterProfile: api.ClusterProfileAWS,
+							},
+						},
+					}},
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+				},
+				Info: ciopconfig.Info{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			name: "special base images required",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				NeedsOS:               true,
+				NeedsBase:             true,
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					InputConfiguration: api.InputConfiguration{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+						BaseImages: map[string]api.ImageStreamTagReference{
+							"base": {
+								Namespace: "ocp",
+								Name:      "4.3",
+								Tag:       "base",
+							},
+							"os": {
+								Namespace: "openshift",
+								Name:      "centos",
+								Tag:       "7",
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Tests:                 []api.TestStepConfiguration{},
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+				},
+				Info: ciopconfig.Info{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			name: "tests configured",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				Tests: []test{
+					{As: "unit", Command: "make test-unit", From: "src"},
+					{As: "cmd", Command: "make test-cmd", From: "bin"},
+				},
+				CustomE2E: []e2eTest{
+					{As: "operator-e2e", Command: "make e2e", Profile: "aws"},
+					{As: "operator-e2e-gcp", Command: "make e2e", Profile: "gcp"},
+				},
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					InputConfiguration: api.InputConfiguration{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Tests: []api.TestStepConfiguration{
+						{
+							As:       "unit",
+							Commands: "make test-unit",
+							ContainerTestConfiguration: &api.ContainerTestConfiguration{
+								From: "src",
+							},
+						},
+						{
+							As:       "cmd",
+							Commands: "make test-cmd",
+							ContainerTestConfiguration: &api.ContainerTestConfiguration{
+								From: "bin",
+							},
+						},
+						{
+							As:       "operator-e2e",
+							Commands: "make e2e",
+							OpenshiftInstallerSrcClusterTestConfiguration: &api.OpenshiftInstallerSrcClusterTestConfiguration{
+								ClusterTestConfiguration: api.ClusterTestConfiguration{
+									ClusterProfile: "aws",
+								},
+							},
+						},
+						{
+							As:       "operator-e2e-gcp",
+							Commands: "make e2e",
+							OpenshiftInstallerSrcClusterTestConfiguration: &api.OpenshiftInstallerSrcClusterTestConfiguration{
+								ClusterTestConfiguration: api.ClusterTestConfiguration{
+									ClusterProfile: "gcp",
+								},
+							},
+						},
+					},
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+				},
+				Info: ciopconfig.Info{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := generateCIOperatorConfig(testCase.config, testCase.originConfig), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect generated CI Operator config: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}

--- a/images/repo-init/Dockerfile
+++ b/images/repo-init/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:7
+LABEL maintainer="skuznets@redhat.com"
+
+ADD repo-init /usr/bin/repo-init
+ENTRYPOINT ["/usr/bin/repo-init"]

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,6 +1,8 @@
 package api
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // ReleaseBuildConfiguration describes how release
 // artifacts are built from a repository of source
@@ -511,6 +513,29 @@ const (
 	ClusterProfileOvirt              ClusterProfile = "ovirt"
 	ClusterProfileVSphere            ClusterProfile = "vsphere"
 )
+
+// ClusterProfiles are all valid cluster profiles
+func ClusterProfiles() []ClusterProfile {
+	return []ClusterProfile{
+		ClusterProfileAWS,
+		ClusterProfileAWSAtomic,
+		ClusterProfileAWSCentos,
+		ClusterProfileAWSCentos40,
+		ClusterProfileAWSGluster,
+		ClusterProfileAzure4,
+		ClusterProfileGCP,
+		ClusterProfileGCP40,
+		ClusterProfileGCPHA,
+		ClusterProfileGCPCRIO,
+		ClusterProfileGCPLogging,
+		ClusterProfileGCPLoggingJournald,
+		ClusterProfileGCPLoggingJSONFile,
+		ClusterProfileGCPLoggingCRIO,
+		ClusterProfileOpenStack,
+		ClusterProfileOvirt,
+		ClusterProfileVSphere,
+	}
+}
 
 // ClusterType maps profiles to the type string used by tests.
 func (p ClusterProfile) ClusterType() string {

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -25,6 +25,8 @@ const (
 	logDiffs      = "diffs"
 	logCiopConfig = "ciop-config"
 
+	// ConfigInRepoPath is the prow config path from release repo
+	ConfigInRepoPath = "core-services/prow/02_config/_config.yaml"
 	// PluginsInRepoPath is the prow plugins config path from release repo
 	PluginsInRepoPath = "core-services/prow/02_config/_plugins.yaml"
 	// JobConfigInRepoPath is the prowjobs path from release repo

--- a/test/repo-init-integration/expected/Makefile
+++ b/test/repo-init-integration/expected/Makefile
@@ -1,0 +1,4 @@
+jobs:
+	ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
+	determinize-prow-jobs --prow-jobs-dir ./ci-operator/jobs
+.PHONY: jobs

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -1,0 +1,30 @@
+images:
+- context_dir: images/blocking-issue-creator/
+  from: os
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/blocking-issue-creator
+  to: blocking-issue-creator
+promotion:
+  namespace: ci
+  tag: latest
+resources:
+  '*':
+    limits:
+      memory: 10Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.13
+tests:
+- artifact_dir: /tmp/artifacts
+  as: unit
+  commands: ARTIFACT_DIR=/tmp/artifacts make test
+  container:
+    from: src

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -1,0 +1,40 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.12
+images:
+- dockerfile_path: images/tests/Dockerfile.rhel
+  from: cli
+  inputs:
+    bin:
+      as:
+      - registry.svc.ci.openshift.org/ocp/builder:golang-1.12
+      paths: null
+  to: tests
+promotion:
+  additional_images:
+    artifacts: artifacts
+  excluded_images:
+  - machine-os-content
+  name: "4.3"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 8Gi
+    requests:
+      cpu: 100m
+      memory: 4Gi
+tag_specification:
+  name: "4.3"
+  namespace: ocp
+tests:
+- artifact_dir: /tmp/artifacts
+  as: unit
+  commands: TMPDIR=/tmp/volume GOTEST_FLAGS='-p 8' ARTIFACT_DIR=/tmp/artifacts TIMEOUT=180s
+    JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh
+  container:
+    from: src
+    memory_backed_volume:
+      size: 4Gi

--- a/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -1,0 +1,24 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.15
+canonical_go_repository: k8s.io/cool
+promotion:
+  name: "4.3"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tag_specification:
+  name: "4.3"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -1,0 +1,46 @@
+base_images:
+  base:
+    name: "4.3"
+    namespace: ocp
+    tag: base
+binary_build_commands: make install
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.12
+promotion:
+  name: "4.3"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tag_specification:
+  name: "4.3"
+  namespace: ocp
+test_binary_build_commands: make test-install
+tests:
+- as: e2e-aws
+  commands: TEST_SUITE=openshift/conformance/parallel run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: unit
+  commands: unit
+  container:
+    from: src
+- as: cmd
+  commands: make test-cmd
+  container:
+    from: bin
+- as: race
+  commands: race
+  container:
+    from: test-bin
+- as: e2e
+  commands: e2e
+  openshift_installer_src:
+    cluster_profile: aws

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -1,0 +1,46 @@
+postsubmits:
+  openshift/ci-tools:
+  - agent: kubernetes
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    name: branch-ci-openshift-ci-tools-master-images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --promote
+        - --repo=ci-tools
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -1,0 +1,98 @@
+presubmits:
+  openshift/ci-tools:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-master-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --repo=ci-tools
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=[images]
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-ci-tools-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --repo=ci-tools
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -1,0 +1,47 @@
+postsubmits:
+  openshift/origin:
+  - agent: kubernetes
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    name: branch-ci-openshift-origin-master-images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --promote
+        - --repo=origin
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=[images]
+        - --target=artifacts
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -1,0 +1,100 @@
+presubmits:
+  openshift/origin:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-master-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --repo=origin
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=[images]
+        - --target=[release:latest]
+        - --target=artifacts
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )images,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-openshift-origin-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=openshift
+        - --repo=origin
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -1,0 +1,51 @@
+presubmits:
+  org/other:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - nonstandard
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-other-nonstandard-unit
+    path_alias: k8s.io/cool
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=nonstandard
+        - --give-pr-author-access-to-namespace=true
+        - --org=org
+        - --repo=other
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-other-nonstandard.yaml
+              name: ci-operator-misc-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -1,0 +1,285 @@
+presubmits:
+  org/repo:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/cmd
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-repo-master-cmd
+    rerun_command: /test cmd
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=org
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=cmd
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )cmd,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-repo-master-e2e
+    rerun_command: /test e2e
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=org
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --secret-dir=/usr/local/e2e-cluster-profile
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=e2e
+        - --template=/usr/local/e2e
+        command:
+        - ci-operator
+        env:
+        - name: CLUSTER_TYPE
+          value: aws
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
+        - name: JOB_NAME_SAFE
+          value: e2e
+        - name: TEST_COMMAND
+          value: e2e
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/e2e-cluster-profile
+          name: cluster-profile
+        - mountPath: /usr/local/e2e
+          name: job-definition
+          subPath: cluster-launch-installer-src.yaml
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-aws
+      - configMap:
+          name: prow-job-cluster-launch-installer-src
+        name: job-definition
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/e2e-aws
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-repo-master-e2e-aws
+    rerun_command: /test e2e-aws
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --lease-server=http://boskos
+        - --org=org
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --secret-dir=/usr/local/e2e-aws-cluster-profile
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=e2e-aws
+        - --template=/usr/local/e2e-aws
+        command:
+        - ci-operator
+        env:
+        - name: CLUSTER_TYPE
+          value: aws
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
+        - name: JOB_NAME_SAFE
+          value: e2e-aws
+        - name: TEST_COMMAND
+          value: TEST_SUITE=openshift/conformance/parallel run-tests
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /usr/local/e2e-aws-cluster-profile
+          name: cluster-profile
+        - mountPath: /usr/local/e2e-aws
+          name: job-definition
+          subPath: cluster-launch-installer-e2e.yaml
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-aws
+      - configMap:
+          name: prow-job-cluster-launch-installer-e2e
+        name: job-definition
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )e2e-aws,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/race
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-repo-master-race
+    rerun_command: /test race
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=org
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=race
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )race,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-repo-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --artifact-dir=$(ARTIFACTS)
+        - --branch=master
+        - --give-pr-author-access-to-namespace=true
+        - --org=org
+        - --repo=repo
+        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
+        - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
+        - --target=unit
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/sentry-dsn
+          name: sentry-dsn
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: sentry-dsn
+        secret:
+          secretName: sentry-dsn
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/test/repo-init-integration/expected/core-services/prow/02_config/_config.yaml
+++ b/test/repo-init-integration/expected/core-services/prow/02_config/_config.yaml
@@ -1,0 +1,83 @@
+branch-protection: {}
+deck:
+  rerun_auth_config: {}
+  spyglass:
+    size_limit: 100000000
+  tide_update_period: 10s
+default_job_timeout: 24h0m0s
+gerrit:
+  ratelimit: 5
+  tick_interval: 1m0s
+github:
+  link_url: https://github.com
+github_reporter:
+  job_types_to_report:
+  - presubmit
+  - postsubmit
+in_repo_config: {}
+log_level: info
+owners_dir_blacklist: {}
+plank:
+  max_goroutines: 20
+  pod_pending_timeout: 24h0m0s
+  pod_running_timeout: 48h0m0s
+pod_namespace: default
+prowjob_namespace: default
+push_gateway:
+  interval: 1m0s
+  serve_metrics: false
+sinker:
+  max_pod_age: 24h0m0s
+  max_prowjob_age: 168h0m0s
+  resync_period: 1h0m0s
+status_error_link: https://github.com/kubernetes/test-infra/issues
+tide:
+  context_options: {}
+  max_goroutines: 20
+  queries:
+  - includedBranches:
+    - release-4.0
+    - release-4.1
+    - release-4.2
+    - release-4.3
+    - release-4.4
+    - openshift-4.1
+    labels:
+    - lgtm
+    - approved
+    - bugzilla/valid-bug
+    - cherry-pick-approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    - bugzilla/invalid-bug
+    repos:
+    - openshift/origin
+    - org/repo
+  - excludedBranches:
+    - release-4.0
+    - release-4.1
+    - release-4.2
+    - release-4.3
+    - release-4.4
+    - openshift-4.1
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    - bugzilla/invalid-bug
+    repos:
+    - openshift/ci-tools
+    - openshift/origin
+    - org/repo
+    - org/other
+  status_update_period: 1m0s
+  sync_period: 1m0s

--- a/test/repo-init-integration/expected/core-services/prow/02_config/_plugins.yaml
+++ b/test/repo-init-integration/expected/core-services/prow/02_config/_plugins.yaml
@@ -1,0 +1,194 @@
+approve:
+- lgtm_acts_as_approve: true
+  repos:
+  - openshift
+  require_self_approval: false
+- repos:
+  - org/repo
+  require_self_approval: false
+- repos:
+  - org/other
+  require_self_approval: false
+blunderbuss:
+  request_count: 2
+bugzilla: {}
+cat: {}
+cherry_pick_unapproved:
+  branchregexp: ^release-.*$
+  comment: This PR is not for the master branch but does not have the `cherry-pick-approved`  label.
+    Adding the `do-not-merge/cherry-pick-not-approved`  label.
+config_updater:
+  gzip: false
+  maps:
+    config/prow/config.yaml:
+      clusters:
+        default:
+        - ""
+      name: config
+    config/prow/plugins.yaml:
+      clusters:
+        default:
+        - ""
+      name: plugins
+external_plugins:
+  openshift:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - pull_request
+    name: needs-rebase
+  org/other:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - pull_request
+    name: needs-rebase
+  org/repo:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - pull_request
+    name: needs-rebase
+golint: {}
+goose: {}
+heart: {}
+label:
+  additional_labels: null
+lgtm:
+- repos:
+  - openshift
+  review_acts_as_lgtm: true
+- repos:
+  - org/repo
+  review_acts_as_lgtm: true
+- repos:
+  - org/other
+  review_acts_as_lgtm: true
+override: {}
+owners:
+  labels_blacklist:
+  - approved
+  - lgtm
+plugins:
+  openshift:
+  - assign
+  - blunderbuss
+  - blockade
+  - bugzilla
+  - cat
+  - dog
+  - heart
+  - golint
+  - goose
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - override
+  - pony
+  - retitle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - owners-label
+  - wip
+  - yuks
+  openshift/origin:
+  - approve
+  org/other:
+  - assign
+  - blunderbuss
+  - blockade
+  - bugzilla
+  - cat
+  - dog
+  - heart
+  - golint
+  - goose
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - override
+  - pony
+  - retitle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - owners-label
+  - wip
+  - yuks
+  - approve
+  org/repo:
+  - assign
+  - blunderbuss
+  - blockade
+  - bugzilla
+  - cat
+  - dog
+  - heart
+  - golint
+  - goose
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - override
+  - pony
+  - retitle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - owners-label
+  - wip
+  - yuks
+  - approve
+project_config: {}
+project_manager: {}
+requiresig: {}
+retitle: {}
+sigmention:
+  regexp: (?m)@kubernetes/sig-([\w-]*)-(misc|test-failures|bugs|feature-requests|proposals|pr-reviews|api-reviews)
+size:
+  l: 0
+  m: 0
+  s: 0
+  xl: 0
+  xxl: 0
+slack: {}

--- a/test/repo-init-integration/input/Makefile
+++ b/test/repo-init-integration/input/Makefile
@@ -1,0 +1,4 @@
+jobs:
+	ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
+	determinize-prow-jobs --prow-jobs-dir ./ci-operator/jobs
+.PHONY: jobs

--- a/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -1,0 +1,30 @@
+images:
+- context_dir: images/blocking-issue-creator/
+  from: os
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/bin/blocking-issue-creator
+  to: blocking-issue-creator
+promotion:
+  namespace: ci
+  tag: latest
+resources:
+  '*':
+    limits:
+      memory: 10Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.13
+tests:
+- artifact_dir: /tmp/artifacts
+  as: unit
+  commands: ARTIFACT_DIR=/tmp/artifacts make test
+  container:
+    from: src

--- a/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -1,0 +1,40 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.12
+images:
+- dockerfile_path: images/tests/Dockerfile.rhel
+  from: cli
+  inputs:
+    bin:
+      as:
+      - registry.svc.ci.openshift.org/ocp/builder:golang-1.12
+      paths: null
+  to: tests
+promotion:
+  additional_images:
+    artifacts: artifacts
+  excluded_images:
+  - machine-os-content
+  name: "4.3"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      memory: 8Gi
+    requests:
+      cpu: 100m
+      memory: 4Gi
+tag_specification:
+  name: "4.3"
+  namespace: ocp
+tests:
+- artifact_dir: /tmp/artifacts
+  as: unit
+  commands: TMPDIR=/tmp/volume GOTEST_FLAGS='-p 8' ARTIFACT_DIR=/tmp/artifacts TIMEOUT=180s
+    JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh
+  container:
+    from: src
+    memory_backed_volume:
+      size: 4Gi

--- a/test/repo-init-integration/input/core-services/prow/02_config/_config.yaml
+++ b/test/repo-init-integration/input/core-services/prow/02_config/_config.yaml
@@ -1,0 +1,43 @@
+tide:
+  queries:
+  - repos:
+    - openshift/origin
+    includedBranches:
+    - release-4.0
+    - release-4.1
+    - release-4.2
+    - release-4.3
+    - release-4.4
+    - openshift-4.1
+    labels:
+    - lgtm
+    - approved
+    - bugzilla/valid-bug
+    - cherry-pick-approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    - bugzilla/invalid-bug
+  - repos:
+    - openshift/ci-tools
+    - openshift/origin
+    excludedBranches:
+    - release-4.0
+    - release-4.1
+    - release-4.2
+    - release-4.3
+    - release-4.4
+    - openshift-4.1
+    labels:
+    - lgtm
+    - approved
+    missingLabels:
+    - needs-rebase
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/work-in-progress
+    - do-not-merge/invalid-owners-file
+    - bugzilla/invalid-bug

--- a/test/repo-init-integration/input/core-services/prow/02_config/_plugins.yaml
+++ b/test/repo-init-integration/input/core-services/prow/02_config/_plugins.yaml
@@ -1,0 +1,55 @@
+plugins:
+  openshift:
+  - assign
+  - blunderbuss
+  - blockade
+  - bugzilla
+  - cat
+  - dog
+  - heart
+  - golint
+  - goose
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - override
+  - pony
+  - retitle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - owners-label
+  - wip
+  - yuks
+
+  openshift/origin:
+  - approve
+
+external_plugins:
+  openshift:
+  - name: refresh
+    events:
+    - issue_comment
+  - name: cherrypick
+    events:
+    - issue_comment
+    - pull_request
+  - name: needs-rebase
+    events:
+    - pull_request
+
+approve:
+- repos:
+  - openshift
+  require_self_approval: false
+  lgtm_acts_as_approve: true
+
+lgtm:
+- repos:
+  - openshift
+  review_acts_as_lgtm: true

--- a/test/repo-init-integration/run.sh
+++ b/test/repo-init-integration/run.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This test runs the repo-init utility and verifies that it generates
+# correct CI Operator configs and edits Prow config as expected
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOTDIR=$(pwd)
+WORKDIR="$( mktemp -d )"
+trap 'rm -rf ${WORKDIR}' EXIT
+
+cd "$WORKDIR"
+# copy config to tmpdir to allow tester to modify config
+cp -ar "$ROOTDIR"/test/repo-init-integration/input/* .
+
+# this test case will copy-cat origin
+inputs=(
+              "org" # Enter the organization for the repository: org
+             "repo" # Enter the repository to initialize: repo
+                 "" # Enter the development branch for the repository: [default: master]
+              "yes" # Does the repository build and promote container images?  [default: no] yes
+              "yes" # Does the repository promote images as part of the OpenShift release?  [default: no] yes
+              "yes" # Do any images build on top of the OpenShift base image?  [default: no] yes
+               "no" # Do any images build on top of the CentOS base image?  [default: no] no
+                 "" # What version of Go does the repository build with? [default: 1.12]
+                 "" # Enter the Go import path for the repository if it uses a vanity URL (e.g. "k8s.io/my-repo"):
+     "make install" # What commands are used to build binaries in the repository? (e.g. "go install ./cmd/...") make install
+"make test-install" # What commands, if any, are used to build test binaries? (e.g. "go install -race ./cmd/..." or "go test -c ./test/...") make test-install
+              "yes" # Are there any test scripts to configure?  [default: no] yes
+             "unit" # What is the name of this test (e.g. "unit")?  unit
+               "no" # Does this test require built binaries?  [default: no] no
+               "no" # Does this test require test binaries?  [default: no] no
+             "unit" # What commands in the repository run the test (e.g. "make test-unit")?  make test-unit
+              "yes" # Are there any more test scripts to configure?  [default: no] yes
+              "cmd" # What is the name of this test (e.g. "unit")?  cmd
+              "yes" # Does this test require built binaries?  [default: no] yes
+    "make test-cmd" # What command  s in the repository run the test (e.g. "make test-unit")?  make test-cmd
+              "yes" # Are there any more test scripts to configure?  [default: no] yes
+             "race" # What is the name of this test (e.g. "unit")?  race
+               "no" # Does this test require built binaries?  [default: no] no
+              "yes" # Does this test require test binaries?  [default: no] yes
+             "race" # What commands in the repository run the test (e.g. "make test-unit")?  make test-race
+               "no" # Are there any more test scripts to configure?  [default: no] no
+              "yes" # Are there any end-to-end test scripts to configure?  [default: no] yes
+              "e2e" # What is the name of this test (e.g. "e2e-operator")?  e2e
+                 "" # Which specific cloud provider does the test require, if any?  [default: aws]
+              "e2e" # What commands in the repository run the test (e.g. "make test-e2e")?  make test-e2e
+               "no" # Are there any more end-to-end test scripts to configure?  [default: no] no
+)
+for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo .
+
+# this test case will copy-cat ci-tools
+inputs=(
+              "org" # Enter the organization for the repository: org
+            "other" # Enter the repository to initialize: repo
+      "nonstandard" # Enter the development branch for the repository: [default: master]
+              "yes" # Does the repository build and promote container images?  [default: no] yes
+                 "" # Does the repository promote images as part of the OpenShift release?  [default: no] yes
+               "no" # Do any images build on top of the OpenShift base image?  [default: no] yes
+               "no" # Do any images build on top of the CentOS base image?  [default: no] no
+             "1.15" # What version of Go does the repository build with? [default: 1.12]
+      "k8s.io/cool" # Enter the Go import path for the repository if it uses a vanity URL (e.g. "k8s.io/my-repo"):
+                 "" # What commands are used to build binaries in the repository? (e.g. "go install ./cmd/...") make install
+                 "" # What commands, if any, are used to build test binaries? (e.g. "go install -race ./cmd/..." or "go test -c ./test/...") make test-install
+              "yes" # Are there any test scripts to configure?  [default: no] yes
+             "unit" # What is the name of this test (e.g. "unit")?  unit
+   "make test-unit" # What commands in the repository run the test (e.g. "make test-unit")?  make test-unit
+               "no" # Are there any more test scripts to configure?  [default: no] yes
+                 "" # Are there any end-to-end test scripts to configure?  [default: no] no
+)
+for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo .
+
+if ! diff -Naupr "$ROOTDIR"/test/repo-init-integration/expected .> "$WORKDIR/diff"; then
+    echo "[ERROR] Got incorrect output state after running repo-init:"
+    cat "$WORKDIR/diff"
+    exit 1
+fi


### PR DESCRIPTION
Adding a new repository to the `openshift/release` repository is
nontrivial and requires understanding of three or four different
configuration formats. New component authors rarely care about any of
the nuance on their first pull and will be happy with a smaller set of
options and more defaults. This tool aims to boil down the initial
configuration to a set of simple questions and lets the user edit that
as necessary afterword.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 

TODO:

 - [x] handle multi-arg reponses
 - [x] improve UX on read failure
 - [x] allow empty strings for defaulting and add a common defaulting format
 - [ ] actually be intelligent with approval and LGTM configurations
 - [x] flesh out integration test and add it to the make target