### PR TITLE
Default artifacts directory, set env

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -13,6 +13,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+const defaultArtifacts = "/tmp/artifacts"
+
+// Default sets default values after loading but before validation
+func (config *ReleaseBuildConfiguration) Default() {
+	for _, step := range config.RawSteps {
+		if step.TestStepConfiguration != nil && step.TestStepConfiguration.ArtifactDir == "" {
+			step.TestStepConfiguration.ArtifactDir = defaultArtifacts
+		}
+	}
+
+	for _, test := range config.Tests {
+		if test.ArtifactDir == "" {
+			test.ArtifactDir = defaultArtifacts
+		}
+	}
+}
+
 // ValidateAtRuntime validates all the configuration's values without knowledge of config
 // repo structure
 func (config *ReleaseBuildConfiguration) ValidateAtRuntime() error {
@@ -27,6 +44,7 @@ func (config *ReleaseBuildConfiguration) ValidateResolved() error {
 
 // Validate validates all the configuration's values.
 func (config *ReleaseBuildConfiguration) Validate(org, repo string) error {
+	config.Default()
 	return config.validate(org, repo, false)
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -319,8 +319,8 @@ type TestStepConfiguration struct {
 	// the repository root to execute tests.
 	Commands string `json:"commands"`
 	// ArtifactDir is an optional directory that contains the
-	// artifacts to upload. If unset, this will default under
-	// the repository root to _output/local/artifacts.
+	// artifacts to upload. If unset, this will default to
+	// "/tmp/artifacts".
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 
 	// Secret is an optional secret object which
@@ -406,7 +406,8 @@ type LiteralTestStep struct {
 	From string `json:"from,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
-	// ArtifactDir is the directory from which artifacts will be extracted when the command finishes.
+	// ArtifactDir is the directory from which artifacts will be extracted
+	// when the command finishes. Defaults to "/tmp/artifacts"
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources,omitempty"`

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -41,6 +41,8 @@ const (
 	// A comma-delimited list of container names that will be returned as individual JUnit
 	// test results.
 	annotationContainersForSubTestResults = "ci-operator.openshift.io/container-sub-tests"
+	// artifactEnv is the env var in which we hold the artifact dir for users
+	artifactEnv = "ARTIFACT_DIR"
 )
 
 // ContainerNotifier receives updates about the status of a poll action on a pod. The caller
@@ -298,6 +300,17 @@ func removeFile(podClient PodClient, ns, name, containerName string, paths []str
 	}
 
 	return nil
+}
+
+func addArtifacts(pod *coreapi.Pod, artifactDir string) {
+	for i := range pod.Spec.Containers {
+		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, coreapi.VolumeMount{
+			Name:      "artifacts",
+			MountPath: artifactDir,
+		})
+		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, coreapi.EnvVar{Name: artifactEnv, Value: artifactDir})
+	}
+	addArtifactsContainer(pod)
 }
 
 func addArtifactsContainer(pod *coreapi.Pod) {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -194,7 +194,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 			continue
 		}
 		name := fmt.Sprintf("%s-%s", s.name, step.As)
-		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources)
+		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources, step.ArtifactDir)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -217,13 +217,6 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 				{Name: "RELEASE_IMAGE_INITIAL", Value: s.releaseInitial},
 				{Name: "RELEASE_IMAGE_LATEST", Value: s.releaseLatest},
 			}...)
-		}
-		if s.artifactDir != "" && step.ArtifactDir != "" {
-			container.VolumeMounts = append(container.VolumeMounts, coreapi.VolumeMount{
-				Name:      "artifacts",
-				MountPath: step.ArtifactDir,
-			})
-			addArtifactsContainer(pod)
 		}
 		addSecret(s.name, pod)
 		ret = append(ret, *pod)

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -95,7 +96,7 @@ func TestGeneratePods(t *testing.T) {
 		"ci.openshift.io/refs.repo":        "repo",
 		"ci.openshift.io/multi-stage-test": "test",
 	}
-	env := []coreapi.EnvVar{
+	coreEnv := []coreapi.EnvVar{
 		{Name: "BUILD_ID", Value: "build id"},
 		{Name: "JOB_NAME", Value: "job"},
 		{Name: "JOB_SPEC", Value: `{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}`},
@@ -106,6 +107,8 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "PULL_REFS", Value: "base ref:base sha"},
 		{Name: "REPO_NAME", Value: "repo"},
 		{Name: "REPO_OWNER", Value: "org"},
+	}
+	customEnv := []coreapi.EnvVar{
 		{Name: "NAMESPACE", Value: "namespace"},
 		{Name: "JOB_NAME_SAFE", Value: "test"},
 		{Name: "JOB_NAME_HASH", Value: "5e8c9"},
@@ -114,6 +117,7 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},
 	}
+
 	jobSpec := api.JobSpec{
 		JobSpec: prowdapi.JobSpec{
 			Job:       "job",
@@ -166,7 +170,7 @@ func TestGeneratePods(t *testing.T) {
 				Image:                    "image0",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
-				Env:                      env,
+				Env:                      append(coreEnv, customEnv...),
 				Resources:                coreapi.ResourceRequirements{},
 				TerminationMessagePolicy: "FallbackToLogsOnError",
 				VolumeMounts: []coreapi.VolumeMount{{
@@ -231,18 +235,18 @@ func TestGeneratePods(t *testing.T) {
 				Image:                    "image1",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
-				Env:                      env,
+				Env:                      append(append(coreEnv, coreapi.EnvVar{Name: "ARTIFACT_DIR", Value: "/artifact/dir"}), customEnv...),
 				Resources:                coreapi.ResourceRequirements{},
 				TerminationMessagePolicy: "FallbackToLogsOnError",
 				VolumeMounts: []coreapi.VolumeMount{{
+					Name:      "artifacts",
+					MountPath: "/artifact/dir",
+				}, {
 					Name:      "secret-wrapper",
 					MountPath: "/tmp/secret-wrapper",
 				}, {
 					Name:      "cluster-profile",
 					MountPath: "/var/run/secrets/ci.openshift.io/cluster-profile",
-				}, {
-					Name:      "artifacts",
-					MountPath: "/artifact/dir",
 				}, {
 					Name:      "test",
 					MountPath: "/var/run/secrets/ci.openshift.io/multi-stage",
@@ -273,6 +277,11 @@ done
 				}},
 			}},
 			Volumes: []coreapi.Volume{{
+				Name: "artifacts",
+				VolumeSource: coreapi.VolumeSource{
+					EmptyDir: &coreapi.EmptyDirVolumeSource{},
+				},
+			}, {
 				Name: "secret-wrapper",
 				VolumeSource: coreapi.VolumeSource{
 					EmptyDir: &coreapi.EmptyDirVolumeSource{},
@@ -285,11 +294,6 @@ done
 					},
 				},
 			}, {
-				Name: "artifacts",
-				VolumeSource: coreapi.VolumeSource{
-					EmptyDir: &coreapi.EmptyDirVolumeSource{},
-				},
-			}, {
 				Name: "test",
 				VolumeSource: coreapi.VolumeSource{
 					Secret: &coreapi.SecretVolumeSource{
@@ -299,8 +303,13 @@ done
 			}},
 		},
 	}}
-	if !reflect.DeepEqual(expected, ret) {
-		t.Fatalf("did not generate expected pods: %s", diff.ObjectReflectDiff(expected, ret))
+	if len(expected) != len(ret) {
+		t.Fatalf("did not generate %d pods, but %d: %s", len(expected), len(ret), diff.ObjectReflectDiff(expected, ret))
+	}
+	for i := range expected {
+		if !equality.Semantic.DeepEqual(expected[i], ret[i]) {
+			t.Errorf("did not generate expected pod: %s", diff.ObjectReflectDiff(expected[i], ret[i]))
+		}
 	}
 }
 

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -77,11 +77,6 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 	var notifier ContainerNotifier = NopNotifier
 	if s.gatherArtifacts() {
 		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.config.As), s.jobSpec.Namespace)
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, coreapi.VolumeMount{
-			Name:      "artifacts",
-			MountPath: s.config.ArtifactDir,
-		})
-		addArtifactsContainer(pod)
 		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
 		notifier = artifacts
 	}
@@ -197,12 +192,13 @@ func generateBasePod(
 	command []string,
 	image string,
 	containerResources coreapi.ResourceRequirements,
+	artifactDir string,
 ) (*coreapi.Pod, error) {
 	envMap, err := downwardapi.EnvForSpec(jobSpec.JobSpec)
 	if err != nil {
 		return nil, err
 	}
-	return &coreapi.Pod{
+	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:   podName,
 			Labels: defaultPodLabels(jobSpec),
@@ -224,11 +220,15 @@ func generateBasePod(
 				},
 			},
 		},
-	}, nil
+	}
+	if artifactDir != "" {
+		addArtifacts(pod, artifactDir)
+	}
+	return pod, nil
 }
 
 func (s *podStep) generatePodForStep(image string, containerResources coreapi.ResourceRequirements) (*coreapi.Pod, error) {
-	pod, err := generateBasePod(s.jobSpec, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources)
+	pod, err := generateBasePod(s.jobSpec, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, s.config.ArtifactDir)
 	if err != nil {
 		return nil, err
 	}

--- a/test/ci-operator-integration/base/expected_files/expected.json
+++ b/test/ci-operator-integration/base/expected_files/expected.json
@@ -1436,6 +1436,10 @@
             {
               "name": "REPO_OWNER",
               "value": "openshift"
+            },
+            {
+              "name": "ARTIFACT_DIR",
+              "value": "/tmp/artifacts"
             }
           ],
           "image": "pipeline:src",
@@ -1452,14 +1456,38 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            },
+            {
               "mountPath": "/tmp/volume",
               "name": "memory-backed"
+            }
+          ]
+        },
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
+          ],
+          "image": "busybox",
+          "name": "artifacts",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
             }
           ]
         }
       ],
       "restartPolicy": "Never",
       "volumes": [
+        {
+          "emptyDir": {},
+          "name": "artifacts"
+        },
         {
           "emptyDir": {
             "medium": "Memory",
@@ -1547,6 +1575,10 @@
             {
               "name": "REPO_OWNER",
               "value": "openshift"
+            },
+            {
+              "name": "ARTIFACT_DIR",
+              "value": "/tmp/artifacts"
             }
           ],
           "image": "pipeline:bin",
@@ -1560,10 +1592,38 @@
               "memory": "8Gi"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError"
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            }
+          ]
+        },
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
+          ],
+          "image": "busybox",
+          "name": "artifacts",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            }
+          ]
         }
       ],
-      "restartPolicy": "Never"
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "emptyDir": {},
+          "name": "artifacts"
+        }
+      ]
     },
     "status": {}
   },


### PR DESCRIPTION
When a user runs a test they should be able to set their artifacts
directory to something other than the default, but they should not need
to do anything special to get the default. All good tests create
artifacts so this should not make much of a difference for the amount of
containers we actually run.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 
/cc @openshift/openshift-team-developer-productivity-test-platform 