### PR TITLE
ci-operator: don't verify resolved config if not using resolver

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -333,7 +333,14 @@ func (o *options) Complete() error {
 	}
 	o.configSpec = config
 
-	if err := o.configSpec.ValidateResolved(); err != nil {
+	var validateFunc func() error
+	if info != nil {
+		validateFunc = o.configSpec.ValidateResolved
+	} else {
+		validateFunc = o.configSpec.ValidateAtRuntime
+	}
+
+	if err := validateFunc(); err != nil {
 		return err
 	}
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -49,6 +49,7 @@ func (config *ReleaseBuildConfiguration) Default() {
 // ValidateAtRuntime validates all the configuration's values without knowledge of config
 // repo structure
 func (config *ReleaseBuildConfiguration) ValidateAtRuntime() error {
+	config.Default()
 	return config.validate("", "", false)
 }
 


### PR DESCRIPTION
Currently, ci-operator is failing for handwritten prowjob tests because the ci-operator expects all configs to be fully resolved even when not using the resolver. This PR changes ci-operator to use `ValidateAtRuntime` instead of `ValidateResolved` when not using the resolver.

In the future, the `ValidateResolved` check should be run when a multistage config is run in case a handwritten job tries to load a multistage config.

/cc @openshift/openshift-team-developer-productivity-test-platform 