### PR TITLE
extract-kubeconfig: update to use oc extract

### DIFF
--- a/hack/extract-kubeconfig.sh
+++ b/hack/extract-kubeconfig.sh
@@ -4,6 +4,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+function cleanup() {
+	for job in $( jobs -p ); do
+		kill -SIGTERM "${job}"
+		wait "${job}"
+	done
+}
+
+trap cleanup EXIT
+
 namespace="${1:-}"
 test="${2:-}"
 if [[ -z "${namespace}" || -z "${test}" ]]; then
@@ -16,31 +25,29 @@ output="$( mktemp -d /tmp/kubeconfig.XXXXX )"
 cat <<EOF >"${output}/extract.sh"
 #!/bin/bash
 
-if [[ "${1}" != "${test}" ]]; then
+if [[ "\${2}" != "${test}" ]]; then
 	# we saw a change to an unrelated secret, nothing to do
 	exit 0
 fi
 
-raw="$( oc get secrets "${test}" --namespace "${namespace}" -o jsonpath="{.data.kubeconfig}" )"
-if [[ -n "${raw}" ]]; then
-	echo -n "${kubeconfig}" | base64 --decode > "${output}/kubeconfig.yaml"
-	echo "\$KUBECONFIG saved to ${output}/kubeconfig.yaml"
+oc extract --namespace "${namespace}" "secret/${test}" --keys=kubeconfig --to="${output}" >/dev/null
+if [[ -s "${output}/kubeconfig" ]]; then
 	exit 0
 fi
-echo "No \$KUBECONFIG for the $test test has been created yet, waiting..."
+echo "No \\\$KUBECONFIG for the ${test} test has been created yet, waiting..." 1>&2
 EOF
 chmod +x "${output}/extract.sh"
 
-oc --namespace "${namespace}" observe secrets -- "${output}/extract.sh" &
+if ! oc --namespace "${namespace}" get secrets >/dev/null; then
+	echo "You do not have permissions to see secrets for this namespace. Did you enter the namespace correctly?"
+	exit 1
+fi
+oc --namespace "${namespace}" observe secrets --no-headers -- "${output}/extract.sh" &
 
 while true; do
-	if [[ -s "${output}/kubeconfig.yaml" ]]; then
+	if [[ -s "${output}/kubeconfig" ]]; then
+		echo "\$KUBECONFIG saved to ${output}/kubeconfig"
 		exit 0
 	fi
 	sleep 1
-done
-
-for job in $( jobs -p ); do
-	kill -SIGTERM "${job}"
-	wait "${job}"
 done


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

New UX:

```
$ hack/extract-kubeconfig.sh ci-op-r680h2s5 e2e-aws
Scanning ci-op-r680h2s5 for the $KUBECONFIG for the e2e-aws test...
Error from server (Forbidden): secrets is forbidden: User "stevekuznetsov" cannot list secrets in the namespace "ci-op-r680h2s5": no RBAC policy matched
You do not have permissions to see secrets for this namespace. Did you enter the namespace correctly?
```

```
$ hack/extract-kubeconfig.sh ci-op-r680h2s5 e2e-aws
Scanning ci-op-r680h2s5 for the $KUBECONFIG for the e2e-aws test...
No $KUBECONFIG for the e2e-aws test has been created yet, waiting...
^C
```

```
$ hack/extract-kubeconfig.sh ci-op-s6xflhby e2e-aws
Scanning ci-op-s6xflhby for the $KUBECONFIG for the e2e-aws test...
$KUBECONFIG saved to /tmp/kubeconfig.CUvcC/kubeconfig
```

/assign @smarterclayton 