### PR TITLE
Add ovirt as a cluster profile

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -377,6 +377,7 @@ field is only valid in tests that provision a cluster (`openshift_ansible`,
 - `gcp`
 - `gcp-ha`
 - `gcp-crio`
+- `ovirt`
 - `vsphere`
 
 These are a subset of the profiles found in the

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -286,6 +286,8 @@ func generatePodSpecTemplate(info *prowgenInfo, secret *cioperatorapi.Secret, re
 		targetCloud = "gcp"
 	case cioperatorapi.ClusterProfileOpenStack:
 		targetCloud = "openstack"
+	case cioperatorapi.ClusterProfileOvirt:
+		targetCloud = "ovirt"
 	case cioperatorapi.ClusterProfileVSphere:
 		targetCloud = "vsphere"
 	}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -189,7 +189,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) []error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileOpenStack, ClusterProfileVSphere:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileOpenStack, ClusterProfileOvirt, ClusterProfileVSphere:
 		return nil
 	}
 	return []error{fmt.Errorf("%q: invalid cluster profile %q", fieldRoot, p)}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -507,6 +507,7 @@ const (
 	ClusterProfileGCPLoggingJSONFile ClusterProfile = "gcp-logging-json-file"
 	ClusterProfileGCPLoggingCRIO     ClusterProfile = "gcp-logging-crio"
 	ClusterProfileOpenStack          ClusterProfile = "openstack"
+	ClusterProfileOvirt              ClusterProfile = "ovirt"
 	ClusterProfileVSphere            ClusterProfile = "vsphere"
 )
 
@@ -536,6 +537,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "openstack"
 	case ClusterProfileVSphere:
 		return "vsphere"
+	case ClusterProfileOvirt:
+		return "ovirt"
 	default:
 		return ""
 	}
@@ -565,6 +568,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "gcp-quota-slice"
 	case ClusterProfileOpenStack:
 		return "openstack-quota-slice"
+	case ClusterProfileOvirt:
+		return "ovirt-quota-slice"
 	case ClusterProfileVSphere:
 		return "vsphere-quota-slice"
 	default:
@@ -575,7 +580,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "azure4", "gcp", "openstack", "vsphere":
+	case "aws", "azure4", "gcp", "openstack", "vsphere", "ovirt":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
This patch adds ovirt as a valid cluster profile

Signed-off-by: Gal Zaidman <gzaidman@redhat.com>