### PR TITLE
add a list of conditions when operating in ci-operator configs

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -191,7 +191,7 @@ func isConfigFile(path string, info os.FileInfo) bool {
 
 // OperateOnCIOperatorConfig runs the callback on the parsed data from
 // the CI Operator configuration file provided
-func OperateOnCIOperatorConfig(path string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
+func OperateOnCIOperatorConfig(path string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error, conditions ...func(*cioperatorapi.ReleaseBuildConfiguration, *Info) bool) error {
 	info, err := InfoFromPath(path)
 	if err != nil {
 		logrus.WithField("source-file", path).WithError(err).Error("Failed to resolve info from CI Operator configuration path")
@@ -202,6 +202,13 @@ func OperateOnCIOperatorConfig(path string, callback func(*cioperatorapi.Release
 		logrus.WithField("source-file", path).WithError(err).Error("Failed to load CI Operator configuration")
 		return err
 	}
+
+	for _, condition := range conditions {
+		if !condition(jobConfig, info) {
+			return nil
+		}
+	}
+
 	if err = callback(jobConfig, info); err != nil {
 		logrus.WithField("source-file", path).WithError(err).Error("Failed to execute callback")
 		return err
@@ -211,18 +218,19 @@ func OperateOnCIOperatorConfig(path string, callback func(*cioperatorapi.Release
 
 // OperateOnCIOperatorConfigDir runs the callback on all CI Operator
 // configuration files found while walking the directory provided
-func OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
-	return OperateOnCIOperatorConfigSubdir(configDir, "", callback)
+func OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error, conditions ...func(*cioperatorapi.ReleaseBuildConfiguration, *Info) bool) error {
+	return OperateOnCIOperatorConfigSubdir(configDir, "", callback, conditions...)
 }
 
-func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
+func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error, conditions ...func(*cioperatorapi.ReleaseBuildConfiguration, *Info) bool) error {
 	return filepath.Walk(filepath.Join(configDir, subDir), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			logrus.WithField("source-file", path).WithError(err).Error("Failed to walk CI Operator configuration dir")
 			return err
 		}
+
 		if isConfigFile(path, info) {
-			if err := OperateOnCIOperatorConfig(path, callback); err != nil {
+			if err := OperateOnCIOperatorConfig(path, callback, conditions...); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
There are many tools that need to run some operations while iterating in the `ci-operator` configuration files only when specific conditions are true.

With this change, we will be able to pass many conditions to be checked before the operation.

Usage example:
```golang
	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
		// Whatever...
		return nil
	}
	conditions := func(c *api.ReleaseBuildConfiguration, i *config.Info) bool {
		return promotion.BuildsOfficialImages(c) || whitelistConfig.IsWhitelisted(i)
	}

	if err := config.OperateOnCIOperatorConfigDir(filepath.Join(releaseRepoPath, config.CiopConfigInRepoPath), callback, conditions); err != nil {
		return ret, fmt.Errorf("error while operating in ci-operator configuration files: %v", err)
	}
```


/cc @stevekuznetsov @petr-muller @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>