### PR TITLE
Applyconfig: Remove level functionality

### DIFF
--- a/cmd/applyconfig/applyconfig.go
+++ b/cmd/applyconfig/applyconfig.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -34,10 +33,6 @@ type options struct {
 }
 
 const (
-	standardLevel level = "standard"
-	adminLevel    level = "admin"
-	allLevel      level = "all"
-
 	ocApply   command = "apply"
 	ocProcess command = "process"
 )
@@ -45,18 +40,8 @@ const (
 const defaultAdminUser = "system:admin"
 
 func (l level) isValid() bool {
-	return l == standardLevel || l == adminLevel || l == allLevel
+	return l == "all"
 }
-
-func (l level) shouldApplyAdmin() bool {
-	return l == adminLevel || l == allLevel
-}
-
-func (l level) shouldApplyStandard() bool {
-	return l == standardLevel || l == allLevel
-}
-
-var adminConfig = regexp.MustCompile(`^admin_.+\.yaml$`)
 
 type nullableStringFlag struct {
 	val     string
@@ -87,7 +72,7 @@ func gatherOptions() *options {
 	opt.level = level(lvl)
 
 	if !opt.level.isValid() {
-		fmt.Fprintf(os.Stderr, "--level: must be one of [standard, admin, all]\n")
+		fmt.Fprintf(os.Stderr, "--level: must be one of [all]\n")
 		os.Exit(1)
 	}
 
@@ -98,16 +83,6 @@ func gatherOptions() *options {
 
 	return opt
 }
-
-func isAdminConfig(filename string) bool {
-	return adminConfig.MatchString(filename)
-}
-
-func isStandardConfig(filename string) bool {
-	return filepath.Ext(filename) == ".yaml" &&
-		!isAdminConfig(filename)
-}
-
 func makeOcCommand(cmd command, kubeConfig, context, path, user string, additionalArgs ...string) *exec.Cmd {
 	args := []string{string(cmd), "-f", path}
 	args = append(args, additionalArgs...)
@@ -241,9 +216,7 @@ func apply(kubeConfig, context, path, user string, dry bool) error {
 	return do.asGenericManifest()
 }
 
-type processFn func(name, path string) error
-
-func applyConfig(rootDir, cfgType string, process processFn) error {
+func applyConfig(rootDir string, o *options) error {
 	failures := false
 	if err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -255,11 +228,19 @@ func applyConfig(rootDir, cfgType string, process processFn) error {
 				logrus.Infof("Skipping directory: %s", path)
 				return filepath.SkipDir
 			}
-			logrus.Infof("Applying %s config in directory: %s", cfgType, path)
+			logrus.Infof("Applying config in directory: %s", path)
 			return nil
 		}
 
-		if err := process(info.Name(), path); err != nil {
+		if filepath.Ext(info.Name()) == ".yaml" {
+			return nil
+		}
+
+		if strings.HasPrefix(info.Name(), "_") {
+			return nil
+		}
+
+		if err := apply(o.kubeConfig, o.context, path, o.user.val, !o.confirm); err != nil {
 			failures = true
 		}
 
@@ -271,7 +252,7 @@ func applyConfig(rootDir, cfgType string, process processFn) error {
 	}
 
 	if failures {
-		return fmt.Errorf("failed to apply admin config")
+		return fmt.Errorf("failed to apply config")
 	}
 
 	return nil
@@ -307,43 +288,14 @@ func main() {
 	o := gatherOptions()
 	var hadErr bool
 
-	if o.level.shouldApplyAdmin() {
-		if !o.user.beenSet {
-			o.user.val = defaultAdminUser
-		}
-
-		f := func(name, path string) error {
-			if !isAdminConfig(name) {
-				return nil
-			}
-			return apply(o.kubeConfig, o.context, path, o.user.val, !o.confirm)
-		}
-
-		for _, dir := range o.directories.Strings() {
-			if err := applyConfig(dir, "admin", f); err != nil {
-				hadErr = true
-				logrus.WithError(err).Error("There were failures while applying admin config")
-			}
-		}
+	if !o.user.beenSet {
+		o.user.val = defaultAdminUser
 	}
 
-	if o.level.shouldApplyStandard() {
-		f := func(name, path string) error {
-			if !isStandardConfig(name) {
-				return nil
-			}
-			if strings.HasPrefix(name, "_") {
-				return nil
-			}
-
-			return apply(o.kubeConfig, o.context, path, o.user.val, !o.confirm)
-		}
-
-		for _, dir := range o.directories.Strings() {
-			if err := applyConfig(dir, "standard", f); err != nil {
-				hadErr = true
-				logrus.WithError(err).Error("There were failures while applying standard config")
-			}
+	for _, dir := range o.directories.Strings() {
+		if err := applyConfig(dir, o); err != nil {
+			hadErr = true
+			logrus.WithError(err).Error("There were failures while applying config")
 		}
 	}
 

--- a/cmd/applyconfig/applyconfig_test.go
+++ b/cmd/applyconfig/applyconfig_test.go
@@ -16,65 +16,6 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 )
 
-func TestIsAdminConfig(t *testing.T) {
-	testCases := []struct {
-		filename string
-		expected bool
-	}{
-		{
-			filename: "admin_01_something_rbac.yaml",
-			expected: true,
-		},
-		{
-			filename: "admin_something_rbac.yaml",
-			expected: true,
-		},
-		// Negative
-		{filename: "cfg_01_something"},
-		{filename: "admin_01_something_rbac"},
-		{filename: "admin_01_something_rbac.yml"},
-		{filename: "admin.yaml"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.filename, func(t *testing.T) {
-			is := isAdminConfig(tc.filename)
-			if is != tc.expected {
-				t.Errorf("expected %t, got %t", tc.expected, is)
-			}
-		})
-	}
-}
-
-func TestIsStandardConfig(t *testing.T) {
-	testCases := []struct {
-		filename string
-		expected bool
-	}{
-		{
-			filename: "01_something_rbac.yaml",
-			expected: true,
-		},
-		{
-			filename: "something_rbac.yaml",
-			expected: true,
-		},
-		// Negative
-		{filename: "admin_01_something.yaml"},
-		{filename: "cfg_01_something_rbac"},
-		{filename: "cfg_01_something_rbac.yml"},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.filename, func(t *testing.T) {
-			is := isStandardConfig(tc.filename)
-			if is != tc.expected {
-				t.Errorf("expected %t, got %t", tc.expected, is)
-			}
-		})
-	}
-}
-
 func TestMakeOcCommand(t *testing.T) {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
This pr removes the level functionality while still keeping the flag
with its old default. Applyconfig will now always fail when not called
with `--level=all`, this is done to make sure we notice these cases.

/assign @stevekuznetsov @petr-muller 