### PR TITLE
fix wait for template instance failing on get with empty key

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -138,7 +138,7 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	log.Printf("Waiting for template instance to be ready")
-	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), instance)
+	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), s.template.Name)
 	if err != nil {
 		return fmt.Errorf("could not wait for template instance to be ready: %v", err)
 	}
@@ -381,10 +381,11 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 	return false, nil
 }
 
-func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
+func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, name string) (*templateapi.TemplateInstance, error) {
 	var actualErr error
+	var instance *templateapi.TemplateInstance
 	err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		instance, actualErr = templateClient.Get(instance.Name, meta.GetOptions{})
+		instance, actualErr = templateClient.Get(name, meta.GetOptions{})
 		if actualErr != nil {
 			return false, nil
 		}


### PR DESCRIPTION
@stevekuznetsov @openshift/openshift-team-developer-productivity-platform @petr-muller @bbguimaraes @droslean @hongkailiu

I believe there is still a small race condition in the template wait logic after my fix from last week.  Though thankfully this one results in the test failing prematurely vs. letting anything pass.

I've seen it a couple of times now.  The latest incarnation is https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-samples-operator/220/pull-ci-openshift-cluster-samples-operator-master-e2e-aws-image-ecosystem/789

The error message is `could not wait for template instance to be ready: resource name may not be empty`

The error comes from the core k8s rest code complaining that we've called `Get` with an empty key ... https://github.com/openshift/ci-tools/blob/master/vendor/k8s.io/client-go/rest/request.go#L223-L230

So how do we get there with the current code:
- the first `instance, actualErr = templateClient.Get(name, meta.GetOptions{})` gets a not found and we return `false, nil` .... but `instance` is defined outside the wait function, and the `Get` will not return `nil` in this case, but an empty `templateapi.TemplateInstance`
- the next call tries to get the name from `instance`, but it is now empty

this, coupled with the fact that we do not need the entire instance in this function, just the name so we can get and verify readiness, calls for this change

PTAL