### PR TITLE
Censor seesion in the log of ci-secret-bootstrap

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -15,6 +15,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
@@ -385,7 +386,8 @@ func TestCompleteOptions(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualError := tc.given.completeOptions()
+			secrets := sets.NewString()
+			actualError := tc.given.completeOptions(&secrets)
 			equalError(t, tc.expectedError, actualError)
 			if tc.expectedError == nil {
 				equal(t, tc.expectedBWPassword, tc.given.bwPassword)
@@ -396,6 +398,7 @@ func TestCompleteOptions(t *testing.T) {
 				}
 				sort.Strings(actualClusters)
 				equal(t, tc.expectedClusters, actualClusters)
+				equal(t, sets.NewString("topSecret"), secrets)
 			}
 		})
 	}

--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -37,6 +37,6 @@ type Client interface {
 }
 
 // NewBitwardenClient generates a BitWarden client
-func NewClient(username, password string) (Client, error) {
-	return newCliClient(username, password)
+func NewClient(username, password string, addSecret func(s string)) (Client, error) {
+	return newCliClient(username, password, addSecret)
 }

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -199,9 +199,10 @@ func TestLoginAndListItems(t *testing.T) {
 				responses: tc.responses,
 			}
 			client := cliClient{
-				username: tc.username,
-				password: tc.password,
-				run:      e.Run,
+				username:  tc.username,
+				password:  tc.password,
+				run:       e.Run,
+				addSecret: func(s string) {},
 			}
 			actualError := client.loginAndListItems()
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-880

Local test results:

```bash
$ ci-secret-bootstrap -bw-user aaa@redhat.com --bw-password-path /tmp/_bw_password --config ./core-services/ci-secret-bootstrap/_config.yaml 
INFO[0000] Parsed kubeconfig context: default           
INFO[0000] Parsed kubeconfig context: build01           
INFO[0000] running bw command ...                        args="[login aaa@redhat.com CENSORED --response]"
INFO[0003] running bw command ...                        args="[--session CENSORED list items]"
INFO[0003] running bw command ...                        args="[--session CENSORED get attachment
```

/cc @openshift/openshift-team-developer-productivity-test-platform 