### PR TITLE
config: partition useful flags

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 type options struct {
-	promotion.Options
+	promotion.FutureOptions
 	username  string
 	tokenPath string
 }
@@ -62,19 +62,8 @@ func main() {
 	client := githubql.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(rawToken))})))
 
 	failed := false
-	if err := config.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := config.LoggerForInfo(*repoInfo)
-		if (o.Org != "" && o.Org != repoInfo.Org) || (o.Repo != "" && o.Repo != repoInfo.Repo) {
-			return nil
-		}
-		if !promotion.PromotesOfficialImages(configuration) {
-			logger.Debugf("Skipping because no offical images are promoted from this configuration")
-			return nil
-		}
-		if configuration.PromotionConfiguration.Name != o.CurrentRelease {
-			logger.Debugf("Skipping because this configuration promotes %s, but the current release is %s", configuration.PromotionConfiguration.Name, o.CurrentRelease)
-			return nil
-		}
 
 		var branches []string
 		for _, futureRelease := range o.FutureReleases.Strings() {

--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
-
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/promotion"
 )

--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -2,18 +2,40 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/getlantern/deepcopy"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/promotion"
 )
 
-func gatherOptions() promotion.Options {
-	o := promotion.Options{}
+type options struct {
+	promotion.FutureOptions
+
+	BumpRelease string
+}
+
+func (o *options) Validate() error {
+	futureReleases := sets.NewString(o.FutureReleases.Strings()...)
+	if o.BumpRelease != "" && !futureReleases.Has(o.BumpRelease) {
+		return fmt.Errorf("future releases %v do not contain bump release %v", futureReleases.List(), o.BumpRelease)
+	}
+
+	return o.Options.Validate()
+}
+
+func (o *options) Bind(fs *flag.FlagSet) {
+	fs.StringVar(&o.BumpRelease, "bump-release", "", "Bump the dev config to this release and manage mirroring.")
+	o.Options.Bind(fs)
+}
+
+func gatherOptions() options {
+	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	o.Bind(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -46,10 +68,7 @@ func main() {
 	}
 
 	var toCommit []config.DataWithInfo
-	if err := config.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
-		if (o.Org != "" && o.Org != info.Org) || (o.Repo != "" && o.Repo != info.Repo) {
-			return nil
-		}
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
 		for _, output := range generateBranchedConfigs(o.CurrentRelease, o.BumpRelease, o.FutureReleases.Strings(), config.DataWithInfo{Configuration: *configuration, Info: *info}) {
 			if !o.Confirm {
 				output.Logger().Info("Would commit new file.")
@@ -77,10 +96,6 @@ func main() {
 }
 
 func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases []string, input config.DataWithInfo) []config.DataWithInfo {
-	if !(promotion.PromotesOfficialImages(&input.Configuration) && input.Configuration.PromotionConfiguration.Name == currentRelease) {
-		return nil
-	}
-
 	var output []config.DataWithInfo
 	input.Logger().Info("Branching configuration.")
 	currentConfig := input.Configuration

--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -7,13 +7,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
-
 	"github.com/openshift/ci-tools/pkg/config"
-	"github.com/openshift/ci-tools/pkg/promotion"
 )
 
-func gatherOptions() promotion.Options {
-	o := promotion.Options{}
+func gatherOptions() config.Options {
+	o := config.Options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	o.Bind(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -29,13 +27,7 @@ func main() {
 	}
 
 	var toCommit []config.DataWithInfo
-	if err := config.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
-		if (o.Org != "" && o.Org != info.Org) || (o.Repo != "" && o.Repo != info.Repo) {
-			return nil
-		}
-		if !(promotion.PromotesOfficialImages(configuration) && configuration.PromotionConfiguration.Name == o.CurrentRelease) {
-			return nil
-		}
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
 		output := config.DataWithInfo{Configuration: *configuration, Info: *info}
 		if !o.Confirm {
 			output.Logger().Info("Would re-format file.")

--- a/cmd/repo-brancher/main.go
+++ b/cmd/repo-brancher/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 type options struct {
-	promotion.Options
+	promotion.FutureOptions
 	gitDir      string
 	username    string
 	tokenPath   string
@@ -105,14 +105,8 @@ func main() {
 	}
 
 	failed := false
-	if err := config.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := config.LoggerForInfo(*repoInfo)
-		if (o.Org != "" && o.Org != repoInfo.Org) || (o.Repo != "" && o.Repo != repoInfo.Repo) {
-			return nil
-		}
-		if !(promotion.PromotesOfficialImages(configuration) && configuration.PromotionConfiguration.Name == o.CurrentRelease) {
-			return nil
-		}
 
 		repoDir := path.Join(gitDir, repoInfo.Org, repoInfo.Repo)
 		if err := os.MkdirAll(repoDir, 0775); err != nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -660,7 +660,7 @@ type OpenshiftAnsibleClusterTestConfiguration struct {
 
 // OpenshiftAnsibleSrcClusterTestConfiguration describes a
 // test that provisions a cluster using openshift-ansible and
-// executes a command in the `src` image.F
+// executes a command in the `src` image.
 type OpenshiftAnsibleSrcClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -127,8 +127,8 @@ func (c ResourceConfiguration) RequirementsForStep(name string) ResourceRequirem
 // to the individual steps in the job. They are passed directly to
 // builds or pods.
 type ResourceRequirements struct {
-	Requests ResourceList `json:"requests"`
-	Limits   ResourceList `json:"limits"`
+	Requests ResourceList `json:"requests,omitempty"`
+	Limits   ResourceList `json:"limits,omitempty"`
 }
 
 // ResourceList is a map of string resource names and resource
@@ -231,7 +231,7 @@ type PromotionConfiguration struct {
 	// Name is an optional image stream name to use that
 	// contains all component tags. If specified, tag is
 	// ignored.
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 
 	// Tag is the ImageStreamTag tagged in for each
 	// build image's ImageStream.
@@ -660,7 +660,7 @@ type OpenshiftAnsibleClusterTestConfiguration struct {
 
 // OpenshiftAnsibleSrcClusterTestConfiguration describes a
 // test that provisions a cluster using openshift-ansible and
-// executes a command in the `src` image.
+// executes a command in the `src` image.F
 type OpenshiftAnsibleSrcClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 }
@@ -742,7 +742,7 @@ type OpenshiftInstallerCustomTestImageClusterTestConfiguration struct {
 	// provided test command.  e.g. stable:console-test
 	From             string `json:"from"`
 	EnableNestedVirt bool   `json:"enable_nested_virt,omitempty"`
-	NestedVirtImage  string `json:"nested_virt_image"`
+	NestedVirtImage  string `json:"nested_virt_image,omitempty"`
 }
 
 // OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration describes a

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/sirupsen/logrus"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
@@ -122,7 +121,25 @@ func (i *Info) RelativePath() string {
 
 // ConfigMapName returns the configmap in which we expect this file to be uploaded
 func (i *Info) ConfigMapName() string {
-	return fmt.Sprintf("ci-operator-%s-configs", promotion.FlavorForBranch(i.Branch))
+	return fmt.Sprintf("ci-operator-%s-configs", FlavorForBranch(i.Branch))
+}
+
+var threeXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-3\.[0-9]+$`)
+var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9]+)$`)
+
+func FlavorForBranch(branch string) string {
+	var flavor string
+	if branch == "master" {
+		flavor = "master"
+	} else if threeXBranches.MatchString(branch) {
+		flavor = "3.x"
+	} else if fourXBranches.MatchString(branch) {
+		matches := fourXBranches.FindStringSubmatch(branch)
+		flavor = matches[2] // the 4.x release string
+	} else {
+		flavor = "misc"
+	}
+	return flavor
 }
 
 // IsCiopConfigCM returns true if a given name is a valid ci-operator config ConfigMap

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -313,3 +313,84 @@ func TestInfo_TestName(t *testing.T) {
 		})
 	}
 }
+
+func TestFlavorForBranch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "master branch goes to master configmap",
+			branch:   "master",
+			expected: "master",
+		},
+		{
+			name:     "enterprise 3.6 branch goes to 3.x configmap",
+			branch:   "enterprise-3.6",
+			expected: "3.x",
+		},
+		{
+			name:     "openshift 3.6 branch goes to 3.x configmap",
+			branch:   "openshift-3.6",
+			expected: "3.x",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "enterprise 3.11 branch goes to 3.x configmap",
+			branch:   "enterprise-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "openshift 3.11 branch goes to 3.x configmap",
+			branch:   "openshift-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "knative release branch goes to misc configmap",
+			branch:   "release-0.2",
+			expected: "misc",
+		},
+		{
+			name:     "azure release branch goes to misc configmap",
+			branch:   "release-v1",
+			expected: "misc",
+		},
+		{
+			name:     "ansible dev branch goes to misc configmap",
+			branch:   "devel-40",
+			expected: "misc",
+		},
+		{
+			name:     "release 4.0 branch goes to 4.0 configmap",
+			branch:   "release-4.0",
+			expected: "4.0",
+		},
+		{
+			name:     "release 4.1 branch goes to 4.1 configmap",
+			branch:   "release-4.1",
+			expected: "4.1",
+		},
+		{
+			name:     "release 4.2 branch goes to 4.2 configmap",
+			branch:   "release-4.2",
+			expected: "4.2",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.expected, func(t *testing.T) {
+			if actual, expected := FlavorForBranch(testCase.branch), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+)
+
+// Options holds options to load CI Operator configuration
+// and select a subset of that configuration to operate on.
+// Configurations can be filtered by --org, --repo, or both.
+type Options struct {
+	ConfigDir string
+	Org       string
+	Repo      string
+
+	logLevel string
+	Confirm  bool
+}
+
+func (o *Options) Validate() error {
+	if o.ConfigDir == "" {
+		return errors.New("required flag --config-dir was unset")
+	}
+
+	level, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		return fmt.Errorf("invalid --log-level: %v", err)
+	}
+	logrus.SetLevel(level)
+	return nil
+}
+
+func (o *Options) Bind(fs *flag.FlagSet) {
+	fs.StringVar(&o.ConfigDir, "config-dir", "", "Path to CI Operator configuration directory.")
+	fs.StringVar(&o.logLevel, "log-level", "info", "Level at which to log output.")
+	fs.StringVar(&o.Org, "org", "", "Limit repos affected to those in this org.")
+	fs.StringVar(&o.Repo, "repo", "", "Limit repos affected to this repo.")
+	fs.BoolVar(&o.Confirm, "confirm", false, "Create the branched configuration files.")
+}
+
+func (o *Options) matches(info *Info) bool {
+	switch {
+	case o.Org == "" && o.Repo == "":
+		return true
+	case o.Org != "" && o.Repo != "":
+		return o.Org == info.Org && o.Repo == info.Repo
+	default:
+		return (o.Org != "" && o.Org == info.Org) || (o.Repo != "" && o.Repo == info.Repo)
+	}
+}
+
+// OperateOnCIOperatorConfigDir filters the full set of configurations
+// down to those that were selected by the user with --{org|repo}
+func (o *Options) OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
+	return OperateOnCIOperatorConfigDir(configDir, func(configuration *cioperatorapi.ReleaseBuildConfiguration, info *Info) error {
+		if !o.matches(info) {
+			return nil
+		}
+		return callback(configuration, info)
+	})
+}

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestOptions_Validate(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		input    Options
+		expected error
+	}{
+		{
+			name:     "nothing set errors",
+			input:    Options{},
+			expected: errors.New("required flag --config-dir was unset"),
+		},
+		{
+			name: "invalid log level errors",
+			input: Options{
+				ConfigDir: "/somewhere",
+				logLevel:  "whoa",
+			},
+			expected: errors.New("invalid --log-level: not a valid logrus Level: \"whoa\""),
+		},
+		{
+			name: "valid config has no errors",
+			input: Options{
+				ConfigDir: "/somewhere",
+				logLevel:  "debug",
+			},
+			expected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := testCase.input.Validate(), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: got incorrect error from validate: expected %v, got %v", testCase.name, expected, actual)
+			}
+		})
+	}
+}
+
+func TestOptions_Matches(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		input    Options
+		info     *Info
+		expected bool
+	}{
+		{
+			name:  "nothing set matches everything",
+			input: Options{},
+			info: &Info{
+				Org:  "org",
+				Repo: "repo",
+			},
+			expected: true,
+		},
+		{
+			name: "org set matches repo under that org",
+			input: Options{
+				Org: "org",
+			},
+			info: &Info{
+				Org:  "org",
+				Repo: "repo",
+			},
+			expected: true,
+		},
+		{
+			name: "org set doesn't match repo under other org",
+			input: Options{
+				Org: "org",
+			},
+			info: &Info{
+				Org:  "arg",
+				Repo: "repo",
+			},
+			expected: false,
+		},
+		{
+			name: "repo set matches repo",
+			input: Options{
+				Repo: "repo",
+			},
+			info: &Info{
+				Org:  "anything",
+				Repo: "repo",
+			},
+			expected: true,
+		},
+		{
+			name: "repo set doesn't match other repo",
+			input: Options{
+				Repo: "repo",
+			},
+			info: &Info{
+				Org:  "anything",
+				Repo: "ripo",
+			},
+			expected: false,
+		},
+		{
+			name: "org and repo set matches org/repo",
+			input: Options{
+				Org:  "org",
+				Repo: "repo",
+			},
+			info: &Info{
+				Org:  "org",
+				Repo: "repo",
+			},
+			expected: true,
+		},
+		{
+			name: "org and repo set doesn't match other repo in org",
+			input: Options{
+				Org:  "org",
+				Repo: "repo",
+			},
+			info: &Info{
+				Org:  "org",
+				Repo: "ripo",
+			},
+			expected: false,
+		},
+		{
+			name: "org and repo set doesn't match repo in other org",
+			input: Options{
+				Org:  "org",
+				Repo: "repo",
+			},
+			info: &Info{
+				Org:  "arg",
+				Repo: "repo",
+			},
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if actual, expected := testCase.input.matches(testCase.info), testCase.expected; actual != expected {
+				t.Errorf("%s: got incorrect match: expected %v, got %v", testCase.name, expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -2,6 +2,7 @@ package jobconfig
 
 import (
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/api/core/v1"
@@ -55,9 +55,9 @@ func (i *Info) Basename() string {
 func (i *Info) ConfigMapName() string {
 	// put periodics not directly correlated to code in the misc job
 	if i.Type == "periodics" && i.Branch == "" {
-		return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(""))
+		return fmt.Sprintf("job-config-%s", config.FlavorForBranch(""))
 	}
-	return fmt.Sprintf("job-config-%s", promotion.FlavorForBranch(i.Branch))
+	return fmt.Sprintf("job-config-%s", config.FlavorForBranch(i.Branch))
 }
 
 // We use the directory/file naming convention to encode useful information

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -1,11 +1,9 @@
 package promotion
 
 import (
-	"reflect"
 	"testing"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestPromotesOfficialImages(t *testing.T) {
@@ -122,87 +120,6 @@ func TestDetermineReleaseBranches(t *testing.T) {
 			}
 			if actual, expected := actualFutureBranch, testCase.expectedFutureBranch; actual != expected {
 				t.Errorf("%s: incorrect future branch, expected %q, got %q", testCase.name, expected, actual)
-			}
-		})
-	}
-}
-
-func TestFlavorForBranch(t *testing.T) {
-	testCases := []struct {
-		name     string
-		branch   string
-		expected string
-	}{
-		{
-			name:     "master branch goes to master configmap",
-			branch:   "master",
-			expected: "master",
-		},
-		{
-			name:     "enterprise 3.6 branch goes to 3.x configmap",
-			branch:   "enterprise-3.6",
-			expected: "3.x",
-		},
-		{
-			name:     "openshift 3.6 branch goes to 3.x configmap",
-			branch:   "openshift-3.6",
-			expected: "3.x",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "enterprise 3.11 branch goes to 3.x configmap",
-			branch:   "enterprise-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "openshift 3.11 branch goes to 3.x configmap",
-			branch:   "openshift-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "knative release branch goes to misc configmap",
-			branch:   "release-0.2",
-			expected: "misc",
-		},
-		{
-			name:     "azure release branch goes to misc configmap",
-			branch:   "release-v1",
-			expected: "misc",
-		},
-		{
-			name:     "ansible dev branch goes to misc configmap",
-			branch:   "devel-40",
-			expected: "misc",
-		},
-		{
-			name:     "release 4.0 branch goes to 4.0 configmap",
-			branch:   "release-4.0",
-			expected: "4.0",
-		},
-		{
-			name:     "release 4.1 branch goes to 4.1 configmap",
-			branch:   "release-4.1",
-			expected: "4.1",
-		},
-		{
-			name:     "release 4.2 branch goes to 4.2 configmap",
-			branch:   "release-4.2",
-			expected: "4.2",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.expected, func(t *testing.T) {
-			if actual, expected := FlavorForBranch(testCase.branch), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
@@ -43,8 +43,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -55,8 +54,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -69,8 +67,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -83,8 +80,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -95,8 +91,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]
@@ -115,8 +110,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -127,8 +121,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -141,8 +134,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -155,8 +147,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -167,8 +158,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
@@ -43,8 +43,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -55,8 +54,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -69,8 +67,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -83,8 +80,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -95,8 +91,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]
@@ -115,8 +110,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -127,8 +121,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -141,8 +134,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -155,8 +147,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -167,8 +158,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
@@ -43,8 +43,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -55,8 +54,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -69,8 +67,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -83,8 +80,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -95,8 +91,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]
@@ -115,8 +110,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -127,8 +121,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -141,8 +134,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ],
@@ -155,8 +147,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           },
           {
@@ -167,8 +158,7 @@
               "requests": {
                 "cpu": "1000m",
                 "memory": "2Gi"
-              },
-              "limits": null
+              }
             }
           }
         ]

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -1388,7 +1388,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1397,7 +1396,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1407,7 +1405,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1416,7 +1413,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1425,7 +1421,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1438,7 +1433,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1447,7 +1441,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1457,7 +1450,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1466,7 +1458,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1475,7 +1466,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1488,7 +1478,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1497,7 +1486,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1507,7 +1495,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1516,7 +1503,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1525,7 +1511,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1537,7 +1522,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1549,7 +1533,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1678,7 +1661,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1687,7 +1669,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1697,7 +1678,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1706,7 +1686,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1715,7 +1694,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1728,7 +1706,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1737,7 +1714,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1747,7 +1723,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1756,7 +1731,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1765,7 +1739,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1778,7 +1751,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1787,7 +1759,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1797,7 +1768,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1806,7 +1776,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1815,7 +1784,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1827,7 +1795,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1839,7 +1806,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1977,7 +1943,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1986,7 +1951,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -1996,7 +1960,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2005,7 +1968,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2014,7 +1976,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2027,7 +1988,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2036,7 +1996,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2046,7 +2005,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2055,7 +2013,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2064,7 +2021,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2077,7 +2033,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2086,7 +2041,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2096,7 +2050,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2105,7 +2058,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2114,7 +2066,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2126,7 +2077,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2138,7 +2088,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2270,7 +2219,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2279,7 +2227,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2289,7 +2236,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2298,7 +2244,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2307,7 +2252,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2320,7 +2264,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2329,7 +2272,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2339,7 +2281,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2348,7 +2289,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2357,7 +2297,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2370,7 +2309,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2379,7 +2317,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2389,7 +2326,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2398,7 +2334,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2407,7 +2342,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2419,7 +2353,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2431,7 +2364,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2563,7 +2495,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2572,7 +2503,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2582,7 +2512,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2591,7 +2520,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2600,7 +2528,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2613,7 +2540,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2622,7 +2548,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2632,7 +2557,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2641,7 +2565,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2650,7 +2573,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2663,7 +2585,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2672,7 +2593,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2682,7 +2602,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2691,7 +2610,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2700,7 +2618,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2712,7 +2629,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2724,7 +2640,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2855,7 +2770,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2864,7 +2778,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2874,7 +2787,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2883,7 +2795,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2892,7 +2803,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2905,7 +2815,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2914,7 +2823,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2924,7 +2832,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2933,7 +2840,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2942,7 +2848,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2955,7 +2860,6 @@
                     gather
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2964,7 +2868,6 @@
                     openshift-cluster destroy
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2974,7 +2877,6 @@
                     setup-rbac-2
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2983,7 +2885,6 @@
                     openshift-cluster install --newFlag
                   from: installer
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -2992,7 +2893,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -3004,7 +2904,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi
@@ -3016,7 +2915,6 @@
                   commands: make integration
                   from: my-image
                   resources:
-                    limits: null
                     requests:
                       cpu: 1000m
                       memory: 2Gi


### PR DESCRIPTION
Previously, we had one set of common options -- for promotion. In
reality, tools may need to load and operate on CI Operator
configuration, honor promotion rules, care about future releases or all
three. As it stands, some tools have flags they don't use (and often our
validation forces them to be set). This refactor separates our concerns
and DRYs out the logic used to select subsets of config from provided
flags. It does not change the end behavior of tools other than the
remove unused flags.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 