### PR TITLE
Reintegrate nested virt enablement into custom-test-image template

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -291,11 +292,6 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 		needsLeaseServer = true
 		clusterProfile = conf.ClusterProfile
 		testImageStreamTag = conf.From
-	} else if conf := test.OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration; conf != nil {
-		template = "cluster-launch-installer-gcp-nested-virt-custom-test-image"
-		needsLeaseServer = true
-		clusterProfile = conf.ClusterProfile
-		testImageStreamTag = conf.From
 	}
 	var targetCloud string
 	switch clusterProfile {
@@ -409,6 +405,12 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 				Value: conf.PreviousRPMDeps},
 			kubeapi.EnvVar{Name: "PREVIOUS_RPM_REPO",
 				Value: fmt.Sprintf("https://rpms.svc.ci.openshift.org/openshift-origin-v%s/", conf.PreviousVersion)})
+	}
+	if conf := test.OpenshiftInstallerCustomTestImageClusterTestConfiguration; conf != nil {
+		container.Env = append(
+			container.Env,
+			kubeapi.EnvVar{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: strconv.FormatBool(conf.EnableNestedVirt)},
+			kubeapi.EnvVar{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: conf.NestedVirtImage})
 	}
 	return podSpec
 }

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -407,10 +407,16 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 				Value: fmt.Sprintf("https://rpms.svc.ci.openshift.org/openshift-origin-v%s/", conf.PreviousVersion)})
 	}
 	if conf := test.OpenshiftInstallerCustomTestImageClusterTestConfiguration; conf != nil {
-		container.Env = append(
-			container.Env,
-			kubeapi.EnvVar{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: strconv.FormatBool(conf.EnableNestedVirt)},
-			kubeapi.EnvVar{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: conf.NestedVirtImage})
+		if conf.EnableNestedVirt {
+			container.Env = append(
+				container.Env,
+				kubeapi.EnvVar{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: strconv.FormatBool(conf.EnableNestedVirt)})
+			if conf.NestedVirtImage != "" {
+				container.Env = append(
+					container.Env,
+					kubeapi.EnvVar{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: conf.NestedVirtImage})
+			}
+		}
 	}
 	return podSpec
 }

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -748,8 +748,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
-					NestedVirtImage:          "nested-virt-image-name",
 					EnableNestedVirt:         true,
+					NestedVirtImage:          "nested-virt-image-name",
 				},
 			},
 
@@ -877,6 +877,133 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
+					EnableNestedVirt:         true,
+				},
+			},
+
+			expected: &kubeapi.PodSpec{
+				ServiceAccountName: "ci-operator",
+				Volumes: []kubeapi.Volume{
+					{
+						Name: "sentry-dsn",
+						VolumeSource: kubeapi.VolumeSource{
+							Secret: &kubeapi.SecretVolumeSource{SecretName: "sentry-dsn"},
+						},
+					},
+					{
+						Name: "apici-ci-operator-credentials",
+						VolumeSource: kubeapi.VolumeSource{
+							Secret: &kubeapi.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []kubeapi.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
+						},
+					},
+					{
+						Name: "pull-secret",
+						VolumeSource: kubeapi.VolumeSource{
+							Secret: &kubeapi.SecretVolumeSource{SecretName: "regcred"},
+						},
+					},
+					{
+						Name: "job-definition",
+						VolumeSource: kubeapi.VolumeSource{
+							ConfigMap: &kubeapi.ConfigMapVolumeSource{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "prow-job-cluster-launch-installer-custom-test-image",
+								},
+							},
+						},
+					},
+					{
+						Name: "cluster-profile",
+						VolumeSource: kubeapi.VolumeSource{
+							Projected: &kubeapi.ProjectedVolumeSource{
+								Sources: []kubeapi.VolumeProjection{
+									{
+										Secret: &kubeapi.SecretProjection{
+											LocalObjectReference: kubeapi.LocalObjectReference{
+												Name: "cluster-secrets-gcp",
+											},
+										},
+									},
+									{
+										ConfigMap: &kubeapi.ConfigMapProjection{
+											LocalObjectReference: kubeapi.LocalObjectReference{
+												Name: "cluster-profile-gcp",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Name: "boskos",
+						VolumeSource: kubeapi.VolumeSource{
+							Secret: &kubeapi.SecretVolumeSource{SecretName: "boskos-credentials", Items: []kubeapi.KeyToPath{{Key: "password", Path: "password"}}},
+						},
+					},
+				},
+				Containers: []kubeapi.Container{{
+					Image:           "ci-operator:latest",
+					ImagePullPolicy: kubeapi.PullAlways,
+					Command:         []string{"ci-operator"},
+					Args: []string{
+						"--give-pr-author-access-to-namespace=true",
+						"--artifact-dir=$(ARTIFACTS)",
+						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
+						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
+						"--org=organization",
+						"--repo=repo",
+						"--branch=branch",
+						"--kubeconfig=/etc/apici/kubeconfig",
+						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
+						"--target=test",
+						"--secret-dir=/usr/local/test-cluster-profile",
+						"--template=/usr/local/test",
+						"--lease-server=https://boskos-ci.svc.ci.openshift.org",
+						"--lease-server-username=ci",
+						"--lease-server-password-file=/etc/boskos/password",
+					},
+					Resources: kubeapi.ResourceRequirements{
+						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
+					},
+					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
+						{Name: "CLUSTER_TYPE", Value: "gcp"},
+						{Name: "JOB_NAME_SAFE", Value: "test"},
+						{Name: "TEST_COMMAND", Value: "commands"},
+						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
+						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "true"},
+					},
+					VolumeMounts: []kubeapi.VolumeMount{
+						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
+						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
+						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
+						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
+						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
+						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-custom-test-image.yaml"},
+					},
+				}},
+			},
+		},
+		{
+			info:    &prowgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			release: "origin-v4.0",
+			test: ciop.TestStepConfiguration{
+				As:       "test",
+				Commands: "commands",
+				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
+					From:                     "pipeline:kubevirt-test",
 					NestedVirtImage:          "",
 					EnableNestedVirt:         false,
 				},
@@ -983,8 +1110,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "false"},
-						{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: ""},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
@@ -1110,8 +1235,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "false"},
-						{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: ""},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -340,10 +340,6 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
 	}
-	if testConfig := test.OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration; testConfig != nil {
-		typeCount++
-		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
-	}
 	if testConfig := test.MultiStageTestConfiguration; testConfig != nil {
 		if resolved {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: non-literal test found in fully-resolved configuration", fieldRoot))

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -343,22 +343,21 @@ type TestStepConfiguration struct {
 	Cron *string `json:"cron,omitempty"`
 
 	// Only one of the following can be not-null.
-	ContainerTestConfiguration                                             *ContainerTestConfiguration                                             `json:"container,omitempty"`
-	MultiStageTestConfiguration                                            *MultiStageTestConfiguration                                            `json:"steps,omitempty"`
-	MultiStageTestConfigurationLiteral                                     *MultiStageTestConfigurationLiteral                                     `json:"literal_steps,omitempty"`
-	OpenshiftAnsibleClusterTestConfiguration                               *OpenshiftAnsibleClusterTestConfiguration                               `json:"openshift_ansible,omitempty"`
-	OpenshiftAnsibleSrcClusterTestConfiguration                            *OpenshiftAnsibleSrcClusterTestConfiguration                            `json:"openshift_ansible_src,omitempty"`
-	OpenshiftAnsibleCustomClusterTestConfiguration                         *OpenshiftAnsibleCustomClusterTestConfiguration                         `json:"openshift_ansible_custom,omitempty"`
-	OpenshiftAnsible40ClusterTestConfiguration                             *OpenshiftAnsible40ClusterTestConfiguration                             `json:"openshift_ansible_40,omitempty"`
-	OpenshiftAnsibleUpgradeClusterTestConfiguration                        *OpenshiftAnsibleUpgradeClusterTestConfiguration                        `json:"openshift_ansible_upgrade,omitempty"`
-	OpenshiftInstallerClusterTestConfiguration                             *OpenshiftInstallerClusterTestConfiguration                             `json:"openshift_installer,omitempty"`
-	OpenshiftInstallerSrcClusterTestConfiguration                          *OpenshiftInstallerSrcClusterTestConfiguration                          `json:"openshift_installer_src,omitempty"`
-	OpenshiftInstallerUPIClusterTestConfiguration                          *OpenshiftInstallerUPIClusterTestConfiguration                          `json:"openshift_installer_upi,omitempty"`
-	OpenshiftInstallerUPISrcClusterTestConfiguration                       *OpenshiftInstallerUPISrcClusterTestConfiguration                       `json:"openshift_installer_upi_src,omitempty"`
-	OpenshiftInstallerConsoleClusterTestConfiguration                      *OpenshiftInstallerConsoleClusterTestConfiguration                      `json:"openshift_installer_console,omitempty"`
-	OpenshiftInstallerRandomClusterTestConfiguration                       *OpenshiftInstallerRandomClusterTestConfiguration                       `json:"openshift_installer_random,omitempty"`
-	OpenshiftInstallerCustomTestImageClusterTestConfiguration              *OpenshiftInstallerCustomTestImageClusterTestConfiguration              `json:"openshift_installer_custom_test_image,omitempty"`
-	OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration *OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration `json:"openshift_installer_gcp_nested_virt_custom_test_image,omitempty"`
+	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
+	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`
+	MultiStageTestConfigurationLiteral                        *MultiStageTestConfigurationLiteral                        `json:"literal_steps,omitempty"`
+	OpenshiftAnsibleClusterTestConfiguration                  *OpenshiftAnsibleClusterTestConfiguration                  `json:"openshift_ansible,omitempty"`
+	OpenshiftAnsibleSrcClusterTestConfiguration               *OpenshiftAnsibleSrcClusterTestConfiguration               `json:"openshift_ansible_src,omitempty"`
+	OpenshiftAnsibleCustomClusterTestConfiguration            *OpenshiftAnsibleCustomClusterTestConfiguration            `json:"openshift_ansible_custom,omitempty"`
+	OpenshiftAnsible40ClusterTestConfiguration                *OpenshiftAnsible40ClusterTestConfiguration                `json:"openshift_ansible_40,omitempty"`
+	OpenshiftAnsibleUpgradeClusterTestConfiguration           *OpenshiftAnsibleUpgradeClusterTestConfiguration           `json:"openshift_ansible_upgrade,omitempty"`
+	OpenshiftInstallerClusterTestConfiguration                *OpenshiftInstallerClusterTestConfiguration                `json:"openshift_installer,omitempty"`
+	OpenshiftInstallerSrcClusterTestConfiguration             *OpenshiftInstallerSrcClusterTestConfiguration             `json:"openshift_installer_src,omitempty"`
+	OpenshiftInstallerUPIClusterTestConfiguration             *OpenshiftInstallerUPIClusterTestConfiguration             `json:"openshift_installer_upi,omitempty"`
+	OpenshiftInstallerUPISrcClusterTestConfiguration          *OpenshiftInstallerUPISrcClusterTestConfiguration          `json:"openshift_installer_upi_src,omitempty"`
+	OpenshiftInstallerConsoleClusterTestConfiguration         *OpenshiftInstallerConsoleClusterTestConfiguration         `json:"openshift_installer_console,omitempty"`
+	OpenshiftInstallerRandomClusterTestConfiguration          *OpenshiftInstallerRandomClusterTestConfiguration          `json:"openshift_installer_random,omitempty"`
+	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
 }
 
 // RegistryReferenceConfig is the struct that step references are unmarshalled into.
@@ -729,7 +728,9 @@ type OpenshiftInstallerCustomTestImageClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 	// From defines the imagestreamtag that will be used to run the
 	// provided test command.  e.g. stable:console-test
-	From string `json:"from"`
+	From             string `json:"from"`
+	EnableNestedVirt bool   `json:"enable_nested_virt,omitempty"`
+	NestedVirtImage  string `json:"nested_virt_image"`
 }
 
 // OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration describes a


### PR DESCRIPTION
We add two variables:
* bool switch for enable-nested-virt on/off
* nested-virt custom image

Prerequisite for openshift/release#7457

/cc @davidvossel @sallyom 