### PR TITLE
Remove duplicate constants from diffs package

### DIFF
--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -14,12 +14,11 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 
 	"github.com/mattn/go-zglob"
-	"github.com/openshift/ci-tools/pkg/diffs"
-	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
 
 type options struct {
@@ -67,14 +66,14 @@ func main() {
 	}
 
 	pluginAgent := plugins.ConfigAgent{}
-	if err := pluginAgent.Load(path.Join(o.releaseRepoDir, diffs.PluginsInRepoPath), true); err != nil {
+	if err := pluginAgent.Load(path.Join(o.releaseRepoDir, config.PluginConfigInRepoPath), true); err != nil {
 		logrus.WithError(err).Fatal("Error loading Prow plugin config.")
 	}
 	pcfg := pluginAgent.Config()
 
 	var pathsToCheck []pathWithConfig
 	configInfos := map[string]*config.Info{}
-	if err := config.OperateOnCIOperatorConfigDir(path.Join(o.releaseRepoDir, diffs.CIOperatorConfigInRepoPath), func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
+	if err := config.OperateOnCIOperatorConfigDir(path.Join(o.releaseRepoDir, config.CiopConfigInRepoPath), func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
 		// we know the path is relative, but there is no API to declare that
 		relPath, _ := filepath.Rel(o.releaseRepoDir, info.Filename)
 		pathsToCheck = append(pathsToCheck, pathWithConfig{path: relPath, configMap: info.ConfigMapName()})
@@ -85,7 +84,7 @@ func main() {
 	}
 
 	var foundFailures bool
-	if err := jobconfig.OperateOnJobConfigDir(path.Join(o.releaseRepoDir, diffs.JobConfigInRepoPath), func(jobConfig *prowconfig.JobConfig, info *jobconfig.Info) error {
+	if err := jobconfig.OperateOnJobConfigDir(path.Join(o.releaseRepoDir, config.JobConfigInRepoPath), func(jobConfig *prowconfig.JobConfig, info *jobconfig.Info) error {
 		// we know the path is relative, but there is no API to declare that
 		relPath, _ := filepath.Rel(o.releaseRepoDir, info.Filename)
 		pathsToCheck = append(pathsToCheck, pathWithConfig{path: relPath, configMap: info.ConfigMapName()})

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -293,10 +293,10 @@ func rehearseMain() error {
 	toRehearseClusterProfiles := diffs.GetPresubmitsForClusterProfiles(prConfig.Prow, changedClusterProfiles, logger)
 	toRehearse.AddAll(toRehearseClusterProfiles)
 
-	resolver := registry.NewResolver(refs, chains, workflows)
-	presubmitsWithChangedRegistry := rehearse.AddRandomJobsForChangedRegistry(changedRegistrySteps, graph, prConfig.Prow.JobConfig.PresubmitsStatic, filepath.Join(o.releaseRepoPath, diffs.CIOperatorConfigInRepoPath), loggers)
+	presubmitsWithChangedRegistry := rehearse.AddRandomJobsForChangedRegistry(changedRegistrySteps, graph, prConfig.Prow.JobConfig.PresubmitsStatic, filepath.Join(o.releaseRepoPath, config.CiopConfigInRepoPath), loggers)
 	toRehearse.AddAll(presubmitsWithChangedRegistry)
 
+	resolver := registry.NewResolver(refs, chains, workflows)
 	jobConfigurer := rehearse.NewJobConfigurer(prConfig.CiOperator, resolver, prNumber, loggers, changedTemplates, changedClusterProfiles, jobSpec.Refs)
 	presubmitsToRehearse := jobConfigurer.ConfigurePresubmitRehearsals(toRehearse)
 	periodicsToRehearse := jobConfigurer.ConfigurePeriodicRehearsals(changedPeriodics)

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	ciopconfig "github.com/openshift/ci-tools/pkg/config"
-	"github.com/openshift/ci-tools/pkg/diffs"
 )
 
 type options struct {
@@ -331,7 +330,7 @@ func fetchOrDefaultWithPrompt(msg, def string) string {
 }
 
 func updateProwConfig(config initConfig, releaseRepo string) error {
-	configPath := path.Join(releaseRepo, diffs.ConfigInRepoPath)
+	configPath := path.Join(releaseRepo, ciopconfig.ConfigInRepoPath)
 	agent := prowconfig.Agent{}
 	if err := agent.Start(configPath, ""); err != nil {
 		return fmt.Errorf("could not load Prow configuration: %v", err)
@@ -391,7 +390,7 @@ No additional "tide" queries will be added.
 func updatePluginConfig(config initConfig, releaseRepo string) error {
 	fmt.Println(`
 Updating Prow plugin configuration ...`)
-	configPath := path.Join(releaseRepo, diffs.PluginsInRepoPath)
+	configPath := path.Join(releaseRepo, ciopconfig.PluginConfigInRepoPath)
 	agent := plugins.ConfigAgent{}
 	if err := agent.Load(configPath, false); err != nil {
 		return fmt.Errorf("could not load Prow plugin configuration: %v", err)
@@ -453,7 +452,7 @@ Generating CI Operator configuration ...`)
 		Repo:   "origin",
 		Branch: "master",
 	}
-	originPath := path.Join(releaseRepo, diffs.CIOperatorConfigInRepoPath, info.RelativePath())
+	originPath := path.Join(releaseRepo, ciopconfig.CiopConfigInRepoPath, info.RelativePath())
 	var originConfig *api.ReleaseBuildConfiguration
 	if err := ciopconfig.OperateOnCIOperatorConfig(originPath, func(configuration *api.ReleaseBuildConfiguration, _ *ciopconfig.Info) error {
 		originConfig = configuration
@@ -463,7 +462,7 @@ Generating CI Operator configuration ...`)
 	}
 
 	generated := generateCIOperatorConfig(config, originConfig.PromotionConfiguration)
-	return generated.CommitTo(path.Join(releaseRepo, diffs.CIOperatorConfigInRepoPath))
+	return generated.CommitTo(path.Join(releaseRepo, ciopconfig.CiopConfigInRepoPath))
 }
 
 func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConfiguration) ciopconfig.DataWithInfo {

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -15,9 +15,8 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/jobconfig"
-
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 )
 
 const (
@@ -25,15 +24,6 @@ const (
 	LogJobName    = "job-name"
 	LogReasons    = "reasons"
 	logCiopConfig = "ciop-config"
-
-	// ConfigInRepoPath is the prow config path from release repo
-	ConfigInRepoPath = "core-services/prow/02_config/_config.yaml"
-	// PluginsInRepoPath is the prow plugins config path from release repo
-	PluginsInRepoPath = "core-services/prow/02_config/_plugins.yaml"
-	// JobConfigInRepoPath is the prowjobs path from release repo
-	JobConfigInRepoPath = "ci-operator/jobs"
-	// CIOperatorConfigInRepoPath is the ci-operator config path from release repo
-	CIOperatorConfigInRepoPath = "ci-operator/config"
 
 	ChosenJob            = "Job has been chosen for rehearsal"
 	newCiopConfigMsg     = "New ci-operator config file"


### PR DESCRIPTION
The same constants are defined in pkg/config/release.go where they fit
better.