### PR TITLE
Remove unnecessary parameter in integration tests

### DIFF
--- a/test/ci-operator-integration/base/run.sh
+++ b/test/ci-operator-integration/base/run.sh
@@ -35,7 +35,6 @@ run_test() {
         --determinize-output \
         --namespace "${TEST_NAMESPACE}" \
         --config "${TEST_CONFIG}" \
-        --lease-server http://boskos.example.com \
         "$@" \
         2> "${WORKDIR}/ci-op-stderr.log" | jq --sort-keys .
     then
@@ -53,7 +52,7 @@ check() {
 }
 
 echo "[INFO] Running ci-operator in dry-mode..."
-run_test > "${DRY_RUN_JSON}"
+run_test --lease-server http://boskos.example.com > "${DRY_RUN_JSON}"
 check "${EXPECTED}" "${DRY_RUN_JSON}"
 
 echo "[INFO] Running ci-operator with a template"
@@ -67,7 +66,8 @@ check "${EXPECTED_WITH_TEMPLATE}" "${DRY_RUN_WITH_TEMPLATE_JSON}"
 echo "[INFO] Running ci-operator with OAuth"
 run_test > "${DRY_RUN_WITH_OAUTH}" \
     --oauth-token-path "${OAUTH_FILE}" \
-    --artifact-dir "${ARTIFACT_DIR}"
+    --artifact-dir "${ARTIFACT_DIR}" \
+    --lease-server http://boskos.example.com
 check \
     "${EXPECTED_WITH_OAUTH}" \
     <(jq '.[] | select(.metadata.name=="src")' "${DRY_RUN_WITH_OAUTH}")
@@ -75,7 +75,8 @@ check \
 echo "[INFO] Running ci-operator with SSH"
 run_test > "${DRY_RUN_WITH_SSH}" \
     --ssh-key-path "${SSH_FILE}" \
-    --artifact-dir "${ARTIFACT_DIR}"
+    --artifact-dir "${ARTIFACT_DIR}" \
+    --lease-server http://boskos.example.com
 check \
     "${EXPECTED_WITH_SSH}" \
     <(jq '.[] | select(.metadata.name=="src")' "${DRY_RUN_WITH_SSH}")


### PR DESCRIPTION
Being negligent about the parameters prevented us from catching
https://github.com/openshift/ci-tools/pull/321 with the existing
integration tests:

```
$ make install integration-ci-operator > /dev/null
$ git revert --no-commit b129c64d35903697444b2fdc4e2e25b58779d7ce
$ make install integration-ci-operator > /dev/null
ERROR: ci-operator failed.
2019/12/13 15:27:42 Resolved source https://github.com/openshift/ci-tools to master@af8a90a2, merging: #1234 538680df @droslean
2019/12/13 15:27:42 Ran for 0s
error: failed to generate steps from config: step "e2e-aws-upgrade" needs a lease but no lease client provided
make: *** [Makefile:48: integration-ci-operator] Error 1
```