### PR TITLE
ci-operator multi-stage: make profile need release

### DIFF
--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -74,7 +74,7 @@ func (p *DeferredParameters) Map() (map[string]string, error) {
 		}
 		v, err := fn()
 		if err != nil {
-			return nil, fmt.Errorf("could not lazily evaluate deferred parameter: %v", err)
+			return nil, fmt.Errorf("could not lazily evaluate deferred parameter %q: %v", k, err)
 		}
 		p.values[k] = v
 		m[k] = v
@@ -154,7 +154,7 @@ func (p *DeferredParameters) Get(name string) (string, error) {
 	if fn, ok := p.fns[name]; ok {
 		value, err := fn()
 		if err != nil {
-			return "", fmt.Errorf("could not lazily evaluate deferred parameter: %v", err)
+			return "", fmt.Errorf("could not lazily evaluate deferred parameter %q: %v", name, err)
 		}
 		p.values[name] = value
 		return value, nil

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -174,13 +174,14 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 			needsRelease = true
 		}
 	}
-	if needsRelease {
-		ret = append(ret, api.ReleaseImagesLink())
-	}
 	if s.profile != "" {
+		needsRelease = true
 		for _, env := range envForProfile {
 			ret = append(ret, s.params.Links(env)...)
 		}
+	}
+	if needsRelease {
+		ret = append(ret, api.ReleaseImagesLink())
 	}
 	return
 }

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -52,7 +52,11 @@ func TestRequires(t *testing.T) {
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			step := multiStageTestStep{config: &tc.config, test: tc.steps}
+			step := MultiStageTestStep(api.TestStepConfiguration{
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Test: tc.steps,
+				},
+			}, &tc.config, nil, nil, nil, nil, nil, "", nil, nil)
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true
@@ -374,21 +378,6 @@ func (e *fakePodExecutor) AddReactors(cs *fake.Clientset) {
 }
 
 func TestRun(t *testing.T) {
-	step := multiStageTestStep{
-		name:   "test",
-		config: &api.ReleaseBuildConfiguration{},
-		jobSpec: &api.JobSpec{
-			JobSpec: prowdapi.JobSpec{
-				Job:       "job",
-				BuildID:   "build_id",
-				ProwJobID: "prow_job_id",
-				Type:      prowapi.PeriodicJob,
-			},
-		},
-		pre:  []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
-		test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-		post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
-	}
 	for _, tc := range []struct {
 		name     string
 		failures sets.String
@@ -428,21 +417,35 @@ func TestRun(t *testing.T) {
 			fakecs := fake.NewSimpleClientset()
 			executor := fakePodExecutor{failures: tc.failures}
 			executor.AddReactors(fakecs)
+			name := "test"
 			client := fakecs.CoreV1()
-			step.podClient = &fakePodClient{NewPodClient(client, nil, nil)}
-			step.secretClient = client
-			step.saClient = client
-			step.rbacClient = fakecs.RbacV1()
+			jobSpec := api.JobSpec{
+				Namespace: "ns",
+				JobSpec: prowdapi.JobSpec{
+					Job:       "job",
+					BuildID:   "build_id",
+					ProwJobID: "prow_job_id",
+					Type:      prowapi.PeriodicJob,
+				},
+			}
+			step := MultiStageTestStep(api.TestStepConfiguration{
+				As: name,
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:  []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
+				},
+			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), "", &jobSpec, nil)
 			if err := step.Run(context.Background(), false); tc.failures == nil && err != nil {
 				t.Error(err)
 				return
 			}
-			secrets, err := step.secretClient.Secrets(step.jobSpec.Namespace).List(meta.ListOptions{})
+			secrets, err := client.Secrets(jobSpec.Namespace).List(meta.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return
 			}
-			if l := secrets.Items; len(l) != 1 || l[0].ObjectMeta.Name != step.name {
+			if l := secrets.Items; len(l) != 1 || l[0].ObjectMeta.Name != name {
 				t.Errorf("unexpected secrets: %#v", l)
 			}
 			var names []string
@@ -463,37 +466,34 @@ func TestArtifacts(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 	ns := "namespace"
-	step := multiStageTestStep{
-		name:        "test",
-		artifactDir: tmp,
-		config:      &api.ReleaseBuildConfiguration{},
-		jobSpec: &api.JobSpec{
-			Namespace: ns,
-			JobSpec: prowdapi.JobSpec{
-				Job:       "job",
-				BuildID:   "build_id",
-				ProwJobID: "prow_job_id",
-				Type:      prowapi.PeriodicJob,
-			},
-		},
-		test: []api.LiteralTestStep{
-			{As: "test0", ArtifactDir: "/path/to/artifacts"},
-			{As: "test1", ArtifactDir: "/path/to/artifacts"},
-		},
-	}
 	fakecs := fake.NewSimpleClientset()
 	executor := fakePodExecutor{}
 	executor.AddReactors(fakecs)
 	client := fakecs.CoreV1()
-	step.podClient = &fakePodClient{NewPodClient(client, nil, nil)}
-	step.secretClient = client
-	step.saClient = client
-	step.rbacClient = fakecs.RbacV1()
+	jobSpec := api.JobSpec{
+		Namespace: ns,
+		JobSpec: prowdapi.JobSpec{
+			Job:       "job",
+			BuildID:   "build_id",
+			ProwJobID: "prow_job_id",
+			Type:      prowapi.PeriodicJob,
+		},
+	}
+	testName := "test"
+	step := MultiStageTestStep(api.TestStepConfiguration{
+		As: testName,
+		MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+			Test: []api.LiteralTestStep{
+				{As: "test0", ArtifactDir: "/path/to/artifacts"},
+				{As: "test1", ArtifactDir: "/path/to/artifacts"},
+			},
+		},
+	}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), tmp, &jobSpec, nil)
 	if err := step.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}
 	for _, x := range []string{"test0", "test1"} {
-		if _, err := os.Stat(filepath.Join(tmp, x)); err != nil {
+		if _, err := os.Stat(filepath.Join(tmp, testName, x)); err != nil {
 			t.Fatalf("error verifying output directory %q exists: %v", x, err)
 		}
 	}
@@ -549,32 +549,28 @@ func TestJUnit(t *testing.T) {
 			executor := fakePodExecutor{failures: tc.failures}
 			executor.AddReactors(fakecs)
 			client := fakecs.CoreV1()
-			step := multiStageTestStep{
-				name:   "test",
-				config: &api.ReleaseBuildConfiguration{},
-				jobSpec: &api.JobSpec{
-					JobSpec: prowdapi.JobSpec{
-						Job:       "job",
-						BuildID:   "build_id",
-						ProwJobID: "prow_job_id",
-						Type:      prowapi.PeriodicJob,
-					},
+			jobSpec := api.JobSpec{
+				JobSpec: prowdapi.JobSpec{
+					Job:       "job",
+					BuildID:   "build_id",
+					ProwJobID: "prow_job_id",
+					Type:      prowapi.PeriodicJob,
 				},
-				pre:  []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
-				test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-				post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
 			}
-			step.podClient = &fakePodClient{NewPodClient(fakecs.CoreV1(), nil, nil)}
-			step.secretClient = client
-			step.saClient = client
-			step.rbacClient = fakecs.RbacV1()
-			step.artifactDir = "/dev/null"
+			step := MultiStageTestStep(api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:  []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
+				},
+			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), "/dev/null", &jobSpec, nil)
 			if err := step.Run(context.Background(), false); tc.failures == nil && err != nil {
 				t.Error(err)
 				return
 			}
 			var names []string
-			for _, t := range step.SubTests() {
+			for _, t := range step.(subtestReporter).SubTests() {
 				names = append(names, t.Name)
 			}
 			if !reflect.DeepEqual(names, tc.expected) {


### PR DESCRIPTION
Effectively for correctness only.  This has worked so far because every E2E
test also uses images from `stable`, which adds the same dependency.