### PR TITLE
secret-wrapper: don't try to create the secret

### DIFF
--- a/cmd/secret-wrapper/main.go
+++ b/cmd/secret-wrapper/main.go
@@ -87,7 +87,7 @@ func (o *options) run() error {
 			return fmt.Errorf("failed to log secret: %v", err)
 		}
 	} else {
-		if _, err := util.UpdateSecret(o.client, secret); err != nil {
+		if _, err := o.client.Update(secret); err != nil {
 			return fmt.Errorf("failed to update secret: %v", err)
 		}
 	}


### PR DESCRIPTION
The secret is always created by `ci-operator`, so this code was never
strictly necessary.  This way, the ServiceAccount used, which
transitively applies to the process executed by the wrapper, can be
restricted to just `update` the specific secret.  This is necessary
because:

- Although we never actually create the Secret, calls fail even if they
  would result in an "already exists" error if the account does not have
  `create` permission.
- `create` cannot be limited to a single secret:
  https://github.com/kubernetes/kubernetes/issues/80295.