### PR TITLE
private-org-sync: add another retried error pattern

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -193,6 +193,7 @@ func maybeTooShallow(pushOutput string) bool {
 	patterns := []string{
 		"shallow update not allowed",
 		"Updates were rejected because the remote contains work that you do",
+		"Updates were rejected because a pushed branch tip is behind its remote",
 	}
 	for _, item := range patterns {
 		if strings.Contains(pushOutput, item) {


### PR DESCRIPTION
Unfortunately error messages change between git versions, I was seeeing
this one with `git 2.18.1` which is the version in CentOS 8 which I want
to use as a base to run in production.

/cc @openshift/openshift-team-developer-productivity-test-platform 