### PR TITLE
Add tool to mirror ci-operator configs to a single repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
 
-integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater
+integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater integration-ci-op-configs-mirror
 .PHONY: integration
 
 integration-prowgen:
@@ -72,3 +72,7 @@ check-breaking-changes:
 integration-group-auto-updater:
 	test/group-auto-updater-integration/run.sh
 .PHONY: integration-group-auto-updater
+
+integration-ci-op-configs-mirror:
+	test/ci-op-configs-mirror-integration/run.sh
+.PHONY: integration-ci-op-configs-mirror

--- a/cmd/ci-op-configs-mirror/main.go
+++ b/cmd/ci-op-configs-mirror/main.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/promotion"
+)
+
+type options struct {
+	configDir string
+	toOrg     string
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.configDir, "config-path", "", "Path to directory containing ci-operator configurations")
+	fs.StringVar(&o.toOrg, "to-org", "", "Name of the organization which the ci-operator configuration files will be mirrored")
+
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) validate() error {
+	if len(o.configDir) == 0 {
+		return errors.New("--config-path is not defined")
+	}
+
+	if len(o.toOrg) == 0 {
+		return errors.New("--to-org is not defined")
+	}
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid option")
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	callback := func(rbc *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+		logger := logrus.WithFields(logrus.Fields{"org": repoInfo.Org, "repo": repoInfo.Repo, "branch": repoInfo.Branch})
+
+		if repoInfo.Org == o.toOrg {
+			return nil
+		}
+
+		if !promotion.BuildsOfficialImages(rbc) {
+			logger.Warn("Skipping...")
+			return nil
+		}
+		logger.Info("Processing...")
+
+		if rbc.CanonicalGoRepository == nil {
+			rbc.CanonicalGoRepository = strP(fmt.Sprintf("github.com/%s/%s", repoInfo.Org, repoInfo.Repo))
+		}
+
+		repoInfo.Org = o.toOrg
+
+		rbc.PromotionConfiguration.Disabled = true
+		rbc.PromotionConfiguration.Name = fmt.Sprintf("%s-private", rbc.PromotionConfiguration.Name)
+
+		dataWithInfo := config.DataWithInfo{
+			Configuration: *rbc,
+			Info:          *repoInfo,
+		}
+
+		if err := dataWithInfo.CommitTo(o.configDir); err != nil {
+			logger.WithError(err).Fatal("couldn't create the configuration file")
+		}
+
+		return nil
+	}
+
+	if err := config.OperateOnCIOperatorConfigDir(o.configDir, callback); err != nil {
+		logrus.WithError(err).Fatal("error while generating the ci-operator configuration files")
+	}
+}
+
+func strP(str string) *string {
+	return &str
+}

--- a/images/ci-op-configs-mirror/Dockerfile
+++ b/images/ci-op-configs-mirror/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:8
+LABEL maintainer="nmoraiti@redhat.com"
+
+ADD ci-op-configs-mirror /usr/bin/ci-op-configs-mirror
+ENTRYPOINT ["/usr/bin/ci-op-configs-mirror"]

--- a/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+build_root:
+  image_stream_tag:
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/input/super/duper/super-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/super/duper/super-duper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+build_root:
+  image_stream_tag:
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/duper
+images:
+- from: base
+  to: test-image
+promotion:
+  disabled: true
+  name: other-private
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/trooper
+images:
+- from: base
+  to: test-image
+promotion:
+  disabled: true
+  name: other-private
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/output/super/duper/super-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super/duper/super-duper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/data/output/super/trooper/super-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super/trooper/super-trooper-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+promotion:
+  namespace: ocp
+  name: other
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-op-configs-mirror-integration/run.sh
+++ b/test/ci-op-configs-mirror-integration/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+WORKDIR="$( mktemp -d )"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+TEST_ROOT="$( dirname "${BASH_SOURCE[0]}")"
+INPUT_FILES="${TEST_ROOT}/data/input"
+OUTPUT_FILES="${TEST_ROOT}/data/output"
+
+cp -r ${INPUT_FILES} ${WORKDIR}
+
+echo "[INFO] Running ci-op-configs-mirror..."
+if ! ci-op-configs-mirror --to-org "super-priv" --config-path "${WORKDIR}/input" 2> "${WORKDIR}/ci-op-configs-mirror-stderr.log"; then
+  echo "ERROR: ci-op-configs-mirror failed:"
+  cat "${WORKDIR}/ci-op-configs-mirror-stderr.log"
+  exit 1
+fi
+
+echo "[INFO] Validating generated ci-operator configuration files"
+if ! diff -Naupr "${WORKDIR}/input" "${OUTPUT_FILES}"; then
+  printf "ERROR: ci-op-configs-mirror output differs from expected\n"
+  exit 1
+fi
+
+echo "[INFO] Success!"


### PR DESCRIPTION
This is a simple tool that syncs ci-operator configuration files from a single or multiple organization to a single organization with the ability to generate a prowgen config file to mark the org as private.

/cc @petr-muller @stevekuznetsov 