### PR TITLE
rehearse: fix excessive rehearsals for variants

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -499,26 +499,21 @@ func generateJobBase(name, prefix string, info *prowgenInfo, label jc.ProwgenLab
 }
 
 func generatePresubmitForTest(name string, info *prowgenInfo, label jc.ProwgenLabel, podSpec *kubeapi.PodSpec, rehearsable bool, pathAlias *string) *prowconfig.Presubmit {
-	if len(info.Variant) > 0 {
-		name = fmt.Sprintf("%s-%s", info.Variant, name)
-	}
+	shortName := info.Info.TestName(name)
 	base := generateJobBase(name, jobconfig.PresubmitPrefix, info, label, podSpec, rehearsable, pathAlias)
 	return &prowconfig.Presubmit{
 		JobBase:   base,
 		AlwaysRun: true,
 		Brancher:  prowconfig.Brancher{Branches: []string{info.Branch}},
 		Reporter: prowconfig.Reporter{
-			Context: fmt.Sprintf("ci/prow/%s", name),
+			Context: fmt.Sprintf("ci/prow/%s", shortName),
 		},
-		RerunCommand: prowconfig.DefaultRerunCommandFor(name),
-		Trigger:      prowconfig.DefaultTriggerFor(name),
+		RerunCommand: prowconfig.DefaultRerunCommandFor(shortName),
+		Trigger:      prowconfig.DefaultTriggerFor(shortName),
 	}
 }
 
 func generatePostsubmitForTest(name string, info *prowgenInfo, label jc.ProwgenLabel, podSpec *kubeapi.PodSpec, pathAlias *string) *prowconfig.Postsubmit {
-	if len(info.Variant) > 0 {
-		name = fmt.Sprintf("%s-%s", info.Variant, name)
-	}
 	base := generateJobBase(name, jobconfig.PostsubmitPrefix, info, label, podSpec, false, pathAlias)
 	return &prowconfig.Postsubmit{
 		JobBase:  base,
@@ -527,9 +522,6 @@ func generatePostsubmitForTest(name string, info *prowgenInfo, label jc.ProwgenL
 }
 
 func generatePeriodicForTest(name string, info *prowgenInfo, label jc.ProwgenLabel, podSpec *kubeapi.PodSpec, rehearsable bool, cron string, pathAlias *string) *prowconfig.Periodic {
-	if len(info.Variant) > 0 {
-		name = fmt.Sprintf("%s-%s", info.Variant, name)
-	}
 	base := generateJobBase(name, jobconfig.PeriodicPrefix, info, label, podSpec, rehearsable, nil)
 	// periodics are not associated with a repo per se, but we can add in an
 	// extra ref so that periodics which want to access the repo tha they are

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -91,8 +91,19 @@ func (i *Info) IsComplete() error {
 	return nil
 }
 
+// TestName returns a short name of a test defined in this file, including
+// variant, if present
+func (i *Info) TestName(testName string) string {
+	if i.Variant == "" {
+		return testName
+	}
+	return fmt.Sprintf("%s-%s", i.Variant, testName)
+}
+
+// JobName returns a full name of a job corresponding to a test defined in this
+// file, including variant, if present
 func (i *Info) JobName(prefix, name string) string {
-	return fmt.Sprintf("%s-ci-%s-%s-%s-%s", prefix, i.Org, i.Repo, i.Branch, name)
+	return fmt.Sprintf("%s-ci-%s-%s-%s-%s", prefix, i.Org, i.Repo, i.Branch, i.TestName(name))
 }
 
 // Basename returns the unique name for this file in the config

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -254,3 +254,62 @@ func TestInfo_ConfigMapName(t *testing.T) {
 		})
 	}
 }
+
+func TestInfo_JobName(t *testing.T) {
+	prefix := "le"
+	testName := "a-test"
+	testCases := []struct {
+		name     string
+		info     Info
+		expected string
+	}{
+		{
+			name:     "without variant",
+			info:     Info{Org: "org", Repo: "repo", Branch: "branch"},
+			expected: "le-ci-org-repo-branch-a-test",
+		},
+		{
+			name:     "with variant",
+			info:     Info{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
+			expected: "le-ci-gro-oper-hcnarb-also-a-test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.info.JobName(prefix, testName)
+			if actual != tc.expected {
+				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestInfo_TestName(t *testing.T) {
+	testName := "a-test"
+	testCases := []struct {
+		name     string
+		info     Info
+		expected string
+	}{
+		{
+			name:     "without variant",
+			info:     Info{Org: "org", Repo: "repo", Branch: "branch"},
+			expected: "a-test",
+		},
+		{
+			name:     "with variant",
+			info:     Info{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
+			expected: "also-a-test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.info.TestName(testName)
+			if actual != tc.expected {
+				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `Info.JobName()` method did not return a name including a variant
(although a variant is one of the member fields of the struct), which
made rehearsal mistakenly treat more jobs as affected by a variant
ci-operator config change. By not matching agains job name including a variant,
it incorrectly selected all non-variant jobs as affected.

Fix `JobName()` together with Prowgen, which was actually depending on
this incorrect behavior, and appended the variant itself. Write few new
GoDocs and tests.