### PR TITLE
[ci-operator-config-mirror] allow the tool to delete the existing but deprecated configs 

### DIFF
--- a/test/integration/ci-operator-config-mirror.sh
+++ b/test/integration/ci-operator-config-mirror.sh
@@ -2,15 +2,23 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
-suite_dir="${OS_ROOT}/test/integration/ci-operator-config-mirror/"
+suite_dir="${OS_ROOT}/test/integration/ci-operator-config-mirror"
 cp -r "${suite_dir}/input" "${BASETMPDIR}"
+cp -r "${suite_dir}/input-to-clean" "${BASETMPDIR}"
+
 actual="${BASETMPDIR}/input"
+actual_to_clean="${BASETMPDIR}/input-to-clean"
+
 expected="${suite_dir}/output"
 
 os::test::junit::declare_suite_start "integration/ci-operator-config-mirror"
 # This test validates the ci-operator-config-mirror tool
 
-os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual} --whitelist-file ${suite_dir}/whitelist.yaml"
+os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual} --clean=false --whitelist-file ${suite_dir}/whitelist.yaml"
 os::integration::compare "${actual}" "${expected}"
+
+os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual_to_clean} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
+os::integration::compare "${actual_to_clean}" "${expected}"
+
 
 os::test::junit::declare_suite_end

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/bar/foo-bar-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/bar/foo-bar-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: foo
+  repo: bar

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-master.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10    
+images:
+- from: base
+  to: test-image
+promotion:
+  name: satin-soul  
+  namespace: non-ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -1,0 +1,39 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/foo/barry-white
+images:
+- from: base
+  to: test-image
+promotion:
+  disabled: true
+  name: satin-soul
+  namespace: non-ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: ""
+  org: super-priv
+  repo: ""

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/foo/barry-white
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: ""
+  org: super-priv
+  repo: ""

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/deprecated-repo/super-priv-deprecated-repo-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/deprecated-repo/super-priv-deprecated-repo-master.yaml
@@ -1,0 +1,43 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: ocp
+    tag: os
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/duper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: duper

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/duper/super-priv-duper-master.yaml
@@ -1,0 +1,43 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: ocp
+    tag: os
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/duper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: duper

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-deprecated.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-deprecated.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/trooper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: trooper

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-master.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/trooper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: trooper

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
@@ -1,0 +1,42 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: ocp
+    tag: os
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/trooper/super-trooper-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper


### PR DESCRIPTION
Introduces a map by repo with their data. Two methods will be responsible to clean up and generate the data.
Adds a `--clean` flag, and default it to true.

/cc @petr-muller @stevekuznetsov @openshift/openshift-team-developer-productivity-test-platform 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
