### PR TITLE
ci-operator: add flag to resolve steps

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -233,6 +233,7 @@ type options struct {
 	sentryDSNPath string
 
 	resolverAddress string
+	registryPath    string
 	org             string
 	repo            string
 	branch          string
@@ -264,6 +265,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.leaseServer, "lease-server", "", "Address of the server that manages leases. Required if any test is configured to acquire a lease.")
 	flag.StringVar(&opt.leaseServerUsername, "lease-server-username", "", "Username used to access the lease server")
 	flag.StringVar(&opt.leaseServerPasswordFile, "lease-server-password-file", "", "The path to password file used to access the lease server")
+	flag.StringVar(&opt.registryPath, "registry", "", "Path to the step registry directory")
 	flag.StringVar(&opt.configSpecPath, "config", "", "The configuration file. If not specified the CONFIG_SPEC environment variable will be used.")
 	flag.Var(&opt.targets, "target", "One or more targets in the configuration to build. Only steps that are required for this target will be run.")
 	flag.BoolVar(&opt.dry, "dry-run", opt.dry, "Print the steps that would be run and the objects that would be created without executing any steps")
@@ -327,7 +329,7 @@ func (o *options) Complete() error {
 			Variant: o.variant,
 		}
 	}
-	config, err := load.Config(o.configSpecPath, info)
+	config, err := load.Config(o.configSpecPath, o.registryPath, info)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %v", err)
 	}

--- a/pkg/load/configAgent.go
+++ b/pkg/load/configAgent.go
@@ -108,7 +108,7 @@ func (a *configAgent) loadFilenameToConfig() error {
 		}
 		ext := filepath.Ext(path)
 		if info != nil && !info.IsDir() && (ext == ".yml" || ext == ".yaml") {
-			configSpec, err := Config(path, nil)
+			configSpec, err := Config(path, "", nil)
 			if err != nil {
 				a.recordError("failed to load ci-operator config")
 				return fmt.Errorf("failed to load ci-operator config (%v)", err)

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -575,7 +575,7 @@ func TestConfig(t *testing.T) {
 					t.Fatalf("%s: failed to populate env var: %v", testCase.name, err)
 				}
 			}
-			config, err := Config(path, nil)
+			config, err := Config(path, "", nil)
 			if err == nil && testCase.expectedError {
 				t.Errorf("%s: expected an error, but got none", testCase.name)
 			}

--- a/test/ci-operator-integration/multi-stage/run.sh
+++ b/test/ci-operator-integration/multi-stage/run.sh
@@ -9,7 +9,8 @@ readonly TEST_ROOT
 readonly TEST_CONFIG_DIR="${TEST_ROOT}/configs"
 readonly TEST_PROWCONFIG="${TEST_ROOT}/../../ci-operator-configresolver-integration/config.yaml"
 readonly TEST_REGISTRY_DIR="${TEST_ROOT}/../../multistage-registry/registry"
-readonly TEST_CONFIG="${TEST_CONFIG_DIR}/master/openshift-hyperkube-master.yaml"
+readonly TEST_CONFIG0="${TEST_CONFIG_DIR}/master/openshift-hyperkube-master.yaml"
+readonly TEST_CONFIG1="${TEST_CONFIG_DIR}/release-4.2/openshift-installer-release-4.2.yaml"
 readonly TEST_NAMESPACE="testns"
 readonly EXPECTED1="${TEST_ROOT}/expected/hyperkube.json"
 readonly EXPECTED2="${TEST_ROOT}/expected/installer.json"
@@ -34,7 +35,7 @@ check() {
 }
 
 echo "[INFO] Running ci-operator in dry-mode..."
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" 2> "${ERR}" | jq --sort-keys . > "${OUT}"; then
+if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG0}" 2> "${ERR}" | jq --sort-keys . > "${OUT}"; then
     echo "ERROR: ci-operator failed."
     cat "${ERR}"
     exit 1
@@ -44,6 +45,20 @@ if ! diff "${EXPECTED1}" "${OUT}"; then
     echo "ERROR: differences have been found against ${EXPECTED1}"
     exit 1
 fi
+
+echo '[INFO] Running test with --registry'
+if ! ci-operator \
+    --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" \
+    --config "${TEST_CONFIG1}" --registry "${TEST_REGISTRY_DIR}" \
+    --lease-server "http://lease" 2> "${ERR}" \
+    | jq --sort-keys . > "${OUT}"
+then
+    echo "ERROR: ci-operator failed."
+    cat "${ERR}"
+    exit 1
+fi
+
+check
 
 echo '[INFO] Running test with ci-operator-configresolver'
 ci-operator-configresolver -config "${TEST_CONFIG_DIR}" -registry "${TEST_REGISTRY_DIR}" -prow-config "${TEST_PROWCONFIG}" -log-level debug -cycle 2m  &> "${WORKDIR}"/output.log &
@@ -63,7 +78,7 @@ for (( i = 0; i < 10; i++ )); do
     sleep 0.5
 done
 
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG}" \
+if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG0}" \
     -resolver-address "http://127.0.0.1:8080" -org "openshift" -repo "installer" -branch "release-4.2" --lease-server "http://lease" 2> "${ERR}" | jq --sort-keys . > "${OUT}"; then
     echo "ERROR: ci-operator failed."
     cat "${ERR}"


### PR DESCRIPTION
Upstreaming a simpler version of a patch I've had for months on my machine.
This requires a local copy of `openshift/release`, but is useful to test
changes to the registry locally (@petr-muller: FYI).