### PR TITLE
ci-operator: correctly default error reaons

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -200,7 +200,7 @@ func main() {
 			message.WriteString(fmt.Sprintf("\n  * %s", err.Error()))
 		}
 		fmt.Fprintf(os.Stderr, "error: some steps failed:%s\n", message.String())
-		opt.Report(errs)
+		opt.Report(defaulted)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 