### PR TITLE
lease: use acquire with priority

### DIFF
--- a/pkg/lease/client_test.go
+++ b/pkg/lease/client_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 func TestAcquire(t *testing.T) {
+
 	ctx := context.Background()
 	var calls []string
 	client := NewFakeClient("owner", "url", nil, &calls)
 	if _, err := client.Acquire("rtype", ctx, nil); err != nil {
 		t.Fatal(err)
 	}
-	expected := []string{"acquire owner rtype free leased"}
+	expected := []string{"acquire owner rtype free leased random"}
 	if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("wrong calls to the boskos client: %v", diff.ObjectDiff(calls, expected))
 	}
@@ -24,7 +25,7 @@ func TestAcquire(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected = []string{
-		"acquire owner rtype free leased",
+		"acquire owner rtype free leased random",
 		"updateone owner rtype0 leased",
 	}
 	if !reflect.DeepEqual(calls, expected) {

--- a/pkg/lease/fake.go
+++ b/pkg/lease/fake.go
@@ -20,6 +20,9 @@ func NewFakeClient(owner, url string, failures sets.String, calls *[]string) Cli
 	if calls == nil {
 		calls = &[]string{}
 	}
+	randId = func() string {
+		return "random"
+	}
 	return newClient(&fakeClient{owner: owner, failures: failures, calls: calls})
 }
 
@@ -34,8 +37,8 @@ func (c *fakeClient) addCall(call string, args ...string) error {
 	return nil
 }
 
-func (c *fakeClient) AcquireWait(_ context.Context, rtype, state, dest string) (*common.Resource, error) {
-	err := c.addCall("acquire", rtype, state, dest)
+func (c *fakeClient) AcquireWaitWithPriority(ctx context.Context, rtype, state, dest, requestID string) (*common.Resource, error) {
+	err := c.addCall("acquire", rtype, state, dest, requestID)
 	return &common.Resource{Name: fmt.Sprintf("%s%d", rtype, len(*c.calls)-1)}, err
 }
 

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -105,20 +105,20 @@ func TestError(t *testing.T) {
 		expected []string
 	}{{
 		name:     "acquire fails",
-		failures: sets.NewString("acquire owner rtype free leased"),
-		expected: []string{"acquire owner rtype free leased"},
+		failures: sets.NewString("acquire owner rtype free leased random"),
+		expected: []string{"acquire owner rtype free leased random"},
 	}, {
 		name:     "release fails",
 		failures: sets.NewString("releaseone owner rtype0 free"),
 		expected: []string{
-			"acquire owner rtype free leased",
+			"acquire owner rtype free leased random",
 			"releaseone owner rtype0 free",
 		},
 	}, {
 		name:     "run fails",
 		runFails: true,
 		expected: []string{
-			"acquire owner rtype free leased",
+			"acquire owner rtype free leased random",
 			"releaseone owner rtype0 free",
 		},
 	}} {
@@ -148,7 +148,7 @@ func TestAcquireRelease(t *testing.T) {
 		t.Fatal("step was not executed")
 	}
 	expected := []string{
-		"acquire owner rtype free leased",
+		"acquire owner rtype free leased random",
 		"releaseone owner rtype0 free",
 	}
 	if !reflect.DeepEqual(calls, expected) {


### PR DESCRIPTION
This was another regression between the usage in `boskosctl` and the
in-house lease adaptation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 