### PR TITLE
registry: refactor naming for component maps

### DIFF
--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -21,7 +21,7 @@ import (
 // memory and retrieve them when provided with a config.Info.
 type ConfigAgent interface {
 	GetConfig(config.Info) (api.ReleaseBuildConfiguration, error)
-	GetFilenameToConfig() FilenameToConfig
+	GetAll() FilenameToConfig
 	GetGeneration() int
 }
 
@@ -84,7 +84,7 @@ func (a *configAgent) GetConfig(info config.Info) (api.ReleaseBuildConfiguration
 	return config, nil
 }
 
-func (a *configAgent) GetFilenameToConfig() FilenameToConfig {
+func (a *configAgent) GetAll() FilenameToConfig {
 	return a.configs
 }
 

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -86,10 +86,10 @@ func configFromResolver(info *ResolverInfo) (*api.ReleaseBuildConfiguration, err
 
 // Registry takes the path to a registry config directory and returns the full set of references, chains,
 // and workflows that the registry's Resolver needs to resolve a user's MultiStageTestConfiguration
-func Registry(root string, flat bool) (references registry.ReferenceMap, chains registry.ChainMap, workflows registry.WorkflowMap, documentation map[string]string, err error) {
-	references = registry.ReferenceMap{}
-	chains = registry.ChainMap{}
-	workflows = registry.WorkflowMap{}
+func Registry(root string, flat bool) (references registry.ReferenceByName, chains registry.ChainByName, workflows registry.WorkflowByName, documentation map[string]string, err error) {
+	references = registry.ReferenceByName{}
+	chains = registry.ChainByName{}
+	workflows = registry.WorkflowByName{}
 	documentation = map[string]string{}
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info != nil && strings.HasPrefix(info.Name(), "..") {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -656,7 +656,7 @@ func TestConfigFromResolver(t *testing.T) {
 
 func TestRegistry(t *testing.T) {
 	var (
-		expectedReferences = registry.ReferenceMap{
+		expectedReferences = registry.ReferenceByName{
 			"ipi-deprovision-deprovision": {
 				As:       "ipi-deprovision-deprovision",
 				From:     "installer",
@@ -696,7 +696,7 @@ func TestRegistry(t *testing.T) {
 		installRef           = `ipi-install-install`
 		installRBACRef       = `ipi-install-rbac`
 
-		expectedChains = registry.ChainMap{
+		expectedChains = registry.ChainByName{
 			"ipi-install": {
 				{
 					Reference: &installRBACRef,
@@ -716,7 +716,7 @@ func TestRegistry(t *testing.T) {
 		installChain     = `ipi-install`
 		deprovisionChain = `ipi-deprovision`
 
-		expectedWorkflows = registry.WorkflowMap{
+		expectedWorkflows = registry.WorkflowByName{
 			"ipi": {
 				Pre: []api.TestStep{{
 					Chain: &installChain,
@@ -731,9 +731,9 @@ func TestRegistry(t *testing.T) {
 			name          string
 			registryDir   string
 			flatRegistry  bool
-			references    registry.ReferenceMap
-			chains        registry.ChainMap
-			workflows     registry.WorkflowMap
+			references    registry.ReferenceByName
+			chains        registry.ChainByName
+			workflows     registry.WorkflowByName
 			expectedError bool
 		}{{
 			name:          "Read registry",
@@ -747,11 +747,11 @@ func TestRegistry(t *testing.T) {
 			name:         "Read configmap style registry",
 			registryDir:  "../../test/multistage-registry/configmap",
 			flatRegistry: true,
-			references: registry.ReferenceMap{
+			references: registry.ReferenceByName{
 				installRef: expectedReferences[installRef],
 			},
-			chains:        registry.ChainMap{},
-			workflows:     registry.WorkflowMap{},
+			chains:        registry.ChainByName{},
+			workflows:     registry.WorkflowByName{},
 			expectedError: false,
 		}}
 	)

--- a/pkg/load/registryAgent.go
+++ b/pkg/load/registryAgent.go
@@ -17,7 +17,7 @@ import (
 // memory and resolve ReleaseBuildConfigurations using the registry
 type RegistryAgent interface {
 	ResolveConfig(config api.ReleaseBuildConfiguration) (api.ReleaseBuildConfiguration, error)
-	GetRegistryComponents() (registry.ReferenceMap, registry.ChainMap, registry.WorkflowMap, map[string]string)
+	GetRegistryComponents() (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string)
 	GetGeneration() int
 }
 
@@ -29,9 +29,9 @@ type registryAgent struct {
 	generation    int
 	errorMetrics  *prometheus.CounterVec
 	flatRegistry  bool
-	references    registry.ReferenceMap
-	chains        registry.ChainMap
-	workflows     registry.WorkflowMap
+	references    registry.ReferenceByName
+	chains        registry.ChainByName
+	workflows     registry.WorkflowByName
 	documentation map[string]string
 }
 
@@ -86,7 +86,7 @@ func (a *registryAgent) GetGeneration() int {
 	return a.generation
 }
 
-func (a *registryAgent) GetRegistryComponents() (registry.ReferenceMap, registry.ChainMap, registry.WorkflowMap, map[string]string) {
+func (a *registryAgent) GetRegistryComponents() (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string) {
 	return a.references, a.chains, a.workflows, a.documentation
 }
 

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -239,7 +239,7 @@ func hasCycles(node *chainNode, ancestors sets.String, traversedPath []string) e
 }
 
 // NewGraph returns a NodeByType map representing the provided step references, chains, and workflows as a directed graph.
-func NewGraph(stepsByName ReferenceMap, chainsByName ChainMap, workflowsByName WorkflowMap) (NodeByName, error) {
+func NewGraph(stepsByName ReferenceByName, chainsByName ChainByName, workflowsByName WorkflowByName) (NodeByName, error) {
 	nodesByName := make(NodeByName)
 	// References can only be children; load them so they can be added as children by workflows and chains
 	referenceNodes := make(referenceNodeByName)

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -17,13 +17,13 @@ var ipiInstall = "ipi-install"
 var ipiDeprovision = "ipi-deprovision"
 var ipi = "ipi"
 
-var referenceMap = ReferenceMap{
+var referenceMap = ReferenceByName{
 	ipiInstallInstall:         {},
 	ipiInstallRBAC:            {},
 	ipiDeprovisionDeprovision: {},
 	ipiDeprovisionMustGather:  {},
 }
-var chainMap = ChainMap{
+var chainMap = ChainByName{
 	ipiInstall: {{
 		Reference: &ipiInstallInstall,
 	}, {
@@ -35,7 +35,7 @@ var chainMap = ChainMap{
 		Reference: &ipiDeprovisionDeprovision,
 	}},
 }
-var workflowMap = WorkflowMap{
+var workflowMap = WorkflowByName{
 	ipi: {
 		Pre: []api.TestStep{{
 			Chain: &ipiInstall,

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -11,20 +11,20 @@ type Resolver interface {
 	Resolve(config api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error)
 }
 
-type ReferenceMap map[string]api.LiteralTestStep
-type ChainMap map[string][]api.TestStep
-type WorkflowMap map[string]api.MultiStageTestConfiguration
+type ReferenceByName map[string]api.LiteralTestStep
+type ChainByName map[string][]api.TestStep
+type WorkflowByName map[string]api.MultiStageTestConfiguration
 
 // registry will hold all the registry information needed to convert between the
 // user provided configs referencing the registry and the internal, complete
 // representation
 type registry struct {
-	stepsByName     ReferenceMap
-	chainsByName    ChainMap
-	workflowsByName WorkflowMap
+	stepsByName     ReferenceByName
+	chainsByName    ChainByName
+	workflowsByName WorkflowByName
 }
 
-func NewResolver(stepsByName ReferenceMap, chainsByName ChainMap, workflowsByName WorkflowMap) Resolver {
+func NewResolver(stepsByName ReferenceByName, chainsByName ChainByName, workflowsByName WorkflowByName) Resolver {
 	return &registry{
 		stepsByName:     stepsByName,
 		chainsByName:    chainsByName,

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -18,9 +18,9 @@ func TestResolve(t *testing.T) {
 	for _, testCase := range []struct {
 		name        string
 		config      api.MultiStageTestConfiguration
-		stepMap     ReferenceMap
-		chainMap    ChainMap
-		workflowMap WorkflowMap
+		stepMap     ReferenceByName
+		chainMap    ChainByName
+		workflowMap WorkflowByName
 		expectedRes api.MultiStageTestConfigurationLiteral
 		expectErr   bool
 	}{{
@@ -98,7 +98,7 @@ func TestResolve(t *testing.T) {
 				Reference: &reference1,
 			}},
 		},
-		stepMap: ReferenceMap{
+		stepMap: ReferenceByName{
 			reference1: {
 				As:       "generic-unit-test",
 				From:     "my-image",
@@ -130,7 +130,7 @@ func TestResolve(t *testing.T) {
 				Reference: &reference1,
 			}},
 		},
-		stepMap: ReferenceMap{
+		stepMap: ReferenceByName{
 			"generic-unit-test-2": {
 				As:       "generic-unit-test-2",
 				From:     "my-image",
@@ -164,7 +164,7 @@ func TestResolve(t *testing.T) {
 				Reference: &teardownRef,
 			}},
 		},
-		chainMap: ChainMap{
+		chainMap: ChainByName{
 			fipsPreChain: {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "ipi-install",
@@ -185,7 +185,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		stepMap: ReferenceMap{
+		stepMap: ReferenceByName{
 			teardownRef: {
 				As:       "ipi-teardown",
 				From:     "installer",
@@ -242,7 +242,7 @@ func TestResolve(t *testing.T) {
 				Reference: &fipsPreChain,
 			}},
 		},
-		chainMap: ChainMap{
+		chainMap: ChainByName{
 			"broken": {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "generic-unit-test-2",
@@ -264,7 +264,7 @@ func TestResolve(t *testing.T) {
 				Chain: &nestedChains,
 			}},
 		},
-		chainMap: ChainMap{
+		chainMap: ChainByName{
 			nestedChains: {{
 				Chain: &chainInstall,
 			}, {
@@ -334,7 +334,7 @@ func TestResolve(t *testing.T) {
 				Chain: &nestedChains,
 			}},
 		},
-		chainMap: ChainMap{
+		chainMap: ChainByName{
 			nestedChains: {{
 				Chain: &chainInstall,
 			}, {
@@ -374,7 +374,7 @@ func TestResolve(t *testing.T) {
 		config: api.MultiStageTestConfiguration{
 			Workflow: &awsWorkflow,
 		},
-		chainMap: ChainMap{
+		chainMap: ChainByName{
 			fipsPreChain: {{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "ipi-install",
@@ -395,7 +395,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		stepMap: ReferenceMap{
+		stepMap: ReferenceByName{
 			teardownRef: {
 				As:       "ipi-teardown",
 				From:     "installer",
@@ -405,7 +405,7 @@ func TestResolve(t *testing.T) {
 					Limits:   api.ResourceList{"memory": "2Gi"},
 				}},
 		},
-		workflowMap: WorkflowMap{
+		workflowMap: WorkflowByName{
 			awsWorkflow: {
 				ClusterProfile: api.ClusterProfileAWS,
 				Pre: []api.TestStep{{
@@ -480,7 +480,7 @@ func TestResolve(t *testing.T) {
 					}},
 			}},
 		},
-		workflowMap: WorkflowMap{
+		workflowMap: WorkflowByName{
 			awsWorkflow: {
 				ClusterProfile: api.ClusterProfileAWS,
 				Pre: []api.TestStep{{


### PR DESCRIPTION
This changes the `ReferenceMap`, `ChainMap`, and `WorkflowMap` type names to `ReferenceByName`, `ChainByName`, and `WorkflowByName` respectively. It also changes the name of the `GetFilenameToConfig` function in `ConfigAgent` to `GetAll`. This keeps the code simpler and less fragile as it disconnects the names from the implementation.