### PR TITLE
pkg/registry: add types for maps of registry components

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -86,10 +86,10 @@ func configFromResolver(info *ResolverInfo) (*api.ReleaseBuildConfiguration, err
 
 // Registry takes the path to a registry config directory and returns the full set of references, chains,
 // and workflows that the registry's Resolver needs to resolve a user's MultiStageTestConfiguration
-func Registry(root string, flat bool) (references map[string]api.LiteralTestStep, chains map[string][]api.TestStep, workflows map[string]api.MultiStageTestConfiguration, err error) {
-	references = map[string]api.LiteralTestStep{}
-	chains = map[string][]api.TestStep{}
-	workflows = map[string]api.MultiStageTestConfiguration{}
+func Registry(root string, flat bool) (references registry.ReferenceMap, chains registry.ChainMap, workflows registry.WorkflowMap, err error) {
+	references = registry.ReferenceMap{}
+	chains = registry.ChainMap{}
+	workflows = registry.WorkflowMap{}
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info != nil && strings.HasPrefix(info.Name(), "..") {
 			if info.IsDir() {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/registry"
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -655,7 +656,7 @@ func TestConfigFromResolver(t *testing.T) {
 
 func TestRegistry(t *testing.T) {
 	var (
-		expectedReferences = map[string]api.LiteralTestStep{
+		expectedReferences = registry.ReferenceMap{
 			"ipi-deprovision-deprovision": {
 				As:       "ipi-deprovision-deprovision",
 				From:     "installer",
@@ -695,7 +696,7 @@ func TestRegistry(t *testing.T) {
 		installRef           = `ipi-install-install`
 		installRBACRef       = `ipi-install-rbac`
 
-		expectedChains = map[string][]api.TestStep{
+		expectedChains = registry.ChainMap{
 			"ipi-install": {
 				{
 					Reference: &installRBACRef,
@@ -715,7 +716,7 @@ func TestRegistry(t *testing.T) {
 		installChain     = `ipi-install`
 		deprovisionChain = `ipi-deprovision`
 
-		expectedWorkflows = map[string]api.MultiStageTestConfiguration{
+		expectedWorkflows = registry.WorkflowMap{
 			"ipi": {
 				Pre: []api.TestStep{{
 					Chain: &installChain,
@@ -730,9 +731,9 @@ func TestRegistry(t *testing.T) {
 			name          string
 			registryDir   string
 			flatRegistry  bool
-			references    map[string]api.LiteralTestStep
-			chains        map[string][]api.TestStep
-			workflows     map[string]api.MultiStageTestConfiguration
+			references    registry.ReferenceMap
+			chains        registry.ChainMap
+			workflows     registry.WorkflowMap
 			expectedError bool
 		}{{
 			name:          "Read registry",
@@ -746,11 +747,11 @@ func TestRegistry(t *testing.T) {
 			name:         "Read configmap style registry",
 			registryDir:  "../../test/multistage-registry/configmap",
 			flatRegistry: true,
-			references: map[string]api.LiteralTestStep{
+			references: registry.ReferenceMap{
 				installRef: expectedReferences[installRef],
 			},
-			chains:        map[string][]api.TestStep{},
-			workflows:     map[string]api.MultiStageTestConfiguration{},
+			chains:        registry.ChainMap{},
+			workflows:     registry.WorkflowMap{},
 			expectedError: false,
 		}}
 	)

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"fmt"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -240,7 +239,7 @@ func hasCycles(node *chainNode, ancestors sets.String, traversedPath []string) e
 }
 
 // NewGraph returns a NodeByType map representing the provided step references, chains, and workflows as a directed graph.
-func NewGraph(stepsByName map[string]api.LiteralTestStep, chainsByName map[string][]api.TestStep, workflowsByName map[string]api.MultiStageTestConfiguration) (NodeByName, error) {
+func NewGraph(stepsByName ReferenceMap, chainsByName ChainMap, workflowsByName WorkflowMap) (NodeByName, error) {
 	nodesByName := make(NodeByName)
 	// References can only be children; load them so they can be added as children by workflows and chains
 	referenceNodes := make(referenceNodeByName)

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -17,13 +17,13 @@ var ipiInstall = "ipi-install"
 var ipiDeprovision = "ipi-deprovision"
 var ipi = "ipi"
 
-var referenceMap = map[string]api.LiteralTestStep{
+var referenceMap = ReferenceMap{
 	ipiInstallInstall:         {},
 	ipiInstallRBAC:            {},
 	ipiDeprovisionDeprovision: {},
 	ipiDeprovisionMustGather:  {},
 }
-var chainMap = map[string][]api.TestStep{
+var chainMap = ChainMap{
 	ipiInstall: {{
 		Reference: &ipiInstallInstall,
 	}, {
@@ -35,7 +35,7 @@ var chainMap = map[string][]api.TestStep{
 		Reference: &ipiDeprovisionDeprovision,
 	}},
 }
-var workflowMap = map[string]api.MultiStageTestConfiguration{
+var workflowMap = WorkflowMap{
 	ipi: {
 		Pre: []api.TestStep{{
 			Chain: &ipiInstall,

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -11,16 +11,20 @@ type Resolver interface {
 	Resolve(config api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error)
 }
 
+type ReferenceMap map[string]api.LiteralTestStep
+type ChainMap map[string][]api.TestStep
+type WorkflowMap map[string]api.MultiStageTestConfiguration
+
 // registry will hold all the registry information needed to convert between the
 // user provided configs referencing the registry and the internal, complete
 // representation
 type registry struct {
-	stepsByName     map[string]api.LiteralTestStep
-	chainsByName    map[string][]api.TestStep
-	workflowsByName map[string]api.MultiStageTestConfiguration
+	stepsByName     ReferenceMap
+	chainsByName    ChainMap
+	workflowsByName WorkflowMap
 }
 
-func NewResolver(stepsByName map[string]api.LiteralTestStep, chainsByName map[string][]api.TestStep, workflowsByName map[string]api.MultiStageTestConfiguration) Resolver {
+func NewResolver(stepsByName ReferenceMap, chainsByName ChainMap, workflowsByName WorkflowMap) Resolver {
 	return &registry{
 		stepsByName:     stepsByName,
 		chainsByName:    chainsByName,

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -18,9 +18,9 @@ func TestResolve(t *testing.T) {
 	for _, testCase := range []struct {
 		name        string
 		config      api.MultiStageTestConfiguration
-		stepMap     map[string]api.LiteralTestStep
-		chainMap    map[string][]api.TestStep
-		workflowMap map[string]api.MultiStageTestConfiguration
+		stepMap     ReferenceMap
+		chainMap    ChainMap
+		workflowMap WorkflowMap
 		expectedRes api.MultiStageTestConfigurationLiteral
 		expectErr   bool
 	}{{
@@ -98,7 +98,7 @@ func TestResolve(t *testing.T) {
 				Reference: &reference1,
 			}},
 		},
-		stepMap: map[string]api.LiteralTestStep{
+		stepMap: ReferenceMap{
 			reference1: {
 				As:       "generic-unit-test",
 				From:     "my-image",
@@ -130,7 +130,7 @@ func TestResolve(t *testing.T) {
 				Reference: &reference1,
 			}},
 		},
-		stepMap: map[string]api.LiteralTestStep{
+		stepMap: ReferenceMap{
 			"generic-unit-test-2": {
 				As:       "generic-unit-test-2",
 				From:     "my-image",
@@ -164,7 +164,7 @@ func TestResolve(t *testing.T) {
 				Reference: &teardownRef,
 			}},
 		},
-		chainMap: map[string][]api.TestStep{
+		chainMap: ChainMap{
 			fipsPreChain: {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "ipi-install",
@@ -185,7 +185,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		stepMap: map[string]api.LiteralTestStep{
+		stepMap: ReferenceMap{
 			teardownRef: {
 				As:       "ipi-teardown",
 				From:     "installer",
@@ -242,7 +242,7 @@ func TestResolve(t *testing.T) {
 				Reference: &fipsPreChain,
 			}},
 		},
-		chainMap: map[string][]api.TestStep{
+		chainMap: ChainMap{
 			"broken": {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "generic-unit-test-2",
@@ -264,7 +264,7 @@ func TestResolve(t *testing.T) {
 				Chain: &nestedChains,
 			}},
 		},
-		chainMap: map[string][]api.TestStep{
+		chainMap: ChainMap{
 			nestedChains: {{
 				Chain: &chainInstall,
 			}, {
@@ -334,7 +334,7 @@ func TestResolve(t *testing.T) {
 				Chain: &nestedChains,
 			}},
 		},
-		chainMap: map[string][]api.TestStep{
+		chainMap: ChainMap{
 			nestedChains: {{
 				Chain: &chainInstall,
 			}, {
@@ -374,7 +374,7 @@ func TestResolve(t *testing.T) {
 		config: api.MultiStageTestConfiguration{
 			Workflow: &awsWorkflow,
 		},
-		chainMap: map[string][]api.TestStep{
+		chainMap: ChainMap{
 			fipsPreChain: {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "ipi-install",
@@ -395,7 +395,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		stepMap: map[string]api.LiteralTestStep{
+		stepMap: ReferenceMap{
 			teardownRef: {
 				As:       "ipi-teardown",
 				From:     "installer",
@@ -405,7 +405,7 @@ func TestResolve(t *testing.T) {
 					Limits:   api.ResourceList{"memory": "2Gi"},
 				}},
 		},
-		workflowMap: map[string]api.MultiStageTestConfiguration{
+		workflowMap: WorkflowMap{
 			awsWorkflow: {
 				ClusterProfile: api.ClusterProfileAWS,
 				Pre: []api.TestStep{{
@@ -480,7 +480,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		workflowMap: map[string]api.MultiStageTestConfiguration{
+		workflowMap: WorkflowMap{
 			awsWorkflow: {
 				ClusterProfile: api.ClusterProfileAWS,
 				Pre: []api.TestStep{{


### PR DESCRIPTION
Add new types for the maps of registry components. This shortens method signatures and type declarations and makes it easier to implement new functions that work with the registry.