### PR TITLE
ci-operator: add finer-grained error identifiers

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -184,12 +184,23 @@ func main() {
 	})
 
 	if err := opt.Complete(); err != nil {
-		opt.Report(results.ForReason(results.ReasonLoadingArgs).ForError(err))
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		opt.Report([]error{results.ForReason(results.ReasonLoadingArgs).ForError(err)})
 		os.Exit(1)
 	}
 
-	if err := opt.Run(); err != nil {
-		opt.Report(err)
+	if errs := opt.Run(); len(errs) > 1 {
+		var defaulted []error
+		for _, err := range errs {
+			defaulted = append(defaulted, results.DefaultReason(err))
+		}
+
+		message := bytes.Buffer{}
+		for _, err := range errs {
+			message.WriteString(fmt.Sprintf("\n  * %s", err.Error()))
+		}
+		fmt.Fprintf(os.Stderr, "error: some steps failed:%s\n", message.String())
+		opt.Report(errs)
 		os.Exit(1)
 	}
 }
@@ -484,21 +495,20 @@ func (o *options) Complete() error {
 	return nil
 }
 
-func (o *options) Report(err error) {
-	err = results.DefaultReason(err)
-
-	fmt.Fprintf(os.Stderr, "error: %v\n", err)
-	o.writeFailingJUnit(err)
+func (o *options) Report(errs []error) {
+	o.writeFailingJUnit(errs)
 
 	reporter, loadErr := o.resultsOptions.Reporter(o.jobSpec, o.consoleHost)
 	if loadErr != nil {
-		log.Printf("could not load result reporting options: %v", err)
+		log.Printf("could not load result reporting options: %v", loadErr)
 		return
 	}
-	reporter.Report(err)
+	for _, err := range errs {
+		reporter.Report(err)
+	}
 }
 
-func (o *options) Run() error {
+func (o *options) Run() []error {
 	start := time.Now()
 	defer func() {
 		log.Printf("Ran for %s", time.Since(start).Truncate(time.Second))
@@ -508,22 +518,22 @@ func (o *options) Run() error {
 	// load the graph from the configuration
 	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, &o.leaseClient, o.targets.values, o.kubeconfigs, dryLogger, o.cloneAuthConfig, o.pullSecret)
 	if err != nil {
-		return results.ForReason(results.ReasonDefaultingConfig).WithError(err).Errorf("failed to generate steps from config: %v", err)
+		return []error{results.ForReason(results.ReasonDefaultingConfig).WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}
 	// Before we create the namespace, we need to ensure all inputs to the graph
 	// have been resolved. We must run this step before we resolve the partial
 	// graph or otherwise two jobs with different targets would create different
 	// artifact caches.
 	if err := o.resolveInputs(buildSteps); err != nil {
-		return results.ForReason(results.ReasonResolvingInputs).WithError(err).Errorf("could not resolve inputs: %v", err)
+		return []error{results.ForReason(results.ReasonResolvingInputs).WithError(err).Errorf("could not resolve inputs: %v", err)}
 	}
 
 	if err := o.writeMetadataJSON(); err != nil {
-		return fmt.Errorf("unable to write metadata.json for build: %v", err)
+		return []error{fmt.Errorf("unable to write metadata.json for build: %v", err)}
 	}
 	if o.print {
 		if err := printDigraph(os.Stdout, buildSteps); err != nil {
-			return fmt.Errorf("could not print graph: %v", err)
+			return []error{fmt.Errorf("could not print graph: %v", err)}
 		}
 		return nil
 	}
@@ -531,17 +541,17 @@ func (o *options) Run() error {
 	// convert the full graph into the subset we must run
 	nodes, err := api.BuildPartialGraph(buildSteps, o.targets.values)
 	if err != nil {
-		return results.ForReason(results.ReasonBuildingGraph).WithError(err).Errorf("could not build execution graph: %v", err)
+		return []error{results.ForReason(results.ReasonBuildingGraph).WithError(err).Errorf("could not build execution graph: %v", err)}
 	}
 
 	if err := printExecutionOrder(nodes); err != nil {
-		return fmt.Errorf("could not print execution order: %v", err)
+		return []error{fmt.Errorf("could not print execution order: %v", err)}
 	}
 
 	// initialize the namespace if necessary and create any resources that must
 	// exist prior to execution
 	if err := o.initializeNamespace(); err != nil {
-		return results.ForReason(results.ReasonInitializingNamespace).WithError(err).Errorf("could not initialize namespace: %v", err)
+		return []error{results.ForReason(results.ReasonInitializingNamespace).WithError(err).Errorf("could not initialize namespace: %v", err)}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	handler := func(s os.Signal) {
@@ -549,28 +559,28 @@ func (o *options) Run() error {
 		cancel()
 	}
 
-	return interrupt.New(handler, o.saveNamespaceArtifacts).Run(func() error {
+	return interrupt.New(handler, o.saveNamespaceArtifacts).Run(func() []error {
 		if o.leaseServer != "" && o.leaseServerUsername != "" && o.leaseServerPasswordFile != "" {
 			if err := o.initializeLeaseClient(); err != nil {
-				return fmt.Errorf("failed to create the lease client: %v", err)
+				return []error{fmt.Errorf("failed to create the lease client: %v", err)}
 			}
 		}
 		client, err := coreclientset.NewForConfig(o.clusterConfig)
 		if err != nil {
-			return fmt.Errorf("could not get core client for cluster config: %v", err)
+			return []error{fmt.Errorf("could not get core client for cluster config: %v", err)}
 		}
 		authClient, err := authclientset.NewForConfig(o.clusterConfig)
 		if err != nil {
-			return fmt.Errorf("could not get auth client for cluster config: %v", err)
+			return []error{fmt.Errorf("could not get auth client for cluster config: %v", err)}
 		}
 		eventRecorder, err := eventRecorder(client, authClient, o.namespace, o.dry)
 		if err != nil {
-			return fmt.Errorf("could not create event recorder: %v", err)
+			return []error{fmt.Errorf("could not create event recorder: %v", err)}
 		}
 		runtimeObject := &coreapi.ObjectReference{Namespace: o.namespace}
 		eventRecorder.Event(runtimeObject, coreapi.EventTypeNormal, "CiJobStarted", eventJobDescription(o.jobSpec, o.namespace))
 		// execute the graph
-		suites, err := steps.Run(ctx, nodes, o.dry)
+		suites, errs := steps.Run(ctx, nodes, o.dry)
 		if err := o.writeJUnit(suites, "operator"); err != nil {
 			log.Printf("warning: Unable to write JUnit result: %v", err)
 		}
@@ -578,12 +588,16 @@ func (o *options) Run() error {
 		if err := o.writeMetadataJSON(); err != nil {
 			log.Printf("warning: unable to update metadata.json for build: %v", err)
 		}
-		if err != nil {
+		if len(errs) > 0 {
 			eventRecorder.Event(runtimeObject, coreapi.EventTypeWarning, "CiJobFailed", eventJobDescription(o.jobSpec, o.namespace))
 			if !o.dry {
 				time.Sleep(time.Second)
 			}
-			return &errWroteJUnit{wrapped: results.ForReason(results.ReasonExecutingGraph).WithError(err).Errorf("could not run steps: %v", err)}
+			var wrapped []error
+			for _, err := range errs {
+				wrapped = append(wrapped, &errWroteJUnit{wrapped: results.ForReason(results.ReasonExecutingGraph).WithError(err).Errorf("could not run steps: %v", err)})
+			}
+			return wrapped
 		}
 
 		for _, step := range postSteps {
@@ -593,7 +607,7 @@ func (o *options) Run() error {
 				if !o.dry {
 					time.Sleep(time.Second)
 				}
-				return results.ForReason(results.ReasonExecutingPost).WithError(err).Errorf("could not run post step %s: %v", step.Name(), err)
+				return []error{results.ForReason(results.ReasonExecutingPost).WithError(err).Errorf("could not run post step %s: %v", step.Name(), err)}
 			}
 		}
 
@@ -1032,23 +1046,28 @@ func (e *errWroteJUnit) Is(target error) bool {
 
 // writeFailingJUnit attempts to write a JUnit artifact when the graph could not be
 // initialized in order to capture the result for higher level automation.
-func (o *options) writeFailingJUnit(err error) {
-	if errors.Is(err, &errWroteJUnit{}) {
+func (o *options) writeFailingJUnit(errs []error) {
+	var testCases []*junit.TestCase
+	for _, err := range errs {
+		if errors.Is(err, &errWroteJUnit{}) {
+			continue
+		}
+		testCases = append(testCases, &junit.TestCase{
+			Name: "initialize",
+			FailureOutput: &junit.FailureOutput{
+				Output: err.Error(),
+			},
+		})
+	}
+	if len(testCases) == 0 {
 		return
 	}
 	suites := &junit.TestSuites{
 		Suites: []*junit.TestSuite{
 			{
-				NumTests:  1,
-				NumFailed: 1,
-				TestCases: []*junit.TestCase{
-					{
-						Name: "initialize",
-						FailureOutput: &junit.FailureOutput{
-							Output: err.Error(),
-						},
-					},
-				},
+				NumTests:  uint(len(errs)),
+				NumFailed: uint(len(errs)),
+				TestCases: testCases,
 			},
 		},
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 func TestProwMetadata(t *testing.T) {

--- a/pkg/interrupt/interrupt.go
+++ b/pkg/interrupt/interrupt.go
@@ -76,7 +76,7 @@ func (h *Handler) Signal(s os.Signal) {
 // Run ensures that any notifications are invoked after the provided fn exits (even if the
 // process is interrupted by an OS termination signal). Notifications are only invoked once
 // per Handler instance, so calling Run more than once will not behave as the user expects.
-func (h *Handler) Run(fn func() error) error {
+func (h *Handler) Run(fn func() []error) []error {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, terminationSignals...)
 	defer func() {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -51,7 +51,7 @@ func Config(path, registryPath string, info *ResolverInfo) (*api.ReleaseBuildCon
 		raw = spec
 	} else {
 		configSpec, err := configFromResolver(info)
-		err = results.ForReason(results.ReasonConfigResolver).ForError(err)
+		err = results.ForReason("config_resolver").ForError(err)
 		return configSpec, err
 	}
 	configSpec := api.ReleaseBuildConfiguration{}

--- a/pkg/results/results.go
+++ b/pkg/results/results.go
@@ -6,33 +6,4 @@ const (
 	// ReasonUnknown is default reason. Occurrences of this reason in metrics
 	// indicate a bug, a failure to identify the reason for an error somewhere.
 	ReasonUnknown Reason = "unknown"
-
-	// ReasonLoadingArgs indicates a failure to load arguments at startup
-	ReasonLoadingArgs Reason = "loading_args"
-	// ReasonMissingJobSpec indicates a missing job specification
-	ReasonMissingJobSpec Reason = "missing_job_spec"
-	// ReasonLoadingConfig indicates a failure to load configuration
-	ReasonLoadingConfig Reason = "loading_config"
-	// ReasonConfigResolver indicates a failure to load configuration from the registry
-	ReasonConfigResolver Reason = "config_resolver"
-	// ReasonValidatingConfig indicates a failure to validate configuration
-	ReasonValidatingConfig Reason = "validating_config"
-	// ReasonDefaultingConfig indicates a failure defaulting configuration
-	ReasonDefaultingConfig Reason = "defaulting_config"
-
-	// ReasonResolvingInputs indicates a failure to resolve inputs
-	ReasonResolvingInputs Reason = "resolving_inputs"
-	// ReasonBuildingGraph indicates a failure to build the execution graph
-	ReasonBuildingGraph Reason = "building_graph"
-	// ReasonInitializingNamespace indicates a failure to initialize the namespace
-	ReasonInitializingNamespace Reason = "initializing_namespace"
-	// ReasonExecutingGraph indicates a failure to execute the job graph
-	ReasonExecutingGraph Reason = "executing_graph"
-	// ReasonExecutingPost indicates a failure to execute the post steps
-	ReasonExecutingPost Reason = "executing_post"
-
-	// ReasonInterrupted indicates that we were interrupted during execution
-	ReasonInterrupted Reason = "interrupted"
-	// ReasonStepFailed indicates a step failed to execute
-	ReasonStepFailed Reason = "step_failed"
 )

--- a/pkg/results/results.go
+++ b/pkg/results/results.go
@@ -30,4 +30,9 @@ const (
 	ReasonExecutingGraph Reason = "executing_graph"
 	// ReasonExecutingPost indicates a failure to execute the post steps
 	ReasonExecutingPost Reason = "executing_post"
+
+	// ReasonInterrupted indicates that we were interrupted during execution
+	ReasonInterrupted Reason = "interrupted"
+	// ReasonStepFailed indicates a step failed to execute
+	ReasonStepFailed Reason = "step_failed"
 )

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -3,6 +3,7 @@ package clusterinstall
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -119,11 +120,15 @@ func (s *e2eTestStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *e2eTestStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("installing_cluster").ForError(s.run(ctx, dry))
+}
+
+func (s *e2eTestStep) run(ctx context.Context, dry bool) error {
 	if dry {
 		return nil
 	}
 	if _, err := s.secretClient.Secrets(s.jobSpec.Namespace).Get(fmt.Sprintf("%s-cluster-profile", s.testConfig.As), meta.GetOptions{}); err != nil {
-		return fmt.Errorf("could not find required secret: %v", err)
+		return results.ForReason("missing_cluster_profile").WithError(err).Errorf("could not find required secret: %v", err)
 	}
 	return s.step.Run(ctx, dry)
 }

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -3,7 +3,6 @@ package clusterinstall
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 
 	coreapi "k8s.io/api/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -30,6 +31,10 @@ func (s *gitSourceStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *gitSourceStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("building_image_from_source").ForError(s.run(ctx, dry))
+}
+
+func (s *gitSourceStep) run(ctx context.Context, dry bool) error {
 	if refs := determineRefsWorkdir(s.jobSpec.Refs, s.jobSpec.ExtraRefs); refs != nil {
 		cloneURI := fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
 		var secretName string

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 
 	coreapi "k8s.io/api/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -12,6 +11,7 @@ import (
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 type gitSourceStep struct {

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"time"
 
@@ -64,6 +65,10 @@ func (s *inputImageTagStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *inputImageTagStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("tagging_input_image").ForError(s.run(ctx, dry))
+}
+
+func (s *inputImageTagStep) run(ctx context.Context, dry bool) error {
 	if len(s.config.BaseImage.Cluster) > 0 {
 		log.Printf("Tagging %s/%s/%s:%s into %s:%s", s.config.BaseImage.Cluster, s.config.BaseImage.Namespace, s.config.BaseImage.Name, s.config.BaseImage.Tag, api.PipelineImageStream, s.config.To)
 	} else {

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/util"
 )
 

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -11,6 +10,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 const leaseEnv = "LEASED_RESOURCE"

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -57,6 +58,10 @@ func (s *leaseStep) SubTests() []*junit.TestCase {
 }
 
 func (s *leaseStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("acquiring_lease").ForError(s.run(ctx, dry))
+}
+
+func (s *leaseStep) run(ctx context.Context, dry bool) error {
 	log.Printf("Acquiring lease for %q", s.leaseType)
 	client := *s.client
 	if client == nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"path/filepath"
 	"strings"
@@ -116,6 +117,10 @@ func (s *multiStageTestStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *multiStageTestStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("executing_multi_stage_test").ForError(s.run(ctx, dry))
+}
+
+func (s *multiStageTestStep) run(ctx context.Context, dry bool) error {
 	s.dry = dry
 	if s.profile != "" {
 		if !dry {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"path/filepath"
 	"strings"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 const (

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -3,18 +3,18 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"strings"
 
-	"k8s.io/client-go/util/retry"
-
 	imageapi "github.com/openshift/api/image/v1"
-	"github.com/openshift/ci-tools/pkg/api"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 // outputImageTagStep will ensure that a tag exists

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"strings"
 
@@ -32,6 +33,10 @@ func (s *outputImageTagStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("tagging_output_image").ForError(s.run(ctx, dry))
+}
+
+func (s *outputImageTagStep) run(ctx context.Context, dry bool) error {
 	toNamespace := s.namespace()
 	if string(s.config.From) == s.config.To.Tag && toNamespace == s.jobSpec.Namespace && s.config.To.Name == api.StableImageStream {
 		log.Printf("Tagging %s into %s", s.config.From, s.config.To.Name)

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,10 @@ func (s *pipelineImageCacheStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *pipelineImageCacheStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("building_cache_image").ForError(s.run(ctx, dry))
+}
+
+func (s *pipelineImageCacheStep) run(ctx context.Context, dry bool) error {
 	dockerfile := rawCommandDockerfile(s.config.From, s.config.Commands)
 	return handleBuild(ctx, s.buildClient, buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -3,15 +3,16 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"strconv"
 	"strings"
 
 	buildapi "github.com/openshift/api/build/v1"
-	"github.com/openshift/ci-tools/pkg/api"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 func rawCommandDockerfile(from api.PipelineImageStreamTagReference, commands string) string {

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"path/filepath"
 
@@ -59,6 +60,10 @@ func (s *podStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *podStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("running_pod").ForError(s.run(ctx, dry))
+}
+
+func (s *podStep) run(ctx context.Context, dry bool) error {
 	if !s.config.SkipLogs {
 		log.Printf("Executing %s %s", s.name, s.config.As)
 	}

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"strings"
 
 	buildapi "github.com/openshift/api/build/v1"
 	"github.com/openshift/api/image/docker10"
-	"github.com/openshift/ci-tools/pkg/api"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 type projectDirectoryImageBuildStep struct {

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"strings"
 
 	buildapi "github.com/openshift/api/build/v1"
@@ -31,6 +32,10 @@ func (s *projectDirectoryImageBuildStep) Inputs(dry bool) (api.InputDefinition, 
 }
 
 func (s *projectDirectoryImageBuildStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("building_project_image").ForError(s.run(ctx, dry))
+}
+
+func (s *projectDirectoryImageBuildStep) run(ctx context.Context, dry bool) error {
 	source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource)
 
 	var workingDir string

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"strings"
 	"time"
@@ -51,6 +52,10 @@ var promotionRetry = wait.Backoff{
 }
 
 func (s *promotionStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("promoting_images").ForError(s.run(ctx, dry))
+}
+
+func (s *promotionStep) run(ctx context.Context, dry bool) error {
 	tags, names := toPromote(s.config, s.images, s.requiredImages)
 	if len(names) == 0 {
 		log.Println("Nothing to promote, skipping...")

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"strings"
 
@@ -39,6 +40,10 @@ func StableImagesTagStep(dstClient imageclientset.ImageV1Interface, jobSpec *api
 }
 
 func (s *stableImagesTagStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("creating_stable_images").ForError(s.run(ctx, dry))
+}
+
+func (s *stableImagesTagStep) run(ctx context.Context, dry bool) error {
 	log.Printf("Will output images to %s:%s", api.StableImageStream, api.ComponentFormatReplacement)
 
 	newIS := &imageapi.ImageStream{
@@ -137,6 +142,10 @@ func sourceName(config api.ReleaseTagConfiguration) string {
 }
 
 func (s *releaseImagesTagStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("creating_release_images").ForError(s.run(ctx, dry))
+}
+
+func (s *releaseImagesTagStep) run(ctx context.Context, dry bool) error {
 	if dry {
 		log.Printf("Tagging shared images from %s", sourceName(s.config))
 	} else {

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 
 	buildapi "github.com/openshift/api/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
@@ -12,6 +11,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 func rpmInjectionDockerfile(from api.PipelineImageStreamTagReference, repo string) string {

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 
 	buildapi "github.com/openshift/api/build/v1"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
@@ -35,6 +36,10 @@ func (s *rpmImageInjectionStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *rpmImageInjectionStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("injecting_rpms").ForError(s.run(ctx, dry))
+}
+
+func (s *rpmImageInjectionStep) run(ctx context.Context, dry bool) error {
 	var host string
 	if dry {
 		host = "dry-fake"

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"net/http"
 	"net/url"
@@ -49,6 +50,10 @@ func (s *rpmServerStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *rpmServerStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("serving_rpms").ForError(s.run(ctx, dry))
+}
+
+func (s *rpmServerStep) run(ctx context.Context, dry bool) error {
 	var imageReference string
 	if dry {
 		imageReference = "dry-fake"

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"net/http"
 	"net/url"
@@ -27,6 +26,7 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 const (

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -46,14 +46,14 @@ func Run(ctx context.Context, graph []*api.StepNode, dry bool) (*junit.TestSuite
 	for {
 		select {
 		case <-ctxDone:
-			executionErrors = append(executionErrors, results.ForReason(results.ReasonInterrupted).ForError(errors.New("execution cancelled")))
+			executionErrors = append(executionErrors, results.ForReason("interrupted").ForError(errors.New("execution cancelled")))
 			interrupted = true
 			ctxDone = nil
 		case out := <-executionResults:
 			testCase := &junit.TestCase{Name: out.node.Step.Description(), Duration: out.duration.Seconds()}
 			if out.err != nil {
 				testCase.FailureOutput = &junit.FailureOutput{Output: out.err.Error()}
-				executionErrors = append(executionErrors, results.ForReason(results.ReasonStepFailed).WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
+				executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
 			} else {
 				if dry {
 					testCase.SkipMessage = &junit.SkipMessage{Message: "Dry run"}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"io"
 	"log"
 	"os"
@@ -28,6 +27,7 @@ import (
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 const (

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"io"
 	"log"
 	"os"
@@ -158,6 +159,10 @@ func (s *sourceStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *sourceStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("cloning_source").ForError(s.run(ctx, dry))
+}
+
+func (s *sourceStep) run(ctx context.Context, dry bool) error {
 	clonerefsRef, err := istObjectReference(s.clonerefsSrcClient, s.config.ClonerefsImage)
 	if err != nil {
 		return fmt.Errorf("could not resolve clonerefs source: %v", err)

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"io"
 	"log"
 	"os"
@@ -58,6 +59,10 @@ func (s *templateExecutionStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *templateExecutionStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("executing_template").ForError(s.run(ctx, dry))
+}
+
+func (s *templateExecutionStep) run(ctx context.Context, dry bool) error {
 	log.Printf("Executing template %s", s.template.Name)
 
 	if len(s.template.Objects) == 0 {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"io"
 	"log"
 	"os"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 const (

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/results"
 	"io/ioutil"
 	"log"
 	"regexp"
@@ -24,6 +25,10 @@ func (s *writeParametersStep) Inputs(dry bool) (api.InputDefinition, error) {
 }
 
 func (s *writeParametersStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("writing_parameters").ForError(s.run(ctx, dry))
+}
+
+func (s *writeParametersStep) run(ctx context.Context, dry bool) error {
 	log.Printf("Writing parameters to %s", s.paramFile)
 	var params []string
 

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"io/ioutil"
 	"log"
 	"regexp"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 type writeParametersStep struct {


### PR DESCRIPTION
ci-operator: bubble up multiple errors to the top

We currently flatten all errors from a potentially parallel execution of
steps in the graph, which makes it impossible to report the results of
any individual failure easily. Instead, bubble up all the errors
individually and format them in a flat way just for presentation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

results: remove constants for reasons

By definition, each of these reasons is only ever going to occur once in
our code, so there is no re-use happening due to the constants. Adding
them is just grunt work and serves no other purpose.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: add top-level error identifiers for steps

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 