### PR TITLE
ci-operator: fix an off-by-one bug in error handling

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -189,7 +189,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if errs := opt.Run(); len(errs) > 1 {
+	if errs := opt.Run(); len(errs) > 0 {
 		var defaulted []error
 		for _, err := range errs {
 			defaulted = append(defaulted, results.DefaultReason(err))


### PR DESCRIPTION
I think this should fix the false negatives where ci-operator-running jobs end with PASS even when some errors happened during the execution.