### PR TITLE
ci-operator: postpone lease client creation

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -487,7 +487,7 @@ func (o *options) Run() error {
 
 	dryLogger := steps.NewDryLogger(o.determinizeOutput)
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, o.leaseClient, o.targets.values, o.kubeconfigs, dryLogger, o.cloneAuthConfig)
+	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, &o.leaseClient, o.targets.values, o.kubeconfigs, dryLogger, o.cloneAuthConfig)
 	if err != nil {
 		return fmt.Errorf("failed to generate steps from config: %v", err)
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -36,7 +36,7 @@ func FromConfig(
 	paramFile, artifactDir string,
 	promote bool,
 	clusterConfig *rest.Config,
-	leaseClient lease.Client,
+	leaseClient *lease.Client,
 	requiredTargets []string,
 	kubeconfigs map[string]rest.Config,
 	dryLogger *steps.DryLogger,

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -139,7 +139,7 @@ func TestError(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls)
 			s := stepNeedsLease{fail: tc.runFails}
-			if LeaseStep(client, "rtype", &s).Run(ctx, false) == nil {
+			if LeaseStep(&client, "rtype", &s).Run(ctx, false) == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
 			if !reflect.DeepEqual(calls, tc.expected) {
@@ -153,7 +153,7 @@ func TestAcquireRelease(t *testing.T) {
 	var calls []string
 	client := lease.NewFakeClient("owner", "url", 0, nil, &calls)
 	step := stepNeedsLease{}
-	withLease := LeaseStep(client, "rtype", &step)
+	withLease := LeaseStep(&client, "rtype", &step)
 	if err := withLease.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Input resolution, required to determine the namespace and, as a
consequence, the lease owner, is done after the steps are created.