### PR TITLE
Revert "fix job name safe env var for the variant jobs"

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -300,13 +300,7 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 	case cioperatorapi.ClusterProfileVSphere:
 		targetCloud = "vsphere"
 	}
-
-	clusterProfileName := fmt.Sprintf("%s-cluster-profile", test.As)
-	if len(info.Variant) > 0 {
-		clusterProfileName = fmt.Sprintf("%s-%s", info.Variant, clusterProfileName)
-	}
-	clusterProfilePath := fmt.Sprintf("/usr/local/%s", clusterProfileName)
-
+	clusterProfilePath := fmt.Sprintf("/usr/local/%s-cluster-profile", test.As)
 	templatePath := fmt.Sprintf("/usr/local/%s", test.As)
 	podSpec := generateCiOperatorPodSpec(info, test.Secrets, []string{test.As})
 	clusterProfileVolume := generateClusterProfileVolume("cluster-profile", fmt.Sprintf("cluster-secrets-%s", targetCloud))
@@ -358,16 +352,10 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 	container.VolumeMounts = append(container.VolumeMounts, kubeapi.VolumeMount{Name: "cluster-profile", MountPath: clusterProfilePath})
 	if len(template) > 0 {
 		container.VolumeMounts = append(container.VolumeMounts, kubeapi.VolumeMount{Name: "job-definition", MountPath: templatePath, SubPath: fmt.Sprintf("%s.yaml", template)})
-
-		jobNameSafe := strings.Replace(test.As, "_", "-", -1)
-		if len(info.Variant) > 0 {
-			jobNameSafe = fmt.Sprintf("%s-%s", info.Variant, jobNameSafe)
-		}
-
 		container.Env = append(
 			container.Env,
 			kubeapi.EnvVar{Name: "CLUSTER_TYPE", Value: targetCloud},
-			kubeapi.EnvVar{Name: "JOB_NAME_SAFE", Value: jobNameSafe},
+			kubeapi.EnvVar{Name: "JOB_NAME_SAFE", Value: strings.Replace(test.As, "_", "-", -1)},
 			kubeapi.EnvVar{Name: "TEST_COMMAND", Value: test.Commands})
 		if len(testImageStreamTag) > 0 {
 			container.Env = append(container.Env,


### PR DESCRIPTION
This reverts commit 7a4efaafe3cb29db765c791965aa2834f1616573.
This reverts commit fb7981adfcac1401f3466369af1c3a80ace1d7bb.

Variants should not be in the same namespace by design (they are
different versions of the same config and we don't support config
in the same namespace). We should identify whatever the fix is
outside, because a variant using e2e-gcp should look exactly like
the core branch using e2e-gcp.