### PR TITLE
rehearse: infer ci-operator config from parameters when needed

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -62,6 +63,32 @@ type Info struct {
 	OrgPath string
 	// RepoPath is the full path to the directory containing config for the repo
 	RepoPath string
+}
+
+// IsComplete returns an error if at least one of Org, Repo, Branch members is
+// empty, otherwise it returns nil
+func (i *Info) IsComplete() error {
+	var missing []string
+	for item, value := range map[string]string{
+		"organization": i.Org,
+		"repository":   i.Repo,
+		"branch":       i.Branch,
+	} {
+		if value == "" {
+			missing = append(missing, item)
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		s := ""
+		if len(missing) > 1 {
+			s = "s"
+		}
+		return fmt.Errorf("missing item%s: %s", s, strings.Join(missing, ", "))
+	}
+
+	return nil
 }
 
 func (i *Info) JobName(prefix, name string) string {

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -85,6 +85,53 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 	}
 }
 
+func TestInfo_IsComplete(t *testing.T) {
+	testCases := []struct {
+		name        string
+		info        Info
+		expectError string
+	}{
+		{
+			name: "All required members -> complete",
+			info: Info{Org: "organization", Repo: "repository", Branch: "branch"},
+		},
+		{
+			name:        "Missing org -> incomplete",
+			info:        Info{Repo: "repository", Branch: "branch"},
+			expectError: "missing item: organization",
+		},
+		{
+			name:        "Missing repo -> incomplete",
+			info:        Info{Org: "organization", Branch: "branch"},
+			expectError: "missing item: repository",
+		},
+		{
+			name:        "Missing branch -> incomplete",
+			info:        Info{Org: "organization", Repo: "repository"},
+			expectError: "missing item: branch",
+		},
+		{
+			name:        "Everything missing -> incomplete",
+			expectError: "missing items: branch, organization, repository",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.info.IsComplete()
+			if err == nil && tc.expectError != "" {
+				t.Errorf("%s: expected error '%s', got nil", tc.expectError, tc.name)
+			}
+			if err != nil {
+				if tc.expectError == "" {
+					t.Errorf("%s: unexpected error %s", tc.name, err.Error())
+				} else if err.Error() != tc.expectError {
+					t.Errorf("%s: expected error '%s', got '%s", tc.name, tc.expectError, err.Error())
+				}
+			}
+		})
+	}
+}
+
 func TestInfo_Basename(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
Improve pj-rehearse to try harder in cases when it needs to rehearse a
job (usually a periodic) which is not apparently tied to any specific
ci-operator config, but is configured to run `ci-operator` with explicit
`--org/--repo/--branch/--variant` options. We were already removing
these options, so we can as well save their values, and use them in case
when the normally used ones are not available (previously we would
simply fail with a "ci-operator config file --.yaml was not found"
message).

The method that removes the args from containers running `ci-operator`
was rewritten to better accomodate the need to save the values,
otherwise the changes are quite simple.