### PR TITLE
test/pj-rehearse: fix an incorrect job

### DIFF
--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
 - agent: kubernetes
   decorate: true
   extra_refs:
-  - base_ref: master
+  - base_ref: ciop-cfg-change
     org: super
     repo: duper
   interval: 24h
@@ -59,7 +59,7 @@ periodics:
 - agent: kubernetes
   decorate: true
   extra_refs:
-  - base_ref: master
+  - base_ref: ciop-cfg-change
     org: super
     repo: duper
   interval: 24h

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -179,7 +179,7 @@
         initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
         sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
     extra_refs:
-    - base_ref: master
+    - base_ref: ciop-cfg-change
       org: super
       repo: duper
       workdir: true
@@ -308,7 +308,7 @@
         initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
         sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
     extra_refs:
-    - base_ref: master
+    - base_ref: ciop-cfg-change
       org: super
       repo: duper
       workdir: true
@@ -618,7 +618,7 @@
   spec:
     agent: kubernetes
     cluster: default
-    context: ci/rehearse/openshift/origin/cluster-profile/test-profile
+    context: ci/rehearse/super/duper/cluster-profile/test-profile
     decoration_config:
       gcs_configuration:
         bucket: origin-ci-test
@@ -636,8 +636,8 @@
         sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
     extra_refs:
     - base_ref: cluster-profile
-      org: openshift
-      repo: origin
+      org: super
+      repo: duper
       workdir: true
     job: rehearse-1234-pull-ci-super-duper-cluster-profile-test-profile
     namespace: test-namespace
@@ -655,10 +655,32 @@
         - name: CLUSTER_TYPE
           value: gcp
         - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-test-profile.yaml
-              name: ci-operator-configs
+          value: |
+            base_images:
+              base:
+                cluster: https://api.ci.openshift.org
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                cluster: https://api.ci.openshift.org
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            images:
+            - from: base
+              to: test-image
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              cluster: https://api.ci.openshift.org
+              name: origin-v4.0
+              namespace: openshift
         - name: JOB_NAME_SAFE
           value: test-profile
         - name: TEST_COMMAND

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-cluster-profile.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-cluster-profile.yaml
@@ -1,0 +1,26 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+images:
+- from: base
+  to: test-image
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+  tag: ''
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -1,5 +1,5 @@
 presubmits:
-  openshift/origin:
+  super/duper:
   - agent: kubernetes
     always_run: false
     branches:
@@ -28,8 +28,8 @@ presubmits:
         - name: CONFIG_SPEC
           valueFrom:
             configMapKeyRef:
-              key: super-duper-test-profile.yaml
-              name: ci-operator-configs
+              key: super-duper-cluster-profile.yaml
+              name: ci-operator-misc-configs
         - name: JOB_NAME_SAFE
           value: test-profile
         - name: TEST_COMMAND


### PR DESCRIPTION
This PR fixes a job in the `pj-rehearse` integration tests that was incorrect. It was using the outdated and unused `ci-operator-configs` configmap, which our `IsCiOpConfigCM` regex did not match against. This resulted in `CONFIG_SPEC` not being inlined. This has been changed to the `ci-operator-misc-configs` configmap, which is used when a configmap is not a master or release branch config.

The job was also referencing a non-existent `ci-operator` config which would cause the `pj-rehearse` to fail and had `openshift/origin` as the org-repo instead of `super/duper`. This has also been fixed.

/cc @openshift/openshift-team-developer-productivity-test-platform 