### PR TITLE
pr-deploy: use correct cm and use create not apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,5 +107,5 @@ update-integration-cvp-trigger:
 
 pr-deploy:
 	oc process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml | oc apply -f - --as system:admin
-	for cm in ci-operator-configs step-registry config; do oc get --export configmap $${cm} -n ci -o json | oc apply -f - -n ci-tools-$(PULL_REQUEST) --as system:admin; done
+	for cm in ci-operator-master-configs step-registry config; do oc get --export configmap $${cm} -n ci -o json | oc create -f - -n ci-tools-$(PULL_REQUEST) --as system:admin; done
 .PHONY: pr-deploy

--- a/hack/pr-deploy.yaml
+++ b/hack/pr-deploy.yaml
@@ -203,7 +203,7 @@ objects:
             name: step-registry
         - name: configs
           configMap:
-            name: ci-operator-configs
+            name: ci-operator-master-configs
         - name: config
           configMap:
             name: config


### PR DESCRIPTION
Use `ci-operator-master-configs` instead of the old, unused `ci-operator-configs`, and use `create` instead of `apply` for `oc` to fix the "annotation too long" issues when using `apply`