### PR TITLE
Revert "ci-operator: check err when waiting for Pods to finish"

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -560,9 +560,6 @@ func waitForPodCompletion(podClient coreclientset.PodInterface, name string, not
 				case <-time.After(5 * time.Second):
 				}
 			}
-			if err != nil {
-				return err
-			}
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
Reverts openshift/ci-tools#480

Multiple tests without artifacts were reported:

- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/206/pull-ci-openshift-cluster-etcd-operator-master-e2e-azure/777
- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/206/pull-ci-openshift-cluster-etcd-operator-master-e2e-aws/888

Looking at executions before the change that is being reverted, artifact gathering takes a significantly long time:

- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/185/pull-ci-openshift-cluster-etcd-operator-master-e2e-azure/709#1:build-log.txt%3A1430
- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/190/pull-ci-openshift-cluster-etcd-operator-master-e2e-azure/721#1:build-log.txt%3A13783
- https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/175/pull-ci-openshift-cluster-etcd-operator-master-e2e-azure/729#1:build-log.txt%3A12128