### PR TITLE
[ci-op-configs-mirror] Enable promotion

### DIFF
--- a/cmd/ci-op-configs-mirror/main.go
+++ b/cmd/ci-op-configs-mirror/main.go
@@ -135,7 +135,6 @@ func privateBaseImages(baseImages map[string]api.ImageStreamTagReference) {
 
 func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
 	if promotion.Namespace == ocpNamespace {
-		promotion.Disabled = true
 		promotion.Name = fmt.Sprintf("%s-priv", promotion.Name)
 		promotion.Namespace = privatePromotionNamespace
 	}

--- a/cmd/ci-op-configs-mirror/main_test.go
+++ b/cmd/ci-op-configs-mirror/main_test.go
@@ -159,7 +159,7 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 		{
 			id:        "changes expected",
 			promotion: &api.PromotionConfiguration{Name: "4.x", Namespace: "ocp"},
-			expected:  &api.PromotionConfiguration{Name: "4.x-priv", Namespace: "ocp-private", Disabled: true},
+			expected:  &api.PromotionConfiguration{Name: "4.x-priv", Namespace: "ocp-private"},
 		},
 	}
 	for _, tc := range testCases {

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
@@ -20,7 +20,6 @@ images:
 - from: base
   to: test-image
 promotion:
-  disabled: true
   name: other-priv
   namespace: ocp-private
 resources:

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -15,7 +15,6 @@ images:
 - from: base
   to: test-image
 promotion:
-  disabled: true
   name: other-priv
   namespace: ocp-private
 resources:


### PR DESCRIPTION
this PR removes the `disable: true` in the promotion configuration on the generated ci-operator configs for the private repositories.

/cc @petr-muller 