### PR TITLE
ci-operator: identify ci-operator specific workloads

### DIFF
--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -101,6 +101,7 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "JOB_NAME", Value: "job"},
 		{Name: "JOB_SPEC", Value: `{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}`},
 		{Name: "JOB_TYPE", Value: "postsubmit"},
+		{Name: "OPENSHIFT_CI", Value: "true"},
 		{Name: "PROW_JOB_ID", Value: "prow job id"},
 		{Name: "PULL_BASE_REF", Value: "base ref"},
 		{Name: "PULL_BASE_SHA", Value: "base sha"},

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -17,8 +17,12 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
-const testSecretName = "test-secret"
-const testSecretDefaultPath = "/usr/test-secrets"
+const (
+	testSecretName        = "test-secret"
+	testSecretDefaultPath = "/usr/test-secrets"
+
+	openshiftCIEnv = "OPENSHIFT_CI"
+)
 
 // PodStepConfiguration allows other steps to reuse the pod launching and monitoring
 // behavior without reimplementing function. It also enforces conventions like naming,
@@ -184,6 +188,7 @@ func generateBasePod(
 	artifactDir string,
 ) (*coreapi.Pod, error) {
 	envMap, err := downwardapi.EnvForSpec(jobSpec.JobSpec)
+	envMap[openshiftCIEnv] = "true"
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -113,6 +113,7 @@ func makeExpectedPod(step *podStep, phaseAfterRun v1.PodPhase) *v1.Pod {
 						"JOB_NAME":      "very-cool-prow-job",
 						"JOB_SPEC":      `{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]}}`,
 						"JOB_TYPE":      string(prowapi.PresubmitJob),
+						"OPENSHIFT_CI":  "true",
 						"PROW_JOB_ID":   "prow-job-id",
 						"PULL_BASE_REF": "base-ref",
 						"PULL_BASE_SHA": "base-sha",

--- a/test/ci-operator-integration/base/expected_files/expected.json
+++ b/test/ci-operator-integration/base/expected_files/expected.json
@@ -1468,6 +1468,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1609,6 +1613,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",

--- a/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
+++ b/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
@@ -1498,6 +1498,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1639,6 +1643,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -500,6 +500,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -689,6 +693,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -882,6 +890,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1071,6 +1083,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -1264,6 +1280,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1455,6 +1475,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1644,6 +1668,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -227,6 +227,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -442,6 +446,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -661,6 +669,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -876,6 +888,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -1095,6 +1111,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1310,6 +1330,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -1529,6 +1553,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -1744,6 +1772,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",
@@ -1963,6 +1995,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -2180,6 +2216,10 @@
               "value": "presubmit"
             },
             {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
               "name": "PROW_JOB_ID",
               "value": "uuid"
             },
@@ -2391,6 +2431,10 @@
             {
               "name": "JOB_TYPE",
               "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
             },
             {
               "name": "PROW_JOB_ID",


### PR DESCRIPTION
Users may want to detect when their workload is being executed by
ci-operator. Today, they can tell that they are executing in Prow by
checking $CI. This change sets $OPENSHIFT_CI so that they can
furthermore detect that they are running under ci-operator specifically.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>