### PR TITLE
Log boskos acquiring time

### DIFF
--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -3,7 +3,9 @@ package lease
 import (
 	"context"
 	"fmt"
+	"log"
 	"sync"
+	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -66,7 +68,10 @@ type client struct {
 }
 
 func (c *client) Acquire(rtype string, cancel context.CancelFunc) (string, error) {
+	start := time.Now()
+	log.Printf("starting to acquire for %s", rtype)
 	r, err := c.boskos.Acquire(rtype, freeState, leasedState)
+	log.Printf("finished acquring for %s in %s", rtype, time.Now().Sub(start).Truncate(time.Second))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Follow up https://github.com/openshift/release/pull/6269

Before we figure out why boskos takes that long, we log the time in the client side.
We could add metric/panels on the sever side too.

/cc @openshift/openshift-team-developer-productivity-test-platform 