### PR TITLE
ci-operator: require basic auth for result aggregator

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -53,13 +53,9 @@ func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, err
 	if o.address == "" {
 		return &noopReporter{}, nil
 	}
-	var password string
-	if o.password != "" {
-		raw, err := ioutil.ReadFile(o.password)
-		if err != nil {
-			return nil, err
-		}
-		password = string(raw)
+	raw, err := ioutil.ReadFile(o.password)
+	if err != nil {
+		return nil, err
 	}
 	return &reporter{
 		spec:        spec,
@@ -67,7 +63,7 @@ func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, err
 		consoleHost: consoleHost,
 		client:      &http.Client{},
 		username:    o.username,
-		password:    password,
+		password:    string(raw),
 	}, nil
 }
 


### PR DESCRIPTION
Depends on #781 and NYI work to populate the fields,

/hold