### PR TITLE
Fix the bugs of ci-secret-bootstrap found in test

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -233,6 +233,9 @@ func constructSecrets(config []secretConfig, bwClient bitwarden.Client) (map[str
 			data[key] = value
 		}
 		for _, secretContext := range secretConfig.To {
+			if secretContext.Type == "" {
+				secretContext.Type = coreapi.SecretTypeOpaque
+			}
 			secret := &coreapi.Secret{
 				Data: data,
 				ObjectMeta: meta.ObjectMeta{
@@ -255,7 +258,7 @@ func updateSecrets(secretsGetters map[string]coreclientset.SecretsGetter, secret
 			secretsGetter := secretsGetters[cluster]
 			if existingSecret, err := secretsGetter.Secrets(secret.Namespace).Get(secret.Name, meta.GetOptions{}); err == nil {
 				if secret.Type != existingSecret.Type {
-					return fmt.Errorf("cannot change secret type from %q to %q (immutable file): %s:%s/%s", existingSecret.Type, secret.Type, cluster, secret.Namespace, secret.Name)
+					return fmt.Errorf("cannot change secret type from %q to %q (immutable field): %s:%s/%s", existingSecret.Type, secret.Type, cluster, secret.Namespace, secret.Name)
 				}
 				if !force && !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) {
 					logrus.Errorf("actual %s:%s/%s differs the expected:\n%s", cluster, secret.Namespace, secret.Name,

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -840,6 +840,7 @@ func TestConstructSecrets(t *testing.T) {
 							"key-name-6": []byte("attachment-name-3-2-value"),
 							"key-name-7": []byte("yyy"),
 						},
+						Type: "Opaque",
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -869,6 +870,7 @@ func TestConstructSecrets(t *testing.T) {
 							"key-name-6": []byte("attachment-name-3-2-value"),
 							"key-name-7": []byte("yyy"),
 						},
+						Type: "Opaque",
 					},
 				},
 			},
@@ -960,8 +962,9 @@ func TestConstructSecrets(t *testing.T) {
 			bwClient: bitwarden.NewFakeClient(
 				[]bitwarden.Item{
 					{
-						ID:   "1",
-						Name: "item-name-1",
+						ID:    "1",
+						Name:  "item-name-1",
+						Login: &bitwarden.Login{Password: "abc"},
 						Fields: []bitwarden.Field{
 							{
 								Name:  "field-name-1",
@@ -1268,7 +1271,7 @@ func TestUpdateSecrets(t *testing.T) {
 				},
 			},
 			force:    true,
-			expected: fmt.Errorf("cannot change secret type from \"kubernetes.io/dockerconfigjson\" to \"\" (immutable file): default:namespace-2/prod-secret-2"),
+			expected: fmt.Errorf("cannot change secret type from \"kubernetes.io/dockerconfigjson\" to \"\" (immutable field): default:namespace-2/prod-secret-2"),
 			expectedSecretsOnDefault: []coreapi.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1330,7 +1333,7 @@ func TestUpdateSecrets(t *testing.T) {
 					},
 				},
 			},
-			expected: fmt.Errorf("cannot change secret type from \"kubernetes.io/dockerconfigjson\" to \"\" (immutable file): default:namespace-2/prod-secret-2"),
+			expected: fmt.Errorf("cannot change secret type from \"kubernetes.io/dockerconfigjson\" to \"\" (immutable field): default:namespace-2/prod-secret-2"),
 			expectedSecretsOnDefault: []coreapi.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
* bw-get-attachment saves the attachment in a file, the output
is the file path. We need to read that file. In the fix, we specify
the path with `--output` of bw-cmd.
* Consider the default value of secret type to fix [1].

1. error log

```
time="2020-01-24T19:42:41Z" level=fatal msg="Failed to update secrets." error="cannot change secret type from \"Opaque\" to \"\" (immutable file): default:ci/sentry-dsn"
```

/cc @openshift/openshift-team-developer-productivity-test-platform 