### PR TITLE
ci-operator-configresolver: serve matching configurations

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -218,7 +218,7 @@ func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.Registry
 			"variant": variant,
 		})
 
-		config, err := configAgent.GetConfig(metadata)
+		config, err := configAgent.GetMatchingConfig(metadata)
 		if err != nil {
 			recordError("config not found")
 			w.WriteHeader(http.StatusNotFound)

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -6,6 +6,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 // IsComplete returns an error if at least one of Org, Repo, Branch members is
@@ -89,4 +91,13 @@ func FlavorForBranch(branch string) string {
 		flavor = "misc"
 	}
 	return flavor
+}
+
+func LogFieldsFor(metadata Metadata) logrus.Fields {
+	return logrus.Fields{
+		"org":     metadata.Org,
+		"repo":    metadata.Repo,
+		"branch":  metadata.Branch,
+		"variant": metadata.Variant,
+	}
 }

--- a/pkg/load/agents/configAgent_test.go
+++ b/pkg/load/agents/configAgent_test.go
@@ -127,7 +127,7 @@ func TestBuildIndexes(t *testing.T) {
 	testCases := []struct {
 		name     string
 		agent    *configAgent
-		configs  load.FilenameToConfig
+		configs  load.ByOrgRepo
 		expected map[string]configIndex
 	}{
 		{
@@ -137,7 +137,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-a": func(_ api.ReleaseBuildConfiguration) []string { return []string{"key-a"} },
 				},
 			},
-			configs:  load.FilenameToConfig{"myfile.yaml": cfg},
+			configs:  load.ByOrgRepo{"org": {"repo": []api.ReleaseBuildConfiguration{cfg}}},
 			expected: map[string]configIndex{"index-a": {"key-a": []*api.ReleaseBuildConfiguration{&cfg}}},
 		},
 		{
@@ -148,7 +148,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-b": func(_ api.ReleaseBuildConfiguration) []string { return []string{"key-b"} },
 				},
 			},
-			configs: load.FilenameToConfig{"myfile.yaml": cfg},
+			configs: load.ByOrgRepo{"org": {"repo": []api.ReleaseBuildConfiguration{cfg}}},
 			expected: map[string]configIndex{
 				"index-a": {"key-a": []*api.ReleaseBuildConfiguration{&cfg}},
 				"index-b": {"key-b": []*api.ReleaseBuildConfiguration{&cfg}},
@@ -161,7 +161,7 @@ func TestBuildIndexes(t *testing.T) {
 					"index-a": func(_ api.ReleaseBuildConfiguration) []string { return nil },
 				},
 			},
-			configs:  load.FilenameToConfig{"myfile.yaml": cfg},
+			configs:  load.ByOrgRepo{"org": {"repo": []api.ReleaseBuildConfiguration{cfg}}},
 			expected: map[string]configIndex{},
 		},
 	}

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -36,7 +36,34 @@ const (
 	commandsSuffix = "-commands.sh"
 )
 
-// FilenameToConfig contains configs keyed by the file they were found int
+// ByOrgRepo maps org --> repo --> list of branched and variant configs
+type ByOrgRepo map[string]map[string][]api.ReleaseBuildConfiguration
+
+func FromPathByOrgRepo(path string) (ByOrgRepo, error) {
+	byFilename, err := FromPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return PartitionByOrgRepo(byFilename), nil
+}
+
+func PartitionByOrgRepo(byFilename FilenameToConfig) ByOrgRepo {
+	byOrgRepo := map[string]map[string][]api.ReleaseBuildConfiguration{}
+	for _, configuration := range byFilename {
+		org, repo := configuration.Metadata.Org, configuration.Metadata.Repo
+		if _, exists := byOrgRepo[org]; !exists {
+			byOrgRepo[org] = map[string][]api.ReleaseBuildConfiguration{}
+		}
+		if _, exists := byOrgRepo[org][repo]; !exists {
+			byOrgRepo[org][repo] = []api.ReleaseBuildConfiguration{}
+		}
+		byOrgRepo[org][repo] = append(byOrgRepo[org][repo], configuration)
+	}
+	return byOrgRepo
+}
+
+// FilenameToConfig contains configs keyed by the file they were found in
 type FilenameToConfig map[string]api.ReleaseBuildConfiguration
 
 // FromPath returns all configs found at or below the given path

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -40,15 +40,15 @@ const (
 type ByOrgRepo map[string]map[string][]api.ReleaseBuildConfiguration
 
 func FromPathByOrgRepo(path string) (ByOrgRepo, error) {
-	byFilename, err := FromPath(path)
+	byFilename, err := fromPath(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return PartitionByOrgRepo(byFilename), nil
+	return partitionByOrgRepo(byFilename), nil
 }
 
-func PartitionByOrgRepo(byFilename FilenameToConfig) ByOrgRepo {
+func partitionByOrgRepo(byFilename filenameToConfig) ByOrgRepo {
 	byOrgRepo := map[string]map[string][]api.ReleaseBuildConfiguration{}
 	for _, configuration := range byFilename {
 		org, repo := configuration.Metadata.Org, configuration.Metadata.Repo
@@ -64,11 +64,11 @@ func PartitionByOrgRepo(byFilename FilenameToConfig) ByOrgRepo {
 }
 
 // FilenameToConfig contains configs keyed by the file they were found in
-type FilenameToConfig map[string]api.ReleaseBuildConfiguration
+type filenameToConfig map[string]api.ReleaseBuildConfiguration
 
 // FromPath returns all configs found at or below the given path
-func FromPath(path string) (FilenameToConfig, error) {
-	configs := FilenameToConfig{}
+func fromPath(path string) (filenameToConfig, error) {
+	configs := filenameToConfig{}
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if info == nil || err != nil {
 			return err

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -848,17 +848,17 @@ func TestRegistry(t *testing.T) {
 func TestPartitionByRepo(t *testing.T) {
 	var testCases = []struct {
 		name   string
-		input  FilenameToConfig
+		input  filenameToConfig
 		output ByOrgRepo
 	}{
 		{
 			name:   "no input",
-			input:  FilenameToConfig{},
+			input:  filenameToConfig{},
 			output: ByOrgRepo{},
 		},
 		{
 			name: "complex input",
-			input: FilenameToConfig{
+			input: filenameToConfig{
 				"a": api.ReleaseBuildConfiguration{Metadata: api.Metadata{
 					Org:    "org",
 					Repo:   "repo",
@@ -920,7 +920,7 @@ func TestPartitionByRepo(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual, expected := PartitionByOrgRepo(testCase.input), testCase.output
+		actual, expected := partitionByOrgRepo(testCase.input), testCase.output
 		if diff := cmp.Diff(actual, expected); diff != "" {
 			t.Errorf("%s: did not get correct partitioned config: %s", testCase.name, diff)
 		}

--- a/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
@@ -102,3 +102,7 @@ tests:
           memory: "7"
         requests:
           memory: "7"
+zz_generated_metadata:
+  org: openshift
+  repo: hyperkube
+  branch: master

--- a/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -38,3 +38,7 @@ tests:
     post:
     - ref: ipi-deprovision-must-gather
     - ref: ipi-deprovision-deprovision
+zz_generated_metadata:
+  org: openshift
+  repo: installer
+  branch: release-4.2


### PR DESCRIPTION
(Creating a new PR because I can not push to steves branch)
At feature-freeze, developers create branches which prefix their working
branch and use Prow's regex matching on branch names to not need to
reconfigure their CI whatsoever. For instance, a master branch will be
used to create master-feature. We now support the same operation in
the configuration server.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com

/cc @openshift/openshift-team-developer-productivity-platform
/assign @AlexNPavel

This pr has one additional commit that minimizes the exported surface of pkg/load. I didn't get around to make the job retrieval an index, because it requires a bit more refactoring wrt to error handling and I don't have time for that now.
closes #767