### PR TITLE
cleanup: stop setting default values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,6 @@ integration:
 	# legacy, so we don't break them
 	test/prowgen-integration/run.sh
 	test/repo-init-integration/run.sh
-	test/validate-prowgen-breaking-changes.sh
 	test/ci-operator-integration/multi-stage/run.sh
 	test/ci-operator-integration/base/run.sh
 	test/secret-wrapper-integration.sh

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -34,8 +34,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -37,8 +37,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
@@ -14,8 +14,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -72,8 +70,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -75,8 +73,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -72,8 +70,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/hack/lib/integration.sh
+++ b/hack/lib/integration.sh
@@ -17,8 +17,12 @@ function os::integration::compare() {
     local expected="$2"
 
     if [[ "${UPDATE:-false}" == "true" ]]; then
-        os::log::info "Updating golden files in ${actual}..."
-        cp -r "${expected}" "${actual}"
+        os::log::info "Updating golden files in ${expected}..."
+        if [[ -d "${actual}" ]]; then
+            cp -a "${actual}/." "${expected}"
+        else
+            cp "${actual}" "${expected}"
+        fi
     fi
 
     os::cmd::expect_success "diff -Naupr --ignore-matching-lines 'startTime' --ignore-matching-lines 'name: \w\{8\}\(-\w\{4\}\)\{3\}-\w\{12\}' --ignore-matching-lines 'sha: \w\{40\}' ${actual} ${expected}"

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -214,8 +214,6 @@ func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secre
 	ret := generatePodSpec(info, secrets)
 	ret.Containers[0].Command = []string{"ci-operator"}
 	ret.Containers[0].Args = append([]string{
-		"--give-pr-author-access-to-namespace=true",
-		"--artifact-dir=$(ARTIFACTS)",
 		"--kubeconfig=/etc/apici/kubeconfig",
 		"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 		"--report-username=ci",

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -49,8 +49,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -102,8 +100,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -157,8 +153,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -220,8 +214,6 @@ func TestGeneratePodSpec(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -278,8 +270,6 @@ func TestGeneratePodSpec(t *testing.T) {
 						ImagePullPolicy: corev1.PullAlways,
 						Command:         []string{"ci-operator"},
 						Args: []string{
-							"--give-pr-author-access-to-namespace=true",
-							"--artifact-dir=$(ARTIFACTS)",
 							"--kubeconfig=/etc/apici/kubeconfig",
 							"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 							"--report-username=ci",
@@ -394,8 +384,6 @@ func TestGeneratePodSpecMultiStage(t *testing.T) {
 			ImagePullPolicy: corev1.PullAlways,
 			Command:         []string{"ci-operator"},
 			Args: []string{
-				"--give-pr-author-access-to-namespace=true",
-				"--artifact-dir=$(ARTIFACTS)",
 				"--kubeconfig=/etc/apici/kubeconfig",
 				"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 				"--report-username=ci",
@@ -501,8 +489,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -600,8 +586,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -711,8 +695,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -824,8 +806,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -937,8 +917,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",
@@ -1047,8 +1025,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ImagePullPolicy: corev1.PullAlways,
 					Command:         []string{"ci-operator"},
 					Args: []string{
-						"--give-pr-author-access-to-namespace=true",
-						"--artifact-dir=$(ARTIFACTS)",
 						"--kubeconfig=/etc/apici/kubeconfig",
 						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 						"--report-username=ci",

--- a/test/integration/ci-operator-prowgen.sh
+++ b/test/integration/ci-operator-prowgen.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+function cleanup() {
+    os::test::junit::reconcile_output
+    os::cleanup::processes
+}
+trap "cleanup" EXIT
+
+suite_dir="${OS_ROOT}/test/prowgen-integration/"
+input_config_dir="${suite_dir}/data/input/config"
+input_jobs_dir="${suite_dir}/data/input/jobs"
+actual="${BASETMPDIR}/jobs"
+mkdir -p "${actual}"
+# we need to seed this with the input data as we operate "in place"
+cp -a "${input_jobs_dir}/." "${actual}"
+expected="${suite_dir}/data/output/jobs"
+
+os::test::junit::declare_suite_start "integration/ci-operator-prowgen"
+# This test validates the ci-operator-prowgen tool
+
+os::cmd::expect_success "ci-operator-prowgen --from-dir ${input_config_dir} --to-dir ${actual}"
+os::integration::compare "${actual}" "${expected}"
+
+os::test::junit::declare_suite_end

--- a/test/integration/ci-operator-prowgen.sh
+++ b/test/integration/ci-operator-prowgen.sh
@@ -7,19 +7,16 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
-suite_dir="${OS_ROOT}/test/prowgen-integration/"
-input_config_dir="${suite_dir}/data/input/config"
-input_jobs_dir="${suite_dir}/data/input/jobs"
+suite_dir="${OS_ROOT}/test/prowgen-integration/data"
 actual="${BASETMPDIR}/jobs"
 mkdir -p "${actual}"
 # we need to seed this with the input data as we operate "in place"
-cp -a "${input_jobs_dir}/." "${actual}"
-expected="${suite_dir}/data/output/jobs"
+cp -a "${suite_dir}/input/jobs/." "${actual}"
 
 os::test::junit::declare_suite_start "integration/ci-operator-prowgen"
 # This test validates the ci-operator-prowgen tool
 
-os::cmd::expect_success "ci-operator-prowgen --from-dir ${input_config_dir} --to-dir ${actual}"
-os::integration::compare "${actual}" "${expected}"
+os::cmd::expect_success "ci-operator-prowgen --from-dir ${suite_dir}/input/config --to-dir ${actual}"
+os::integration::compare "${actual}" "${suite_dir}/output/jobs"
 
 os::test::junit::declare_suite_end

--- a/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -16,8 +16,6 @@ periodics:
   spec:
     containers:
     - args:
-      - --artifact-dir=$(ARTIFACTS)
-      - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
       - --oauth-token-path=/usr/local/github-credentials/oauth

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -15,8 +15,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth

--- a/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
@@ -107,8 +105,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
@@ -172,8 +168,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth

--- a/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -15,8 +15,6 @@ periodics:
   spec:
     containers:
     - args:
-      - --artifact-dir=$(ARTIFACTS)
-      - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
       - --report-password-file=/etc/report/password.txt
@@ -94,8 +92,6 @@ periodics:
   spec:
     containers:
     - args:
-      - --artifact-dir=$(ARTIFACTS)
-      - --give-pr-author-access-to-namespace=true
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
       - --kubeconfig=/etc/apici/kubeconfig
       - --report-password-file=/etc/report/password.txt

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -14,8 +14,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote
@@ -76,8 +74,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -102,8 +100,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -169,8 +165,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -225,8 +219,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -283,8 +275,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -343,8 +333,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -14,8 +14,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/prowgen-integration/data/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -16,8 +16,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -83,8 +81,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -139,8 +135,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -15,8 +15,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -74,8 +72,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -15,8 +15,6 @@ postsubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --promote

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -76,8 +74,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -18,8 +18,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -17,8 +17,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -74,8 +72,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
@@ -163,8 +159,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
@@ -252,8 +246,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
@@ -309,8 +301,6 @@ presubmits:
     spec:
       containers:
       - args:
-        - --artifact-dir=$(ARTIFACTS)
-        - --give-pr-author-access-to-namespace=true
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt


### PR DESCRIPTION
make: don't check breaking changes in integration

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hack: be more intelligent on updates

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

test: migrate the prowgen integration test

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator-prowgen: stop setting default values

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 