### PR TITLE
Determinize job config: Set api.ci cluster if cluster is unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )
 .PHONY: format
 
+update-integration:
+	UPDATE=true make integration
+
 integration: integration-prowgen integration-pj-rehearse integration-ci-operator integration-ci-operator-configresolver integration-secret-wrapper integration-testgrid-generator integration-repo-init integration-group-auto-updater integration-ci-op-configs-mirror integration-cvp-trigger
 .PHONY: integration
 

--- a/cmd/determinize-prow-jobs/main_test.go
+++ b/cmd/determinize-prow-jobs/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestDefaultJobConfig(t *testing.T) {
+	jc := &config.JobConfig{
+		PresubmitsStatic: map[string][]config.Presubmit{
+			"a": {{}, {}, {JobBase: config.JobBase{Cluster: "default"}}},
+			"b": {{}, {}},
+		},
+		PostsubmitsStatic: map[string][]config.Postsubmit{
+			"a": {{}, {}, {JobBase: config.JobBase{Cluster: "default"}}},
+			"b": {{}, {}},
+		},
+		Periodics: []config.Periodic{{}, {}, {JobBase: config.JobBase{Cluster: "default"}}},
+	}
+
+	defaultJobConfig(jc)
+
+	for k := range jc.PresubmitsStatic {
+		for _, j := range jc.PresubmitsStatic[k] {
+			if j.Cluster != "api.ci" {
+				t.Errorf("expected cluster to be 'api.ci', was '%s'", j.Cluster)
+			}
+		}
+	}
+	for k := range jc.PostsubmitsStatic {
+		for _, j := range jc.PostsubmitsStatic[k] {
+			if j.Cluster != "api.ci" {
+				t.Errorf("expected cluster to be 'api.ci', was '%s'", j.Cluster)
+			}
+		}
+	}
+	for _, j := range jc.Periodics {
+		if j.Cluster != "api.ci" {
+			t.Errorf("expected cluster to be 'api.ci', was '%s'", j.Cluster)
+		}
+	}
+}

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -416,7 +416,9 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 	merged.Optional = old.Optional
 	merged.MaxConcurrency = old.MaxConcurrency
 	merged.SkipReport = old.SkipReport
-	merged.Cluster = old.Cluster
+	if old.Cluster != "" {
+		merged.Cluster = old.Cluster
+	}
 
 	return merged
 }
@@ -428,7 +430,9 @@ func mergePostsubmits(old, new *prowconfig.Postsubmit) prowconfig.Postsubmit {
 	merged := *new
 
 	merged.MaxConcurrency = old.MaxConcurrency
-	merged.Cluster = old.Cluster
+	if old.Cluster != "" {
+		merged.Cluster = old.Cluster
+	}
 
 	return merged
 }
@@ -440,7 +444,9 @@ func mergePeriodics(old, new *prowconfig.Periodic) prowconfig.Periodic {
 	merged := *new
 
 	merged.MaxConcurrency = old.MaxConcurrency
-	merged.Cluster = old.Cluster
+	if old.Cluster != "" {
+		merged.Cluster = old.Cluster
+	}
 
 	return merged
 }

--- a/test/prowgen-integration/run.sh
+++ b/test/prowgen-integration/run.sh
@@ -41,29 +41,6 @@ EOF
   exit 1
 fi
 
-determinized_output_jobs_dir="${workdir}/determinized"
-mkdir -p "${determinized_output_jobs_dir}"
-cp -r "${generated_output_jobs_dir}"/* "${determinized_output_jobs_dir}"
-
-echo "[INFO] Determinizing Prow jobs..."
-determinize-prow-jobs --prow-jobs-dir "${determinized_output_jobs_dir}/${subdir}"
-
-echo "[INFO] Validating determinized Prow jobs..."
-if [[ "$UPDATE" = true ]]; then
-  rm -rf "${generated_output_jobs_dir}"
-  cp -r "${determinized_output_jobs_dir}" "${generated_output_jobs_dir}"
-fi
-if ! diff -Naupr "${determinized_output_jobs_dir}" "${generated_output_jobs_dir}"> "${workdir}/gen_diff"; then
-  cat << EOF
-ERROR: Prow job generator did not output determinized jobs!
-ERROR: The following errors were found:
-
-EOF
-  cat "${workdir}/gen_diff"
-  echo "ERROR: If this is expected, run \`make update-integration\`"
-  exit 1
-fi
-
 if [[ "${subdir}" ]]; then
   echo "[INFO] Verifying other sub-directories were not modified..."
   rm -rf "${generated_output_jobs_dir}/${subdir}"

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - agent: kubernetes
     branches:
     - ^master$
+    cluster: api.ci
     decorate: true
     decoration_config:
       skip_cloning: true

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -117,6 +118,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - agent: kubernetes
     branches:
     - ^master$
+    cluster: api.ci
     decorate: true
     decoration_config:
       skip_cloning: true

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -121,6 +122,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     branches:
     - nonstandard
+    cluster: api.ci
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -4,6 +4,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/cmd
     decorate: true
     decoration_config:
@@ -117,6 +118,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -206,6 +208,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/e2e-aws
     decorate: true
     decoration_config:
@@ -295,6 +298,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/race
     decorate: true
     decoration_config:
@@ -408,6 +412,7 @@ presubmits:
     always_run: true
     branches:
     - master
+    cluster: api.ci
     context: ci/prow/unit
     decorate: true
     decoration_config:


### PR DESCRIPTION
I do realize that mutating the jobs means the tool does more than what would expect it to do, but its the one thing we run over all jobs. Maybe rename it?

/assign @petr-muller 