### PR TITLE
pkg/load: add validation during registry loading

### DIFF
--- a/test/ci-operator-configresolver-integration/run.sh
+++ b/test/ci-operator-configresolver-integration/run.sh
@@ -60,7 +60,8 @@ if ! diff -Naupr tests/expected/openshift-installer-release-4.2-golang111.json <
 fi
 currGen=$(curl 'http://127.0.0.1:8080/registryGeneration')
 export currGen
-cp -a multistage-registry/registry2 multistage-registry/registry
+rm -rf multistage-registry/registry/*
+cp -a multistage-registry/registry2/* multistage-registry/registry
 for (( i = 0; i < 10; i++ )); do
     if [[ "$(curl http://127.0.0.1:8080/registryGeneration 2>/dev/null)" -gt $currGen+1 ]]; then
         break


### PR DESCRIPTION
Add validation during registry loading. This makes the registry contents much more consistent and prevents naming collisions. It should also significantly reduce the complexity of implementing rehearsals for the changes in the step_registry.

This also adds error logging for registry loading errors that occur in the reload watcher and fixes a bug in the configresolver integration tests.