### PR TITLE
fix job name safe env var for the variant jobs

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -352,10 +352,16 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 	container.VolumeMounts = append(container.VolumeMounts, kubeapi.VolumeMount{Name: "cluster-profile", MountPath: clusterProfilePath})
 	if len(template) > 0 {
 		container.VolumeMounts = append(container.VolumeMounts, kubeapi.VolumeMount{Name: "job-definition", MountPath: templatePath, SubPath: fmt.Sprintf("%s.yaml", template)})
+
+		jobNameSafe := strings.Replace(test.As, "_", "-", -1)
+		if len(info.Variant) > 0 {
+			jobNameSafe = fmt.Sprintf("%s-%s", info.Variant, jobNameSafe)
+		}
+
 		container.Env = append(
 			container.Env,
 			kubeapi.EnvVar{Name: "CLUSTER_TYPE", Value: targetCloud},
-			kubeapi.EnvVar{Name: "JOB_NAME_SAFE", Value: strings.Replace(test.As, "_", "-", -1)},
+			kubeapi.EnvVar{Name: "JOB_NAME_SAFE", Value: jobNameSafe},
 			kubeapi.EnvVar{Name: "TEST_COMMAND", Value: test.Commands})
 		if len(testImageStreamTag) > 0 {
 			container.Env = append(container.Env,


### PR DESCRIPTION
When there are `_variant` `ci-operator` configs, `prowgen` generates, as it should, the job name with the prefix `variant-`. However, it doesn't do the same in the `JOB_NAME_SAFE` environment variable. That caused race problems like:
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_tektoncd-pipeline/364/pull-ci-openshift-tektoncd-pipeline-release-v0.11.0-rc3-variant-e2e/10  

/cc @openshift/openshift-team-developer-productivity-test-platform 
