### PR TITLE
Revertd92df0facdccf541f126d679750e214bd33c7c9d

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -382,23 +382,21 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 }
 
 func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
-	var actualErr error
-	err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		instance, actualErr = templateClient.Get(instance.Name, meta.GetOptions{})
-		if actualErr != nil {
-			return false, nil
+	for {
+		ready, err := templateInstanceReady(instance)
+		if err != nil {
+			return nil, fmt.Errorf("could not determine if template instance was ready: %v", err)
 		}
-		ready := false
-		ready, actualErr = templateInstanceReady(instance)
 		if ready {
-			return true, nil
+			return instance, nil
 		}
-		return false, nil
-	})
-	if err == nil {
-		return instance, nil
+
+		time.Sleep(2 * time.Second)
+		instance, err = templateClient.Get(instance.Name, meta.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("unable to retrieve existing template instance: %v", err)
+		}
 	}
-	return nil, actualErr
 }
 
 func createOrRestartTemplateInstance(templateClient templateclientset.TemplateInstanceInterface, podClient coreclientset.PodInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
@@ -422,7 +420,6 @@ func createOrRestartTemplateInstance(templateClient templateclientset.TemplateIn
 func waitForCompletedTemplateInstanceDeletion(templateClient templateclientset.TemplateInstanceInterface, podClient coreclientset.PodInterface, name string) error {
 	instance, err := templateClient.Get(name, meta.GetOptions{})
 	if errors.IsNotFound(err) {
-		log.Printf("Template instance %s already deleted, do not need to wait any longer", name)
 		return nil
 	}
 
@@ -434,8 +431,6 @@ func waitForCompletedTemplateInstanceDeletion(templateClient templateclientset.T
 		Preconditions:     &meta.Preconditions{UID: &uid},
 	})
 	if errors.IsNotFound(err) {
-		log.Printf("After initial existence check, a delete of template %s and instance %s received a not found error ",
-			name, string(instance.UID))
 		return nil
 	}
 	if err != nil {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -138,7 +138,7 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	log.Printf("Waiting for template instance to be ready")
-	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), s.template.Name)
+	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), instance)
 	if err != nil {
 		return fmt.Errorf("could not wait for template instance to be ready: %v", err)
 	}
@@ -381,11 +381,10 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 	return false, nil
 }
 
-func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, name string) (*templateapi.TemplateInstance, error) {
+func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
 	var actualErr error
-	var instance *templateapi.TemplateInstance
 	err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		instance, actualErr = templateClient.Get(name, meta.GetOptions{})
+		instance, actualErr = templateClient.Get(instance.Name, meta.GetOptions{})
 		if actualErr != nil {
 			return false, nil
 		}


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/CEKNRGF25/p1579544330056200

Some check passed without running the test pod from the template.

/cc @openshift/openshift-team-developer-productivity-test-platform 

/assign @petr-muller @gabemontero 