### PR TITLE
prowgen,pj-rehearse: do not add CONFIG_SPEC to generated jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	prowJobLabelVariant = "ci-operator.openshift.io/variant"
-
 	sentryDsnMountName  = "sentry-dsn"
 	sentryDsnSecretName = "sentry-dsn"
 	sentryDsnMountPath  = "/etc/sentry-dsn"
@@ -94,14 +92,6 @@ func (o *options) process() error {
 // Various pieces are derived from `org`, `repo`, `branch` and `target`.
 // `additionalArgs` are passed as additional arguments to `ci-operator`
 func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeapi.PodSpec {
-	configMapKeyRef := kubeapi.EnvVarSource{
-		ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-			LocalObjectReference: kubeapi.LocalObjectReference{
-				Name: info.ConfigMapName(),
-			},
-			Key: info.Basename(),
-		},
-	}
 	volumeMounts := []kubeapi.VolumeMount{
 		{
 			Name:      sentryDsnMountName,
@@ -185,7 +175,6 @@ func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeap
 			{
 				Image:           "ci-operator:latest",
 				ImagePullPolicy: kubeapi.PullAlways,
-				Env:             []kubeapi.EnvVar{{Name: "CONFIG_SPEC", ValueFrom: &configMapKeyRef}},
 				Resources: kubeapi.ResourceRequirements{
 					Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 				},
@@ -476,7 +465,7 @@ func generateJobBase(name, prefix string, info *prowgenInfo, label jc.ProwgenLab
 
 	jobName := info.Info.JobName(prefix, name)
 	if len(info.Variant) > 0 {
-		labels[prowJobLabelVariant] = info.Variant
+		labels[jc.ProwJobLabelVariant] = info.Variant
 	}
 	newTrue := true
 	dc := &v1.DecorationConfig{SkipCloning: &newTrue}

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"io/ioutil"
 	"log"
 	"os"
@@ -13,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	kubeapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,7 +21,6 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	ciop "github.com/openshift/ci-tools/pkg/api"
-
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
@@ -64,17 +63,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -130,17 +118,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -196,17 +173,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
@@ -271,17 +237,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -337,17 +292,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						Resources: kubeapi.ResourceRequirements{
 							Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 						},
-						Env: []kubeapi.EnvVar{{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "org-repo-branch.yaml",
-								},
-							},
-						}},
 						VolumeMounts: []kubeapi.VolumeMount{
 							{
 								Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true,
@@ -498,17 +442,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -614,17 +547,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "aws"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -715,19 +637,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
@@ -839,17 +748,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -967,17 +865,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1095,17 +982,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1220,17 +1096,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1719,12 +1584,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1786,12 +1645,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1854,12 +1707,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1919,12 +1766,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1987,12 +1828,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2083,12 +1918,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2129,12 +1958,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2199,12 +2022,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2266,12 +2083,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2336,12 +2147,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2391,12 +2196,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2431,12 +2230,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2524,12 +2317,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2568,12 +2355,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2636,12 +2417,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2701,12 +2476,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2769,12 +2538,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2822,12 +2585,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2860,12 +2617,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -23,6 +23,7 @@ type ProwgenLabel string
 const (
 	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
 	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
+	ProwJobLabelVariant                = "ci-operator.openshift.io/variant"
 	Generated             ProwgenLabel = "true"
 	New                   ProwgenLabel = "newly-generated"
 	PresubmitPrefix                    = "pull"

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -104,6 +104,11 @@ func CompletePrimaryRefs(refs pjapi.Refs, jb prowconfig.JobBase) *pjapi.Refs {
 	return &refs
 }
 
+func getTrimmedBranch(branches []string) string {
+	return strings.TrimPrefix(strings.TrimSuffix(branches[0], "$"), "^")
+
+}
+
 func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber int, refs *pjapi.Refs) (*prowconfig.Presubmit, error) {
 	var rehearsal prowconfig.Presubmit
 	deepcopy.Copy(&rehearsal, source)
@@ -114,7 +119,7 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	var context string
 
 	if len(source.Branches) > 0 {
-		branch = strings.TrimPrefix(strings.TrimSuffix(source.Branches[0], "$"), "^")
+		branch = getTrimmedBranch(source.Branches)
 		if len(repo) > 0 {
 			orgRepo := strings.Split(repo, "/")
 			jobOrg := orgRepo[0]
@@ -228,9 +233,14 @@ func hasRehearsableLabel(labels map[string]string) bool {
 // of the needed config file passed to the job as a direct value. This needs
 // to happen because the rehearsed Prow jobs may depend on these config files
 // being also changed by the tested PR.
-func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, resolver registry.Resolver, loggers Loggers) error {
+func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, resolver registry.Resolver, info config.Info, loggers Loggers) error {
+	configSpecSet := false
+	// replace all ConfigMapKeyRef mounts with inline config maps
 	for index := range container.Env {
 		env := &(container.Env[index])
+		if env.Name == "CONFIG_SPEC" {
+			configSpecSet = true
+		}
 		if env.ValueFrom == nil {
 			continue
 		}
@@ -260,6 +270,38 @@ func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, res
 			env.Value = string(ciOpConfigContent)
 			env.ValueFrom = nil
 		}
+	}
+	// if CONFIG_SPEC has already been set, do not add new CONFIG_SPEC section
+	if configSpecSet {
+		return nil
+	}
+	// inline CONFIG_SPEC for all ci-operator jobs
+	if container.Command != nil && container.Command[0] == "ci-operator" {
+		filename := info.Basename()
+		loggers.Debug.WithField(logCiopConfigFile, filename).Debug("Rehearsal job uses ci-operator config ConfigMap, needed content will be inlined")
+		ciopConfig, ok := ciopConfigs[filename]
+		if !ok {
+			return fmt.Errorf("ci-operator config file %s was not found", filename)
+		}
+		ciopConfigResolved, err := registry.ResolveConfig(resolver, ciopConfig.Configuration)
+		if err != nil {
+			loggers.Job.WithError(err).Error("Failed resolve ReleaseBuildConfiguration")
+			return err
+		}
+
+		ciOpConfigContent, err := yaml.Marshal(ciopConfigResolved)
+		if err != nil {
+			loggers.Job.WithError(err).Error("Failed to marshal ci-operator config file")
+			return err
+		}
+
+		envs := container.Env
+		env := v1.EnvVar{
+			Name:  "CONFIG_SPEC",
+			Value: string(ciOpConfigContent),
+		}
+		envs = append(envs, env)
+		container.Env = envs
 	}
 	return nil
 }
@@ -296,6 +338,14 @@ func fillTemplateMap(templates []config.ConfigMapSource) map[string]string {
 	return templateMap
 }
 
+func variantFromLabels(labels map[string]string) string {
+	variant := ""
+	if variantLabel, ok := labels[jobconfig.ProwJobLabelVariant]; ok {
+		variant = variantLabel
+	}
+	return variant
+}
+
 // ConfigurePeriodicRehearsals adds the required configuration for the periodics to be rehearsed.
 func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics) []prowconfig.Periodic {
 	var rehearsals []prowconfig.Periodic
@@ -303,7 +353,15 @@ func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics)
 	filteredPeriodics := filterPeriodics(periodics, jc.loggers.Job)
 	for _, job := range filteredPeriodics {
 		jobLogger := jc.loggers.Job.WithField("target-job", job.Name)
-		if err := jc.configureJobSpec(job.Spec, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+		info := config.Info{
+			Variant: variantFromLabels(job.Labels),
+		}
+		if len(job.ExtraRefs) != 0 {
+			info.Org = job.ExtraRefs[0].Org
+			info.Repo = job.ExtraRefs[0].Repo
+			info.Branch = job.ExtraRefs[0].BaseRef
+		}
+		if err := jc.configureJobSpec(job.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 			jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal periodic job")
 			continue
 		}
@@ -320,16 +378,27 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 	var rehearsals []*prowconfig.Presubmit
 
 	presubmitsFiltered := filterPresubmits(presubmits, jc.loggers.Job)
-	for repo, jobs := range presubmitsFiltered {
+	for orgrepo, jobs := range presubmitsFiltered {
 		for _, job := range jobs {
-			jobLogger := jc.loggers.Job.WithFields(logrus.Fields{"target-repo": repo, "target-job": job.Name})
-			rehearsal, err := makeRehearsalPresubmit(&job, repo, jc.prNumber, jc.refs)
+			jobLogger := jc.loggers.Job.WithFields(logrus.Fields{"target-repo": orgrepo, "target-job": job.Name})
+			rehearsal, err := makeRehearsalPresubmit(&job, orgrepo, jc.prNumber, jc.refs)
 			if err != nil {
 				jobLogger.WithError(err).Warn("Failed to make a rehearsal presubmit")
 				continue
 			}
 
-			if err := jc.configureJobSpec(rehearsal.Spec, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+			splitOrgRepo := strings.Split(orgrepo, "/")
+			if len(splitOrgRepo) != 2 {
+				jobLogger.WithError(fmt.Errorf("failed to identify org and repo from string %s", orgrepo)).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
+			}
+			info := config.Info{
+				Org:     splitOrgRepo[0],
+				Repo:    splitOrgRepo[1],
+				Branch:  getTrimmedBranch(job.Branches),
+				Variant: variantFromLabels(job.Labels),
+			}
+
+			if err := jc.configureJobSpec(rehearsal.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 				jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
 				continue
 			}
@@ -341,8 +410,8 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 	return rehearsals
 }
 
-func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, logger *logrus.Entry) error {
-	if err := inlineCiOpConfig(spec.Containers[0], jc.ciopConfigs, jc.registryResolver, jc.loggers); err != nil {
+func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, info config.Info, logger *logrus.Entry) error {
+	if err := inlineCiOpConfig(spec.Containers[0], jc.ciopConfigs, jc.registryResolver, info, jc.loggers); err != nil {
 		return err
 	}
 	// Remove configresolver flags from ci-operator jobs

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -30,12 +30,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-org-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -106,12 +100,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-org-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -34,11 +34,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: private-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -27,12 +27,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -35,11 +35,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -129,12 +124,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -206,12 +195,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -279,12 +262,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -355,12 +332,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=test
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: subdir-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=test
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: subdir-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -32,11 +32,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: aws
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-aws-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -119,11 +114,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -25,12 +25,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -95,12 +89,6 @@ postsubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -33,11 +33,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -123,12 +118,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -192,12 +181,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -267,12 +250,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -335,12 +312,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -400,12 +371,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -468,12 +433,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -537,12 +496,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -609,12 +562,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -677,12 +624,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -748,12 +689,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -26,12 +26,6 @@ postsubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -29,12 +29,6 @@ presubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -98,12 +92,6 @@ presubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -173,12 +161,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -241,12 +223,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -306,12 +282,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -374,12 +344,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -25,12 +25,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -161,12 +149,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -229,12 +211,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -26,12 +26,6 @@ postsubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -30,12 +30,6 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -100,12 +94,6 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -165,12 +153,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -233,12 +215,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -29,12 +29,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-other-nonstandard.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -98,12 +92,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-other-nonstandard.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -169,11 +157,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: TEST_COMMAND
@@ -267,11 +250,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -357,12 +335,6 @@ presubmits:
         - --target=race
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -425,12 +397,6 @@ presubmits:
         - --target=race
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -490,12 +456,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -558,12 +518,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
This PR removes generation of the `CONFIG_SPEC` env var from `ci-operator-prowgen`. It also updates `pj-rehearse` to not depend on `CONFIG_SPEC` being set and instead use other methods of determining what config file needs to be inlined.

/cc @openshift/openshift-team-developer-productivity-test-platform 