### PR TITLE
private-org-sync: allow failing on missing destinations

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -464,12 +464,12 @@ func main() {
 		destination.org = o.targetOrg
 		gitDir, err := syncer.makeGitDir(source.org, source.repo)
 		if err != nil {
-			syncErrors = append(syncErrors, err)
+			syncErrors = append(syncErrors, fmt.Errorf("%s->%s: %v", source.String(), destination.String(), err))
 			return nil
 		}
 
 		if err := syncer.mirror(gitDir, source, destination); err != nil {
-			syncErrors = append(syncErrors, err)
+			syncErrors = append(syncErrors, fmt.Errorf("%s->%s: %v", source.String(), destination.String(), err))
 		}
 		return nil
 	}


### PR DESCRIPTION
After https://github.com/openshift/release/pull/6963 we will expect all destinations to be existing repos. Hence, add an option that causes the tool to fail when the destination repo does not exist.

@openshift/openshift-team-developer-productivity-test-platform 