### PR TITLE
Keep integr8ly-ansible-tower-configuration on default

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -204,7 +204,7 @@ var (
 		"integr8ly/integreatly-operator/.*",
 		"integr8ly/installation/.*",
 		"integr8ly/heimdall/.*",
-		"integr8ly/ansible-tower-configuration/.*",
+		//"integr8ly/ansible-tower-configuration/.*",
 		"fabric8-services/toolchain-operator/.*",
 		"openshift/csi-external-attacher/.*",
 		"openshift/cluster-api-provider-azure/.*",


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1582750095166700?thread_ts=1582739113.156800&cid=GB7NB0CUC

required by https://github.com/openshift/release/pull/7337

/cc @openshift/openshift-team-developer-productivity-test-platform

/assign @AlexNPavel