### PR TITLE
fix retry around template instance ready check (in case it is called …

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -382,21 +382,28 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 }
 
 func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
-	for {
-		ready, err := templateInstanceReady(instance)
-		if err != nil {
-			return nil, fmt.Errorf("could not determine if template instance was ready: %v", err)
+	var actualErr error
+	err := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+		ready, actualErr := templateInstanceReady(instance)
+		if actualErr != nil {
+			log.Printf("could not determine if template instance was ready: %v", actualErr)
+			return false, nil
 		}
 		if ready {
-			return instance, nil
+			return true, nil
 		}
 
-		time.Sleep(2 * time.Second)
-		instance, err = templateClient.Get(instance.Name, meta.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve existing template instance: %v", err)
+		instance, actualErr = templateClient.Get(instance.Name, meta.GetOptions{})
+		if actualErr != nil {
+			log.Printf("unable to retrieve existing template instance: %v", actualErr)
+			return false, nil
 		}
+		return true, nil
+	})
+	if err == nil {
+		return instance, nil
 	}
+	return nil, actualErr
 }
 
 func createOrRestartTemplateInstance(templateClient templateclientset.TemplateInstanceInterface, podClient coreclientset.PodInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {


### PR DESCRIPTION
…before the templates instance is created)

Please see https://coreos.slack.com/archives/CBN38N3MW/p1578667979391000 for my analysis of a race condition on the template instance ready check in ci-tools.

A quick synopsis of my analysis of https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-samples-operator/211/pull-ci-openshift-cluster-samples-operator-master-e2e-aws-upgrade/335

(though I've had a lot of other similar failures over the last few days)

- I see that the e2e-aws-upgrade template instance does exist in my PR's namespace, where it was created at creationTimestamp: "2020-01-10T14:47:14Z"
- In the prow log, it starts waiting for the instance at 2020/01/10 14:47:09 Waiting for template instance to be ready ... so yeah a few seconds before it was created
- the existing for loop actual punts if it cannot find the templateinstance on the first pass

@openshift/openshift-team-developer-productivity-platform PTAL

or if that is not the right team, @petr-muller @bbguimaraes @droslean @hongkailiu @stevekuznetsov PTAL

thanks