### PR TITLE
multi-stage: expose cluster profile location via env

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -25,6 +25,7 @@ const (
 	clusterProfileMountPath = "/var/run/secrets/ci.openshift.io/cluster-profile"
 	secretMountPath         = "/var/run/secrets/ci.openshift.io/multi-stage"
 	secretMountEnv          = "SHARED_DIR"
+	clusterProfileMountEnv  = "CLUSTER_PROFILE_DIR"
 )
 
 type multiStageTestStep struct {
@@ -340,10 +341,13 @@ func addProfile(name string, profile api.ClusterProfile, pod *coreapi.Pod) {
 		Name:      volumeName,
 		MountPath: clusterProfileMountPath,
 	})
-	container.Env = append(container.Env, coreapi.EnvVar{
+	container.Env = append(container.Env, []coreapi.EnvVar{{
 		Name:  "CLUSTER_TYPE",
 		Value: profile.ClusterType(),
-	})
+	}, {
+		Name:  clusterProfileMountEnv,
+		Value: clusterProfileMountPath,
+	}}...)
 }
 
 func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, shortCircuit bool) error {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -113,6 +113,7 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "JOB_NAME_SAFE", Value: "test"},
 		{Name: "JOB_NAME_HASH", Value: "5e8c9"},
 		{Name: "CLUSTER_TYPE", Value: "aws"},
+		{Name: "CLUSTER_PROFILE_DIR", Value: "/var/run/secrets/ci.openshift.io/cluster-profile"},
 		{Name: "KUBECONFIG", Value: "/var/run/secrets/ci.openshift.io/multi-stage/kubeconfig"},
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},


### PR DESCRIPTION
By not expecting users to refer to hard-coded paths we give ourselves
breathing room in case we need to change how things work under the
covers in the future as well as providing a more streamlined interface
between the infrastructure and the test step.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 