### PR TITLE
Revert "Default artifacts directory, set env"

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -13,23 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-const defaultArtifacts = "/tmp/artifacts"
-
-// Default sets default values after loading but before validation
-func (config *ReleaseBuildConfiguration) Default() {
-	for _, step := range config.RawSteps {
-		if step.TestStepConfiguration != nil && step.TestStepConfiguration.ArtifactDir == "" {
-			step.TestStepConfiguration.ArtifactDir = defaultArtifacts
-		}
-	}
-
-	for _, test := range config.Tests {
-		if test.ArtifactDir == "" {
-			test.ArtifactDir = defaultArtifacts
-		}
-	}
-}
-
 // ValidateAtRuntime validates all the configuration's values without knowledge of config
 // repo structure
 func (config *ReleaseBuildConfiguration) ValidateAtRuntime() error {
@@ -44,7 +27,6 @@ func (config *ReleaseBuildConfiguration) ValidateResolved() error {
 
 // Validate validates all the configuration's values.
 func (config *ReleaseBuildConfiguration) Validate(org, repo string) error {
-	config.Default()
 	return config.validate(org, repo, false)
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -319,8 +319,8 @@ type TestStepConfiguration struct {
 	// the repository root to execute tests.
 	Commands string `json:"commands"`
 	// ArtifactDir is an optional directory that contains the
-	// artifacts to upload. If unset, this will default to
-	// "/tmp/artifacts".
+	// artifacts to upload. If unset, this will default under
+	// the repository root to _output/local/artifacts.
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 
 	// Secret is an optional secret object which
@@ -406,8 +406,7 @@ type LiteralTestStep struct {
 	From string `json:"from,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
-	// ArtifactDir is the directory from which artifacts will be extracted
-	// when the command finishes. Defaults to "/tmp/artifacts"
+	// ArtifactDir is the directory from which artifacts will be extracted when the command finishes.
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources,omitempty"`

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -41,8 +41,6 @@ const (
 	// A comma-delimited list of container names that will be returned as individual JUnit
 	// test results.
 	annotationContainersForSubTestResults = "ci-operator.openshift.io/container-sub-tests"
-	// artifactEnv is the env var in which we hold the artifact dir for users
-	artifactEnv = "ARTIFACT_DIR"
 )
 
 // ContainerNotifier receives updates about the status of a poll action on a pod. The caller
@@ -300,17 +298,6 @@ func removeFile(podClient PodClient, ns, name, containerName string, paths []str
 	}
 
 	return nil
-}
-
-func addArtifacts(pod *coreapi.Pod, artifactDir string) {
-	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, coreapi.VolumeMount{
-			Name:      "artifacts",
-			MountPath: artifactDir,
-		})
-		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, coreapi.EnvVar{Name: artifactEnv, Value: artifactDir})
-	}
-	addArtifactsContainer(pod)
 }
 
 func addArtifactsContainer(pod *coreapi.Pod) {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -194,7 +194,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 			continue
 		}
 		name := fmt.Sprintf("%s-%s", s.name, step.As)
-		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources, step.ArtifactDir)
+		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources)
 		if err != nil {
 			errs = append(errs, err)
 			continue
@@ -217,6 +217,13 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 				{Name: "RELEASE_IMAGE_INITIAL", Value: s.releaseInitial},
 				{Name: "RELEASE_IMAGE_LATEST", Value: s.releaseLatest},
 			}...)
+		}
+		if s.artifactDir != "" && step.ArtifactDir != "" {
+			container.VolumeMounts = append(container.VolumeMounts, coreapi.VolumeMount{
+				Name:      "artifacts",
+				MountPath: step.ArtifactDir,
+			})
+			addArtifactsContainer(pod)
 		}
 		addSecret(s.name, pod)
 		ret = append(ret, *pod)

--- a/test/ci-operator-integration/base/expected_files/expected.json
+++ b/test/ci-operator-integration/base/expected_files/expected.json
@@ -1436,10 +1436,6 @@
             {
               "name": "REPO_OWNER",
               "value": "openshift"
-            },
-            {
-              "name": "ARTIFACT_DIR",
-              "value": "/tmp/artifacts"
             }
           ],
           "image": "pipeline:src",
@@ -1456,38 +1452,14 @@
           "terminationMessagePolicy": "FallbackToLogsOnError",
           "volumeMounts": [
             {
-              "mountPath": "/tmp/artifacts",
-              "name": "artifacts"
-            },
-            {
               "mountPath": "/tmp/volume",
               "name": "memory-backed"
-            }
-          ]
-        },
-        {
-          "command": [
-            "/bin/sh",
-            "-c",
-            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
-          ],
-          "image": "busybox",
-          "name": "artifacts",
-          "resources": {},
-          "volumeMounts": [
-            {
-              "mountPath": "/tmp/artifacts",
-              "name": "artifacts"
             }
           ]
         }
       ],
       "restartPolicy": "Never",
       "volumes": [
-        {
-          "emptyDir": {},
-          "name": "artifacts"
-        },
         {
           "emptyDir": {
             "medium": "Memory",
@@ -1575,10 +1547,6 @@
             {
               "name": "REPO_OWNER",
               "value": "openshift"
-            },
-            {
-              "name": "ARTIFACT_DIR",
-              "value": "/tmp/artifacts"
             }
           ],
           "image": "pipeline:bin",
@@ -1592,38 +1560,10 @@
               "memory": "8Gi"
             }
           },
-          "terminationMessagePolicy": "FallbackToLogsOnError",
-          "volumeMounts": [
-            {
-              "mountPath": "/tmp/artifacts",
-              "name": "artifacts"
-            }
-          ]
-        },
-        {
-          "command": [
-            "/bin/sh",
-            "-c",
-            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
-          ],
-          "image": "busybox",
-          "name": "artifacts",
-          "resources": {},
-          "volumeMounts": [
-            {
-              "mountPath": "/tmp/artifacts",
-              "name": "artifacts"
-            }
-          ]
+          "terminationMessagePolicy": "FallbackToLogsOnError"
         }
       ],
-      "restartPolicy": "Never",
-      "volumes": [
-        {
-          "emptyDir": {},
-          "name": "artifacts"
-        }
-      ]
+      "restartPolicy": "Never"
     },
     "status": {}
   },


### PR DESCRIPTION
Reverts openshift/ci-tools#286

Jobs starting to fail
```console
failed to create or restart test pod: unable to create pod: Pod "e2e-prod-4.2" is invalid: spec.containers[1].volumeMounts[0].name: Not found: "artifacts"
```
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.2/78