### PR TITLE
prowgen: add --lease-server to one test type

### DIFF
--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -417,7 +417,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--branch=branch",
 						"--target=test",
 						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test"},
+						"--template=/usr/local/test",
+						"--lease-server=http://boskos"},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},


### PR DESCRIPTION
Last requirement for https://github.com/openshift/release/pull/5802.

Rehearsals work as expected (even the ones with flakes =):

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/5802/rehearse-5802-pull-ci-openshift-origin-master-e2e-aws/6
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/5802/rehearse-5802-pull-ci-openshift-origin-master-e2e-azure/6
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/5802/rehearse-5802-pull-ci-openshift-origin-master-e2e-cmd/6

On Monday, I'll open the corresponding PR in `openshift/release`, merge all,
and monitor.  If no disruption occurs, we can move on to replacing all lease
containers and finally remove the temporary code.

/hold