### PR TITLE
rehearse: set no-fail=false to stage its removal

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -44,7 +44,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to actually submit rehearsal jobs to Prow")
-	fs.BoolVar(&o.noFail, "no-fail", true, "Whether to actually end unsuccessfuly when something breaks")
+	fs.BoolVar(&o.noFail, "no-fail", false, "Whether to actually end unsuccessfuly when something breaks")
 	fs.BoolVar(&o.local, "local", false, "Whether this is a local execution or part of a CI job")
 
 	fs.StringVar(&o.debugLogPath, "debug-log", "", "Alternate file for debug output, defaults to stderr")


### PR DESCRIPTION
I want to entirely remove this code (it was only useful at the beginning
when we wanted to run in a stealth mode) and to do that, I need to
remove the option from the jobs that calls `pj-rehearse`. To do that, I
need to make the `--no-fail=false` the default so I can remove the option
without actually changing the behavior.