### PR TITLE
Revert "ci-operator multi-stage: ignore existing `stable:`"

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -263,7 +263,10 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 		if s.config.IsPipelineImage(image) || s.config.BuildsImage(image) {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
 		} else {
-			image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
+			// TODO remove once jobs are migrated
+			if !strings.HasPrefix(image, "stable:") {
+				image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
+			}
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -263,10 +263,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 		if s.config.IsPipelineImage(image) || s.config.BuildsImage(image) {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
 		} else {
-			// TODO remove once jobs are migrated
-			if !strings.HasPrefix(image, "stable:") {
-				image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
-			}
+			image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -262,6 +262,8 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 		image := step.From
 		if s.config.IsPipelineImage(image) || s.config.BuildsImage(image) {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, image)
+		} else {
+			image = fmt.Sprintf("%s:%s", api.StableImageStream, image)
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -76,7 +76,7 @@ func TestGeneratePods(t *testing.T) {
 			MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 				ClusterProfile: api.ClusterProfileAWS,
 				Test: []api.LiteralTestStep{{
-					As: "step0", From: "image0", Commands: "command0",
+					As: "step0", From: "src", Commands: "command0",
 				}, {
 					As:          "step1",
 					From:        "image1",
@@ -171,7 +171,7 @@ func TestGeneratePods(t *testing.T) {
 			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step0",
-				Image:                    "image0",
+				Image:                    "pipeline:src",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
 				Env:                      append(coreEnv, customEnv...),
@@ -238,7 +238,7 @@ func TestGeneratePods(t *testing.T) {
 			}},
 			Containers: []coreapi.Container{{
 				Name:                     "step1",
-				Image:                    "image1",
+				Image:                    "stable:image1",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
 				Env:                      append(append(coreEnv, coreapi.EnvVar{Name: "ARTIFACT_DIR", Value: "/artifact/dir"}), customEnv...),

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1181,7 +1181,7 @@ tag_specification:
 `
 const imageExampleRef = `ref:
   as: org-repo-e2e
-  from: stable:repo-tests
+  from: repo-tests
   commands: org-repo-e2e-commands.sh
   resources:
     requests:
@@ -1206,7 +1206,7 @@ const imageExampleLiteral = `- as: repo-e2e
     workflow: ipi
     test:
     - as: e2e
-      from: stable:repo-tests
+      from: repo-tests
       commands: |-
         #!/bin/bash
         e2e-tests # as built by go test -c

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -743,7 +743,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "post1",
           "resources": {
             "limits": {

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -297,7 +297,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "my-image",
+          "image": "stable:my-image",
           "name": "e2e",
           "resources": {
             "requests": {
@@ -514,7 +514,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-deprovision",
           "resources": {
             "requests": {
@@ -731,7 +731,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-must-gather",
           "resources": {
             "requests": {
@@ -948,7 +948,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-install",
           "resources": {
             "requests": {
@@ -1165,7 +1165,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-rbac",
           "resources": {
             "requests": {
@@ -1382,7 +1382,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "my-image",
+          "image": "stable:my-image",
           "name": "e2e",
           "resources": {
             "requests": {
@@ -1599,7 +1599,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-deprovision",
           "resources": {
             "requests": {
@@ -1816,7 +1816,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-deprovision-must-gather",
           "resources": {
             "requests": {
@@ -2033,7 +2033,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-install",
           "resources": {
             "requests": {
@@ -2250,7 +2250,7 @@
               "value": "/var/run/secrets/ci.openshift.io/multi-stage"
             }
           ],
-          "image": "installer",
+          "image": "stable:installer",
           "name": "ipi-install-rbac",
           "resources": {
             "requests": {


### PR DESCRIPTION
This reverts commit b72fccf706599296534d38adbe6a27381e7babb7.

https://github.com/openshift/release/pull/7693

/hold