### PR TITLE
Enable golangci-lint in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,8 @@ validate-vendor:
 .PHONY: validate-vendor
 
 lint:
-	gofmt -s -l $(shell go list -f '{{ .Dir }}' ./... ) | grep ".*\.go"; if [ "$$?" = "0" ]; then gofmt -s -d $(shell go list -f '{{ .Dir }}' ./... ); exit 1; fi
-	go vet ./...
 .PHONY: lint
+	./hack/lint.sh
 
 format:
 	gofmt -s -w $(shell go list -f '{{ .Dir }}' ./... )

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Checking gofmt"
+gofmt -s -l $(go list -f '{{ .Dir }}' ./... ) | grep ".*\.go"; if [ "$$?" = "0" ]; then gofmt -s -d $(shell go list -f '{{ .Dir }}' ./... ); exit 1; fi
+
+echo "Running go vet"
+go vet ./...
+
+echo "Running golangci-lint"
+golangci-lint run --disable-all --enable=unused,deadcode,gosimple ./...


### PR DESCRIPTION
Enables golangci-lint with three linters:
* `unused`: Finds variables that are assigned to and then never read from until they go out of scope or are written to again. This finds correctness issues.
* `deadcode`: Pretty much what it says. Doesn't find correctness issues but IMHO good to have to keep things simple
* `gosimple`: Also pretty much what it says. Doesn't find correctness issues either, but keeps the code simple

/assign @bbguimaraes @petr-muller 