### PR TITLE
ci-operator multi-stage: create service account

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -169,7 +169,7 @@ func FromConfig(
 			buildSteps = append(buildSteps, initialReleaseStep)
 		} else if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if test := testStep.MultiStageTestConfigurationLiteral; test != nil {
-				step = steps.MultiStageTestStep(*testStep, config, params, podClient, secretGetter, artifactDir, jobSpec, dryLogger)
+				step = steps.MultiStageTestStep(*testStep, config, params, podClient, secretGetter, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
 				if test.ClusterProfile != "" {
 					step = steps.LeaseStep(leaseClient, test.ClusterProfile.LeaseType(), step)
 				}

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -617,6 +617,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -807,6 +808,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -997,6 +999,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -1187,6 +1190,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -1377,6 +1381,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -1567,6 +1572,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -1757,6 +1763,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
       "volumes": [
         {
           "emptyDir": {},
@@ -1820,6 +1827,28 @@
   },
   {
     "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "multi-stage"
+      },
+      "name": "multi-stage"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "multi-stage"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "multi-stage"
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
     "kind": "Role",
     "metadata": {
       "creationTimestamp": null,
@@ -1901,6 +1930,57 @@
     ]
   },
   {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "multi-stage"
+      },
+      "name": "multi-stage"
+    },
+    "rules": [
+      {
+        "apiGroups": [
+          "rbac.authorization.k8s.io"
+        ],
+        "resources": [
+          "rolebindings"
+        ],
+        "verbs": [
+          "create",
+          "list"
+        ]
+      },
+      {
+        "apiGroups": [
+          ""
+        ],
+        "resourceNames": [
+          "multi-stage"
+        ],
+        "resources": [
+          "secrets"
+        ],
+        "verbs": [
+          "update"
+        ]
+      },
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams/layers"
+        ],
+        "verbs": [
+          "get"
+        ]
+      }
+    ]
+  },
+  {
     "apiVersion": "v1",
     "kind": "Secret",
     "metadata": {
@@ -1924,6 +2004,17 @@
       "creationTimestamp": null,
       "name": "ci-operator",
       "namespace": "testns"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "multi-stage"
+      },
+      "name": "multi-stage"
     }
   }
 ]

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -342,6 +342,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-azure",
       "volumes": [
         {
           "emptyDir": {},
@@ -530,6 +531,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-azure",
       "volumes": [
         {
           "emptyDir": {},
@@ -718,6 +720,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-azure",
       "volumes": [
         {
           "emptyDir": {},
@@ -906,6 +909,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-azure",
       "volumes": [
         {
           "emptyDir": {},
@@ -1094,6 +1098,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-azure",
       "volumes": [
         {
           "emptyDir": {},
@@ -1282,6 +1287,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-gcp",
       "volumes": [
         {
           "emptyDir": {},
@@ -1470,6 +1476,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-gcp",
       "volumes": [
         {
           "emptyDir": {},
@@ -1658,6 +1665,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-gcp",
       "volumes": [
         {
           "emptyDir": {},
@@ -1846,6 +1854,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-gcp",
       "volumes": [
         {
           "emptyDir": {},
@@ -2034,6 +2043,7 @@
         }
       ],
       "restartPolicy": "Never",
+      "serviceAccountName": "e2e-gcp",
       "volumes": [
         {
           "emptyDir": {},
@@ -2154,6 +2164,152 @@
     "status": {}
   },
   {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-azure"
+      },
+      "name": "e2e-azure"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "e2e-azure"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "e2e-azure"
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "RoleBinding",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-gcp"
+      },
+      "name": "e2e-gcp"
+    },
+    "roleRef": {
+      "apiGroup": "",
+      "kind": "Role",
+      "name": "e2e-gcp"
+    },
+    "subjects": [
+      {
+        "kind": "ServiceAccount",
+        "name": "e2e-gcp"
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-azure"
+      },
+      "name": "e2e-azure"
+    },
+    "rules": [
+      {
+        "apiGroups": [
+          "rbac.authorization.k8s.io"
+        ],
+        "resources": [
+          "rolebindings"
+        ],
+        "verbs": [
+          "create",
+          "list"
+        ]
+      },
+      {
+        "apiGroups": [
+          ""
+        ],
+        "resourceNames": [
+          "e2e-azure"
+        ],
+        "resources": [
+          "secrets"
+        ],
+        "verbs": [
+          "update"
+        ]
+      },
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams/layers"
+        ],
+        "verbs": [
+          "get"
+        ]
+      }
+    ]
+  },
+  {
+    "apiVersion": "rbac.authorization.k8s.io/v1",
+    "kind": "Role",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-gcp"
+      },
+      "name": "e2e-gcp"
+    },
+    "rules": [
+      {
+        "apiGroups": [
+          "rbac.authorization.k8s.io"
+        ],
+        "resources": [
+          "rolebindings"
+        ],
+        "verbs": [
+          "create",
+          "list"
+        ]
+      },
+      {
+        "apiGroups": [
+          ""
+        ],
+        "resourceNames": [
+          "e2e-gcp"
+        ],
+        "resources": [
+          "secrets"
+        ],
+        "verbs": [
+          "update"
+        ]
+      },
+      {
+        "apiGroups": [
+          "",
+          "image.openshift.io"
+        ],
+        "resources": [
+          "imagestreams/layers"
+        ],
+        "verbs": [
+          "get"
+        ]
+      }
+    ]
+  },
+  {
     "apiVersion": "v1",
     "kind": "Secret",
     "metadata": {
@@ -2166,6 +2322,28 @@
     "kind": "Secret",
     "metadata": {
       "creationTimestamp": null,
+      "name": "e2e-gcp"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-azure"
+      },
+      "name": "e2e-azure"
+    }
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "ServiceAccount",
+    "metadata": {
+      "creationTimestamp": null,
+      "labels": {
+        "ci.openshift.io/multi-stage-test": "e2e-gcp"
+      },
       "name": "e2e-gcp"
     }
   }


### PR DESCRIPTION
This addresses two problems: allowing the `secret-wrapper` to update its
Secret and allowing tests to manipulate a limited set of objects in the
test namespace.

Template tests are "allowed" to create any kind of resource because they
are evaluated by the ci-operator ServiceAccount, an admin in the test
namespace.  Multi-stage tests currently use the same account as other
tests (`default`), so their set of allowed operations is much more
limited.

This commit creates:

- a ServiceAccount specific to each test
- a Role that can
  - list/create RoleBindings
  - get/list/create the test-specific Secret
  - get imagestream/layers
- a RoleBinding that assigns the Role above and the
  `system:image-puller` ClusterRole to the test's ServiceAccount