### PR TITLE
fix missing future-release flag

### DIFF
--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/getlantern/deepcopy"
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -31,7 +32,7 @@ func (o *options) Validate() error {
 
 func (o *options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.BumpRelease, "bump-release", "", "Bump the dev config to this release and manage mirroring.")
-	o.Options.Bind(fs)
+	o.FutureOptions.Bind(fs)
 }
 
 func gatherOptions() options {


### PR DESCRIPTION
fixes the missing `---future-release` flag binding.
/cc @openshift/openshift-team-developer-productivity-test-platform 

before
```console
$ config-brancher --help
Usage of config-brancher:
  -bump-release string
    	Bump the dev config to this release and manage mirroring.
  -config-dir string
    	Path to CI Operator configuration directory.
  -confirm
    	Create the branched configuration files.
  -current-release string
    	Configurations targeting this release will get branched.
  -log-level string
    	Level at which to log output. (default "info")
  -org string
    	Limit repos affected to those in this org.
  -repo string
    	Limit repos affected to this repo.
```

after
```console
$ config-brancher --help
Usage of config-brancher:
  -bump-release string
    	Bump the dev config to this release and manage mirroring.
  -config-dir string
    	Path to CI Operator configuration directory.
  -confirm
    	Create the branched configuration files.
  -current-release string
    	Configurations targeting this release will get branched.
  -future-release value
    	Configurations will get branched to target this release, provide one or more times.
  -log-level string
    	Level at which to log output. (default "info")
  -org string
    	Limit repos affected to those in this org.
  -repo string
    	Limit repos affected to this repo.

```