### PR TITLE
Fix integration tests on build01

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -31,6 +31,9 @@ type inputImageTagStep struct {
 }
 
 func (s *inputImageTagStep) Inputs(dry bool) (api.InputDefinition, error) {
+	if dry {
+		return api.InputDefinition{"sha256:integration-test"}, nil
+	}
 	if len(s.imageName) > 0 {
 		return api.InputDefinition{s.imageName}, nil
 	}


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1584442888068900?thread_ts=1584441133.066500&cid=GB7NB0CUC

This one never worked.
https://prow.svc.ci.openshift.org/job-history/origin-ci-test/pr-logs/directory/pull-ci-openshift-ci-tools-master-integration-build01

/cc @openshift/openshift-team-developer-productivity-test-platform 

/hold

watching rehearsals