### PR TITLE
private-org-sync: fail-fast when destination does not exist

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -235,6 +235,25 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 	logger := g.logger.WithFields(mirrorFields)
 	logger.Info("Syncing content between locations")
 
+	// We ls-remote destination first thing because when it does not exist
+	// we do not need to do any of the remaining operations.
+	logger.Debug("Determining HEAD of destination branch")
+	destUrlRaw := fmt.Sprintf("https://github.com/%s/%s", dst.org, dst.repo)
+	destUrl, err := url.Parse(destUrlRaw)
+	if err != nil {
+		logger.WithField("remote-url", destUrlRaw).WithError(err).Error("Failed to construct URL for the destination remote")
+		return fmt.Errorf("failed to construct URL for the destination remote")
+	}
+	destUrl.User = url.User(g.token)
+
+	dstHeads, err := getRemoteBranchHeads(logger, g.git, repoDir, destUrl.String())
+	if err != nil {
+		// This is currently fine but eventually should be controlled by a switch
+		logger.Warn("Destination repository does not exist or we cannot access it")
+		return nil
+	}
+	dstCommitHash := dstHeads[dst.branch]
+
 	logger.Debug("Initializing git repository")
 	if _, exitCode, err := g.git(logger, repoDir, "init", "--bare"); err != nil || exitCode != 0 {
 		logger.WithField("exit-code", exitCode).WithError(err).Error("Failed to initialize local git directory")
@@ -265,24 +284,6 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 			return fmt.Errorf("failed to set up source remote")
 		}
 	}
-
-	// We ls-remote destination first because it is more likely to not exist
-	logger.Debug("Determining HEAD of destination branch")
-	destUrlRaw := fmt.Sprintf("https://github.com/%s/%s", dst.org, dst.repo)
-	destUrl, err := url.Parse(destUrlRaw)
-	if err != nil {
-		logger.WithField("remote-url", destUrlRaw).WithError(err).Error("Failed to construct URL for the destination remote")
-		return fmt.Errorf("failed to construct URL for the destination remote")
-	}
-	destUrl.User = url.User(g.token)
-
-	dstHeads, err := getRemoteBranchHeads(logger, g.git, repoDir, destUrl.String())
-	if err != nil {
-		// This is currently fine but eventually should be controlled by a switch
-		logger.Warn("Destination repository does not exist or we cannot access it")
-		return nil
-	}
-	dstCommitHash := dstHeads[dst.branch]
 
 	logger.Debug("Determining HEAD of source branch")
 	srcHeads, err := getRemoteBranchHeads(logger, g.git, repoDir, srcRemote)

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -259,10 +259,10 @@ func TestMirror(t *testing.T) {
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			confirm:     true,
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo", exitCode: 1},
 				{call: "remote add org-repo https://github.com/org/repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{call: "push https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
@@ -273,6 +273,7 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo", exitCode: 1},
 				{call: "remote add org-repo https://github.com/org/repo", exitCode: 1},
@@ -285,9 +286,9 @@ func TestMirror(t *testing.T) {
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			confirm:     true,
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{call: "push https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
@@ -298,9 +299,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
@@ -311,9 +312,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch\nanother-sha refs/heads/another-branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
@@ -324,9 +325,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2", exitCode: 1},
 			},
@@ -337,9 +338,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch", exitCode: 1},
@@ -351,9 +352,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 			},
 		},
@@ -362,9 +363,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", exitCode: 1},
 			},
 			expectError: true,
@@ -374,9 +375,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "some-sha refs/heads/not-the-branch"},
 			},
 			expectError: true,
@@ -387,8 +388,6 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
-				{call: "init --bare"},
-				{call: "remote get-url org-repo"},
 				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", exitCode: 1},
 			},
 		},
@@ -397,9 +396,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch"},
 				{call: "push --dry-run https://TOKEN@github.com/dest/repo FETCH_HEAD:refs/heads/branch"},
@@ -409,9 +408,9 @@ func TestMirror(t *testing.T) {
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "init --bare"},
 				{call: "remote get-url org-repo"},
-				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "dest-sha refs/heads/branch"},
 				{call: "ls-remote --heads org-repo", output: "source-sha refs/heads/branch"},
 				{call: "fetch org-repo branch --depth=2"},
 				{


### PR DESCRIPTION
This saves hundreds of useless git executions in the current state when `openshift-priv` is empty.

/cc @openshift/openshift-team-developer-productivity-test-platform 