### PR TITLE
Add cluster for base_rpm_images

### DIFF
--- a/cmd/config-migrator/main.go
+++ b/cmd/config-migrator/main.go
@@ -68,11 +68,17 @@ func generateMigratedConfigs(input config.DataWithInfo) []config.DataWithInfo {
 		return nil
 	}
 
-	var newBaseImages map[string]api.ImageStreamTagReference
-	for k, baseImage := range futureConfig.BaseImages {
-		if newBaseImages == nil {
-			newBaseImages = map[string]api.ImageStreamTagReference{}
+	newBaseRPMImages := map[string]api.ImageStreamTagReference{}
+	for k, baseRPMImage := range futureConfig.BaseRPMImages {
+		if baseRPMImage.Cluster == "" {
+			baseRPMImage.Cluster = prowClusterURL
 		}
+		newBaseRPMImages[k] = baseRPMImage
+	}
+	futureConfig.BaseRPMImages = newBaseRPMImages
+
+	newBaseImages := map[string]api.ImageStreamTagReference{}
+	for k, baseImage := range futureConfig.BaseImages {
 		if baseImage.Cluster == "" {
 			baseImage.Cluster = prowClusterURL
 		}


### PR DESCRIPTION
This PR is used to generate https://github.com/openshift/release/pull/7415

/cc @openshift/openshift-team-developer-productivity-test-platform 

We missed the case base_rpm_images before.