### PR TITLE
ci-operator,prowgen: don't set redundant ci-operator flags

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -198,10 +198,6 @@ func generateCiOperatorPodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secre
 		"--give-pr-author-access-to-namespace=true",
 		"--artifact-dir=$(ARTIFACTS)",
 		fmt.Sprintf("--sentry-dsn-path=%s", sentryDsnSecretPath),
-		"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-		fmt.Sprintf("--org=%s", info.Org),
-		fmt.Sprintf("--repo=%s", info.Repo),
-		fmt.Sprintf("--branch=%s", info.Branch),
 		"--kubeconfig=/etc/apici/kubeconfig",
 		"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 	}, additionalArgs...)

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -52,10 +52,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=org",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=target",
@@ -105,10 +101,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=org",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--promote",
@@ -159,10 +151,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=org",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--promote",
@@ -224,10 +212,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=org",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=target",
@@ -280,10 +264,6 @@ func TestGeneratePodSpec(t *testing.T) {
 							"--give-pr-author-access-to-namespace=true",
 							"--artifact-dir=$(ARTIFACTS)",
 							"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-							"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-							"--org=org",
-							"--repo=repo",
-							"--branch=branch",
 							"--kubeconfig=/etc/apici/kubeconfig",
 							"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 							"--target=target",
@@ -429,10 +409,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -530,10 +506,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -623,10 +595,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -731,10 +699,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -848,10 +812,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -965,10 +925,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -1079,10 +1035,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						"--give-pr-author-access-to-namespace=true",
 						"--artifact-dir=$(ARTIFACTS)",
 						"--sentry-dsn-path=/etc/sentry-dsn/ci-operator",
-						"--resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org",
-						"--org=organization",
-						"--repo=repo",
-						"--branch=branch",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--target=test",
@@ -1572,14 +1524,10 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -1634,13 +1582,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -1696,13 +1640,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -1755,13 +1695,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -1817,13 +1753,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -1946,13 +1878,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --variant=rhel
@@ -2010,13 +1938,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --variant=rhel
@@ -2071,13 +1995,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         - --variant=rhel
@@ -2135,13 +2055,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         - --variant=rhel
@@ -2217,14 +2133,10 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --variant=rhel
@@ -2344,13 +2256,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -2406,13 +2314,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -2465,13 +2369,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -2527,13 +2427,9 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -2605,14 +2501,10 @@ tests:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=branch
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -148,6 +148,8 @@ const (
 	annotationIdleCleanupDurationTTL = "ci.openshift.io/ttl.soft"
 	// annotationCleanupDurationTTL is the annotation for requesting namespace cleanup after the namespace has been active
 	annotationCleanupDurationTTL = "ci.openshift.io/ttl.hard"
+	// configResolverAddress is the default configresolver address in api.ci
+	configResolverAddress = "http://ci-operator-configresolver-ci.svc.ci.openshift.org"
 )
 
 // CustomProwMetadata the name of the custom prow metadata file that's expected to be found in the artifacts directory.
@@ -285,7 +287,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.leaseServerUsername, "lease-server-username", "", "Username used to access the lease server")
 	flag.StringVar(&opt.leaseServerPasswordFile, "lease-server-password-file", "", "The path to password file used to access the lease server")
 	flag.StringVar(&opt.registryPath, "registry", "", "Path to the step registry directory")
-	flag.StringVar(&opt.configSpecPath, "config", "", "The configuration file. If not specified the CONFIG_SPEC environment variable will be used.")
+	flag.StringVar(&opt.configSpecPath, "config", "", "The configuration file. If not specified the CONFIG_SPEC environment variable or the configresolver will be used.")
 	flag.Var(&opt.targets, "target", "One or more targets in the configuration to build. Only steps that are required for this target will be run.")
 	flag.BoolVar(&opt.dry, "dry-run", opt.dry, "Print the steps that would be run and the objects that would be created without executing any steps")
 	flag.BoolVar(&opt.print, "print-graph", opt.print, "Print a directed graph of the build steps and exit. Intended for use with the golang digraph utility.")
@@ -318,7 +320,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.BoolVar(&opt.determinizeOutput, "determinize-output", false, "Determinize dry run's output by ordering the created objects.")
 
 	// flags needed for the configresolver
-	flag.StringVar(&opt.resolverAddress, "resolver-address", "", "Address of configresolver")
+	flag.StringVar(&opt.resolverAddress, "resolver-address", configResolverAddress, "Address of configresolver")
 	flag.StringVar(&opt.org, "org", "", "Org of the project (used by configresolver)")
 	flag.StringVar(&opt.repo, "repo", "", "Repo of the project (used by configresolver)")
 	flag.StringVar(&opt.branch, "branch", "", "Branch of the project (used by configresolver)")
@@ -332,32 +334,6 @@ func bindOptions(flag *flag.FlagSet) *options {
 }
 
 func (o *options) Complete() error {
-	if len(o.resolverAddress) > 0 && (len(o.org) == 0 || len(o.repo) == 0 || len(o.branch) == 0) {
-		return fmt.Errorf("if resolverAddress is set, org, repo, and branch must also be set")
-	}
-	if (len(o.org) > 0 || len(o.repo) > 0 || len(o.branch) > 0) && len(o.resolverAddress) == 0 {
-		return fmt.Errorf("if org, repo, and/or branch are set, resolverAddress must also be set")
-	}
-	var info *load.ResolverInfo
-	if len(o.resolverAddress) > 0 {
-		info = &load.ResolverInfo{
-			Address: o.resolverAddress,
-			Org:     o.org,
-			Repo:    o.repo,
-			Branch:  o.branch,
-			Variant: o.variant,
-		}
-	}
-	config, err := load.Config(o.configSpecPath, o.registryPath, info)
-	if err != nil {
-		return fmt.Errorf("failed to load configuration: %v", err)
-	}
-	o.configSpec = config
-
-	if err := o.configSpec.ValidateResolved(); err != nil {
-		return err
-	}
-
 	jobSpec, err := api.ResolveSpecFromEnv()
 	if err != nil {
 		if len(o.gitRef) == 0 {
@@ -379,6 +355,18 @@ func (o *options) Complete() error {
 	}
 	jobSpec.BaseNamespace = o.baseNamespace
 	o.jobSpec = jobSpec
+
+	info := o.getResolverInfo(jobSpec)
+
+	config, err := load.Config(o.configSpecPath, o.registryPath, info)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %v", err)
+	}
+	o.configSpec = config
+
+	if err := o.configSpec.ValidateResolved(); err != nil {
+		return err
+	}
 
 	if o.dry && o.verbose {
 		config, _ := yaml.Marshal(o.configSpec)
@@ -1496,4 +1484,39 @@ func getPullSecretFromFile(filename string) (*coreapi.Secret, error) {
 	}
 	secret.Data[coreapi.DockerConfigJsonKey] = src
 	return secret, nil
+}
+
+func (o *options) getResolverInfo(jobSpec *api.JobSpec) *load.ResolverInfo {
+	// address and variant can only be set via options
+	info := &load.ResolverInfo{
+		Address: o.resolverAddress,
+		Variant: o.variant,
+	}
+
+	allRefs := jobSpec.ExtraRefs
+	if jobSpec.Refs != nil {
+		allRefs = append([]prowapi.Refs{*jobSpec.Refs}, allRefs...)
+	}
+
+	// identify org, repo, and branch from refs object
+	for _, ref := range allRefs {
+		if ref.Org != "" && ref.Repo != "" && ref.BaseRef != "" {
+			info.Org = ref.Org
+			info.Repo = ref.Repo
+			info.Branch = ref.BaseRef
+			break
+		}
+	}
+
+	// if flags set, override previous values
+	if o.org != "" {
+		info.Org = o.org
+	}
+	if o.repo != "" {
+		info.Repo = o.repo
+	}
+	if o.branch != "" {
+		info.Branch = o.branch
+	}
+	return info
 }

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -13,8 +13,10 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	"k8s.io/utils/diff"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load"
 )
 
 func TestSanitizeMessage(t *testing.T) {
@@ -238,4 +240,175 @@ func verifyMetadata(jobSpec *api.JobSpec, namespace string, customMetadata map[s
 	}
 
 	return nil
+}
+
+func TestGetResolverInfo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		opt      *options
+		jobSpec  *api.JobSpec
+		expected *load.ResolverInfo
+	}{{
+		name: "Only JobSpec Refs",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					Repo:    "testRepo",
+					BaseRef: "testBranch",
+				},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "testOrganization",
+			Repo:    "testRepo",
+			Branch:  "testBranch",
+		},
+	}, {
+		name: "JobSpec Refs w/ vairant set via flag",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+			variant:         "v2",
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					Repo:    "testRepo",
+					BaseRef: "testBranch",
+				},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "testOrganization",
+			Repo:    "testRepo",
+			Branch:  "testBranch",
+			Variant: "v2",
+		},
+	}, {
+		name: "Ref with ExtraRefs",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					Repo:    "testRepo",
+					BaseRef: "testBranch",
+				},
+				ExtraRefs: []prowapi.Refs{{
+					Org:     "anotherOrganization",
+					Repo:    "anotherRepo",
+					BaseRef: "anotherBranch",
+				}},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "testOrganization",
+			Repo:    "testRepo",
+			Branch:  "testBranch",
+		},
+	}, {
+		name: "Incomplete refs not used",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					BaseRef: "testBranch",
+				},
+				ExtraRefs: []prowapi.Refs{{
+					Org:     "anotherOrganization",
+					Repo:    "anotherRepo",
+					BaseRef: "anotherBranch",
+				}},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "anotherOrganization",
+			Repo:    "anotherRepo",
+			Branch:  "anotherBranch",
+		},
+	}, {
+		name: "Refs with single field overridden by options",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+			repo:            "anotherRepo",
+			variant:         "v2",
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					Repo:    "testRepo",
+					BaseRef: "testBranch",
+				},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "testOrganization",
+			Repo:    "anotherRepo",
+			Branch:  "testBranch",
+			Variant: "v2",
+		},
+	}, {
+		name: "Only options",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+			org:             "testOrganization",
+			repo:            "testRepo",
+			branch:          "testBranch",
+			variant:         "v2",
+		},
+		jobSpec: &api.JobSpec{},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "testOrganization",
+			Repo:    "testRepo",
+			Branch:  "testBranch",
+			Variant: "v2",
+		},
+	}, {
+		name: "All fields overridden by options",
+		opt: &options{
+			resolverAddress: configResolverAddress,
+			org:             "anotherOrganization",
+			repo:            "anotherRepo",
+			branch:          "anotherBranch",
+			variant:         "v2",
+		},
+		jobSpec: &api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{
+					Org:     "testOrganization",
+					Repo:    "testRepo",
+					BaseRef: "testBranch",
+				},
+			},
+		},
+		expected: &load.ResolverInfo{
+			Address: configResolverAddress,
+			Org:     "anotherOrganization",
+			Repo:    "anotherRepo",
+			Branch:  "anotherBranch",
+			Variant: "v2",
+		},
+	}}
+	for _, testCase := range testCases {
+		actual := testCase.opt.getResolverInfo(testCase.jobSpec)
+		if !reflect.DeepEqual(actual, testCase.expected) {
+			t.Errorf("%s: Actual does not match expected:\n%s", testCase.name, diff.ObjectReflectDiff(testCase.expected, actual))
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -37,5 +37,6 @@ require (
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/test-infra v0.0.0-20200314074034-a0cadb92a2b4
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -28,22 +28,21 @@ type ResolverInfo struct {
 }
 
 func Config(path, registryPath string, info *ResolverInfo) (*api.ReleaseBuildConfiguration, error) {
-	// Load the standard configuration from the configresolver, path, or env
+	// Load the standard configuration path, env, or configresolver (in that order of priority)
 	var raw string
-	if info != nil {
-		return configFromResolver(info)
-	} else if len(path) > 0 {
+	if len(path) > 0 {
 		data, err := ioutil.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("--config error: %v", err)
 		}
 		raw = string(data)
-	} else {
-		var ok bool
-		raw, ok = os.LookupEnv("CONFIG_SPEC")
-		if !ok || len(raw) == 0 {
-			return nil, fmt.Errorf("CONFIG_SPEC environment variable is not set or empty and no config file was set")
+	} else if spec, ok := os.LookupEnv("CONFIG_SPEC"); ok {
+		if len(spec) == 0 {
+			return nil, errors.New("CONFIG_SPEC environment variable cannot be set to an empty string")
 		}
+		raw = spec
+	} else {
+		return configFromResolver(info)
 	}
 	configSpec := api.ReleaseBuildConfiguration{}
 	if err := yaml.Unmarshal([]byte(raw), &configSpec); err != nil {

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -4,14 +4,14 @@
     "kind": "Build",
     "metadata": {
       "annotations": {
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "creates": "bin",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
@@ -75,14 +75,14 @@
     "kind": "Build",
     "metadata": {
       "annotations": {
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "creates": "src",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
@@ -112,7 +112,7 @@
       },
       "serviceAccount": "builder",
       "source": {
-        "dockerfile": "\nFROM pipeline:root\nADD ./app.binary /clonerefs\nRUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw\nWORKDIR /go/src/github.com/openshift/ci-tools/\nENV GOPATH=/go\nRUN git submodule update --init\n",
+        "dockerfile": "\nFROM pipeline:root\nADD ./app.binary /clonerefs\nRUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw\nWORKDIR /go/src/github.com/openshift/installer/\nENV GOPATH=/go\nRUN git submodule update --init\n",
         "images": [
           {
             "as": null,
@@ -139,7 +139,7 @@
             },
             {
               "name": "CLONEREFS_OPTIONS",
-              "value": "{\"src_root\":\"/go\",\"log\":\"/dev/null\",\"git_user_name\":\"ci-robot\",\"git_user_email\":\"ci-robot@openshift.io\",\"refs\":[{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}],\"fail\":true}"
+              "value": "{\"src_root\":\"/go\",\"log\":\"/dev/null\",\"git_user_name\":\"ci-robot\",\"git_user_email\":\"ci-robot@openshift.io\",\"refs\":[{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}],\"fail\":true}"
             }
           ],
           "forcePull": true,
@@ -165,14 +165,14 @@
     "kind": "Build",
     "metadata": {
       "annotations": {
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "creates": "tests",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
@@ -453,15 +453,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "post0",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -493,7 +493,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -505,7 +505,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -521,11 +521,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -644,15 +644,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "post1",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -684,7 +684,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -696,7 +696,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -712,11 +712,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -835,15 +835,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "pre0",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -875,7 +875,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -887,7 +887,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -903,11 +903,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1026,15 +1026,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "pre1",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1066,7 +1066,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1078,7 +1078,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1094,11 +1094,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1217,15 +1217,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test0",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1257,7 +1257,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1269,7 +1269,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1285,11 +1285,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1408,15 +1408,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test1",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1448,7 +1448,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1460,7 +1460,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1476,11 +1476,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1599,15 +1599,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test2",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "multi-stage",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1639,7 +1639,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1651,7 +1651,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1667,11 +1667,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -4,14 +4,14 @@
     "kind": "Build",
     "metadata": {
       "annotations": {
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "creates": "src",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
@@ -41,7 +41,7 @@
       },
       "serviceAccount": "builder",
       "source": {
-        "dockerfile": "\nFROM pipeline:root\nADD ./app.binary /clonerefs\nRUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw\nWORKDIR /go/src/github.com/openshift/ci-tools/\nENV GOPATH=/go\nRUN git submodule update --init\n",
+        "dockerfile": "\nFROM pipeline:root\nADD ./app.binary /clonerefs\nRUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw\nWORKDIR /go/src/github.com/openshift/installer/\nENV GOPATH=/go\nRUN git submodule update --init\n",
         "images": [
           {
             "as": null,
@@ -68,7 +68,7 @@
             },
             {
               "name": "CLONEREFS_OPTIONS",
-              "value": "{\"src_root\":\"/go\",\"log\":\"/dev/null\",\"git_user_name\":\"ci-robot\",\"git_user_email\":\"ci-robot@openshift.io\",\"refs\":[{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}],\"fail\":true}"
+              "value": "{\"src_root\":\"/go\",\"log\":\"/dev/null\",\"git_user_name\":\"ci-robot\",\"git_user_email\":\"ci-robot@openshift.io\",\"refs\":[{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}],\"fail\":true}"
             }
           ],
           "forcePull": true,
@@ -180,15 +180,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "e2e",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-azure",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -220,7 +220,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -232,7 +232,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -248,11 +248,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -397,15 +397,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-deprovision",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-azure",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -437,7 +437,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -449,7 +449,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -465,11 +465,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -614,15 +614,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-must-gather",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-azure",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -654,7 +654,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -666,7 +666,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -682,11 +682,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -831,15 +831,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-install",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-azure",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -871,7 +871,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -883,7 +883,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -899,11 +899,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1048,15 +1048,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-rbac",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-azure",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1088,7 +1088,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1100,7 +1100,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1116,11 +1116,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1265,15 +1265,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "e2e",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-gcp",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1305,7 +1305,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1317,7 +1317,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1333,11 +1333,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1482,15 +1482,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-deprovision",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-gcp",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1522,7 +1522,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1534,7 +1534,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1550,11 +1550,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1699,15 +1699,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-must-gather",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-gcp",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1739,7 +1739,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1751,7 +1751,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1767,11 +1767,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -1916,15 +1916,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-install",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-gcp",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -1956,7 +1956,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -1968,7 +1968,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -1984,11 +1984,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -2133,15 +2133,15 @@
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "ipi-install-rbac",
         "ci-operator.openshift.io/save-container-logs": "true",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
         "ci.openshift.io/multi-stage-test": "e2e-gcp",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration"
       },
@@ -2173,7 +2173,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -2185,7 +2185,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -2201,11 +2201,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",
@@ -2349,14 +2349,14 @@
     "metadata": {
       "annotations": {
         "ci-operator.openshift.io/container-sub-tests": "test",
-        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
       "creationTimestamp": null,
       "labels": {
         "build-id": "0",
-        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.branch": "release-4.2",
         "ci.openshift.io/refs.org": "openshift",
-        "ci.openshift.io/refs.repo": "ci-tools",
+        "ci.openshift.io/refs.repo": "installer",
         "created-by-ci": "true",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
         "prow.k8s.io/id": "uuid"
@@ -2386,7 +2386,7 @@
             },
             {
               "name": "JOB_SPEC",
-              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
             },
             {
               "name": "JOB_TYPE",
@@ -2398,7 +2398,7 @@
             },
             {
               "name": "PULL_BASE_REF",
-              "value": "master"
+              "value": "release-4.2"
             },
             {
               "name": "PULL_BASE_SHA",
@@ -2414,11 +2414,11 @@
             },
             {
               "name": "PULL_REFS",
-              "value": "master:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
             },
             {
               "name": "REPO_NAME",
-              "value": "ci-tools"
+              "value": "installer"
             },
             {
               "name": "REPO_OWNER",

--- a/test/ci-operator-integration/multi-stage/run.sh
+++ b/test/ci-operator-integration/multi-stage/run.sh
@@ -18,7 +18,8 @@ readonly OUT="${WORKDIR}/out.json"
 readonly ERR="${WORKDIR}/err.json"
 readonly ARTIFACT_DIR="${WORKDIR}/artifacts"
 
-export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-release-master-ci-operator-integration","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"af8a90a2faf965eeda949dc1c607c48d3ffcda3e","pulls":[{"number":1234,"author":"droslean","sha":"538680dfd2f6cff3b3506c80ca182dcb0dd22a58"}]}}'
+# CI-Operator requires JOB_SPEC to be set; ci-operator also uses the JOB_SPEC for configuring the args for configresolver
+export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-release-master-ci-operator-integration","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"installer","base_ref":"release-4.2","base_sha":"af8a90a2faf965eeda949dc1c607c48d3ffcda3e","pulls":[{"number":1234,"author":"droslean","sha":"538680dfd2f6cff3b3506c80ca182dcb0dd22a58"}]}}'
 # set by Prow
 unset BUILD_ID
 
@@ -28,7 +29,7 @@ check() {
         cat "${ERR}"
         return 1
     fi
-    if ! diff "${EXPECTED2}" "${OUT}"; then
+    if ! diff -Naupr "${EXPECTED2}" "${OUT}"; then
         echo "ERROR: differences have been found against ${EXPECTED2}"
         return 1
     fi
@@ -41,7 +42,7 @@ if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" 
     exit 1
 fi
 
-if ! diff "${EXPECTED1}" "${OUT}"; then
+if ! diff -Naupr "${EXPECTED1}" "${OUT}"; then
     echo "ERROR: differences have been found against ${EXPECTED1}"
     exit 1
 fi
@@ -78,8 +79,8 @@ for (( i = 0; i < 10; i++ )); do
     sleep 0.5
 done
 
-if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" --config "${TEST_CONFIG0}" \
-    -resolver-address "http://127.0.0.1:8080" -org "openshift" -repo "installer" -branch "release-4.2" --lease-server "http://lease" 2> "${ERR}" | jq --sort-keys . > "${OUT}"; then
+if ! ci-operator --dry-run --determinize-output --namespace "${TEST_NAMESPACE}" \
+    -resolver-address "http://127.0.0.1:8080" --lease-server "http://lease" 2> "${ERR}" | jq --sort-keys . > "${OUT}"; then
     echo "ERROR: ci-operator failed."
     cat "${ERR}"
     kill $(jobs -p)

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -18,14 +18,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private-org
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -88,14 +84,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private-org
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -17,14 +17,10 @@ periodics:
     containers:
     - args:
       - --artifact-dir=$(ARTIFACTS)
-      - --branch=master
       - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
       - --oauth-token-path=/usr/local/github-credentials/oauth
-      - --org=private
-      - --repo=duper
-      - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
       - --target=e2e-nightly

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -14,15 +14,11 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -18,14 +18,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=e2e
@@ -111,14 +107,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -182,14 +174,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -250,14 +238,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -320,14 +304,10 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
-        - --org=private
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=subdir
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=test
         command:
@@ -79,13 +75,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=subdir
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=test
         command:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -16,13 +16,9 @@ periodics:
     containers:
     - args:
       - --artifact-dir=$(ARTIFACTS)
-      - --branch=master
       - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
-      - --org=super
-      - --repo=duper
-      - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
       - --secret-dir=/usr/local/e2e-aws-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
       - --target=e2e-aws-nightly
@@ -98,13 +94,9 @@ periodics:
     containers:
     - args:
       - --artifact-dir=$(ARTIFACTS)
-      - --branch=master
       - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
-      - --org=super
-      - --repo=duper
-      - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
       - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
       - --target=e2e-nightly

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -13,14 +13,10 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -76,14 +72,10 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --variant=variant

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=e2e
@@ -106,13 +102,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -169,13 +161,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -239,13 +227,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -301,13 +285,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -360,13 +340,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -422,13 +398,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -483,13 +455,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -549,13 +517,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -612,13 +576,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         - --variant=variant
@@ -677,13 +637,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         - --variant=variant

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master-removed-promotion
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -79,13 +75,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master-removed-promotion
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -13,14 +13,10 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
         - --promote
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=src

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=src
@@ -80,13 +76,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=src
@@ -150,13 +142,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -212,13 +200,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=lint
         command:
@@ -271,13 +255,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -333,13 +313,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=release-3.11
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=super
-        - --repo=duper
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -13,14 +13,10 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
         - --promote
-        - --repo=ci-tools
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=ci-tools
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -79,13 +75,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=ci-tools
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         command:
@@ -138,13 +130,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=ci-tools
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -200,13 +188,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=ci-tools
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -13,14 +13,10 @@ postsubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
         - --promote
-        - --repo=origin
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=artifacts

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=origin
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -81,13 +77,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=origin
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=[images]
         - --target=[release:latest]
@@ -142,13 +134,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=origin
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -204,13 +192,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=openshift
-        - --repo=origin
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -18,13 +18,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=nonstandard
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=other
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -81,13 +77,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=nonstandard
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=other
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -17,13 +17,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=cmd
         command:
@@ -79,13 +75,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=cmd
         command:
@@ -138,16 +130,12 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
         - --lease-server-username=ci
         - --lease-server=https://boskos-ci.svc.ci.openshift.org
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=e2e
@@ -231,16 +219,12 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
         - --lease-server-username=ci
         - --lease-server=https://boskos-ci.svc.ci.openshift.org
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --secret-dir=/usr/local/e2e-aws-cluster-profile
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=e2e-aws
@@ -324,13 +308,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=race
         command:
@@ -386,13 +366,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=race
         command:
@@ -445,13 +421,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:
@@ -507,13 +479,9 @@ presubmits:
       containers:
       - args:
         - --artifact-dir=$(ARTIFACTS)
-        - --branch=master
         - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
-        - --org=org
-        - --repo=repo
-        - --resolver-address=http://ci-operator-configresolver-ci.svc.ci.openshift.org
         - --sentry-dsn-path=/etc/sentry-dsn/ci-operator
         - --target=unit
         command:

--- a/vendor/k8s.io/utils/diff/diff.go
+++ b/vendor/k8s.io/utils/diff/diff.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/davecgh/go-spew/spew"
+
+	"k8s.io/utils/field"
+)
+
+// StringDiff diffs a and b and returns a human readable diff.
+func StringDiff(a, b string) string {
+	ba := []byte(a)
+	bb := []byte(b)
+	out := []byte{}
+	i := 0
+	for ; i < len(ba) && i < len(bb); i++ {
+		if ba[i] != bb[i] {
+			break
+		}
+		out = append(out, ba[i])
+	}
+	out = append(out, []byte("\n\nA: ")...)
+	out = append(out, ba[i:]...)
+	out = append(out, []byte("\n\nB: ")...)
+	out = append(out, bb[i:]...)
+	out = append(out, []byte("\n\n")...)
+	return string(out)
+}
+
+// ObjectDiff writes the two objects out as JSON and prints out the identical part of
+// the objects followed by the remaining part of 'a' and finally the remaining part of 'b'.
+// For debugging tests.
+func ObjectDiff(a, b interface{}) string {
+	ab, err := json.Marshal(a)
+	if err != nil {
+		panic(fmt.Sprintf("a: %v", err))
+	}
+	bb, err := json.Marshal(b)
+	if err != nil {
+		panic(fmt.Sprintf("b: %v", err))
+	}
+	return StringDiff(string(ab), string(bb))
+}
+
+// ObjectGoPrintDiff is like ObjectDiff, but uses go-spew to print the objects,
+// which shows absolutely everything by recursing into every single pointer
+// (go's %#v formatters OTOH stop at a certain point). This is needed when you
+// can't figure out why reflect.DeepEqual is returning false and nothing is
+// showing you differences. This will.
+func ObjectGoPrintDiff(a, b interface{}) string {
+	s := spew.ConfigState{DisableMethods: true}
+	return StringDiff(
+		s.Sprintf("%#v", a),
+		s.Sprintf("%#v", b),
+	)
+}
+
+// ObjectReflectDiff returns a diff computed through reflection, without serializing to JSON.
+func ObjectReflectDiff(a, b interface{}) string {
+	vA, vB := reflect.ValueOf(a), reflect.ValueOf(b)
+	if vA.Type() != vB.Type() {
+		return fmt.Sprintf("type A %T and type B %T do not match", a, b)
+	}
+	diffs := objectReflectDiff(field.NewPath("object"), vA, vB)
+	if len(diffs) == 0 {
+		return "<no diffs>"
+	}
+	out := []string{""}
+	for _, d := range diffs {
+		elidedA, elidedB := limit(d.a, d.b, 80)
+		out = append(out,
+			fmt.Sprintf("%s:", d.path),
+			fmt.Sprintf("  a: %s", elidedA),
+			fmt.Sprintf("  b: %s", elidedB),
+		)
+	}
+	return strings.Join(out, "\n")
+}
+
+// limit:
+// 1. stringifies aObj and bObj
+// 2. elides identical prefixes if either is too long
+// 3. elides remaining content from the end if either is too long
+func limit(aObj, bObj interface{}, max int) (string, string) {
+	elidedPrefix := ""
+	elidedASuffix := ""
+	elidedBSuffix := ""
+	a, b := fmt.Sprintf("%#v", aObj), fmt.Sprintf("%#v", bObj)
+
+	if aObj != nil && bObj != nil {
+		if aType, bType := fmt.Sprintf("%T", aObj), fmt.Sprintf("%T", bObj); aType != bType {
+			a = fmt.Sprintf("%s (%s)", a, aType)
+			b = fmt.Sprintf("%s (%s)", b, bType)
+		}
+	}
+
+	for {
+		switch {
+		case len(a) > max && len(a) > 4 && len(b) > 4 && a[:4] == b[:4]:
+			// a is too long, b has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(b) > max && len(b) > 4 && len(a) > 4 && a[:4] == b[:4]:
+			// b is too long, a has data, and the first several characters are the same
+			elidedPrefix = "..."
+			a = a[2:]
+			b = b[2:]
+
+		case len(a) > max:
+			a = a[:max]
+			elidedASuffix = "..."
+
+		case len(b) > max:
+			b = b[:max]
+			elidedBSuffix = "..."
+
+		default:
+			// both are short enough
+			return elidedPrefix + a + elidedASuffix, elidedPrefix + b + elidedBSuffix
+		}
+	}
+}
+
+func public(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[:1] == strings.ToUpper(s[:1])
+}
+
+type diff struct {
+	path *field.Path
+	a, b interface{}
+}
+
+type orderedDiffs []diff
+
+func (d orderedDiffs) Len() int      { return len(d) }
+func (d orderedDiffs) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d orderedDiffs) Less(i, j int) bool {
+	a, b := d[i].path.String(), d[j].path.String()
+	if a < b {
+		return true
+	}
+	return false
+}
+
+func objectReflectDiff(path *field.Path, a, b reflect.Value) []diff {
+	switch a.Type().Kind() {
+	case reflect.Struct:
+		var changes []diff
+		for i := 0; i < a.Type().NumField(); i++ {
+			if !public(a.Type().Field(i).Name) {
+				if reflect.DeepEqual(a.Interface(), b.Interface()) {
+					continue
+				}
+				return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+			}
+			if sub := objectReflectDiff(path.Child(a.Type().Field(i).Name), a.Field(i), b.Field(i)); len(sub) > 0 {
+				changes = append(changes, sub...)
+			}
+		}
+		return changes
+	case reflect.Ptr, reflect.Interface:
+		if a.IsNil() || b.IsNil() {
+			switch {
+			case a.IsNil() && b.IsNil():
+				return nil
+			case a.IsNil():
+				return []diff{{path: path, a: nil, b: b.Interface()}}
+			default:
+				return []diff{{path: path, a: a.Interface(), b: nil}}
+			}
+		}
+		return objectReflectDiff(path, a.Elem(), b.Elem())
+	case reflect.Chan:
+		if !reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+		}
+		return nil
+	case reflect.Slice:
+		lA, lB := a.Len(), b.Len()
+		l := lA
+		if lB < lA {
+			l = lB
+		}
+		if lA == lB && lA == 0 {
+			if a.IsNil() != b.IsNil() {
+				return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+			}
+			return nil
+		}
+		var diffs []diff
+		for i := 0; i < l; i++ {
+			if !reflect.DeepEqual(a.Index(i), b.Index(i)) {
+				diffs = append(diffs, objectReflectDiff(path.Index(i), a.Index(i), b.Index(i))...)
+			}
+		}
+		for i := l; i < lA; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: a.Index(i), b: nil})
+		}
+		for i := l; i < lB; i++ {
+			diffs = append(diffs, diff{path: path.Index(i), a: nil, b: b.Index(i)})
+		}
+		return diffs
+	case reflect.Map:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		aKeys := make(map[interface{}]interface{})
+		for _, key := range a.MapKeys() {
+			aKeys[key.Interface()] = a.MapIndex(key).Interface()
+		}
+		var missing []diff
+		for _, key := range b.MapKeys() {
+			if _, ok := aKeys[key.Interface()]; ok {
+				delete(aKeys, key.Interface())
+				if reflect.DeepEqual(a.MapIndex(key).Interface(), b.MapIndex(key).Interface()) {
+					continue
+				}
+				missing = append(missing, objectReflectDiff(path.Key(fmt.Sprintf("%s", key.Interface())), a.MapIndex(key), b.MapIndex(key))...)
+				continue
+			}
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key.Interface())), a: nil, b: b.MapIndex(key).Interface()})
+		}
+		for key, value := range aKeys {
+			missing = append(missing, diff{path: path.Key(fmt.Sprintf("%s", key)), a: value, b: nil})
+		}
+		if len(missing) == 0 {
+			missing = append(missing, diff{path: path, a: a.Interface(), b: b.Interface()})
+		}
+		sort.Sort(orderedDiffs(missing))
+		return missing
+	default:
+		if reflect.DeepEqual(a.Interface(), b.Interface()) {
+			return nil
+		}
+		if !a.CanInterface() {
+			return []diff{{path: path, a: fmt.Sprintf("%#v", a), b: fmt.Sprintf("%#v", b)}}
+		}
+		return []diff{{path: path, a: a.Interface(), b: b.Interface()}}
+	}
+}
+
+// ObjectGoPrintSideBySide prints a and b as textual dumps side by side,
+// enabling easy visual scanning for mismatches.
+func ObjectGoPrintSideBySide(a, b interface{}) string {
+	s := spew.ConfigState{
+		Indent: " ",
+		// Extra deep spew.
+		DisableMethods: true,
+	}
+	sA := s.Sdump(a)
+	sB := s.Sdump(b)
+
+	linesA := strings.Split(sA, "\n")
+	linesB := strings.Split(sB, "\n")
+	width := 0
+	for _, s := range linesA {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	for _, s := range linesB {
+		l := len(s)
+		if l > width {
+			width = l
+		}
+	}
+	buf := &bytes.Buffer{}
+	w := tabwriter.NewWriter(buf, width, 0, 1, ' ', 0)
+	max := len(linesA)
+	if len(linesB) > max {
+		max = len(linesB)
+	}
+	for i := 0; i < max; i++ {
+		var a, b string
+		if i < len(linesA) {
+			a = linesA[i]
+		}
+		if i < len(linesB) {
+			b = linesB[i]
+		}
+		fmt.Fprintf(w, "%s\t%s\n", a, b)
+	}
+	w.Flush()
+	return buf.String()
+}

--- a/vendor/k8s.io/utils/field/path.go
+++ b/vendor/k8s.io/utils/field/path.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package field
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// Path represents the path from some root to a particular field.
+type Path struct {
+	name   string // the name of this field or "" if this is an index
+	index  string // if name == "", this is a subscript (index or map key) of the previous element
+	parent *Path  // nil if this is the root element
+}
+
+// NewPath creates a root Path object.
+func NewPath(name string, moreNames ...string) *Path {
+	r := &Path{name: name, parent: nil}
+	for _, anotherName := range moreNames {
+		r = &Path{name: anotherName, parent: r}
+	}
+	return r
+}
+
+// Root returns the root element of this Path.
+func (p *Path) Root() *Path {
+	for ; p.parent != nil; p = p.parent {
+		// Do nothing.
+	}
+	return p
+}
+
+// Child creates a new Path that is a child of the method receiver.
+func (p *Path) Child(name string, moreNames ...string) *Path {
+	r := NewPath(name, moreNames...)
+	r.Root().parent = p
+	return r
+}
+
+// Index indicates that the previous Path is to be subscripted by an int.
+// This sets the same underlying value as Key.
+func (p *Path) Index(index int) *Path {
+	return &Path{index: strconv.Itoa(index), parent: p}
+}
+
+// Key indicates that the previous Path is to be subscripted by a string.
+// This sets the same underlying value as Index.
+func (p *Path) Key(key string) *Path {
+	return &Path{index: key, parent: p}
+}
+
+// String produces a string representation of the Path.
+func (p *Path) String() string {
+	// make a slice to iterate
+	elems := []*Path{}
+	for ; p != nil; p = p.parent {
+		elems = append(elems, p)
+	}
+
+	// iterate, but it has to be backwards
+	buf := bytes.NewBuffer(nil)
+	for i := range elems {
+		p := elems[len(elems)-1-i]
+		if p.parent != nil && len(p.name) > 0 {
+			// This is either the root or it is a subscript.
+			buf.WriteString(".")
+		}
+		if len(p.name) > 0 {
+			buf.WriteString(p.name)
+		} else {
+			fmt.Fprintf(buf, "[%s]", p.index)
+		}
+	}
+	return buf.String()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -857,6 +857,8 @@ k8s.io/test-infra/prow/version
 k8s.io/test-infra/robots/pr-creator/updater
 # k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 k8s.io/utils/buffer
+k8s.io/utils/diff
+k8s.io/utils/field
 k8s.io/utils/integer
 k8s.io/utils/trace
 # knative.dev/pkg v0.0.0-20191111150521-6d806b998379


### PR DESCRIPTION
This is a revert of #551, which reverted #545. There were some issues in the `openshift/release` repo that were resulting in errors after #545 was merged. Those have been fixed and this PR should be ready to go again.