### PR TITLE
ipi-deprovision: use US pacific time zone

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -26,12 +26,12 @@ EOF
   done
 done
 
-gce_cluster_age_cutoff="$(TZ=":Africa/Abidjan" date --date="${CLUSTER_TTL}-4 hours" '+%Y-%m-%dT%H:%M+0000')"
+gce_cluster_age_cutoff="$(TZ=":America/Los_Angeles" date --date="${CLUSTER_TTL}-4 hours" '+%Y-%m-%dT%H:%M%z')"
 echo "deprovisioning clusters with a creationTimestamp before ${gce_cluster_age_cutoff} in GCE ..."
 export CLOUDSDK_CONFIG=/tmp/gcloudconfig
 mkdir -p "${CLOUDSDK_CONFIG}"
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M+0000')<${gce_cluster_age_cutoff} AND name~'ci-*'"
+export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND name~'ci-*'"
 for network in $( gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}" --format "value(name)" ); do
   infraID="${network%"-network"}"
   region="$( gcloud --project=openshift-gce-devel-ci compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" || true )"


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```
$ export CLUSTER_TTL='30 minutes ago'
$ export gce_cluster_age_cutoff="$(TZ=":America/Los_Angeles" date --date="${CLUSTER_TTL}-4 hours" '+%Y-%m-%dT%H:%M%z')"
$ echo "deprovisioning clusters with a creationTimestamp before ${gce_cluster_age_cutoff} in GCE ..."
deprovisioning clusters with a creationTimestamp before 2020-01-23T08:33-0800 in GCE ...
$ export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND name~'ci-*'"
$ gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}" --format "value(name, creationTimestamp.date('%Y-%m-%dT%H:%M%z'))"
ci-op-20c3i7xz-dee8c    2020-01-22T22:17-0800
ci-op-70smjrrs-dee8c    2020-01-21T21:25-0800
ci-op-97kvk-network     2020-01-21T04:39-0800
ci-op-b86tsl7p-dee8c    2020-01-22T12:49-0800
ci-op-bc6rxmm1-dee8c    2020-01-22T13:08-0800
ci-op-i0lsw0bb-dee8c    2020-01-21T17:12-0800
ci-op-kgdb6t3r-dee8c    2020-01-22T07:49-0800
ci-op-lw5z5-network     2020-01-23T06:52-0800
ci-op-n6jwtcd2-dee8c    2020-01-21T16:36-0800
ci-op-nqb9c7pg-dee8c    2020-01-21T22:07-0800
ci-op-qdbnj-network     2020-01-21T06:53-0800
ci-op-v5vwz-network     2020-01-23T08:24-0800
ci-op-x6zdz-network     2020-01-23T08:15-0800
ci-op-z55txdrh-dee8c    2020-01-22T06:40-0800
```