### PR TITLE
add secret keys for git source strategy builds

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1470,9 +1470,13 @@ func getCloneSecretFromPath(cloneAuthType steps.CloneAuthType, secretPath string
 		// https://github.com/kubernetes/api/blob/master/core/v1/types.go#L5466-L5470
 		secret.Data[coreapi.SSHAuthPrivateKey] = data
 	} else if cloneAuthType == steps.CloneAuthTypeOAuth {
-		secret.Type = coreapi.SecretTypeOpaque
+		secret.Type = coreapi.SecretTypeBasicAuth
 		secret.Name = fmt.Sprintf("oauth-%s", hash)
 		secret.Data[steps.OauthSecretKey] = data
+
+		// Those keys will be used in a git source strategy build
+		secret.Data["username"] = data
+		secret.Data["password"] = data
 	}
 
 	return secret, nil


### PR DESCRIPTION
@petr-muller 

When we use an `OAuth` token authentication,  we want the same secret to being used if there is a git source strategy build. (e.x `build_root.project_image)

Note: Having the secret as `BasicAuth` type doesn't break anything.