### PR TITLE
prowgen,pj-rehearse: do not add CONFIG_SPEC to generated jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	prowJobLabelVariant = "ci-operator.openshift.io/variant"
-
 	sentryDsnMountName  = "sentry-dsn"
 	sentryDsnSecretName = "sentry-dsn"
 	sentryDsnMountPath  = "/etc/sentry-dsn"
@@ -94,14 +92,6 @@ func (o *options) process() error {
 // Various pieces are derived from `org`, `repo`, `branch` and `target`.
 // `additionalArgs` are passed as additional arguments to `ci-operator`
 func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeapi.PodSpec {
-	configMapKeyRef := kubeapi.EnvVarSource{
-		ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-			LocalObjectReference: kubeapi.LocalObjectReference{
-				Name: info.ConfigMapName(),
-			},
-			Key: info.Basename(),
-		},
-	}
 	volumeMounts := []kubeapi.VolumeMount{
 		{
 			Name:      sentryDsnMountName,
@@ -185,7 +175,6 @@ func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeap
 			{
 				Image:           "ci-operator:latest",
 				ImagePullPolicy: kubeapi.PullAlways,
-				Env:             []kubeapi.EnvVar{{Name: "CONFIG_SPEC", ValueFrom: &configMapKeyRef}},
 				Resources: kubeapi.ResourceRequirements{
 					Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 				},
@@ -476,7 +465,7 @@ func generateJobBase(name, prefix string, info *prowgenInfo, label jc.ProwgenLab
 
 	jobName := info.Info.JobName(prefix, name)
 	if len(info.Variant) > 0 {
-		labels[prowJobLabelVariant] = info.Variant
+		labels[jc.ProwJobLabelVariant] = info.Variant
 	}
 	newTrue := true
 	dc := &v1.DecorationConfig{SkipCloning: &newTrue}

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"io/ioutil"
 	"log"
 	"os"
@@ -13,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	kubeapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -21,7 +21,6 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	ciop "github.com/openshift/ci-tools/pkg/api"
-
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
@@ -64,17 +63,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -130,17 +118,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -196,17 +173,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
@@ -271,17 +237,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
-					Env: []kubeapi.EnvVar{{
-						Name: "CONFIG_SPEC",
-						ValueFrom: &kubeapi.EnvVarSource{
-							ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-								LocalObjectReference: kubeapi.LocalObjectReference{
-									Name: "ci-operator-misc-configs",
-								},
-								Key: "org-repo-branch.yaml",
-							},
-						},
-					}},
 					VolumeMounts: []kubeapi.VolumeMount{{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"}},
@@ -337,17 +292,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						Resources: kubeapi.ResourceRequirements{
 							Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 						},
-						Env: []kubeapi.EnvVar{{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "org-repo-branch.yaml",
-								},
-							},
-						}},
 						VolumeMounts: []kubeapi.VolumeMount{
 							{
 								Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true,
@@ -498,17 +442,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -614,17 +547,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "aws"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -715,19 +637,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 					},
 					VolumeMounts: []kubeapi.VolumeMount{
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
@@ -839,17 +748,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -967,17 +865,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1095,17 +982,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1220,17 +1096,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 					},
 					Env: []kubeapi.EnvVar{
-						{
-							Name: "CONFIG_SPEC",
-							ValueFrom: &kubeapi.EnvVarSource{
-								ConfigMapKeyRef: &kubeapi.ConfigMapKeySelector{
-									LocalObjectReference: kubeapi.LocalObjectReference{
-										Name: "ci-operator-misc-configs",
-									},
-									Key: "organization-repo-branch.yaml",
-								},
-							},
-						},
 						{Name: "CLUSTER_TYPE", Value: "gcp"},
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
@@ -1719,12 +1584,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1786,12 +1645,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1854,12 +1707,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1919,12 +1766,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1987,12 +1828,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2083,12 +1918,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2129,12 +1958,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2199,12 +2022,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2266,12 +2083,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2336,12 +2147,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2391,12 +2196,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2431,12 +2230,6 @@ tests:
         - --variant=rhel
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch__rhel.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2524,12 +2317,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2568,12 +2355,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2636,12 +2417,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2701,12 +2476,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2769,12 +2538,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2822,12 +2585,6 @@ tests:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2860,12 +2617,6 @@ tests:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-branch.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -17,6 +17,7 @@ import (
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
 
 var ignoreUnexported = cmpopts.IgnoreUnexported(prowconfig.Presubmit{}, prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{})
@@ -388,6 +389,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 			Branches: []string{baseCiopConfig.Branch},
 		},
 		JobBase: prowconfig.JobBase{
+			Name:  baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "test"),
 			Agent: string(pjapi.KubernetesAgent),
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
@@ -427,7 +429,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 								t.Fatal(err)
 							}
-							ret.Name = "org-repo-branch-testjob"
+							ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
@@ -441,7 +443,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 				if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 					t.Fatal(err)
 				}
-				ret.Name = "org-repo-branch-testjob"
+				ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 				ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 				return ret
 			}(),
@@ -457,7 +459,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 								t.Fatal(err)
 							}
-							ret.Name = "org-repo-branch-testjob"
+							ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 							moreEnvVars := []v1.EnvVar{{
 								Name:  "SOMETHING",
 								Value: "value of SOMETHING",
@@ -476,7 +478,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 				if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 					t.Fatal(err)
 				}
-				ret.Name = "org-repo-branch-testjob"
+				ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 				moreEnvVars := []v1.EnvVar{{
 					Name:  "SOMETHING",
 					Value: "value of SOMETHING",
@@ -497,7 +499,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 								t.Fatal(err)
 							}
-							ret.Name = "org-repo-branch-testjob"
+							ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 							ret.Spec.Containers[0].Env[0].ValueFrom.ConfigMapKeyRef.Key = baseCiopConfig.Filename
 							return ret
 						}(),
@@ -517,7 +519,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 							if err := deepcopy.Copy(&ret, &basePresubmitWithCiop); err != nil {
 								t.Fatal(err)
 							}
-							ret.Name = "org-repo-branch-testjob"
+							ret.Name = baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "testjob")
 							ret.Agent = string(pjapi.JenkinsAgent)
 							ret.Spec.Containers[0].Env = []v1.EnvVar{}
 							return ret
@@ -631,7 +633,7 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 					PostsubmitsStatic: map[string][]prowconfig.Postsubmit{
 						"org/repo": {{
 							JobBase: prowconfig.JobBase{
-								Name:  "branch-ci-org-repo-branch-images",
+								Name:  "branch-ci-org-repo-BRANCH-images",
 								Agent: "kubernetes",
 								Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "BRANCH"}),
 							},

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -23,6 +23,7 @@ type ProwgenLabel string
 const (
 	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
 	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
+	ProwJobLabelVariant                = "ci-operator.openshift.io/variant"
 	Generated             ProwgenLabel = "true"
 	New                   ProwgenLabel = "newly-generated"
 	PresubmitPrefix                    = "pull"

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -35,11 +35,59 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
 
 const testingRegistry = "../../test/multistage-registry/registry"
+
+const testingCiOpCfgYAML = "tests:\n- as: job1\n  commands: \"\"\n- as: job2\n  commands: \"\"\n"
+
+// configFiles contains the info needed to allow inlineCiOpConfig to successfully inline
+// CONFIG_SPEC and not fail
+func generateTestConfigFiles() config.ByFilename {
+	return config.ByFilename{
+		"targetOrg-targetRepo-master.yaml": config.DataWithInfo{
+			Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{
+					{As: "job1"},
+					{As: "job2"},
+				},
+			},
+			Info: config.Info{
+				Org:    "targetOrg",
+				Repo:   "targetRepo",
+				Branch: "master",
+			},
+		},
+		"targetOrg-targetRepo-not-master.yaml": config.DataWithInfo{
+			Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{
+					{As: "job1"},
+					{As: "job2"},
+				},
+			},
+			Info: config.Info{
+				Org:    "targetOrg",
+				Repo:   "targetRepo",
+				Branch: "not-master",
+			},
+		}, "anotherOrg-anotherRepo-master.yaml": config.DataWithInfo{
+			Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{
+					{As: "job1"},
+					{As: "job2"},
+				},
+			},
+			Info: config.Info{
+				Org:    "anotherOrg",
+				Repo:   "anotherRepo",
+				Branch: "master",
+			},
+		},
+	}
+}
 
 var update = flag.Bool("update", false, "update fixtures")
 
@@ -175,7 +223,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		Branch: "master",
 	}
 	testCiopConfig := api.ReleaseBuildConfiguration{}
-	testCiopCongigContent, err := yaml.Marshal(&testCiopConfig)
+	testCiopConfigContent, err := yaml.Marshal(&testCiopConfig)
 	if err != nil {
 		t.Fatal("Failed to marshal ci-operator config")
 	}
@@ -208,7 +256,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
 		configs:     config.ByFilename{"filename": {Info: testCiopConfigInfo, Configuration: testCiopConfig}},
-		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopCongigContent)}},
+		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopConfigContent)}},
 	}, {
 		description:   "bad CM key is handled",
 		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
@@ -227,7 +275,7 @@ func TestInlineCiopConfig(t *testing.T) {
 			job := makeTestingPresubmitForEnv(tc.sourceEnv)
 			expectedJob := makeTestingPresubmitForEnv(tc.expectedEnv)
 
-			err := inlineCiOpConfig(job.Spec.Containers[0], tc.configs, resolver, testLoggers)
+			err := inlineCiOpConfig(&job.Spec.Containers[0], tc.configs, resolver, testCiopConfigInfo, testLoggers)
 
 			if tc.expectedError && err == nil {
 				t.Errorf("Expected inlineCiopConfig() to return an error, none returned")
@@ -253,11 +301,11 @@ func makeTestingPresubmit(name, context, branch string) *prowconfig.Presubmit {
 		JobBase: prowconfig.JobBase{
 			Agent:  "kubernetes",
 			Name:   name,
-			Labels: map[string]string{rehearseLabel: "123", "pj-rehearse.openshift.io/can-be-rehearsed": "true"},
+			Labels: map[string]string{rehearseLabel: "123", jobconfig.CanBeRehearsedLabel: "true"},
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Command: []string{"ci-operator"},
-					Args:    []string{"--resolver-address=http://ci-operator-resolver", "--org", "openshift", "--repo=origin", "--branch", "master", "--variant", "v2"},
+					Args:    []string{"--resolver-address=http://ci-operator-resolver", "--org", "openshift", "--repo=origin", "--branch", "master"},
 				}},
 			},
 		},
@@ -378,6 +426,8 @@ func makeTestingProwJob(namespace, jobName, context string, refs *pjapi.Refs, or
 			PodSpec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Command: []string{"ci-operator"},
+					Args:    []string{},
+					Env:     []v1.EnvVar{{Name: "CONFIG_SPEC", Value: testingCiOpCfgYAML}},
 				}},
 			},
 		},
@@ -422,7 +472,7 @@ func makeSuccessfulFinishReactor(watcher watch.Interface, jobs map[string][]prow
 func TestExecuteJobsErrors(t *testing.T) {
 	testPrNumber, testNamespace, testRepoPath, testRefs := makeTestData()
 	targetOrgRepo := "targetOrg/targetRepo"
-	testCiopConfigs := config.ByFilename{}
+	testCiopConfigs := generateTestConfigFiles()
 
 	testCases := []struct {
 		description  string
@@ -483,7 +533,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 func TestExecuteJobsUnsuccessful(t *testing.T) {
 	testPrNumber, testNamespace, testRepoPath, testRefs := makeTestData()
 	targetOrgRepo := "targetOrg/targetRepo"
-	testCiopConfigs := config.ByFilename{}
+	testCiopConfigs := generateTestConfigFiles()
 
 	testCases := []struct {
 		description string
@@ -563,7 +613,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 	targetRepo := "targetRepo"
 	anotherTargetOrg := "anotherOrg"
 	anotherTargetRepo := "anotherRepo"
-	testCiopConfigs := config.ByFilename{}
+	testCiopConfigs := generateTestConfigFiles()
 
 	testCases := []struct {
 		description  string
@@ -1175,5 +1225,58 @@ func compareWithFixture(t *testing.T, output string, update bool) {
 
 	if diffStr != "" {
 		t.Errorf("got diff between expected and actual result: \n%s\n\nIf this is expected, re-run the test with `-update` flag to update the fixture.", diffStr)
+	}
+}
+
+func TestGetTrimmedBranch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected string
+	}{{
+		name:     "master with regex",
+		input:    []string{"^master$"},
+		expected: "master",
+	}, {
+		name:     "release-4.2 no regex",
+		input:    []string{"release-4.2"},
+		expected: "release-4.2",
+	}}
+	for _, testCase := range testCases {
+		branch := getTrimmedBranch(testCase.input)
+		if branch != testCase.expected {
+			t.Errorf("%s: getTrimmedBranches returned %s, expected %s", testCase.name, branch, testCase.expected)
+		}
+	}
+}
+
+func TestVariantFromLabels(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    map[string]string
+		expected string
+	}{{
+		name:     "no labels",
+		input:    map[string]string{},
+		expected: "",
+	}, {
+		name: "generated label",
+		input: map[string]string{
+			jobconfig.ProwJobLabelGenerated: "true",
+		},
+		expected: "",
+	}, {
+		name: "generated and variant labels",
+		input: map[string]string{
+			jobconfig.ProwJobLabelGenerated: "true",
+			jobconfig.ProwJobLabelVariant:   "v2",
+		},
+		expected: "v2",
+	}}
+	for _, testCase := range testCases {
+		variant := variantFromLabels(testCase.input)
+		if variant != testCase.expected {
+			t.Errorf("%s: variantFromLabels returned %s, expected %s", testCase.name, variant, testCase.expected)
+		}
 	}
 }

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -24,12 +24,6 @@ presubmits:
         - --target=custom
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-ciop-cfg-change-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -66,12 +60,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -21,12 +21,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -62,11 +56,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -122,12 +111,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -164,12 +147,6 @@ presubmits:
         - --target=integration
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -205,11 +182,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -264,11 +236,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: openstack
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -318,12 +285,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -21,11 +21,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-ciop-cfg-change.yaml
-            name: ci-operator-misc-configs
       - name: JOB_NAME_SAFE
         value: e2e
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -20,12 +20,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,11 +55,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -121,12 +110,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -163,12 +146,6 @@ presubmits:
         - --target=integration
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -206,12 +183,6 @@ presubmits:
         - --target=multistage
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -264,12 +235,6 @@ presubmits:
         - --target=multistage2
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -322,12 +287,6 @@ presubmits:
         - --target=multistage3
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -380,12 +339,6 @@ presubmits:
         - --target=multistage4
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -438,12 +391,6 @@ presubmits:
         - --target=multistage5
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -495,12 +442,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -197,6 +197,12 @@
         env:
         - name: CLUSTER_TYPE
           value: gcp
+        - name: JOB_NAME_SAFE
+          value: e2e
+        - name: RPM_REPO_OPENSHIFT_ORIGIN
+          value: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
+        - name: TEST_COMMAND
+          value: make test-e2e
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -226,12 +232,6 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
-        - name: JOB_NAME_SAFE
-          value: e2e
-        - name: RPM_REPO_OPENSHIFT_ORIGIN
-          value: https://rpms.svc.ci.openshift.org/openshift-origin-v3.11/
-        - name: TEST_COMMAND
-          value: make test-e2e
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -654,6 +654,10 @@
         env:
         - name: CLUSTER_TYPE
           value: gcp
+        - name: JOB_NAME_SAFE
+          value: test-profile
+        - name: TEST_COMMAND
+          value: make test
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -681,10 +685,6 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
-        - name: JOB_NAME_SAFE
-          value: test-profile
-        - name: TEST_COMMAND
-          value: make test
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -885,6 +885,10 @@
         env:
         - name: CLUSTER_TYPE
           value: aws
+        - name: JOB_NAME_SAFE
+          value: e2e-aws
+        - name: TEST_COMMAND
+          value: changed command
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -912,10 +916,6 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
-        - name: JOB_NAME_SAFE
-          value: e2e-aws
-        - name: TEST_COMMAND
-          value: changed command
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1116,6 +1116,10 @@
         env:
         - name: CLUSTER_TYPE
           value: aws
+        - name: JOB_NAME_SAFE
+          value: e2e-aws
+        - name: TEST_COMMAND
+          value: TEST_SUITE=openshift/conformance/parallel run-tests
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -1143,10 +1147,6 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
-        - name: JOB_NAME_SAFE
-          value: e2e-aws
-        - name: TEST_COMMAND
-          value: TEST_SUITE=openshift/conformance/parallel run-tests
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1243,6 +1243,10 @@
         env:
         - name: CLUSTER_TYPE
           value: openstack
+        - name: JOB_NAME_SAFE
+          value: e2e-aws
+        - name: TEST_COMMAND
+          value: TEST_SUITE=openshift/conformance/parallel run-tests
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -1270,10 +1274,6 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
-        - name: JOB_NAME_SAFE
-          value: e2e-aws
-        - name: TEST_COMMAND
-          value: TEST_SUITE=openshift/conformance/parallel run-tests
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1658,6 +1658,10 @@
         env:
         - name: CLUSTER_TYPE
           value: aws
+        - name: JOB_NAME_SAFE
+          value: e2e-aws
+        - name: TEST_COMMAND
+          value: changed command
         - name: CONFIG_SPEC
           value: |
             base_images:
@@ -1869,10 +1873,6 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
-        - name: JOB_NAME_SAFE
-          value: e2e-aws
-        - name: TEST_COMMAND
-          value: changed command
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -24,12 +24,6 @@ presubmits:
         - --target=custom
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-ciop-cfg-change-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -66,12 +60,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-ciop-cfg-change.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -25,11 +25,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-cluster-profile.yaml
-              name: ci-operator-misc-configs
         - name: JOB_NAME_SAFE
           value: test-profile
         - name: TEST_COMMAND

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -18,12 +18,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -57,11 +51,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -117,12 +106,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -157,12 +140,6 @@ presubmits:
         - --target=integration
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -196,11 +173,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -253,11 +225,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: openstack
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -305,12 +272,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -18,11 +18,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-ciop-cfg-change.yaml
-            name: ci-operator-misc-configs
       - name: JOB_NAME_SAFE
         value: e2e
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/pj-rehearse-integration/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -20,12 +20,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -61,11 +55,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -121,12 +110,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -163,12 +146,6 @@ presubmits:
         - --target=integration
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -206,12 +183,6 @@ presubmits:
         - --target=multistage
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -264,12 +235,6 @@ presubmits:
         - --target=multistage2
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -322,12 +287,6 @@ presubmits:
         - --target=multistage3
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -380,12 +339,6 @@ presubmits:
         - --target=multistage4
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -437,12 +390,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-trooper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -30,12 +30,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-org-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -106,12 +100,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-org-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -34,11 +34,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: private-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -27,12 +27,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -35,11 +35,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -129,12 +124,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -206,12 +195,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -279,12 +262,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -355,12 +332,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: private-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=test
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: subdir-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=test
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: subdir-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -32,11 +32,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: aws
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-aws-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -119,11 +114,6 @@ periodics:
       env:
       - name: CLUSTER_TYPE
         value: gcp
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-master.yaml
-            name: ci-operator-master-configs
       - name: JOB_NAME_SAFE
         value: e2e-nightly
       - name: RPM_REPO_OPENSHIFT_ORIGIN

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -25,12 +25,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -95,12 +89,6 @@ postsubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -33,11 +33,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: gcp
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -123,12 +118,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -192,12 +181,6 @@ presubmits:
         - --target=[release:latest]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -267,12 +250,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -335,12 +312,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -400,12 +371,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -468,12 +433,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -537,12 +496,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -609,12 +562,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -677,12 +624,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -748,12 +689,6 @@ presubmits:
         - --variant=variant
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master__variant.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-master-removed-promotion.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -26,12 +26,6 @@ postsubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -29,12 +29,6 @@ presubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -98,12 +92,6 @@ presubmits:
         - --target=src
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -173,12 +161,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -241,12 +223,6 @@ presubmits:
         - --target=lint
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -306,12 +282,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -374,12 +344,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: super-duper-release-3.11.yaml
-              name: ci-operator-3.x-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -25,12 +25,6 @@ postsubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=[images]
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -161,12 +149,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -229,12 +211,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-ci-tools-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -26,12 +26,6 @@ postsubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -30,12 +30,6 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -100,12 +94,6 @@ presubmits:
         - --target=artifacts
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -165,12 +153,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -233,12 +215,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: openshift-origin-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -29,12 +29,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-other-nonstandard.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -98,12 +92,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-other-nonstandard.yaml
-              name: ci-operator-misc-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -28,12 +28,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -96,12 +90,6 @@ presubmits:
         - --target=cmd
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -169,11 +157,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e
         - name: TEST_COMMAND
@@ -267,11 +250,6 @@ presubmits:
         env:
         - name: CLUSTER_TYPE
           value: aws
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         - name: JOB_NAME_SAFE
           value: e2e-aws
         - name: TEST_COMMAND
@@ -357,12 +335,6 @@ presubmits:
         - --target=race
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -425,12 +397,6 @@ presubmits:
         - --target=race
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -490,12 +456,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -558,12 +518,6 @@ presubmits:
         - --target=unit
         command:
         - ci-operator
-        env:
-        - name: CONFIG_SPEC
-          valueFrom:
-            configMapKeyRef:
-              key: org-repo-master.yaml
-              name: ci-operator-master-configs
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""


### PR DESCRIPTION
This is a fixed version of #534.

Fixes:
- Use pointer to job container passed to `inlineCiopConfig` so that the `CONFIG_SPEC` env could properly be added to the `Env` array
- Use jobnames instead of filenames inside envs for the `GetPresubmitsForCiopConfigs` and `GetPostsubmitsForCiopConfigs` in the diffs package
- Remove the `CONFIG_SPEC` env var from all jobs in the `pj-rehearse` integration tests