### PR TITLE
OpenStack: Add profile type for OpenStack Vexxhost cloud

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -291,6 +291,8 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 		targetCloud = "libvirt-s390x"
 	case cioperatorapi.ClusterProfileOpenStack:
 		targetCloud = "openstack"
+	case cioperatorapi.ClusterProfileOpenStackVexxhost:
+		targetCloud = "openstack-vexxhost"
 	case cioperatorapi.ClusterProfileOpenStackPpc64le:
 		targetCloud = "openstack-ppc64le"
 	case cioperatorapi.ClusterProfileOvirt:
@@ -305,7 +307,7 @@ func generatePodSpecOthers(info *prowgenInfo, release string, test *cioperatorap
 	podSpec := generateCiOperatorPodSpec(info, test.Secrets, []string{test.As})
 	clusterProfileVolume := generateClusterProfileVolume("cluster-profile", fmt.Sprintf("cluster-secrets-%s", targetCloud))
 	switch clusterProfile {
-	case cioperatorapi.ClusterProfileAWS, cioperatorapi.ClusterProfileAzure4, cioperatorapi.ClusterProfileLibvirtS390x, cioperatorapi.ClusterProfileOpenStack, cioperatorapi.ClusterProfileOpenStackPpc64le, cioperatorapi.ClusterProfileVSphere:
+	case cioperatorapi.ClusterProfileAWS, cioperatorapi.ClusterProfileAzure4, cioperatorapi.ClusterProfileLibvirtS390x, cioperatorapi.ClusterProfileOpenStack, cioperatorapi.ClusterProfileOpenStackVexxhost, cioperatorapi.ClusterProfileOpenStackPpc64le, cioperatorapi.ClusterProfileVSphere:
 	default:
 		clusterProfileVolume.VolumeSource.Projected.Sources = append(clusterProfileVolume.VolumeSource.Projected.Sources, kubeapi.VolumeProjection{
 			ConfigMap: &kubeapi.ConfigMapProjection{

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -247,7 +247,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) []error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileLibvirtS390x, ClusterProfileOpenStack, ClusterProfileOpenStackPpc64le, ClusterProfileOvirt, ClusterProfilePacket, ClusterProfileVSphere:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileLibvirtS390x, ClusterProfileOpenStack, ClusterProfileOpenStackVexxhost, ClusterProfileOpenStackPpc64le, ClusterProfileOvirt, ClusterProfilePacket, ClusterProfileVSphere:
 		return nil
 	}
 	return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -519,6 +519,7 @@ const (
 	ClusterProfileGCPLoggingCRIO     ClusterProfile = "gcp-logging-crio"
 	ClusterProfileLibvirtS390x       ClusterProfile = "libvirt-s390x"
 	ClusterProfileOpenStack          ClusterProfile = "openstack"
+	ClusterProfileOpenStackVexxhost  ClusterProfile = "openstack-vexxhost"
 	ClusterProfileOpenStackPpc64le   ClusterProfile = "openstack-ppc64le"
 	ClusterProfileOvirt              ClusterProfile = "ovirt"
 	ClusterProfilePacket             ClusterProfile = "packet"
@@ -544,6 +545,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileGCPLoggingCRIO,
 		ClusterProfileLibvirtS390x,
 		ClusterProfileOpenStack,
+		ClusterProfileOpenStackVexxhost,
 		ClusterProfileOpenStackPpc64le,
 		ClusterProfileOvirt,
 		ClusterProfilePacket,
@@ -577,6 +579,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-s390x"
 	case ClusterProfileOpenStack:
 		return "openstack"
+	case ClusterProfileOpenStackVexxhost:
+		return "openstack-vexxhost"
 	case ClusterProfileOpenStackPpc64le:
 		return "openstack-ppc64le"
 	case ClusterProfileVSphere:
@@ -616,6 +620,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "libvirt-s390x-quota-slice"
 	case ClusterProfileOpenStack:
 		return "openstack-quota-slice"
+	case ClusterProfileOpenStackVexxhost:
+		return "openstack-vexxhost-quota-slice"
 	case ClusterProfileOpenStackPpc64le:
 		return "openstack-ppc64le-quota-slice"
 	case ClusterProfileOvirt:
@@ -632,7 +638,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "azure4", "gcp", "libvirt-s390x", "openstack", "openstack-ppc64le", "vsphere", "ovirt", "packet":
+	case "aws", "azure4", "gcp", "libvirt-s390x", "openstack", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
We're adding a new OpenStack cloud on Vexxhost to run some of our CI jobs. We need a separate cluster profile in order to differentiate boskos leases pools.