### PR TITLE
prowgen: build all promoted images in `images` presubmits

### DIFF
--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -24,6 +24,7 @@ presubmits:
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
+        - --target=src
         command:
         - ci-operator
         env:


### PR DESCRIPTION
Previously, it was possible to not attempt to build all promoted images
in any of the PR presubmits. Make the `images` presubmit target all
images that are promoted, including those in `additional_images`.

Resolves: https://github.com/openshift/ci-tools/issues/284

/cc @openshift/openshift-team-developer-productivity-test-platform 