### PR TITLE
Include branches in whitelist configuration

### DIFF
--- a/pkg/config/whitelist.go
+++ b/pkg/config/whitelist.go
@@ -12,15 +12,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-// WhitelistConfig holds a list of repositories mapped by organization
+// WhitelistConfig holds a list of repositories mapped by organization and repository
 type WhitelistConfig struct {
-	Whitelist map[string][]string `json:"whitelist,omitempty"`
+	Whitelist map[string]map[string][]string `json:"whitelist,omitempty"`
 }
 
 func (w *WhitelistConfig) IsWhitelisted(info *Info) bool {
 	if whiteRepos, ok := w.Whitelist[info.Org]; ok {
-		if sets.NewString(whiteRepos...).Has(info.Repo) {
-			return true
+		if branches, ok := whiteRepos[info.Repo]; ok {
+			if sets.NewString(branches...).Has(info.Branch) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/config/whitelist_test.go
+++ b/pkg/config/whitelist_test.go
@@ -12,22 +12,56 @@ func TestIsWhiteListed(t *testing.T) {
 		expected  bool
 	}{
 		{
-			id:        "org/repo is not in whitelist",
-			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1, repo2"}}},
-			info:      &Info{Org: "anotherOrg", Repo: "anotherRepo"},
-			expected:  false,
+			id: "org/repo is not in whitelist",
+			whitelist: WhitelistConfig{
+				Whitelist: map[string]map[string][]string{
+					"openshift": {
+						"repo1": {"master", "release-4.x"},
+						"repo2": {"master", "release-4.x"},
+					},
+				},
+			},
+			info:     &Info{Org: "anotherOrg", Repo: "anotherRepo", Branch: "anotherBranch"},
+			expected: false,
 		},
 		{
-			id:        "org is in whitelist but not repo",
-			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1, repo2"}}},
-			info:      &Info{Org: "openshift", Repo: "anotherRepo"},
-			expected:  false,
+			id: "org is in whitelist but not repo",
+			whitelist: WhitelistConfig{
+				Whitelist: map[string]map[string][]string{
+					"openshift": {
+						"repo1": {"master", "release-4.x"},
+						"repo2": {"master", "release-4.x"},
+					},
+				},
+			},
+			info:     &Info{Org: "openshift", Repo: "anotherRepo"},
+			expected: false,
 		},
 		{
-			id:        "org/repo is in whitelist",
-			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1", "repo2"}}},
-			info:      &Info{Org: "openshift", Repo: "repo1"},
-			expected:  true,
+			id: "org/repo is in whitelist but not the branch",
+			whitelist: WhitelistConfig{
+				Whitelist: map[string]map[string][]string{
+					"openshift": {
+						"repo1": {"master", "release-4.x"},
+						"repo2": {"master", "release-4.x"},
+					},
+				},
+			},
+			info:     &Info{Org: "openshift", Repo: "repo1", Branch: "anotherBranch"},
+			expected: false,
+		},
+		{
+			id: "org/repo/branch is in whitelist",
+			whitelist: WhitelistConfig{
+				Whitelist: map[string]map[string][]string{
+					"openshift": {
+						"repo1": {"master", "release-4.x"},
+						"repo2": {"master", "release-4.x"},
+					},
+				},
+			},
+			info:     &Info{Org: "openshift", Repo: "repo1", Branch: "release-4.x"},
+			expected: true,
 		},
 	}
 


### PR DESCRIPTION
Before making the tools to actually use the whitelist configuration by reading a file in the release repository,  include also a list of branches that should be whitelisted. 
Example of the YAML file:
```yaml
whitelist:
  openshift:
    release:
      - master
      - release-4.x
    ci-tools:
      - master
      - test-branch
  testshift:
    repo1:
      - branch1
      - branch2
    repo2:
      - branch1
      - branch2
```

/cc @petr-muller @stevekuznetsov @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>