### PR TITLE
ci-operator-prowgen: set max concurrency on publication jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -597,7 +597,9 @@ func generateJobs(
 
 		if configSpec.PromotionConfiguration != nil {
 			podSpec := generateCiOperatorPodSpec(info, nil, imageTargets, []string{"--promote"}...)
-			postsubmits[orgrepo] = append(postsubmits[orgrepo], *generatePostsubmitForTest("images", info, label, podSpec, configSpec.CanonicalGoRepository))
+			postsubmit := generatePostsubmitForTest("images", info, label, podSpec, configSpec.CanonicalGoRepository)
+			postsubmit.MaxConcurrency = 1
+			postsubmits[orgrepo] = append(postsubmits[orgrepo], *postsubmit)
 		}
 	}
 

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -1266,8 +1266,9 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 				PostsubmitsStatic: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
-						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: standardPostsubmitJobLabels,
+						Name:           "branch-ci-organization-repository-branch-images",
+						Labels:         standardPostsubmitJobLabels,
+						MaxConcurrency: 1,
 					}},
 				}},
 			},
@@ -1342,8 +1343,9 @@ func TestGenerateJobs(t *testing.T) {
 				}},
 				PostsubmitsStatic: map[string][]prowconfig.Postsubmit{"organization/repository": {{
 					JobBase: prowconfig.JobBase{
-						Name:   "branch-ci-organization-repository-branch-images",
-						Labels: standardPostsubmitJobLabels,
+						Name:           "branch-ci-organization-repository-branch-images",
+						Labels:         standardPostsubmitJobLabels,
+						MaxConcurrency: 1,
 					}},
 				}},
 			},

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -28,6 +28,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:
       containers:

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -31,6 +31,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: rhel
+    max_concurrency: 1
     name: branch-ci-super-duper-branch-rhel-images
     spec:
       containers:

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
@@ -8,6 +8,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:
       containers:

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
     hidden: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-private-duper-master-images
     spec:
       containers:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-super-duper-master-images
     spec:
       containers:
@@ -66,6 +67,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: variant
+    max_concurrency: 1
     name: branch-ci-super-duper-master-variant-images
     path_alias: whoa.com/super/duper
     spec:

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -8,6 +8,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-super-duper-release-3.11-images
     spec:
       containers:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-openshift-ci-tools-master-images
     spec:
       containers:

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
     name: branch-ci-openshift-origin-master-images
     spec:
       containers:


### PR DESCRIPTION
Publication jobs change external state. When publication jobs are
triggered concurrently, they can race to finish and the resulting state
of external systems is not correct. Setting a maximum concurrency for
these jobs of 1 will sacrifice throughput for correctness.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 
/cc @openshift/openshift-team-developer-productivity-test-platform 