### PR TITLE
Revert "Revert "Merge pull request #604 from hongkailiu/cluster_stanza""

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -450,16 +450,21 @@ func (o *options) Complete() error {
 		o.templates = append(o.templates, template)
 	}
 
-	clusterConfig, err := util.LoadClusterConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load cluster config: %v", err)
+	o.clusterConfig = &rest.Config{}
+	if !o.dry {
+
+		clusterConfig, err := util.LoadClusterConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load cluster config: %v", err)
+		}
+
+		if len(o.impersonateUser) > 0 {
+			clusterConfig.Impersonate = rest.ImpersonationConfig{UserName: o.impersonateUser}
+		}
+
+		o.clusterConfig = clusterConfig
 	}
 
-	if len(o.impersonateUser) > 0 {
-		clusterConfig.Impersonate = rest.ImpersonationConfig{UserName: o.impersonateUser}
-	}
-
-	o.clusterConfig = clusterConfig
 	configs, _, err := util.LoadKubeConfigs(o.kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to load kubeconfig from '%s': %v", o.kubeconfig, err)

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -494,6 +494,7 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 			Name:      originConfig.Name,
 		}
 		generated.Configuration.ReleaseTagConfiguration = &api.ReleaseTagConfiguration{
+			Cluster:   "https://api.ci.openshift.org",
 			Namespace: originConfig.Namespace,
 			Name:      originConfig.Name,
 		}
@@ -518,6 +519,7 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 
 	if config.NeedsBase {
 		generated.Configuration.BaseImages["base"] = api.ImageStreamTagReference{
+			Cluster:   "https://api.ci.openshift.org",
 			Namespace: originConfig.Namespace,
 			Name:      originConfig.Name,
 			Tag:       "base",
@@ -526,6 +528,7 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 
 	if config.NeedsOS {
 		generated.Configuration.BaseImages["os"] = api.ImageStreamTagReference{
+			Cluster:   "https://api.ci.openshift.org",
 			Namespace: "openshift",
 			Name:      "centos",
 			Tag:       "7",
@@ -534,6 +537,7 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 
 	generated.Configuration.BuildRootImage = &api.BuildRootImageConfiguration{
 		ImageStreamTagReference: &api.ImageStreamTagReference{
+			Cluster:   "https://api.ci.openshift.org",
 			Namespace: "openshift",
 			Name:      "release",
 			Tag:       fmt.Sprintf("golang-%s", config.GoVersion),

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -322,6 +322,7 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					InputConfiguration: api.InputConfiguration{
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "release",
 								Tag:       "golang-1",
@@ -366,11 +367,13 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Cluster:   "https://api.ci.openshift.org",
 							Namespace: "promote",
 							Name:      "version",
 						},
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "release",
 								Tag:       "golang-1",
@@ -414,11 +417,13 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Cluster:   "https://api.ci.openshift.org",
 							Namespace: "promote",
 							Name:      "version",
 						},
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "release",
 								Tag:       "golang-1",
@@ -467,6 +472,7 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					InputConfiguration: api.InputConfiguration{
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "release",
 								Tag:       "golang-1",
@@ -474,11 +480,13 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 						},
 						BaseImages: map[string]api.ImageStreamTagReference{
 							"base": {
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "promote",
 								Name:      "version",
 								Tag:       "base",
 							},
 							"os": {
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "centos",
 								Tag:       "7",
@@ -525,6 +533,7 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					InputConfiguration: api.InputConfiguration{
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Cluster:   "https://api.ci.openshift.org",
 								Namespace: "openshift",
 								Name:      "release",
 								Tag:       "golang-1",

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -114,12 +114,17 @@ func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImage
 		return nil
 	}
 
-	if input.ProjectImageBuild != nil && input.ImageStreamTagReference != nil {
-		return []error{fmt.Errorf("%s: both image_stream_tag and project_image cannot be set", fieldRoot)}
-	} else if input.ProjectImageBuild == nil && input.ImageStreamTagReference == nil {
-		return []error{fmt.Errorf("%s: you have to specify either image_stream_tag or project_image", fieldRoot)}
+	var validationErrors []error
+	if input.ImageStreamTagReference != nil && len(input.ImageStreamTagReference.Cluster) == 0 {
+		validationErrors = append(validationErrors, fmt.Errorf("%s.image_stream_tag: no cluster defined", fieldRoot))
 	}
-	return nil
+
+	if input.ProjectImageBuild != nil && input.ImageStreamTagReference != nil {
+		validationErrors = append(validationErrors, fmt.Errorf("%s: both image_stream_tag and project_image cannot be set", fieldRoot))
+	} else if input.ProjectImageBuild == nil && input.ImageStreamTagReference == nil {
+		validationErrors = append(validationErrors, fmt.Errorf("%s: you have to specify either image_stream_tag or project_image", fieldRoot))
+	}
+	return validationErrors
 }
 
 func validateTestStepConfiguration(fieldRoot string, input []TestStepConfiguration, release *ReleaseTagConfiguration, resolved bool) []error {
@@ -198,6 +203,9 @@ func validateImageStreamTagReferenceMap(fieldRoot string, input map[string]Image
 		if k == "root" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.%s can't be named 'root'", fieldRoot, k))
 		}
+		if len(v.Cluster) == 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("%s[%s]: no cluster defined", fieldRoot, k))
+		}
 		validationErrors = append(validationErrors, validateImageStreamTagReference(fmt.Sprintf("%s.%s", fieldRoot, k), v)...)
 	}
 	return validationErrors
@@ -229,6 +237,10 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 	if len(input.Name) == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s: no name defined", fieldRoot))
+	}
+
+	if len(input.Cluster) == 0 {
+		return append(validationErrors, fmt.Errorf("%s: no cluster defined", fieldRoot))
 	}
 	return validationErrors
 }

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -410,6 +411,11 @@ func TestValidateBuildRoot(t *testing.T) {
 			hasImages:            true,
 			expectedValid:        false,
 		},
+		{
+			id:                   "build root without cluster",
+			buildRootImageConfig: &BuildRootImageConfiguration{ImageStreamTagReference: &ImageStreamTagReference{}},
+			expectedValid:        false,
+		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			if errs := validateBuildRootImageConfiguration("build_root", tc.buildRootImageConfig, tc.hasImages); len(errs) > 0 && tc.expectedValid {
@@ -432,6 +438,11 @@ func TestValidateBaseImages(t *testing.T) {
 			baseImages: map[string]ImageStreamTagReference{"test": {Cluster: "test"},
 				"test2": {Tag: "test2"}, "test3": {Cluster: "test3"},
 			},
+			expectedValid: false,
+		},
+		{
+			id:            "no cluster error",
+			baseImages:    map[string]ImageStreamTagReference{"test": {Name: "test", Tag: "test"}},
 			expectedValid: false,
 		},
 	} {
@@ -783,6 +794,32 @@ func TestValidatePromotion(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			if actual, expected := validatePromotionConfiguration("promotion", test.input), test.expected; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect errors: %v", test.name, diff.ObjectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestValidateReleaseTagConfiguration(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		input    ReleaseTagConfiguration
+		expected []error
+	}{
+		{
+			name:     "no cluster defined error",
+			input:    ReleaseTagConfiguration{Name: "test", Namespace: "test"},
+			expected: []error{fmt.Errorf("tag_specification: no cluster defined")},
+		},
+		{
+			name:     "valid tag_specification",
+			input:    ReleaseTagConfiguration{Name: "test", Namespace: "test", Cluster: "https://test.com"},
+			expected: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := validateReleaseTagConfiguration("tag_specification", testCase.input), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect errors: %v", testCase.name, diff.ObjectDiff(actual, expected))
 			}
 		})
 	}

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -326,7 +326,7 @@ func addSecretWrapper(pod *coreapi.Pod) {
 	})
 	mount := coreapi.VolumeMount{Name: volume, MountPath: dir}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coreapi.Container{
-		Image:                    "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+		Image:                    fmt.Sprintf("%s/ci/secret-wrapper:latest", apiCIRegistry),
 		Name:                     "cp-secret-wrapper",
 		Command:                  []string{"cp"},
 		Args:                     []string{"/bin/secret-wrapper", bin},

--- a/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: origin-v4.0
     namespace: openshift
     tag: base
@@ -7,10 +8,12 @@ images:
 - from: base
   to: test-image
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: origin-v4.0
   namespace: openshift
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     namespace: openshift
     name: release
     tag: golang-1.10

--- a/test/ci-op-configs-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
+++ b/test/ci-op-configs-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: origin-v4.0
     namespace: openshift
     tag: base
@@ -7,10 +8,12 @@ images:
 - from: base
   to: test-image
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: origin-v4.0
   namespace: openshift
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     namespace: openshift
     name: release
     tag: golang-1.10

--- a/test/ci-operator-configresolver-integration/ci-op-configmaps/master/..2019_11_15_19_57_20.547184898/openshift-installer-master.yaml
+++ b/test/ci-operator-configresolver-integration/ci-op-configmaps/master/..2019_11_15_19_57_20.547184898/openshift-installer-master.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.4"
     namespace: ocp
     tag: base

--- a/test/ci-operator-configresolver-integration/ci-op-configmaps/release-4.2/..2019_11_15_19_57_20.547184898/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-configresolver-integration/ci-op-configmaps/release-4.2/..2019_11_15_19_57_20.547184898/openshift-installer-release-4.2.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.2"
     namespace: ocp
     tag: base

--- a/test/ci-operator-configresolver-integration/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-configresolver-integration/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.2"
     namespace: ocp
     tag: base

--- a/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
+++ b/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.2"
     namespace: ocp
     tag: base

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
@@ -1,6 +1,7 @@
 {
   "base_images": {
     "base": {
+      "cluster": "https://api.ci.openshift.org",
       "namespace": "ocp",
       "name": "4.2",
       "tag": "base"

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
@@ -1,6 +1,7 @@
 {
   "base_images": {
     "base": {
+      "cluster": "https://api.ci.openshift.org",
       "namespace": "ocp",
       "name": "4.2",
       "tag": "base"

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
@@ -1,6 +1,7 @@
 {
   "base_images": {
     "base": {
+      "cluster": "https://api.ci.openshift.org",
       "namespace": "ocp",
       "name": "4.2",
       "tag": "base"

--- a/test/ci-operator-integration/base/config/test-config.yaml
+++ b/test/ci-operator-integration/base/config/test-config.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: base
@@ -9,10 +10,12 @@ base_images:
     namespace: openshift
     tag: "29"
   cli:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: cli
   machine-os-content-base:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: machine-os-content
@@ -172,6 +175,7 @@ resources:
       memory: 30Gi
 rpm_build_commands: make build-rpms
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "ci-operator-test"
   namespace: ci
 tests:

--- a/test/ci-operator-integration/base/expected_files/expected.json
+++ b/test/ci-operator-integration/base/expected_files/expected.json
@@ -1118,9 +1118,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1152,9 +1151,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "fedora@sha256:SHA",
-        "namespace": "openshift"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/openshift/fedora@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1186,9 +1184,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1220,9 +1217,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1254,9 +1250,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "src-cache-origin@sha256:SHA",
-        "namespace": "ci"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ci/src-cache-origin@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},

--- a/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
+++ b/test/ci-operator-integration/base/expected_files/expected_pull_secret.json
@@ -1148,9 +1148,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1182,9 +1181,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "fedora@sha256:SHA",
-        "namespace": "openshift"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/openshift/fedora@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1216,9 +1214,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1250,9 +1247,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -1284,9 +1280,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "src-cache-origin@sha256:SHA",
-        "namespace": "ci"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ci/src-cache-origin@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},

--- a/test/ci-operator-integration/base/expected_files/expected_with_template.json
+++ b/test/ci-operator-integration/base/expected_files/expected_with_template.json
@@ -841,9 +841,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -875,9 +874,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "fedora@sha256:SHA",
-        "namespace": "openshift"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/openshift/fedora@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -909,9 +907,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -943,9 +940,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -977,9 +973,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "src-cache-origin@sha256:SHA",
-        "namespace": "ci"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ci/src-cache-origin@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},

--- a/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
@@ -1,9 +1,11 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: base
   cli:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: cli
@@ -34,6 +36,7 @@ resources:
       cpu: 100m
       memory: 4Gi
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "ci-operator-test"
   namespace: ci
 tests:

--- a/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -1,5 +1,6 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.2"
     namespace: ocp
     tag: base

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -316,9 +316,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -350,9 +349,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.3@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.3@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -384,9 +382,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "src-cache-origin@sha256:SHA",
-        "namespace": "ci"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ci/src-cache-origin@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -111,9 +111,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "4.2@sha256:SHA",
-        "namespace": "ocp"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/ocp/4.2@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},
@@ -145,9 +144,8 @@
     "tag": {
       "annotations": null,
       "from": {
-        "kind": "ImageStreamImage",
-        "name": "release@sha256:SHA",
-        "namespace": "openshift"
+        "kind": "DockerImage",
+        "name": "registry.svc.ci.openshift.org/openshift/release@sha256:SHA"
       },
       "generation": null,
       "importPolicy": {},

--- a/test/prowgen-integration/data/input/config/private-org/duper/private-org-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/private-org/duper/private-org-duper-master.yaml
@@ -1,9 +1,11 @@
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: origin-v4.0
   namespace: openshift
   tag: ''
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     namespace: openshift
     name: release
     tag: golang-1.10

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -19,6 +19,7 @@ resources:
       memory: 200Mi
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.13

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -1,5 +1,6 @@
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.12
@@ -27,6 +28,7 @@ resources:
       cpu: 100m
       memory: 4Gi
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "4.3"
   namespace: ocp
 tests:

--- a/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -1,5 +1,6 @@
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.15
@@ -15,6 +16,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "4.3"
   namespace: ocp
 tests:

--- a/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -1,11 +1,13 @@
 base_images:
   base:
+    cluster: https://api.ci.openshift.org
     name: "4.3"
     namespace: ocp
     tag: base
 binary_build_commands: make install
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.13
@@ -20,6 +22,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "4.3"
   namespace: ocp
 test_binary_build_commands: make test-install

--- a/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -19,6 +19,7 @@ resources:
       memory: 200Mi
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.13

--- a/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -1,5 +1,6 @@
 build_root:
   image_stream_tag:
+    cluster: https://api.ci.openshift.org
     name: release
     namespace: openshift
     tag: golang-1.12
@@ -27,6 +28,7 @@ resources:
       cpu: 100m
       memory: 4Gi
 tag_specification:
+  cluster: https://api.ci.openshift.org
   name: "4.3"
   namespace: ocp
 tests:


### PR DESCRIPTION
It was reverted because the integration tests are broken when there is a kubeconfig in $HOME folder with api.ci context (our laptop env.) because it still loads the config. It works on CI because there is no such config in the pod.

We add a commit in this PR to fix that by not loading the config in $HOME folder.