### PR TITLE
testgrid-config-generator: Include new dashboard type 'broken'

### DIFF
--- a/cmd/testgrid-config-generator/README.md
+++ b/cmd/testgrid-config-generator/README.md
@@ -1,6 +1,20 @@
 # Updating TestGrid configuration
 
-This utility updates the TestGrid configuration to include promotion gates and informers [defined][release-controller-config] for [the OpenShift release-controller][release-controller].
+This utility updates the TestGrid configuration based on our job annotations and [release-controller configuration][release-controller].
+
+Blocking jobs are those that signal widespread failure of the platform. These are traditionally the core end-to-end test runs on our major platforms and upgrades from previous versions. Informing jobs are a broader suite that test the variety of enviroments and configurations our customers expect. Broken jobs are those that have a known, triaged failure that prevents their function for a sustained period of time (more than a week).
+
+The release config and the job annotation combine to determine the dashboard. If a job in the release definition is an upgrade job it goes into
+the overall informing dashboard (because upgrades cross dashboards), if it is optional it is considered informing, and is otherwise considered
+blocking. If the job has the `ci.openshift.io/release-type` annotation that will override the default on the job (unless the job is blocking
+on the release controller and the annotation is informing).
+
+The name of jobs are used to determine which dashboard tab they are grouped with. If they have `-okd-` in their name they are grouped as an
+OKD tab, and if they have `-ocp-` or `-origin-` they are considered OCP tabs. The job must have an `-X.Y` identifier to be associated to a
+release version.
+
+New jobs should start in `broken` until they have successive runs, then they can graduate to `informing` or `blocking`. A job does not have
+to be referenced by the release controller to be informing - the release controller simply ensures it is run once per release build.
 
 ```console
 $ testgrid-config-generator -testgrid-config path/to/k8s.io/test-infra/config/testgrids/openshift -release-config path/to/openshift/release/core-services/release-controller/_releases -prow-jobs-dir path/to/openshift/release/ci-operator/jobs

--- a/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
+++ b/test/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
@@ -15,6 +15,13 @@ periodics:
 - agent: kubernetes
   decorate: true
   interval: 12h
+  labels:
+    ci.openshift.io/release-type: broken
+    job-release: '4.3'
+  name: release-openshift-origin-job-without-release-label-broken
+- agent: kubernetes
+  decorate: true
+  interval: 12h
   name: release-openshift-origin-job-without-informing
 - agent: kubernetes
   decorate: true
@@ -23,3 +30,43 @@ periodics:
     ci.openshift.io/release-type: informing
     job-release: "4.2"
   name: release-openshift-ocp-job
+- agent: kubernetes
+  decorate: true
+  interval: "@yearly"
+  name: release-openshift-origin-installer-e2e-aws-upgrade
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: release-openshift-origin-installer-e2e-aws-optional-4.1
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: release-openshift-origin-installer-e2e-aws-optional-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: release-openshift-ocp-installer-e2e-aws-optional-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: release-openshift-origin-installer-e2e-aws-4.1
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  name: release-openshift-origin-installer-e2e-aws-serial-4.1
+- agent: kubernetes
+  decorate: true
+  interval: 48h
+  name: release-openshift-origin-installer-e2e-aws-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 2h
+  name: release-openshift-origin-installer-e2e-aws-serial-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 48h
+  name: release-openshift-ocp-installer-e2e-aws-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 2h
+  name: release-openshift-ocp-installer-e2e-aws-serial-4.2

--- a/test/testgrid-config-generator/expected/groups.yaml
+++ b/test/testgrid-config-generator/expected/groups.yaml
@@ -6,4 +6,5 @@ dashboard_groups:
   - redhat-openshift-ocp-release-4.1-informing
   - redhat-openshift-ocp-release-4.2-blocking
   - redhat-openshift-ocp-release-4.2-informing
+  - redhat-openshift-ocp-release-4.3-broken
   name: redhat

--- a/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.3-broken.yaml
+++ b/test/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.3-broken.yaml
@@ -1,0 +1,34 @@
+dashboards:
+- dashboard_tab:
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-job-without-release-label-broken
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-job-without-release-label-broken
+  name: redhat-openshift-ocp-release-4.3-broken
+test_groups:
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-job-without-release-label-broken
+  name: release-openshift-origin-job-without-release-label-broken


### PR DESCRIPTION
The periodic label overrides the release config suggestion. The
generator is restructured to be simpler as a result. A new 'broken'
type is introduced for jobs we deem failures.

This is a result of agreement with release oversight.