### PR TITLE
hack/pr-deploy: build images faster

### DIFF
--- a/hack/pr-deploy.yaml
+++ b/hack/pr-deploy.yaml
@@ -92,7 +92,7 @@ objects:
         FROM api.ci.openshift.org/openshift/release:golang-1.13
 
         COPY . .
-        RUN make install
+        RUN go install ./cmd/ci-operator-configresolver/...
       git:
         ref: ${BRANCH}
         uri: https://github.com/${USER}/ci-tools.git


### PR DESCRIPTION
`pr-deploy` is useful to generate an example of changes to webreg, but the builds are very slow. Part of this is because it is running `make` install to build the binaries, which builds all of the ci-tools binaries instead of just the resolver. This is unnecessary for the `pr-deploy` command, so this changes that to `go install ./cmd/ci-operator-configresolver/...`

/cc @stevekuznetsov 