### PR TITLE
Add the CVP trigger tool skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
 
-integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater integration-ci-op-configs-mirror
+integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater integration-ci-op-configs-mirror integration-cvp-trigger
 .PHONY: integration
 
 integration-prowgen:
@@ -92,6 +92,15 @@ integration-group-auto-updater:
 integration-ci-op-configs-mirror:
 	test/ci-op-configs-mirror-integration/run.sh
 .PHONY: integration-ci-op-configs-mirror
+
+integration-cvp-trigger:
+	test/cvp-trigger-integration/run.sh
+.PHONY: integration-cvp-trigger
+
+update-integration-cvp-trigger:
+	test/cvp-trigger-integration/run.sh --update
+.PHONY: integration-cvp-trigger
+
 
 pr-deploy:
 	oc process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml | oc apply -f - --as system:admin

--- a/cmd/cvp-trigger/README.md
+++ b/cmd/cvp-trigger/README.md
@@ -1,0 +1,4 @@
+# CVP Trigger
+
+CVP Trigger tool will be used by the CVP pipeline to parametrize and trigger
+the verification jobs for optional operator artifacts built internally in RH. 

--- a/cmd/cvp-trigger/main.go
+++ b/cmd/cvp-trigger/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/rest"
+
+	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	pjclientset "k8s.io/test-infra/prow/client/clientset/versioned"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pjutil"
+
+	"github.com/openshift/ci-tools/pkg/util"
+)
+
+const (
+	prowConfigPathOption = "prow-config-path"
+	jobConfigPathOption  = "job-config-path"
+	periodicOption       = "periodic"
+)
+
+type options struct {
+	confirm bool
+
+	prowConfigPath string
+	jobConfigPath  string
+
+	periodic string
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.BoolVar(&o.confirm, "confirm", false, "Whether to actually submit the job to Prow")
+	fs.StringVar(&o.prowConfigPath, prowConfigPathOption, "", "Path to the Prow config file")
+	fs.StringVar(&o.jobConfigPath, jobConfigPathOption, "", "Path to the Prow job config directory")
+	fs.StringVar(&o.periodic, "periodic", "", "Name of the Periodic job to manually trigger")
+
+	_ = fs.Parse(os.Args[1:])
+	return o
+}
+
+func (o options) validate() error {
+	if o.prowConfigPath == "" {
+		return fmt.Errorf("required parameter %s was not provided", prowConfigPathOption)
+	}
+
+	if o.jobConfigPath == "" {
+		return fmt.Errorf("required parameter %s was not provided", jobConfigPathOption)
+	}
+
+	if o.periodic == "" {
+		return fmt.Errorf("required parameter %s was not provided", periodicOption)
+	}
+
+	return nil
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("incorrect options")
+	}
+
+	go func() {
+		interrupts.WaitForGracefulShutdown()
+		os.Exit(1)
+	}()
+
+	config, err := prowconfig.Load(o.prowConfigPath, o.jobConfigPath)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to read Prow configuration")
+	}
+
+	var selected *prowconfig.Periodic
+	for _, job := range config.AllPeriodics() {
+		if job.Name == o.periodic {
+			selected = &job
+			break
+		}
+	}
+
+	if selected == nil {
+		logrus.WithField("job-name", o.periodic).Fatal("failed to find the job")
+	}
+
+	prowjob := pjutil.NewProwJob(pjutil.PeriodicSpec(*selected), nil, nil)
+	if !o.confirm {
+		jobAsYAML, err := yaml.Marshal(prowjob)
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to marshal the prowjob to YAML")
+		}
+		fmt.Printf(string(jobAsYAML))
+		os.Exit(0)
+	}
+
+	var clusterConfig *rest.Config
+	clusterConfig, err = util.LoadClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to load cluster configuration")
+	}
+
+	pjcset, err := pjclientset.NewForConfig(clusterConfig)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create prowjob clientset")
+	}
+	pjclient := pjcset.ProwV1().ProwJobs(config.ProwJobNamespace)
+
+	logrus.WithFields(pjutil.ProwJobFields(&prowjob)).Info("submitting a new prowjob")
+	created, err := pjclient.Create(&prowjob)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to submit the prowjob")
+	}
+
+	logger := logrus.WithFields(pjutil.ProwJobFields(created))
+	logger.Info("submitted the prowjob, waiting for its result")
+
+	selector := fields.SelectorFromSet(map[string]string{"metadata.name": created.Name})
+
+	for {
+		w, err := pjclient.Watch(metav1.ListOptions{FieldSelector: selector.String()})
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to create watch for ProwJobs")
+		}
+
+		for event := range w.ResultChan() {
+			prowJob, ok := event.Object.(*pjapi.ProwJob)
+			if !ok {
+				logrus.WithField("object-type", fmt.Sprintf("%T", event.Object)).Fatal("received an unexpected object from Watch")
+			}
+			switch prowJob.Status.State {
+			case pjapi.FailureState, pjapi.AbortedState, pjapi.ErrorState:
+				logrus.Fatal("job failed")
+			case pjapi.SuccessState:
+				logrus.Info("job succeeded")
+				os.Exit(0)
+			}
+		}
+	}
+}

--- a/cmd/cvp-trigger/main_test.go
+++ b/cmd/cvp-trigger/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+func TestValidateOptions(t *testing.T) {
+	testcases := []struct {
+		description string
+		opts        options
+		expectError bool
+	}{
+		{
+			description: "valid options",
+			opts: options{
+				prowConfigPath: "not/empty",
+				jobConfigPath:  "also/not/empty",
+				periodic:       "some-job",
+			},
+		},
+		{
+			description: "missing prow configuration",
+			opts: options{
+				jobConfigPath: "not/empty",
+				periodic:      "some-job",
+			},
+			expectError: true,
+		},
+		{
+			description: "missing prow job configuration",
+			opts: options{
+				prowConfigPath: "not/empty",
+				periodic:       "some-job",
+			},
+			expectError: true,
+		},
+		{
+			description: "missing job",
+			opts: options{
+				prowConfigPath: "not/empty",
+				jobConfigPath:  "also/not/empty",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := tc.opts.validate()
+			if err == nil && tc.expectError {
+				t.Errorf("%s: expected error, got nil", tc.description)
+			}
+			if err != nil && !tc.expectError {
+				t.Errorf("%s: unexpected validation error: %v", tc.description, err)
+			}
+		})
+	}
+}

--- a/test/cvp-trigger-integration/config.yaml
+++ b/test/cvp-trigger-integration/config.yaml
@@ -1,0 +1,20 @@
+plank:
+  job_url_prefix: 'https://openshift-gce-devel.appspot.com/build/'
+  job_url_template: 'https://openshift-gce-devel.appspot.com/build/origin-ci-test/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if ne .Spec.Refs.Repo "origin"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
+  report_template: '[Full PR test history](https://openshift-gce-devel.appspot.com/pr/{{if ne .Spec.Refs.Repo "origin"}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://openshift-gce-devel.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
+  default_decoration_configs:
+    "*":
+      timeout: 14400000000000 # 4h
+      grace_period: 15000000000 # 15s
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+      gcs_configuration:
+        bucket: origin-ci-test
+        path_strategy: single
+        default_org: openshift
+        default_repo: origin
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+prowjob_namespace: test-namespace

--- a/test/cvp-trigger-integration/jobs.yaml
+++ b/test/cvp-trigger-integration/jobs.yaml
@@ -1,0 +1,53 @@
+periodics:
+- agent: kubernetes
+  labels:
+    ci.openshift.io/role: infra
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: ci-tools
+  cron: ""
+  decorate: true
+  decoration_config:
+    timeout: 8h
+  interval: 5m
+  name: periodic-ipi-deprovision
+  spec:
+    containers:
+    - command:
+      - ./cmd/ipi-deprovision/ipi-deprovision.sh
+      image: registry.svc.ci.openshift.org/ci/ipi-deprovision:latest
+      imagePullPolicy: Always
+      env:
+      - name: HOME
+        value: "/tmp"
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: "/aws/.awscred"
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: "/gcp/gce.json"
+      - name: CLUSTER_TTL
+        value: "30 minutes ago"
+      name: "ipi-deprovision"
+      resources:
+          requests:
+            cpu: 500m
+      volumeMounts:
+      - mountPath: /aws
+        name: cluster-secrets-aws
+      - mountPath: /gcp
+        name: cluster-secrets-gcp
+    volumes:
+    - name: cluster-secrets-aws
+      secret:
+        secretName: cluster-secrets-aws
+        items:
+        - key: ".awscred"
+          path: ".awscred"
+    - name: cluster-secrets-gcp
+      secret:
+        secretName: cluster-secrets-gcp
+        items:
+        - key: "gce.json"
+          path: "gce.json"
+    serviceAccountName: ipi-deprovisioner

--- a/test/cvp-trigger-integration/periodic-ipi-deprovision.expected
+++ b/test/cvp-trigger-integration/periodic-ipi-deprovision.expected
@@ -1,0 +1,78 @@
+apiVersion: prow.k8s.io/v1
+kind: ProwJob
+metadata:
+  annotations:
+    prow.k8s.io/job: periodic-ipi-deprovision
+  creationTimestamp: null
+  labels:
+    created-by-prow: "true"
+    prow.k8s.io/job: periodic-ipi-deprovision
+    prow.k8s.io/type: periodic
+  name: b496e2c9-6235-11ea-8699-8c16455629bd
+spec:
+  agent: kubernetes
+  cluster: default
+  decoration_config:
+    gcs_configuration:
+      bucket: origin-ci-test
+      default_org: openshift
+      default_repo: origin
+      path_strategy: single
+    gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+    grace_period: 15s
+    timeout: 8h0m0s
+    utility_images:
+      clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+      entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+      initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+      sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: ci-tools
+  job: periodic-ipi-deprovision
+  namespace: default
+  pod_spec:
+    containers:
+    - command:
+      - ./cmd/ipi-deprovision/ipi-deprovision.sh
+      env:
+      - name: HOME
+        value: /tmp
+      - name: AWS_SHARED_CREDENTIALS_FILE
+        value: /aws/.awscred
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /gcp/gce.json
+      - name: CLUSTER_TTL
+        value: 30 minutes ago
+      image: registry.svc.ci.openshift.org/ci/ipi-deprovision:latest
+      imagePullPolicy: Always
+      name: ipi-deprovision
+      resources:
+        requests:
+          cpu: 500m
+      volumeMounts:
+      - mountPath: /aws
+        name: cluster-secrets-aws
+      - mountPath: /gcp
+        name: cluster-secrets-gcp
+    serviceAccountName: ipi-deprovisioner
+    volumes:
+    - name: cluster-secrets-aws
+      secret:
+        items:
+        - key: .awscred
+          path: .awscred
+        secretName: cluster-secrets-aws
+    - name: cluster-secrets-gcp
+      secret:
+        items:
+        - key: gce.json
+          path: gce.json
+        secretName: cluster-secrets-gcp
+  report: true
+  rerun_auth_config: {}
+  type: periodic
+status:
+  startTime: "2020-03-09T18:42:19Z"
+  state: triggered

--- a/test/cvp-trigger-integration/run.sh
+++ b/test/cvp-trigger-integration/run.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+datadir="$(dirname "${BASH_SOURCE[0]}")"
+prow_config="$datadir/config.yaml"
+job_config="$datadir/jobs.yaml"
+job="periodic-ipi-deprovision"
+
+output="$workdir/$job.output"
+expected="$datadir/$job.expected"
+
+update=false
+if [[ ${1:-} == "--update" ]]; then
+  update=true
+fi
+
+echo "[INFO] Running CVP trigger"
+cvp-trigger --prow-config-path="$prow_config" --job-config-path="$job_config" --periodic="$job" >"$workdir/$job.output"
+
+if [[ $update == "true" ]]; then
+  echo "[INFO] Updating $expected:"
+  diff -u "$output" "$expected" || true
+  cp "$output" "$expected"
+fi
+
+echo "[INFO] Validating triggered Prow job"
+if ! diff -u "$expected" "$output" \
+  --ignore-matching-lines 'startTime' \
+  --ignore-matching-lines 'name: \w\{8\}\(-\w\{4\}\)\{3\}-\w\{12\}' \
+  --ignore-matching-lines 'sha: \w\{40\}' >"$workdir/diff" \
+  ; then
+  echo "ERROR: Different Prow job triggered:"
+  cat "$workdir/diff"
+  exit 1
+fi


### PR DESCRIPTION
CVP Trigger tool will be used by the CVP pipeline to parametrize and
trigger the verification jobs for optional operator artifacts built
internally in RH.

Right now the tool reads Prow config, finds a specified periodic job
specification, creates a Prowjob, submits it to the cluster and waits
until the job finishes.

In the future we expect this tool to perform some job parametrization.

/cc @openshift/openshift-team-developer-productivity-test-platform  @dirgim 