### PR TITLE
ci-operator-configresolver: serve matching configurations

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -218,7 +218,7 @@ func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.Registry
 			"variant": variant,
 		})
 
-		config, err := configAgent.GetConfig(metadata)
+		config, err := configAgent.GetMatchingConfig(metadata)
 		if err != nil {
 			recordError("config not found")
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // IsComplete returns an error if at least one of Org, Repo, Branch members is
@@ -89,4 +91,13 @@ func FlavorForBranch(branch string) string {
 		flavor = "misc"
 	}
 	return flavor
+}
+
+func LogFieldsFor(metadata Metadata) logrus.Fields {
+	return logrus.Fields{
+		"org":     metadata.Org,
+		"repo":    metadata.Repo,
+		"branch":  metadata.Branch,
+		"variant": metadata.Variant,
+	}
 }

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -36,7 +36,34 @@ const (
 	commandsSuffix = "-commands.sh"
 )
 
-// FilenameToConfig contains configs keyed by the file they were found int
+// ByOrgRepo maps org --> repo --> list of branched and variant configs
+type ByOrgRepo map[string]map[string][]api.ReleaseBuildConfiguration
+
+func FromPathByOrgRepo(path string) (ByOrgRepo, error) {
+	byFilename, err := FromPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return PartitionByOrgRepo(byFilename), nil
+}
+
+func PartitionByOrgRepo(byFilename FilenameToConfig) ByOrgRepo {
+	byOrgRepo := map[string]map[string][]api.ReleaseBuildConfiguration{}
+	for _, configuration := range byFilename {
+		org, repo := configuration.Metadata.Org, configuration.Metadata.Repo
+		if _, exists := byOrgRepo[org]; !exists {
+			byOrgRepo[org] = map[string][]api.ReleaseBuildConfiguration{}
+		}
+		if _, exists := byOrgRepo[org][repo]; !exists {
+			byOrgRepo[org][repo] = []api.ReleaseBuildConfiguration{}
+		}
+		byOrgRepo[org][repo] = append(byOrgRepo[org][repo], configuration)
+	}
+	return byOrgRepo
+}
+
+// FilenameToConfig contains configs keyed by the file they were found in
 type FilenameToConfig map[string]api.ReleaseBuildConfiguration
 
 // FromPath returns all configs found at or below the given path

--- a/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
@@ -102,3 +102,7 @@ tests:
           memory: "7"
         requests:
           memory: "7"
+zz_generated_metadata:
+  org: openshift
+  repo: hyperkube
+  branch: master

--- a/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -38,3 +38,7 @@ tests:
     post:
     - ref: ipi-deprovision-must-gather
     - ref: ipi-deprovision-deprovision
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: release-4.2


### PR DESCRIPTION
At feature-freeze, developers create branches which prefix their working
branch and use Prow's regex matching on branch names to not need to
reconfigure their CI whatsoever. For instance, a `master` branch will be
used to create `master-feature`. We now support the same operation in
the configuration server.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @openshift/openshift-team-developer-productivity-platform 
/assign @AlexNPavel 