### PR TITLE
ci-operator-checkconfig: disallow duplicate promotions

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
-	"os"
+	"github.com/openshift/ci-tools/pkg/steps/release"
 )
 
 func main() {
@@ -18,11 +23,64 @@ func main() {
 		os.Exit(1)
 	}
 
+	seen := map[api.ImageStreamTagReference][]*config.Info{}
 	if err := config.OperateOnCIOperatorConfigDir(configDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		// validation is implicit, so we don't need to do anything
+		// but record the images we saw for future validation
+		for _, tag := range promotedTags(configuration) {
+			seen[tag] = append(seen[tag], repoInfo)
+		}
 		return nil
 	}); err != nil {
 		fmt.Printf("error validating configuration files: %v\n", err)
 		os.Exit(1)
 	}
+
+	var dupes []error
+	for tag, infos := range seen {
+		if len(infos) > 1 {
+			formatted := []string{}
+			for _, info := range infos {
+				identifier := fmt.Sprintf("%s/%s@%s", info.Org, info.Repo, info.Branch)
+				if info.Variant != "" {
+					identifier = fmt.Sprintf("%s [%s]", identifier, info.Variant)
+				}
+				formatted = append(formatted, identifier)
+			}
+			dupes = append(dupes, fmt.Errorf("output tag %s/%s:%s is promoted from more than one place: %v", tag.Namespace, tag.Name, tag.Tag, strings.Join(formatted, ", ")))
+		}
+	}
+	if len(dupes) > 0 {
+		fmt.Println("non-unique image publication found: ")
+		for _, dupe := range dupes {
+			fmt.Printf("ERROR: %v\n", dupe)
+		}
+		os.Exit(1)
+	}
+}
+
+func promotedTags(configuration *api.ReleaseBuildConfiguration) []api.ImageStreamTagReference {
+	if configuration.PromotionConfiguration == nil {
+		return nil
+	}
+	tags, _ := release.ToPromote(*configuration.PromotionConfiguration, configuration.Images, sets.NewString())
+	var promotedTags []api.ImageStreamTagReference
+	for dst := range tags {
+		var tag api.ImageStreamTagReference
+		if configuration.PromotionConfiguration.Name != "" {
+			tag = api.ImageStreamTagReference{
+				Namespace: configuration.PromotionConfiguration.Namespace,
+				Name:      configuration.PromotionConfiguration.Name,
+				Tag:       dst,
+			}
+		} else { // promotion.Tag must be set
+			tag = api.ImageStreamTagReference{
+				Namespace: configuration.PromotionConfiguration.Namespace,
+				Name:      dst,
+				Tag:       configuration.PromotionConfiguration.Tag,
+			}
+		}
+		promotedTags = append(promotedTags, tag)
+	}
+	return promotedTags
 }

--- a/cmd/ci-operator-checkconfig/main_test.go
+++ b/cmd/ci-operator-checkconfig/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/utils/diff"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestPromotedTags(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		input    *api.ReleaseBuildConfiguration
+		expected []api.ImageStreamTagReference
+	}{
+		{
+			name:     "no promotion, no output",
+			input:    &api.ReleaseBuildConfiguration{},
+			expected: nil,
+		},
+		{
+			name: "promoted image means output tags",
+			input: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+					{To: api.PipelineImageStreamTagReference("foo")},
+				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "roger",
+					Name:      "fred",
+				},
+			},
+			expected: []api.ImageStreamTagReference{{
+				Namespace: "roger",
+				Name:      "fred",
+				Tag:       "foo",
+			}},
+		},
+		{
+			name: "promoted image by tag means output tags",
+			input: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+					{To: api.PipelineImageStreamTagReference("foo")},
+				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "roger",
+					Tag:       "fred",
+				},
+			},
+			expected: []api.ImageStreamTagReference{{
+				Namespace: "roger",
+				Name:      "foo",
+				Tag:       "fred",
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := promotedTags(testCase.input), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect promoted tags: %v", testCase.name, diff.ObjectDiff(actual, expected))
+			}
+		})
+	}
+}

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -1,0 +1,153 @@
+package release
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/diff"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestToPromote(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		config           api.PromotionConfiguration
+		images           []api.ProjectDirectoryImageBuildStepConfiguration
+		requiredImages   sets.String
+		expectedBySource map[string]string
+		expectedNames    sets.String
+	}{
+		{
+			name: "disabled config returns nothing",
+			config: api.PromotionConfiguration{
+				Disabled: true,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{},
+			expectedNames:    sets.NewString(),
+		},
+		{
+			name: "enabled config returns input list",
+			config: api.PromotionConfiguration{
+				Disabled: false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"},
+			expectedNames:    sets.NewString("foo", "bar", "baz"),
+		},
+		{
+			name: "enabled config with prefix returns prefixed input list",
+			config: api.PromotionConfiguration{
+				Disabled:   false,
+				NamePrefix: "some",
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"somefoo": "foo", "somebar": "bar", "somebaz": "baz"},
+			expectedNames:    sets.NewString("somefoo", "somebar", "somebaz"),
+		},
+		{
+			name: "enabled config with exclude returns filtered input list",
+			config: api.PromotionConfiguration{
+				ExcludedImages: []string{"foo"},
+				Disabled:       false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"bar": "bar", "baz": "baz"},
+			expectedNames:    sets.NewString("bar", "baz"),
+		},
+		{
+			name: "enabled config with optional image returns subset of input list",
+			config: api.PromotionConfiguration{
+				Disabled: false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar"), Optional: true},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"foo": "foo", "baz": "baz"},
+			expectedNames:    sets.NewString("foo", "baz"),
+		},
+		{
+			name: "enabled config with optional but required image returns full input list",
+			config: api.PromotionConfiguration{
+				Disabled: false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar"), Optional: true},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString("bar"),
+			expectedBySource: map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"},
+			expectedNames:    sets.NewString("foo", "bar", "baz"),
+		},
+		{
+			name: "enabled config with additional images returns appended input list",
+			config: api.PromotionConfiguration{
+				AdditionalImages: map[string]string{"boo": "ah"},
+				Disabled:         false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"foo": "foo", "bar": "bar", "baz": "baz", "boo": "ah"},
+			expectedNames:    sets.NewString("foo", "bar", "baz", "boo"),
+		},
+		{
+			name: "enabled config with excludes and additional images returns filtered, appended input list",
+			config: api.PromotionConfiguration{
+				ExcludedImages:   []string{"foo"},
+				AdditionalImages: map[string]string{"boo": "ah"},
+				Disabled:         false,
+			},
+			images: []api.ProjectDirectoryImageBuildStepConfiguration{
+				{To: api.PipelineImageStreamTagReference("foo")},
+				{To: api.PipelineImageStreamTagReference("bar")},
+				{To: api.PipelineImageStreamTagReference("baz")},
+			},
+			requiredImages:   sets.NewString(),
+			expectedBySource: map[string]string{"bar": "bar", "baz": "baz", "boo": "ah"},
+			expectedNames:    sets.NewString("bar", "baz", "boo"),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			bySource, names := ToPromote(test.config, test.images, test.requiredImages)
+			if actual, expected := bySource, test.expectedBySource; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect tags by source: %s", test.name, diff.ObjectDiff(actual, expected))
+			}
+
+			if actual, expected := names, test.expectedNames; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect names: %s", test.name, diff.ObjectDiff(actual, expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
It should never be possible for separate source configurations to
publish the same image tag.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>