### PR TITLE
ci-operator multi-stage: save container logs

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -41,6 +41,9 @@ const (
 	// A comma-delimited list of container names that will be returned as individual JUnit
 	// test results.
 	annotationContainersForSubTestResults = "ci-operator.openshift.io/container-sub-tests"
+	// A boolean value which indicates that the logs from all containers in the
+	// pod must be copied to the artifact directory (default is "false").
+	annotationSaveContainerLogs = "ci-operator.openshift.io/save-container-logs"
 	// artifactEnv is the env var in which we hold the artifact dir for users
 	artifactEnv = "ARTIFACT_DIR"
 )
@@ -623,7 +626,7 @@ func gatherContainerLogsOutput(podClient PodClient, artifactDir, namespace, podN
 	}
 	pod := &list.Items[0]
 
-	if pod.Annotations["ci-operator.openshift.io/save-container-logs"] != "true" {
+	if pod.Annotations[annotationSaveContainerLogs] != "true" {
 		return nil
 	}
 

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -261,6 +261,8 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 			errs = append(errs, err)
 			continue
 		}
+		delete(pod.Labels, ProwJobIdLabel)
+		pod.Annotations[annotationSaveContainerLogs] = "true"
 		pod.Labels[multiStageTestLabel] = s.name
 		pod.Spec.ServiceAccountName = s.name
 		addSecretWrapper(pod)

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -89,7 +89,6 @@ func TestGeneratePods(t *testing.T) {
 	labels := map[string]string{
 		"job":                              "job",
 		"build-id":                         "build id",
-		"prow.k8s.io/id":                   "prow job id",
 		"created-by-ci":                    "true",
 		"ci.openshift.io/refs.branch":      "base ref",
 		"ci.openshift.io/refs.org":         "org",
@@ -149,6 +148,7 @@ func TestGeneratePods(t *testing.T) {
 			Annotations: map[string]string{
 				"ci.openshift.io/job-spec":                     "",
 				"ci-operator.openshift.io/container-sub-tests": "step0",
+				"ci-operator.openshift.io/save-container-logs": "true",
 			},
 		},
 		Spec: coreapi.PodSpec{
@@ -215,6 +215,7 @@ func TestGeneratePods(t *testing.T) {
 			Annotations: map[string]string{
 				"ci.openshift.io/job-spec":                     "",
 				"ci-operator.openshift.io/container-sub-tests": "step1",
+				"ci-operator.openshift.io/save-container-logs": "true",
 			},
 		},
 		Spec: coreapi.PodSpec{

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -452,6 +452,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "post0",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -462,8 +463,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-post0"
     },
@@ -643,6 +643,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "post1",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -653,8 +654,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-post1"
     },
@@ -834,6 +834,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "pre0",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -844,8 +845,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-pre0"
     },
@@ -1025,6 +1025,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "pre1",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1035,8 +1036,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-pre1"
     },
@@ -1216,6 +1216,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test0",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1226,8 +1227,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-test0"
     },
@@ -1407,6 +1407,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test1",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1417,8 +1418,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-test1"
     },
@@ -1598,6 +1598,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test2",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1608,8 +1609,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "multi-stage-test2"
     },

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -179,6 +179,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "e2e",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -189,8 +190,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-azure-e2e"
     },
@@ -368,6 +368,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-deprovision",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -378,8 +379,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-azure-ipi-deprovision-deprovision"
     },
@@ -557,6 +557,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-must-gather",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -567,8 +568,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-azure-ipi-deprovision-must-gather"
     },
@@ -746,6 +746,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-install",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -756,8 +757,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-azure-ipi-install-install"
     },
@@ -935,6 +935,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-rbac",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -945,8 +946,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-azure-ipi-install-rbac"
     },
@@ -1124,6 +1124,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "e2e",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1134,8 +1135,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-gcp-e2e"
     },
@@ -1313,6 +1313,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-deprovision",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1323,8 +1324,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-gcp-ipi-deprovision-deprovision"
     },
@@ -1502,6 +1502,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-must-gather",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1512,8 +1513,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-gcp-ipi-deprovision-must-gather"
     },
@@ -1691,6 +1691,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-install",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1701,8 +1702,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-gcp-ipi-install-install"
     },
@@ -1880,6 +1880,7 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-rbac",
+        "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
@@ -1890,8 +1891,7 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
-        "job": "pull-ci-openshift-release-master-ci-operator-integration",
-        "prow.k8s.io/id": "uuid"
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
       "name": "e2e-gcp-ipi-install-rbac"
     },


### PR DESCRIPTION
Add an annotation to pods created by multi-stage tests to write the logs of
all containers into the artifact directory, as is done for template tests.
The `prow.k8s.io/id` label is removed so logs are not collected once more
by the `artifact-uploader` controller.  Detailed discussion:

https://github.com/openshift/release/pull/6708#issuecomment-579772817