### PR TITLE
webreg: replace `centos:7` with `base`

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -965,7 +965,7 @@ testing are <code>OWNERS</code> files and files that end in <code>.md</code>.
 
 const refExample = `ref:
   as: ipi-conf                   # name of the step
-  from: centos:7                 # image to run the commands in
+  from: base                     # image to run the commands in
   commands: ipi-conf-commands.sh # script file containing the command(s) to be run
   resources:
     requests:


### PR DESCRIPTION
In the same spirit as:

- https://github.com/openshift/ci-tools/pull/561
- https://github.com/openshift/release/pull/7693

Eventually, a section detailing which images are accepted in that field
should be added.