### PR TITLE
webreg: number lines and make them linkable

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1535,11 +1535,15 @@ func WebRegHandler(regAgent agents.RegistryAgent, confAgent agents.ConfigAgent, 
 func syntax(source string, lexer chroma.Lexer) (string, error) {
 	var output bytes.Buffer
 	style := styles.Get("dracula")
-	formatter := html.New(html.Standalone(false))
+	// hightlighted lines based on linking currently require WithClasses to be used
+	formatter := html.New(html.Standalone(false), html.LinkableLineNumbers(true, "line"), html.WithLineNumbers(true), html.WithClasses(true))
 	iterator, err := lexer.Tokenise(nil, source)
 	if err != nil {
-		return "", fmt.Errorf("failed to tokenise source: %w", err)
+		return "", fmt.Errorf("failed to tokenise source: %v", err)
 	}
+	output.WriteString("<style>")
+	formatter.WriteCSS(&output, style)
+	output.WriteString("</style>")
 	err = formatter.Format(&output, style, iterator)
 	return output.String(), err
 }


### PR DESCRIPTION
This PR adds line numbers printed next to the lines as well as lines that can be linked to and be highlighted.

The `chroma` package does not currently have support for clickable links which leads to some limitations.
- To link to a line, you manually append `line%d` to the address
- This doesn't work for the help pages, as all code blocks would have the same id prefixes. Clickable lines would solve this problem as we could make unique prefixes for each block.

/cc @stevekuznetsov 