### PR TITLE
boskos: bump acquire timeout to 120m

### DIFF
--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -86,7 +86,7 @@ type lease struct {
 
 func (c *client) Acquire(rtype string, ctx context.Context, cancel context.CancelFunc) (string, error) {
 	var cancelAcquire context.CancelFunc
-	ctx, cancelAcquire = context.WithTimeout(ctx, 50*time.Minute)
+	ctx, cancelAcquire = context.WithTimeout(ctx, 120*time.Minute)
 	defer cancelAcquire()
 	r, err := c.boskos.AcquireWaitWithPriority(ctx, rtype, freeState, leasedState, randId())
 	if err != nil {


### PR DESCRIPTION
We have a global timeout of 4h, so a 50m timeout is unnecessarily
restrictive for jobs that could grab a lease and still have time to
finish in their allotted window.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 
