### PR TITLE
 api: declare our directory structure and naming an api, use it 

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/api"
 	"net/http"
 	"os"
 	"strconv"
@@ -17,7 +18,6 @@ import (
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
 
-	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/webreg"
 )
@@ -205,7 +205,7 @@ func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.Registry
 			return
 		}
 		variant := r.URL.Query().Get(variantQuery)
-		info := config.Info{
+		metadata := api.Metadata{
 			Org:     org,
 			Repo:    repo,
 			Branch:  branch,
@@ -218,7 +218,7 @@ func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.Registry
 			"variant": variant,
 		})
 
-		config, err := configAgent.GetConfig(info)
+		config, err := configAgent.GetConfig(metadata)
 		if err != nil {
 			recordError("config not found")
 			w.WriteHeader(http.StatusNotFound)

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -98,7 +98,7 @@ func generateJobsToDir(dir string, label jc.ProwgenLabel) func(configSpec *ciope
 	cache := map[string]*config.Prowgen{}
 	return func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
-		pInfo := &prowgen.ProwgenInfo{Info: *info, Config: config.Prowgen{Private: false, Expose: false}}
+		pInfo := &prowgen.ProwgenInfo{Metadata: info.Metadata, Config: config.Prowgen{Private: false, Expose: false}}
 		var ok bool
 		var err error
 		var orgConfig, repoConfig *config.Prowgen

--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -31,7 +31,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					PromotionConfiguration: nil,
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 				},
 			},
 			output: nil,
@@ -48,7 +48,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 				},
 			},
 			output: nil,
@@ -65,7 +65,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "branch",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 				},
 			},
 			output: nil,
@@ -109,7 +109,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "master",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 				},
 			},
 			output: []config.DataWithInfo{
@@ -149,7 +149,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-current-release",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-current-release"},
 					},
 				},
 			},
@@ -172,7 +172,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "openshift-current-release",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "openshift-current-release"},
 				},
 			},
 			output: []config.DataWithInfo{},
@@ -216,7 +216,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "master",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 				},
 			},
 			output: []config.DataWithInfo{
@@ -256,7 +256,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-current-release",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-current-release"},
 					},
 				},
 				{
@@ -294,7 +294,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-future-release-1",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-future-release-1"},
 					},
 				},
 				{
@@ -332,7 +332,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-future-release-2",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-future-release-2"},
 					},
 				},
 			},
@@ -356,7 +356,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 					},
 				},
 				Info: config.Info{
-					Org: "org", Repo: "repo", Branch: "master",
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 				},
 			},
 			output: []config.DataWithInfo{
@@ -374,7 +374,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "master",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 					},
 				},
 				{
@@ -391,7 +391,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-current-release",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-current-release"},
 					},
 				},
 				{
@@ -409,7 +409,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-future-release-1",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-future-release-1"},
 					},
 				},
 				{
@@ -426,7 +426,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						},
 					},
 					Info: config.Info{
-						Org: "org", Repo: "repo", Branch: "release-future-release-2",
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-future-release-2"},
 					},
 				},
 			},

--- a/cmd/config-change-trigger/main.go
+++ b/cmd/config-change-trigger/main.go
@@ -146,15 +146,15 @@ func jobsFor(changedImagesPostsubmits []diffs.PostsubmitInContext, getter refGet
 	var jobs []v1.ProwJob
 	var errs []error
 	for _, data := range changedImagesPostsubmits {
-		sha, err := getter.GetRef(data.Info.Org, data.Info.Repo, fmt.Sprintf("heads/%s", data.Info.Branch))
+		sha, err := getter.GetRef(data.Metadata.Org, data.Metadata.Repo, fmt.Sprintf("heads/%s", data.Metadata.Branch))
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
 		refs := v1.Refs{
-			Org:     data.Info.Org,
-			Repo:    data.Info.Repo,
-			BaseRef: data.Info.Branch,
+			Org:     data.Metadata.Org,
+			Repo:    data.Metadata.Repo,
+			BaseRef: data.Metadata.Branch,
 			BaseSHA: sha,
 		}
 		jobs = append(jobs, pjutil.NewProwJob(pjutil.PostsubmitSpec(data.Job, refs), data.Job.Labels, data.Job.Annotations))

--- a/cmd/config-change-trigger/main_test.go
+++ b/cmd/config-change-trigger/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/api"
 	"reflect"
 	"testing"
 
@@ -10,7 +11,6 @@ import (
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 
-	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/diffs"
 )
 
@@ -51,7 +51,7 @@ func TestJobsFor(t *testing.T) {
 				data: map[refId]string{},
 				errs: map[refId]error{{org: "org", repo: "repo", ref: "heads/master"}: errors.New("oops")},
 			},
-			changed:     []diffs.PostsubmitInContext{{Info: config.Info{Org: "org", Repo: "repo", Branch: "master"}}},
+			changed:     []diffs.PostsubmitInContext{{Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"}}},
 			expectedErr: true,
 		},
 		{
@@ -61,7 +61,7 @@ func TestJobsFor(t *testing.T) {
 				errs: map[refId]error{},
 			},
 			changed: []diffs.PostsubmitInContext{{
-				Info: config.Info{Org: "org", Repo: "repo", Branch: "master"},
+				Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 				Job: prowconfig.Postsubmit{
 					JobBase: prowconfig.JobBase{
 						Name:  "my-images",
@@ -84,7 +84,7 @@ func TestJobsFor(t *testing.T) {
 				errs: map[refId]error{{org: "org", repo: "repo", ref: "heads/release-1.13"}: errors.New("oops")},
 			},
 			changed: []diffs.PostsubmitInContext{{
-				Info: config.Info{Org: "org", Repo: "repo", Branch: "master"},
+				Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
 				Job: prowconfig.Postsubmit{
 					JobBase: prowconfig.JobBase{
 						Name:  "my-images",
@@ -92,7 +92,7 @@ func TestJobsFor(t *testing.T) {
 					},
 				},
 			}, {
-				Info: config.Info{Org: "org", Repo: "repo", Branch: "release-1.13"},
+				Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-1.13"},
 			}},
 			expected: []v1.ProwJobSpec{{
 				Type:   v1.PostsubmitJob,

--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -37,12 +37,7 @@ func main() {
 		// we treat the filepath as the ultimate source of truth for this
 		// data, but we record it in the configuration files to ensure that
 		// it's easy to consume it for downstream tools
-		output.Configuration.Metadata = api.Metadata{
-			Org:     info.Org,
-			Repo:    info.Repo,
-			Branch:  info.Branch,
-			Variant: info.Variant,
-		}
+		output.Configuration.Metadata = info.Metadata
 
 		// we are walking the config so we need to commit once we're done
 		toCommit = append(toCommit, output)

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -166,7 +166,7 @@ func rehearseMain() error {
 	}
 
 	// We can only detect changes if we managed to load both ci-operator config versions
-	changedCiopConfigData := config.ByFilename{}
+	changedCiopConfigData := config.DataByFilename{}
 	affectedJobs := make(map[string]sets.String)
 	if masterConfig.CiOperator != nil && prConfig.CiOperator != nil {
 		data, jobs := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -171,8 +171,10 @@ func TestOptionsMakeFilter(t *testing.T) {
 				ciop = notOfficial
 			}
 			info := &config.Info{
-				Org:  tc.repoOrg,
-				Repo: tc.repoName,
+				Metadata: api.Metadata{
+					Org:  tc.repoOrg,
+					Repo: tc.repoName,
+				},
 			}
 			var called bool
 			callback := func(*api.ReleaseBuildConfiguration, *config.Info) error {

--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -345,7 +345,7 @@ func getAllConfigs(releaseRepoPath string, logger *logrus.Entry) (*config.Releas
 	c := &config.ReleaseRepoConfig{}
 	var err error
 	ciopConfigPath := filepath.Join(releaseRepoPath, config.CiopConfigInRepoPath)
-	c.CiOperator, err = config.LoadConfigByFilename(ciopConfigPath)
+	c.CiOperator, err = config.LoadDataByFilename(ciopConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load ci-operator configuration from release repo: %v", err)
 	}

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -447,7 +447,7 @@ Ensure that webhooks are set up for Prow to watch GitHub state.`)
 func createCIOperatorConfig(config initConfig, releaseRepo string) error {
 	fmt.Println(`
 Generating CI Operator configuration ...`)
-	info := ciopconfig.Info{
+	info := api.Metadata{
 		Org:    "openshift",
 		Repo:   "origin",
 		Branch: "master",
@@ -468,9 +468,11 @@ Generating CI Operator configuration ...`)
 func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConfiguration) ciopconfig.DataWithInfo {
 	generated := ciopconfig.DataWithInfo{
 		Info: ciopconfig.Info{
-			Org:    config.Org,
-			Repo:   config.Repo,
-			Branch: config.Branch,
+			Metadata: api.Metadata{
+				Org:    config.Org,
+				Repo:   config.Repo,
+				Branch: config.Branch,
+			},
 		},
 		Configuration: api.ReleaseBuildConfiguration{
 			BinaryBuildCommands:     config.BuildCommands,

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -339,9 +339,11 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					}},
 				},
 				Info: ciopconfig.Info{
-					Org:    "org",
-					Repo:   "repo",
-					Branch: "branch",
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
 				},
 			},
 		},
@@ -388,9 +390,11 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					}},
 				},
 				Info: ciopconfig.Info{
-					Org:    "org",
-					Repo:   "repo",
-					Branch: "branch",
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
 				},
 			},
 		},
@@ -446,9 +450,11 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					}},
 				},
 				Info: ciopconfig.Info{
-					Org:    "org",
-					Repo:   "repo",
-					Branch: "branch",
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
 				},
 			},
 		},
@@ -501,9 +507,11 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					}},
 				},
 				Info: ciopconfig.Info{
-					Org:    "org",
-					Repo:   "repo",
-					Branch: "branch",
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
 				},
 			},
 		},
@@ -581,9 +589,11 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 					}},
 				},
 				Info: ciopconfig.Info{
-					Org:    "org",
-					Repo:   "repo",
-					Branch: "branch",
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
 				},
 			},
 		},

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// IsComplete returns an error if at least one of Org, Repo, Branch members is
+// empty, otherwise it returns nil
+func (m *Metadata) IsComplete() error {
+	var missing []string
+	for item, value := range map[string]string{
+		"organization": m.Org,
+		"repository":   m.Repo,
+		"branch":       m.Branch,
+	} {
+		if value == "" {
+			missing = append(missing, item)
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		s := ""
+		if len(missing) > 1 {
+			s = "s"
+		}
+		return fmt.Errorf("missing item%s: %s", s, strings.Join(missing, ", "))
+	}
+
+	return nil
+}
+
+// TestName returns a short name of a test defined in this file, including
+// variant, if present
+func (m *Metadata) TestName(testName string) string {
+	if m.Variant == "" {
+		return testName
+	}
+	return fmt.Sprintf("%s-%s", m.Variant, testName)
+}
+
+// JobName returns a full name of a job corresponding to a test defined in this
+// file, including variant, if present
+func (m *Metadata) JobName(prefix, name string) string {
+	return fmt.Sprintf("%s-ci-%s-%s-%s-%s", prefix, m.Org, m.Repo, m.Branch, m.TestName(name))
+}
+
+// Basename returns the unique name for this file in the config
+func (m *Metadata) Basename() string {
+	basename := strings.Join([]string{m.Org, m.Repo, m.Branch}, "-")
+	if m.Variant != "" {
+		basename = fmt.Sprintf("%s__%s", basename, m.Variant)
+	}
+	return fmt.Sprintf("%s.yaml", basename)
+}
+
+// RelativePath returns the path to the config under the root config dir
+func (m *Metadata) RelativePath() string {
+	return path.Join(m.Org, m.Repo, m.Basename())
+}
+
+// ConfigMapName returns the configmap in which we expect this file to be uploaded
+func (m *Metadata) ConfigMapName() string {
+	return fmt.Sprintf("ci-operator-%s-configs", FlavorForBranch(m.Branch))
+}
+
+// IsCiopConfigCM returns true if a given name is a valid ci-operator config ConfigMap
+func IsCiopConfigCM(name string) bool {
+	return regexp.MustCompile(`^ci-operator-.+-configs$`).MatchString(name)
+}
+
+var threeXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-3\.[0-9]+$`)
+var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9]+)$`)
+
+func FlavorForBranch(branch string) string {
+	var flavor string
+	if branch == "master" {
+		flavor = "master"
+	} else if threeXBranches.MatchString(branch) {
+		flavor = "3.x"
+	} else if fourXBranches.MatchString(branch) {
+		matches := fourXBranches.FindStringSubmatch(branch)
+		flavor = matches[2] // the 4.x release string
+	} else {
+		flavor = "misc"
+	}
+	return flavor
+}

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -1,0 +1,317 @@
+package api
+
+import (
+	"k8s.io/utils/diff"
+	"reflect"
+	"testing"
+)
+
+func TestMetadata_IsComplete(t *testing.T) {
+	testCases := []struct {
+		name        string
+		metadata    Metadata
+		expectError string
+	}{
+		{
+			name:     "All required members -> complete",
+			metadata: Metadata{Org: "organization", Repo: "repository", Branch: "branch"},
+		},
+		{
+			name:        "Missing org -> incomplete",
+			metadata:    Metadata{Repo: "repository", Branch: "branch"},
+			expectError: "missing item: organization",
+		},
+		{
+			name:        "Missing repo -> incomplete",
+			metadata:    Metadata{Org: "organization", Branch: "branch"},
+			expectError: "missing item: repository",
+		},
+		{
+			name:        "Missing branch -> incomplete",
+			metadata:    Metadata{Org: "organization", Repo: "repository"},
+			expectError: "missing item: branch",
+		},
+		{
+			name:        "Everything missing -> incomplete",
+			expectError: "missing items: branch, organization, repository",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.metadata.IsComplete()
+			if err == nil && tc.expectError != "" {
+				t.Errorf("%s: expected error '%s', got nil", tc.expectError, tc.name)
+			}
+			if err != nil {
+				if tc.expectError == "" {
+					t.Errorf("%s: unexpected error %s", tc.name, err.Error())
+				} else if err.Error() != tc.expectError {
+					t.Errorf("%s: expected error '%s', got '%s", tc.name, tc.expectError, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestMetadata_Basename(t *testing.T) {
+	testCases := []struct {
+		name     string
+		metadata *Metadata
+		expected string
+	}{
+		{
+			name: "simple path creates simple basename",
+			metadata: &Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "",
+			},
+			expected: "org-repo-branch.yaml",
+		},
+		{
+			name: "path with variant creates complex basename",
+			metadata: &Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			expected: "org-repo-branch__variant.yaml",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.expected, func(t *testing.T) {
+			if actual, expected := testCase.metadata.Basename(), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestMetadata_ConfigMapName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "master branch goes to master configmap",
+			branch:   "master",
+			expected: "ci-operator-master-configs",
+		},
+		{
+			name:     "enterprise 3.6 branch goes to 3.x configmap",
+			branch:   "enterprise-3.6",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "openshift 3.6 branch goes to 3.x configmap",
+			branch:   "openshift-3.6",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "enterprise 3.11 branch goes to 3.x configmap",
+			branch:   "enterprise-3.11",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "openshift 3.11 branch goes to 3.x configmap",
+			branch:   "openshift-3.11",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "knative release branch goes to misc configmap",
+			branch:   "release-0.2",
+			expected: "ci-operator-misc-configs",
+		},
+		{
+			name:     "azure release branch goes to misc configmap",
+			branch:   "release-v1",
+			expected: "ci-operator-misc-configs",
+		},
+		{
+			name:     "ansible dev branch goes to misc configmap",
+			branch:   "devel-40",
+			expected: "ci-operator-misc-configs",
+		},
+		{
+			name:     "release 4.0 branch goes to 4.0 configmap",
+			branch:   "release-4.0",
+			expected: "ci-operator-4.0-configs",
+		},
+		{
+			name:     "release 4.1 branch goes to 4.1 configmap",
+			branch:   "release-4.1",
+			expected: "ci-operator-4.1-configs",
+		},
+		{
+			name:     "release 4.2 branch goes to 4.2 configmap",
+			branch:   "release-4.2",
+			expected: "ci-operator-4.2-configs",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.expected, func(t *testing.T) {
+			info := Metadata{Branch: testCase.branch}
+			actual, expected := info.ConfigMapName(), testCase.expected
+			if !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+			// test that ConfigMapName() stays in sync with IsCiopConfigCM()
+			if !IsCiopConfigCM(actual) {
+				t.Errorf("%s: IsCiopConfigCM() returned false for %s", testCase.name, actual)
+			}
+		})
+	}
+}
+
+func TestMetadata_JobName(t *testing.T) {
+	prefix := "le"
+	testName := "a-test"
+	testCases := []struct {
+		name     string
+		metadata Metadata
+		expected string
+	}{
+		{
+			name:     "without variant",
+			metadata: Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+			expected: "le-ci-org-repo-branch-a-test",
+		},
+		{
+			name:     "with variant",
+			metadata: Metadata{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
+			expected: "le-ci-gro-oper-hcnarb-also-a-test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.metadata.JobName(prefix, testName)
+			if actual != tc.expected {
+				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestMetadata_TestName(t *testing.T) {
+	testName := "a-test"
+	testCases := []struct {
+		name     string
+		metadata Metadata
+		expected string
+	}{
+		{
+			name:     "without variant",
+			metadata: Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+			expected: "a-test",
+		},
+		{
+			name:     "with variant",
+			metadata: Metadata{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
+			expected: "also-a-test",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.metadata.TestName(testName)
+			if actual != tc.expected {
+				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestFlavorForBranch(t *testing.T) {
+	testCases := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "master branch goes to master configmap",
+			branch:   "master",
+			expected: "master",
+		},
+		{
+			name:     "enterprise 3.6 branch goes to 3.x configmap",
+			branch:   "enterprise-3.6",
+			expected: "3.x",
+		},
+		{
+			name:     "openshift 3.6 branch goes to 3.x configmap",
+			branch:   "openshift-3.6",
+			expected: "3.x",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "enterprise 3.11 branch goes to 3.x configmap",
+			branch:   "enterprise-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "openshift 3.11 branch goes to 3.x configmap",
+			branch:   "openshift-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "release 3.11 branch goes to 3.x configmap",
+			branch:   "release-3.11",
+			expected: "3.x",
+		},
+		{
+			name:     "knative release branch goes to misc configmap",
+			branch:   "release-0.2",
+			expected: "misc",
+		},
+		{
+			name:     "azure release branch goes to misc configmap",
+			branch:   "release-v1",
+			expected: "misc",
+		},
+		{
+			name:     "ansible dev branch goes to misc configmap",
+			branch:   "devel-40",
+			expected: "misc",
+		},
+		{
+			name:     "release 4.0 branch goes to 4.0 configmap",
+			branch:   "release-4.0",
+			expected: "4.0",
+		},
+		{
+			name:     "release 4.1 branch goes to 4.1 configmap",
+			branch:   "release-4.1",
+			expected: "4.1",
+		},
+		{
+			name:     "release 4.2 branch goes to 4.2 configmap",
+			branch:   "release-4.2",
+			expected: "4.2",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.expected, func(t *testing.T) {
+			if actual, expected := FlavorForBranch(testCase.branch), testCase.expected; !reflect.DeepEqual(actual, expected) {
+				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			}
+		})
+	}
+}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -267,10 +267,10 @@ func (i *DataWithInfo) CommitTo(dir string) error {
 	return nil
 }
 
-// ByFilename stores CI Operator configurations with their metadata by filename
-type ByFilename map[string]DataWithInfo
+// DataByFilename stores CI Operator configurations with their metadata by filename
+type DataByFilename map[string]DataWithInfo
 
-func (all ByFilename) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration, handledElements *Info) error {
+func (all DataByFilename) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration, handledElements *Info) error {
 	all[handledElements.Basename()] = DataWithInfo{
 		Configuration: *handledConfig,
 		Info:          *handledElements,
@@ -278,8 +278,8 @@ func (all ByFilename) add(handledConfig *cioperatorapi.ReleaseBuildConfiguration
 	return nil
 }
 
-func LoadConfigByFilename(path string) (ByFilename, error) {
-	config := ByFilename{}
+func LoadDataByFilename(path string) (DataByFilename, error) {
+	config := DataByFilename{}
 	if err := OperateOnCIOperatorConfigDir(path, config.add); err != nil {
 		return nil, err
 	}

--- a/pkg/config/load_test.go
+++ b/pkg/config/load_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/openshift/ci-tools/pkg/api"
 	"reflect"
 	"testing"
 
@@ -18,10 +19,12 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 			name: "simple path parses fine",
 			path: "./org/repo/org-repo-branch.yaml",
 			expected: &Info{
-				Org:      "org",
-				Repo:     "repo",
-				Branch:   "branch",
-				Variant:  "",
+				Metadata: api.Metadata{
+					Org:     "org",
+					Repo:    "repo",
+					Branch:  "branch",
+					Variant: "",
+				},
 				Filename: "./org/repo/org-repo-branch.yaml",
 				OrgPath:  "org",
 				RepoPath: "org/repo",
@@ -38,10 +41,12 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 			name: "prefix to a valid path parses fine",
 			path: "./something/crazy/org/repo/org-repo-branch.yaml",
 			expected: &Info{
-				Org:      "org",
-				Repo:     "repo",
-				Branch:   "branch",
-				Variant:  "",
+				Metadata: api.Metadata{
+					Org:     "org",
+					Repo:    "repo",
+					Branch:  "branch",
+					Variant: "",
+				},
 				Filename: "./something/crazy/org/repo/org-repo-branch.yaml",
 				OrgPath:  "something/crazy/org",
 				RepoPath: "something/crazy/org/repo",
@@ -58,10 +63,12 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 			name: "path with variant parses fine",
 			path: "./org/repo/org-repo-branch__variant.yaml",
 			expected: &Info{
-				Org:      "org",
-				Repo:     "repo",
-				Branch:   "branch",
-				Variant:  "variant",
+				Metadata: api.Metadata{
+					Org:     "org",
+					Repo:    "repo",
+					Branch:  "branch",
+					Variant: "variant",
+				},
 				Filename: "./org/repo/org-repo-branch__variant.yaml",
 				OrgPath:  "org",
 				RepoPath: "org/repo",
@@ -80,316 +87,6 @@ func TestExtractRepoElementsFromPath(t *testing.T) {
 			}
 			if actual, expected := repoInfo, testCase.expected; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: didn't get correct elements: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
-			}
-		})
-	}
-}
-
-func TestInfo_IsComplete(t *testing.T) {
-	testCases := []struct {
-		name        string
-		info        Info
-		expectError string
-	}{
-		{
-			name: "All required members -> complete",
-			info: Info{Org: "organization", Repo: "repository", Branch: "branch"},
-		},
-		{
-			name:        "Missing org -> incomplete",
-			info:        Info{Repo: "repository", Branch: "branch"},
-			expectError: "missing item: organization",
-		},
-		{
-			name:        "Missing repo -> incomplete",
-			info:        Info{Org: "organization", Branch: "branch"},
-			expectError: "missing item: repository",
-		},
-		{
-			name:        "Missing branch -> incomplete",
-			info:        Info{Org: "organization", Repo: "repository"},
-			expectError: "missing item: branch",
-		},
-		{
-			name:        "Everything missing -> incomplete",
-			expectError: "missing items: branch, organization, repository",
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.info.IsComplete()
-			if err == nil && tc.expectError != "" {
-				t.Errorf("%s: expected error '%s', got nil", tc.expectError, tc.name)
-			}
-			if err != nil {
-				if tc.expectError == "" {
-					t.Errorf("%s: unexpected error %s", tc.name, err.Error())
-				} else if err.Error() != tc.expectError {
-					t.Errorf("%s: expected error '%s', got '%s", tc.name, tc.expectError, err.Error())
-				}
-			}
-		})
-	}
-}
-
-func TestInfo_Basename(t *testing.T) {
-	testCases := []struct {
-		name     string
-		info     *Info
-		expected string
-	}{
-		{
-			name: "simple path creates simple basename",
-			info: &Info{
-				Org:     "org",
-				Repo:    "repo",
-				Branch:  "branch",
-				Variant: "",
-			},
-			expected: "org-repo-branch.yaml",
-		},
-		{
-			name: "path with variant creates complex basename",
-			info: &Info{
-				Org:     "org",
-				Repo:    "repo",
-				Branch:  "branch",
-				Variant: "variant",
-			},
-			expected: "org-repo-branch__variant.yaml",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.expected, func(t *testing.T) {
-			if actual, expected := testCase.info.Basename(), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
-			}
-		})
-	}
-}
-
-func TestInfo_ConfigMapName(t *testing.T) {
-	testCases := []struct {
-		name     string
-		branch   string
-		expected string
-	}{
-		{
-			name:     "master branch goes to master configmap",
-			branch:   "master",
-			expected: "ci-operator-master-configs",
-		},
-		{
-			name:     "enterprise 3.6 branch goes to 3.x configmap",
-			branch:   "enterprise-3.6",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "openshift 3.6 branch goes to 3.x configmap",
-			branch:   "openshift-3.6",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "enterprise 3.11 branch goes to 3.x configmap",
-			branch:   "enterprise-3.11",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "openshift 3.11 branch goes to 3.x configmap",
-			branch:   "openshift-3.11",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "ci-operator-3.x-configs",
-		},
-		{
-			name:     "knative release branch goes to misc configmap",
-			branch:   "release-0.2",
-			expected: "ci-operator-misc-configs",
-		},
-		{
-			name:     "azure release branch goes to misc configmap",
-			branch:   "release-v1",
-			expected: "ci-operator-misc-configs",
-		},
-		{
-			name:     "ansible dev branch goes to misc configmap",
-			branch:   "devel-40",
-			expected: "ci-operator-misc-configs",
-		},
-		{
-			name:     "release 4.0 branch goes to 4.0 configmap",
-			branch:   "release-4.0",
-			expected: "ci-operator-4.0-configs",
-		},
-		{
-			name:     "release 4.1 branch goes to 4.1 configmap",
-			branch:   "release-4.1",
-			expected: "ci-operator-4.1-configs",
-		},
-		{
-			name:     "release 4.2 branch goes to 4.2 configmap",
-			branch:   "release-4.2",
-			expected: "ci-operator-4.2-configs",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.expected, func(t *testing.T) {
-			info := Info{Branch: testCase.branch}
-			actual, expected := info.ConfigMapName(), testCase.expected
-			if !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
-			}
-			// test that ConfigMapName() stays in sync with IsCiopConfigCM()
-			if !IsCiopConfigCM(actual) {
-				t.Errorf("%s: IsCiopConfigCM() returned false for %s", testCase.name, actual)
-			}
-		})
-	}
-}
-
-func TestInfo_JobName(t *testing.T) {
-	prefix := "le"
-	testName := "a-test"
-	testCases := []struct {
-		name     string
-		info     Info
-		expected string
-	}{
-		{
-			name:     "without variant",
-			info:     Info{Org: "org", Repo: "repo", Branch: "branch"},
-			expected: "le-ci-org-repo-branch-a-test",
-		},
-		{
-			name:     "with variant",
-			info:     Info{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
-			expected: "le-ci-gro-oper-hcnarb-also-a-test",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := tc.info.JobName(prefix, testName)
-			if actual != tc.expected {
-				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
-			}
-		})
-	}
-}
-
-func TestInfo_TestName(t *testing.T) {
-	testName := "a-test"
-	testCases := []struct {
-		name     string
-		info     Info
-		expected string
-	}{
-		{
-			name:     "without variant",
-			info:     Info{Org: "org", Repo: "repo", Branch: "branch"},
-			expected: "a-test",
-		},
-		{
-			name:     "with variant",
-			info:     Info{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
-			expected: "also-a-test",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := tc.info.TestName(testName)
-			if actual != tc.expected {
-				t.Errorf("%s: expected '%s', got '%s'", tc.name, tc.expected, actual)
-			}
-		})
-	}
-}
-
-func TestFlavorForBranch(t *testing.T) {
-	testCases := []struct {
-		name     string
-		branch   string
-		expected string
-	}{
-		{
-			name:     "master branch goes to master configmap",
-			branch:   "master",
-			expected: "master",
-		},
-		{
-			name:     "enterprise 3.6 branch goes to 3.x configmap",
-			branch:   "enterprise-3.6",
-			expected: "3.x",
-		},
-		{
-			name:     "openshift 3.6 branch goes to 3.x configmap",
-			branch:   "openshift-3.6",
-			expected: "3.x",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "enterprise 3.11 branch goes to 3.x configmap",
-			branch:   "enterprise-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "openshift 3.11 branch goes to 3.x configmap",
-			branch:   "openshift-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "release 3.11 branch goes to 3.x configmap",
-			branch:   "release-3.11",
-			expected: "3.x",
-		},
-		{
-			name:     "knative release branch goes to misc configmap",
-			branch:   "release-0.2",
-			expected: "misc",
-		},
-		{
-			name:     "azure release branch goes to misc configmap",
-			branch:   "release-v1",
-			expected: "misc",
-		},
-		{
-			name:     "ansible dev branch goes to misc configmap",
-			branch:   "devel-40",
-			expected: "misc",
-		},
-		{
-			name:     "release 4.0 branch goes to 4.0 configmap",
-			branch:   "release-4.0",
-			expected: "4.0",
-		},
-		{
-			name:     "release 4.1 branch goes to 4.1 configmap",
-			branch:   "release-4.1",
-			expected: "4.1",
-		},
-		{
-			name:     "release 4.2 branch goes to 4.2 configmap",
-			branch:   "release-4.2",
-			expected: "4.2",
-		},
-	}
-	for _, testCase := range testCases {
-		t.Run(testCase.expected, func(t *testing.T) {
-			if actual, expected := FlavorForBranch(testCase.branch), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: didn't get correct basename: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}
 		})
 	}

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -41,14 +41,14 @@ func (o *Options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.Repo, "repo", "", "Limit repos affected to this repo.")
 }
 
-func (o *Options) matches(info *Info) bool {
+func (o *Options) matches(metadata cioperatorapi.Metadata) bool {
 	switch {
 	case o.Org == "" && o.Repo == "":
 		return true
 	case o.Org != "" && o.Repo != "":
-		return o.Org == info.Org && o.Repo == info.Repo
+		return o.Org == metadata.Org && o.Repo == metadata.Repo
 	default:
-		return (o.Org != "" && o.Org == info.Org) || (o.Repo != "" && o.Repo == info.Repo)
+		return (o.Org != "" && o.Org == metadata.Org) || (o.Repo != "" && o.Repo == metadata.Repo)
 	}
 }
 
@@ -56,7 +56,7 @@ func (o *Options) matches(info *Info) bool {
 // down to those that were selected by the user with --{org|repo}
 func (o *Options) OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
 	return OperateOnCIOperatorConfigDir(configDir, func(configuration *cioperatorapi.ReleaseBuildConfiguration, info *Info) error {
-		if !o.matches(info) {
+		if !o.matches(info.Metadata) {
 			return nil
 		}
 		return callback(configuration, info)

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"flag"
+	"github.com/openshift/ci-tools/pkg/api"
 	"reflect"
 	"testing"
 )
@@ -145,13 +146,13 @@ func TestOptions_Matches(t *testing.T) {
 	var testCases = []struct {
 		name     string
 		input    Options
-		info     *Info
+		metadata api.Metadata
 		expected bool
 	}{
 		{
 			name:  "nothing set matches everything",
 			input: Options{},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "org",
 				Repo: "repo",
 			},
@@ -162,7 +163,7 @@ func TestOptions_Matches(t *testing.T) {
 			input: Options{
 				Org: "org",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "org",
 				Repo: "repo",
 			},
@@ -173,7 +174,7 @@ func TestOptions_Matches(t *testing.T) {
 			input: Options{
 				Org: "org",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "arg",
 				Repo: "repo",
 			},
@@ -184,7 +185,7 @@ func TestOptions_Matches(t *testing.T) {
 			input: Options{
 				Repo: "repo",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "anything",
 				Repo: "repo",
 			},
@@ -195,7 +196,7 @@ func TestOptions_Matches(t *testing.T) {
 			input: Options{
 				Repo: "repo",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "anything",
 				Repo: "ripo",
 			},
@@ -207,7 +208,7 @@ func TestOptions_Matches(t *testing.T) {
 				Org:  "org",
 				Repo: "repo",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "org",
 				Repo: "repo",
 			},
@@ -219,7 +220,7 @@ func TestOptions_Matches(t *testing.T) {
 				Org:  "org",
 				Repo: "repo",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "org",
 				Repo: "ripo",
 			},
@@ -231,7 +232,7 @@ func TestOptions_Matches(t *testing.T) {
 				Org:  "org",
 				Repo: "repo",
 			},
-			info: &Info{
+			metadata: api.Metadata{
 				Org:  "arg",
 				Repo: "repo",
 			},
@@ -241,7 +242,7 @@ func TestOptions_Matches(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := testCase.input.matches(testCase.info), testCase.expected; actual != expected {
+			if actual, expected := testCase.input.matches(testCase.metadata), testCase.expected; actual != expected {
 				t.Errorf("%s: got incorrect match: expected %v, got %v", testCase.name, expected, actual)
 			}
 		})

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -44,7 +44,7 @@ const (
 // ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)
 type ReleaseRepoConfig struct {
 	Prow       *prowconfig.Config
-	CiOperator ByFilename
+	CiOperator DataByFilename
 }
 
 func git(repoPath string, args ...string) (string, error) {
@@ -107,7 +107,7 @@ func GetAllConfigs(releaseRepoPath string, logger *logrus.Entry) *ReleaseRepoCon
 	config := &ReleaseRepoConfig{}
 	var err error
 	ciopConfigPath := filepath.Join(releaseRepoPath, CiopConfigInRepoPath)
-	config.CiOperator, err = LoadConfigByFilename(ciopConfigPath)
+	config.CiOperator, err = LoadDataByFilename(ciopConfigPath)
 	if err != nil {
 		logger.WithError(err).Warn("failed to load ci-operator configuration from release repo")
 	}

--- a/pkg/config/whitelist_test.go
+++ b/pkg/config/whitelist_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/openshift/ci-tools/pkg/api"
 	"testing"
 )
 
@@ -14,19 +15,19 @@ func TestIsWhiteListed(t *testing.T) {
 		{
 			id:        "org/repo is not in whitelist",
 			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1, repo2"}}},
-			info:      &Info{Org: "anotherOrg", Repo: "anotherRepo"},
+			info:      &Info{Metadata: api.Metadata{Org: "anotherOrg", Repo: "anotherRepo"}},
 			expected:  false,
 		},
 		{
 			id:        "org is in whitelist but not repo",
 			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1, repo2"}}},
-			info:      &Info{Org: "openshift", Repo: "anotherRepo"},
+			info:      &Info{Metadata: api.Metadata{Org: "openshift", Repo: "anotherRepo"}},
 			expected:  false,
 		},
 		{
 			id:        "org/repo is in whitelist",
 			whitelist: WhitelistConfig{Whitelist: map[string][]string{"openshift": {"repo1", "repo2"}}},
-			info:      &Info{Org: "openshift", Repo: "repo1"},
+			info:      &Info{Metadata: api.Metadata{Org: "openshift", Repo: "repo1"}},
 			expected:  true,
 		},
 	}

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -32,8 +32,8 @@ const (
 
 // GetChangedCiopConfigs identifies CI Operator configurations that are new or have changed and
 // determines for each which jobs are impacted if job-specific changes were made
-func GetChangedCiopConfigs(masterConfig, prConfig config.ByFilename, logger *logrus.Entry) (config.ByFilename, map[string]sets.String) {
-	ret := config.ByFilename{}
+func GetChangedCiopConfigs(masterConfig, prConfig config.DataByFilename, logger *logrus.Entry) (config.DataByFilename, map[string]sets.String) {
+	ret := config.DataByFilename{}
 	affectedJobs := map[string]sets.String{}
 
 	for filename, newConfig := range prConfig {
@@ -137,7 +137,7 @@ type PostsubmitInContext struct {
 
 // GetImagesPostsubmitsForCiopConfigs determines the [images] postsubmit jobs affected by the changed
 // ci-operator configurations
-func GetImagesPostsubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.ByFilename) []PostsubmitInContext {
+func GetImagesPostsubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.DataByFilename) []PostsubmitInContext {
 	var ret []PostsubmitInContext
 
 	for _, data := range ciopConfigs {
@@ -163,7 +163,7 @@ func GetImagesPostsubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfi
 	return ret
 }
 
-func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.ByFilename, affectedJobs map[string]sets.String, logger *logrus.Entry) config.Presubmits {
+func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs config.DataByFilename, affectedJobs map[string]sets.String, logger *logrus.Entry) config.Presubmits {
 	ret := config.Presubmits{}
 
 	for _, data := range ciopConfigs {

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -131,8 +131,8 @@ func getJobsByRepoAndName(presubmits config.Presubmits) map[string]map[string]pr
 
 // PostsubmitInContext is a postsubmit with the org/repo#branch for which it will trigger
 type PostsubmitInContext struct {
-	Info config.Info
-	Job  prowconfig.Postsubmit
+	Metadata cioperatorapi.Metadata
+	Job      prowconfig.Postsubmit
 }
 
 // GetImagesPostsubmitsForCiopConfigs determines the [images] postsubmit jobs affected by the changed
@@ -153,8 +153,8 @@ func GetImagesPostsubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfi
 
 			if testName == "images" {
 				ret = append(ret, PostsubmitInContext{
-					Info: data.Info,
-					Job:  job,
+					Metadata: data.Info.Metadata,
+					Job:      job,
 				})
 			}
 		}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -53,9 +53,11 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			},
 		},
 		Info: config.Info{
-			Org:      "org",
-			Repo:     "repo",
-			Branch:   "branch",
+			Metadata: cioperatorapi.Metadata{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
 			Filename: "org-repo-branch.yaml",
 		},
 	}
@@ -403,9 +405,11 @@ func makeConfig(p []prowconfig.Presubmit) *prowconfig.Config {
 
 func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 	baseCiopConfig := config.Info{
-		Org:      "org",
-		Repo:     "repo",
-		Branch:   "branch",
+		Metadata: cioperatorapi.Metadata{
+			Org:    "org",
+			Repo:   "repo",
+			Branch: "branch",
+		},
 		Filename: "org-repo-branch.yaml",
 	}
 
@@ -568,16 +572,16 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 	}
 }
 
-func podSpecReferencing(info config.Info) *v1.PodSpec {
+func podSpecReferencing(metadata cioperatorapi.Metadata) *v1.PodSpec {
 	return &v1.PodSpec{
 		Containers: []v1.Container{{
 			Env: []v1.EnvVar{{
 				ValueFrom: &v1.EnvVarSource{
 					ConfigMapKeyRef: &v1.ConfigMapKeySelector{
 						LocalObjectReference: v1.LocalObjectReference{
-							Name: info.ConfigMapName(),
+							Name: metadata.ConfigMapName(),
 						},
-						Key: info.Basename(),
+						Key: metadata.Basename(),
 					},
 				},
 			}},
@@ -601,7 +605,7 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 							JobBase: prowconfig.JobBase{
 								Name:  "branch-ci-org-repo-branch-images",
 								Agent: "kubernetes",
-								Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "branch"}),
+								Spec:  podSpecReferencing(cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}),
 							},
 						}},
 					},
@@ -619,7 +623,7 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 				},
 			},
 			ciopConfigs: map[string]config.DataWithInfo{
-				"org-repo-branch.yaml": {Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+				"org-repo-branch.yaml": {Info: config.Info{Metadata: cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}}},
 			},
 		},
 		{
@@ -631,22 +635,22 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 							JobBase: prowconfig.JobBase{
 								Name:  "branch-ci-org-repo-branch-images",
 								Agent: "kubernetes",
-								Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "branch"}),
+								Spec:  podSpecReferencing(cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}),
 							},
 						}},
 					},
 				},
 			},
 			ciopConfigs: map[string]config.DataWithInfo{
-				"org-repo-branch.yaml": {Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+				"org-repo-branch.yaml": {Info: config.Info{Metadata: cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}}},
 			},
 			expected: []PostsubmitInContext{{
-				Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"},
+				Metadata: cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 				Job: prowconfig.Postsubmit{
 					JobBase: prowconfig.JobBase{
 						Name:  "branch-ci-org-repo-branch-images",
 						Agent: "kubernetes",
-						Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "branch"}),
+						Spec:  podSpecReferencing(cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}),
 					},
 				},
 			}},
@@ -660,14 +664,14 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 							JobBase: prowconfig.JobBase{
 								Name:  "branch-ci-org-repo-BRANCH-images",
 								Agent: "kubernetes",
-								Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "BRANCH"}),
+								Spec:  podSpecReferencing(cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "BRANCH"}),
 							},
 						}},
 					},
 				},
 			},
 			ciopConfigs: map[string]config.DataWithInfo{
-				"org-repo-branch.yaml": {Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+				"org-repo-branch.yaml": {Info: config.Info{Metadata: cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}}},
 			},
 		},
 		{
@@ -679,14 +683,14 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 							JobBase: prowconfig.JobBase{
 								Name:  "branch-ci-org-repo-branch-othertest",
 								Agent: "kubernetes",
-								Spec:  podSpecReferencing(config.Info{Org: "org", Repo: "repo", Branch: "branch"}),
+								Spec:  podSpecReferencing(cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}),
 							},
 						}},
 					},
 				},
 			},
 			ciopConfigs: map[string]config.DataWithInfo{
-				"org-repo-branch.yaml": {Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+				"org-repo-branch.yaml": {Info: config.Info{Metadata: cioperatorapi.Metadata{Org: "org", Repo: "repo", Branch: "branch"}}},
 			},
 		},
 	}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -62,97 +62,97 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 
 	testCases := []struct {
 		name                 string
-		configGenerator      func(*testing.T) (before, after config.ByFilename)
-		expected             func() config.ByFilename
+		configGenerator      func(*testing.T) (before, after config.DataByFilename)
+		expected             func() config.DataByFilename
 		expectedAffectedJobs map[string]sets.String
 	}{{
 		name: "no changes",
-		configGenerator: func(t *testing.T) (config.ByFilename, config.ByFilename) {
-			before := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
-			after := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
+		configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
+			before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
+			after := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
 			return before, after
 		},
-		expected:             func() config.ByFilename { return config.ByFilename{} },
+		expected:             func() config.DataByFilename { return config.DataByFilename{} },
 		expectedAffectedJobs: map[string]sets.String{},
 	}, {
 		name: "new config",
-		configGenerator: func(t *testing.T) (config.ByFilename, config.ByFilename) {
-			before := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
-			after := config.ByFilename{
+		configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
+			before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
+			after := config.DataByFilename{
 				"org-repo-branch.yaml":         baseCiopConfig,
 				"org-repo-another-branch.yaml": baseCiopConfig,
 			}
 			return before, after
 		},
-		expected: func() config.ByFilename {
-			return config.ByFilename{"org-repo-another-branch.yaml": baseCiopConfig}
+		expected: func() config.DataByFilename {
+			return config.DataByFilename{"org-repo-another-branch.yaml": baseCiopConfig}
 		},
 		expectedAffectedJobs: map[string]sets.String{},
 	}, {
 		name: "changed config",
-		configGenerator: func(t *testing.T) (config.ByFilename, config.ByFilename) {
-			before := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
+		configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
+			before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
 			afterConfig := config.DataWithInfo{}
 			if err := deepcopy.Copy(&afterConfig, &baseCiopConfig); err != nil {
 				t.Fatal(err)
 			}
 			afterConfig.Configuration.InputConfiguration.ReleaseTagConfiguration.Name = "another-name"
-			after := config.ByFilename{"org-repo-branch.yaml": afterConfig}
+			after := config.DataByFilename{"org-repo-branch.yaml": afterConfig}
 			return before, after
 		},
-		expected: func() config.ByFilename {
+		expected: func() config.DataByFilename {
 			expected := config.DataWithInfo{}
 			if err := deepcopy.Copy(&expected, &baseCiopConfig); err != nil {
 				t.Fatal(err)
 			}
 			expected.Configuration.InputConfiguration.ReleaseTagConfiguration.Name = "another-name"
-			return config.ByFilename{"org-repo-branch.yaml": expected}
+			return config.DataByFilename{"org-repo-branch.yaml": expected}
 		},
 		expectedAffectedJobs: map[string]sets.String{},
 	},
 		{
 			name: "changed tests",
-			configGenerator: func(t *testing.T) (config.ByFilename, config.ByFilename) {
-				before := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
+			configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
+				before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
 				afterConfig := config.DataWithInfo{}
 				if err := deepcopy.Copy(&afterConfig, &baseCiopConfig); err != nil {
 					t.Fatal(err)
 				}
 				afterConfig.Configuration.Tests[0].Commands = "changed commands"
-				after := config.ByFilename{"org-repo-branch.yaml": afterConfig}
+				after := config.DataByFilename{"org-repo-branch.yaml": afterConfig}
 				return before, after
 			},
-			expected: func() config.ByFilename {
+			expected: func() config.DataByFilename {
 				expected := config.DataWithInfo{}
 				if err := deepcopy.Copy(&expected, &baseCiopConfig); err != nil {
 					t.Fatal(err)
 				}
 				expected.Configuration.Tests[0].Commands = "changed commands"
-				return config.ByFilename{"org-repo-branch.yaml": expected}
+				return config.DataByFilename{"org-repo-branch.yaml": expected}
 			},
 			expectedAffectedJobs: map[string]sets.String{"org-repo-branch.yaml": {"unit": sets.Empty{}}},
 		},
 		{
 			name: "changed multiple tests",
-			configGenerator: func(t *testing.T) (config.ByFilename, config.ByFilename) {
-				before := config.ByFilename{"org-repo-branch.yaml": baseCiopConfig}
+			configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
+				before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
 				afterConfig := config.DataWithInfo{}
 				if err := deepcopy.Copy(&afterConfig, &baseCiopConfig); err != nil {
 					t.Fatal(err)
 				}
 				afterConfig.Configuration.Tests[0].Commands = "changed commands"
 				afterConfig.Configuration.Tests[1].Commands = "changed commands"
-				after := config.ByFilename{"org-repo-branch.yaml": afterConfig}
+				after := config.DataByFilename{"org-repo-branch.yaml": afterConfig}
 				return before, after
 			},
-			expected: func() config.ByFilename {
+			expected: func() config.DataByFilename {
 				expected := config.DataWithInfo{}
 				if err := deepcopy.Copy(&expected, &baseCiopConfig); err != nil {
 					t.Fatal(err)
 				}
 				expected.Configuration.Tests[0].Commands = "changed commands"
 				expected.Configuration.Tests[1].Commands = "changed commands"
-				return config.ByFilename{"org-repo-branch.yaml": expected}
+				return config.DataByFilename{"org-repo-branch.yaml": expected}
 			},
 			expectedAffectedJobs: map[string]sets.String{
 				"org-repo-branch.yaml": {
@@ -441,7 +441,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 	testCases := []struct {
 		description string
 		prow        *prowconfig.Config
-		ciop        config.ByFilename
+		ciop        config.DataByFilename
 		expected    config.Presubmits
 	}{{
 		description: "return a presubmit using one of the input ciop configs",
@@ -461,7 +461,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 					}},
 			},
 		},
-		ciop: config.ByFilename{baseCiopConfig.Filename: {Info: baseCiopConfig}},
+		ciop: config.DataByFilename{baseCiopConfig.Filename: {Info: baseCiopConfig}},
 		expected: config.Presubmits{"org/repo": {
 			func() prowconfig.Presubmit {
 				ret := prowconfig.Presubmit{}
@@ -496,7 +496,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 					}},
 			},
 		},
-		ciop: config.ByFilename{baseCiopConfig.Filename: {Info: baseCiopConfig}},
+		ciop: config.DataByFilename{baseCiopConfig.Filename: {Info: baseCiopConfig}},
 		expected: config.Presubmits{"org/repo": {
 			func() prowconfig.Presubmit {
 				ret := prowconfig.Presubmit{}
@@ -531,7 +531,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 					}},
 			},
 		},
-		ciop:     config.ByFilename{},
+		ciop:     config.DataByFilename{},
 		expected: config.Presubmits{},
 	}, {
 		description: "handle jenkins presubmits",
@@ -552,7 +552,7 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 					}},
 			},
 		},
-		ciop:     config.ByFilename{},
+		ciop:     config.DataByFilename{},
 		expected: config.Presubmits{},
 	},
 	}
@@ -589,7 +589,7 @@ func TestGetImagesPostsubmitsForCiopConfigs(t *testing.T) {
 	var testCases = []struct {
 		name        string
 		prowConfig  *prowconfig.Config
-		ciopConfigs config.ByFilename
+		ciopConfigs config.DataByFilename
 		expected    []PostsubmitInContext
 	}{
 		{

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -17,7 +17,6 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/config"
 )
 
 type ProwgenLabel string
@@ -57,9 +56,9 @@ func (i *Info) Basename() string {
 func (i *Info) ConfigMapName() string {
 	// put periodics not directly correlated to code in the misc job
 	if i.Type == "periodics" && i.Branch == "" {
-		return fmt.Sprintf("job-config-%s", config.FlavorForBranch(""))
+		return fmt.Sprintf("job-config-%s", cioperatorapi.FlavorForBranch(""))
 	}
-	return fmt.Sprintf("job-config-%s", config.FlavorForBranch(i.Branch))
+	return fmt.Sprintf("job-config-%s", cioperatorapi.FlavorForBranch(i.Branch))
 }
 
 // We use the directory/file naming convention to encode useful information

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -11,14 +11,13 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/coalescer"
-	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/load"
 )
 
 // ConfigAgent is an interface that can load configs from disk into
 // memory and retrieve them when provided with a config.Info.
 type ConfigAgent interface {
-	GetConfig(config.Info) (api.ReleaseBuildConfiguration, error)
+	GetConfig(metadata api.Metadata) (api.ReleaseBuildConfiguration, error)
 	GetAll() load.FilenameToConfig
 	GetGeneration() int
 	AddIndex(indexName string, indexFunc IndexFn) error
@@ -80,12 +79,12 @@ func (a *configAgent) recordError(label string) {
 	a.errorMetrics.With(labels).Inc()
 }
 
-func (a *configAgent) GetConfig(info config.Info) (api.ReleaseBuildConfiguration, error) {
+func (a *configAgent) GetConfig(metadata api.Metadata) (api.ReleaseBuildConfiguration, error) {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
-	config, ok := a.configs[info.Basename()]
+	config, ok := a.configs[metadata.Basename()]
 	if !ok {
-		return api.ReleaseBuildConfiguration{}, fmt.Errorf("Could not find config %s", info.Basename())
+		return api.ReleaseBuildConfiguration{}, fmt.Errorf("Could not find config %s", metadata.Basename())
 	}
 	return config, nil
 }

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -25,7 +25,7 @@ const (
 )
 
 type ProwgenInfo struct {
-	config.Info
+	cioperatorapi.Metadata
 	Config config.Prowgen
 }
 
@@ -415,7 +415,7 @@ func generatePodSpecOthers(info *ProwgenInfo, release string, test *cioperatorap
 }
 
 func generatePresubmitForTest(name string, info *ProwgenInfo, label jc.ProwgenLabel, podSpec *corev1.PodSpec, rehearsable bool, pathAlias *string) *prowconfig.Presubmit {
-	shortName := info.Info.TestName(name)
+	shortName := info.TestName(name)
 	base := generateJobBase(name, jc.PresubmitPrefix, info, label, podSpec, rehearsable, pathAlias)
 	return &prowconfig.Presubmit{
 		JobBase:   base,
@@ -511,7 +511,7 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, label jc.ProwgenLab
 		labels[jc.CanBeRehearsedLabel] = string(jc.Generated)
 	}
 
-	jobName := info.Info.JobName(prefix, name)
+	jobName := info.JobName(prefix, name)
 	if len(info.Variant) > 0 {
 		labels[jc.ProwJobLabelVariant] = info.Variant
 	}

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -38,7 +38,7 @@ func TestGeneratePodSpec(t *testing.T) {
 	}{
 		{
 			description: "standard use case",
-			info:        &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:        &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			secrets:     nil,
 			targets:     []string{"target"},
 
@@ -80,7 +80,7 @@ func TestGeneratePodSpec(t *testing.T) {
 		},
 		{
 			description:    "additional args are included in podspec",
-			info:           &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:           &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			secrets:        nil,
 			targets:        []string{"target"},
 			additionalArgs: []string{"--promote", "--some=thing"},
@@ -125,7 +125,7 @@ func TestGeneratePodSpec(t *testing.T) {
 		},
 		{
 			description:    "additional args and secret are included in podspec",
-			info:           &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:           &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			secrets:        []*ciop.Secret{{Name: "secret-name", MountPath: "/usr/local/test-secret"}},
 			targets:        []string{"target"},
 			additionalArgs: []string{"--promote", "--some=thing"},
@@ -180,7 +180,7 @@ func TestGeneratePodSpec(t *testing.T) {
 		},
 		{
 			description: "multiple targets",
-			info:        &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:        &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			secrets:     nil,
 			targets:     []string{"target", "more", "and-more"},
 
@@ -223,8 +223,8 @@ func TestGeneratePodSpec(t *testing.T) {
 		{
 			description: "private job",
 			info: &ProwgenInfo{
-				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				Config: config.Prowgen{Private: true},
+				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				Config:   config.Prowgen{Private: true},
 			},
 			secrets: nil,
 			targets: []string{"target"},
@@ -301,7 +301,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 		expected *corev1.PodSpec
 	}{
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -392,7 +392,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -486,7 +486,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As: "test",
@@ -561,7 +561,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -668,7 +668,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -773,7 +773,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -878,7 +878,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			},
 		},
 		{
-			info:    &ProwgenInfo{Info: config.Info{Org: "organization", Repo: "repo", Branch: "branch"}},
+			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
 				As:       "test",
@@ -1002,7 +1002,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	}{{
 		description: "presubmit for standard test",
 		test:        "testname",
-		repoInfo:    &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 
 		expected: &prowconfig.Presubmit{
 			JobBase: prowconfig.JobBase{
@@ -1029,7 +1029,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 		{
 			description: "presubmit for a test in a variant config",
 			test:        "testname",
-			repoInfo:    &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
 
 			expected: &prowconfig.Presubmit{
 				JobBase: prowconfig.JobBase{
@@ -1075,7 +1075,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 	}{{
 		description: "periodic for standard test",
 		test:        "testname",
-		repoInfo:    &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 
 		expected: &prowconfig.Periodic{
 			Cron: "@yearly",
@@ -1101,7 +1101,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		{
 			description: "periodic for a test in a variant config",
 			test:        "testname",
-			repoInfo:    &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
 			expected: &prowconfig.Periodic{
 				Cron: "@yearly",
 				JobBase: prowconfig.JobBase{
@@ -1148,7 +1148,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 	}{
 		{
 			name: "name",
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1170,7 +1170,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 		},
 		{
 			name: "Name",
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "Organization",
 				Repo:   "Repository",
 				Branch: "Branch",
@@ -1190,7 +1190,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 		},
 		{
 			name: "name",
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "Organization",
 				Repo:   "Repository",
 				Branch: "Branch",
@@ -1236,7 +1236,7 @@ func TestGenerateJobs(t *testing.T) {
 					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}},
 					{As: "leTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}}},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1263,7 +1263,7 @@ func TestGenerateJobs(t *testing.T) {
 				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				PromotionConfiguration: &ciop.PromotionConfiguration{},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1305,7 +1305,7 @@ func TestGenerateJobs(t *testing.T) {
 					},
 				},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1328,7 +1328,7 @@ func TestGenerateJobs(t *testing.T) {
 					},
 				}},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1348,7 +1348,7 @@ func TestGenerateJobs(t *testing.T) {
 				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "ci"},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1377,7 +1377,7 @@ func TestGenerateJobs(t *testing.T) {
 					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "openshift"},
 				},
 			},
-			repoInfo: &ProwgenInfo{Info: config.Info{
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
 				Repo:   "repository",
 				Branch: "branch",
@@ -1423,7 +1423,7 @@ func TestGenerateJobBase(t *testing.T) {
 			testName: "no special options",
 			name:     "test",
 			prefix:   "pull",
-			info:     &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:     &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			label:    jobconfig.Generated,
 			podSpec:  &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			expected: prowconfig.JobBase{
@@ -1440,7 +1440,7 @@ func TestGenerateJobBase(t *testing.T) {
 			testName:    "rehearsable",
 			name:        "test",
 			prefix:      "pull",
-			info:        &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch"}},
+			info:        &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			label:       jobconfig.Generated,
 			podSpec:     &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			rehearsable: true,
@@ -1459,7 +1459,7 @@ func TestGenerateJobBase(t *testing.T) {
 			testName: "config variant",
 			name:     "test",
 			prefix:   "pull",
-			info:     &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch", Variant: "whatever"}},
+			info:     &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "whatever"}},
 			label:    jobconfig.Generated,
 			podSpec:  &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			expected: prowconfig.JobBase{
@@ -1477,7 +1477,7 @@ func TestGenerateJobBase(t *testing.T) {
 			testName:  "path alias",
 			name:      "test",
 			prefix:    "pull",
-			info:      &ProwgenInfo{Info: config.Info{Org: "org", Repo: "repo", Branch: "branch", Variant: "whatever"}},
+			info:      &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "whatever"}},
 			label:     jobconfig.Generated,
 			podSpec:   &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			pathAlias: &path,
@@ -1497,8 +1497,8 @@ func TestGenerateJobBase(t *testing.T) {
 			name:     "test",
 			prefix:   "pull",
 			info: &ProwgenInfo{
-				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				Config: config.Prowgen{Private: true},
+				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				Config:   config.Prowgen{Private: true},
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
@@ -1518,8 +1518,8 @@ func TestGenerateJobBase(t *testing.T) {
 			name:     "test",
 			prefix:   "pull",
 			info: &ProwgenInfo{
-				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				Config: config.Prowgen{Private: true, Expose: true},
+				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				Config:   config.Prowgen{Private: true, Expose: true},
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
@@ -1539,8 +1539,8 @@ func TestGenerateJobBase(t *testing.T) {
 			name:     "test",
 			prefix:   "pull",
 			info: &ProwgenInfo{
-				Info:   config.Info{Org: "org", Repo: "repo", Branch: "branch"},
-				Config: config.Prowgen{Private: false, Expose: true},
+				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				Config:   config.Prowgen{Private: false, Expose: true},
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -233,7 +233,7 @@ func hasRehearsableLabel(labels map[string]string) bool {
 // of the needed config file passed to the job as a direct value. This needs
 // to happen because the rehearsed Prow jobs may depend on these config files
 // being also changed by the tested PR.
-func inlineCiOpConfig(container *v1.Container, ciopConfigs config.ByFilename, resolver registry.Resolver, info config.Info, loggers Loggers) error {
+func inlineCiOpConfig(container *v1.Container, ciopConfigs config.DataByFilename, resolver registry.Resolver, info config.Info, loggers Loggers) error {
 	configSpecSet := false
 	// replace all ConfigMapKeyRef mounts with inline config maps
 	for index := range container.Env {
@@ -311,7 +311,7 @@ func inlineCiOpConfig(container *v1.Container, ciopConfigs config.ByFilename, re
 
 // JobConfigurer holds all the information that is needed for the configuration of the jobs.
 type JobConfigurer struct {
-	ciopConfigs      config.ByFilename
+	ciopConfigs      config.DataByFilename
 	registryResolver registry.Resolver
 	profiles         []config.ConfigMapSource
 	prNumber         int
@@ -321,7 +321,7 @@ type JobConfigurer struct {
 }
 
 // NewJobConfigurer filters the jobs and returns a new JobConfigurer.
-func NewJobConfigurer(ciopConfigs config.ByFilename, resolver registry.Resolver, prNumber int, loggers Loggers, templates []config.ConfigMapSource, profiles []config.ConfigMapSource, refs *pjapi.Refs) *JobConfigurer {
+func NewJobConfigurer(ciopConfigs config.DataByFilename, resolver registry.Resolver, prNumber int, loggers Loggers, templates []config.ConfigMapSource, profiles []config.ConfigMapSource, refs *pjapi.Refs) *JobConfigurer {
 	return &JobConfigurer{
 		ciopConfigs:      ciopConfigs,
 		registryResolver: resolver,
@@ -492,7 +492,7 @@ func getPresubmitByJobName(presubmits []prowconfig.Presubmit, name string) (prow
 	return prowconfig.Presubmit{}, fmt.Errorf("could not find presubmit with name: %s", name)
 }
 
-func getPresubmitsForRegistryStep(node registry.Node, configs config.ByFilename, prConfigPresubmits map[string][]prowconfig.Presubmit, addedConfigs []*api.MultiStageTestConfiguration) (map[string][]prowconfig.Presubmit, []*api.MultiStageTestConfiguration, error) {
+func getPresubmitsForRegistryStep(node registry.Node, configs config.DataByFilename, prConfigPresubmits map[string][]prowconfig.Presubmit, addedConfigs []*api.MultiStageTestConfiguration) (map[string][]prowconfig.Presubmit, []*api.MultiStageTestConfiguration, error) {
 	toTest := make(map[string][]prowconfig.Presubmit)
 	// get sorted list of configs keys to make the function deterministic
 	var keys []string
@@ -573,7 +573,7 @@ func expandAncestors(changed, graph registry.NodeByName) {
 }
 
 func AddRandomJobsForChangedRegistry(regSteps, graph registry.NodeByName, prConfigPresubmits map[string][]prowconfig.Presubmit, configPath string, loggers Loggers) config.Presubmits {
-	configsByFilename, err := config.LoadConfigByFilename(configPath)
+	configsByFilename, err := config.LoadDataByFilename(configPath)
 	if err != nil {
 		loggers.Debug.Errorf("Failed to load config by filename in AddRandomJobsForChangedRegistry: %v", err)
 	}

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -233,7 +233,7 @@ func hasRehearsableLabel(labels map[string]string) bool {
 // of the needed config file passed to the job as a direct value. This needs
 // to happen because the rehearsed Prow jobs may depend on these config files
 // being also changed by the tested PR.
-func inlineCiOpConfig(container *v1.Container, ciopConfigs config.DataByFilename, resolver registry.Resolver, info config.Info, loggers Loggers) error {
+func inlineCiOpConfig(container *v1.Container, ciopConfigs config.DataByFilename, resolver registry.Resolver, metadata api.Metadata, loggers Loggers) error {
 	configSpecSet := false
 	// replace all ConfigMapKeyRef mounts with inline config maps
 	for index := range container.Env {
@@ -247,7 +247,7 @@ func inlineCiOpConfig(container *v1.Container, ciopConfigs config.DataByFilename
 		if env.ValueFrom.ConfigMapKeyRef == nil {
 			continue
 		}
-		if config.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
+		if api.IsCiopConfigCM(env.ValueFrom.ConfigMapKeyRef.Name) {
 			filename := env.ValueFrom.ConfigMapKeyRef.Key
 
 			loggers.Debug.WithField(logCiopConfigFile, filename).Debug("Rehearsal job uses ci-operator config ConfigMap, needed content will be inlined")
@@ -277,10 +277,10 @@ func inlineCiOpConfig(container *v1.Container, ciopConfigs config.DataByFilename
 	}
 	// inline CONFIG_SPEC for all ci-operator jobs
 	if container.Command != nil && container.Command[0] == "ci-operator" {
-		if err := info.IsComplete(); err != nil {
+		if err := metadata.IsComplete(); err != nil {
 			return fmt.Errorf("could not infer which ci-operator config this job uses: %v", err)
 		}
-		filename := info.Basename()
+		filename := metadata.Basename()
 		loggers.Debug.WithField(logCiopConfigFile, filename).Debug("Rehearsal job uses ci-operator config ConfigMap, needed content will be inlined")
 		ciopConfig, ok := ciopConfigs[filename]
 		if !ok {
@@ -356,15 +356,15 @@ func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics)
 	filteredPeriodics := filterPeriodics(periodics, jc.loggers.Job)
 	for _, job := range filteredPeriodics {
 		jobLogger := jc.loggers.Job.WithField("target-job", job.Name)
-		info := config.Info{
+		metadata := api.Metadata{
 			Variant: variantFromLabels(job.Labels),
 		}
 		if len(job.ExtraRefs) != 0 {
-			info.Org = job.ExtraRefs[0].Org
-			info.Repo = job.ExtraRefs[0].Repo
-			info.Branch = job.ExtraRefs[0].BaseRef
+			metadata.Org = job.ExtraRefs[0].Org
+			metadata.Repo = job.ExtraRefs[0].Repo
+			metadata.Branch = job.ExtraRefs[0].BaseRef
 		}
-		if err := jc.configureJobSpec(job.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+		if err := jc.configureJobSpec(job.Spec, metadata, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 			jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal periodic job")
 			continue
 		}
@@ -394,14 +394,14 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 			if len(splitOrgRepo) != 2 {
 				jobLogger.WithError(fmt.Errorf("failed to identify org and repo from string %s", orgrepo)).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
 			}
-			info := config.Info{
+			metadata := api.Metadata{
 				Org:     splitOrgRepo[0],
 				Repo:    splitOrgRepo[1],
 				Branch:  getTrimmedBranch(job.Branches),
 				Variant: variantFromLabels(job.Labels),
 			}
 
-			if err := jc.configureJobSpec(rehearsal.Spec, info, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
+			if err := jc.configureJobSpec(rehearsal.Spec, metadata, jc.loggers.Debug.WithField("name", job.Name)); err != nil {
 				jobLogger.WithError(err).Warn("Failed to inline ci-operator-config into rehearsal presubmit job")
 				continue
 			}
@@ -413,20 +413,20 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 	return rehearsals
 }
 
-func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, info config.Info, logger *logrus.Entry) error {
+func (jc *JobConfigurer) configureJobSpec(spec *v1.PodSpec, metadata api.Metadata, logger *logrus.Entry) error {
 	// Remove configresolver flags from ci-operator jobs
-	var infoFromFlags config.Info
+	var metadataFromFlags api.Metadata
 	if len(spec.Containers[0].Command) > 0 && spec.Containers[0].Command[0] == "ci-operator" {
-		spec.Containers[0].Args, infoFromFlags = removeConfigResolverFlags(spec.Containers[0].Args)
+		spec.Containers[0].Args, metadataFromFlags = removeConfigResolverFlags(spec.Containers[0].Args)
 	}
 
 	// Periodics may not be tied to a specific ci-operator configuration, but
 	// we may have inferred ci-op config from ci-operator flags
-	if info.IsComplete() != nil && infoFromFlags.IsComplete() == nil {
-		info = infoFromFlags
+	if metadata.IsComplete() != nil && metadataFromFlags.IsComplete() == nil {
+		metadata = metadataFromFlags
 	}
 
-	if err := inlineCiOpConfig(&spec.Containers[0], jc.ciopConfigs, jc.registryResolver, info, jc.loggers); err != nil {
+	if err := inlineCiOpConfig(&spec.Containers[0], jc.ciopConfigs, jc.registryResolver, metadata, jc.loggers); err != nil {
 		return err
 	}
 
@@ -831,9 +831,9 @@ func (e *Executor) waitForJobs(jobs sets.String, selector string) (bool, error) 
 	}
 }
 
-func removeConfigResolverFlags(args []string) ([]string, config.Info) {
+func removeConfigResolverFlags(args []string) ([]string, api.Metadata) {
 	var newArgs []string
-	var usedConfig config.Info
+	var usedConfig api.Metadata
 	toConfig := map[string]*string{
 		"org":     &usedConfig.Org,
 		"repo":    &usedConfig.Repo,

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -56,9 +56,11 @@ func generateTestConfigFiles() config.DataByFilename {
 				},
 			},
 			Info: config.Info{
-				Org:    "targetOrg",
-				Repo:   "targetRepo",
-				Branch: "master",
+				Metadata: api.Metadata{
+					Org:    "targetOrg",
+					Repo:   "targetRepo",
+					Branch: "master",
+				},
 			},
 		},
 		"targetOrg-targetRepo-not-master.yaml": config.DataWithInfo{
@@ -69,9 +71,11 @@ func generateTestConfigFiles() config.DataByFilename {
 				},
 			},
 			Info: config.Info{
-				Org:    "targetOrg",
-				Repo:   "targetRepo",
-				Branch: "not-master",
+				Metadata: api.Metadata{
+					Org:    "targetOrg",
+					Repo:   "targetRepo",
+					Branch: "not-master",
+				},
 			},
 		}, "anotherOrg-anotherRepo-master.yaml": config.DataWithInfo{
 			Configuration: api.ReleaseBuildConfiguration{
@@ -81,9 +85,11 @@ func generateTestConfigFiles() config.DataByFilename {
 				},
 			},
 			Info: config.Info{
-				Org:    "anotherOrg",
-				Repo:   "anotherRepo",
-				Branch: "master",
+				Metadata: api.Metadata{
+					Org:    "anotherOrg",
+					Repo:   "anotherRepo",
+					Branch: "master",
+				},
 			},
 		},
 	}
@@ -217,9 +223,9 @@ func makeCMReference(cmName, key string) *v1.EnvVarSource {
 }
 
 func TestInlineCiopConfig(t *testing.T) {
-	testCiopConfigInfo := config.Info{
-		Org:    "org",
-		Repo:   "repo",
+	testCiopConfigInfo := api.Metadata{
+		Org:    "targetOrg",
+		Repo:   "targetRepo",
 		Branch: "master",
 	}
 	testCiopConfig := api.ReleaseBuildConfiguration{}
@@ -255,7 +261,7 @@ func TestInlineCiopConfig(t *testing.T) {
 	}, {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
-		configs:     config.DataByFilename{"filename": {Info: testCiopConfigInfo, Configuration: testCiopConfig}},
+		configs:     config.DataByFilename{"filename": {Info: config.Info{Metadata: testCiopConfigInfo}, Configuration: testCiopConfig}},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopConfigContent)}},
 	}, {
 		description:   "bad CM key is handled",
@@ -1161,12 +1167,12 @@ func TestRemoveConfigResolverFlags(t *testing.T) {
 		description  string
 		input        []string
 		expectedArgs []string
-		expectedInfo config.Info
+		expectedInfo api.Metadata
 	}{{
 		description:  "just resolver flags",
 		input:        []string{"--resolver-address=http://ci-operator-resolver", "--org=openshift", "--repo=origin", "--branch=master", "--variant=v2"},
 		expectedArgs: nil,
-		expectedInfo: config.Info{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
+		expectedInfo: api.Metadata{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
 	}, {
 		description:  "no resolver flags",
 		input:        []string{"--artifact-dir=$(ARTIFACTS)", "--target=target"},
@@ -1175,12 +1181,12 @@ func TestRemoveConfigResolverFlags(t *testing.T) {
 		description:  "mixed resolver and non-resolver flags",
 		input:        []string{"--artifact-dir=$(ARTIFACTS)", "--resolver-address=http://ci-operator-resolver", "--org=openshift", "--target=target", "--repo=origin", "--branch=master", "--variant=v2"},
 		expectedArgs: []string{"--artifact-dir=$(ARTIFACTS)", "--target=target"},
-		expectedInfo: config.Info{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
+		expectedInfo: api.Metadata{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
 	}, {
 		description:  "spaces in between flag and value",
 		input:        []string{"--artifact-dir=$(ARTIFACTS)", "--resolver-address=http://ci-operator-resolver", "--org", "openshift", "--target=target", "--repo", "origin", "--branch", "master", "--variant=v2"},
 		expectedArgs: []string{"--artifact-dir=$(ARTIFACTS)", "--target=target"},
-		expectedInfo: config.Info{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
+		expectedInfo: api.Metadata{Org: "openshift", Repo: "origin", Branch: "master", Variant: "v2"},
 	}}
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -46,8 +46,8 @@ const testingCiOpCfgYAML = "tests:\n- as: job1\n- as: job2\nzz_generated_metadat
 
 // configFiles contains the info needed to allow inlineCiOpConfig to successfully inline
 // CONFIG_SPEC and not fail
-func generateTestConfigFiles() config.ByFilename {
-	return config.ByFilename{
+func generateTestConfigFiles() config.DataByFilename {
+	return config.DataByFilename{
 		"targetOrg-targetRepo-master.yaml": config.DataWithInfo{
 			Configuration: api.ReleaseBuildConfiguration{
 				Tests: []api.TestStepConfiguration{
@@ -231,36 +231,36 @@ func TestInlineCiopConfig(t *testing.T) {
 	testCases := []struct {
 		description   string
 		sourceEnv     []v1.EnvVar
-		configs       config.ByFilename
+		configs       config.DataByFilename
 		expectedEnv   []v1.EnvVar
 		expectedError bool
 	}{{
 		description: "empty env -> no changes",
-		configs:     config.ByFilename{},
+		configs:     config.DataByFilename{},
 	}, {
 		description: "no Env.ValueFrom -> no changes",
 		sourceEnv:   []v1.EnvVar{{Name: "T", Value: "V"}},
-		configs:     config.ByFilename{},
+		configs:     config.DataByFilename{},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: "V"}},
 	}, {
 		description: "no Env.ValueFrom.ConfigMapKeyRef -> no changes",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{}}}},
-		configs:     config.ByFilename{},
+		configs:     config.DataByFilename{},
 		expectedEnv: []v1.EnvVar{{Name: "T", ValueFrom: &v1.EnvVarSource{ResourceFieldRef: &v1.ResourceFieldSelector{}}}},
 	}, {
 		description: "CM reference but not ci-operator-configs -> no changes",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference("test-cm", "key")}},
-		configs:     config.ByFilename{},
+		configs:     config.DataByFilename{},
 		expectedEnv: []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference("test-cm", "key")}},
 	}, {
 		description: "CM reference to ci-operator-configs -> cm content inlined",
 		sourceEnv:   []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
-		configs:     config.ByFilename{"filename": {Info: testCiopConfigInfo, Configuration: testCiopConfig}},
+		configs:     config.DataByFilename{"filename": {Info: testCiopConfigInfo, Configuration: testCiopConfig}},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopConfigContent)}},
 	}, {
 		description:   "bad CM key is handled",
 		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
-		configs:       config.ByFilename{},
+		configs:       config.DataByFilename{},
 		expectedError: true,
 	}}
 


### PR DESCRIPTION
config: rename type storing data by filename

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

config: use Metadata type when loading from directories

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

api: declare our directory structure and naming an api, use it

We have an API/interface around how we format names and identifiers
based on what org/repo/branch/variant is being considered. Refactor code
to make this an obvious API.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 