### PR TITLE
prowgen: temporarily rename private postsubmits

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -508,7 +508,16 @@ func generatePostsubmitForTest(name string, info *prowgenInfo, label jc.ProwgenL
 	if len(info.Variant) > 0 {
 		name = fmt.Sprintf("%s-%s", info.Variant, name)
 	}
-	base := generateJobBase(name, jobconfig.PostsubmitPrefix, info, label, podSpec, false, pathAlias)
+
+	prefix := jobconfig.PostsubmitPrefix
+	// TODO(petr-muller) Revert this after DPTP-823
+	// For the CVE effort we expect many builds to be broken for some time
+	// so we are changing the name to not be covered by the regexes that
+	// openshift org build cops are watching.
+	if info.config.Private {
+		prefix = "priv"
+	}
+	base := generateJobBase(name, prefix, info, label, podSpec, false, pathAlias)
 	return &prowconfig.Postsubmit{
 		JobBase:  base,
 		Brancher: prowconfig.Brancher{Branches: []string{makeBranchExplicit(info.Branch)}},

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
     hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-    name: branch-ci-private-duper-master-images
+    name: priv-ci-private-duper-master-images
     spec:
       containers:
       - args:


### PR DESCRIPTION
Revert this after DPTP-823

For the CVE effort we expect many builds to be broken for some time
so we are changing the name to not be covered by the regexes that
openshift org build cops are watching.

/cc @droslean 