### PR TITLE
ci-operator: annotate errors at the top-most levels

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/registry"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 // ResolverInfo contains the data needed to get a config from the configresolver
@@ -49,7 +50,9 @@ func Config(path, registryPath string, info *ResolverInfo) (*api.ReleaseBuildCon
 		}
 		raw = spec
 	} else {
-		return configFromResolver(info)
+		configSpec, err := configFromResolver(info)
+		err = results.ForReason(results.ReasonConfigResolver).ForError(err)
+		return configSpec, err
 	}
 	configSpec := api.ReleaseBuildConfiguration{}
 	if err := yaml.UnmarshalStrict([]byte(raw), &configSpec); err != nil {

--- a/pkg/results/error.go
+++ b/pkg/results/error.go
@@ -1,0 +1,121 @@
+package results
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error holds a message and a child, allowing for an error
+// The common use-case here will be to wrap errors from callsites:
+//
+// if err := doSomething(data); err != nil {
+//     return results.ForReason(results.ReasonFoo).WithError(err).Errorf("could not do something for data: %v", data)
+// }
+type Error struct {
+	reason  Reason
+	message string
+	wrapped error
+}
+
+// Error makes an Error an error
+func (e *Error) Error() string {
+	return e.message
+}
+
+// Unwrap allows nesting of errors
+func (e *Error) Unwrap() error {
+	return e.wrapped
+}
+
+// Is allows us to say we are an Error
+func (e *Error) Is(target error) bool {
+	_, is := target.(*Error)
+	return is
+}
+
+// FullReason provides the chain of error reasons, divided by colons
+func (e *Error) FullReason() string {
+	reasonedError := &Error{}
+	if !errors.As(e.wrapped, &reasonedError) {
+		return string(e.reason)
+	}
+	return fmt.Sprintf("%s:%s", e.reason, reasonedError.FullReason())
+}
+
+// FullReason attempts to get the full reason from an error, or uses
+// unknown when it's not something we can do
+func FullReason(err error) string {
+	reasonedError := &Error{}
+	if !errors.As(err, &reasonedError) {
+		return string(ReasonUnknown)
+	}
+	return reasonedError.FullReason()
+}
+
+// BuilderWithReason starts the builder chain
+type BuilderWithReason struct {
+	Error
+}
+
+// ForReason is a constructor for an Error from a Reason. We expect
+// users to then add a child and a error message to this Error.
+func ForReason(reason Reason) *BuilderWithReason {
+	if reason == "" {
+		// we don't want to publish metrics with an empty label, so
+		// we enforce that there's some default (if useless) value
+		reason = ReasonUnknown
+	}
+	return &BuilderWithReason{
+		Error: Error{
+			reason: reason,
+		},
+	}
+}
+
+// BuilderWithReasonAndError adds a child error to the builder
+type BuilderWithReasonAndError struct {
+	Error
+}
+
+// WithError is a builder that adds a child to the Error. We
+// expect users to continue to build the Error by adding a message.
+func (e *BuilderWithReason) WithError(err error) *BuilderWithReasonAndError {
+	b := &BuilderWithReasonAndError{
+		Error: e.Error,
+	}
+	b.wrapped = err
+	return b
+}
+
+// Errorf is a builder that adds in the main error to an Error.
+// This is expected to be the final builder/producer in a chain,
+// so we return an error and not an Error
+func (e *BuilderWithReasonAndError) Errorf(format string, args ...interface{}) error {
+	e.message = fmt.Sprintf(format, args...)
+	return &e.Error
+}
+
+// ForError is a constructor for when a caller does not want to add
+// a child but instead wants a simple error. For instance, wrapping
+// the outcome of a function that doesn't return an Error itself:
+//
+//  err := results.ForReason(results.ReasonLoadingArgs).ForError(doSomething())
+func (e *BuilderWithReason) ForError(err error) error {
+	if err == nil {
+		return nil
+	}
+	e.message = err.Error()
+	return &e.Error
+}
+
+// DefaultReason is a constructor that adds a reason if needed, when we
+// want to ensure that consumers downstream of a callsite have an Error.
+//
+// annotated := DefaultReason(doSomething())
+func DefaultReason(err error) error {
+	if errors.Is(err, &Error{}) {
+		return err
+	}
+
+	return ForReason(ReasonUnknown).ForError(err)
+}

--- a/pkg/results/error_test.go
+++ b/pkg/results/error_test.go
@@ -1,0 +1,48 @@
+package results
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	base := errors.New("failure")
+	if actual, expected := FullReason(base), "unknown"; actual != expected {
+		t.Errorf("got incorrect reason for base error; expected %s, got %v", expected, actual)
+	}
+	initial := ForReason("oops").WithError(base).Errorf("couldn't do it")
+	if actual, expected := FullReason(initial), "oops"; actual != expected {
+		t.Errorf("got incorrect reason for initial error; expected %s, got %v", expected, actual)
+	}
+	second := ForReason("whoopsie").WithError(initial).Errorf("couldn't do it")
+	if actual, expected := FullReason(second), "whoopsie:oops"; actual != expected {
+		t.Errorf("got incorrect reason for second error; expected %s, got %v", expected, actual)
+	}
+	third := ForReason("argh").WithError(second).Errorf("couldn't do it")
+	if actual, expected := FullReason(third), "argh:whoopsie:oops"; actual != expected {
+		t.Errorf("got incorrect reason for third error; expected %s, got %v", expected, actual)
+	}
+
+	simple := ForReason("simple").ForError(base)
+	if actual, expected := FullReason(simple), "simple"; actual != expected {
+		t.Errorf("got incorrect reason for simple error; expected %s, got %v", expected, actual)
+	}
+
+	none := ForReason("fake").ForError(nil)
+	if none != nil {
+		t.Errorf("expected a wrapped nil error to be nil, got %v", none)
+	}
+
+	alsoNone := DefaultReason(nil)
+	if alsoNone != nil {
+		t.Errorf("expected a wrapped nil error to be nil, got %v", alsoNone)
+	}
+	withDefault := DefaultReason(base)
+	if actual, expected := FullReason(withDefault), "unknown"; actual != expected {
+		t.Errorf("got incorrect reason for defaulted error; expected %s, got %v", expected, actual)
+	}
+	unchanged := DefaultReason(initial)
+	if actual, expected := FullReason(unchanged), "oops"; actual != expected {
+		t.Errorf("got incorrect reason for unchanged error; expected %s, got %v", expected, actual)
+	}
+}

--- a/pkg/results/results.go
+++ b/pkg/results/results.go
@@ -1,0 +1,33 @@
+package results
+
+type Reason string
+
+const (
+	// ReasonUnknown is default reason. Occurrences of this reason in metrics
+	// indicate a bug, a failure to identify the reason for an error somewhere.
+	ReasonUnknown Reason = "unknown"
+
+	// ReasonLoadingArgs indicates a failure to load arguments at startup
+	ReasonLoadingArgs Reason = "loading_args"
+	// ReasonMissingJobSpec indicates a missing job specification
+	ReasonMissingJobSpec Reason = "missing_job_spec"
+	// ReasonLoadingConfig indicates a failure to load configuration
+	ReasonLoadingConfig Reason = "loading_config"
+	// ReasonConfigResolver indicates a failure to load configuration from the registry
+	ReasonConfigResolver Reason = "config_resolver"
+	// ReasonValidatingConfig indicates a failure to validate configuration
+	ReasonValidatingConfig Reason = "validating_config"
+	// ReasonDefaultingConfig indicates a failure defaulting configuration
+	ReasonDefaultingConfig Reason = "defaulting_config"
+
+	// ReasonResolvingInputs indicates a failure to resolve inputs
+	ReasonResolvingInputs Reason = "resolving_inputs"
+	// ReasonBuildingGraph indicates a failure to build the execution graph
+	ReasonBuildingGraph Reason = "building_graph"
+	// ReasonInitializingNamespace indicates a failure to initialize the namespace
+	ReasonInitializingNamespace Reason = "initializing_namespace"
+	// ReasonExecutingGraph indicates a failure to execute the job graph
+	ReasonExecutingGraph Reason = "executing_graph"
+	// ReasonExecutingPost indicates a failure to execute the post steps
+	ReasonExecutingPost Reason = "executing_post"
+)


### PR DESCRIPTION
In order to be able to expose a history over time of known, annotated
reasons for failure in the ci-operator process, we need a mechanism to
communicate these errors, with annotations, thoughout the codebase. In
order to allow administrators to apply default policy while also
allowing for specific error causes, a concatentating mechanism is used
in defining the error reason string. This will allow for queries for a
specific subsystem or a symptom that may occur across subsystems by
using regular expression matching on these error strings.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 