### PR TITLE
testgrid: Gather more testgrid results for jobs that run less frequently

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -87,7 +87,7 @@ func dashboardTabFor(name string) *config.DashboardTab {
 	return &config.DashboardTab{
 		Name:             name,
 		TestGroupName:    name,
-		BaseOptions:      "width=10&exclude-filter-by-regex=Monitor%5Cscluster",
+		BaseOptions:      "width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24",
 		OpenTestTemplate: &config.LinkTemplate{Url: "https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>"},
 		FileBugTemplate: &config.LinkTemplate{
 			Url: "https://github.com/openshift/origin/issues/new",

--- a/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-blocking.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.1
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-blocking.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-optional-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-job
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -80,9 +80,11 @@ dashboards:
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
   name: release-openshift-ocp-installer-e2e-aws-optional-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
   name: release-openshift-ocp-job
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
   name: release-openshift-origin-installer-e2e-aws-optional-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
   name: release-openshift-origin-job


### PR DESCRIPTION
Many periodics are on 24h or 48h intervals, so test grid's default of 7
days doesn't show much info. For those jobs, use a heuristic to try and get
100 test results based on the configured interval of the periodic, between
7d (the default) and 60d (a reasonable max).

Release controller jobs are not changed because they are run at intervals
outside of our control.

Also:

testgrid: Exclude the test container summary junit from testgrid

The test container junit (generated by ci-operator) is already summarized
by the overall test result (if we fail test, we fail the overall run), but
the summary page for test grid will count it as part of the flake rate and
failure percentage. A downside of this change is that if the test container
breaks test grid won't show a specific red box (but prow would), and also
that we can't see the time the full test suite takes to run in the table
graph, which is an acceptable tradeoff for making the test summary clearer.