### PR TITLE
keep the 'approve' value in the private plugins repo level

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	openshiftPrivOrg = "openshift-priv"
+	openshiftPrivOrg   = "openshift-priv"
+	approvePluginValue = "approve"
 )
 
 type options struct {
@@ -328,6 +329,12 @@ func mergeCommonPrivatePlugins(plugins map[string][]string, privateReposWithValu
 		if len(repeatedValues) > 0 {
 			privateOrgPlugins = privateOrgPlugins.Union(valuesSet.Intersection(repeatedValues))
 			repoLevelPlugins = repoLevelPlugins.Union(valuesSet.Difference(repeatedValues))
+
+			// We want to keep the `approve` value in the repo level
+			// because it interacts with the tide.queries.
+			if valuesSet.Has(approvePluginValue) {
+				repoLevelPlugins.Insert(approvePluginValue)
+			}
 		} else {
 			repoLevelPlugins.Insert(repoValues...)
 		}
@@ -339,6 +346,7 @@ func mergeCommonPrivatePlugins(plugins map[string][]string, privateReposWithValu
 	}
 
 	if len(privateOrgPlugins.List()) > 0 {
+		privateOrgPlugins.Delete(approvePluginValue)
 		logrus.WithField("value", privateOrgPlugins.List()).Info("Generating openshift-priv org.")
 		plugins[openshiftPrivOrg] = privateOrgPlugins.List()
 	}

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -632,9 +632,9 @@ func TestInjectPrivatePlugins(t *testing.T) {
 				"openshift/testRepo1": {"approve"},
 				"testshift/testRepo3": {"approve", "trigger"},
 
-				"openshift-priv":           {"approve", "hold", "lgtm"},
-				"openshift-priv/testRepo1": {"cat", "dog"},
-				"openshift-priv/testRepo3": {"label", "milestone", "trigger"},
+				"openshift-priv":           {"hold", "lgtm"},
+				"openshift-priv/testRepo1": {"approve", "cat", "dog"},
+				"openshift-priv/testRepo3": {"approve", "label", "milestone", "trigger"},
 			},
 		},
 	}


### PR DESCRIPTION
considering https://github.com/openshift/release/pull/7712 merged, the fix seems to work.

`$ checkconfig --config-path ./core-services/prow/02_config/_config.yaml  --job-config-path ./ci-operator/jobs/  --plugin-config ./core-services/prow/02_config/_plugins.yaml  --strict --exclude-warning long-job-names --exclude-warning mismatched-tide-lenient`
```
{"component":"unset","file":"/home/nmoraitis/go/src/k8s.io/test-infra/prow/cmd/checkconfig/main.go:325","func":"main.main","level":"info","msg":"checkconfig passes without any error!","time":"2020-03-17T16:10:14+01:00"}
```

/cc @petr-muller 
/cc @openshift/openshift-team-developer-productivity-test-platform 