### PR TITLE
prowgen: mount secrets at /secrets/secret.Name

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -142,7 +142,7 @@ func generatePodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secret) *kubeap
 	for _, secret := range secrets {
 		volumeMounts = append(volumeMounts, kubeapi.VolumeMount{
 			Name:      secret.Name,
-			MountPath: secret.MountPath,
+			MountPath: fmt.Sprintf("/secrets/%s", secret.Name),
 			ReadOnly:  true,
 		})
 
@@ -208,7 +208,7 @@ func generateCiOperatorPodSpec(info *prowgenInfo, secrets []*cioperatorapi.Secre
 		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--oauth-token-path=%s", filepath.Join(oauthTokenPath, oauthKey)))
 	}
 	for _, secret := range secrets {
-		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--secret-dir=%s", secret.MountPath))
+		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--secret-dir=/secrets/%s", secret.Name))
 	}
 
 	if len(info.Variant) > 0 {

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -35,7 +35,7 @@ var unexportedFields = []cmp.Option{
 }
 
 func TestGeneratePodSpec(t *testing.T) {
-	testSecret := &ciop.Secret{Name: "test-secret", MountPath: "/usr/local/test-secret"}
+	testSecret := &ciop.Secret{Name: "secret-name", MountPath: "/usr/local/test-secret"}
 	tests := []struct {
 		description    string
 		info           *prowgenInfo
@@ -145,6 +145,7 @@ func TestGeneratePodSpec(t *testing.T) {
 			},
 		},
 		{
+			description:    "additional args and secret are included in podspec",
 			info:           &prowgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
 			secrets:        []*ciop.Secret{testSecret},
 			targets:        []string{"target"},
@@ -165,7 +166,7 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--promote",
 						"--some=thing",
 						"--target=target",
-						fmt.Sprintf("--secret-dir=%s", testSecret.MountPath),
+						fmt.Sprintf("--secret-dir=/secrets/%s", testSecret.Name),
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
@@ -174,7 +175,7 @@ func TestGeneratePodSpec(t *testing.T) {
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: testSecret.Name, MountPath: testSecret.MountPath, ReadOnly: true},
+						{Name: testSecret.Name, MountPath: fmt.Sprintf("/secrets/%s", testSecret.Name), ReadOnly: true},
 					},
 				}},
 				Volumes: []kubeapi.Volume{

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -35,7 +35,6 @@ var unexportedFields = []cmp.Option{
 }
 
 func TestGeneratePodSpec(t *testing.T) {
-	testSecret := &ciop.Secret{Name: "secret-name", MountPath: "/usr/local/test-secret"}
 	tests := []struct {
 		description    string
 		info           *prowgenInfo
@@ -147,7 +146,7 @@ func TestGeneratePodSpec(t *testing.T) {
 		{
 			description:    "additional args and secret are included in podspec",
 			info:           &prowgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
-			secrets:        []*ciop.Secret{testSecret},
+			secrets:        []*ciop.Secret{{Name: "secret-name", MountPath: "/usr/local/test-secret"}},
 			targets:        []string{"target"},
 			additionalArgs: []string{"--promote", "--some=thing"},
 
@@ -166,7 +165,7 @@ func TestGeneratePodSpec(t *testing.T) {
 						"--promote",
 						"--some=thing",
 						"--target=target",
-						fmt.Sprintf("--secret-dir=/secrets/%s", testSecret.Name),
+						"--secret-dir=/secrets/secret-name",
 					},
 					Resources: kubeapi.ResourceRequirements{
 						Requests: kubeapi.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
@@ -175,7 +174,7 @@ func TestGeneratePodSpec(t *testing.T) {
 						{Name: "sentry-dsn", MountPath: "/etc/sentry-dsn", ReadOnly: true},
 						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
 						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: testSecret.Name, MountPath: fmt.Sprintf("/secrets/%s", testSecret.Name), ReadOnly: true},
+						{Name: "secret-name", MountPath: "/secrets/secret-name", ReadOnly: true},
 					},
 				}},
 				Volumes: []kubeapi.Volume{
@@ -198,9 +197,9 @@ func TestGeneratePodSpec(t *testing.T) {
 						},
 					},
 					{
-						Name: testSecret.Name,
+						Name: "secret-name",
 						VolumeSource: kubeapi.VolumeSource{
-							Secret: &kubeapi.SecretVolumeSource{SecretName: testSecret.Name},
+							Secret: &kubeapi.SecretVolumeSource{SecretName: "secret-name"},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes bug where created secret name is different from secret name in podspec, causing a volume mount error.

This will require a regen PR in openshift/release

/cc @stevekuznetsov 