### PR TITLE
Revert "Applyconfig: Remove level functionality"

### DIFF
--- a/cmd/applyconfig/applyconfig_test.go
+++ b/cmd/applyconfig/applyconfig_test.go
@@ -16,6 +16,65 @@ import (
 	"k8s.io/test-infra/prow/logrusutil"
 )
 
+func TestIsAdminConfig(t *testing.T) {
+	testCases := []struct {
+		filename string
+		expected bool
+	}{
+		{
+			filename: "admin_01_something_rbac.yaml",
+			expected: true,
+		},
+		{
+			filename: "admin_something_rbac.yaml",
+			expected: true,
+		},
+		// Negative
+		{filename: "cfg_01_something"},
+		{filename: "admin_01_something_rbac"},
+		{filename: "admin_01_something_rbac.yml"},
+		{filename: "admin.yaml"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			is := isAdminConfig(tc.filename)
+			if is != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, is)
+			}
+		})
+	}
+}
+
+func TestIsStandardConfig(t *testing.T) {
+	testCases := []struct {
+		filename string
+		expected bool
+	}{
+		{
+			filename: "01_something_rbac.yaml",
+			expected: true,
+		},
+		{
+			filename: "something_rbac.yaml",
+			expected: true,
+		},
+		// Negative
+		{filename: "admin_01_something.yaml"},
+		{filename: "cfg_01_something_rbac"},
+		{filename: "cfg_01_something_rbac.yml"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			is := isStandardConfig(tc.filename)
+			if is != tc.expected {
+				t.Errorf("expected %t, got %t", tc.expected, is)
+			}
+		})
+	}
+}
+
 func TestMakeOcCommand(t *testing.T) {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
Reverts openshift/ci-tools#645

Apparently broke stuff, example from https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/8216/pull-ci-openshift-release-master-services-dry/9718:
```
 time="2020-04-08T11:54:25Z" level=error msg="oc apply -f services/README.md --dry-run: failed to apply\nW0408 11:54:23.698493      26 helpers.go:535] --dry-run is deprecated and can be replaced with --dry-run=client.\nerror: error parsing services/README.md: error converting YAML to JSON: yaml: line 4: mapping values are not allowed in this context\n"
```