### PR TITLE
ci-operator multi-stage: fix artifact directory

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -389,6 +389,7 @@ func addProfile(name string, profile api.ClusterProfile, pod *coreapi.Pod) {
 
 func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, shortCircuit bool) error {
 	done := ctx.Done()
+	namePrefix := s.name + "-"
 	var errs []error
 	for _, pod := range pods {
 		log.Printf("Executing %q", pod.Name)
@@ -396,7 +397,8 @@ func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, sh
 		for _, c := range pod.Spec.Containers {
 			if c.Name == "artifacts" {
 				container := pod.Spec.Containers[0].Name
-				artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, container), s.jobSpec.Namespace)
+				dir := filepath.Join(s.artifactDir, strings.TrimPrefix(pod.Name, namePrefix))
+				artifacts := NewArtifactWorker(s.podClient, dir, s.jobSpec.Namespace)
 				artifacts.CollectFromPod(pod.Name, []string{container}, nil)
 				notifier = artifacts
 				break

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -476,10 +476,10 @@ func TestArtifacts(t *testing.T) {
 				Type:      prowapi.PeriodicJob,
 			},
 		},
-		test: []api.LiteralTestStep{{
-			As:          "test0",
-			ArtifactDir: "/path/to/artifacts",
-		}},
+		test: []api.LiteralTestStep{
+			{As: "test0", ArtifactDir: "/path/to/artifacts"},
+			{As: "test1", ArtifactDir: "/path/to/artifacts"},
+		},
 	}
 	fakecs := fake.NewSimpleClientset()
 	executor := fakePodExecutor{}
@@ -492,8 +492,10 @@ func TestArtifacts(t *testing.T) {
 	if err := step.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(filepath.Join(tmp, "test")); err != nil {
-		t.Fatalf("error verifying output directory exists: %v", err)
+	for _, x := range []string{"test0", "test1"} {
+		if _, err := os.Stat(filepath.Join(tmp, x)); err != nil {
+			t.Fatalf("error verifying output directory %q exists: %v", x, err)
+		}
 	}
 }
 


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/657 unified the container
names of all multi-stage pods, causing artifacts to be written to the
same directory.