### PR TITLE
Generate pull-secret arg for migrated jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -152,6 +152,11 @@ func generatePodSpec(info *prowgenInfo, secret *cioperatorapi.Secret) *kubeapi.P
 				MountPath: "/etc/apici",
 				ReadOnly:  true,
 			},
+			{
+				Name:      "pull-secret",
+				MountPath: "/etc/pull-secret",
+				ReadOnly:  true,
+			},
 		}
 	}
 
@@ -182,6 +187,12 @@ func generatePodSpec(info *prowgenInfo, secret *cioperatorapi.Secret) *kubeapi.P
 							},
 						},
 					},
+				},
+			},
+			{
+				Name: "pull-secret",
+				VolumeSource: kubeapi.VolumeSource{
+					Secret: &kubeapi.SecretVolumeSource{SecretName: "regcred"},
 				},
 			},
 		}
@@ -264,6 +275,7 @@ func generateCiOperatorPodSpec(info *prowgenInfo, secret *cioperatorapi.Secret, 
 			fmt.Sprintf("--repo=%s", info.Repo),
 			fmt.Sprintf("--branch=%s", info.Branch),
 			"--kubeconfig=/etc/apici/kubeconfig",
+			"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 		}, additionalArgs...)
 	}
 	for _, target := range targets {


### PR DESCRIPTION
Follow up of https://github.com/openshift/ci-tools/pull/290/files

/cc @openshift/openshift-team-developer-productivity-test-platform 

/hold

need to prepare for the PR to recover breaking changes