### PR TITLE
Rehearsals: Don't force reporting

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -163,7 +163,6 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 		rehearsal.Labels = make(map[string]string, 1)
 	}
 	rehearsal.Labels[rehearseLabel] = strconv.Itoa(prNumber)
-	rehearsal.SkipReport = false
 
 	return &rehearsal, nil
 }

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -339,9 +339,6 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 	hiddenPresubmit := &prowconfig.Presubmit{}
 	deepcopy.Copy(hiddenPresubmit, sourcePresubmit)
 	hiddenPresubmit.Hidden = true
-	notReportingPresubmit := &prowconfig.Presubmit{}
-	deepcopy.Copy(notReportingPresubmit, sourcePresubmit)
-	notReportingPresubmit.SkipReport = true
 
 	testCases := []struct {
 		testID   string
@@ -367,11 +364,6 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 			testID:   "job that belong to the same org but different repo than refs",
 			refs:     &pjapi.Refs{Org: "org", Repo: "anotherRepo"},
 			original: sourcePresubmit,
-		},
-		{
-			testID:   "job that doesn't report reports on rehearsal",
-			refs:     &pjapi.Refs{Org: "org", Repo: "repo"},
-			original: notReportingPresubmit,
 		},
 	}
 


### PR DESCRIPTION
We forced rehearsals to report, but that may confuse ppl that are not aware that some jobs are not expected to pass, which is why they were set to `report: false` in the first place.

If reporting is explicitly wanted for the rehearsal, the job itself can be changed to `report: true`.

/assign @petr-muller 