### PR TITLE
ci-operator: make pod functions interruptible

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -397,7 +397,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	if _, err := createOrRestartPod(s.podClient.Pods(s.jobSpec.Namespace), pod); err != nil {
 		return fmt.Errorf("failed to create or restart %q pod: %v", pod.Name, err)
 	}
-	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier, false); err != nil {
+	if err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace), pod.Name, notifier, false); err != nil {
 		return fmt.Errorf("%q pod %q failed: %v", s.name, pod.Name, err)
 	}
 	s.subTests = append(s.subTests, notifier.SubTests(fmt.Sprintf("%s - %s ", s.Description(), pod.Name))...)

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -109,7 +109,7 @@ func (s *podStep) Run(ctx context.Context, dry bool) error {
 		s.subTests = testCaseNotifier.SubTests(s.Description() + " - ")
 	}()
 
-	if err := waitForPodCompletion(s.podClient.Pods(s.jobSpec.Namespace), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
+	if err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
 		return fmt.Errorf("%s %q failed: %v", s.name, pod.Name, err)
 	}
 	return nil
@@ -282,10 +282,10 @@ func getSecretVolumeMountFromSecret(secretMountPath string) []coreapi.VolumeMoun
 // PodStep and is intended for other steps that may need to run transient actions.
 // This pod will not be able to gather artifacts, nor will it report log messages
 // unless it fails.
-func RunPod(podClient PodClient, pod *coreapi.Pod) error {
+func RunPod(ctx context.Context, podClient PodClient, pod *coreapi.Pod) error {
 	pod, err := createOrRestartPod(podClient.Pods(pod.Namespace), pod)
 	if err != nil {
 		return err
 	}
-	return waitForPodCompletion(podClient.Pods(pod.Namespace), pod.Name, nil, true)
+	return waitForPodCompletion(ctx, podClient.Pods(pod.Namespace), pod.Name, nil, true)
 }

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -349,7 +349,7 @@ func (s *assembleReleaseStep) importFromReleaseImage(ctx context.Context, dry bo
 	// get the CLI image from the payload (since we need it to run oc adm release extract)
 	target := fmt.Sprintf("release-images-%s", tag)
 	targetCLI := fmt.Sprintf("%s-cli", target)
-	if err := steps.RunPod(s.podClient, &coreapi.Pod{
+	if err := steps.RunPod(context.TODO(), s.podClient, &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      targetCLI,
 			Namespace: s.jobSpec.Namespace,


### PR DESCRIPTION
/hold

I would like to monitor jobs when this is merged.