### PR TITLE
rehearse: fix detection of jobs affected by ciop config changes

### DIFF
--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -230,10 +230,10 @@ func ciOpFileName(job prowconfig.JobBase) (string, bool) {
 	}
 	for _, env := range job.Spec.Containers[0].Env {
 		if env.ValueFrom == nil {
-			return "", false
+			continue
 		}
 		if env.ValueFrom.ConfigMapKeyRef == nil {
-			return "", false
+			continue
 		}
 		if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 			return env.ValueFrom.ConfigMapKeyRef.Key, true

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -6,21 +6,20 @@ import (
 	"testing"
 
 	"github.com/getlantern/deepcopy"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-
 	"github.com/openshift/ci-tools/pkg/config"
 )
+
+var ignoreUnexported = cmpopts.IgnoreUnexported(prowconfig.Presubmit{}, prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{})
 
 func TestGetChangedCiopConfigs(t *testing.T) {
 	baseCiopConfig := config.DataWithInfo{
@@ -165,11 +164,11 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			expected := tc.expected()
 
 			if !reflect.DeepEqual(expected, actual) {
-				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", diff.ObjectReflectDiff(expected, actual))
+				t.Errorf("Detected changed ci-operator config changes differ from expected:\n%s", cmp.Diff(expected, actual))
 			}
 
 			if !reflect.DeepEqual(tc.expectedAffectedJobs, affectedJobs) {
-				t.Errorf("Affected jobs differ from expected:\n%s", diff.ObjectReflectDiff(tc.expectedAffectedJobs, affectedJobs))
+				t.Errorf("Affected jobs differ from expected:\n%s", cmp.Diff(tc.expectedAffectedJobs, affectedJobs, ignoreUnexported))
 			}
 		})
 	}
@@ -362,7 +361,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 			before, after := testCase.configGenerator(t)
 			p := GetChangedPresubmits(before, after, logrus.NewEntry(logrus.New()))
 			if !equality.Semantic.DeepEqual(p, testCase.expected) {
-				t.Fatalf(diff.ObjectDiff(testCase.expected["org/repo"], p["org/repo"]))
+				t.Fatalf(cmp.Diff(testCase.expected["org/repo"], p["org/repo"], ignoreUnexported))
 			}
 		})
 	}
@@ -496,7 +495,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 			presubmits := GetPresubmitsForCiopConfigs(tc.prow, tc.ciop, affectedJobs)
 
 			if !reflect.DeepEqual(tc.expected, presubmits) {
-				t.Errorf("Returned presubmits differ from expected:\n%s", diff.ObjectDiff(tc.expected, presubmits))
+				t.Errorf("Returned presubmits differ from expected:\n%s", cmp.Diff(tc.expected, presubmits, ignoreUnexported))
 			}
 		})
 	}
@@ -628,7 +627,7 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if actual, expected := GetImagesPostsubmitsForCiopConfigs(testCase.prowConfig, testCase.ciopConfigs), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: got incorrect images postsubmits: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+				t.Errorf("%s: got incorrect images postsubmits: %v", testCase.name, cmp.Diff(actual, expected, ignoreUnexported))
 			}
 		})
 	}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -447,6 +447,46 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 			}(),
 		}},
 	}, {
+		description: "return a presubmit using one of the input ciop configs, with additional env vars",
+		prow: &prowconfig.Config{
+			JobConfig: prowconfig.JobConfig{
+				PresubmitsStatic: map[string][]prowconfig.Presubmit{
+					"org/repo": {
+						func() prowconfig.Presubmit {
+							ret := prowconfig.Presubmit{}
+							if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
+								t.Fatal(err)
+							}
+							ret.Name = "org-repo-branch-testjob"
+							moreEnvVars := []v1.EnvVar{{
+								Name:  "SOMETHING",
+								Value: "value of SOMETHING",
+							}}
+							ret.Spec.Containers[0].Env = append(moreEnvVars, ret.Spec.Containers[0].Env...)
+							ret.Spec.Containers[0].Env[len(moreEnvVars)].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
+							return ret
+						}(),
+					}},
+			},
+		},
+		ciop: config.ByFilename{baseCiopConfig.Filename: {Info: baseCiopConfig}},
+		expected: config.Presubmits{"org/repo": {
+			func() prowconfig.Presubmit {
+				ret := prowconfig.Presubmit{}
+				if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
+					t.Fatal(err)
+				}
+				ret.Name = "org-repo-branch-testjob"
+				moreEnvVars := []v1.EnvVar{{
+					Name:  "SOMETHING",
+					Value: "value of SOMETHING",
+				}}
+				ret.Spec.Containers[0].Env = append(moreEnvVars, ret.Spec.Containers[0].Env...)
+				ret.Spec.Containers[0].Env[len(moreEnvVars)].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
+				return ret
+			}(),
+		}},
+	}, {
 		description: "do not return a presubmit using a ciop config not present in input",
 		prow: &prowconfig.Config{
 			JobConfig: prowconfig.JobConfig{


### PR DESCRIPTION
Previously we have mistakenly bailed out early from the check if a given
job uses a ci-operator config, whenever we encountered items that
populated an envvar from something else than a ConfigMap key reference.

Fix this so that we check in all EnvVar items.

Fixes: #350 #339 

---

Additionally, I migrated the unit tests to use `cmp.Diff` instead of (deprecated) `diff.Object*Diff` family, because the latter was panicking on the unexported fields in job structs.

/cc @openshift/openshift-team-developer-productivity-test-platform 