### PR TITLE
webreg: improve graphs

### DIFF
--- a/pkg/webreg/graphviz.go
+++ b/pkg/webreg/graphviz.go
@@ -130,10 +130,10 @@ func addEmptySubgraph(mainGraph graph, name string) (graph, int) {
 
 }
 
-func workflowDotFile(name string, workflows registry.WorkflowByName, chains registry.ChainByName) string {
+func workflowDotFile(name string, workflows registry.WorkflowByName, chains registry.ChainByName, wfType string) string {
 	workflow := workflows[name]
 	mainGraph := graph{
-		label: fmt.Sprintf("Workflow \"%s\"", name),
+		label: fmt.Sprintf("%s \"%s\"", wfType, name),
 	}
 	var preIndex, testIndex, postIndex int
 	if len(workflow.Pre) == 0 {
@@ -167,8 +167,8 @@ func workflowDotFile(name string, workflows registry.WorkflowByName, chains regi
 	return writeDotFile(mainGraph)
 }
 
-func WorkflowGraph(name string, workflows registry.WorkflowByName, chains registry.ChainByName) ([]byte, error) {
-	return renderDotFile(workflowDotFile(name, workflows, chains))
+func WorkflowGraph(name string, workflows registry.WorkflowByName, chains registry.ChainByName, wfType string) ([]byte, error) {
+	return renderDotFile(workflowDotFile(name, workflows, chains, wfType))
 }
 
 func chainDotFile(name string, chains registry.ChainByName) string {
@@ -256,10 +256,15 @@ func writeDotFile(mainGraph graph) string {
 			attrs = append(attrs, fmt.Sprintf("lhead=cluster_%d", edge.dst))
 		}
 		builder.WriteString(fmt.Sprintf("%s%d -> %d ", indentPrefix, srcNode, dstNode))
-		if len(attrs) == 1 {
-			builder.WriteString(fmt.Sprintf("[%s]", attrs[0]))
-		} else if len(attrs) == 2 {
-			builder.WriteString(fmt.Sprintf("[%s %s minlen=2]", attrs[0], attrs[1]))
+		if len(attrs) > 0 {
+			builder.WriteString(fmt.Sprintf("[%s", attrs[0]))
+			if len(attrs) > 1 {
+				builder.WriteString(fmt.Sprintf(" %s", attrs[1]))
+			}
+			if edge.dstType == subgraphType {
+				builder.WriteString(" minlen=2")
+			}
+			builder.WriteString("]")
 		}
 		builder.WriteString(";\n")
 	}

--- a/pkg/webreg/graphviz_test.go
+++ b/pkg/webreg/graphviz_test.go
@@ -108,7 +108,7 @@ func TestWorkflowDotFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to load registry: %v", err)
 	}
-	ipi := workflowDotFile("ipi", workflows, chains)
+	ipi := workflowDotFile("ipi", workflows, chains, workflowType)
 	if ipi != ipiWorkflow {
 		t.Errorf("Generated dot file for ipi differs from expected: %s", diff.StringDiff(ipiWorkflow, ipi))
 	}

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -189,7 +189,7 @@ const workflowJobPage = `
 <h2 id="post" title="Steps run by this {{ toLower $type }} to clean up and teardown test resources, in runtime order"><a href="#post">Post Steps</a></h2>
 {{ template "stepTable" .Steps.Post }}
 <h2 id="graph" title="Visual representation of steps run by this {{ toLower $type }}"><a href="#graph">Step Graph</a></h2>
-{{ workflowGraph .As }}
+{{ workflowGraph .As .Type }}
 `
 
 const jobSearchPage = `
@@ -1448,8 +1448,8 @@ func getBaseTemplate(workflows registry.WorkflowByName, chains registry.ChainByN
 				return template.HTML(str)
 			},
 			"toLower": strings.ToLower,
-			"workflowGraph": func(as string) template.HTML {
-				svg, err := WorkflowGraph(as, workflows, chains)
+			"workflowGraph": func(as string, wfType string) template.HTML {
+				svg, err := WorkflowGraph(as, workflows, chains, wfType)
 				if err != nil {
 					return template.HTML(err.Error())
 				}


### PR DESCRIPTION
This makes 2 changes to slightly improve the workflow and job graphs generated for webreg.

1. Dynamically name graph as "Job ..." or "Workflow ..." instead of all jobs being named as workflows.
2. Fix length issues of some arrows between nodes and subgraphs.