### PR TITLE
ci-operator: omit `commands` in tests if empty

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -319,7 +319,7 @@ type TestStepConfiguration struct {
 	As string `json:"as"`
 	// Commands are the shell commands to run in
 	// the repository root to execute tests.
-	Commands string `json:"commands"`
+	Commands string `json:"commands,omitempty"`
 	// ArtifactDir is an optional directory that contains the
 	// artifacts to upload. If unset, this will default to
 	// "/tmp/artifacts".

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -42,7 +42,7 @@ import (
 
 const testingRegistry = "../../test/multistage-registry/registry"
 
-const testingCiOpCfgYAML = "tests:\n- as: job1\n  commands: \"\"\n- as: job2\n  commands: \"\"\n"
+const testingCiOpCfgYAML = "tests:\n- as: job1\n- as: job2\n"
 
 // configFiles contains the info needed to allow inlineCiOpConfig to successfully inline
 // CONFIG_SPEC and not fail

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
@@ -31,7 +31,6 @@
     },
     {
       "as": "e2e-azure",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "azure",
         "pre": [
@@ -104,7 +103,6 @@
     },
     {
       "as": "e2e-gcp",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "gcp",
         "pre": [

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
@@ -31,7 +31,6 @@
     },
     {
       "as": "e2e-azure",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "azure",
         "pre": [
@@ -104,7 +103,6 @@
     },
     {
       "as": "e2e-gcp",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "gcp",
         "pre": [

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
@@ -31,7 +31,6 @@
     },
     {
       "as": "e2e-azure",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "azure",
         "pre": [
@@ -104,7 +103,6 @@
     },
     {
       "as": "e2e-gcp",
-      "commands": "",
       "literal_steps": {
         "cluster_profile": "gcp",
         "pre": [

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -1399,7 +1399,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1450,7 +1449,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1501,7 +1499,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -1552,7 +1549,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -1565,7 +1561,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -1695,7 +1690,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1746,7 +1740,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1797,7 +1790,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -1848,7 +1840,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -1861,7 +1852,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2001,7 +1991,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2052,7 +2041,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2103,7 +2091,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -2154,7 +2141,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2167,7 +2153,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2307,7 +2292,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2358,7 +2342,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2409,7 +2392,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -2460,7 +2442,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2473,7 +2454,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2613,7 +2593,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2664,7 +2643,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2715,7 +2693,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -2766,7 +2743,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2779,7 +2755,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -2918,7 +2893,6 @@
               container:
                 from: src
             - as: multistage
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -2969,7 +2943,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage2
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -3020,7 +2993,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage3
-              commands: ""
               literal_steps:
                 cluster_profile: azure
                 post:
@@ -3071,7 +3043,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage4
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -3084,7 +3055,6 @@
                       cpu: 1000m
                       memory: 2Gi
             - as: multistage5
-              commands: ""
               literal_steps:
                 cluster_profile: ""
                 test:


### PR DESCRIPTION
`Commands` in tests is no longer a required field since the introduction
of multi-stage tests.  Add `omitempty` so that tools stop adding it
unnecessarily.