### PR TITLE
Fix default postsubmit.MaxConcurrency = 1 for promotion jobs

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -2,7 +2,6 @@ package jobconfig
 
 import (
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/config"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,6 +15,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "k8s.io/test-infra/prow/config"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
 )
 
 type ProwgenLabel string
@@ -429,7 +431,9 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 func mergePostsubmits(old, new *prowconfig.Postsubmit) prowconfig.Postsubmit {
 	merged := *new
 
-	merged.MaxConcurrency = old.MaxConcurrency
+	if _, ok := merged.Labels[cioperatorapi.PromotionJobLabelKey]; !ok {
+		merged.MaxConcurrency = old.MaxConcurrency
+	}
 	if old.Cluster != "" {
 		merged.Cluster = old.Cluster
 	}

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -508,6 +508,63 @@ func TestMergePostsubmits(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "job with promotion label and MaxConcurrency 1",
+			old: &prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					Labels:         map[string]string{"foo": "bar"},
+					MaxConcurrency: 3,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+			new: &prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					Labels:         map[string]string{"foo": "bar", "ci-operator.openshift.io/is-promotion": "bla"},
+					MaxConcurrency: 1,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+			expected: prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					Labels:         map[string]string{"foo": "bar", "ci-operator.openshift.io/is-promotion": "bla"},
+					MaxConcurrency: 1,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+		},
+		{
+			name: "job without promotion label",
+			old: &prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					MaxConcurrency: 3,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+			new: &prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					MaxConcurrency: 1,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+			expected: prowconfig.Postsubmit{
+				JobBase: prowconfig.JobBase{
+					Name:           "pull-ci-super-duper",
+					MaxConcurrency: 3,
+					Agent:          "agent",
+					Cluster:        "somewhere",
+				},
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1588003186030600?thread_ts=1588002752.029100&cid=GB7NB0CUC

/cc @stevekuznetsov @alvaroaleman 

Breaking change ... Need to prepare the PR for release change.
Fix tests if breaking.

Update:
Added unit tests and https://github.com/openshift/release/pull/8610