### PR TITLE
Build static binaries

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -4,6 +4,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+export CGO_ENABLED=0
+
 # if we're not building an official output binary, we don't care to tag it
 if [[ -z "${OPENSHIFT_CI:-}" ]]; then
 	go install ./cmd/...


### PR DESCRIPTION
As they are more portable and don't inhibit varying behavior depending on the glibc they have been compiled against.
