### PR TITLE
[ci-op-configs-mirror] Update only integration imagestreams to private ones

### DIFF
--- a/cmd/ci-op-configs-mirror/main.go
+++ b/cmd/ci-op-configs-mirror/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -87,6 +88,10 @@ func main() {
 			privateBaseImages(rbc.BaseImages)
 		}
 
+		if len(rbc.BaseRPMImages) > 0 {
+			privateBaseImages(rbc.BaseRPMImages)
+		}
+
 		if rbc.PromotionConfiguration != nil {
 			privatePromotionConfiguration(rbc.PromotionConfiguration)
 		}
@@ -125,7 +130,7 @@ func privateBuildRoot(buildRoot *api.BuildRootImageConfiguration) {
 
 func privateBaseImages(baseImages map[string]api.ImageStreamTagReference) {
 	for name, reference := range baseImages {
-		if reference.Namespace == ocpNamespace {
+		if reference.Namespace == ocpNamespace && isIntegrationImageStream(reference.Name) {
 			reference.Name = fmt.Sprintf("%s-priv", reference.Name)
 			reference.Namespace = privatePromotionNamespace
 			baseImages[name] = reference
@@ -143,4 +148,11 @@ func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
 
 func strP(str string) *string {
 	return &str
+}
+
+func isIntegrationImageStream(name string) bool {
+	if strings.HasPrefix(name, "4.") {
+		return true
+	}
+	return false
 }

--- a/cmd/ci-op-configs-mirror/main_test.go
+++ b/cmd/ci-op-configs-mirror/main_test.go
@@ -120,22 +120,24 @@ func TestPrivateBaseImages(t *testing.T) {
 			baseImages: map[string]api.ImageStreamTagReference{
 				"base": {Name: "origin-v4", Namespace: "openshift"},
 				"os":   {Name: "centos", Namespace: "ocp"},
+				"test": {Name: "4.3", Namespace: "ocp"},
 			},
 			expected: map[string]api.ImageStreamTagReference{
 				"base": {Name: "origin-v4", Namespace: "openshift"},
-				"os":   {Name: "centos-priv", Namespace: "ocp-private"},
+				"os":   {Name: "centos", Namespace: "ocp"},
+				"test": {Name: "4.3-priv", Namespace: "ocp-private"},
 			},
 		},
 
 		{
 			id: "massive changes",
 			baseImages: map[string]api.ImageStreamTagReference{
-				"base": {Name: "origin-v4", Namespace: "ocp"},
-				"os":   {Name: "centos", Namespace: "ocp"},
+				"base": {Name: "4.2", Namespace: "ocp"},
+				"os":   {Name: "4.3", Namespace: "ocp"},
 			},
 			expected: map[string]api.ImageStreamTagReference{
-				"base": {Name: "origin-v4-priv", Namespace: "ocp-private"},
-				"os":   {Name: "centos-priv", Namespace: "ocp-private"},
+				"base": {Name: "4.2-priv", Namespace: "ocp-private"},
+				"os":   {Name: "4.3-priv", Namespace: "ocp-private"},
 			},
 		},
 	}

--- a/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
@@ -6,8 +6,8 @@ base_images:
     tag: base
   os:
     cluster: https://api.ci.openshift.org
-    name: centos-priv
-    namespace: ocp-private
+    name: centos
+    namespace: ocp
     tag: os
 build_root:
   image_stream_tag:


### PR DESCRIPTION
/cc @petr-muller 

This PR adds an extra check to update only integration imagestreams instead. Also, update the `base_rpm_images` as well.