### PR TITLE
rehearse: simplify detection of jobs with changed clusters

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -289,10 +289,6 @@ func rehearseMain() int {
 	changedPeriodics := diffs.GetChangedPeriodics(masterConfig.Prow, prConfig.Prow, logger)
 	toRehearse := diffs.GetChangedPresubmits(masterConfig.Prow, prConfig.Prow, logger)
 
-	clusterChangedPresubmits, clusterChangedPeriodics := diffs.GetChangedClusterJobs(masterConfig.Prow, prConfig.Prow, logger)
-	changedPeriodics.AddAll(clusterChangedPeriodics)
-	toRehearse.AddAll(clusterChangedPresubmits)
-
 	presubmitsWithChangedCiopConfigs := diffs.GetPresubmitsForCiopConfigs(prConfig.Prow, changedCiopConfigData, affectedJobs)
 	toRehearse.AddAll(presubmitsWithChangedCiopConfigs)
 


### PR DESCRIPTION
There is no reason why this needs to be in a separate method when
existing methods already iterate over all jobs and check for different
fields.