### PR TITLE
Move prowgen config to config package

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -712,18 +712,13 @@ func generateJobs(
 	}
 }
 
-// Prowgen holds the information of the prowgen's configuration file.
-type Config struct {
-	Private bool `json:"private,omitempty"`
-}
-
 type prowgenInfo struct {
 	config.Info
-	config Config
+	config config.Prowgen
 }
 
-func readProwgenConfig(path string) (*Config, error) {
-	var pConfig *Config
+func readProwgenConfig(path string) (*config.Prowgen, error) {
+	var pConfig *config.Prowgen
 	b, err := ioutil.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("prowgen config found in path %s but couldn't read the file: %v", path, err)
@@ -749,13 +744,13 @@ func readProwgenConfig(path string) (*Config, error) {
 // because the drop-in is not there).
 func generateJobsToDir(dir string, label jc.ProwgenLabel) func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 	// Return a closure so the cache is shared among callback calls
-	cache := map[string]*Config{}
+	cache := map[string]*config.Prowgen{}
 	return func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
-		pInfo := &prowgenInfo{Info: *info, config: Config{Private: false}}
+		pInfo := &prowgenInfo{Info: *info, config: config.Prowgen{Private: false}}
 		var ok bool
 		var err error
-		var orgConfig, repoConfig *Config
+		var orgConfig, repoConfig *config.Prowgen
 
 		if orgConfig, ok = cache[info.Org]; !ok {
 			if cache[info.Org], err = readProwgenConfig(filepath.Join(info.OrgPath, prowgenConfigFile)); err != nil {

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -242,7 +242,7 @@ func TestGeneratePodSpec(t *testing.T) {
 			description: "private job",
 			info: &prowgenInfo{
 				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				config: Config{Private: true},
+				config: config.Prowgen{Private: true},
 			},
 			secrets: nil,
 			targets: []string{"target"},
@@ -1996,7 +1996,7 @@ func TestGenerateJobBase(t *testing.T) {
 			prefix:   "pull",
 			info: &prowgenInfo{
 				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				config: Config{Private: true},
+				config: config.Prowgen{Private: true},
 			},
 			label:   jobconfig.Generated,
 			podSpec: &kubeapi.PodSpec{Containers: []kubeapi.Container{{Name: "test"}}},

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -16,6 +16,11 @@ import (
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 )
 
+// Prowgen holds the information of the prowgen's configuration file.
+type Prowgen struct {
+	Private bool `json:"private,omitempty"`
+}
+
 func readCiOperatorConfig(configFilePath string, info Info) (*cioperatorapi.ReleaseBuildConfiguration, error) {
 	data, err := ioutil.ReadFile(configFilePath)
 	if err != nil {


### PR DESCRIPTION
This is needed for the new tool that syncs ci-operator configs.

/cc @openshift/openshift-team-developer-productivity-test-platform 