### PR TITLE
pkg/registry: add registry graph

### DIFF
--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -1,0 +1,295 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Type declarations
+
+// NodeType identifies the type of registry element a Node refers to
+type NodeType int
+
+const (
+	Workflow NodeType = iota
+	Chain
+	Reference
+)
+
+// Node is an interface that allows a user to identify ancestors and descendants of a step registry element
+type Node interface {
+	Name() string
+	GetNodeType() NodeType
+	GetAncestorNames() sets.String
+	GetDescendantNames() sets.String
+}
+
+// NodeByName provides a mapping from node name to the Node interface
+type NodeByName map[string]Node
+
+type nodeWithName struct {
+	name string
+}
+
+type nodeWithParents struct {
+	workflowParents workflowNodeSet
+	chainParents    chainNodeSet
+}
+
+type nodeWithChildren struct {
+	chainChildren     chainNodeSet
+	referenceChildren referenceNodeSet
+}
+
+type workflowNode struct {
+	nodeWithName
+	nodeWithChildren
+}
+
+type chainNode struct {
+	nodeWithName
+	nodeWithParents
+	nodeWithChildren
+}
+
+type referenceNode struct {
+	nodeWithName
+	nodeWithParents
+}
+
+// Verify that all node types implement Node
+var _ = Node(&workflowNode{})
+var _ = Node(&chainNode{})
+var _ = Node(&referenceNode{})
+
+// internal node type sets
+type workflowNodeSet map[*workflowNode]sets.Empty
+type chainNodeSet map[*chainNode]sets.Empty
+type referenceNodeSet map[*referenceNode]sets.Empty
+
+// Name -> internal node type maps
+type workflowNodeByName map[string]*workflowNode
+type chainNodeByName map[string]*chainNode
+type referenceNodeByName map[string]*referenceNode
+
+// Set functions
+
+func (set workflowNodeSet) insert(node *workflowNode) {
+	set[node] = sets.Empty{}
+}
+
+func (set workflowNodeSet) list() []*workflowNode {
+	res := make([]*workflowNode, 0, len(set))
+	for key := range set {
+		res = append(res, key)
+	}
+	return res
+}
+
+func (set chainNodeSet) insert(node *chainNode) {
+	set[node] = sets.Empty{}
+}
+
+func (set chainNodeSet) list() []*chainNode {
+	res := make([]*chainNode, 0, len(set))
+	for key := range set {
+		res = append(res, key)
+	}
+	return res
+}
+
+func (set referenceNodeSet) insert(node *referenceNode) {
+	set[node] = sets.Empty{}
+}
+
+func (set referenceNodeSet) list() []*referenceNode {
+	res := make([]*referenceNode, 0, len(set))
+	for key := range set {
+		res = append(res, key)
+	}
+	return res
+}
+
+// Interface Functions
+// Name function
+
+func (n *nodeWithName) Name() string {
+	return n.name
+}
+
+// GetNodeType functions
+
+func (*workflowNode) GetNodeType() NodeType {
+	return Workflow
+}
+
+func (*chainNode) GetNodeType() NodeType {
+	return Chain
+}
+
+func (*referenceNode) GetNodeType() NodeType {
+	return Reference
+}
+
+// GetAncestorNames functions
+
+func (n *nodeWithParents) GetAncestorNames() sets.String {
+	ancestors := sets.NewString()
+	for parent := range n.workflowParents {
+		ancestors.Insert(parent.Name())
+	}
+	for parent := range n.chainParents {
+		ancestors.Insert(parent.Name())
+		ancestors.Insert(parent.GetAncestorNames().List()...)
+	}
+	return ancestors
+}
+
+func (*workflowNode) GetAncestorNames() sets.String { return nil }
+
+// GetDescendantNames function
+
+func (n *nodeWithChildren) GetDescendantNames() sets.String {
+	descendants := sets.NewString()
+	for child := range n.referenceChildren {
+		descendants.Insert(child.Name())
+	}
+	for child := range n.chainChildren {
+		descendants.Insert(child.Name())
+		descendants.Insert(child.GetDescendantNames().List()...)
+	}
+	return descendants
+}
+
+func (*referenceNode) GetDescendantNames() sets.String { return nil }
+
+// Struct helper functions
+// addChild functions
+
+func (n *workflowNode) addChainChild(child *chainNode) {
+	n.chainChildren.insert(child)
+	child.workflowParents.insert(n)
+}
+
+func (n *workflowNode) addReferenceChild(child *referenceNode) {
+	n.referenceChildren.insert(child)
+	child.workflowParents.insert(n)
+}
+
+func (n *chainNode) addChainChild(child *chainNode) {
+	n.chainChildren.insert(child)
+	child.chainParents.insert(n)
+}
+
+func (n *chainNode) addReferenceChild(child *referenceNode) {
+	n.referenceChildren.insert(child)
+	child.chainParents.insert(n)
+}
+
+func newNodeWithName(name string) nodeWithName {
+	return nodeWithName{name: name}
+}
+
+func newNodeWithParents() nodeWithParents {
+	return nodeWithParents{
+		chainParents:    make(chainNodeSet),
+		workflowParents: make(workflowNodeSet),
+	}
+}
+
+func newNodeWithChildren() nodeWithChildren {
+	return nodeWithChildren{
+		chainChildren:     make(chainNodeSet),
+		referenceChildren: make(referenceNodeSet),
+	}
+}
+
+func hasCycles(node *chainNode, ancestors sets.String, traversedPath []string) error {
+	if ancestors == nil {
+		ancestors = make(sets.String)
+	}
+	if ancestors.Has(node.name) {
+		return fmt.Errorf("Cycle detected: %s is an ancestor of itself; traversedPath: %v", node.name, append(traversedPath, node.name))
+	}
+	ancestors.Insert(node.name)
+	for child := range node.chainChildren {
+		if child.GetNodeType() != Chain {
+			continue
+		}
+		// get new copy of ancestors and traversedPath so the root node's set isn't changed
+		ancestorsCopy := sets.NewString()
+		for _, ancestor := range ancestors.List() {
+			ancestorsCopy.Insert(ancestor)
+		}
+		traversedPathCopy := append(traversedPath[:0:0], traversedPath...)
+		traversedPathCopy = append(traversedPathCopy, node.name)
+		if err := hasCycles(child, ancestorsCopy, traversedPathCopy); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func NewGraph(stepsByName map[string]api.LiteralTestStep, chainsByName map[string][]api.TestStep, workflowsByName map[string]api.MultiStageTestConfiguration) (NodeByName, error) {
+	nodesByName := make(NodeByName)
+	// References can only be children; load them so they can be added as children by workflows and chains
+	referenceNodes := make(referenceNodeByName)
+	for name := range stepsByName {
+		node := &referenceNode{
+			nodeWithName:    newNodeWithName(name),
+			nodeWithParents: newNodeWithParents(),
+		}
+		referenceNodes[name] = node
+		nodesByName[name] = Node(node)
+	}
+	// since we may load the parent chain before a child chain, we need to make the parent->child links after loading all chains
+	parentChildChain := make(map[*chainNode]string)
+	chainNodes := make(chainNodeByName)
+	for name, chain := range chainsByName {
+		node := &chainNode{
+			nodeWithName:     newNodeWithName(name),
+			nodeWithChildren: newNodeWithChildren(),
+			nodeWithParents:  newNodeWithParents(),
+		}
+		chainNodes[name] = node
+		nodesByName[name] = Node(node)
+		for _, step := range chain {
+			if step.Reference != nil {
+				node.addReferenceChild(referenceNodes[*step.Reference])
+			}
+			if step.Chain != nil {
+				parentChildChain[node] = *step.Chain
+			}
+		}
+	}
+	for parent, child := range parentChildChain {
+		parent.addChainChild(chainNodes[child])
+	}
+	// verify that no cycles exist
+	for _, chain := range chainNodes {
+		if err := hasCycles(chain, make(sets.String), []string{}); err != nil {
+			return nil, err
+		}
+	}
+	workflowNodes := make(workflowNodeByName)
+	for name, workflow := range workflowsByName {
+		node := &workflowNode{
+			nodeWithName:     newNodeWithName(name),
+			nodeWithChildren: newNodeWithChildren(),
+		}
+		workflowNodes[name] = node
+		nodesByName[name] = Node(node)
+		steps := append(workflow.Pre, append(workflow.Test, workflow.Post...)...)
+		for _, step := range steps {
+			if step.Reference != nil {
+				node.addReferenceChild(referenceNodes[*step.Reference])
+			}
+			if step.Chain != nil {
+				node.addChainChild(chainNodes[*step.Chain])
+			}
+		}
+	}
+	return nodesByName, nil
+}

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -20,9 +20,13 @@ const (
 
 // Node is an interface that allows a user to identify ancestors and descendants of a step registry element
 type Node interface {
+	// Name returns the name of the registry element a Node refers to
 	Name() string
+	// Type returns the type of the registry element a Node refers to
 	Type() Type
+	// AncestorNames returns a set of strings containing the names of all of the node's ancestors
 	AncestorNames() sets.String
+	// DescendantNames returns a set of strings containing the names of all of the node's descendants
 	DescendantNames() sets.String
 }
 
@@ -232,6 +236,7 @@ func hasCycles(node *chainNode, ancestors sets.String, traversedPath []string) e
 	return nil
 }
 
+// NewGraph returns a NodeByType map representing the provided step references, chains, and workflows as a directed graph.
 func NewGraph(stepsByName map[string]api.LiteralTestStep, chainsByName map[string][]api.TestStep, workflowsByName map[string]api.MultiStageTestConfiguration) (NodeByName, error) {
 	nodesByName := make(NodeByName)
 	// References can only be children; load them so they can be added as children by workflows and chains

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // These maps contain the representation of ../../test/multistage-registry/registry with the
-// minimum of amount necessary to create a graph
+// minimum of amount of information necessary to create a graph
 var ipiInstallInstall = "ipi-install-install"
 var ipiInstallRBAC = "ipi-install-rbac"
 var ipiDeprovisionMustGather = "ipi-deprovision-must-gather"

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -1,0 +1,159 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// These maps contain the representation of ../../test/multistage-registry/registry with the
+// minimum of amount necessary to create a graph
+var ipiInstallInstall = "ipi-install-install"
+var ipiInstallRBAC = "ipi-install-rbac"
+var ipiDeprovisionMustGather = "ipi-deprovision-must-gather"
+var ipiDeprovisionDeprovision = "ipi-deprovision-deprovision"
+var ipiInstall = "ipi-install"
+var ipiDeprovision = "ipi-deprovision"
+var ipi = "ipi"
+
+var referenceMap = map[string]api.LiteralTestStep{
+	ipiInstallInstall:         {},
+	ipiInstallRBAC:            {},
+	ipiDeprovisionDeprovision: {},
+	ipiDeprovisionMustGather:  {},
+}
+var chainMap = map[string][]api.TestStep{
+	ipiInstall: {{
+		Reference: &ipiInstallInstall,
+	}, {
+		Reference: &ipiInstallRBAC,
+	}},
+	ipiDeprovision: {{
+		Reference: &ipiDeprovisionMustGather,
+	}, {
+		Reference: &ipiDeprovisionDeprovision,
+	}},
+}
+var workflowMap = map[string]api.MultiStageTestConfiguration{
+	ipi: {
+		Pre: []api.TestStep{{
+			Chain: &ipiInstall,
+		}},
+		Post: []api.TestStep{{
+			Chain: &ipiDeprovision,
+		}},
+	},
+}
+
+func TestAncestorNames(t *testing.T) {
+	testCases := []struct {
+		name string
+		set  sets.String
+	}{{
+		name: ipi,
+		set:  sets.String{},
+	}, {
+		name: ipiInstall,
+		set: sets.String{
+			ipi: sets.Empty{},
+		},
+	}, {
+		name: ipiDeprovisionMustGather,
+		set: sets.String{
+			ipi:            sets.Empty{},
+			ipiDeprovision: sets.Empty{},
+		},
+	}}
+
+	graph, err := NewGraph(referenceMap, chainMap, workflowMap)
+	if err != nil {
+		t.Fatalf("failed to create graph: %v", err)
+	}
+	for _, testCase := range testCases {
+		node := graph[testCase.name]
+		if !testCase.set.Equal(node.AncestorNames()) {
+			t.Errorf("%s: ancestor sets not equal", testCase.name)
+		}
+	}
+}
+
+func TestDescendantNames(t *testing.T) {
+	testCases := []struct {
+		name string
+		set  sets.String
+	}{{
+		name: ipi,
+		set: sets.String{
+			ipiInstall:                sets.Empty{},
+			ipiInstallInstall:         sets.Empty{},
+			ipiInstallRBAC:            sets.Empty{},
+			ipiDeprovision:            sets.Empty{},
+			ipiDeprovisionMustGather:  sets.Empty{},
+			ipiDeprovisionDeprovision: sets.Empty{},
+		},
+	}, {
+		name: ipiInstall,
+		set: sets.String{
+			ipiInstallInstall: sets.Empty{},
+			ipiInstallRBAC:    sets.Empty{},
+		},
+	}, {
+		name: ipiDeprovisionMustGather,
+		set:  sets.String{},
+	}}
+
+	graph, err := NewGraph(referenceMap, chainMap, workflowMap)
+	if err != nil {
+		t.Fatalf("failed to create graph: %v", err)
+	}
+	for _, testCase := range testCases {
+		node := graph[testCase.name]
+		if !testCase.set.Equal(node.DescendantNames()) {
+			t.Errorf("%s: descendant sets not equal", testCase.name)
+		}
+	}
+}
+
+func TestHasCycles(t *testing.T) {
+	chain1 := &chainNode{
+		nodeWithName:     newNodeWithName("chain1"),
+		nodeWithParents:  newNodeWithParents(),
+		nodeWithChildren: newNodeWithChildren(),
+	}
+	chain2 := &chainNode{
+		nodeWithName:     newNodeWithName("chain2"),
+		nodeWithParents:  newNodeWithParents(),
+		nodeWithChildren: newNodeWithChildren(),
+	}
+	chain1.addChainChild(chain2)
+	chain3 := &chainNode{
+		nodeWithName:     newNodeWithName("chain3"),
+		nodeWithParents:  newNodeWithParents(),
+		nodeWithChildren: newNodeWithChildren(),
+	}
+	chain2.addChainChild(chain3)
+
+	chainSet := make(chainNodeSet)
+	chainSet.insert(chain1)
+	chainSet.insert(chain2)
+	chainSet.insert(chain3)
+
+	// No cycles currently exist; should pass
+	for chain := range chainSet {
+		if err := hasCycles(chain, nil, nil); err != nil {
+			t.Errorf("Error reported unexpectedly: %v", err)
+		}
+	}
+	// Add a cycle
+	chain3.addChainChild(chain1)
+	hasErr := false
+	for chain := range chainSet {
+		if err := hasCycles(chain, nil, nil); err != nil {
+			hasErr = true
+		}
+	}
+	if !hasErr {
+		t.Errorf("Did not get error when a chain had a cycle")
+	}
+}


### PR DESCRIPTION
This adds a registry graph, which allows a user to identify all ancestors or descendants of a registry component as well as detect any cycles in the chains.

Will be used in pj-rehearse and greatly simplify #267 