### PR TITLE
ipi-deprovisioner: do not prematurely exit on no-matching grep

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -39,7 +39,7 @@ gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIAL
 export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M+0000')<${cluster_age_cutoff} AND name~'ci-*'"
 for network in $( gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}" --format "value(name)" ); do
   infraID="${network%"-network"}"
-  region="$( gcloud --project=openshift-gce-devel-ci compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" )"
+  region="$( gcloud --project=openshift-gce-devel-ci compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" || true )"
   if [[ -z "${region:-}" ]]; then
     echo "could not determine region for cluster ${infraID}, ignoring ..."
     continue


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 