### PR TITLE
ci-operator: use lease client in upgrade tests

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -97,7 +97,7 @@ objects:
       # we want to gather the teardown logs no matter what
       ci-operator.openshift.io/wait-for-container-artifacts: teardown
       ci-operator.openshift.io/save-container-logs: "true"
-      ci-operator.openshift.io/container-sub-tests: "lease,setup,test,teardown"
+      ci-operator.openshift.io/container-sub-tests: "setup,test,teardown"
   spec:
     restartPolicy: Never
     activeDeadlineSeconds: 18000
@@ -112,67 +112,6 @@ objects:
         secretName: ${JOB_NAME_SAFE}-cluster-profile
 
     containers:
-
-    - name: lease
-      image: registry.svc.ci.openshift.org/ci/boskoscli:latest
-      terminationMessagePolicy: FallbackToLogsOnError
-      resources:
-        requests:
-          cpu: 10m
-          memory: 10Mi
-        limits:
-          memory: 200Mi
-      volumeMounts:
-      - name: shared-tmp
-        mountPath: /tmp/shared
-      - name: cluster-profile
-        mountPath: /tmp/cluster
-      - name: artifacts
-        mountPath: /tmp/artifacts
-      env:
-      - name: CLUSTER_TYPE
-        value: ${CLUSTER_TYPE}
-      - name: CLUSTER_NAME
-        value: ${NAMESPACE}-${JOB_NAME_HASH}
-      command:
-      - /bin/bash
-      - -c
-      - |
-        #!/bin/bash
-        set -euo pipefail
-
-        trap 'rc=$?; CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi; if test "${rc}" -ne 0; then touch /tmp/shared/exit; fi; exit "${rc}"' EXIT
-
-        # hack for bazel
-        function boskosctl() {
-          /app/boskos/cmd/cli/app.binary "${@}"
-        }
-
-        echo "[INFO] Acquiring a lease ..."
-        resource="$( boskosctl --server-url http://boskos.ci --owner-name "${CLUSTER_NAME}" acquire --type "${CLUSTER_TYPE}-quota-slice" --state free --target-state leased --timeout 150m )"
-        touch /tmp/shared/leased
-        echo "[INFO] Lease acquired!"
-        echo "[INFO] Leased resource: ${resource}"
-
-        function release() {
-            local resource_name; resource_name="$( jq .name --raw-output <<<"${resource}" )"
-            echo "[INFO] Releasing the lease on resouce ${resource_name}..."
-            boskosctl --server-url http://boskos.ci --owner-name "${CLUSTER_NAME}" release --name "${resource_name}" --target-state free
-        }
-        trap release EXIT
-
-        echo "[INFO] Sending heartbeats to retain the lease..."
-        boskosctl --server-url http://boskos.ci --owner-name "${CLUSTER_NAME}" heartbeat --resource "${resource}" &
-
-        while true; do
-          if [[ -f /tmp/shared/exit ]]; then
-            echo "Another process exited" 2>&1
-            exit 0
-          fi
-
-          sleep 15 & wait $!
-        done
-
     # Once the cluster is up, executes shared tests
     - name: test
       image: ${IMAGE_TESTS}
@@ -448,20 +387,6 @@ objects:
 
         trap 'rc=$?; if test "${rc}" -eq 0; then touch /tmp/setup-success; else touch /tmp/exit; fi; exit "${rc}"' EXIT
         trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
-
-        while true; do
-          if [[ -f /tmp/exit ]]; then
-            echo "Another process exited" 2>&1
-            exit 1
-          fi
-          if [[ -f /tmp/leased ]]; then
-            echo "Lease acquired, installing..."
-            break
-          fi
-
-          sleep 15 & wait
-        done
-
         cp "$(command -v openshift-install)" /tmp
         mkdir /tmp/artifacts/installer
 

--- a/test/ci-operator-integration/base/run.sh
+++ b/test/ci-operator-integration/base/run.sh
@@ -29,8 +29,15 @@ export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-release-master-ci-
 # set by Prow
 unset BUILD_ID
 
+readonly args=(
+    --dry-run
+    --determinize-output
+    --lease-server http://boskos.example.com
+    --namespace "${TEST_NAMESPACE}"
+    --config "${TEST_CONFIG}"
+)
 echo "[INFO] Running ci-operator in dry-mode..."
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" 2> "${WORKDIR}/ci-op-stderr.log" | jq --sort-keys . > "${DRY_RUN_JSON}"; then
+if ! ci-operator "${args[@]}" 2> "${WORKDIR}/ci-op-stderr.log" | jq --sort-keys . > "${DRY_RUN_JSON}"; then
     echo "ERROR: ci-operator failed."
     cat "${WORKDIR}/ci-op-stderr.log"
     exit 1
@@ -46,7 +53,7 @@ export IMAGE_FORMAT="test"
 export CLUSTER_TYPE="aws"
 export TEST_COMMAND="test command"
 
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" --template "${TEST_TEMPLATE}" --target test-template --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_TEMPLATE_JSON}"; then
+if ! ci-operator "${args[@]}" --template "${TEST_TEMPLATE}" --target test-template --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_TEMPLATE_JSON}"; then
     echo "ERROR: ci-operator failed."
     cat "${WORKDIR}/ci-op-stderr.log"
     exit 1
@@ -58,7 +65,7 @@ if ! diff "${EXPECTED_WITH_TEMPLATE}" "${DRY_RUN_WITH_TEMPLATE_JSON}"; then
 fi
 
 echo "[INFO] Running ci-operator with OAuth"
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" --oauth-token-path "${OAUTH_FILE}" --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_OAUTH}"; then
+if ! ci-operator "${args[@]}" --oauth-token-path "${OAUTH_FILE}" --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_OAUTH}"; then
     echo "ERROR: ci-operator failed."
     cat "${WORKDIR}/ci-op-stderr.log"
     exit 1
@@ -70,7 +77,7 @@ if ! diff <(jq '.[] | select(.metadata.name=="src")' ${DRY_RUN_WITH_OAUTH}) <(ca
 fi
 
 echo "[INFO] Running ci-operator with SSH"
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" --ssh-key-path "${SSH_FILE}" --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_SSH}"; then
+if ! ci-operator "${args[@]}" --ssh-key-path "${SSH_FILE}" --artifact-dir "${ARTIFACT_DIR}" 2> "${WORKDIR}/ci-op-stderr.log" | jq -S . > "${DRY_RUN_WITH_SSH}"; then
     echo "ERROR: ci-operator failed."
     cat "${WORKDIR}/ci-op-stderr.log"
     exit 1


### PR DESCRIPTION
Clean the temporary code to filter templates, which will now be
permanent since not all templates actually had a `lease` container, as
initially thought.  The logic is changed slightly, but should be
practically equivalent.