### PR TITLE
Revert "prowgen,pj-rehearse: do not add CONFIG_SPEC to generated jobs"

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -26,6 +26,8 @@ import (
 )
 
 const (
+	prowJobLabelVariant = "ci-operator.openshift.io/variant"
+
 	sentryDsnMountName  = "sentry-dsn"
 	sentryDsnSecretName = "sentry-dsn"
 	sentryDsnMountPath  = "/etc/sentry-dsn"
@@ -92,6 +94,14 @@ func (o *options) process() error {
 // Various pieces are derived from `org`, `repo`, `branch` and `target`.
 // `additionalArgs` are passed as additional arguments to `ci-operator`
 func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeapi.PodSpec {
+	configMapKeyRef := kubeapi.EnvVarSource{
+		ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+			LocalObjectReference: kubeapi.LocalObjectReference{
+				Name: info.ConfigMapName(),
+			},
+			Key: info.Basename(),
+		},
+	}
 	volumeMounts := []kubeapi.VolumeMount{
 		{
 			Name:      sentryDsnMountName,
@@ -175,6 +185,7 @@ func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeap
 			{
 				Image:           "ci-operator:latest",
 				ImagePullPolicy: kubeapi.PullAlways,
+				Env:             []kubeapi.EnvVar{{Name: "CONFIG_SPEC", ValueFrom: &configMapKeyRef}},
 				Resources: kubeapi.ResourceRequirements{
 					Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 				},
@@ -465,7 +476,7 @@ func generateJobBase(name, prefix string, info *prowgenInfo, label jc.ProwgenLab
 
 	jobName := info.Info.JobName(prefix, name)
 	if len(info.Variant) > 0 {
-		labels[jc.ProwJobLabelVariant] = info.Variant
+		labels[prowJobLabelVariant] = info.Variant
 	}
 	newTrue := true
 	dc := &v1.DecorationConfig{SkipCloning: &newTrue}

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"io/ioutil"
 	"log"
 	"os"
@@ -11,8 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	kubeapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,6 +21,7 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	ciop "github.com/openshift/ci-tools/pkg/api"
+
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
@@ -63,6 +64,17 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-misc-configs",
+								},
+								Key: "org-repo-branch.yaml",
+							},
+						},
+					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -118,6 +130,17 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-misc-configs",
+								},
+								Key: "org-repo-branch.yaml",
+							},
+						},
+					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -173,6 +196,17 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-misc-configs",
+								},
+								Key: "org-repo-branch.yaml",
+							},
+						},
+					}},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
@@ -237,6 +271,17 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
+					Env: []kubeapi.EnvVar{{
+						Name: "CONFIG_SPEC",
+						ValueFrom: &kubeapi.EnvVarSource{
+							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+								LocalObjectReference: kubeapi.LocalObjectReference{
+									Name: "ci-operator-misc-configs",
+								},
+								Key: "org-repo-branch.yaml",
+							},
+						},
+					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -292,6 +337,17 @@ func TestGeneratePodSpec(t *testing.T) {
 						Resources: kubeapi.ResourceRequirements{
 							Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 						},
+						Env: []kubeapi.EnvVar{{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "org-repo-branch.yaml",
+								},
+							},
+						}},
 						VolumeMounts: []kubeapi.VolumeMount{
 							{
 								Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true,
@@ -442,6 +498,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -547,6 +614,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "aws"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -637,6 +715,19 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
+					},
+					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
@@ -748,6 +839,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -865,6 +967,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -982,6 +1095,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1096,6 +1220,17 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
+						{
+							Name: "CONFIG_SPEC",
+							ValueFrom: &kubeapi.EnvVarSource{
+								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
+									LocalObjectReference: kubeapi.LocalObjectReference{
+										Name: "ci-operator-misc-configs",
+									},
+									Key: "organization-repo-branch.yaml",
+								},
+							},
+						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1584,6 +1719,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1645,6 +1786,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1707,6 +1854,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1766,6 +1919,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1828,6 +1987,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1918,6 +2083,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1958,6 +2129,12 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2022,6 +2199,12 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2083,6 +2266,12 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2147,6 +2336,12 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2196,6 +2391,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2230,6 +2431,12 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch__rhel.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2317,6 +2524,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2355,6 +2568,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2417,6 +2636,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2476,6 +2701,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2538,6 +2769,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2585,6 +2822,12 @@ tests:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2617,6 +2860,12 @@ tests:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-branch.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -23,7 +23,6 @@ type ProwgenLabel string
 const (
 	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
 	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
-	ProwJobLabelVariant                = "ci-operator.openshift.io/variant"
 	Generated             ProwgenLabel = "true"
 	New                   ProwgenLabel = "newly-generated"
 	PresubmitPrefix                    = "pull"

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -104,11 +104,6 @@ func CompletePrimaryRefs(refs pjapi.Refs, jb prowconfig.JobBase) *pjapi.Refs {
 	return &refs
 }
 
-func getTrimmedBranch(branches []string) string {
-	return strings.TrimPrefix(strings.TrimSuffix(branches[0], "$"), "^")
-
-}
-
 func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber int, refs *pjapi.Refs) (*prowconfig.Presubmit, error) {
 	var rehearsal prowconfig.Presubmit
 	deepcopy.Copy(&rehearsal, source)
@@ -119,7 +114,7 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	var context string
 
 	if len(source.Branches) > 0 {
-		branch = getTrimmedBranch(source.Branches)
+		branch = strings.TrimPrefix(strings.TrimSuffix(source.Branches[0], "$"), "^")
 		if len(repo) > 0 {
 			orgRepo := strings.Split(repo, "/")
 			jobOrg := orgRepo[0]
@@ -233,14 +228,9 @@ func hasRehearsableLabel(labels map[string]string) bool {
 // of the needed config file passed to the job as a direct value. This needs
 // to happen because the rehearsed Prow jobs may depend on these config files
 // being also changed by the tested PR.
-func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, resolver registry.Resolver, info config.Info, loggers Loggers) error {
-	configSpecSet := false
-	// replace all ConfigMapKeyRef mounts with inline config maps
+func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, resolver registry.Resolver, loggers Loggers) error {
 	for index := range container.Env {
 		env := &(container.Env[index])
-		if env.Name == "CONFIG_SPEC" {
-			configSpecSet = true
-		}
 		if env.ValueFrom == nil {
 			continue
 		}
@@ -270,38 +260,6 @@ func inlineCiOpConfig(container v1.Container, ciopConfigs config.ByFilename, res
 			env.Value = string(ciOpConfigContent)
 			env.ValueFrom = nil
 		}
-	}
-	// if CONFIG_SPEC has already been set, do not add new CONFIG_SPEC section
-	if configSpecSet {
-		return nil
-	}
-	// inline CONFIG_SPEC for all ci-operator jobs
-	if container.Command != nil && container.Command[0] == "ci-operator" {
-		filename := info.Basename()
-		loggers.Debug.WithField(logCiopConfigFile, filename).Debug("Rehearsal job uses ci-operator config ConfigMap, needed content will be inlined")
-		ciopConfig, ok := ciopConfigs[filename]
-		if !ok {
-			return fmt.Errorf("ci-operator config file %s was not found", filename)
-		}
-		ciopConfigResolved, err := registry.ResolveConfig(resolver, ciopConfig.Configuration)
-		if err != nil {
-			loggers.Job.WithError(err).Error("Failed resolve ReleaseBuildConfiguration")
-			return err
-		}
-
-		ciOpConfigContent, err := yaml.Marshal(ciopConfigResolved)
-		if err != nil {
-			loggers.Job.WithError(err).Error("Failed to marshal ci-operator config file")
-			return err
-		}
-
-		envs := container.Env
-		env := v1.EnvVar{
-			Name:  "CONFIG_SPEC",
-			Value: string(ciOpConfigContent),
-		}
-		envs = append(envs, env)
-		container.Env = envs
 	}
 	return nil
 }
@@ -338,14 +296,6 @@ func fillTemplateMap(templates []config.ConfigMapSource) map[string]string {
 	return templateMap
 }
 
-func variantFromLabels(labels map[string]string) string {
-	variant := ""
-	if variantLabel, ok := labels[jobconfig.ProwJobLabelVariant]; ok {
-		variant = variantLabel
-	}
-	return variant
-}
-
 // ConfigurePeriodicRehearsals adds the required configuration for the periodics to be rehearsed.
 func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics) []prowconfig.Periodic {
 	var rehearsals []prowconfig.Periodic
@@ -353,15 +303,7 @@ func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics)
 	filteredPeriodics := filterPeriodics(periodics, jc.loggers.Job)
 	for _, job := range filteredPeriodics {
 		jobLogger := jc.loggers.Job.WithField("target-job", job.Name)
-		info := config.Info{
-			Variant: variantFromLabels(job.Labels),
-		}
-		if len(job.ExtraRefs) != 0 {
-			info.Org = job.ExtraRefs[0].Org
-			info.Repo = job.ExtraRefs[0].Repo
-			info.Branch = job.ExtraRefs[0].BaseRef
-		}
-		if err := jc.configureJobSpec(job.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+		if err := jc.configureJobSpec(job.Spec, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 			jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal periodic job")
 			continue
 		}
@@ -378,27 +320,16 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 	var rehearsals []*prowconfig.Presubmit
 
 	presubmitsFiltered := filterPresubmits(presubmits, jc.loggers.Job)
-	for orgrepo, jobs := range presubmitsFiltered {
+	for repo, jobs := range presubmitsFiltered {
 		for _, job := range jobs {
-			jobLogger := jc.loggers.Job.WithFields(logrus.Fields{"target-repo": orgrepo, "target-job": job.Name})
-			rehearsal, err := makeRehearsalPresubmit(&job, orgrepo, jc.prNumber, jc.refs)
+			jobLogger := jc.loggers.Job.WithFields(logrus.Fields{"target-repo": repo, "target-job": job.Name})
+			rehearsal, err := makeRehearsalPresubmit(&job, repo, jc.prNumber, jc.refs)
 			if err != nil {
 				jobLogger.WithError(err).Warn("Failed to make a rehearsal presubmit")
 				continue
 			}
 
-			splitOrgRepo := strings.Split(orgrepo, "/")
-			if len(splitOrgRepo) != 2 {
-				jobLogger.WithError(fmt.Errorf("failed to identify org and repo from string %s", orgrepo)).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
-			}
-			info := config.Info{
-				Org:     splitOrgRepo[0],
-				Repo:    splitOrgRepo[1],
-				Branch:  getTrimmedBranch(job.Branches),
-				Variant: variantFromLabels(job.Labels),
-			}
-
-			if err := jc.configureJobSpec(rehearsal.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+			if err := jc.configureJobSpec(rehearsal.Spec, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 				jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
 				continue
 			}
@@ -410,8 +341,8 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 	return rehearsals
 }
 
-func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, info config.Info, logger *logrus.Entry) error {
-	if err := inlineCiOpConfig(spec.Containers[0], jc.ciopConfigs, jc.registryResolver, info, jc.loggers); err != nil {
+func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, logger *logrus.Entry) error {
+	if err := inlineCiOpConfig(spec.Containers[0], jc.ciopConfigs, jc.registryResolver, jc.loggers); err != nil {
 		return err
 	}
 	// Remove configresolver flags from ci-operator jobs

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -35,57 +35,11 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
-	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
 
 const testingRegistry = "../../test/multistage-registry/registry"
-
-// configFiles contains the info needed to allow inlineCiOpConfig to successfully inline
-// CONFIG_SPEC and not fail
-func generateTestConfigFiles() config.ByFilename {
-	return config.ByFilename{
-		"targetOrg-targetRepo-master.yaml": config.DataWithInfo{
-			Configuration: api.ReleaseBuildConfiguration{
-				Tests: []api.TestStepConfiguration{
-					{As: "job1"},
-					{As: "job2"},
-				},
-			},
-			Info: config.Info{
-				Org:    "targetOrg",
-				Repo:   "targetRepo",
-				Branch: "master",
-			},
-		},
-		"targetOrg-targetRepo-not-master.yaml": config.DataWithInfo{
-			Configuration: api.ReleaseBuildConfiguration{
-				Tests: []api.TestStepConfiguration{
-					{As: "job1"},
-					{As: "job2"},
-				},
-			},
-			Info: config.Info{
-				Org:    "targetOrg",
-				Repo:   "targetRepo",
-				Branch: "not-master",
-			},
-		}, "anotherOrg-anotherRepo-master.yaml": config.DataWithInfo{
-			Configuration: api.ReleaseBuildConfiguration{
-				Tests: []api.TestStepConfiguration{
-					{As: "job1"},
-					{As: "job2"},
-				},
-			},
-			Info: config.Info{
-				Org:    "anotherOrg",
-				Repo:   "anotherRepo",
-				Branch: "master",
-			},
-		},
-	}
-}
 
 var update = flag.Bool("update", false, "update fixtures")
 
@@ -221,7 +175,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		Branch: "master",
 	}
 	testCiopConfig := api.ReleaseBuildConfiguration{}
-	testCiopConfigContent, err := yaml.Marshal(&testCiopConfig)
+	testCiopCongigContent, err := yaml.Marshal(&testCiopConfig)
 	if err != nil {
 		t.Fatal("Failed to marshal ci-operator config")
 	}
@@ -254,7 +208,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
 		configs:     config.ByFilename{"filename": {Info: testCiopConfigInfo, Configuration: testCiopConfig}},
-		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopConfigContent)}},
+		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopCongigContent)}},
 	}, {
 		description:   "bad CM key is handled",
 		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
@@ -273,7 +227,7 @@ func TestInlineCiopConfig(t *testing.T) {
 			job := makeTestingPresubmitForEnv(tc.sourceEnv)
 			expectedJob := makeTestingPresubmitForEnv(tc.expectedEnv)
 
-			err := inlineCiOpConfig(job.Spec.Containers[0], tc.configs, resolver, testCiopConfigInfo, testLoggers)
+			err := inlineCiOpConfig(job.Spec.Containers[0], tc.configs, resolver, testLoggers)
 
 			if tc.expectedError && err == nil {
 				t.Errorf("Expected inlineCiopConfig() to return an error, none returned")
@@ -299,11 +253,11 @@ func makeTestingPresubmit(name, context, branch string) *prowconfig.Presubmit {
 		JobBase: prowconfig.JobBase{
 			Agent:  "kubernetes",
 			Name:   name,
-			Labels: map[string]string{rehearseLabel: "123", jobconfig.CanBeRehearsedLabel: "true"},
+			Labels: map[string]string{rehearseLabel: "123", "pj-rehearse.openshift.io/can-be-rehearsed": "true"},
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Command: []string{"ci-operator"},
-					Args:    []string{"--resolver-address=http://ci-operator-resolver", "--org", "openshift", "--repo=origin", "--branch", "master"},
+					Args:    []string{"--resolver-address=http://ci-operator-resolver", "--org", "openshift", "--repo=origin", "--branch", "master", "--variant", "v2"},
 				}},
 			},
 		},
@@ -468,7 +422,7 @@ func makeSuccessfulFinishReactor(watcher watch.Interface, jobs map[string][]prow
 func TestExecuteJobsErrors(t *testing.T) {
 	testPrNumber, testNamespace, testRepoPath, testRefs := makeTestData()
 	targetOrgRepo := "targetOrg/targetRepo"
-	testCiopConfigs := generateTestConfigFiles()
+	testCiopConfigs := config.ByFilename{}
 
 	testCases := []struct {
 		description  string
@@ -529,7 +483,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 func TestExecuteJobsUnsuccessful(t *testing.T) {
 	testPrNumber, testNamespace, testRepoPath, testRefs := makeTestData()
 	targetOrgRepo := "targetOrg/targetRepo"
-	testCiopConfigs := generateTestConfigFiles()
+	testCiopConfigs := config.ByFilename{}
 
 	testCases := []struct {
 		description string
@@ -609,7 +563,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 	targetRepo := "targetRepo"
 	anotherTargetOrg := "anotherOrg"
 	anotherTargetRepo := "anotherRepo"
-	testCiopConfigs := generateTestConfigFiles()
+	testCiopConfigs := config.ByFilename{}
 
 	testCases := []struct {
 		description  string
@@ -1221,58 +1175,5 @@ func compareWithFixture(t *testing.T, output string, update bool) {
 
 	if diffStr != "" {
 		t.Errorf("got diff between expected and actual result: \n%s\n\nIf this is expected, re-run the test with `-update` flag to update the fixture.", diffStr)
-	}
-}
-
-func TestGetTrimmedBranch(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    []string
-		expected string
-	}{{
-		name:     "master with regex",
-		input:    []string{"^master$"},
-		expected: "master",
-	}, {
-		name:     "release-4.2 no regex",
-		input:    []string{"release-4.2"},
-		expected: "release-4.2",
-	}}
-	for _, testCase := range testCases {
-		branch := getTrimmedBranch(testCase.input)
-		if branch != testCase.expected {
-			t.Errorf("%s: getTrimmedBranches returned %s, expected %s", testCase.name, branch, testCase.expected)
-		}
-	}
-}
-
-func TestVariantFromLabels(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    map[string]string
-		expected string
-	}{{
-		name:     "no labels",
-		input:    map[string]string{},
-		expected: "",
-	}, {
-		name: "generated label",
-		input: map[string]string{
-			jobconfig.ProwJobLabelGenerated: "true",
-		},
-		expected: "",
-	}, {
-		name: "generated and variant labels",
-		input: map[string]string{
-			jobconfig.ProwJobLabelGenerated: "true",
-			jobconfig.ProwJobLabelVariant:   "v2",
-		},
-		expected: "v2",
-	}}
-	for _, testCase := range testCases {
-		variant := variantFromLabels(testCase.input)
-		if variant != testCase.expected {
-			t.Errorf("%s: variantFromLabels returned %s, expected %s", testCase.name, variant, testCase.expected)
-		}
 	}
 }

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -30,6 +30,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-org-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -100,6 +106,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-org-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -34,6 +34,11 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: private-duper-master.yaml
+            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -27,6 +27,12 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -35,6 +35,11 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -124,6 +129,12 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -195,6 +206,12 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -262,6 +279,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -332,6 +355,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: private-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -28,6 +28,12 @@ presubmits:
         - --target=test
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: subdir-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -90,6 +96,12 @@ presubmits:
         - --target=test
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: subdir-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -32,6 +32,11 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: aws
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-aws-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -114,6 +119,11 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
+      - name: CONFIG_SPEC
+        valueFrom:
+          configMapKeyRef:
+            key: super-duper-master.yaml
+            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -25,6 +25,12 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -89,6 +95,12 @@ postsubmits:
         - --variant=variant
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master__variant.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -33,6 +33,11 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -118,6 +123,12 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -181,6 +192,12 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -250,6 +267,12 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -312,6 +335,12 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -371,6 +400,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -433,6 +468,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -496,6 +537,12 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master__variant.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -562,6 +609,12 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master__variant.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -624,6 +677,12 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master__variant.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -689,6 +748,12 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master__variant.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -28,6 +28,12 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master-removed-promotion.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -90,6 +96,12 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-master-removed-promotion.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -26,6 +26,12 @@ postsubmits:
         - --target=src
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -29,6 +29,12 @@ presubmits:
         - --target=src
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -92,6 +98,12 @@ presubmits:
         - --target=src
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -161,6 +173,12 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -223,6 +241,12 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -282,6 +306,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -344,6 +374,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: super-duper-release-3.11.yaml
+              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -25,6 +25,12 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -28,6 +28,12 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -90,6 +96,12 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -149,6 +161,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -211,6 +229,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-ci-tools-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -26,6 +26,12 @@ postsubmits:
         - --target=artifacts
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -30,6 +30,12 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -94,6 +100,12 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -153,6 +165,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -215,6 +233,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: openshift-origin-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -29,6 +29,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-other-nonstandard.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -92,6 +98,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-other-nonstandard.yaml
+              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -28,6 +28,12 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -90,6 +96,12 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -157,6 +169,11 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: TEST_COMMAND
@@ -250,6 +267,11 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -335,6 +357,12 @@ presubmits:
         - --target=race
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -397,6 +425,12 @@ presubmits:
         - --target=race
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -456,6 +490,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -518,6 +558,12 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          valueFrom:
+            configMapKeyRef:
+              key: org-repo-master.yaml
+              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
Reverts openshift/ci-tools#534

There is currently a small mistake from that PR that breaks rehearsals. Working on fixing that as well as updating the integration tests to run without `CONFIG_SPEC` set