### PR TITLE
pkg/load: make agents a sub-package

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/test-infra/prow/pjutil"
 
 	"github.com/openshift/ci-tools/pkg/config"
-	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/webreg"
 )
 
@@ -184,7 +184,7 @@ func genericHandler() http.HandlerFunc {
 	}
 }
 
-func resolveConfig(configAgent load.ConfigAgent, registryAgent load.RegistryAgent) http.HandlerFunc {
+func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.RegistryAgent) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			w.WriteHeader(http.StatusNotImplemented)
@@ -243,14 +243,14 @@ func resolveConfig(configAgent load.ConfigAgent, registryAgent load.RegistryAgen
 	}
 }
 
-func getConfigGeneration(agent load.ConfigAgent) http.HandlerFunc {
+func getConfigGeneration(agent agents.ConfigAgent) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "%d", agent.GetGeneration())
 	}
 }
 
-func getRegistryGeneration(agent load.RegistryAgent) http.HandlerFunc {
+func getRegistryGeneration(agent agents.RegistryAgent) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "%d", agent.GetGeneration())
@@ -274,12 +274,12 @@ func main() {
 	health := pjutil.NewHealth()
 	metrics.ExposeMetrics("ci-operator-configresolver", prowConfig.PushGateway{})
 
-	configAgent, err := load.NewConfigAgent(o.configPath, o.cycle, configresolverMetrics.errorRate)
+	configAgent, err := agents.NewConfigAgent(o.configPath, o.cycle, configresolverMetrics.errorRate)
 	if err != nil {
 		log.Fatalf("Failed to get config agent: %v", err)
 	}
 
-	registryAgent, err := load.NewRegistryAgent(o.registryPath, o.cycle, configresolverMetrics.errorRate, o.flatRegistry)
+	registryAgent, err := agents.NewRegistryAgent(o.registryPath, o.cycle, configresolverMetrics.errorRate, o.flatRegistry)
 	if err != nil {
 		log.Fatalf("Failed to get registry agent: %v", err)
 	}

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -1,4 +1,4 @@
-package load
+package agents
 
 import (
 	"fmt"
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/coalescer"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/load"
 )
 
 // ConfigAgent is an interface that can load configs from disk into
@@ -111,7 +112,7 @@ func (a *configAgent) loadFilenameToConfig() error {
 		}
 		ext := filepath.Ext(path)
 		if info != nil && !info.IsDir() && (ext == ".yml" || ext == ".yaml") {
-			configSpec, err := Config(path, "", nil)
+			configSpec, err := load.Config(path, "", nil)
 			if err != nil {
 				a.recordError("failed to load ci-operator config")
 				return fmt.Errorf("failed to load ci-operator config (%v)", err)

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -1,16 +1,18 @@
-package load
+package agents
 
 import (
 	"fmt"
 	"sync"
 	"time"
 
-	"github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/coalescer"
-	"github.com/openshift/ci-tools/pkg/registry"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/coalescer"
+	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/openshift/ci-tools/pkg/registry"
 )
 
 // RegistryAgent is an interface that can load a registry from disk into
@@ -93,7 +95,7 @@ func (a *registryAgent) GetRegistryComponents() (registry.ReferenceByName, regis
 func (a *registryAgent) loadRegistry() error {
 	log.Debug("Reloading registry")
 	startTime := time.Now()
-	references, chains, workflows, documentation, err := Registry(a.registryPath, a.flatRegistry)
+	references, chains, workflows, documentation, err := load.Registry(a.registryPath, a.flatRegistry)
 	if err != nil {
 		a.recordError("failed to load ci-operator registry")
 		return fmt.Errorf("failed to load ci-operator registry (%v)", err)

--- a/pkg/load/agents/utils.go
+++ b/pkg/load/agents/utils.go
@@ -1,4 +1,4 @@
-package load
+package agents
 
 import (
 	"context"

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -18,7 +18,7 @@ import (
 	prowConfig "k8s.io/test-infra/prow/config"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
 
@@ -930,7 +930,7 @@ func helpHandler(subPath string, w http.ResponseWriter, req *http.Request) {
 	writePage(w, "Step Registry Help Page", helpTemplate, data)
 }
 
-func mainPageHandler(agent load.RegistryAgent, templateString string, w http.ResponseWriter, req *http.Request) {
+func mainPageHandler(agent agents.RegistryAgent, templateString string, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 
@@ -954,7 +954,7 @@ func mainPageHandler(agent load.RegistryAgent, templateString string, w http.Res
 	writePage(w, "Step Registry Help Page", page, comps)
 }
 
-func WebRegHandler(regAgent load.RegistryAgent, confAgent load.ConfigAgent, jobAgent *prowConfig.Agent) http.HandlerFunc {
+func WebRegHandler(regAgent agents.RegistryAgent, confAgent agents.ConfigAgent, jobAgent *prowConfig.Agent) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		trimmedPath := strings.TrimPrefix(req.URL.Path, req.URL.Host)
 		// remove leading slash
@@ -1021,7 +1021,7 @@ func syntaxBash(source string) (string, error) {
 	return syntax(source, lexers.Get("bash"))
 }
 
-func referenceHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http.Request) {
+func referenceHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
@@ -1055,7 +1055,7 @@ func referenceHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http
 	writePage(w, "Registry Reference Help Page", page, ref)
 }
 
-func chainHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http.Request) {
+func chainHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
@@ -1076,7 +1076,7 @@ func chainHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http.Req
 	writePage(w, "Registry Chain Help Page", page, chain)
 }
 
-func workflowHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http.Request) {
+func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
@@ -1099,7 +1099,7 @@ func workflowHandler(agent load.RegistryAgent, w http.ResponseWriter, req *http.
 	writePage(w, "Registry Workflow Help Page", page, workflow)
 }
 
-func findConfigForJob(jobName string, configs load.FilenameToConfig) (api.MultiStageTestConfiguration, error) {
+func findConfigForJob(jobName string, configs agents.FilenameToConfig) (api.MultiStageTestConfiguration, error) {
 	splitJobName := strings.Split(jobName, "-")
 	var filename, testname string
 	var config api.ReleaseBuildConfiguration
@@ -1125,7 +1125,7 @@ func findConfigForJob(jobName string, configs load.FilenameToConfig) (api.MultiS
 	return api.MultiStageTestConfiguration{}, fmt.Errorf("Could not find job %s. Job either does not exist or is not a multi stage test", jobName)
 }
 
-func jobHandler(regAgent load.RegistryAgent, confAgent load.ConfigAgent, w http.ResponseWriter, req *http.Request) {
+func jobHandler(regAgent agents.RegistryAgent, confAgent agents.ConfigAgent, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
@@ -1219,7 +1219,7 @@ func (j *Jobs) addJob(orgName, repoName, branchName, testName string) {
 }
 
 // getAllMultiStageTests return a map that has the config name in org-repo-branch format as the key and the test names for multi stage jobs as the value
-func getAllMultiStageTests(confAgent load.ConfigAgent, jobAgent *prowConfig.Agent) *Jobs {
+func getAllMultiStageTests(confAgent agents.ConfigAgent, jobAgent *prowConfig.Agent) *Jobs {
 	jobs := &Jobs{}
 	configs := confAgent.GetAll()
 	allRepos := jobAgent.Config().AllRepos
@@ -1254,7 +1254,7 @@ func getAllMultiStageTests(confAgent load.ConfigAgent, jobAgent *prowConfig.Agen
 	return jobs
 }
 
-func searchHandler(confAgent load.ConfigAgent, jobAgent *prowConfig.Agent, w http.ResponseWriter, req *http.Request) {
+func searchHandler(confAgent agents.ConfigAgent, jobAgent *prowConfig.Agent, w http.ResponseWriter, req *http.Request) {
 	start := time.Now()
 	defer func() { logrus.Infof("rendered in %s", time.Now().Sub(start)) }()
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")


### PR DESCRIPTION
Importing `pkg/load` resulted in the `init` function in `test-infra`'s
`pkg/utils/interrupts` being executed, accidentally changing signal
handling.