### PR TITLE
Specify pull secret in build steps

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -474,7 +474,7 @@ func (o *options) Run() error {
 
 	dryLogger := steps.NewDryLogger(o.determinizeOutput)
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, &o.leaseClient, o.targets.values, o.kubeconfigs, dryLogger, o.cloneAuthConfig)
+	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, &o.leaseClient, o.targets.values, o.kubeconfigs, dryLogger, o.cloneAuthConfig, o.pullSecret)
 	if err != nil {
 		return fmt.Errorf("failed to generate steps from config: %v", err)
 	}
@@ -1464,7 +1464,7 @@ func getPullSecretFromFile(filename string) (*coreapi.Secret, error) {
 	secret := &coreapi.Secret{
 		Data: make(map[string][]byte),
 		ObjectMeta: meta.ObjectMeta{
-			Name: fmt.Sprintf("regcred"),
+			Name: steps.PullSecretName,
 		},
 		Type: coreapi.SecretTypeDockerConfigJson,
 	}

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	coreapi "k8s.io/api/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	buildapi "github.com/openshift/api/build/v1"
@@ -21,6 +22,7 @@ type gitSourceStep struct {
 	jobSpec         *api.JobSpec
 	dryLogger       *DryLogger
 	cloneAuthConfig *CloneAuthConfig
+	pullSecret      *coreapi.Secret
 }
 
 func (s *gitSourceStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -44,7 +46,7 @@ func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
 				URI: cloneURI,
 				Ref: refs.BaseRef,
 			},
-		}, s.config.DockerfilePath, s.resources), dry, s.artifactDir, s.dryLogger)
+		}, s.config.DockerfilePath, s.resources, s.pullSecret), dry, s.artifactDir, s.dryLogger)
 	}
 
 	return fmt.Errorf("nothing to build source image from, no refs")
@@ -92,7 +94,7 @@ func determineRefsWorkdir(refs *prowapi.Refs, extraRefs []prowapi.Refs) *prowapi
 }
 
 // GitSourceStep returns gitSourceStep that holds all the required information to create a build from a git source.
-func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, cloneAuthConfig *CloneAuthConfig) api.Step {
+func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, cloneAuthConfig *CloneAuthConfig, pullSecret *coreapi.Secret) api.Step {
 	return &gitSourceStep{
 		config:          config,
 		resources:       resources,
@@ -102,5 +104,6 @@ func GitSourceStep(config api.ProjectDirectoryImageBuildInputs, resources api.Re
 		jobSpec:         jobSpec,
 		dryLogger:       dryLogger,
 		cloneAuthConfig: cloneAuthConfig,
+		pullSecret:      pullSecret,
 	}
 }

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -9,6 +9,7 @@ import (
 	buildapi "github.com/openshift/api/build/v1"
 	"github.com/openshift/ci-tools/pkg/api"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,6 +26,7 @@ type pipelineImageCacheStep struct {
 	artifactDir string
 	jobSpec     *api.JobSpec
 	dryLogger   *DryLogger
+	pullSecret  *coreapi.Secret
 }
 
 func (s *pipelineImageCacheStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -41,6 +43,7 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
+		s.pullSecret,
 	), dry, s.artifactDir, s.dryLogger)
 }
 
@@ -85,7 +88,7 @@ func (s *pipelineImageCacheStep) Description() string {
 	return fmt.Sprintf("Store build results into a layer on top of %s and save as %s", s.config.From, s.config.To)
 }
 
-func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
+func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, pullSecret *coreapi.Secret) api.Step {
 	return &pipelineImageCacheStep{
 		config:      config,
 		resources:   resources,
@@ -94,5 +97,6 @@ func PipelineImageCacheStep(config api.PipelineImageCacheStepConfiguration, reso
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 		dryLogger:   dryLogger,
+		pullSecret:  pullSecret,
 	}
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -23,6 +23,7 @@ type projectDirectoryImageBuildStep struct {
 	jobSpec     *api.JobSpec
 	artifactDir string
 	dryLogger   *DryLogger
+	pullSecret  *coreapi.Secret
 }
 
 func (s *projectDirectoryImageBuildStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -103,6 +104,7 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) erro
 		},
 		s.config.DockerfilePath,
 		s.resources,
+		s.pullSecret,
 	)
 	for k, v := range labels {
 		build.Spec.Output.ImageLabels = append(build.Spec.Output.ImageLabels, buildapi.ImageLabel{
@@ -163,7 +165,7 @@ func (s *projectDirectoryImageBuildStep) Description() string {
 	return fmt.Sprintf("Build image %s from the repository", s.config.To)
 }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, pullSecret *coreapi.Secret) api.Step {
 	return &projectDirectoryImageBuildStep{
 		config:      config,
 		resources:   resources,
@@ -173,5 +175,6 @@ func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepCon
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 		dryLogger:   dryLogger,
+		pullSecret:  pullSecret,
 	}
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -7,6 +7,7 @@ import (
 	buildapi "github.com/openshift/api/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -26,6 +27,7 @@ type rpmImageInjectionStep struct {
 	artifactDir string
 	jobSpec     *api.JobSpec
 	dryLogger   *DryLogger
+	pullSecret  *coreapi.Secret
 }
 
 func (s *rpmImageInjectionStep) Inputs(ctx context.Context, dry bool) (api.InputDefinition, error) {
@@ -52,6 +54,7 @@ func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
 		},
 		"",
 		s.resources,
+		s.pullSecret,
 	), dry, s.artifactDir, s.dryLogger)
 }
 
@@ -77,7 +80,7 @@ func (s *rpmImageInjectionStep) Description() string {
 	return "Inject an RPM repository that will point at the RPM server"
 }
 
-func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger) api.Step {
+func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, routeClient routeclientset.RoutesGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, pullSecret *coreapi.Secret) api.Step {
 	return &rpmImageInjectionStep{
 		config:      config,
 		resources:   resources,
@@ -87,5 +90,6 @@ func RPMImageInjectionStep(config api.RPMImageInjectionStepConfiguration, resour
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 		dryLogger:   dryLogger,
+		pullSecret:  pullSecret,
 	}
 }

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -31,6 +31,7 @@ func TestCreateBuild(t *testing.T) {
 		clonerefsRef    coreapi.ObjectReference
 		resources       api.ResourceConfiguration
 		cloneAuthConfig *CloneAuthConfig
+		pullSecret      *coreapi.Secret
 		expected        *buildapi.Build
 	}{
 		{
@@ -116,6 +117,112 @@ RUN git submodule update --init
 							DockerStrategy: &buildapi.DockerBuildStrategy{
 								DockerfilePath:          "",
 								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
+								ForcePull:               true,
+								NoCache:                 true,
+								Env:                     []coreapi.EnvVar{{Name: "foo", Value: "bar"}, {Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}`}},
+								ImageOptimizationPolicy: &layer,
+							},
+						},
+						Output: buildapi.BuildOutput{
+							To: &coreapi.ObjectReference{
+								Kind:      "ImageStreamTag",
+								Namespace: "namespace",
+								Name:      "pipeline:src",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with a pull secret",
+			config: api.SourceStepConfiguration{
+				From: api.PipelineImageStreamTagReferenceRoot,
+				To:   api.PipelineImageStreamTagReferenceSource,
+				ClonerefsImage: api.ImageStreamTagReference{
+					Cluster:   "https://api.ci.openshift.org",
+					Namespace: "ci",
+					Name:      "clonerefs",
+					Tag:       "latest",
+				},
+				ClonerefsPath: "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+					Refs: &prowapi.Refs{
+						Org:     "org",
+						Repo:    "repo",
+						BaseRef: "master",
+						BaseSHA: "masterSHA",
+						Pulls: []prowapi.Pull{{
+							Number: 1,
+							SHA:    "pullSHA",
+						}},
+					},
+				},
+				Namespace: "namespace",
+			},
+			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
+			pullSecret: &coreapi.Secret{
+				Data:       map[string][]byte{coreapi.DockerConfigJsonKey: []byte("secret")},
+				ObjectMeta: meta.ObjectMeta{Name: PullSecretName},
+				Type:       coreapi.SecretTypeDockerConfigJson,
+			},
+
+			expected: &buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{
+					Name:      "src",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"job":                         "job",
+						"build-id":                    "buildId",
+						"prow.k8s.io/id":              "prowJobId",
+						"creates":                     "src",
+						"created-by-ci":               "true",
+						"ci.openshift.io/refs.org":    "org",
+						"ci.openshift.io/refs.repo":   "repo",
+						"ci.openshift.io/refs.branch": "master",
+					},
+					Annotations: map[string]string{
+						"ci.openshift.io/job-spec": ``, // set via unexported fields so will be empty
+					},
+				},
+				Spec: buildapi.BuildSpec{
+					CommonSpec: buildapi.CommonSpec{
+						Resources:      coreapi.ResourceRequirements{Requests: map[coreapi.ResourceName]resource.Quantity{"cpu": resource.MustParse("200m")}},
+						ServiceAccount: "builder",
+						Source: buildapi.BuildSource{
+							Type: buildapi.BuildSourceDockerfile,
+							Dockerfile: strP(`
+FROM pipeline:root
+ADD ./app.binary /clonerefs
+RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
+WORKDIR /go/src/github.com/org/repo/
+ENV GOPATH=/go
+RUN git submodule update --init
+`),
+							Images: []buildapi.ImageSource{
+								{
+									From: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
+									Paths: []buildapi.ImageSourcePath{
+										{
+											SourcePath:     "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary",
+											DestinationDir: ".",
+										},
+									},
+								},
+							},
+						},
+						Strategy: buildapi.BuildStrategy{
+							Type: buildapi.DockerBuildStrategyType,
+							DockerStrategy: &buildapi.DockerBuildStrategy{
+								DockerfilePath:          "",
+								From:                    &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "namespace", Name: "pipeline:root"},
+								PullSecret:              &coreapi.LocalObjectReference{Name: "regcred"},
 								ForcePull:               true,
 								NoCache:                 true,
 								Env:                     []coreapi.EnvVar{{Name: "foo", Value: "bar"}, {Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}`}},
@@ -685,7 +792,7 @@ RUN rm -f /oauth-token
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := createBuild(testCase.config, testCase.jobSpec, testCase.clonerefsRef, testCase.resources, testCase.cloneAuthConfig), testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
+			if actual, expected := createBuild(testCase.config, testCase.jobSpec, testCase.clonerefsRef, testCase.resources, testCase.cloneAuthConfig, testCase.pullSecret), testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect build: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})

--- a/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
+++ b/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
@@ -1,0 +1,1949 @@
+[
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "artifacts",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "artifacts",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:artifacts",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": [
+              "bin"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:bin-cross"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "/go/src/github.com/openshift/origin/_output/local/releases/Dockerfile"
+              }
+            ]
+          },
+          {
+            "as": [
+              "rpms"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:rpms"
+            },
+            "paths": null
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:base",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "base-machine-with-rpms",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "base-machine-with-rpms",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:base-machine-with-rpms",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "FROM pipeline:base-machine\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0' > /etc/yum.repos.d/built.repo",
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:base-machine",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "base-with-rpms",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "base-with-rpms",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:base-with-rpms",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "FROM pipeline:base\nRUN echo $'[built]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0\\n\\n[origin-local-release]\\nname = Built RPMs\\nbaseurl = http://dry-fake/\\ngpgcheck = 0\\nenabled = 0' > /etc/yum.repos.d/built.repo",
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:base",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "bin",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "bin",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:bin",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "12Gi"
+        },
+        "requests": {
+          "cpu": "3",
+          "memory": "7Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "FROM pipeline:src\nRUN [\"/bin/bash\", \"-c\", \"set -o errexit; umask 0002; make build WHAT='vendor/k8s.io/kubernetes/cmd/hyperkube'\"]",
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:src",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "bin-cross",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "bin-cross",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:bin-cross",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "12Gi"
+        },
+        "requests": {
+          "cpu": "3",
+          "memory": "8Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "FROM pipeline:bin\nRUN [\"/bin/bash\", \"-c\", \"set -o errexit; umask 0002; mkdir -p _output/local/releases; touch _output/local/releases/CHECKSUM; echo $'FROM bin AS bin\\\\nFROM rpms AS rpms\\\\nFROM centos:7\\\\nCOPY --from=bin /go/src/github.com/openshift/origin/_output/local/releases /srv/zips/\\\\nCOPY --from=rpms /go/src/github.com/openshift/origin/_output/local/releases/rpms/* /srv/repo/' > _output/local/releases/Dockerfile; make build-cross\"]",
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:bin",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "hyperkube",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "hyperkube",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:hyperkube",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "12Gi"
+        },
+        "requests": {
+          "cpu": "3",
+          "memory": "7Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": [
+              "registry.svc.ci.openshift.org/ocp/builder:golang-1.12"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:bin"
+            },
+            "paths": null
+          },
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "dockerfilePath": "images/hyperkube/Dockerfile.rhel",
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:base",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "machine-os-content",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "machine-os-content",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:machine-os-content",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": [
+              "fedora:29"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:base-machine-with-rpms"
+            },
+            "paths": null
+          },
+          {
+            "as": [
+              "registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:machine-os-content-base"
+            },
+            "paths": null
+          },
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/images/os//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:base",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "rpms",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "rpms",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:rpms",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "10Gi"
+        },
+        "requests": {
+          "cpu": "4",
+          "memory": "8Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "FROM pipeline:bin\nRUN [\"/bin/bash\", \"-c\", \"set -o errexit; umask 0002; make build-rpms; ln -s $( pwd )/_output/local/releases/rpms/ /srv/repo\"]",
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:bin",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "src",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "src",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:src",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "\nFROM pipeline:root\nADD ./app.binary /clonerefs\nRUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw\nWORKDIR /go/src/github.com/openshift/ci-tools/\nENV GOPATH=/go\nRUN git submodule update --init\n",
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "DockerImage",
+              "name": "registry.svc.ci.openshift.org/ci/clonerefs@sha256:SHA"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "/app/prow/cmd/clonerefs/app.binary.runfiles/io_k8s_test_infra/prow/cmd/clonerefs/linux_amd64_pure_stripped/app.binary"
+              }
+            ]
+          }
+        ],
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            },
+            {
+              "name": "CLONEREFS_OPTIONS",
+              "value": "{\"src_root\":\"/go\",\"log\":\"/dev/null\",\"git_user_name\":\"ci-robot\",\"git_user_email\":\"ci-robot@openshift.io\",\"refs\":[{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}],\"fail\":true}"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:root",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "tests",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "tests",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:tests",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "12Gi"
+        },
+        "requests": {
+          "cpu": "3",
+          "memory": "7Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": [
+              "registry.svc.ci.openshift.org/ocp/builder:golang-1.12"
+            ],
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:bin"
+            },
+            "paths": null
+          },
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "dockerfilePath": "images/tests/Dockerfile.rhel",
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:cli",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "apps/v1",
+    "kind": "Deployment",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "app": "rpm-repo",
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/ttl.ignore": "true",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "rpm-repo",
+      "namespace": "testns"
+    },
+    "spec": {
+      "replicas": 2,
+      "selector": {
+        "matchLabels": {
+          "app": "rpm-repo",
+          "build-id": "0",
+          "ci.openshift.io/refs.branch": "master",
+          "ci.openshift.io/refs.org": "openshift",
+          "ci.openshift.io/refs.repo": "ci-tools",
+          "ci.openshift.io/ttl.ignore": "true",
+          "created-by-ci": "true",
+          "job": "pull-ci-openshift-release-master-ci-operator-integration",
+          "prow.k8s.io/id": "uuid"
+        }
+      },
+      "strategy": {},
+      "template": {
+        "metadata": {
+          "creationTimestamp": null,
+          "labels": {
+            "app": "rpm-repo",
+            "build-id": "0",
+            "ci.openshift.io/refs.branch": "master",
+            "ci.openshift.io/refs.org": "openshift",
+            "ci.openshift.io/refs.repo": "ci-tools",
+            "ci.openshift.io/ttl.ignore": "true",
+            "created-by-ci": "true",
+            "job": "pull-ci-openshift-release-master-ci-operator-integration",
+            "prow.k8s.io/id": "uuid"
+          }
+        },
+        "spec": {
+          "containers": [
+            {
+              "args": [
+                "\n#!/bin/bash\ncat <<END >>/tmp/serve.py\nimport time, threading, socket, SocketServer, BaseHTTPServer, SimpleHTTPServer\n\n# Create socket\naddr = ('', 8080)\nsock = socket.socket (socket.AF_INET, socket.SOCK_STREAM)\nsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)\nsock.bind(addr)\nsock.listen(5)\n\n# Launch multiple listeners as threads\nclass Thread(threading.Thread):\n\tdef __init__(self, i):\n\t\tthreading.Thread.__init__(self)\n\t\tself.i = i\n\t\tself.daemon = True\n\t\tself.start()\n\tdef run(self):\n\t\thttpd = BaseHTTPServer.HTTPServer(addr, SimpleHTTPServer.SimpleHTTPRequestHandler, False)\n\n\t\t# Prevent the HTTP server from re-binding every handler.\n\t\t# https://stackoverflow.com/questions/46210672/\n\t\thttpd.socket = sock\n\t\thttpd.server_bind = self.server_close = lambda self: None\n\n\t\thttpd.serve_forever()\n[Thread(i) for i in range(100)]\ntime.sleep(9e9)\nEND\npython /tmp/serve.py\n\t\t\t\t\t\t\t"
+              ],
+              "command": [
+                "/bin/bash",
+                "-c"
+              ],
+              "image": "dry-fake",
+              "imagePullPolicy": "Always",
+              "livenessProbe": {
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 1,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 1
+              },
+              "name": "rpm-repo",
+              "ports": [
+                {
+                  "containerPort": 8080,
+                  "protocol": "TCP"
+                }
+              ],
+              "readinessProbe": {
+                "httpGet": {
+                  "path": "/",
+                  "port": 8080,
+                  "scheme": "HTTP"
+                },
+                "initialDelaySeconds": 1,
+                "periodSeconds": 10,
+                "successThreshold": 1,
+                "timeoutSeconds": 1
+              },
+              "resources": {
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "50Mi"
+                }
+              },
+              "workingDir": "/srv/repo"
+            }
+          ],
+          "terminationGracePeriodSeconds": 1
+        }
+      }
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "pipeline:base",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "4.3@sha256:SHA",
+        "namespace": "ocp"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "pipeline:base-machine",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "fedora@sha256:SHA",
+        "namespace": "openshift"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "pipeline:cli",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "4.3@sha256:SHA",
+        "namespace": "ocp"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "pipeline:machine-os-content-base",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "4.3@sha256:SHA",
+        "namespace": "ocp"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "pipeline:root",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "src-cache-origin@sha256:SHA",
+        "namespace": "ci"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:artifacts",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:hyperkube",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:machine-os-content",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:tests",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "kind": "ImageStream",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable"
+    },
+    "spec": {
+      "lookupPolicy": {
+        "local": true
+      }
+    },
+    "status": {
+      "dockerImageRepository": ""
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "ci-operator.openshift.io/container-sub-tests": "test",
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "unit"
+    },
+    "spec": {
+      "containers": [
+        {
+          "command": [
+            "/bin/bash",
+            "-c",
+            "#!/bin/bash\nset -eu\nTMPDIR=/tmp/volume GOTEST_FLAGS='-p 8' ARTIFACT_DIR=/tmp/artifacts TIMEOUT=180s JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh"
+          ],
+          "env": [
+            {
+              "name": "BUILD_ID",
+              "value": "0"
+            },
+            {
+              "name": "CI",
+              "value": "true"
+            },
+            {
+              "name": "JOB_NAME",
+              "value": "pull-ci-openshift-release-master-ci-operator-integration"
+            },
+            {
+              "name": "JOB_SPEC",
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+            },
+            {
+              "name": "JOB_TYPE",
+              "value": "presubmit"
+            },
+            {
+              "name": "PROW_JOB_ID",
+              "value": "uuid"
+            },
+            {
+              "name": "PULL_BASE_REF",
+              "value": "master"
+            },
+            {
+              "name": "PULL_BASE_SHA",
+              "value": "af8a90a2faf965eeda949dc1c607c48d3ffcda3e"
+            },
+            {
+              "name": "PULL_NUMBER",
+              "value": "1234"
+            },
+            {
+              "name": "PULL_PULL_SHA",
+              "value": "538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "PULL_REFS",
+              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "REPO_NAME",
+              "value": "ci-tools"
+            },
+            {
+              "name": "REPO_OWNER",
+              "value": "openshift"
+            },
+            {
+              "name": "ARTIFACT_DIR",
+              "value": "/tmp/artifacts"
+            }
+          ],
+          "image": "pipeline:src",
+          "name": "test",
+          "resources": {
+            "limits": {
+              "memory": "11Gi"
+            },
+            "requests": {
+              "cpu": "6",
+              "memory": "8Gi"
+            }
+          },
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            },
+            {
+              "mountPath": "/tmp/volume",
+              "name": "memory-backed"
+            }
+          ]
+        },
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
+          ],
+          "image": "busybox",
+          "name": "artifacts",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            }
+          ]
+        }
+      ],
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "emptyDir": {},
+          "name": "artifacts"
+        },
+        {
+          "emptyDir": {
+            "medium": "Memory",
+            "sizeLimit": "4Gi"
+          },
+          "name": "memory-backed"
+        }
+      ]
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "ci-operator.openshift.io/container-sub-tests": "test",
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "verify"
+    },
+    "spec": {
+      "containers": [
+        {
+          "command": [
+            "/bin/bash",
+            "-c",
+            "#!/bin/bash\nset -eu\nARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make verify -k"
+          ],
+          "env": [
+            {
+              "name": "BUILD_ID",
+              "value": "0"
+            },
+            {
+              "name": "CI",
+              "value": "true"
+            },
+            {
+              "name": "JOB_NAME",
+              "value": "pull-ci-openshift-release-master-ci-operator-integration"
+            },
+            {
+              "name": "JOB_SPEC",
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+            },
+            {
+              "name": "JOB_TYPE",
+              "value": "presubmit"
+            },
+            {
+              "name": "PROW_JOB_ID",
+              "value": "uuid"
+            },
+            {
+              "name": "PULL_BASE_REF",
+              "value": "master"
+            },
+            {
+              "name": "PULL_BASE_SHA",
+              "value": "af8a90a2faf965eeda949dc1c607c48d3ffcda3e"
+            },
+            {
+              "name": "PULL_NUMBER",
+              "value": "1234"
+            },
+            {
+              "name": "PULL_PULL_SHA",
+              "value": "538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "PULL_REFS",
+              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "REPO_NAME",
+              "value": "ci-tools"
+            },
+            {
+              "name": "REPO_OWNER",
+              "value": "openshift"
+            },
+            {
+              "name": "ARTIFACT_DIR",
+              "value": "/tmp/artifacts"
+            }
+          ],
+          "image": "pipeline:bin",
+          "name": "test",
+          "resources": {
+            "limits": {
+              "memory": "12Gi"
+            },
+            "requests": {
+              "cpu": "3",
+              "memory": "8Gi"
+            }
+          },
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            },
+            {
+              "mountPath": "/dontlook",
+              "name": "test-secret",
+              "readOnly": true
+            }
+          ]
+        },
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
+          ],
+          "image": "busybox",
+          "name": "artifacts",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            }
+          ]
+        }
+      ],
+      "restartPolicy": "Never",
+      "volumes": [
+        {
+          "emptyDir": {},
+          "name": "artifacts"
+        },
+        {
+          "name": "test-secret",
+          "secret": {
+            "secretName": "topsecret"
+          }
+        }
+      ]
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator-image",
+      "namespace": "testns"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "ci-operator-image"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "ci-operator",
+        "namespace": "testns"
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator-image",
+      "namespace": "testns"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "ci-operator-image"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "ci-operator",
+        "namespace": "testns"
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator-image",
+      "namespace": "testns"
+    },
+    "rules": [
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams/layers"
+        ],
+        "verbs": [
+          "get",
+          "update"
+        ]
+      },
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams",
+          "imagestreamtags"
+        ],
+        "verbs": [
+          "create",
+          "get",
+          "list",
+          "update",
+          "watch"
+        ]
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator-image",
+      "namespace": "testns"
+    },
+    "rules": [
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams/layers"
+        ],
+        "verbs": [
+          "get",
+          "update"
+        ]
+      },
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams",
+          "imagestreamtags"
+        ],
+        "verbs": [
+          "create",
+          "get",
+          "list",
+          "update",
+          "watch"
+        ]
+      }
+    ]
+  },
+  {
+    "apiVersion": "route.openshift.io/v1",
+    "kind": "Route",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "app": "rpm-repo",
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/ttl.ignore": "true",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "rpm-repo",
+      "namespace": "testns"
+    },
+    "spec": {
+      "host": "",
+      "port": {
+        "targetPort": 8080
+      },
+      "subdomain": "",
+      "to": {
+        "kind": "",
+        "name": "rpm-repo",
+        "weight": null
+      }
+    },
+    "status": {
+      "ingress": null
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator",
+      "namespace": "testns"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "ci-operator",
+      "namespace": "testns"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "app": "rpm-repo",
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/ttl.ignore": "true",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "rpm-repo",
+      "namespace": "testns"
+    },
+    "spec": {
+      "ports": [
+        {
+          "port": 8080,
+          "protocol": "TCP",
+          "targetPort": 8080
+        }
+      ],
+      "selector": {
+        "app": "rpm-repo"
+      }
+    },
+    "status": {
+      "loadBalancer": {}
+    }
+  }
+]

--- a/test/ci-operator-integration/base/run.sh
+++ b/test/ci-operator-integration/base/run.sh
@@ -15,11 +15,15 @@ readonly EXPECTED="${TEST_ROOT}/expected_files/expected.json"
 readonly EXPECTED_WITH_TEMPLATE="${TEST_ROOT}/expected_files/expected_with_template.json"
 readonly EXPECTED_WITH_OAUTH="${TEST_ROOT}/expected_files/expected_src_oauth.json"
 readonly EXPECTED_WITH_SSH="${TEST_ROOT}/expected_files/expected_src_ssh.json"
+EXPECTED_WITH_PULL_SECRET="${TEST_ROOT}/expected_files/expected_pull_secret.json"
+readonly EXPECTED_WITH_PULL_SECRET
 
 readonly DRY_RUN_JSON="${WORKDIR}/ci-op-dry.json"
 readonly DRY_RUN_WITH_TEMPLATE_JSON="${WORKDIR}/ci-op-template-dry.json"
 readonly DRY_RUN_WITH_OAUTH="${WORKDIR}/ci-op-oauth-dry.json"
 readonly DRY_RUN_WITH_SSH="${WORKDIR}/ci-op-ssh-dry.json"
+DRY_RUN_WITH_PULL_SECRET="${WORKDIR}/ci-op-pull-secret-dry.json"
+readonly DRY_RUN_WITH_PULL_SECRET
 
 readonly OAUTH_FILE="${TEST_ROOT}/auth_files/oauth-token"
 readonly SSH_FILE="${TEST_ROOT}/auth_files/id_rsa"
@@ -80,5 +84,13 @@ run_test > "${DRY_RUN_WITH_SSH}" \
 check \
     "${EXPECTED_WITH_SSH}" \
     <(jq '.[] | select(.metadata.name=="src")' "${DRY_RUN_WITH_SSH}")
+
+PULL_SECRET_PATH="${WORKDIR}/pull_secret"
+readonly PULL_SECRET_PATH
+touch "${PULL_SECRET_PATH}"
+
+echo "[INFO] Running ci-operator with a pull secret"
+run_test --lease-server http://boskos.example.com --image-import-pull-secret "${PULL_SECRET_PATH}" > "${DRY_RUN_WITH_PULL_SECRET}"
+check "${EXPECTED_WITH_PULL_SECRET}" "${DRY_RUN_WITH_PULL_SECRET}"
 
 echo "[INFO] Success"


### PR DESCRIPTION
openshift/installer repo has builds which need accessimages in api.ci.

The default pull secret by build is from SA `builder` on the same cluster.

We use the pull secrets created with https://github.com/openshift/release/pull/6478 which contains oauth for both registries on api.ci and build01.

/cc @openshift/openshift-team-developer-productivity-test-platform 

Verified by
https://github.com/openshift/release/pull/6420#issuecomment-567329232
