### PR TITLE
Improve the secret-bootstrap tool

### DIFF
--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -25,6 +25,7 @@ type Item struct {
 type Client interface {
 	GetFieldOnItem(itemName, fieldName string) ([]byte, error)
 	GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error)
+	Logout() ([]byte, error)
 }
 
 // NewBitwardenClient generates a BitWarden client

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -402,6 +402,57 @@ func TestGetAttachmentOnItem(t *testing.T) {
 	}
 }
 
+func TestLogout(t *testing.T) {
+	client := &cliClient{}
+	testCases := []struct {
+		name          string
+		responses     map[string]execResponse
+		expectedCalls [][]string
+		expected      []byte
+		expectedErr   error
+	}{
+		{
+			name: "basic case",
+			responses: map[string]execResponse{
+				"logout": {
+					out: []byte(`You have logged out.
+`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"logout"},
+			},
+			expected: []byte(`You have logged out.
+`),
+		},
+		{
+			name: "some err",
+			responses: map[string]execResponse{
+				"logout": {
+					err: fmt.Errorf("some err"),
+				},
+			},
+			expectedCalls: [][]string{
+				{"logout"},
+			},
+			expectedErr: fmt.Errorf("some err"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := fakeExecutor{
+				records:   [][]string{},
+				responses: tc.responses,
+			}
+			client.run = e.Run
+			actual, actualErr := client.Logout()
+			equalError(t, tc.expectedErr, actualErr)
+			equal(t, tc.expected, actual)
+			equal(t, tc.expectedCalls, e.records)
+		})
+	}
+}
+
 type execResponse struct {
 	out []byte
 	err error

--- a/pkg/bitwarden/fake.go
+++ b/pkg/bitwarden/fake.go
@@ -35,6 +35,10 @@ func (c fakeClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte
 	return nil, fmt.Errorf("failed to find attachment %s in item %s", attachmentName, itemName)
 }
 
+func (c fakeClient) Logout() ([]byte, error) {
+	return []byte("logged out"), nil
+}
+
 // NewFakeClient generates a fake BitWarden client which is supposed to used only for testing
 func NewFakeClient(items []Item, attachments map[string]string) Client {
 	return fakeClient{items: items, attachments: attachments}

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -27,7 +27,8 @@ func LoadClusterConfig() (*rest.Config, error) {
 }
 
 func LoadKubeConfigs(kubeconfig string) (map[string]rest.Config, string, error) {
-	loader := &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}
+	loader := clientcmd.NewDefaultClientConfigLoadingRules()
+	loader.ExplicitPath = kubeconfig
 	cfg, err := loader.Load()
 	if err != nil {
 		return nil, "", err

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -57,11 +57,6 @@ func TestLoadKubeConfigs(t *testing.T) {
 		expectedError   error
 	}{
 		{
-			name: "empty string",
-			//help us avoid nil checking
-			expectedConfigs: map[string]rest.Config{},
-		},
-		{
 			name:          "file not exist",
 			kubeconfig:    "/tmp/file-not-exists",
 			expectedError: fmt.Errorf("stat /tmp/file-not-exists: no such file or directory"),


### PR DESCRIPTION
* Load kubeconfig from default e.g., $HOME/.kube/config if
`--kubeconfig` is not set.
* Log standard err when bw cmd failed
* Add logout to avoid "you have already logged in" error.

/cc @openshift/openshift-team-developer-productivity-test-platform 