### PR TITLE
add variant prefix in secret names

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -300,7 +300,13 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 	case cioperatorapi.ClusterProfileVSphere:
 		targetCloud = "vsphere"
 	}
-	clusterProfilePath := fmt.Sprintf("/usr/local/%s-cluster-profile", test.As)
+
+	clusterProfileName := fmt.Sprintf("%s-cluster-profile", test.As)
+	if len(info.Variant) > 0 {
+		clusterProfileName = fmt.Sprintf("%s-%s", info.Variant, clusterProfileName)
+	}
+	clusterProfilePath := fmt.Sprintf("/usr/local/%s", clusterProfileName)
+
 	templatePath := fmt.Sprintf("/usr/local/%s", test.As)
 	podSpec := generateCiOperatorPodSpec(info, test.Secrets, []string{test.As})
 	clusterProfileVolume := generateClusterProfileVolume("cluster-profile", fmt.Sprintf("cluster-secrets-%s", targetCloud))


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 

after #614 merged we change the value of the `JOB_NAME_SAFE` env var. Unfortunately, this is being used in the template as the name of the secret for mounting, but `ci-operator` creates the secret without the variant prefix.

This PR will resolve this issue. Related JIRA https://issues.redhat.com/browse/DPTP-1019