### PR TITLE
Pass optional operator installation parameters to steps

### DIFF
--- a/pkg/steps/optional_operators.go
+++ b/pkg/steps/optional_operators.go
@@ -1,0 +1,109 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	coreapi "k8s.io/api/core/v1"
+)
+
+const (
+	ooIndex            = "OO_INDEX"
+	ooPackage          = "OO_PACKAGE"
+	ooChannel          = "OO_CHANNEL"
+	ooInstallNamespace = "OO_INSTALL_NAMESPACE"
+	ooTargetNamespaces = "OO_TARGET_NAMESPACES"
+)
+
+// optionalOperator is the information needed by the optional operator installation
+// steps to be able to subscribe and install an optional operator
+type optionalOperator struct {
+	// Index is the pullspec of an index image
+	Index string
+	// Package is the name of the operator package to be installed
+	Package string
+	// Channel is name of the operator channel to track
+	Channel string
+	// Namespace is the name of the namespace into which the operator and catalog
+	// will be installed (optional)
+	Namespace string
+	// TargetNamespaces is a list of namespaces the operator will target. If empty,
+	// all namespaces will be targeted.
+	TargetNamespaces []string
+}
+
+// getter is a subset of api.Parameters
+type getter interface {
+	Get(name string) (string, error)
+}
+
+// resolveOptionalOperator extracts an optionalOperator instance from the
+// given parameters. If no optional operator-related parameters are set, returns
+// nil
+func resolveOptionalOperator(parameters getter) (*optionalOperator, error) {
+	var err error
+	var oo optionalOperator
+
+	required := map[string]*string{
+		ooIndex:   &oo.Index,
+		ooPackage: &oo.Package,
+		ooChannel: &oo.Channel,
+	}
+
+	for param, valuePointer := range required {
+		value, err := parameters.Get(param)
+		if err != nil {
+			return nil, err
+		}
+		*valuePointer = value
+	}
+
+	if oo.Namespace, err = parameters.Get(ooInstallNamespace); err != nil {
+		oo.Namespace = ""
+	}
+	if targetNamespaces, err := parameters.Get(ooTargetNamespaces); err != nil || targetNamespaces == "" {
+		oo.TargetNamespaces = nil
+	} else {
+		oo.TargetNamespaces = strings.Split(targetNamespaces, ",")
+	}
+
+	if oo.Index != "" || oo.Package != "" || oo.Channel != "" || oo.Namespace != "" || len(oo.TargetNamespaces) > 0 {
+		for param, value := range required {
+			if *value == "" {
+				return nil, fmt.Errorf("at least one of optional operator parameters OO_* is set, but not the required parameter %s", param)
+			}
+		}
+	}
+
+	if oo.Index == "" && oo.Package == "" && oo.Channel == "" {
+		return nil, nil
+	}
+
+	return &oo, nil
+}
+
+// asEnv creates EnvVar slice embeddable into a Container that will execute
+// the optional operator installation step.
+func (oo *optionalOperator) asEnv() []coreapi.EnvVar {
+	env := []coreapi.EnvVar{
+		{Name: ooIndex, Value: oo.Index},
+		{Name: ooPackage, Value: oo.Package},
+		{Name: ooChannel, Value: oo.Channel},
+	}
+
+	if oo.Namespace != "" {
+		env = append(env, coreapi.EnvVar{
+			Name:  ooInstallNamespace,
+			Value: oo.Namespace,
+		})
+	}
+
+	if len(oo.TargetNamespaces) > 0 {
+		env = append(env, coreapi.EnvVar{
+			Name:  ooTargetNamespaces,
+			Value: strings.Join(oo.TargetNamespaces, ","),
+		})
+	}
+
+	return env
+}

--- a/pkg/steps/optional_operators_test.go
+++ b/pkg/steps/optional_operators_test.go
@@ -1,0 +1,164 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+type fakeParams map[string]string
+
+func (f fakeParams) Get(name string) (string, error) {
+	return f[name], nil
+}
+
+func TestResolveOptionalOperator(t *testing.T) {
+	testCases := []struct {
+		description string
+		params      fakeParams
+
+		expectedOO  *optionalOperator
+		expectError bool
+	}{
+		{
+			description: "no parameters yield nil",
+			params:      fakeParams{},
+		},
+		{
+			description: "only required parameters",
+			params: fakeParams{
+				"OO_INDEX":   "le index",
+				"OO_PACKAGE": "le package",
+				"OO_CHANNEL": "le channel",
+			},
+			expectedOO: &optionalOperator{
+				Index:   "le index",
+				Package: "le package",
+				Channel: "le channel",
+			},
+		},
+		{
+			description: "all parameters",
+			params: fakeParams{
+				"OO_INDEX":             "le index",
+				"OO_PACKAGE":           "le package",
+				"OO_CHANNEL":           "le channel",
+				"OO_INSTALL_NAMESPACE": "le namespace",
+				"OO_TARGET_NAMESPACES": "un,deux,trois",
+			},
+			expectedOO: &optionalOperator{
+				Index:            "le index",
+				Package:          "le package",
+				Channel:          "le channel",
+				Namespace:        "le namespace",
+				TargetNamespaces: []string{"un", "deux", "trois"},
+			},
+		},
+		{
+			description: "missing index -> error",
+			params: fakeParams{
+				"OO_PACKAGE":           "le package",
+				"OO_CHANNEL":           "le channel",
+				"OO_INSTALL_NAMESPACE": "le namespace",
+				"OO_TARGET_NAMESPACES": "un,deux,trois",
+			},
+			expectError: true,
+		},
+		{
+			description: "missing package -> error",
+			params: fakeParams{
+				"OO_INDEX":             "le index",
+				"OO_CHANNEL":           "le channel",
+				"OO_INSTALL_NAMESPACE": "le namespace",
+				"OO_TARGET_NAMESPACES": "un,deux,trois",
+			},
+			expectError: true,
+		},
+		{
+			description: "missing channel -> error",
+			params: fakeParams{
+				"OO_INDEX":             "le index",
+				"OO_PACKAGE":           "le package",
+				"OO_INSTALL_NAMESPACE": "le namespace",
+				"OO_TARGET_NAMESPACES": "un,deux,trois",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual, err := resolveOptionalOperator(tc.params)
+			if err != nil && !tc.expectError {
+				t.Errorf("%s: unexpected error: %v", tc.description, err)
+			} else if err == nil && tc.expectError {
+				t.Errorf("%s: expected error, got nil", tc.description)
+			} else if !tc.expectError && !equality.Semantic.DeepEqual(actual, tc.expectedOO) {
+				t.Errorf("%s: result differs from expected:\n%s", tc.description, cmp.Diff(tc.expectedOO, actual))
+			}
+		})
+	}
+}
+
+func TestAsEnv(t *testing.T) {
+	testCases := []struct {
+		description string
+		oo          optionalOperator
+		expected    []coreapi.EnvVar
+	}{
+		{
+			description: "only the required parameters",
+			oo: optionalOperator{
+				Index:   "INDEX",
+				Package: "PACKAGE",
+				Channel: "CHANNEL",
+			},
+			expected: []coreapi.EnvVar{
+				{Name: "OO_INDEX", Value: "INDEX"},
+				{Name: "OO_PACKAGE", Value: "PACKAGE"},
+				{Name: "OO_CHANNEL", Value: "CHANNEL"},
+			},
+		},
+		{
+			description: "with install Namespace",
+			oo: optionalOperator{
+				Index:     "INDEX",
+				Package:   "PACKAGE",
+				Channel:   "CHANNEL",
+				Namespace: "NAMESPACE",
+			},
+			expected: []coreapi.EnvVar{
+				{Name: "OO_INDEX", Value: "INDEX"},
+				{Name: "OO_PACKAGE", Value: "PACKAGE"},
+				{Name: "OO_CHANNEL", Value: "CHANNEL"},
+				{Name: "OO_INSTALL_NAMESPACE", Value: "NAMESPACE"},
+			},
+		},
+		{
+			description: "with target namespaces",
+			oo: optionalOperator{
+				Index:            "INDEX",
+				Package:          "PACKAGE",
+				Channel:          "CHANNEL",
+				TargetNamespaces: []string{"NS1", "NS2"},
+			},
+			expected: []coreapi.EnvVar{
+				{Name: "OO_INDEX", Value: "INDEX"},
+				{Name: "OO_PACKAGE", Value: "PACKAGE"},
+				{Name: "OO_CHANNEL", Value: "CHANNEL"},
+				{Name: "OO_TARGET_NAMESPACES", Value: "NS1,NS2"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := tc.oo.asEnv()
+			if !equality.Semantic.DeepEqual(actual, tc.expected) {
+				t.Errorf("%s: result differs:\n%s", tc.description, cmp.Diff(tc.expected, tc.oo.asEnv()))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The parameters correspond to the inputs in:
https://steps.svc.ci.openshift.org/registry/optional-operators-subscribe

Right now, this only passes the same information passed into ci-operator
via environmental variables (similar how the `RELEASE_IMAGE_*` ones are
consumed). In the future, some images built by ci-operator itself will
be used to populate these parameters.

/cc @openshift/openshift-team-developer-productivity-test-platform 
/assign  @stevekuznetsov 