### PR TITLE
ci-operator multi-stage: name containers "test"

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -282,7 +282,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep) ([]coreap
 			continue
 		}
 		name := fmt.Sprintf("%s-%s", s.name, step.As)
-		pod, err := generateBasePod(s.jobSpec, name, step.As, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources, step.ArtifactDir)
+		pod, err := generateBasePod(s.jobSpec, name, "test", []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + step.Commands}, image, resources, step.ArtifactDir)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -155,7 +155,7 @@ func TestGeneratePods(t *testing.T) {
 			Labels: labels,
 			Annotations: map[string]string{
 				"ci.openshift.io/job-spec":                     "",
-				"ci-operator.openshift.io/container-sub-tests": "step0",
+				"ci-operator.openshift.io/container-sub-tests": "test",
 				"ci-operator.openshift.io/save-container-logs": "true",
 			},
 		},
@@ -177,7 +177,7 @@ func TestGeneratePods(t *testing.T) {
 				TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 			}},
 			Containers: []coreapi.Container{{
-				Name:                     "step0",
+				Name:                     "test",
 				Image:                    "pipeline:src",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand0"},
@@ -222,7 +222,7 @@ func TestGeneratePods(t *testing.T) {
 			Labels: labels,
 			Annotations: map[string]string{
 				"ci.openshift.io/job-spec":                     "",
-				"ci-operator.openshift.io/container-sub-tests": "step1",
+				"ci-operator.openshift.io/container-sub-tests": "test",
 				"ci-operator.openshift.io/save-container-logs": "true",
 			},
 		},
@@ -244,7 +244,7 @@ func TestGeneratePods(t *testing.T) {
 				TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 			}},
 			Containers: []coreapi.Container{{
-				Name:                     "step1",
+				Name:                     "test",
 				Image:                    "stable:image1",
 				Command:                  []string{"/tmp/secret-wrapper/secret-wrapper"},
 				Args:                     []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\ncommand1"},
@@ -492,7 +492,7 @@ func TestArtifacts(t *testing.T) {
 	if err := step.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(tmp, "test0")); err != nil {
+	if _, err := os.Stat(filepath.Join(tmp, "test")); err != nil {
 		t.Fatalf("error verifying output directory exists: %v", err)
 	}
 }
@@ -505,41 +505,41 @@ func TestJUnit(t *testing.T) {
 	}{{
 		name: "no step fails",
 		expected: []string{
-			"Run multi-stage test test - test-pre0 container pre0",
-			"Run multi-stage test test - test-pre1 container pre1",
-			"Run multi-stage test test - test-test0 container test0",
-			"Run multi-stage test test - test-test1 container test1",
-			"Run multi-stage test test - test-post0 container post0",
-			"Run multi-stage test test - test-post1 container post1",
+			"Run multi-stage test test - test-pre0 container test",
+			"Run multi-stage test test - test-pre1 container test",
+			"Run multi-stage test test - test-test0 container test",
+			"Run multi-stage test test - test-test1 container test",
+			"Run multi-stage test test - test-post0 container test",
+			"Run multi-stage test test - test-post1 container test",
 		},
 	}, {
 		name:     "failure in a pre step",
 		failures: sets.NewString("test-pre0"),
 		expected: []string{
-			"Run multi-stage test test - test-pre0 container pre0",
-			"Run multi-stage test test - test-post0 container post0",
-			"Run multi-stage test test - test-post1 container post1",
+			"Run multi-stage test test - test-pre0 container test",
+			"Run multi-stage test test - test-post0 container test",
+			"Run multi-stage test test - test-post1 container test",
 		},
 	}, {
 		name:     "failure in a test step",
 		failures: sets.NewString("test-test0"),
 		expected: []string{
-			"Run multi-stage test test - test-pre0 container pre0",
-			"Run multi-stage test test - test-pre1 container pre1",
-			"Run multi-stage test test - test-test0 container test0",
-			"Run multi-stage test test - test-post0 container post0",
-			"Run multi-stage test test - test-post1 container post1",
+			"Run multi-stage test test - test-pre0 container test",
+			"Run multi-stage test test - test-pre1 container test",
+			"Run multi-stage test test - test-test0 container test",
+			"Run multi-stage test test - test-post0 container test",
+			"Run multi-stage test test - test-post1 container test",
 		},
 	}, {
 		name:     "failure in a post step",
 		failures: sets.NewString("test-post1"),
 		expected: []string{
-			"Run multi-stage test test - test-pre0 container pre0",
-			"Run multi-stage test test - test-pre1 container pre1",
-			"Run multi-stage test test - test-test0 container test0",
-			"Run multi-stage test test - test-test1 container test1",
-			"Run multi-stage test test - test-post0 container post0",
-			"Run multi-stage test test - test-post1 container post1",
+			"Run multi-stage test test - test-pre0 container test",
+			"Run multi-stage test test - test-pre1 container test",
+			"Run multi-stage test test - test-test0 container test",
+			"Run multi-stage test test - test-test1 container test",
+			"Run multi-stage test test - test-post0 container test",
+			"Run multi-stage test test - test-post1 container test",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -448,7 +448,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "post0",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -554,7 +554,7 @@
             }
           ],
           "image": "pipeline:tests",
-          "name": "post0",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "6"
@@ -643,7 +643,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "post1",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -749,7 +749,7 @@
             }
           ],
           "image": "stable:installer",
-          "name": "post1",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "7"
@@ -838,7 +838,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "pre0",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -944,7 +944,7 @@
             }
           ],
           "image": "pipeline:base",
-          "name": "pre0",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "1"
@@ -1033,7 +1033,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "pre1",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -1139,7 +1139,7 @@
             }
           ],
           "image": "pipeline:root",
-          "name": "pre1",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "2"
@@ -1228,7 +1228,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "test0",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -1334,7 +1334,7 @@
             }
           ],
           "image": "pipeline:src",
-          "name": "test0",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "3"
@@ -1423,7 +1423,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "test1",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -1529,7 +1529,7 @@
             }
           ],
           "image": "pipeline:bin",
-          "name": "test1",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "4"
@@ -1618,7 +1618,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "test2",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -1724,7 +1724,7 @@
             }
           ],
           "image": "pipeline:cli",
-          "name": "test2",
+          "name": "test",
           "resources": {
             "limits": {
               "memory": "5"

--- a/test/ci-operator-integration/multi-stage/expected/installer.json
+++ b/test/ci-operator-integration/multi-stage/expected/installer.json
@@ -176,7 +176,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "e2e",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -304,7 +304,7 @@
             }
           ],
           "image": "stable:my-image",
-          "name": "e2e",
+          "name": "test",
           "resources": {
             "requests": {
               "cpu": "1",
@@ -401,7 +401,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-deprovision",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -529,7 +529,7 @@
             }
           ],
           "image": "stable:installer",
-          "name": "ipi-deprovision-deprovision",
+          "name": "test",
           "resources": {
             "requests": {
               "cpu": "1",
@@ -626,7 +626,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "ipi-deprovision-must-gather",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -754,7 +754,7 @@
             }
           ],
           "image": "stable:installer",
-          "name": "ipi-deprovision-must-gather",
+          "name": "test",
           "resources": {
             "requests": {
               "cpu": "1",
@@ -851,7 +851,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "ipi-install-install",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -979,7 +979,7 @@
             }
           ],
           "image": "stable:installer",
-          "name": "ipi-install-install",
+          "name": "test",
           "resources": {
             "requests": {
               "cpu": "1",
@@ -1076,7 +1076,7 @@
     "kind": "Pod",
     "metadata": {
       "annotations": {
-        "ci-operator.openshift.io/container-sub-tests": "ipi-install-rbac",
+        "ci-operator.openshift.io/container-sub-tests": "test",
         "ci-operator.openshift.io/save-container-logs": "true",
         "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
       },
@@ -1204,7 +1204,7 @@
             }
           ],
           "image": "stable:installer",
-          "name": "ipi-install-rbac",
+          "name": "test",
           "resources": {
             "requests": {
               "cpu": "1",


### PR DESCRIPTION
https://github.com/openshift/ci-tools/issues/633

Follow regular container tests and name the container "test" (the pod
name remains the same, i.e. the step name).

Resulting JUnit output:

```xml
<testcase name="Run multi-stage test unit - unit-pre container test" time="0"></testcase>
<testcase name="Run multi-stage test unit - unit-unit container test" time="72"></testcase>
<testcase name="Run multi-stage test unit - unit-post container test" time="0">
```

Resulting artifacts directory:

```
artifacts/
└── unit
    └── test
        └── container-logs
            ├── cp-secret-wrapper.log.gz
            └── test.log.gz
```