### PR TITLE
autoowners: Add signoff to git commit message if requested.

### DIFF
--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -173,6 +173,29 @@ func TestGetTitle(t *testing.T) {
 	}
 }
 
+func TestGetCommitMessage(t *testing.T) {
+	const blankMessage = "Sync OWNERS files"
+
+	result := getCommitMessage(blankMessage, options{gitSignoff: false})
+	if blankMessage != result {
+		t.Errorf("message '%s' differs from expected '%s'", result, blankMessage)
+	}
+
+	const name = "John Doe"
+	const email = "jdoe@example.org"
+	o := options{
+		gitSignoff: true,
+		gitName:    name,
+		gitEmail:   email,
+	}
+	expect := blankMessage + "\n\nSigned-off-by: " + name + " <" + email + ">"
+	result = getCommitMessage(blankMessage, o)
+
+	if expect != result {
+		t.Errorf("message '%s' differs from expected '%s'", result, expect)
+	}
+}
+
 func TestGetBody(t *testing.T) {
 	expect := `The OWNERS file has been synced for the following folder(s):
 


### PR DESCRIPTION
When the repository the PR is created against is configured to use the [dco plugin](https://github.com/kubernetes/test-infra/blob/master/prow/plugins/dco/dco.go#L80), the check fails because the commit is missing the signoff that is required by dco.

This PR adds the signoff.

Fixes #787 