### PR TITLE
Autoconfigbrancher: Run determinize-prow-jobs

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -195,6 +195,11 @@ func main() {
 
 	commitIfNeeded("private-prow-configs-mirror --release-repo-path .", author)
 
+	cmd = "/usr/bin/determinize-prow-jobs"
+	args = []string{"--prow-jobs-dir", "--prow-jobs-dir", "./ci-operator/jobs"}
+	run(cmd, args...)
+	commitIfNeeded("determinize-prow-jobs  --prow-jobs-dir ./ci-operator/jobs", author)
+
 	if count == 0 {
 		logrus.Info("no new commits, existing ...")
 		return


### PR DESCRIPTION
needs https://github.com/openshift/release/pull/7846

Needed, because what autoconfigbrancher produces does not currently pass the `ordered-prow-config` presubmit, see e.G. here: https://github.com/openshift/release/pull/7821

/assign @petr-muller 