### PR TITLE
breaking-changes check: revert `git -C` to pushd/popd

### DIFF
--- a/test/validate-prowgen-breaking-changes.sh
+++ b/test/validate-prowgen-breaking-changes.sh
@@ -9,12 +9,16 @@ trap 'rm -rf "${workdir}"' EXIT
 
 git clone https://github.com/openshift/release.git --depth 1 "${workdir}/release"
 
+# We need to enter the git directory and run git commands from there, our git
+# is too old to know the `-C` option.
+pushd "${workdir}/release"
+
 ci-operator-prowgen --from-dir "${workdir}/release/ci-operator/config" --to-dir "${workdir}/release/ci-operator/jobs"
 
-out="$(git -C "${workdir}/release" status --porcelain)"
+out="$(git status --porcelain)"
 if [[ -n "$out" ]]; then
   echo "ERROR: Changes in openshift/release:"
-  git -C "${workdir}/release" diff
+  git diff
   echo "ERROR: Running Prowgen in openshift/release results in changes ^^^"
   echo "ERROR: To avoid breaking openshift/release for everyone you should regenerate"
   echo "ERROR: the jobs there and merge the changes ASAP after this change to Prowgen"
@@ -24,10 +28,10 @@ else
 fi
 
 determinize-prow-config --prow-config-dir "${workdir}/release/core-services/prow/02_config"
-out="$(git -C "${workdir}/release" status --porcelain)"
+out="$(git status --porcelain)"
 if [[ -n "$out" ]]; then
   echo "ERROR: Changes in openshift/release:"
-  git -C "${workdir}/release" diff
+  git diff
   echo "ERROR: Running determinize-prow-config in openshift/release results in changes ^^^"
   echo "ERROR: To avoid breaking openshift/release for everyone you should make a PR there"
   echo "ERROR: to include these changes and merge it ASAP after this change to ci-tools"
@@ -35,3 +39,5 @@ if [[ -n "$out" ]]; then
 else
   echo "Running determinize-prow-config in openshift/release does not result in changes, no followups needed"
 fi
+
+popd


### PR DESCRIPTION
The git in our build root is too old to know `-C`.

Note: the job is currently expected to fail until https://github.com/openshift/release/pull/7107 merges

/cc @stevekuznetsov 