### PR TITLE
Add a ReconcileRequestCoalescer

### DIFF
--- a/pkg/controller/util/request_coalescer.go
+++ b/pkg/controller/util/request_coalescer.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"sync"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// NewReconcileRequestCoalescer returns a reconcile wrapper that will delay new reconcile.Requests
+// after a sucessful reconciliation for coalesceWindow time.
+// A successful reconciliation is defined as as one where all returned values are empty or nil
+func NewReconcileRequestCoalescer(upstream reconcile.Reconciler, coalesceWindow time.Duration) reconcile.Reconciler {
+	return &reconcileRequestCoalescer{
+		lock:                              &sync.RWMutex{},
+		lastSuccessfulReconciliationCache: map[string]time.Time{},
+		coalesceWindow:                    coalesceWindow,
+		upstream:                          upstream,
+		timeSince:                         time.Since,
+	}
+}
+
+type reconcileRequestCoalescer struct {
+	lock                              *sync.RWMutex
+	lastSuccessfulReconciliationCache map[string]time.Time
+	coalesceWindow                    time.Duration
+	upstream                          reconcile.Reconciler
+	timeSince                         func(time.Time) time.Duration
+}
+
+func (rc *reconcileRequestCoalescer) Reconcile(r reconcile.Request) (reconcile.Result, error) {
+	rc.lock.RLock()
+	lastSuccessfulReconciliation := rc.lastSuccessfulReconciliationCache[r.String()]
+	rc.lock.RUnlock()
+
+	if expiredTime := rc.timeSince(lastSuccessfulReconciliation); expiredTime < rc.coalesceWindow {
+		return reconcile.Result{RequeueAfter: time.Duration(rc.coalesceWindow - expiredTime)}, nil
+	}
+
+	result, err := rc.upstream.Reconcile(r)
+	if !IsReconcileSuccessfull(result, err) {
+		return result, err
+	}
+
+	// Stamp before acquiring the lock as that might take some time
+	successfulReconcileTime := time.Now()
+	rc.lock.Lock()
+	rc.lastSuccessfulReconciliationCache[r.String()] = successfulReconcileTime
+	rc.lock.Unlock()
+
+	return result, err
+}
+
+func IsReconcileSuccessfull(result reconcile.Result, err error) bool {
+	return err == nil && !result.Requeue && int64(result.RequeueAfter) == 0
+}

--- a/pkg/controller/util/request_coalescer_test.go
+++ b/pkg/controller/util/request_coalescer_test.go
@@ -1,0 +1,99 @@
+package util
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileRequestCoalescer(t *testing.T) {
+	testCases := []struct {
+		name           string
+		coalescerMod   func(*reconcileRequestCoalescer)
+		expectedResult reconcile.Result
+		expectedError  string
+	}{
+		{
+			name:           "Coalescer hit cache, RequeueAfter is returned",
+			expectedResult: reconcile.Result{RequeueAfter: time.Duration(1)},
+		},
+		{
+			name: "Cache miss, Requeue is returned",
+			coalescerMod: func(rc *reconcileRequestCoalescer) {
+				rc.upstream = reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{Requeue: true}, nil
+				})
+				rc.coalesceWindow = time.Duration(0)
+			},
+			expectedResult: reconcile.Result{Requeue: true},
+		},
+		{
+			name: "Cache miss, RequeueAfter is returned",
+			coalescerMod: func(rc *reconcileRequestCoalescer) {
+				rc.upstream = reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{RequeueAfter: time.Duration(3)}, nil
+				})
+				rc.coalesceWindow = time.Duration(0)
+			},
+			expectedResult: reconcile.Result{RequeueAfter: time.Duration(3)},
+		},
+		{
+			name: "Cache miss, Error is returned",
+			coalescerMod: func(rc *reconcileRequestCoalescer) {
+				rc.upstream = reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{}, errors.New("some-err")
+				})
+				rc.coalesceWindow = time.Duration(0)
+			},
+			expectedError: "some-err",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rcInterfaced := NewReconcileRequestCoalescer(
+				reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+					return reconcile.Result{}, nil
+				}),
+				time.Duration(2),
+			)
+			rc := rcInterfaced.(*reconcileRequestCoalescer)
+			rc.timeSince = func(_ time.Time) time.Duration { return time.Duration(1) }
+
+			if tc.coalescerMod != nil {
+				tc.coalescerMod(rc)
+			}
+
+			result, err := rc.Reconcile(reconcile.Request{})
+			errMsg := ""
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if diff := cmp.Diff(errMsg, tc.expectedError); diff != "" {
+				t.Errorf("error differs from expected error: %s", diff)
+			}
+			if diff := cmp.Diff(result, tc.expectedResult); diff != "" {
+				t.Errorf("result differs from expectedResult: %s", diff)
+			}
+		})
+	}
+}
+
+func TestReconcileRequestCoalescer_threadSafety(t *testing.T) {
+	reconciler := NewReconcileRequestCoalescer(
+		reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+			return reconcile.Result{}, nil
+		}),
+		time.Duration(1),
+	)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() { reconciler.Reconcile(reconcile.Request{}); wg.Done() }()
+	go func() { reconciler.Reconcile(reconcile.Request{}); wg.Done() }()
+	wg.Wait()
+}


### PR DESCRIPTION
This allows to delay ReconcileRequests after a successful Reconciliation
in order to decrease load for controllers that watch objects that change
very frequently.

Needed now for the ImageStreamTagReconciler but may be useful elsewhere.

To give a bit more background: ImageStreamTags do not support watching (https://github.com/openshift/api/issues/601). This means that:
* We have to watch ImageStreams instead
* And enqueue each and every ImageStreamTag in them on every event (basically whenever any changes)
* Since api.ci has some imageStreams that basically permanently get events, we produce _a lot_ of events
* This results in a high load because the ImageStreamTag reconciler has a somewhat expensive reconcile loop where it does a git fetch and some json unmarshaling

Apart from the approach suggested in this PR it would also be possible to filter the update events and check which ImageStreamTag in the ImageSteam actually got changed. This has some drawbacks though:
* The kube api does not guarantee that a given change will be observed, it only guarantees that watchers get any event per change, but that event may not contain the given update
* We want to periodically reconcile which is done internally by generating artifical update events which we would swallow with that approach. We could workaround that as well by creating a ticker that directly enqueues all imageStreamTags once every interval but its obviously a bit more involved.

Considering that we never rebuilt anything on missed events, introducing some delay to reduce load is IMHO good enough.

/assign @petr-muller 