### PR TITLE
Revert "applyconfig: use --validate"

### DIFF
--- a/cmd/applyconfig/applyconfig.go
+++ b/cmd/applyconfig/applyconfig.go
@@ -39,8 +39,6 @@ const (
 
 	ocApply   command = "apply"
 	ocProcess command = "process"
-
-	validateFlag string = "--validate"
 )
 
 const defaultAdminUser = "system:admin"
@@ -148,7 +146,7 @@ type configApplier struct {
 }
 
 func makeOcApply(kubeConfig, context, path, user string, dry bool) *exec.Cmd {
-	cmd := makeOcCommand(ocApply, kubeConfig, context, path, user, validateFlag)
+	cmd := makeOcCommand(ocApply, kubeConfig, context, path, user)
 	if dry {
 		cmd.Args = append(cmd.Args, "--dry-run")
 	}

--- a/cmd/applyconfig/applyconfig_test.go
+++ b/cmd/applyconfig/applyconfig_test.go
@@ -158,33 +158,33 @@ func TestMakeOcApply(t *testing.T) {
 		{
 			name:     "no user, not dry",
 			path:     "/path/to/file",
-			expected: []string{"oc", "apply", "-f", "/path/to/file", "--validate"},
+			expected: []string{"oc", "apply", "-f", "/path/to/file"},
 		},
 		{
 			name:     "no user, dry",
 			path:     "/path/to/different/file",
 			dry:      true,
-			expected: []string{"oc", "apply", "-f", "/path/to/different/file", "--validate", "--dry-run"},
+			expected: []string{"oc", "apply", "-f", "/path/to/different/file", "--dry-run"},
 		},
 		{
 			name:     "user, dry",
 			path:     "/path/to/file",
 			dry:      true,
 			user:     "joe",
-			expected: []string{"oc", "apply", "-f", "/path/to/file", "--validate", "--as", "joe", "--dry-run"},
+			expected: []string{"oc", "apply", "-f", "/path/to/file", "--as", "joe", "--dry-run"},
 		},
 		{
 			name:     "user, not dry",
 			path:     "/path/to/file",
 			user:     "joe",
-			expected: []string{"oc", "apply", "-f", "/path/to/file", "--validate", "--as", "joe"},
+			expected: []string{"oc", "apply", "-f", "/path/to/file", "--as", "joe"},
 		},
 		{
 			name:     "context, user, not dry",
 			context:  "/context-name",
 			path:     "/path/to/file",
 			user:     "joe",
-			expected: []string{"oc", "apply", "-f", "/path/to/file", "--validate", "--as", "joe", "--context", "/context-name"},
+			expected: []string{"oc", "apply", "-f", "/path/to/file", "--as", "joe", "--context", "/context-name"},
 		},
 		{
 			name:       "kubeConfig, context, user, not dry",
@@ -192,7 +192,7 @@ func TestMakeOcApply(t *testing.T) {
 			context:    "/context-name",
 			path:       "/path/to/file",
 			user:       "joe",
-			expected:   []string{"oc", "apply", "-f", "/path/to/file", "--validate", "--as", "joe", "--kubeconfig", "/tmp/config", "--context", "/context-name"},
+			expected:   []string{"oc", "apply", "-f", "/path/to/file", "--as", "joe", "--kubeconfig", "/tmp/config", "--context", "/context-name"},
 		},
 	}
 
@@ -245,25 +245,25 @@ func TestAsGenericManifest(t *testing.T) {
 			description:   "success: oc apply -f path",
 			applier:       &configApplier{path: "path"},
 			executions:    []error{nil}, // expect a single successful call
-			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--validate"}},
+			expectedCalls: [][]string{{"oc", "apply", "-f", "path"}},
 		},
 		{
 			description:   "success: oc apply -f path --dry-run",
 			applier:       &configApplier{path: "path", dry: true},
 			executions:    []error{nil}, // expect a single successful call
-			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--validate", "--dry-run"}},
+			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--dry-run"}},
 		},
 		{
 			description:   "success: oc apply -f path --dry-run --as user",
 			applier:       &configApplier{path: "path", user: "user", dry: true},
 			executions:    []error{nil}, // expect a single successful call
-			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--validate", "--as", "user", "--dry-run"}},
+			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--as", "user", "--dry-run"}},
 		},
 		{
 			description:   "failure: oc apply -f path",
 			applier:       &configApplier{path: "path"},
 			executions:    []error{fmt.Errorf("NOPE")},
-			expectedCalls: [][]string{{"oc", "apply", "-f", "path", "--validate"}},
+			expectedCalls: [][]string{{"oc", "apply", "-f", "path"}},
 			expectedError: true,
 		},
 	}
@@ -302,7 +302,7 @@ func TestAsTemplate(t *testing.T) {
 			description:   "success",
 			applier:       &configApplier{path: "path"},
 			executions:    []error{nil, nil},
-			expectedCalls: [][]string{{"oc", "process", "-f", "path"}, {"oc", "apply", "-f", "-", "--validate"}},
+			expectedCalls: [][]string{{"oc", "process", "-f", "path"}, {"oc", "apply", "-f", "-"}},
 		},
 		{
 			description: "success with params",
@@ -322,13 +322,13 @@ func TestAsTemplate(t *testing.T) {
 				},
 				{Name: "name", Description: "description does not matter", Value: "master"},
 			},
-			expectedCalls: [][]string{{"oc", "process", "-f", "path", "-p", "image=docker.io/redis"}, {"oc", "apply", "-f", "-", "--validate"}},
+			expectedCalls: [][]string{{"oc", "process", "-f", "path", "-p", "image=docker.io/redis"}, {"oc", "apply", "-f", "-"}},
 		},
 		{
 			description:   "oc apply fails",
 			applier:       &configApplier{path: "path"},
 			executions:    []error{nil, fmt.Errorf("REALLY NOPE")},
-			expectedCalls: [][]string{{"oc", "process", "-f", "path"}, {"oc", "apply", "-f", "-", "--validate"}},
+			expectedCalls: [][]string{{"oc", "process", "-f", "path"}, {"oc", "apply", "-f", "-"}},
 			expectedError: true,
 		},
 		{


### PR DESCRIPTION
Reverts openshift/ci-tools#371

Looks like a ton of our config does not pass this, breaking merges to openshift/release:

```
time="2020-01-15T13:14:19Z" level=error msg="oc apply -f core-services/base-ci-images/images-ocp.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/base-ci-images/images-ocp.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:20Z" level=error msg="oc apply -f core-services/base-ci-images/images-origin.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/base-ci-images/images-origin.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:22Z" level=error msg="oc apply -f core-services/ci-operator-configresolver/ci-operator-configresolver.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-operator-configresolver/ci-operator-configresolver.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route, ValidationError(Route.spec): missing required field \"host\" in com.github.openshift.api.route.v1.RouteSpec]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:22Z" level=error msg="oc apply -f core-services/ci-rpms/artifacts-master.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-rpms/artifacts-master.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"kind\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:22Z" level=error msg="oc apply -f core-services/ci-rpms/artifacts-release-3.11.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-rpms/artifacts-release-3.11.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"kind\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:23Z" level=error msg="oc apply -f core-services/ci-rpms/artifacts-release-4.1.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-rpms/artifacts-release-4.1.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"kind\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:23Z" level=error msg="oc apply -f core-services/ci-rpms/artifacts-release-4.2.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-rpms/artifacts-release-4.2.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"kind\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:23Z" level=error msg="oc apply -f core-services/ci-rpms/artifacts-rpms.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-rpms/artifacts-rpms.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"kind\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:24Z" level=error msg="oc apply -f core-services/ci-search/deploy.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/ci-search/deploy.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:27Z" level=error msg="oc apply -f - --validate --dry-run: failed to apply\nerror: error validating \"STDIN\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec): missing required field \"host\" in com.github.openshift.api.route.v1.RouteSpec, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:28Z" level=error msg="oc apply -f - --validate --dry-run: failed to apply\nerror: error validating \"STDIN\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec): missing required field \"host\" in com.github.openshift.api.route.v1.RouteSpec, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:29Z" level=error msg="oc apply -f core-services/prow/03_deployment/ghproxy.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/prow/03_deployment/ghproxy.yaml\": error validating data: ValidationError(Deployment.spec): missing required field \"selector\" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:29Z" level=error msg="oc apply -f core-services/prow/03_deployment/hook.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/prow/03_deployment/hook.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec): missing required field \"host\" in com.github.openshift.api.route.v1.RouteSpec, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:32Z" level=error msg="oc apply -f core-services/prow/03_deployment/statusreconciler.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/prow/03_deployment/statusreconciler.yaml\": error validating data: ValidationError(Deployment.spec): missing required field \"selector\" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:33Z" level=error msg="oc apply -f - --validate --dry-run: failed to apply\nerror: error validating \"STDIN\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route.spec): missing required field \"host\" in com.github.openshift.api.route.v1.RouteSpec, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:33Z" level=error msg="oc apply -f core-services/release-controller/deploy-ocp-controller-ppc64le.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/deploy-ocp-controller-ppc64le.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:33Z" level=error msg="oc apply -f core-services/release-controller/deploy-ocp-controller-s390x.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/deploy-ocp-controller-s390x.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:34Z" level=error msg="oc apply -f core-services/release-controller/deploy-ocp-controller.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/deploy-ocp-controller.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:34Z" level=error msg="oc apply -f core-services/release-controller/deploy-origin-controller.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/deploy-origin-controller.yaml\": error validating data: [ValidationError(Route.spec.to): missing required field \"weight\" in com.github.openshift.api.route.v1.RouteTargetReference, ValidationError(Route): missing required field \"status\" in com.github.openshift.api.route.v1.Route]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:34Z" level=error msg="oc apply -f core-services/release-controller/images-ocp-4.1.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-ocp-4.1.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:35Z" level=error msg="oc apply -f core-services/release-controller/images-ocp-4.2.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-ocp-4.2.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:35Z" level=error msg="oc apply -f core-services/release-controller/images-ocp-4.3.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-ocp-4.3.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:35Z" level=error msg="oc apply -f core-services/release-controller/images-ocp-4.4.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-ocp-4.4.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:35Z" level=error msg="oc apply -f core-services/release-controller/images-ocp-4.5.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-ocp-4.5.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:36Z" level=error msg="oc apply -f core-services/release-controller/images-origin-4.3.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-origin-4.3.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:36Z" level=error msg="oc apply -f core-services/release-controller/images-origin-4.4.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-origin-4.4.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:36Z" level=error msg="oc apply -f core-services/release-controller/images-origin-4.5.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/release-controller/images-origin-4.5.yaml\": error validating data: ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:39Z" level=error msg="oc apply -f core-services/sshd-bastion/build.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/sshd-bastion/build.yaml\": error validating data: [ValidationError(BuildConfig.spec.strategy): missing required field \"type\" in com.github.openshift.api.build.v1.BuildStrategy, ValidationError(BuildConfig.spec): missing required field \"nodeSelector\" in com.github.openshift.api.build.v1.BuildConfigSpec, ValidationError(BuildConfig): missing required field \"status\" in com.github.openshift.api.build.v1.BuildConfig]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:41Z" level=error msg="oc apply -f core-services/supplemental-ci-images/src-cache-origin.yaml --validate --dry-run: failed to apply\nerror: error validating \"core-services/supplemental-ci-images/src-cache-origin.yaml\": error validating data: [ValidationError(ImageStream): missing required field \"spec\" in com.github.openshift.api.image.v1.ImageStream, ValidationError(BuildConfig.spec.source): missing required field \"type\" in com.github.openshift.api.build.v1.BuildSource, ValidationError(BuildConfig.spec.strategy): missing required field \"type\" in com.github.openshift.api.build.v1.BuildStrategy, ValidationError(BuildConfig.spec): missing required field \"triggers\" in com.github.openshift.api.build.v1.BuildConfigSpec, ValidationError(BuildConfig.spec): missing required field \"nodeSelector\" in com.github.openshift.api.build.v1.BuildConfigSpec, ValidationError(BuildConfig): missing required field \"status\" in com.github.openshift.api.build.v1.BuildConfig]; if you choose to ignore these errors, turn validation off with --validate=false\n"
time="2020-01-15T13:14:42Z" level=error msg="There were failures while applying standard config"
```

I think we'll need to weed out the failures first.