### PR TITLE
Add tool to mirror ci-operator configs to a single private repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
 
-integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater
+integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater integration-ci-op-configs-mirror
 .PHONY: integration
 
 integration-prowgen:
@@ -72,3 +72,7 @@ check-breaking-changes:
 integration-group-auto-updater:
 	test/group-auto-updater-integration/run.sh
 .PHONY: integration-group-auto-updater
+
+integration-ci-op-configs-mirror:
+	test/ci-op-configs-mirror-integration/run.sh
+.PHONY: integration-ci-op-configs-mirror

--- a/cmd/ci-op-configs-mirror/main.go
+++ b/cmd/ci-op-configs-mirror/main.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+)
+
+const (
+	prowgenConfigFile = ".config.prowgen"
+)
+
+type options struct {
+	dryRun         bool
+	configDir      string
+	destinationDir string
+	fromOrg        string
+	toOrg          string
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.configDir, "config-path", "", "Path to directory containing ci-operator configurations")
+	fs.StringVar(&o.destinationDir, "destination-path", "", "Path of the destination of the generated ci-operator configurations")
+
+	fs.StringVar(&o.fromOrg, "from-org", "", "Mirror the ci-operator configuration files from a single organization, if specified")
+	fs.StringVar(&o.toOrg, "to-org", "", "Name of the organization which the ci-operator configuration files will be mirrored")
+
+	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether to actually generate the new ci-operator configuration files")
+
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) validate() error {
+	if len(o.configDir) == 0 {
+		return errors.New("--config-path is not defined")
+	}
+	if len(o.destinationDir) == 0 && !o.dryRun {
+		return errors.New("--destination-path is not defined")
+	}
+	if len(o.toOrg) == 0 {
+		return errors.New("--to-org is not defined")
+	}
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid option")
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	prowgenConfig := config.Prowgen{Private: true}
+
+	dryBuff := &bytes.Buffer{}
+	callback := func(rbc *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+		logger := logrus.WithFields(logrus.Fields{"org": repoInfo.Org, "repo": repoInfo.Repo})
+
+		if len(o.fromOrg) > 0 && repoInfo.Org != o.fromOrg {
+			logger.Warning("Skipping...")
+			return nil
+		}
+
+		logger.Info("Processing...")
+		data, err := yaml.Marshal(rbc)
+		if err != nil {
+			logger.WithError(err).Fatal("couldn't marshal ci-operator's configuration")
+		}
+
+		filename := fmt.Sprintf("%s-%s-%s.yaml", o.toOrg, repoInfo.Repo, repoInfo.Branch)
+		orgRepoDestinationDir := filepath.Join(o.destinationDir, o.toOrg, repoInfo.Repo)
+		fileFullPath := filepath.Join(orgRepoDestinationDir, filename)
+
+		if o.dryRun {
+			dryBuff.WriteString(fmt.Sprintf("%s:\n%v\n", fileFullPath, string(data)))
+			return nil
+		}
+
+		if err := os.MkdirAll(orgRepoDestinationDir, 0755); err != nil {
+			logger.WithError(err).Fatal("couldn't create destination's directory")
+		}
+
+		if err := ioutil.WriteFile(fileFullPath, data, 0755); err != nil {
+			logger.WithError(err).Fatal("error while writing to file")
+		}
+
+		return nil
+	}
+
+	if err := config.OperateOnCIOperatorConfigDir(o.configDir, callback); err != nil {
+		if err != nil {
+			logrus.WithError(err).Fatal("error while generating the ci-operator configuration files")
+		}
+	}
+
+	data, err := yaml.Marshal(prowgenConfig)
+	if err != nil {
+		logrus.WithError(err).Fatal("couldn't marshal prowgen configuration")
+	}
+
+	prowgenConfigFullPath := filepath.Join(o.destinationDir, o.toOrg, prowgenConfigFile)
+	if o.dryRun {
+		dryBuff.WriteString(fmt.Sprintf("%s:\n%v", prowgenConfigFullPath, string(data)))
+		fmt.Printf("%s", dryBuff)
+	} else {
+		if err := ioutil.WriteFile(prowgenConfigFullPath, data, 0755); err != nil {
+			logrus.WithError(err).Fatal("error while writing to file")
+		}
+	}
+}

--- a/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/input/super/duper/super-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/super/duper/super-duper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/expected_files/expected.yaml
+++ b/test/ci-op-configs-mirror-integration/expected_files/expected.yaml
@@ -1,0 +1,107 @@
+super-priv/bar/super-priv-bar-master.yaml:
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+super-priv/duper/super-priv-duper-master.yaml:
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+super-priv/trooper/super-priv-trooper-master.yaml:
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+super-priv/.config.prowgen:
+private: true

--- a/test/ci-op-configs-mirror-integration/expected_files/expected_skipped.yaml
+++ b/test/ci-op-configs-mirror-integration/expected_files/expected_skipped.yaml
@@ -1,0 +1,72 @@
+super-priv/duper/super-priv-duper-master.yaml:
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+super-priv/trooper/super-priv-trooper-master.yaml:
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+
+super-priv/.config.prowgen:
+private: true

--- a/test/ci-op-configs-mirror-integration/run.sh
+++ b/test/ci-op-configs-mirror-integration/run.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+WORKDIR="$( mktemp -d )"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+TEST_ROOT="$( dirname "${BASH_SOURCE[0]}")"
+INPUT_FILES="${TEST_ROOT}/data/input"
+EXPECTED="${TEST_ROOT}/expected_files/expected.yaml"
+EXPECTED_SKIPPED="${TEST_ROOT}/expected_files/expected_skipped.yaml"
+
+
+echo "[INFO] Running ci-op-configs-mirror in dry-mode..."
+if ! ci-op-configs-mirror --to-org super-priv --config-path "${INPUT_FILES}" --dry-run 2> "${WORKDIR}/ci-op-configs-mirror-stderr.log" > "${WORKDIR}/ci-op-configs-mirror-stdout.log"; then
+  echo "ERROR: ci-op-configs-mirror failed:"
+  cat "${WORKDIR}/ci-op-configs-mirror-stderr.log"
+  exit 1
+fi
+
+echo "[INFO] Validating generated ci-operator configuration files"
+if ! diff -u "${EXPECTED}" "${WORKDIR}/ci-op-configs-mirror-stdout.log"; then
+  printf "ERROR: ci-op-configs-mirror output differs from expected\n"
+  exit 1
+fi
+
+
+echo "[INFO] Running ci-op-configs-mirror in dry-mode from specifig org..."
+if ! ci-op-configs-mirror --from-org super --to-org super-priv --config-path "${INPUT_FILES}" --dry-run 2> "${WORKDIR}/ci-op-configs-mirror-stderr_skipped.log" > "${WORKDIR}/ci-op-configs-mirror-stdout_skipped.log"; then
+  echo "ERROR: ci-op-configs-mirror failed:"
+  cat "${WORKDIR}/ci-op-configs-mirror-stderr.log"
+  exit 1
+fi
+
+echo "[INFO] Validating generated ci-operator configuration files"
+if ! diff -u "${EXPECTED_SKIPPED}" "${WORKDIR}/ci-op-configs-mirror-stdout_skipped.log"; then
+  printf "ERROR: ci-op-configs-mirror output differs from expected\n"
+  exit 1
+fi
+
+
+
+echo "[INFO] Success!"
+


### PR DESCRIPTION
This is a simple tool that syncs ci-operator configuration files from a single or multiple organization to a single organization and generates a prowgen config file to mark the org as private.