### PR TITLE
Simplify 2 commands in integration tests

### DIFF
--- a/test/repo-init-integration/run.sh
+++ b/test/repo-init-integration/run.sh
@@ -13,7 +13,7 @@ trap 'rm -rf ${WORKDIR}' EXIT
 
 cd "$WORKDIR"
 # copy config to tmpdir to allow tester to modify config
-cp -ar "$ROOTDIR"/test/repo-init-integration/input/* .
+cp -a "$ROOTDIR"/test/repo-init-integration/input/* .
 
 # this test case will copy-cat origin
 inputs=(

--- a/test/secret-wrapper-integration.sh
+++ b/test/secret-wrapper-integration.sh
@@ -85,7 +85,7 @@ test_signal() {
     secret-wrapper --dry-run sleep 1d 2> "${ERR}" &
     pid=$!
     if ! timeout 1s sh -c \
-        'until pgrep --count --parent "$1" sleep > /dev/null ; do :; done' \
+        'until pgrep -P "$1" sleep > /dev/null ; do :; done' \
         sh "${pid}"
     then
         kill "${pid}"


### PR DESCRIPTION
```
#with -a, -r is there too.
man cp
       -a, --archive
              same as -dR --preserve=all

       -R, -r, --recursive
              copy directories recursively

# we redirect the output to /dev/null
# and thus should not matter much if or not we suppress the output
man pgrep
       -c, --count
              Suppress normal output; instead print a count of matching processes.  When count does not match anything, e.g.
              returns zero, the command will return non-zero value.

       -P, --parent ppid,...
              Only match processes whose parent process ID is listed.
```


The real reason that I want this PR: it is more mac-os friendly with it.
