### PR TITLE
Revert "Keep presubmits openshift/release on default"

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -300,7 +300,7 @@ var (
 		"openshift/grafana/.*",
 		"openshift/library/.*",
 		"openshift/kubefed-operator/.*",
-		//"openshift/release/.*",
+		"openshift/release/.*",
 		"openshift/cluster-machine-approver/.*",
 		"openshift/source-to-image/.*",
 		"openshift/kube-rbac-proxy/.*",


### PR DESCRIPTION
This reverts commit f62fa40ded839b672ea84a22fb7cdb0e4435e362.

required by https://github.com/openshift/release/pull/7387

/cc @openshift/openshift-team-developer-productivity-test-platform

/hold

wait for jobs' rehearsals