### PR TITLE
prowgen: add custom secret to custom test image

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -773,6 +773,7 @@ type OpenshiftInstallerCustomTestImageClusterTestConfiguration struct {
 	From             string `json:"from"`
 	EnableNestedVirt bool   `json:"enable_nested_virt,omitempty"`
 	NestedVirtImage  string `json:"nested_virt_image,omitempty"`
+	CustomSecretName string `json:"custom_secret_name,omitempty"`
 }
 
 // OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration describes a

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -375,6 +375,13 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 					corev1.EnvVar{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: conf.NestedVirtImage})
 			}
 		}
+		customSecretName := "empty-secret"
+		if conf.CustomSecretName != "" {
+			customSecretName = conf.CustomSecretName
+		}
+		container.Env = append(
+			container.Env,
+			corev1.EnvVar{Name: "CUSTOM_SECRET_NAME", Value: customSecretName})
 	}
 	return podSpec
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -732,6 +732,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
 						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "true"},
 						{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: "nested-virt-image-name"},
+						{Name: "CUSTOM_SECRET_NAME", Value: "empty-secret"},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 
@@ -755,6 +756,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
 					EnableNestedVirt:         true,
+					CustomSecretName:         "custom-secret",
 				},
 			},
 
@@ -844,6 +846,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "TEST_COMMAND", Value: "commands"},
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
 						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "true"},
+						{Name: "CUSTOM_SECRET_NAME", Value: "custom-secret"},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 
@@ -956,6 +959,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
+						{Name: "CUSTOM_SECRET_NAME", Value: "empty-secret"},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 
@@ -1066,6 +1070,7 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 						{Name: "JOB_NAME_SAFE", Value: "test"},
 						{Name: "TEST_COMMAND", Value: "commands"},
 						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
+						{Name: "CUSTOM_SECRET_NAME", Value: "empty-secret"},
 					},
 					VolumeMounts: []corev1.VolumeMount{
 


### PR DESCRIPTION
In some cases, we need to use secrets during e2e tests. For example,
when we pull pre-released images from a private registry. To support
this use case, the custom test image template now accepts a
`custom_secret_name` parameter that allows users to specify a name of a
secret to mount to the custom test pod.

For users who don't specify it, a default empty secret will be used and
mounted to their test pod. This will have no effects on the tests pod.

Signed-off-by: Daniel Belenky <dbelenky@redhat.com>