### PR TITLE
pkg/lease: increase mutual exclusion

### DIFF
--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -87,12 +87,12 @@ func (c *client) Heartbeat() error {
 }
 
 func (c *client) Release(name string) error {
+	c.Lock()
+	defer c.Unlock()
 	if err := c.boskos.ReleaseOne(name, freeState); err != nil {
 		return err
 	}
-	c.Lock()
 	delete(c.cancel, name)
-	c.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
The following sequence happens in production where `boskos` takes an
extraordinarily long time to respond to each operation (JSON lines are
the server logs):

```
2019-11-12 16:50:36 debug: start update
2019-11-12 16:50:48 debug: start release
{"level":"info","msg":"Updated resource 0cff6b17-983f-450e-97a9-0a495ea37627","time":"2019-11-12T16:51:51Z"}
2019-11-12 16:51:51 debug: end update
2019-11-12 16:51:51 debug: start update
{"level":"info","msg":"Done with resource 0cff6b17-983f-450e-97a9-0a495ea37627, set to state free","time":"2019-11-12T16:53:11Z"}
2019-11-12 16:53:12 debug: end release
2019-11-12 16:53:12 debug: end update
2019-11-12 16:53:12 cleanup: Deleting pods with label ci.openshift.io/multi-stage-test=e2e
2019-11-12 16:53:12 failed to update leases: failed to update lease "0cff6b17-983f-450e-97a9-0a495ea37627": no resource name 0cff6b17-983f-450e-97a9-0a495ea37627
```

I.e. because `boskos` takes ~1m to respond, a `release` and an `update`
request queue and the latter eventually returns an error when they both
finish.

This commit ensures requests are serialized.