### PR TITLE
pkg/steps/template: force a failure when cancelled

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -177,6 +177,13 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 			}
 		}
 	}
+	// TODO properly identify deleted templates in waitForPodCompletion
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("template test cancelled")
+	default:
+		break
+	}
 	return nil
 }
 


### PR DESCRIPTION
`waitForPodCompletion` is unreliable, sometimes failing to report an
error when the test is cancelled.  Compare:

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/6331/rehearse-6331-pull-ci-openshift-origin-master-e2e-cmd/5
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/1311/pull-ci-openshift-machine-config-operator-fcos-e2e-aws/124

Force a failure by testing if the cancelling context is done.