### PR TITLE
ci-operator: fixes in template-handling logic

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -138,7 +138,7 @@ func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
 	}
 
 	log.Printf("Waiting for template instance to be ready")
-	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), instance)
+	instance, err = waitForTemplateInstanceReady(s.templateClient.TemplateInstances(s.jobSpec.Namespace), s.template.Name)
 	if err != nil {
 		return fmt.Errorf("could not wait for template instance to be ready: %v", err)
 	}
@@ -381,10 +381,11 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 	return false, nil
 }
 
-func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {
+func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, name string) (*templateapi.TemplateInstance, error) {
 	var actualErr error
+	var instance *templateapi.TemplateInstance
 	err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		instance, actualErr = templateClient.Get(instance.Name, meta.GetOptions{})
+		instance, actualErr = templateClient.Get(name, meta.GetOptions{})
 		if actualErr != nil {
 			return false, nil
 		}

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -382,24 +382,17 @@ func isPodCompleted(podClient coreclientset.PodInterface, name string) (bool, er
 }
 
 func waitForTemplateInstanceReady(templateClient templateclientset.TemplateInstanceInterface, name string) (*templateapi.TemplateInstance, error) {
-	var actualErr error
 	var instance *templateapi.TemplateInstance
 	err := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
-		instance, actualErr = templateClient.Get(name, meta.GetOptions{})
-		if actualErr != nil {
+		var getErr error
+		if instance, getErr = templateClient.Get(name, meta.GetOptions{}); getErr != nil {
 			return false, nil
 		}
-		ready := false
-		ready, actualErr = templateInstanceReady(instance)
-		if ready {
-			return true, nil
-		}
-		return false, nil
+
+		return templateInstanceReady(instance)
 	})
-	if err == nil {
-		return instance, nil
-	}
-	return nil, actualErr
+
+	return instance, err
 }
 
 func createOrRestartTemplateInstance(templateClient templateclientset.TemplateInstanceInterface, podClient coreclientset.PodInterface, instance *templateapi.TemplateInstance) (*templateapi.TemplateInstance, error) {


### PR DESCRIPTION
Another shot at the issue described in https://github.com/openshift/ci-tools/pull/359, essentially a re-revert of https://github.com/openshift/ci-tools/pull/392 with additional fixes.

Previously, it was possible for `waitForTemplateInstanceReady` to exit
with `instance, nil` (no error) even when `templateInstanceReady`
returned an error. This then likely caused the cases where ci-operator
treat this operation as success and never run any tests (it continued to
wait until no containers were running, which was true for the template
that failed to instantiate).

Fix this so that the error from `waitForTemplateInstanceReady` is
propagated to the polling method return code. This way the polling ends
only either on timeout (returning an error), or when
`templateInstanceReady` returns ready=true. In that case the error is
still propagated outside and we return it. We never exit the polling on
the error when `Get`-ing the template, and its errors are never
propagated out. If `Get` never succeeds, we end on timeout and the error
path is triggered anyway.

The code allowed some streamlining, I think it is now more clear about
what it is supposed to do.

I considered fixing the issue by making `templateInstanceReady` return
`false` on errors, meaning the polling should continue, but I think
that semantics would not be correct. A template that failed to
instantiate is an error condition and there is no point in waiting for
it further.

/cc @gabemontero @stevekuznetsov @bbguimaraes 