### PR TITLE
ci-op-configs-mirror: Use private namespace and imagestream on Promotion config

### DIFF
--- a/cmd/ci-op-configs-mirror/main.go
+++ b/cmd/ci-op-configs-mirror/main.go
@@ -15,6 +15,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/promotion"
 )
 
+const (
+	privateNamespace = "ocp-private"
+)
+
 type options struct {
 	configDir string
 	toOrg     string
@@ -73,7 +77,8 @@ func main() {
 		repoInfo.Org = o.toOrg
 
 		rbc.PromotionConfiguration.Disabled = true
-		rbc.PromotionConfiguration.Name = fmt.Sprintf("%s-private", rbc.PromotionConfiguration.Name)
+		rbc.PromotionConfiguration.Namespace = privateNamespace
+		rbc.PromotionConfiguration.Name = fmt.Sprintf("%s-priv", rbc.PromotionConfiguration.Name)
 
 		dataWithInfo := config.DataWithInfo{
 			Configuration: *rbc,

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
@@ -16,8 +16,8 @@ images:
   to: test-image
 promotion:
   disabled: true
-  name: other-private
-  namespace: ocp
+  name: other-priv
+  namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -16,8 +16,8 @@ images:
   to: test-image
 promotion:
   disabled: true
-  name: other-private
-  namespace: ocp
+  name: other-priv
+  namespace: ocp-private
 resources:
   '*':
     limits:


### PR DESCRIPTION
follow-up of https://github.com/openshift/release/pull/7114
/cc @petr-muller 