### PR TITLE
secret-wrapper: unify input and output directories

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -182,7 +182,7 @@ func (s *multiStageTestStep) setupRBAC() error {
 			APIGroups:     []string{""},
 			Resources:     []string{"secrets"},
 			ResourceNames: []string{s.name},
-			Verbs:         []string{"update"},
+			Verbs:         []string{"get", "update"},
 		}, {
 			APIGroups: []string{"", "image.openshift.io"},
 			Resources: []string{"imagestreams/layers"},

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -1963,6 +1963,7 @@
           "secrets"
         ],
         "verbs": [
+          "get",
           "update"
         ]
       },

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -2521,6 +2521,7 @@
           "secrets"
         ],
         "verbs": [
+          "get",
           "update"
         ]
       },
@@ -2572,6 +2573,7 @@
           "secrets"
         ],
         "verbs": [
+          "get",
           "update"
         ]
       },


### PR DESCRIPTION
Copy the input directory (where the secret is mounted) to the output
directory and use that to overwrite the secret after the wrapped command
is executed.  This is done so the program:

- deals with a single directory
- does not have to copy files manually to preserve them
- can delete files from the secret by removing them from the directory