### PR TITLE
ci-operator: record org, repo branch and variant in config

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -97,6 +97,7 @@ func main() {
 		}
 
 		repoInfo.Org = o.toOrg
+		rbc.Metadata.Org = o.toOrg
 		dataWithInfo := config.DataWithInfo{
 			Configuration: *rbc,
 			Info:          *repoInfo,

--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -34,6 +34,16 @@ func main() {
 			return nil
 		}
 
+		// we treat the filepath as the ultimate source of truth for this
+		// data, but we record it in the configuration files to ensure that
+		// it's easy to consume it for downstream tools
+		output.Configuration.Metadata = api.Metadata{
+			Org:     info.Org,
+			Repo:    info.Repo,
+			Branch:  info.Branch,
+			Variant: info.Variant,
+		}
+
 		// we are walking the config so we need to commit once we're done
 		toCommit = append(toCommit, output)
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -21,6 +21,8 @@ const (
 //  - raw steps that can be used to create custom and
 //    fine-grained build flows
 type ReleaseBuildConfiguration struct {
+	Metadata Metadata `json:"zz_generated_metadata"`
+
 	InputConfiguration `json:",inline"`
 
 	// BinaryBuildCommands will create a "bin" image based on "src" that
@@ -74,6 +76,14 @@ type ReleaseBuildConfiguration struct {
 	// input types. The special name '*' may be used to set default
 	// requests and limits.
 	Resources ResourceConfiguration `json:"resources,omitempty"`
+}
+
+// Metadata describes the source repo for which a config is written
+type Metadata struct {
+	Org     string `json:"org"`
+	Repo    string `json:"repo"`
+	Branch  string `json:"branch"`
+	Variant string `json:"variant,omitempty"`
 }
 
 // BuildsImage checks if an image is built by the release configuration.

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -42,7 +42,7 @@ import (
 
 const testingRegistry = "../../test/multistage-registry/registry"
 
-const testingCiOpCfgYAML = "tests:\n- as: job1\n- as: job2\n"
+const testingCiOpCfgYAML = "tests:\n- as: job1\n- as: job2\nzz_generated_metadata:\n  branch: \"\"\n  org: \"\"\n  repo: \"\"\n"
 
 // configFiles contains the info needed to allow inlineCiOpConfig to successfully inline
 // CONFIG_SPEC and not fail

--- a/test/ci-operator-config-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/input/foo/bar/foo-bar-master.yaml
@@ -4,27 +4,31 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: foo
+  repo: bar

--- a/test/ci-operator-config-mirror-integration/data/input/super/duper/super-duper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/input/super/duper/super-duper-master.yaml
@@ -9,31 +9,34 @@ base_images:
     name: centos
     namespace: ocp
     tag: os
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/ci-operator-config-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/input/super/trooper/super-trooper-master.yaml
@@ -4,31 +4,34 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper

--- a/test/ci-operator-config-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/foo/bar/foo-bar-master.yaml
@@ -4,27 +4,31 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: foo
+  repo: bar

--- a/test/ci-operator-config-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/super-priv/duper/super-priv-duper-master.yaml
@@ -37,3 +37,7 @@ tests:
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: duper

--- a/test/ci-operator-config-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -32,3 +32,7 @@ tests:
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: trooper

--- a/test/ci-operator-config-mirror-integration/data/output/super/duper/super-duper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/super/duper/super-duper-master.yaml
@@ -9,31 +9,34 @@ base_images:
     name: centos
     namespace: ocp
     tag: os
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/ci-operator-config-mirror-integration/data/output/super/trooper/super-trooper-master.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/super/trooper/super-trooper-master.yaml
@@ -4,31 +4,34 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper

--- a/test/ci-operator-configresolver-integration/ci-op-configmaps/master/..2019_11_15_19_57_20.547184898/openshift-installer-master.yaml
+++ b/test/ci-operator-configresolver-integration/ci-op-configmaps/master/..2019_11_15_19_57_20.547184898/openshift-installer-master.yaml
@@ -1,3 +1,7 @@
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: master
 base_images:
   base:
     cluster: https://api.ci.openshift.org

--- a/test/ci-operator-configresolver-integration/ci-op-configmaps/release-4.2/..2019_11_15_19_57_20.547184898/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-configresolver-integration/ci-op-configmaps/release-4.2/..2019_11_15_19_57_20.547184898/openshift-installer-release-4.2.yaml
@@ -1,3 +1,7 @@
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: release-4.2
 base_images:
   base:
     cluster: https://api.ci.openshift.org

--- a/test/ci-operator-configresolver-integration/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-configresolver-integration/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -1,3 +1,7 @@
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: release-4.2
 base_images:
   base:
     cluster: https://api.ci.openshift.org

--- a/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
+++ b/test/ci-operator-configresolver-integration/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml
@@ -1,3 +1,7 @@
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: release-4.2
 base_images:
   base:
     cluster: https://api.ci.openshift.org

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-golang111.json
@@ -1,4 +1,9 @@
 {
+  "zz_generated_metadata": {
+    "org": "openshift",
+    "repo": "installer",
+    "branch": "release-4.2"
+  },
   "base_images": {
     "base": {
       "cluster": "https://api.ci.openshift.org",

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2-regChange.json
@@ -1,4 +1,9 @@
 {
+  "zz_generated_metadata": {
+    "org": "openshift",
+    "repo": "installer",
+    "branch": "release-4.2"
+  },
   "base_images": {
     "base": {
       "cluster": "https://api.ci.openshift.org",

--- a/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
+++ b/test/ci-operator-configresolver-integration/expected/openshift-installer-release-4.2.json
@@ -1,4 +1,9 @@
 {
+  "zz_generated_metadata": {
+    "org": "openshift",
+    "repo": "installer",
+    "branch": "release-4.2"
+  },
   "base_images": {
     "base": {
       "cluster": "https://api.ci.openshift.org",

--- a/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
@@ -4,25 +4,28 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
 images:
 - from: base
   to: test-image
 - from: base
   to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-build_root:
-  image_stream_tag:
-    cluster: https://api.ci.openshift.org
-    namespace: openshift
-    name: release
-    tag: golang-1.10
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: ciop-cfg-change
+  org: super
+  repo: duper

--- a/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-master.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/config/super/duper/super-duper-master.yaml
@@ -4,23 +4,26 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/pj-rehearse-integration/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/pj-rehearse-integration/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -4,26 +4,25 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make unit CHANGED
@@ -31,55 +30,63 @@ tests:
     from: src
 - as: multistage
   steps:
-    workflow: ipi
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
-- as: multistage2 # identical to above; should be ignored by rehearse tool
+    workflow: ipi
+- as: multistage2
   steps:
-    workflow: ipi
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
-- as: multistage3 # new cluster_profile field; should be rehearsed
+    workflow: ipi
+- as: multistage3
   steps:
     cluster_profile: azure
+    test:
+    - as: e2e
+      commands: make integration
+      from: my-image
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
     workflow: ipi
-    test:
-    - as: e2e
-      from: my-image
-      commands: make integration
-      resources:
-        requests:
-          cpu: 1000m
-          memory: 2Gi
-- as: multistage4 # shouldn't get rehearsed since it doesn't use changed registry components
+- as: multistage4
   steps:
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
-- as: multistage5 # doesn't exist in previous revision; should get tested
+- as: multistage5
   steps:
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -158,7 +158,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 1e57006d-b7c8-11e9-a628-54e1ad07d68a
+    name: 770b3e5e-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -232,6 +232,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: ciop-cfg-change
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -258,18 +262,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 362ea74ab530befb4201e0d447d7a19174edb8d3
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 2a2c6326002a2df6099cb3cadf145f338ad3e137
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-06-18T09:30:17Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -286,7 +290,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 1d97c3ab-b9f3-11e9-ae13-54e1ad07d68a
+    name: 770b3ffa-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -350,6 +354,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: ciop-cfg-change
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -359,18 +367,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: af9ec8fe29f22367f34ba1176cfdbf624fe77cab
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 783e2532831a60e2ea50eb7fea52bcba2ecb6107
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-08-08T15:42:23Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -387,7 +395,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: a4d7cde0-eb8f-11e9-ac83-54ee753e2644
+    name: 770b3202-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -457,6 +465,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: ciop-cfg-change
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -468,18 +480,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 92aeb56b6799e26148806168e5636cd7f793bee2
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 1303e418a8be200e400667c6ea6e7a549e4a8f6f
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-10-10T18:56:18Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -497,7 +509,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 9bdfbae2-405b-11e9-ac33-74d435fb2dc0
+    name: 770b32f9-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -563,6 +575,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: ciop-cfg-change
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -572,18 +588,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 328cef7c6235073b55754d503b98c9233eaa9955
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 2a4d89d759b611ad3f423378c7d78f3af15d78e2
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-06T22:03:01Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -600,7 +616,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: aa2b50c7-4b4e-11e9-b014-e86a6403f52c
+    name: 770b34f0-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -672,6 +688,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: cluster-profile
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -698,18 +718,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -726,7 +746,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: df02e525-2e1e-11e9-bbf5-8c16455629bd
+    name: 770b2df9-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -790,6 +810,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -801,18 +825,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-06T22:03:01Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -829,7 +853,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 44acebef-4fc4-11e9-b82b-54e1ad07d68a
+    name: 770b2fe2-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -901,6 +925,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -927,18 +955,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 7effc9d6d41c9038e853dc54814eaace10f0bbfa
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: bb928f30f5790ce48231cb1b2601a135869da8cc
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-06T22:03:01Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -955,7 +983,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: df02e8fc-2e1e-11e9-bbf5-8c16455629bd
+    name: 770b3112-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -1019,6 +1047,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1030,18 +1062,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1058,7 +1090,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ab89c04c-4fc2-11e9-96b2-54e1ad07d68a
+    name: 770b33d4-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -1130,6 +1162,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1156,18 +1192,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: bfd4c4d0fe97177b4278dfef1691c7ef8dca1af0
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4fe34c7d9b223067e30397a98a64bc0915d602e2
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-26T12:28:33Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1184,7 +1220,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ab89c26f-4fc2-11e9-96b2-54e1ad07d68a
+    name: 770b363e-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -1256,6 +1292,10 @@
               cluster: https://api.ci.openshift.org
               name: origin-v4.0
               namespace: openshift
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1282,18 +1322,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: bfd4c4d0fe97177b4278dfef1691c7ef8dca1af0
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4fe34c7d9b223067e30397a98a64bc0915d602e2
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-26T12:28:33Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1310,7 +1350,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: df02ea78-2e1e-11e9-bbf5-8c16455629bd
+    name: 770b3745-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -1536,6 +1576,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1547,18 +1591,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: bb928f30f5790ce48231cb1b2601a135869da8cc
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-03-06T22:03:01Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1575,7 +1619,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 44acf399-4fc4-11e9-b82b-54e1ad07d68a
+    name: 770b3823-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -1809,6 +1853,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -1835,18 +1883,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 7effc9d6d41c9038e853dc54814eaace10f0bbfa
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: bb928f30f5790ce48231cb1b2601a135869da8cc
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1864,7 +1912,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 72fccf67-1b9d-11ea-a5f6-8c1645feb4f4
+    name: 770b3b77-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -2091,6 +2139,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2111,18 +2163,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: 9691f0df19066bb68113f19dad0389184279fefe
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: bd54f9c2b25d95fbcde47597e52c6866be831382
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-12-10T22:36:04Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2140,7 +2192,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 72fcd110-1b9d-11ea-a5f6-8c1645feb4f4
+    name: 770b3d63-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -2367,6 +2419,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2387,18 +2443,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: 9691f0df19066bb68113f19dad0389184279fefe
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: bb928f30f5790ce48231cb1b2601a135869da8cc
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2416,7 +2472,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 72fccbb1-1b9d-11ea-a5f6-8c1645feb4f4
+    name: 770b3944-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -2643,6 +2699,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2663,18 +2723,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2692,7 +2752,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7216cd7e-4c84-11e9-996c-54e1ad07d68a
+    name: 770b3a57-8b04-11ea-a187-98fa9bcb3ca2
     namespace: test-namespace
   spec:
     agent: kubernetes
@@ -2918,6 +2978,10 @@
                     requests:
                       cpu: 1000m
                       memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -2927,17 +2991,17 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: a1e0de27c562d86647c901554094d12d7c358ba8
+      base_sha: 32db953cb0ed936a25475d6aba2625b0ff4a2347
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 7c0b9788f819121ac637fa3f8a319d0bc2cda73e
+        sha: a937d41182950a2f60a58e1c49c73fd3cf1cac2f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2019-02-11T17:02:53Z"
+    startTime: "2020-04-30T17:03:08Z"
     state: triggered
 

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
@@ -4,23 +4,26 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: ciop-cfg-change
+  org: super
+  repo: duper

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-cluster-profile.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-cluster-profile.yaml
@@ -4,23 +4,26 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: cluster-profile
+  org: super
+  repo: duper

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-master.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/duper/super-duper-master.yaml
@@ -4,23 +4,26 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/pj-rehearse-integration/master/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/pj-rehearse-integration/master/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -4,26 +4,25 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make unit
@@ -31,45 +30,52 @@ tests:
     from: src
 - as: multistage
   steps:
-    workflow: ipi
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
-- as: multistage2 # identical to above; should be ignored by rehearse tool
+    workflow: ipi
+- as: multistage2
   steps:
-    workflow: ipi
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
-- as: multistage3 # new cluster_profile field; should be rehearsed
+    workflow: ipi
+- as: multistage3
   steps:
     cluster_profile: azure
+    test:
+    - as: e2e
+      commands: make integration
+      from: my-image
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
     workflow: ipi
-    test:
-    - as: e2e
-      from: my-image
-      commands: make integration
-      resources:
-        requests:
-          cpu: 1000m
-          memory: 2Gi
-- as: multistage4 # shouldn't get rehearsed since it doesn't use changed registry components
+- as: multistage4
   steps:
+    cluster_profile: ""
     test:
     - as: e2e
-      from: my-image
       commands: make integration
+      from: my-image
       resources:
         requests:
           cpu: 1000m
           memory: 2Gi
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper

--- a/test/prowgen-integration/data/input/config/private-org/duper/private-org-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/private-org/duper/private-org-duper-master.yaml
@@ -1,13 +1,8 @@
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
 resources:
   '*':
@@ -15,8 +10,16 @@ resources:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: private-org
+  repo: duper

--- a/test/prowgen-integration/data/input/config/private/duper/private-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/private/duper/private-duper-master.yaml
@@ -4,29 +4,28 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
@@ -38,6 +37,10 @@ tests:
     cluster_profile: gcp
 - as: e2e-nightly
   commands: make e2e
+  cron: '@yearly'
   openshift_ansible:
     cluster_profile: gcp
-  cron: '@yearly'
+zz_generated_metadata:
+  branch: master
+  org: private
+  repo: duper

--- a/test/prowgen-integration/data/input/config/subdir/repo/subdir-repo-master.yaml
+++ b/test/prowgen-integration/data/input/config/subdir/repo/subdir-repo-master.yaml
@@ -1,8 +1,8 @@
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
 resources:
   '*':
@@ -15,3 +15,7 @@ tests:
   commands: make test
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: subdir
+  repo: repo

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master-removed-promotion.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master-removed-promotion.yaml
@@ -4,25 +4,26 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-# promotion is not present here but the promoting postsubmit exists in the
-# input, so that job should be pruned in the output
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+zz_generated_metadata:
+  branch: master-removed-promotion
+  org: super
+  repo: duper

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master.yaml
@@ -4,29 +4,28 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp # will add --target [release:latest] to the promote job
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
@@ -42,11 +41,15 @@ tests:
     cluster_profile: gcp
 - as: e2e-nightly
   commands: make e2e
+  cron: '@yearly'
   openshift_ansible:
     cluster_profile: gcp
-  cron: '@yearly'
 - as: e2e-aws-nightly
   commands: make e2e
+  cron: '@yearly'
   openshift_ansible:
     cluster_profile: aws
-  cron: '@yearly'
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-master__variant.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-master__variant.yaml
@@ -4,32 +4,36 @@ base_images:
     name: origin-v4.0
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v4.0
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: ocp # will add --target [release:latest] to the promote job
-  name: other
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+canonical_go_repository: whoa.com/super/duper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
   container:
     from: src
-canonical_go_repository: whoa.com/super/duper
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper
+  variant: variant

--- a/test/prowgen-integration/data/input/config/super/duper/super-duper-release-3.11.yaml
+++ b/test/prowgen-integration/data/input/config/super/duper/super-duper-release-3.11.yaml
@@ -4,31 +4,30 @@ base_images:
     name: origin-v3.11
     namespace: openshift
     tag: base
-images:
-- from: base
-  to: test-image
-tag_specification:
-  cluster: https://api.ci.openshift.org
-  name: origin-v3.11
-  namespace: openshift
-  tag: ''
-promotion:
-  namespace: openshift
-  name: other
-  additional_images:
-    super-duper-src: src
 build_root:
   image_stream_tag:
     cluster: https://api.ci.openshift.org
-    namespace: openshift
     name: release
+    namespace: openshift
     tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  additional_images:
+    super-duper-src: src
+  name: other
+  namespace: openshift
 resources:
   '*':
     limits:
       cpu: 500Mi
     requests:
       cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v3.11
+  namespace: openshift
 tests:
 - as: unit
   commands: make test-unit
@@ -38,3 +37,7 @@ tests:
   commands: make test-lint
   container:
     from: src
+zz_generated_metadata:
+  branch: release-3.11
+  org: super
+  repo: duper

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -1,3 +1,9 @@
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.13
 images:
 - context_dir: images/blocking-issue-creator/
   from: os
@@ -17,15 +23,13 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-build_root:
-  image_stream_tag:
-    cluster: https://api.ci.openshift.org
-    name: release
-    namespace: openshift
-    tag: golang-1.13
 tests:
 - artifact_dir: /tmp/artifacts
   as: unit
   commands: ARTIFACT_DIR=/tmp/artifacts make test
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: ci-tools

--- a/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -40,3 +40,7 @@ tests:
     from: src
     memory_backed_volume:
       size: 4Gi
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: origin

--- a/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -24,3 +24,7 @@ tests:
   commands: make test-unit
   container:
     from: src
+zz_generated_metadata:
+  branch: nonstandard
+  org: org
+  repo: other

--- a/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/repo-init-integration/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -47,3 +47,7 @@ tests:
   commands: e2e
   openshift_installer_src:
     cluster_profile: aws
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: repo

--- a/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -1,3 +1,9 @@
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.13
 images:
 - context_dir: images/blocking-issue-creator/
   from: os
@@ -17,15 +23,13 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-build_root:
-  image_stream_tag:
-    cluster: https://api.ci.openshift.org
-    name: release
-    namespace: openshift
-    tag: golang-1.13
 tests:
 - artifact_dir: /tmp/artifacts
   as: unit
   commands: ARTIFACT_DIR=/tmp/artifacts make test
   container:
     from: src
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: ci-tools

--- a/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/repo-init-integration/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -40,3 +40,7 @@ tests:
     from: src
     memory_backed_volume:
       size: 4Gi
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: origin

--- a/test/repo-init-integration/run.sh
+++ b/test/repo-init-integration/run.sh
@@ -73,6 +73,7 @@ inputs=(
 for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo .
 ci-operator-prowgen --from-dir ./ci-operator/config --to-dir ./ci-operator/jobs
 sanitize-prow-jobs --prow-jobs-dir ./ci-operator/jobs --config-path ./core-services/sanitize-prow-jobs/_config.yaml
+determinize-ci-operator --config-dir ./ci-operator/config --confirm
 
 if [[  "${UPDATE:-}" = true ]]; then
   rm -rf  "$ROOTDIR"/test/repo-init-integration/expected/*


### PR DESCRIPTION
We want downstream users of a CI Operator configuration that may not be
loading it from the release repository to be able to determine what org,
repo, branch and variant the configuration is for. We add these fields
as auto-generated metadata to the configuration file, and ensure that
they are set correctly when determinizing. We still want there to be
just one source of truth and we do not want users to have to set them,
or for users to be able to make a mistake setting them, so the
determinizer treats the directory tree as the source of truth.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 