### PR TITLE
reporter: Fix nil pointer dereference in Report

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -139,6 +139,7 @@ func (r *reporter) Report(err error) {
 	resp, err := r.client.Post(fmt.Sprintf("%s/result", r.address), "application/json", bytes.NewReader(data))
 	if err != nil {
 		glog.V(4).Infof("could not create report request: %v", err)
+		return
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
* `pkg/results/report.go` (`Report`): Do not try to dereference the response value from the HTTP client if the client returned an error.


----

This is intended to resolve the following error:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x1704aee]
    
    goroutine 1 [running]:
    github.com/openshift/ci-tools/pkg/results.(*reporter).Report(0xc0007334d0, 0x1e85480, 0xc00067cc00)
    	/go/src/github.com/openshift/ci-tools/pkg/results/report.go:144 +0x2fe
    main.(*options).Report(0xc0001f2b00, 0x1e83ec0, 0xc00067cc00)
    	/go/src/github.com/openshift/ci-tools/cmd/ci-operator/main.go:504 +0xf7
    main.main()
    	/go/src/github.com/openshift/ci-tools/cmd/ci-operator/main.go:201 +0x30e

https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/9968