### PR TITLE
Use pointer in the kubeconfig map

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -270,7 +270,7 @@ type options struct {
 	metadataRevision int
 
 	kubeconfig  string
-	kubeconfigs map[string]rest.Config
+	kubeconfigs map[string]*rest.Config
 
 	pullSecretPath string
 	pullSecret     *coreapi.Secret

--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -129,7 +129,7 @@ func (o *options) completeOptions(secrets *sets.String) error {
 				if !ok {
 					return fmt.Errorf("config[%d].to[%d]: failed to find cluster context %q in the kubeconfig", i, j, secretContext.Cluster)
 				}
-				client, err := coreclientset.NewForConfig(&kc)
+				client, err := coreclientset.NewForConfig(kc)
 				if err != nil {
 					return err
 				}

--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -97,9 +97,8 @@ func (o *options) completeOptions(secrets *sets.String) error {
 		logrus.WithError(err).Warn("Encountered errors while loading kubeconfigs")
 	}
 	if o.impersonateUser != "" {
-		for cluster, kubeConfig := range kubeConfigs {
+		for _, kubeConfig := range kubeConfigs {
 			kubeConfig.Impersonate = rest.ImpersonationConfig{UserName: o.impersonateUser}
-			kubeConfigs[cluster] = kubeConfig
 		}
 	}
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -39,7 +39,7 @@ func FromConfig(
 	clusterConfig *rest.Config,
 	leaseClient *lease.Client,
 	requiredTargets []string,
-	kubeconfigs map[string]rest.Config,
+	kubeconfigs map[string]*rest.Config,
 	dryLogger *steps.DryLogger,
 	cloneAuthConfig *steps.CloneAuthConfig,
 	pullSecret *coreapi.Secret,
@@ -277,7 +277,7 @@ func promotionDefaults(configSpec *api.ReleaseBuildConfiguration) (*api.Promotio
 	return config, nil
 }
 
-func clusterImageStreamClient(client imageclientset.ImageV1Interface, config *rest.Config, overrideClusterHost string, kubeconfigs map[string]rest.Config) (imageclientset.ImageV1Interface, error) {
+func clusterImageStreamClient(client imageclientset.ImageV1Interface, config *rest.Config, overrideClusterHost string, kubeconfigs map[string]*rest.Config) (imageclientset.ImageV1Interface, error) {
 	if config == nil || len(overrideClusterHost) == 0 {
 		return client, nil
 	}
@@ -287,7 +287,7 @@ func clusterImageStreamClient(client imageclientset.ImageV1Interface, config *re
 
 	for _, c := range kubeconfigs {
 		if equivalentHosts(c.Host, overrideClusterHost) {
-			return imageclientset.NewForConfig(&c)
+			return imageclientset.NewForConfig(c)
 		}
 	}
 

--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -27,14 +27,14 @@ func LoadClusterConfig() (*rest.Config, error) {
 	return clusterConfig, nil
 }
 
-func LoadKubeConfigs(kubeconfig string) (map[string]rest.Config, string, error) {
+func LoadKubeConfigs(kubeconfig string) (map[string]*rest.Config, string, error) {
 	loader := clientcmd.NewDefaultClientConfigLoadingRules()
 	loader.ExplicitPath = kubeconfig
 	cfg, err := loader.Load()
 	if err != nil {
 		return nil, "", err
 	}
-	configs := map[string]rest.Config{}
+	configs := map[string]*rest.Config{}
 	var errs []error
 	for context := range cfg.Contexts {
 		contextCfg, err := clientcmd.NewNonInteractiveClientConfig(*cfg, context, &clientcmd.ConfigOverrides{}, loader).ClientConfig()
@@ -43,7 +43,7 @@ func LoadKubeConfigs(kubeconfig string) (map[string]rest.Config, string, error) 
 			errs = append(errs, fmt.Errorf("create %s client: %v", context, err))
 			continue
 		}
-		configs[context] = *contextCfg
+		configs[context] = contextCfg
 		logrus.Infof("Parsed kubeconfig context: %s", context)
 	}
 	return configs, cfg.CurrentContext, utilerrors.NewAggregate(errs)

--- a/pkg/util/client_test.go
+++ b/pkg/util/client_test.go
@@ -52,7 +52,7 @@ func TestLoadKubeConfigs(t *testing.T) {
 	var testCases = []struct {
 		name            string
 		kubeconfig      string
-		expectedConfigs map[string]rest.Config
+		expectedConfigs map[string]*rest.Config
 		expectedContext string
 		expectedError   error
 	}{
@@ -64,7 +64,7 @@ func TestLoadKubeConfigs(t *testing.T) {
 		{
 			name:       "file kubeconfig1",
 			kubeconfig: filename1,
-			expectedConfigs: map[string]rest.Config{
+			expectedConfigs: map[string]*rest.Config{
 				"ci/api-build01-ci-devcluster-openshift-com:6443": {
 					Host:        "https://api.build01.ci.devcluster.openshift.com:6443",
 					BearerToken: "TOKEN",


### PR DESCRIPTION
Like the rest of the places, rest config is always a pointer.
I should have done this from the beginning.

/cc @stevekuznetsov @alvaroaleman 