### PR TITLE
ci-operator multi-stage: default images to `stable`

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -263,7 +263,10 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 		if s.config.IsPipelineImage(image) || s.config.BuildsImage(image) {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
 		} else {
-			image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
+			// TODO remove once jobs are migrated
+			if !strings.HasPrefix(image, "stable:") {
+				image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
+			}
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -262,6 +262,8 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 		image := step.From
 		if s.config.IsPipelineImage(image) || s.config.BuildsImage(image) {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
+		} else {
+			image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -76,7 +76,7 @@ func TestGeneratePods(t *testing.T) {
 			MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 				ClusterProfile: api.ClusterProfileAWS,
 				Test: []api.LiteralTestStep{{
-					As: "step0", From: "image0", Commands: "command0",
+					As: "step0", From: "src", Commands: "command0",
 				}, {
 					As:          "step1",
 					From:        "image1",
@@ -171,7 +171,7 @@ func TestGeneratePods(t *testing.T) {
 			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step0",
-				Image:                    "image0",
+				Image:                    "pipeline:src",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
 				Env:                      append(coreEnv, customEnv...),
@@ -238,7 +238,7 @@ func TestGeneratePods(t *testing.T) {
 			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step1",
-				Image:                    "image1",
+				Image:                    "stable:image1",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
 				Env:                      append(append(coreEnv, coreapi.EnvVar{Name: "ARTIFACT_DIR", Value: "/artifact/dir"}), customEnv...),

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -743,7 +743,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "post1",
           "resources": {
             "limits": {

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -297,7 +297,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "my-image",
+          "image": "stable:my-image",
           "name": "e2e",
           "resources": {
             "requests": {
@@ -514,7 +514,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-deprovision",
           "resources": {
             "requests": {
@@ -731,7 +731,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-must-gather",
           "resources": {
             "requests": {
@@ -948,7 +948,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-install",
           "resources": {
             "requests": {
@@ -1165,7 +1165,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-rbac",
           "resources": {
             "requests": {
@@ -1382,7 +1382,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "my-image",
+          "image": "stable:my-image",
           "name": "e2e",
           "resources": {
             "requests": {
@@ -1599,7 +1599,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-deprovision",
           "resources": {
             "requests": {
@@ -1816,7 +1816,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-must-gather",
           "resources": {
             "requests": {
@@ -2033,7 +2033,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-install",
           "resources": {
             "requests": {
@@ -2250,7 +2250,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-rbac",
           "resources": {
             "requests": {


### PR DESCRIPTION
Contrary to all other areas of `ci-operator`, multi-stage tests need to be
able to use images from both the `pipeline` and `stable` ImageStreams.

The set of images that are part of the `pipeline` IS can be identified from
the configuration, but `stable` is populated at runtime after steps are
instantiated.  Crucially, support for arbitrary external images
(i.e. outside the release configuration) is not desired, so the simple rule
of identifying if an image is declared in the configuration and defaulting
it to `stable` otherwise can be used.