### PR TITLE
lease: log when acquiring, lower timeout

### DIFF
--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -86,7 +86,7 @@ type lease struct {
 
 func (c *client) Acquire(rtype string, ctx context.Context, cancel context.CancelFunc) (string, error) {
 	var cancelAcquire context.CancelFunc
-	ctx, cancelAcquire = context.WithTimeout(ctx, 150*time.Minute)
+	ctx, cancelAcquire = context.WithTimeout(ctx, 50*time.Minute)
 	defer cancelAcquire()
 	r, err := c.boskos.AcquireWaitWithPriority(ctx, rtype, freeState, leasedState, randId())
 	if err != nil {

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -55,6 +55,7 @@ func (s *leaseStep) Run(ctx context.Context, dry bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to acquire lease: %v", err)
 	}
+	log.Printf("Acquired lease %q for %q", lease, s.leaseType)
 	var errs []error
 	errs = append(errs, s.wrapped.Run(ctx, dry))
 	log.Printf("Releasing lease for %q", s.leaseType)


### PR DESCRIPTION
The CI NS TTL controller will remove namespaces that are inactive for
more than an hour. Therefore, it does not make sense for CI Operator to
wait for more than an hour while acquiring a lease, or the underlying
namespace will be removed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 