### PR TITLE
[prowgen] Generate private jobs by using OAuth token instead of SSH 

### DIFF
--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -20,11 +20,11 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --oauth-token-path=/usr/local/github-credentials/oauth
         - --org=private-org
         - --repo=duper
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
         - --target=unit
         command:
         - ci-operator
@@ -41,17 +41,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-          name: github-ssh-credentials-openshift-bot
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
         - mountPath: /etc/sentry-dsn
           name: sentry-dsn
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-ssh-credentials-openshift-bot
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
-          secretName: github-ssh-credentials-openshift-bot
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -19,12 +19,12 @@ periodics:
       - --artifact-dir=$(ARTIFACTS)
       - --branch=master
       - --give-pr-author-access-to-namespace=true
+      - --oauth-token-path=/usr/local/github-credentials/oauth
       - --org=private
       - --repo=duper
       - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-      - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
       - --target=e2e-nightly
       - --template=/usr/local/e2e-nightly
       command:
@@ -52,8 +52,8 @@ periodics:
       volumeMounts:
       - mountPath: /usr/local/e2e-nightly-cluster-profile
         name: cluster-profile
-      - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-        name: github-ssh-credentials-openshift-bot
+      - mountPath: /usr/local/github-credentials
+        name: github-credentials-openshift-ci-robot-private-git-cloner
         readOnly: true
       - mountPath: /usr/local/e2e-nightly
         name: job-definition
@@ -70,9 +70,9 @@ periodics:
             name: cluster-secrets-gcp
         - configMap:
             name: cluster-profile-gcp
-    - name: github-ssh-credentials-openshift-bot
+    - name: github-credentials-openshift-ci-robot-private-git-cloner
       secret:
-        secretName: github-ssh-credentials-openshift-bot
+        secretName: github-credentials-openshift-ci-robot-private-git-cloner
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -16,12 +16,12 @@ postsubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --oauth-token-path=/usr/local/github-credentials/oauth
         - --org=private
         - --promote
         - --repo=duper
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
         - --target=[images]
         command:
         - ci-operator
@@ -38,17 +38,17 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-          name: github-ssh-credentials-openshift-bot
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
         - mountPath: /etc/sentry-dsn
           name: sentry-dsn
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-ssh-credentials-openshift-bot
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
-          secretName: github-ssh-credentials-openshift-bot
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -20,12 +20,12 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --oauth-token-path=/usr/local/github-credentials/oauth
         - --org=private
         - --repo=duper
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
         - --target=e2e
         - --template=/usr/local/e2e
         command:
@@ -53,8 +53,8 @@ presubmits:
         volumeMounts:
         - mountPath: /usr/local/e2e-cluster-profile
           name: cluster-profile
-        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-          name: github-ssh-credentials-openshift-bot
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
         - mountPath: /usr/local/e2e
           name: job-definition
@@ -71,9 +71,9 @@ presubmits:
               name: cluster-secrets-gcp
           - configMap:
               name: cluster-profile-gcp
-      - name: github-ssh-credentials-openshift-bot
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
-          secretName: github-ssh-credentials-openshift-bot
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - configMap:
           name: prow-job-cluster-launch-e2e
         name: job-definition
@@ -101,11 +101,11 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --oauth-token-path=/usr/local/github-credentials/oauth
         - --org=private
         - --repo=duper
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
         - --target=[images]
         - --target=[release:latest]
         command:
@@ -123,17 +123,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-          name: github-ssh-credentials-openshift-bot
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
         - mountPath: /etc/sentry-dsn
           name: sentry-dsn
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-ssh-credentials-openshift-bot
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
-          secretName: github-ssh-credentials-openshift-bot
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn
@@ -158,11 +158,11 @@ presubmits:
         - --artifact-dir=$(ARTIFACTS)
         - --branch=master
         - --give-pr-author-access-to-namespace=true
+        - --oauth-token-path=/usr/local/github-credentials/oauth
         - --org=private
         - --repo=duper
         - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
-        - --ssh-key-path=/usr/local/github-ssh-credentials-openshift-bot/id_rsa
         - --target=unit
         command:
         - ci-operator
@@ -179,17 +179,17 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /usr/local/github-ssh-credentials-openshift-bot
-          name: github-ssh-credentials-openshift-bot
+        - mountPath: /usr/local/github-credentials
+          name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
         - mountPath: /etc/sentry-dsn
           name: sentry-dsn
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-ssh-credentials-openshift-bot
+      - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
-          secretName: github-ssh-credentials-openshift-bot
+          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: sentry-dsn
         secret:
           secretName: sentry-dsn


### PR DESCRIPTION
Since `clonerefs` now supports OAuth authentication, we want to get rid of the SSH configuration and use an OAuth token instead.

Note: OAuth requires a `cloneURI` with a scheme included. 

/cc @petr-muller @stevekuznetsov 