### PR TITLE
c-o-config-mirror: dont disable promotion for official image repos on whitelist

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -97,7 +97,7 @@ func main() {
 		}
 
 		if rbc.PromotionConfiguration != nil {
-			if o.WhitelistConfig.IsWhitelisted(repoInfo) {
+			if !promotion.BuildsOfficialImages(rbc) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
 				logger.Warn("Repo is whitelisted. Disable promotion...")
 				rbc.PromotionConfiguration.Disabled = true
 			}

--- a/test/ci-operator-config-mirror-integration/data/input/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/ci-operator-config-mirror-integration/data/input/foo/barry-white/foo-barry-white-official.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-operator-config-mirror-integration/data/output/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/foo/barry-white/foo-barry-white-official.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/ci-operator-config-mirror-integration/data/output/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/ci-operator-config-mirror-integration/data/output/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/foo/barry-white
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: ""
+  org: super-priv
+  repo: ""


### PR DESCRIPTION
For repos that are both whitelisted and have official images we must not
disable promotion (they would be included even if not whitelisted, and they would not disable promotion in such case)

/cc @droslean 