### PR TITLE
Install git for private-org-sync and base it on centos:8

### DIFF
--- a/images/private-org-sync/Dockerfile
+++ b/images/private-org-sync/Dockerfile
@@ -1,5 +1,6 @@
-FROM centos:7
+FROM centos:8
 LABEL maintainer="muller@redhat.com"
 
+RUN yum install -y git && yum clean all
 ADD private-org-sync /usr/bin/private-org-sync
 ENTRYPOINT ["/usr/bin/private-org-sync"]


### PR DESCRIPTION
(I know I need to change ci-op config to actually base the thing on centos:8)

/cc @openshift/openshift-team-developer-productivity-test-platform 