### PR TITLE
Move ci-op recursive config loading from pkg/load/agents to pkg/load

### DIFF
--- a/pkg/load/agents/configAgent_test.go
+++ b/pkg/load/agents/configAgent_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load"
 )
 
 func TestGetFromIndex(t *testing.T) {
@@ -124,7 +125,7 @@ func TestBuildIndexes(t *testing.T) {
 	testCases := []struct {
 		name     string
 		agent    *configAgent
-		configs  FilenameToConfig
+		configs  load.FilenameToConfig
 		expected map[string]configIndex
 	}{
 		{
@@ -134,7 +135,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-a": func(_ api.ReleaseBuildConfiguration) []string { return []string{"key-a"} },
 				},
 			},
-			configs:  FilenameToConfig{"myfile.yaml": cfg},
+			configs:  load.FilenameToConfig{"myfile.yaml": cfg},
 			expected: map[string]configIndex{"index-a": {"key-a": []*api.ReleaseBuildConfiguration{&cfg}}},
 		},
 		{
@@ -145,7 +146,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-b": func(_ api.ReleaseBuildConfiguration) []string { return []string{"key-b"} },
 				},
 			},
-			configs: FilenameToConfig{"myfile.yaml": cfg},
+			configs: load.FilenameToConfig{"myfile.yaml": cfg},
 			expected: map[string]configIndex{
 				"index-a": {"key-a": []*api.ReleaseBuildConfiguration{&cfg}},
 				"index-b": {"key-b": []*api.ReleaseBuildConfiguration{&cfg}},
@@ -158,7 +159,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-a": func(_ api.ReleaseBuildConfiguration) []string { return nil },
 				},
 			},
-			configs:  FilenameToConfig{"myfile.yaml": cfg},
+			configs:  load.FilenameToConfig{"myfile.yaml": cfg},
 			expected: map[string]configIndex{},
 		},
 	}

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -18,6 +18,7 @@ import (
 	prowConfig "k8s.io/test-infra/prow/config"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
@@ -1816,7 +1817,7 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 	writePage(w, "Registry Workflow Help Page", page, workflow)
 }
 
-func findConfigForJob(jobName string, configs agents.FilenameToConfig) (api.MultiStageTestConfiguration, error) {
+func findConfigForJob(jobName string, configs load.FilenameToConfig) (api.MultiStageTestConfiguration, error) {
 	splitJobName := strings.Split(jobName, "-")
 	var filename, testname string
 	var config api.ReleaseBuildConfiguration


### PR DESCRIPTION
Currently, the code to move all ci-op configs is part of the agent.
However there are cases where this is needed but an agent is not, e.G. a
CLI that acts on all configs.

This PR does not change any code, it just moves code around.

/assign @AlexNPavel 