### PR TITLE
Set LC_ALL in artifacts so that aws cli would convert unicode correctly

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -717,6 +717,8 @@ objects:
         value: test
       - name: HOME
         value: /tmp
+      - name: LC_ALL
+        value: en_US.UTF-8
       command:
       - /bin/bash
       - -c

--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -839,7 +839,7 @@ objects:
           while IFS= read -r i; do
             mkdir -p "/tmp/artifacts/nodes/${i}"
             if [[ "${CLUSTER_TYPE}" = "aws" ]]; then
-              queue /tmp/artifacts/nodes/$i/console aws ec2 get-console-output --instance-id "${i}"
+              queue /tmp/artifacts/nodes/$i/console aws ec2 get-console-output --instance-id "${i}" --output text
             fi
           done < /tmp/node-provider-IDs
 


### PR DESCRIPTION
* Set LC_ALL so that py2-based `aws ec2 get-console-output` wouldn't crash with UnicodeEncodeError
* Store only text (json by default) in output file

Backport of https://github.com/openshift/release/pull/6536

/cc @wking 