### PR TITLE
hack: inject ldflags only on official builds

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -4,6 +4,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# if we're not building an official output binary, we don't care to tag it
+if [[ -z "${OPENSHIFT_CI:-}" ]]; then
+	go install ./cmd/...
+	exit
+fi
+
 git_commit="$( git describe --tags --always --dirty )"
 build_date="$( date -u '+%Y%m%d' )"
 version="v${build_date}-${git_commit}"


### PR DESCRIPTION
With a simple `go install ./cmd/...` we re-use the cache.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @bbguimaraes 