### PR TITLE
Add a tool for syncing git content between mirrors

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/promotion"
+)
+
+type options struct {
+	configDir string
+	tokenPath string
+	targetOrg string
+
+	org  string
+	repo string
+
+	gitDir  string
+	confirm bool
+}
+
+func (o *options) validate() []error {
+	var errs []error
+	if o.configDir == "" {
+		errs = append(errs, fmt.Errorf("--config-dir is required"))
+	}
+
+	if o.targetOrg == "" {
+		errs = append(errs, fmt.Errorf("--target-org is required"))
+	}
+	if o.org != "" && o.targetOrg == o.org {
+		errs = append(errs, fmt.Errorf("--only-org cannot be equal to --target-org"))
+	}
+
+	if o.repo != "" {
+		if o.org != "" {
+			errs = append(errs, fmt.Errorf("--only-org cannot be used together with --only-repo"))
+		}
+		items := strings.Split(o.repo, "/")
+		if len(items) != 2 {
+			errs = append(errs, fmt.Errorf("--only-repo must have org/repo format"))
+		}
+		if items[0] == o.targetOrg {
+			errs = append(errs, fmt.Errorf("repo passed in --repo-only must have org different from --target-org"))
+		}
+	}
+
+	if o.tokenPath == "" {
+		errs = append(errs, fmt.Errorf("--token-path is required"))
+	}
+	return errs
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.tokenPath, "token-path", "", "Path to token to use when pushing to GitHub.")
+	fs.StringVar(&o.configDir, "config-path", "", "Path to directory containing ci-operator configurations")
+	fs.StringVar(&o.targetOrg, "target-org", "", "Name of the org holding repos into which the git content should be mirrored")
+
+	fs.StringVar(&o.org, "only-org", "", "Mirror only repos that belong to this org")
+	fs.StringVar(&o.repo, "only-repo", "", "Mirror only a single repo")
+	fs.StringVar(&o.gitDir, "git-dir", "", "Path to directory in which to perform Git operations")
+	fs.BoolVar(&o.confirm, "confirm", false, "Set true to actually execute all world-changing operations")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatal("Could not parse options")
+	}
+	return o
+}
+
+type gitFunc func(logger *logrus.Entry, dir string, command ...string) (string, int, error)
+
+func gitExec(logger *logrus.Entry, dir string, command ...string) (string, int, error) {
+	cmdLogger := logger.WithField("command", fmt.Sprintf("git %s", strings.Join(command, " ")))
+	cmd := exec.Command("git", command...)
+	cmd.Dir = dir
+	cmdLogger.Debug("Running git")
+	raw, err := cmd.CombinedOutput()
+	out := string(raw)
+	var exitCode int
+	if err != nil {
+		errLogger := cmdLogger.WithError(err).WithField("output", out)
+		if ee, ok := err.(*exec.ExitError); !ok {
+			errLogger.Error("Failed to run git command")
+		} else {
+			exitCode = ee.ExitCode()
+			errLogger.Debug("Git command was executed but completed with non-zero exit code")
+			err = nil
+		}
+	} else {
+		cmdLogger.WithField("output", out).Debug("Executed command")
+	}
+
+	return out, exitCode, err
+}
+
+type RemoteBranchHeads map[string]string
+
+func getRemoteBranchHeads(logger *logrus.Entry, git gitFunc, repoDir, remote string) (RemoteBranchHeads, error) {
+	heads := RemoteBranchHeads{}
+	out, exitCode, err := git(logger, repoDir, "ls-remote", "--heads", remote)
+	if err != nil {
+		return nil, err
+	}
+	if exitCode != 0 {
+		return nil, fmt.Errorf("ls-remote failed: (exit code=%d)", exitCode)
+	}
+
+	out = strings.TrimSpace(out)
+	if len(out) == 0 {
+		return heads, nil
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("unexpected ls-remote output line: %s", line)
+		}
+
+		branch := strings.TrimPrefix(fields[1], "refs/heads/")
+		if len(branch) == len(fields[1]) {
+			return nil, fmt.Errorf("unexpected ls-remote output line: %s", line)
+		}
+		heads[branch] = fields[0]
+	}
+
+	return heads, nil
+}
+
+// gitSyncer contains all code necessary to synchronize content from one GitHub
+// location (org, repo, branch) to another
+type gitSyncer struct {
+	// GitHub token
+	// Needs permissions to read the source and write to the destination
+	token string
+	// Path to a directory with local git repositories used for fetching and
+	// pushing git content.
+	root string
+	// If false, no write operations will be done.
+	confirm bool
+	logger  *logrus.Entry
+
+	// wrapper for `git` execution: it is a member of the struct for testability
+	git gitFunc
+}
+
+const fullFetch = 0
+const startDepth = 1
+const maxExpDepth = 6 // means we do at most `--depth=64`, then fallback to `--unshallow`
+const unshallow = maxExpDepth + 1
+
+func makeFetch(logger *logrus.Entry, repoDir string, git gitFunc, remote, branch string, expDepth int) func() error {
+	return func() error {
+		fetch := []string{"fetch", remote, branch}
+
+		depthArg := "full fetch" // no depth arg is used when doing a full fetch
+		if expDepth != fullFetch {
+			depthArg = "--unshallow"
+			if expDepth < unshallow {
+				depthArg = fmt.Sprintf("--depth=%d", int(math.Exp2(float64(expDepth))))
+			}
+
+			fetch = append(fetch, depthArg)
+		}
+
+		logger.Infof("Fetching from source (%s)", depthArg)
+		if out, exitCode, err := git(logger, repoDir, fetch...); err != nil || exitCode != 0 {
+			logger.WithError(err).WithField("exit-code", exitCode).WithField("output", out).Error("Failed to fetch from source")
+			return fmt.Errorf("failed to fetch from source")
+		}
+		return nil
+	}
+}
+
+func maybeTooShallow(pushOutput string) bool {
+	patterns := []string{
+		"shallow update not allowed",
+		"Updates were rejected because the remote contains work that you do",
+	}
+	for _, item := range patterns {
+		if strings.Contains(pushOutput, item) {
+			return true
+		}
+	}
+	return false
+}
+
+// location specifies a GitHub repository branch used as a source or destination
+type location struct {
+	org, repo, branch string
+}
+
+func (l location) String() string {
+	return fmt.Sprintf("%s/%s@%s", l.org, l.repo, l.branch)
+}
+
+// makeGitDir creates a directory for a local git repo used for fetching content
+// from the given location and pushing it to any other git repo
+func (g gitSyncer) makeGitDir(org, repo string) (string, error) {
+	repoDir := filepath.Join(g.root, org, repo)
+	err := os.MkdirAll(repoDir, 0755)
+	return repoDir, err
+}
+
+// mirror syncs content from source location to destination one, using a local
+// repository in the given path. The `repoDir` directory must exist and be
+// either empty, or previously used in a `mirror()` call. If it is empty,
+// a bare git repository will be initialized in it. The git content from
+// the `src` location will be fetched to this local repository and then
+// pushed to the `dst` location. Multiple `mirror` calls over the same `repoDir`
+// will reuse the content fetched in previous calls, acting like a cache.
+func (g gitSyncer) mirror(repoDir string, src, dst location) error {
+	mirrorFields := logrus.Fields{
+		"source":      src.String(),
+		"destination": dst.String(),
+		"local-repo":  repoDir,
+	}
+	logger := g.logger.WithFields(mirrorFields)
+	logger.Info("Syncing content between locations")
+
+	logger.Debug("Initializing git repository")
+	if _, exitCode, err := g.git(logger, repoDir, "init", "--bare"); err != nil || exitCode != 0 {
+		logger.WithField("exit-code", exitCode).WithError(err).Error("Failed to initialize local git directory")
+		return fmt.Errorf("failed to initialize local git directory")
+	}
+
+	// We set up a named remote for our source, called $org-$repo
+	// We do this to allow git to reuse already fetched refs in subsequent fetches
+	// so the local git repository acts like a cache.
+	srcRemote := fmt.Sprintf("%s-%s", src.org, src.repo)
+	_, exitCode, err := g.git(logger, repoDir, "remote", "get-url", srcRemote)
+	if err != nil {
+		logger.WithError(err).Error("Failed to query local git repository for remotes")
+		return fmt.Errorf("failed to query local git repository for remotes")
+	}
+	if exitCode != 0 {
+		remoteSetupLogger := logger.WithField("remote-name", srcRemote)
+		remoteSetupLogger.Debug("Remote does not exist, setting up")
+		srcUrl, err := url.Parse(fmt.Sprintf("https://github.com/%s/%s", src.org, src.repo))
+		if err != nil {
+			remoteSetupLogger.WithError(err).Error("Failed to construct URL for the source remote")
+			return fmt.Errorf("failed to construct URL for the source remote")
+		}
+		remoteSetupLogger = remoteSetupLogger.WithField("remote-url", srcUrl.String())
+		remoteSetupLogger.Debug("Adding remote")
+		if _, exitCode, err := g.git(logger, repoDir, "remote", "add", srcRemote, srcUrl.String()); err != nil || exitCode != 0 {
+			remoteSetupLogger.WithField("exit-code", exitCode).WithError(err).Error("Failed to set up source remote")
+			return fmt.Errorf("failed to set up source remote")
+		}
+	}
+
+	// We ls-remote destination first because it is more likely to not exist
+	logger.Debug("Determining HEAD of destination branch")
+	destUrlRaw := fmt.Sprintf("https://github.com/%s/%s", dst.org, dst.repo)
+	destUrl, err := url.Parse(destUrlRaw)
+	if err != nil {
+		logger.WithField("remote-url", destUrlRaw).WithError(err).Error("Failed to construct URL for the destination remote")
+		return fmt.Errorf("failed to construct URL for the destination remote")
+	}
+	destUrl.User = url.User(g.token)
+
+	dstHeads, err := getRemoteBranchHeads(logger, g.git, repoDir, destUrl.String())
+	if err != nil {
+		// This is currently fine but eventually should be controlled by a switch
+		logger.Warn("Destination repository does not exist or we cannot access it")
+		return nil
+	}
+	dstCommitHash := dstHeads[dst.branch]
+
+	logger.Debug("Determining HEAD of source branch")
+	srcHeads, err := getRemoteBranchHeads(logger, g.git, repoDir, srcRemote)
+	if err != nil {
+		logger.WithError(err).Error("Failed to determine branch HEADs in source")
+		return fmt.Errorf("failed to determine branch HEADs in source")
+	}
+	srcCommitHash, ok := srcHeads[src.branch]
+	if !ok {
+		logger.WithError(err).Error("Branch does not exist in source remote")
+		return fmt.Errorf("branch does not exist in source remote")
+	}
+
+	if srcCommitHash == dstCommitHash {
+		logger.Info("Branches are already in sync")
+		return nil
+	}
+
+	depth := startDepth
+	if len(dstHeads) == 0 {
+		logger.Info("Destination is an empty repo: will do a full fetch right away")
+		depth = fullFetch
+	}
+
+	push := func() (retry func() error, err error) {
+		cmd := []string{"push"}
+		var logDryRun string
+		if !g.confirm {
+			cmd = append(cmd, "--dry-run")
+			logDryRun = " (dry-run)"
+		}
+		cmd = append(cmd, destUrl.String(), fmt.Sprintf("FETCH_HEAD:refs/heads/%s", dst.branch))
+		logger.Infof("Pushing to destination%s", logDryRun)
+
+		out, exitCode, err := g.git(logger, repoDir, cmd...)
+		if err == nil && exitCode == 0 {
+			logger.Debug("Successfully pushed to destination")
+			return nil, nil
+		}
+
+		if !maybeTooShallow(out) || err != nil {
+			message := "failed to push to destination, no retry possible"
+			logger.WithError(err).WithField("exit-code", exitCode).WithField("output", out).Error(message)
+			return nil, fmt.Errorf(message)
+		}
+
+		if depth == unshallow {
+			message := "failed to push to destination, no retry possible (already fetched full history)"
+			logger.Error(message)
+			return nil, fmt.Errorf(message)
+		}
+
+		shallowOut, shallowExitCode, shallowErr := g.git(logger, repoDir, "rev-parse", "--is-shallow-repository")
+		if shallowErr != nil || shallowExitCode != 0 {
+			message := "failed to push to destination, no retry possible (cannot determine whether our git repo is shallow)"
+			logger.WithError(shallowErr).WithField("exit-code", shallowExitCode).WithField("output", shallowOut).Error(message)
+			return nil, fmt.Errorf(message)
+		}
+
+		switch strings.TrimSpace(shallowOut) {
+		case "false":
+			message := "failed to push to destination, no retry possible (already fetched full history)"
+			logger.Error(message)
+			return nil, fmt.Errorf(message)
+		case "true":
+			depth++
+			return makeFetch(logger, repoDir, g.git, srcRemote, src.branch, depth), nil
+		default:
+			message := "failed to push to destination, no retry possible (cannot determine whether our git repo is shallow)"
+			logger.Error(message)
+			logger.Error("`rev-parse --is-shallow-repo` likely not supported by used git")
+			return nil, fmt.Errorf(message)
+		}
+	}
+
+	fetch := makeFetch(logger, repoDir, g.git, srcRemote, src.branch, depth)
+	for fetch != nil {
+		err := fetch()
+		if err != nil {
+			return err
+		}
+
+		fetch, err = push()
+		if err != nil {
+			return err
+		}
+		if fetch != nil {
+			logger.Info("failed to push to destination, retrying with deeper fetch")
+		}
+	}
+
+	return nil
+}
+
+// makeFilter creates a callback usable for OperateOnCIOperatorConfigDir that
+// only calls the original callback on files matching the business rules and
+// options passed to the program
+func (o *options) makeFilter(callback func(*api.ReleaseBuildConfiguration, *config.Info) error) func(*api.ReleaseBuildConfiguration, *config.Info) error {
+	return func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
+		if o.org != "" && o.org != i.Org {
+			return nil
+		}
+		if o.repo != "" && o.repo != fmt.Sprintf("%s/%s", i.Org, i.Repo) {
+			return nil
+		}
+		if !promotion.BuildsOfficialImages(c) {
+			return nil
+		}
+		return callback(c, i)
+	}
+}
+
+func main() {
+	o := gatherOptions()
+	if errs := o.validate(); len(errs) > 0 {
+		for _, err := range errs {
+			logrus.WithError(err).Error("Invalid option")
+		}
+		logrus.Fatal("Invalid options, exiting")
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	var token string
+	if rawToken, err := ioutil.ReadFile(o.tokenPath); err != nil {
+		logrus.WithError(err).Fatal("Failed to read GitHub token")
+	} else {
+		token = strings.TrimSpace(string(rawToken))
+		getter := func() sets.String {
+			return sets.NewString(token)
+		}
+		logrus.SetFormatter(logrusutil.NewCensoringFormatter(logrus.StandardLogger().Formatter, getter))
+	}
+
+	if o.gitDir == "" {
+		var err error
+		if o.gitDir, err = ioutil.TempDir("", ""); err != nil {
+			logrus.WithError(err).Fatal("Failed to create temporary directory for git operations")
+		}
+		defer func() {
+			if err := os.RemoveAll(o.gitDir); err != nil {
+				logrus.WithError(err).Fatal("Failed to clean up temporary directory for git operations")
+			}
+		}()
+	}
+
+	syncer := gitSyncer{
+		token:   token,
+		root:    o.gitDir,
+		confirm: o.confirm,
+		git:     gitExec,
+	}
+
+	var syncErrors []error
+	callback := func(_ *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+		syncer.logger = config.LoggerForInfo(*repoInfo)
+		source := location{
+			org:    repoInfo.Org,
+			repo:   repoInfo.Repo,
+			branch: repoInfo.Branch,
+		}
+		destination := source
+		destination.org = o.targetOrg
+		gitDir, err := syncer.makeGitDir(source.org, source.repo)
+		if err != nil {
+			syncErrors = append(syncErrors, err)
+			return nil
+		}
+
+		if err := syncer.mirror(gitDir, source, destination); err != nil {
+			syncErrors = append(syncErrors, err)
+		}
+		return nil
+	}
+
+	callback = o.makeFilter(callback)
+	if err := config.OperateOnCIOperatorConfigDir(o.configDir, callback); err != nil || len(syncErrors) > 0 {
+		if err != nil {
+			syncErrors = append(syncErrors, err)
+		}
+		e := errorutil.NewAggregate(syncErrors...)
+		logrus.WithError(e).Fatal("There were failures during git content synchronization")
+	}
+}

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -1,0 +1,482 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/promotion"
+)
+
+func TestOptionsValidate(t *testing.T) {
+	good := options{
+		configDir: "path/to/dir",
+		tokenPath: "path/to/token",
+		targetOrg: "org",
+	}
+	testcases := []struct {
+		description string
+		bad         *options
+
+		org  string
+		repo string
+
+		expectedErrors int
+	}{
+		{
+			description: "good options pass validation",
+		},
+		{
+			description:    "missing --config-dir does not pass validation",
+			bad:            &options{tokenPath: "path/to/token", targetOrg: "org"},
+			expectedErrors: 1,
+		},
+		{
+			description:    "missing --token-path does not pass validation",
+			bad:            &options{configDir: "path/to/dir", targetOrg: "org"},
+			expectedErrors: 1,
+		},
+		{
+			description:    "missing --target-org does not pass validation",
+			bad:            &options{configDir: "path/to/dir", tokenPath: "path/to/token"},
+			expectedErrors: 1,
+		},
+		{
+			description: "--only-org different from --target-org passes validation",
+			org:         "different-org",
+		},
+		{
+			description:    "--only-org same as --target-org does not pass validation",
+			org:            "org",
+			expectedErrors: 1,
+		},
+		{
+			description:    "--only-org and --only-repo does not pass validation",
+			org:            "different-org",
+			repo:           "another-org/repo",
+			expectedErrors: 1,
+		},
+		{
+			description:    "bad --only-repo does not pass validation",
+			repo:           "not-a-repo",
+			expectedErrors: 1,
+		},
+		{
+			description:    "--only-repo in --target-org does not pass validation",
+			repo:           "org/repo",
+			expectedErrors: 1,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			opts := good
+			if tc.bad != nil {
+				opts = *tc.bad
+			}
+			opts.org = tc.org
+			opts.repo = tc.repo
+
+			errs := opts.validate()
+			if len(errs) != tc.expectedErrors {
+				t.Errorf("%s: expected %d errors, got %d (%v)", tc.description, tc.expectedErrors, len(errs), errs)
+			}
+		})
+	}
+}
+
+func TestOptionsMakeFilter(t *testing.T) {
+	official := &api.ReleaseBuildConfiguration{
+		PromotionConfiguration: &api.PromotionConfiguration{
+			Namespace: "ocp",
+		},
+	}
+	notOfficial := &api.ReleaseBuildConfiguration{
+		PromotionConfiguration: &api.PromotionConfiguration{
+			Namespace: "not-ocp",
+		},
+	}
+	// Check that our assumptions about what is an official image still holds
+	if !promotion.BuildsOfficialImages(official) {
+		t.Fatal("Test data assumed to be official images are not official images")
+	}
+	if promotion.BuildsOfficialImages(notOfficial) {
+		t.Fatal("Test data assumed to be non-official images are official images")
+	}
+	testcases := []struct {
+		description   string
+		optionOrg     string
+		optionRepo    string
+		repoOrg       string
+		repoName      string
+		callbackError error
+		notOfficial   bool
+
+		expectCall  bool
+		expectError bool
+	}{
+		{
+			description: "no org option passed, callbacks are not filtered",
+			expectCall:  true,
+		},
+		{
+			description: "org option passed, callback is made for repo in that org",
+			optionOrg:   "org",
+			repoOrg:     "org",
+			expectCall:  true,
+		},
+		{
+			description: "org option passed, callback is not made for repo not in that org",
+			optionOrg:   "org",
+			repoOrg:     "not-org",
+			expectCall:  false,
+		},
+		{
+			description: "repo option passed, callback is made for that repo",
+			optionRepo:  "org/repo",
+			repoOrg:     "org",
+			repoName:    "repo",
+			expectCall:  true,
+		},
+		{
+			description: "repo option passed, callback is not made for other repo",
+			optionRepo:  "org/repo",
+			repoOrg:     "org",
+			repoName:    "not-repo",
+			expectCall:  false,
+		},
+		{
+			description:   "callback is made and its error is propagated",
+			callbackError: fmt.Errorf("FAIL"),
+			expectCall:    true,
+			expectError:   true,
+		},
+		{
+			description: "no filter options but repo does not build official images, callback is not made",
+			notOfficial: true,
+			expectCall:  false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			o := &options{
+				org:  tc.optionOrg,
+				repo: tc.optionRepo,
+			}
+			ciop := official
+			if tc.notOfficial {
+				ciop = notOfficial
+			}
+			info := &config.Info{
+				Org:  tc.repoOrg,
+				Repo: tc.repoName,
+			}
+			var called bool
+			callback := func(*api.ReleaseBuildConfiguration, *config.Info) error {
+				called = true
+				return tc.callbackError
+			}
+			err := o.makeFilter(callback)(ciop, info)
+			if err == nil && tc.expectError {
+				t.Errorf("%s: expected error, got none", tc.description)
+			}
+			if err != nil && !tc.expectError {
+				t.Errorf("%s: got unexpected error: %v", tc.description, err)
+			}
+			if called != tc.expectCall {
+				var expected, actual string
+				if !tc.expectCall {
+					expected = "not "
+				}
+				if !called {
+					actual = " not"
+				}
+				t.Errorf("%s: expected callback to %sbe called, it was%s", tc.description, expected, actual)
+			}
+		})
+	}
+}
+
+type mockGitCall struct {
+	call     string
+	output   string
+	exitCode int
+}
+
+type mockGit struct {
+	next     int
+	expected []mockGitCall
+
+	tc string
+	t  *testing.T
+}
+
+func (m *mockGit) exec(_ *logrus.Entry, _ string, command ...string) (string, int, error) {
+	cmd := strings.Join(command, " ")
+	if m.next >= len(m.expected) {
+		m.t.Fatalf("%s:\nunexpected git call: %s", m.tc, cmd)
+		return "", 0, nil
+	}
+	if m.expected[m.next].call != cmd {
+		m.t.Fatalf("%s:\nunexpected git call:\n  expected: %s\n  called:   %s", m.tc, m.expected[m.next].call, cmd)
+		return "", 0, nil
+	}
+
+	out := m.expected[m.next].output
+	exitCode := m.expected[m.next].exitCode
+	m.next++
+
+	return out, exitCode, nil
+}
+
+func (m mockGit) check() error {
+	if m.next != len(m.expected) {
+		return fmt.Errorf("unexpected number of git calls: expected %d, done %d", len(m.expected), m.next)
+	}
+	return nil
+}
+
+func TestMirror(t *testing.T) {
+	token := "TOKEN"
+	org, repo, branch := "org", "repo", "branch"
+	destOrg := "dest"
+	testCases := []struct {
+		description string
+
+		src     location
+		dst     location
+		confirm bool
+
+		expectedGitCalls []mockGitCall
+		expectError      bool
+	}{
+		{
+			description: "cold cache, confirm, success -> no error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			confirm:     true,
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo", exitCode: 1},
+				{call: "remote add org-repo https://github.com/org/repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{call: "push https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		},
+		{
+			description: "cold cache, fails to set up remote -> error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo", exitCode: 1},
+				{call: "remote add org-repo https://github.com/org/repo", exitCode: 1},
+			},
+			expectError: true,
+		},
+		{
+			description: "warm cache, confirm, success -> no error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			confirm:     true,
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{call: "push https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		},
+		{
+			description: "warm cache, no confirm, success -> push with dry run",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		},
+		{
+			description: "warm cache, no confirm, source has more branches -> push with dry run",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch\nanother-sha refs/heads/another-branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		},
+		{
+			description: "warm cache, fails to fetch -> error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2", exitCode: 1},
+			},
+			expectError: true,
+		},
+		{
+			description: "warm cache, no confirm, fails to push -> error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch", exitCode: 1},
+			},
+			expectError: true,
+		},
+		{
+			description: "warm cache, branches are in sync -> no fetch, no push",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+			},
+		},
+		{
+			description: "warm cache, ls-remote source fails -> error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", exitCode: 1},
+			},
+			expectError: true,
+		},
+		{
+			description: "warm cache, source branch does not exist -> error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "some-sha refs/heads/not-the-branch"},
+			},
+			expectError: true,
+		},
+		{ // If git ls-remote fails, destination repository does not exist
+			// At the moment, this is intentionally not an error
+			description: "warm cache, ls-remote destination fails on git -> no error",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", exitCode: 1},
+			},
+		},
+		{
+			description: "warm cache, destination is empty repo, needs many commits -> full fetch then success",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch"},
+				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		}, {
+			description: "warm cache, destination needs 50 commits -> retries deepening fetches, then success",
+			src:         location{org: org, repo: repo, branch: branch},
+			dst:         location{org: destOrg, repo: repo, branch: branch},
+			expectedGitCalls: []mockGitCall{
+				{call: "init --bare"},
+				{call: "remote get-url org-repo"},
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
+				{call: "fetch org-repo branch --depth=2"},
+				{
+					call:     "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch",
+					exitCode: 1,
+					output:   "...Updates were rejected because the remote contains work that you do...",
+				},
+				{call: "rev-parse --is-shallow-repository", output: "true"},
+				{call: "fetch org-repo branch --depth=4"},
+				{
+					call:     "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch",
+					exitCode: 1,
+					output:   "...Updates were rejected because the remote contains work that you do...",
+				},
+				{call: "rev-parse --is-shallow-repository", output: "true"},
+				{call: "fetch org-repo branch --depth=8"},
+				{
+					call:     "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch",
+					exitCode: 1,
+					output:   "...Updates were rejected because the remote contains work that you do...",
+				},
+				{call: "rev-parse --is-shallow-repository", output: "true"},
+				{call: "fetch org-repo branch --depth=16"},
+				{
+					call:     "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch",
+					exitCode: 1,
+					output:   "...Updates were rejected because the remote contains work that you do...",
+				},
+				{call: "rev-parse --is-shallow-repository", output: "true"},
+				{call: "fetch org-repo branch --depth=32"},
+				{
+					call:     "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch",
+					exitCode: 1,
+					output:   "...Updates were rejected because the remote contains work that you do...",
+				},
+				{call: "rev-parse --is-shallow-repository", output: "true"},
+				{call: "fetch org-repo branch --depth=64"},
+				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			git := mockGit{
+				expected: tc.expectedGitCalls,
+				tc:       tc.description,
+				t:        t,
+			}
+			m := gitSyncer{
+				logger:  logrus.WithField("test", tc.description),
+				token:   token,
+				confirm: tc.confirm,
+				root:    "git-dir",
+				git:     git.exec,
+			}
+			err := m.mirror("repo-dir", tc.src, tc.dst)
+			if err == nil && tc.expectError {
+				t.Errorf("%s:\nexpected error, got nil", tc.description)
+			}
+			if err != nil && !tc.expectError {
+				t.Errorf("%s:\nunexpected error: %v", tc.description, err)
+			}
+			if err = git.check(); err != nil {
+				t.Errorf("%s:\nbad git operation: %v", tc.description, err)
+			}
+		})
+	}
+}

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -21,7 +21,7 @@ const (
 // being promoted. This is a proxy for determining if a configuration contributes to
 // the release payload.
 func PromotesOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
-	return !isDisabled(configSpec) && buildOfficialImages(configSpec)
+	return !isDisabled(configSpec) && BuildsOfficialImages(configSpec)
 }
 
 func isDisabled(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
@@ -30,7 +30,7 @@ func isDisabled(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 
 // buildOfficialImages determines if a configuration will result in official images
 // being built.
-func buildOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
+func BuildsOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 	promotionNamespace := extractPromotionNamespace(configSpec)
 	promotionName := extractPromotionName(configSpec)
 	return RefersToOfficialImage(promotionName, promotionNamespace)


### PR DESCRIPTION
This tool automatically syncs code from which "official" images are
built from their public git repo locations to their mirrors in private
GitHub organization. It is intended to be run in a Prow periodic job
with an interval of less than an hour.

Both source and destination are queried with `git ls-remote`: if they are
already in sync, no further git operations are done. When the destination is
detected to be an empty repo, full `git fetch` is done against a source,
and FETCH_HEAD is then pushed to the destination. When the destination
is a non-empty repository, `git fetch --depth X` is done against the
source and the resulting shallow branch tip is attempted to be pushed.
When this fails, X is exponentially increased and the fetch is retried.
When a threshold is hit, the shallow branch tip is fully fetched with
`--unshallow` and the push is retried again.

Currently the tool does not fail when the destination repository does not exist
at all: this should allow running against full openshift/release while
repository mirrors are created in the private org.

/cc @openshift/openshift-team-developer-productivity-test-platform 