### PR TITLE
pkg/lease: use AcquireWait instead of Acquire

### DIFF
--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -17,7 +18,7 @@ const (
 )
 
 type boskosClient interface {
-	Acquire(rtype, state, dest string) (*common.Resource, error)
+	AcquireWait(ctx context.Context, rtype, state, dest string) (*common.Resource, error)
 	UpdateOne(name, dest string, _ *common.UserData) error
 	ReleaseOne(name, dest string) error
 	ReleaseAll(dest string) error
@@ -27,8 +28,10 @@ type boskosClient interface {
 // updated.
 type Client interface {
 	// Acquire leases a resource and returns the lease name.
-	// `cancel` is called if any subsequent updates to the lease fail.
-	Acquire(rtype string, cancel context.CancelFunc) (string, error)
+	// Will block until a resource is available or 150m pass, `ctx` can be used
+	// to abort the operation, `cancel` is called if any subsequent updates to
+	// the lease fail.
+	Acquire(rtype string, ctx context.Context, cancel context.CancelFunc) (string, error)
 	// Heartbeat updates all leases. It calls the cancellation function of each
 	// lease it fails to update.
 	Heartbeat() error
@@ -65,8 +68,11 @@ type client struct {
 	cancel map[string]context.CancelFunc
 }
 
-func (c *client) Acquire(rtype string, cancel context.CancelFunc) (string, error) {
-	r, err := c.boskos.Acquire(rtype, freeState, leasedState)
+func (c *client) Acquire(rtype string, ctx context.Context, cancel context.CancelFunc) (string, error) {
+	var cancelAcquire context.CancelFunc
+	ctx, cancelAcquire = context.WithTimeout(ctx, 150*time.Minute)
+	defer cancelAcquire()
+	r, err := c.boskos.AcquireWait(ctx, rtype, freeState, leasedState)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/lease/client_test.go
+++ b/pkg/lease/client_test.go
@@ -1,6 +1,7 @@
 package lease
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -9,9 +10,10 @@ import (
 )
 
 func TestAcquire(t *testing.T) {
+	ctx := context.Background()
 	var calls []string
 	client := NewFakeClient("owner", "url", nil, &calls)
-	if _, err := client.Acquire("rtype", nil); err != nil {
+	if _, err := client.Acquire("rtype", ctx, nil); err != nil {
 		t.Fatal(err)
 	}
 	expected := []string{"acquire owner rtype free leased"}
@@ -39,10 +41,11 @@ func TestAcquire(t *testing.T) {
 }
 
 func TestHeartbeatCancel(t *testing.T) {
+	ctx := context.Background()
 	var calls []string
 	client := NewFakeClient("owner", "url", sets.NewString("updateone owner rtype0 leased"), &calls)
 	var called bool
-	if _, err := client.Acquire("rtype", func() { called = true }); err != nil {
+	if _, err := client.Acquire("rtype", ctx, func() { called = true }); err != nil {
 		t.Fatal(err)
 	}
 	if err := client.Heartbeat(); err == nil {

--- a/pkg/lease/fake.go
+++ b/pkg/lease/fake.go
@@ -1,6 +1,7 @@
 package lease
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,7 +34,7 @@ func (c *fakeClient) addCall(call string, args ...string) error {
 	return nil
 }
 
-func (c *fakeClient) Acquire(rtype, state, dest string) (*common.Resource, error) {
+func (c *fakeClient) AcquireWait(_ context.Context, rtype, state, dest string) (*common.Resource, error) {
 	err := c.addCall("acquire", rtype, state, dest)
 	return &common.Resource{Name: fmt.Sprintf("%s%d", rtype, len(*c.calls)-1)}, err
 }

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -39,7 +39,7 @@ func (s *leaseStep) Provides() (api.ParameterMap, api.StepLink) { return s.wrapp
 func (s *leaseStep) Run(ctx context.Context, dry bool) error {
 	log.Printf("Acquiring lease for %q", s.leaseType)
 	ctx, cancel := context.WithCancel(ctx)
-	lease, err := s.client.Acquire(s.leaseType, cancel)
+	lease, err := s.client.Acquire(s.leaseType, ctx, cancel)
 	if err != nil {
 		return fmt.Errorf("failed to acquire lease: %v", err)
 	}


### PR DESCRIPTION
Many resource types have very low maximum values and rely on waiting for
extended periods of time until one is available.

The hard-coded timeout period used is based on the original templates
(https://github.com/openshift/release/pull/5802).