### PR TITLE
Rehersals: Always report

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -156,6 +156,7 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 		rehearsal.Labels = make(map[string]string, 1)
 	}
 	rehearsal.Labels[rehearseLabel] = strconv.Itoa(prNumber)
+	rehearsal.SkipReport = false
 
 	return &rehearsal, nil
 }


### PR DESCRIPTION
It doesn't really make sense to execute the rehearsal job without reporting its status, but there are some cases where ppl might not want the original job to be reported (e.G. canary it out without getting ppl worried).

/assign @petr-muller 