### PR TITLE
Don't call out to make jobs in repo-init

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"reflect"
 	"strings"
@@ -249,10 +248,6 @@ create this run without using the interactive interface:
 
 	if err := createCIOperatorConfig(config, o.releaseRepo); err != nil {
 		errorExit(fmt.Sprintf("could not generate new CI Operator configuration: %v", err))
-	}
-
-	if err := generateProwJobs(o.releaseRepo); err != nil {
-		errorExit(fmt.Sprintf("could not generate Prow jobs: %v", err))
 	}
 }
 
@@ -567,16 +562,4 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 		})
 	}
 	return generated
-}
-
-func generateProwJobs(releaseRepo string) error {
-	fmt.Println(`
-Generating new Prow jobs and checking formatting...`)
-	cmd := exec.Command("make", "jobs")
-	cmd.Dir = releaseRepo
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("could not run \"make jobs\": %v\n output: %v", err, string(out))
-	}
-	return nil
 }

--- a/test/repo-init-integration/expected/Makefile
+++ b/test/repo-init-integration/expected/Makefile
@@ -1,4 +1,0 @@
-jobs:
-	ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
-	determinize-prow-jobs --prow-jobs-dir ./ci-operator/jobs
-.PHONY: jobs

--- a/test/repo-init-integration/input/Makefile
+++ b/test/repo-init-integration/input/Makefile
@@ -1,4 +1,0 @@
-jobs:
-	ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
-	determinize-prow-jobs --prow-jobs-dir ./ci-operator/jobs
-.PHONY: jobs

--- a/test/repo-init-integration/run.sh
+++ b/test/repo-init-integration/run.sh
@@ -71,6 +71,8 @@ inputs=(
                  "" # Are there any end-to-end test scripts to configure?  [default: no] no
 )
 for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo .
+ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
+determinize-prow-jobs --prow-jobs-dir ./ci-operator/jobs
 
 if ! diff -Naupr "$ROOTDIR"/test/repo-init-integration/expected .> "$WORKDIR/diff"; then
     echo "[ERROR] Got incorrect output state after running repo-init:"


### PR DESCRIPTION
Since we're running repo-init in a container in the first place, this
would require nested virtualization and all sorts of craziness, so we
can just chain the make targets instead.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>