### PR TITLE
Private prow configs mirroring tool

### DIFF
--- a/cmd/private-prow-configs-mirror/README.md
+++ b/cmd/private-prow-configs-mirror/README.md
@@ -1,0 +1,25 @@
+# Private Prow Configs Mirror
+
+The purpose of this tool is to generate the prow's configuration for the repositories of the `openshift-priv`
+organization. 
+
+It walks through all the ci-operator configuration files to get the information of which repositories are promoting
+official images.
+When a configuration is detected, the tool generates the configuration for the corresponding repository of the `openshift-priv` organization instead.
+
+The following components of the configs will be affected:
+
+### Prow Config
+* branch-protection
+* context_options
+* tide.merge_method
+* tide.queries
+* tide.pr_status_base_urls
+* plank.default_decoration_configs
+* plank.job_url_prefix_config
+
+### Prow Plugins
+* approve
+* lgtm
+* plugins
+* bugzilla

--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -1,0 +1,436 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/plugins"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/promotion"
+)
+
+const (
+	openshiftPrivOrg = "openshift-priv"
+)
+
+type options struct {
+	releaseRepoPath string
+}
+
+type orgReposWithOfficialImages map[string]sets.String
+
+func (o orgReposWithOfficialImages) isOfficialRepo(org, repo string) bool {
+	if _, ok := o[org]; ok {
+		if o[org].Has(repo) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *orgReposWithOfficialImages) isOfficialRepoFull(orgRepo string) bool {
+	if orgRepoList := strings.Split(orgRepo, "/"); len(orgRepoList) == 2 {
+		return o.isOfficialRepo(orgRepoList[0], orgRepoList[1])
+	}
+	return false
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.releaseRepoPath, "release-repo-path", "", "Path to a openshift/release repository directory")
+	fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o *options) validate() error {
+	if len(o.releaseRepoPath) == 0 {
+		return errors.New("--release-repo-path is not defined")
+	}
+	return nil
+}
+
+func loadProwPlugins(pluginsPath string) (*plugins.Configuration, error) {
+	agent := plugins.ConfigAgent{}
+	if err := agent.Load(pluginsPath, false); err != nil {
+		return nil, err
+	}
+	return agent.Config(), nil
+}
+
+func updateProwConfig(configFile string, config prowconfig.ProwConfig) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("could not marshal Prow configuration: %v", err)
+	}
+
+	return ioutil.WriteFile(configFile, data, 0644)
+}
+
+func updateProwPlugins(pluginsFile string, config *plugins.Configuration) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("could not marshal Prow configuration: %v", err)
+	}
+
+	return ioutil.WriteFile(pluginsFile, data, 0644)
+}
+
+func privateOrgRepo(repo string) string {
+	return fmt.Sprintf("%s/%s", openshiftPrivOrg, repo)
+}
+
+func getOrgReposWithOfficialImages(releaseRepoPath string) (orgReposWithOfficialImages, error) {
+	ret := make(orgReposWithOfficialImages)
+
+	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
+		if !promotion.BuildsOfficialImages(c) {
+			return nil
+		}
+
+		if _, ok := ret[i.Org]; !ok {
+			ret[i.Org] = sets.NewString(i.Repo)
+		} else {
+			ret[i.Org].Insert(i.Repo)
+		}
+
+		return nil
+	}
+
+	if err := config.OperateOnCIOperatorConfigDir(filepath.Join(releaseRepoPath, config.CiopConfigInRepoPath), callback); err != nil {
+		return ret, fmt.Errorf("error while operating in ci-operator configuration files: %v", err)
+	}
+
+	return ret, nil
+}
+
+func injectPrivateBranchProtection(branchProtection prowconfig.BranchProtection, orgRepos orgReposWithOfficialImages) {
+	privateOrg := prowconfig.Org{
+		Repos: make(map[string]prowconfig.Repo),
+	}
+
+	logrus.Info("Processing...")
+	for orgName, orgValue := range branchProtection.Orgs {
+		for repoName, repoValue := range orgValue.Repos {
+			if orgRepos.isOfficialRepo(orgName, repoName) {
+				logrus.WithField("repo", repoName).Info("Found")
+				privateOrg.Repos[repoName] = repoValue
+			}
+		}
+
+	}
+
+	if len(privateOrg.Repos) > 0 {
+		branchProtection.Orgs[openshiftPrivOrg] = privateOrg
+	}
+}
+
+func injectPrivateTideOrgContextPolicy(contextOptions prowconfig.TideContextPolicyOptions, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+	privateOrgRepos := make(map[string]prowconfig.TideRepoContextPolicy)
+
+	for orgName, orgValue := range contextOptions.Orgs {
+		for repoName, repoValue := range orgValue.Repos {
+			if orgRepos.isOfficialRepo(orgName, repoName) {
+				logrus.WithField("repo", repoName).Info("Found")
+				privateOrgRepos[repoName] = repoValue
+			}
+		}
+	}
+
+	if len(privateOrgRepos) > 0 {
+		contextOptions.Orgs[openshiftPrivOrg] = prowconfig.TideOrgContextPolicy{Repos: privateOrgRepos}
+	}
+}
+
+func injectPrivateReposTideQueries(tideQueries []prowconfig.TideQuery, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for index, tideQuery := range tideQueries {
+		repos := sets.NewString(tideQuery.Repos...)
+
+		for _, orgRepo := range tideQuery.Repos {
+			if orgRepos.isOfficialRepoFull(orgRepo) {
+				repo := strings.Split(orgRepo, "/")[1]
+
+				logrus.WithField("repo", repo).Info("Found")
+				repos.Insert(privateOrgRepo(repo))
+			}
+		}
+
+		tideQueries[index].Repos = repos.List()
+	}
+}
+
+func injectPrivateMergeType(tideMergeTypes map[string]github.PullRequestMergeType, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for orgRepo, value := range tideMergeTypes {
+		if orgRepos.isOfficialRepoFull(orgRepo) {
+			repo := strings.Split(orgRepo, "/")[1]
+
+			logrus.WithField("repo", repo).Info("Found")
+			tideMergeTypes[privateOrgRepo(repo)] = value
+		}
+	}
+}
+
+func injectPrivatePRStatusBaseURLs(prStatusBaseURLs map[string]string, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for orgRepo, value := range prStatusBaseURLs {
+		if orgRepos.isOfficialRepoFull(orgRepo) {
+			repo := strings.Split(orgRepo, "/")[1]
+
+			logrus.WithField("repo", repo).Info("Found")
+			prStatusBaseURLs[privateOrgRepo(repo)] = value
+		}
+	}
+}
+
+func injectPrivatePlankDefaultDecorationConfigs(defaultDecorationConfigs map[string]*prowapi.DecorationConfig, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for orgRepo, value := range defaultDecorationConfigs {
+		if orgRepos.isOfficialRepoFull(orgRepo) {
+			repo := strings.Split(orgRepo, "/")[1]
+
+			logrus.WithField("repo", repo).Info("Found")
+			defaultDecorationConfigs[privateOrgRepo(repo)] = value
+		}
+	}
+}
+
+func injectPrivateJobURLPrefixConfig(jobURLPrefixConfig map[string]string, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for orgRepo, value := range jobURLPrefixConfig {
+		if orgRepos.isOfficialRepoFull(orgRepo) {
+			repo := strings.Split(orgRepo, "/")[1]
+
+			logrus.WithField("repo", repo).Info("Found")
+			jobURLPrefixConfig[privateOrgRepo(repo)] = value
+		}
+	}
+}
+
+func injectPrivateApprovePlugin(approves []plugins.Approve, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for index, approve := range approves {
+		repos := sets.NewString(approve.Repos...)
+
+		for _, orgRepo := range approve.Repos {
+			if orgRepos.isOfficialRepoFull(orgRepo) {
+				repo := strings.Split(orgRepo, "/")[1]
+
+				logrus.WithField("repo", repo).Info("Found")
+				repos.Insert(privateOrgRepo(repo))
+			}
+		}
+
+		approves[index].Repos = repos.List()
+	}
+}
+
+func injectPrivateLGTMPlugin(lgtms []plugins.Lgtm, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	for index, lgtm := range lgtms {
+		repos := sets.NewString(lgtm.Repos...)
+
+		for _, orgRepo := range lgtm.Repos {
+			if orgRepos.isOfficialRepoFull(orgRepo) {
+				repo := strings.Split(orgRepo, "/")[1]
+
+				logrus.WithField("repo", repo).Info("Found")
+				repos.Insert(privateOrgRepo(repo))
+			}
+		}
+
+		lgtms[index].Repos = repos.List()
+	}
+}
+
+func injectPrivateBugzillaPlugin(bugzillaPlugins plugins.Bugzilla, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	privateRepos := make(map[string]plugins.BugzillaRepoOptions)
+	for org, orgValue := range bugzillaPlugins.Orgs {
+		for repo, value := range orgValue.Repos {
+			if orgRepos.isOfficialRepo(org, repo) {
+				logrus.WithField("repo", repo).Info("Found")
+				privateRepos[repo] = value
+			}
+		}
+	}
+
+	if len(privateRepos) > 0 {
+		bugzillaPlugins.Orgs[openshiftPrivOrg] = plugins.BugzillaOrgOptions{Repos: privateRepos}
+	}
+}
+
+func injectPrivatePlugins(plugins map[string][]string, orgRepos orgReposWithOfficialImages) {
+	logrus.Info("Processing...")
+
+	var allPrivate []string
+
+	privateReposWithValues := make(map[string][]string)
+
+	for orgRepo, value := range plugins {
+		if orgRepos.isOfficialRepoFull(orgRepo) {
+			newValue := value
+
+			// We want to append the org level values, because the private repo
+			// can exist in different org with different configuration.
+			org := strings.Split(orgRepo, "/")[0]
+			if _, ok := plugins[org]; ok {
+				newValue = append(newValue, plugins[org]...)
+			}
+
+			privateReposWithValues[privateOrgRepo(strings.Split(orgRepo, "/")[1])] = newValue
+			allPrivate = append(allPrivate, newValue...)
+		}
+	}
+
+	mergeCommonPrivatePlugins(plugins, privateReposWithValues, getRepeatedValues(allPrivate))
+}
+
+// mergeCommonPrivatePlugins detects the common values from all the private repositories
+// and merges them into the org `openshift-priv` level.
+// In addition, it generates a repo. if it contains an extra non-common field.
+func mergeCommonPrivatePlugins(plugins map[string][]string, privateReposWithValues map[string][]string, repeatedValues sets.String) {
+	privateOrgPlugins := sets.NewString()
+
+	for repoName, repoValues := range privateReposWithValues {
+		repoLevelPlugins := sets.NewString()
+		valuesSet := sets.NewString(repoValues...)
+
+		if len(repeatedValues) > 0 {
+			privateOrgPlugins = privateOrgPlugins.Union(valuesSet.Intersection(repeatedValues))
+			repoLevelPlugins = repoLevelPlugins.Union(valuesSet.Difference(repeatedValues))
+		} else {
+			repoLevelPlugins.Insert(repoValues...)
+		}
+
+		if len(repoLevelPlugins.List()) > 0 {
+			logrus.WithFields(logrus.Fields{"repo": repoName, "value": repoLevelPlugins.List()}).Info("Generating repo")
+			plugins[repoName] = repoLevelPlugins.List()
+		}
+	}
+
+	if len(privateOrgPlugins.List()) > 0 {
+		logrus.WithField("value", privateOrgPlugins.List()).Info("Generating openshift-priv org.")
+		plugins[openshiftPrivOrg] = privateOrgPlugins.List()
+	}
+}
+
+func getRepeatedValues(values []string) sets.String {
+	temp := sets.NewString()
+	repeated := sets.NewString()
+
+	for _, value := range values {
+		if temp.Has(value) {
+			repeated.Insert(value)
+		} else {
+			temp.Insert(value)
+		}
+	}
+
+	return repeated
+}
+
+func getAllConfigs(releaseRepoPath string, logger *logrus.Entry) (*config.ReleaseRepoConfig, error) {
+	c := &config.ReleaseRepoConfig{}
+	var err error
+	ciopConfigPath := filepath.Join(releaseRepoPath, config.CiopConfigInRepoPath)
+	c.CiOperator, err = config.LoadConfigByFilename(ciopConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load ci-operator configuration from release repo: %v", err)
+	}
+
+	prowConfigPath := filepath.Join(releaseRepoPath, config.ConfigInRepoPath)
+	prowJobConfigPath := filepath.Join(releaseRepoPath, config.JobConfigInRepoPath)
+	c.Prow, err = prowconfig.Load(prowConfigPath, prowJobConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load Prow configuration from release repo: %v", err)
+	}
+
+	return c, nil
+}
+
+func main() {
+	logrus.SetReportCaller(true)
+	logrus.SetFormatter(&logrus.TextFormatter{
+		CallerPrettyfier: func(f *runtime.Frame) (string, string) {
+			return fmt.Sprintf("%s()", f.Function), fmt.Sprintf("%s:%d", path.Base(f.File), f.Line)
+		},
+	})
+
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid option")
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	configs, err := getAllConfigs(o.releaseRepoPath, logrus.NewEntry(logrus.New()))
+	if err != nil {
+		logrus.Fatal("couldn't get the prow and ci-operator configs")
+	}
+	prowConfig := configs.Prow.ProwConfig
+
+	pluginsConfigFile := filepath.Join(o.releaseRepoPath, config.PluginConfigInRepoPath)
+	pluginsConfig, err := loadProwPlugins(pluginsConfigFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("could not load Prow plugin configuration")
+	}
+
+	logrus.Info("Getting a summary of the orgs/repos that promote official images")
+	orgRepos, err := getOrgReposWithOfficialImages(o.releaseRepoPath)
+	if err != nil {
+		logrus.WithError(err).Fatal("couldn't get the list of org/repos that promote official images")
+	}
+
+	injectPrivateBranchProtection(prowConfig.BranchProtection, orgRepos)
+	injectPrivateTideOrgContextPolicy(prowConfig.Tide.ContextOptions, orgRepos)
+	injectPrivateMergeType(prowConfig.Tide.MergeType, orgRepos)
+	injectPrivateReposTideQueries(prowConfig.Tide.Queries, orgRepos)
+	injectPrivatePRStatusBaseURLs(prowConfig.Tide.PRStatusBaseURLs, orgRepos)
+	injectPrivatePlankDefaultDecorationConfigs(prowConfig.Plank.DefaultDecorationConfigs, orgRepos)
+	injectPrivateJobURLPrefixConfig(prowConfig.Plank.JobURLPrefixConfig, orgRepos)
+	injectPrivateApprovePlugin(pluginsConfig.Approve, orgRepos)
+	injectPrivateLGTMPlugin(pluginsConfig.Lgtm, orgRepos)
+	injectPrivatePlugins(pluginsConfig.Plugins, orgRepos)
+	injectPrivateBugzillaPlugin(pluginsConfig.Bugzilla, orgRepos)
+
+	if err := updateProwConfig(filepath.Join(o.releaseRepoPath, config.ConfigInRepoPath), prowConfig); err != nil {
+		logrus.WithError(err).Fatal("couldn't update prow config file")
+	}
+
+	if err := updateProwPlugins(pluginsConfigFile, pluginsConfig); err != nil {
+		logrus.WithError(err).Fatal("couldn't update prow plugins file")
+	}
+}

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -1,0 +1,650 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+var orgRepos = orgReposWithOfficialImages{
+	"openshift": sets.NewString("testRepo1", "testRepo2"),
+	"testshift": sets.NewString("testRepo3", "testRepo4"),
+}
+
+func pBool(b bool) *bool {
+	return &b
+}
+
+func TestInjectPrivateBranchProtection(t *testing.T) {
+	testCases := []struct {
+		id               string
+		branchProtection prowconfig.BranchProtection
+		expected         prowconfig.BranchProtection
+	}{
+		{
+			id: "no changes expected",
+			branchProtection: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{
+						"anotherRepo1": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(false)}}}}}},
+				},
+			},
+			expected: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{
+						"anotherRepo1": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(false)}}}}}},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			branchProtection: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{
+						"testRepo1": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(false)}}}}}},
+				},
+			},
+			expected: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{
+						"testRepo1": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(false)}}}}}},
+					"openshift-priv": {Repos: map[string]prowconfig.Repo{
+						"testRepo1": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(false)}}}}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateBranchProtection(tc.branchProtection, orgRepos)
+			if !reflect.DeepEqual(tc.branchProtection, tc.expected) {
+				t.Fatal(cmp.Diff(tc.branchProtection, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateTideOrgContextPolicy(t *testing.T) {
+	testCases := []struct {
+		id                   string
+		contextPolicyOptions prowconfig.TideContextPolicyOptions
+		expected             prowconfig.TideContextPolicyOptions
+	}{
+		{
+			id: "no changes expected",
+			contextPolicyOptions: prowconfig.TideContextPolicyOptions{
+				Orgs: map[string]prowconfig.TideOrgContextPolicy{
+					"openshift": {Repos: map[string]prowconfig.TideRepoContextPolicy{
+						"anotherRepo1": {TideContextPolicy: prowconfig.TideContextPolicy{
+							SkipUnknownContexts: pBool(true)}}}},
+				},
+			},
+			expected: prowconfig.TideContextPolicyOptions{
+				Orgs: map[string]prowconfig.TideOrgContextPolicy{
+					"openshift": {Repos: map[string]prowconfig.TideRepoContextPolicy{
+						"anotherRepo1": {TideContextPolicy: prowconfig.TideContextPolicy{
+							SkipUnknownContexts: pBool(true)}}}},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			contextPolicyOptions: prowconfig.TideContextPolicyOptions{
+				Orgs: map[string]prowconfig.TideOrgContextPolicy{
+					"openshift": {Repos: map[string]prowconfig.TideRepoContextPolicy{
+						"testRepo1": {TideContextPolicy: prowconfig.TideContextPolicy{
+							SkipUnknownContexts: pBool(true)}}}},
+				},
+			},
+			expected: prowconfig.TideContextPolicyOptions{
+				Orgs: map[string]prowconfig.TideOrgContextPolicy{
+					"openshift": {Repos: map[string]prowconfig.TideRepoContextPolicy{
+						"testRepo1": {TideContextPolicy: prowconfig.TideContextPolicy{
+							SkipUnknownContexts: pBool(true)}}}},
+					"openshift-priv": {Repos: map[string]prowconfig.TideRepoContextPolicy{
+						"testRepo1": {TideContextPolicy: prowconfig.TideContextPolicy{
+							SkipUnknownContexts: pBool(true)}}}},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateTideOrgContextPolicy(tc.contextPolicyOptions, orgRepos)
+			if !reflect.DeepEqual(tc.contextPolicyOptions, tc.expected) {
+				t.Fatal(cmp.Diff(tc.contextPolicyOptions, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateReposTideQueries(t *testing.T) {
+	testCases := []struct {
+		id          string
+		tideQueries []prowconfig.TideQuery
+		expected    []prowconfig.TideQuery
+	}{
+		{
+			id: "no changes expected",
+			tideQueries: []prowconfig.TideQuery{
+				{
+					IncludedBranches: []string{"release-4.0", "release-4.1"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo1"},
+				},
+				{
+					ExcludedBranches: []string{"release-4.2", "release-4.3"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo2"},
+				},
+			},
+			expected: []prowconfig.TideQuery{
+				{
+					IncludedBranches: []string{"release-4.0", "release-4.1"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo1"},
+				},
+				{
+					ExcludedBranches: []string{"release-4.2", "release-4.3"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo2"},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			tideQueries: []prowconfig.TideQuery{
+				{
+					IncludedBranches: []string{"release-4.0", "release-4.1"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/testRepo1", "testshift/testRepo3"},
+				},
+				{
+					ExcludedBranches: []string{"release-4.2", "release-4.3"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo2"},
+				},
+			},
+			expected: []prowconfig.TideQuery{
+				{
+					IncludedBranches: []string{"release-4.0", "release-4.1"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos: []string{
+						"openshift-priv/testRepo1", "openshift-priv/testRepo3",
+						"openshift/testRepo1", "testshift/testRepo3",
+					},
+				},
+				{
+					ExcludedBranches: []string{"release-4.2", "release-4.3"},
+					Labels:           []string{"lgtm", "approved"},
+					MissingLabels:    []string{"needs-rebase", "do-not-merge/work-in-progress"},
+					Repos:            []string{"openshift/anotherRepo2"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateReposTideQueries(tc.tideQueries, orgRepos)
+			if !reflect.DeepEqual(tc.tideQueries, tc.expected) {
+				t.Fatal(cmp.Diff(tc.tideQueries, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateMergeType(t *testing.T) {
+	testCases := []struct {
+		id             string
+		tideMergeTypes map[string]github.PullRequestMergeType
+		expected       map[string]github.PullRequestMergeType
+	}{
+		{
+			id: "no changes expected",
+			tideMergeTypes: map[string]github.PullRequestMergeType{
+				"anotherOrg/Repo": github.MergeMerge,
+				"openshift/Repo2": github.MergeRebase,
+				"testshift/Repo3": github.MergeSquash,
+			},
+			expected: map[string]github.PullRequestMergeType{
+				"anotherOrg/Repo": github.MergeMerge,
+				"openshift/Repo2": github.MergeRebase,
+				"testshift/Repo3": github.MergeSquash,
+			},
+		},
+		{
+			id: "changes expected",
+			tideMergeTypes: map[string]github.PullRequestMergeType{
+				"anotherOrg/Repo":       github.MergeMerge,
+				"openshift/testRepo1":   github.MergeSquash,
+				"openshift/anotherRepo": github.MergeSquash,
+				"testshift/anotherRepo": github.MergeMerge,
+				"testshift/testRepo3":   github.MergeMerge,
+			},
+			expected: map[string]github.PullRequestMergeType{
+				"anotherOrg/Repo":          github.MergeMerge,
+				"openshift/testRepo1":      github.MergeSquash,
+				"openshift/anotherRepo":    github.MergeSquash,
+				"testshift/anotherRepo":    github.MergeMerge,
+				"testshift/testRepo3":      github.MergeMerge,
+				"openshift-priv/testRepo1": github.MergeSquash,
+				"openshift-priv/testRepo3": github.MergeMerge,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateMergeType(tc.tideMergeTypes, orgRepos)
+			if !reflect.DeepEqual(tc.tideMergeTypes, tc.expected) {
+				t.Fatalf(cmp.Diff(tc.tideMergeTypes, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivatePRStatusBaseURLs(t *testing.T) {
+	testCases := []struct {
+		id               string
+		prStatusBaseURLs map[string]string
+		expected         map[string]string
+	}{
+		{
+			id: "no changes expected",
+			prStatusBaseURLs: map[string]string{
+				"openshift":              "https://test.com",
+				"testshift":              "https://test.com",
+				"openshift/anotherRepo1": "https://test.com",
+			},
+			expected: map[string]string{
+				"openshift":              "https://test.com",
+				"testshift":              "https://test.com",
+				"openshift/anotherRepo1": "https://test.com",
+			},
+		},
+		{
+			id: "changes expected",
+			prStatusBaseURLs: map[string]string{
+				"openshift":              "https://test.com",
+				"openshift/anotherRepo1": "https://test.com",
+				"openshift/testRepo1":    "https://test.com",
+				"testshift/testRepo3":    "https://test.com",
+			},
+			expected: map[string]string{
+				"openshift":                "https://test.com",
+				"openshift-priv/testRepo1": "https://test.com",
+				"openshift-priv/testRepo3": "https://test.com",
+				"openshift/anotherRepo1":   "https://test.com",
+				"openshift/testRepo1":      "https://test.com",
+				"testshift/testRepo3":      "https://test.com",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivatePRStatusBaseURLs(tc.prStatusBaseURLs, orgRepos)
+			if !reflect.DeepEqual(tc.prStatusBaseURLs, tc.expected) {
+				t.Fatal(cmp.Diff(tc.prStatusBaseURLs, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivatePlankDefaultDecorationConfigs(t *testing.T) {
+	testCases := []struct {
+		id                       string
+		defaultDecorationConfigs map[string]*prowapi.DecorationConfig
+		expected                 map[string]*prowapi.DecorationConfig
+	}{
+		{
+			id: "no changes expected",
+			defaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
+				"openshift":              {GCSCredentialsSecret: "gcs_secret", SkipCloning: pBool(true)},
+				"openshift/anotherRepo1": {GCSCredentialsSecret: "gcs_secret2", SkipCloning: pBool(false)},
+			},
+			expected: map[string]*prowapi.DecorationConfig{
+				"openshift":              {GCSCredentialsSecret: "gcs_secret", SkipCloning: pBool(true)},
+				"openshift/anotherRepo1": {GCSCredentialsSecret: "gcs_secret2", SkipCloning: pBool(false)},
+			},
+		},
+		{
+			id: "changes expected",
+			defaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
+				"openshift":           {GCSCredentialsSecret: "gcs_secret", SkipCloning: pBool(true)},
+				"openshift/testRepo1": {GCSCredentialsSecret: "gcs_secret2", SkipCloning: pBool(false)},
+			},
+			expected: map[string]*prowapi.DecorationConfig{
+				"openshift":                {GCSCredentialsSecret: "gcs_secret", SkipCloning: pBool(true)},
+				"openshift/testRepo1":      {GCSCredentialsSecret: "gcs_secret2", SkipCloning: pBool(false)},
+				"openshift-priv/testRepo1": {GCSCredentialsSecret: "gcs_secret2", SkipCloning: pBool(false)},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivatePlankDefaultDecorationConfigs(tc.defaultDecorationConfigs, orgRepos)
+			if !reflect.DeepEqual(tc.defaultDecorationConfigs, tc.expected) {
+				t.Fatal(cmp.Diff(tc.defaultDecorationConfigs, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateJobURLPrefixConfig(t *testing.T) {
+	testCases := []struct {
+		id                 string
+		jobURLPrefixConfig map[string]string
+		expected           map[string]string
+	}{
+		{
+			id: "no changes expected",
+			jobURLPrefixConfig: map[string]string{
+				"openshift":              "https://test.com",
+				"openshift/anotherRepo1": "https://test.com",
+			},
+			expected: map[string]string{
+				"openshift":              "https://test.com",
+				"openshift/anotherRepo1": "https://test.com",
+			},
+		},
+		{
+			id: "changes expected",
+			jobURLPrefixConfig: map[string]string{
+				"openshift":           "https://test.com",
+				"openshift/testRepo1": "https://test.com",
+				"testshift/testRepo3": "https://test.com",
+			},
+			expected: map[string]string{
+				"openshift":                "https://test.com",
+				"openshift/testRepo1":      "https://test.com",
+				"testshift/testRepo3":      "https://test.com",
+				"openshift-priv/testRepo1": "https://test.com",
+				"openshift-priv/testRepo3": "https://test.com",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateJobURLPrefixConfig(tc.jobURLPrefixConfig, orgRepos)
+			if !reflect.DeepEqual(tc.jobURLPrefixConfig, tc.expected) {
+				t.Fatal(cmp.Diff(tc.jobURLPrefixConfig, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateApprovePlugin(t *testing.T) {
+	testCases := []struct {
+		id       string
+		approves []plugins.Approve
+		expected []plugins.Approve
+	}{
+		{
+			id: "no changes expected",
+			approves: []plugins.Approve{
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+				},
+			},
+			expected: []plugins.Approve{
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			approves: []plugins.Approve{
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/testRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift/anotherRepo3", "testshift/testRepo3"},
+				},
+			},
+			expected: []plugins.Approve{
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift-priv/testRepo1", "openshift/testRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					IgnoreReviewState: pBool(false),
+					LgtmActsAsApprove: true,
+					Repos:             []string{"openshift-priv/testRepo3", "openshift/anotherRepo3", "testshift/testRepo3"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateApprovePlugin(tc.approves, orgRepos)
+			if !reflect.DeepEqual(tc.approves, tc.expected) {
+				t.Fatal(cmp.Diff(tc.approves, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateLGTMPlugin(t *testing.T) {
+	testCases := []struct {
+		id       string
+		lgtms    []plugins.Lgtm
+		expected []plugins.Lgtm
+	}{
+		{
+			id: "no changes expected",
+			lgtms: []plugins.Lgtm{
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+				},
+			},
+			expected: []plugins.Lgtm{
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/anotherRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/anotherRepo3", "testshift/anotherRepo4"},
+				},
+			},
+		},
+		{
+			id: "changes expected",
+			lgtms: []plugins.Lgtm{
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/testRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift/anotherRepo3", "testshift/testRepo3"},
+				},
+			},
+			expected: []plugins.Lgtm{
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift-priv/testRepo1", "openshift/testRepo1", "testshift/anotherRepo2"},
+				},
+				{
+					ReviewActsAsLgtm: true,
+					Repos:            []string{"openshift-priv/testRepo3", "openshift/anotherRepo3", "testshift/testRepo3"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateLGTMPlugin(tc.lgtms, orgRepos)
+			if !reflect.DeepEqual(tc.lgtms, tc.expected) {
+				t.Fatal(cmp.Diff(tc.lgtms, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivateBugzillaPlugin(t *testing.T) {
+	testCases := []struct {
+		id       string
+		bugzilla plugins.Bugzilla
+		expected plugins.Bugzilla
+	}{
+		{
+			id: "no changes expected",
+			bugzilla: plugins.Bugzilla{
+				Orgs: map[string]plugins.BugzillaOrgOptions{
+					"openshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"anotherRepo1": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+					"testshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"anotherRepo2": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+				},
+			},
+			expected: plugins.Bugzilla{
+				Orgs: map[string]plugins.BugzillaOrgOptions{
+					"openshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"anotherRepo1": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+					"testshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"anotherRepo2": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+				},
+			},
+		},
+
+		{
+			id: "changes expected",
+			bugzilla: plugins.Bugzilla{
+				Orgs: map[string]plugins.BugzillaOrgOptions{
+					"openshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"testRepo1": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+					"testshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"testRepo3": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+				},
+			},
+			expected: plugins.Bugzilla{
+				Orgs: map[string]plugins.BugzillaOrgOptions{
+					"openshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"testRepo1": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+					"testshift": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"testRepo3": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}}},
+					"openshift-priv": {Repos: map[string]plugins.BugzillaRepoOptions{
+						"testRepo1": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}},
+						"testRepo3": {Branches: map[string]plugins.BugzillaBranchOptions{"master": {ExcludeDefaults: pBool(true)}}}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivateBugzillaPlugin(tc.bugzilla, orgRepos)
+			if !reflect.DeepEqual(tc.bugzilla, tc.expected) {
+				t.Fatal(cmp.Diff(tc.bugzilla, tc.expected))
+			}
+		})
+	}
+}
+
+func TestInjectPrivatePlugins(t *testing.T) {
+	testCases := []struct {
+		id       string
+		plugins  map[string][]string
+		expected map[string][]string
+	}{
+		{
+			id:       "no changes expected",
+			plugins:  map[string][]string{"openshift/anotherRepo1": {"approve", "lgtm", "cat", "dog"}},
+			expected: map[string][]string{"openshift/anotherRepo1": {"approve", "lgtm", "cat", "dog"}},
+		},
+		{
+			id: "changes expected",
+			plugins: map[string][]string{
+				"openshift/testRepo1": {"approve", "lgtm", "cat", "dog"},
+			},
+			expected: map[string][]string{
+				"openshift-priv/testRepo1": {"approve", "cat", "dog", "lgtm"},
+				"openshift/testRepo1":      {"approve", "lgtm", "cat", "dog"},
+			},
+		},
+		{
+			id: "changes expected, multiple org/repos",
+			plugins: map[string][]string{
+				"openshift":           {"lgtm", "cat", "dog", "hold"},
+				"testshift":           {"lgtm", "milestone", "label", "hold"},
+				"openshift/testRepo1": {"approve"},
+				"testshift/testRepo3": {"approve", "trigger"},
+			},
+			expected: map[string][]string{
+				"openshift":           {"lgtm", "cat", "dog", "hold"},
+				"testshift":           {"lgtm", "milestone", "label", "hold"},
+				"openshift/testRepo1": {"approve"},
+				"testshift/testRepo3": {"approve", "trigger"},
+
+				"openshift-priv":           {"approve", "hold", "lgtm"},
+				"openshift-priv/testRepo1": {"cat", "dog"},
+				"openshift-priv/testRepo3": {"label", "milestone", "trigger"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			injectPrivatePlugins(tc.plugins, orgRepos)
+			if !reflect.DeepEqual(tc.plugins, tc.expected) {
+				t.Fatal(cmp.Diff(tc.plugins, tc.expected))
+			}
+		})
+	}
+}

--- a/images/private-prow-config-mirror/Dockerfile
+++ b/images/private-prow-config-mirror/Dockerfile
@@ -1,0 +1,5 @@
+FROM centos:8
+LABEL maintainer="nmoraiti@redhat.com"
+
+ADD private-prow-config-mirror /usr/bin/private-prow-config-mirror
+ENTRYPOINT ["/usr/bin/private-prow-config-mirror"]


### PR DESCRIPTION
This tool detects the configuration of all of the org/repos that promotes official images and injects an `openshift-priv/repo` version of the config.

Affected configuration: 

`config.branch-protection`
`config.context_options`
`config.tide.merge_method`
`config.tide.queries`
`config.tide.pr_status_base_urls`
`config.plank.default_decoration_configs`
`config.plank.job_url_prefix_config`
`plugins.approve`
`plugins.lgtm`
`plugins.plugins`
`plugins.bugzilla`

/cc @petr-muller @stevekuznetsov 
/cc @openshift/openshift-team-developer-productivity-test-platform 