### PR TITLE
Revert "Add private-prow-configs-mirror tool in autoconfigbrancher pipeline"

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -191,12 +191,6 @@ func main() {
 
 	commitIfNeeded(fmt.Sprintf("%s --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs", "ci-operator-prowgen"), author)
 
-	cmd = "/usr/bin/private-prow-configs-mirror"
-	args = []string{"--release-repo-path", "."}
-	run(cmd, args...)
-
-	commitIfNeeded(fmt.Sprintf("%s --release-repo-path .", "private-prow-configs-mirror"), author)
-
 	if count == 0 {
 		logrus.Info("no new commits, existing ...")
 		return

--- a/images/autoconfigbrancher/Dockerfile
+++ b/images/autoconfigbrancher/Dockerfile
@@ -5,7 +5,6 @@ ADD config-brancher /usr/bin/config-brancher
 ADD ci-operator-prowgen /usr/bin/ci-operator-prowgen
 ADD autoconfigbrancher /usr/bin/autoconfigbrancher
 ADD ci-op-configs-mirror /usr/bin/ci-op-configs-mirror
-ADD private-prow-configs-mirror /usr/bin/private-prow-configs-mirror
 
 RUN yum install -y git && \
     yum clean all && \


### PR DESCRIPTION
Reverts openshift/ci-tools#558

`private-prow-configs-mirror` tool generates a warning. Reverting until the fix will land.