### PR TITLE
rehearse,registry: make explicit maps for type in NodeByName

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -183,7 +183,7 @@ func rehearseMain() error {
 		affectedJobs = jobs
 	}
 
-	var changedRegistrySteps registry.NodeByName
+	var changedRegistrySteps []registry.Node
 	var refs registry.ReferenceByName
 	var chains registry.ChainByName
 	var workflows registry.WorkflowByName
@@ -214,8 +214,8 @@ func rehearseMain() error {
 	}
 	if len(changedRegistrySteps) != 0 {
 		var names []string
-		for step := range changedRegistrySteps {
-			names = append(names, step)
+		for _, step := range changedRegistrySteps {
+			names = append(names, step.Name())
 		}
 		logger.Infof("found %d changed registry steps: %s", len(changedRegistrySteps), strings.Join(names, ", "))
 	}

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -16,14 +16,23 @@ var ipiInstall = "ipi-install"
 var ipiDeprovision = "ipi-deprovision"
 var ipi = "ipi"
 var nested = "nested"
+var ipiConf = "ipi-conf"
+var ipiConfAWS = "ipi-conf-aws"
 
 var referenceMap = ReferenceByName{
 	ipiInstallInstall:         {},
 	ipiInstallRBAC:            {},
 	ipiDeprovisionDeprovision: {},
 	ipiDeprovisionMustGather:  {},
+	ipiConf:                   {},
+	ipiConfAWS:                {},
 }
 var chainMap = ChainByName{
+	ipiConfAWS: {{
+		Reference: &ipiConf,
+	}, {
+		Reference: &ipiConfAWS,
+	}},
 	ipiInstall: {{
 		Reference: &ipiInstallInstall,
 	}, {
@@ -94,6 +103,12 @@ func TestAncestors(t *testing.T) {
 			&chainNode{nodeWithName: nodeWithName{name: ipiDeprovision}},
 			&chainNode{nodeWithName: nodeWithName{name: nested}},
 		},
+	}, {
+		name:     ipiConfAWS,
+		nodeType: Reference,
+		expected: []Node{
+			&chainNode{nodeWithName: nodeWithName{name: ipiConfAWS}},
+		},
 	}}
 
 	graph, err := NewGraph(referenceMap, chainMap, workflowMap)
@@ -153,6 +168,13 @@ func TestDescendants(t *testing.T) {
 			&chainNode{nodeWithName: nodeWithName{name: ipiDeprovision}},
 			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionMustGather}},
 			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionDeprovision}},
+		},
+	}, {
+		name:     ipiConfAWS,
+		nodeType: Chain,
+		expected: []Node{
+			&referenceNode{nodeWithName: nodeWithName{name: ipiConfAWS}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiConf}},
 		},
 	}}
 

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // These maps contain the representation of ../../test/multistage-registry/registry with the
@@ -16,6 +15,7 @@ var ipiDeprovisionDeprovision = "ipi-deprovision-deprovision"
 var ipiInstall = "ipi-install"
 var ipiDeprovision = "ipi-deprovision"
 var ipi = "ipi"
+var nested = "nested"
 
 var referenceMap = ReferenceByName{
 	ipiInstallInstall:         {},
@@ -34,6 +34,11 @@ var chainMap = ChainByName{
 	}, {
 		Reference: &ipiDeprovisionDeprovision,
 	}},
+	nested: {{
+		Chain: &ipiInstall,
+	}, {
+		Chain: &ipiDeprovision,
+	}},
 }
 var workflowMap = WorkflowByName{
 	ipi: {
@@ -46,23 +51,48 @@ var workflowMap = WorkflowByName{
 	},
 }
 
-func TestAncestorNames(t *testing.T) {
+func nodesEqual(x, y []Node) bool {
+	if len(x) != len(y) {
+		return false
+	}
+	for _, xNode := range x {
+		found := false
+		for _, yNode := range y {
+			if xNode.Name() == yNode.Name() && xNode.Type() == yNode.Type() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestAncestors(t *testing.T) {
 	testCases := []struct {
-		name string
-		set  sets.String
+		name     string
+		nodeType Type
+		expected []Node
 	}{{
-		name: ipi,
-		set:  sets.String{},
+		name:     ipi,
+		nodeType: Workflow,
+		expected: []Node{},
 	}, {
-		name: ipiInstall,
-		set: sets.String{
-			ipi: sets.Empty{},
+		name:     ipiInstall,
+		nodeType: Chain,
+		expected: []Node{
+			&workflowNode{nodeWithName: nodeWithName{name: ipi}},
+			&chainNode{nodeWithName: nodeWithName{name: nested}},
 		},
 	}, {
-		name: ipiDeprovisionMustGather,
-		set: sets.String{
-			ipi:            sets.Empty{},
-			ipiDeprovision: sets.Empty{},
+		name:     ipiDeprovisionMustGather,
+		nodeType: Reference,
+		expected: []Node{
+			&workflowNode{nodeWithName: nodeWithName{name: ipi}},
+			&chainNode{nodeWithName: nodeWithName{name: ipiDeprovision}},
+			&chainNode{nodeWithName: nodeWithName{name: nested}},
 		},
 	}}
 
@@ -71,36 +101,59 @@ func TestAncestorNames(t *testing.T) {
 		t.Fatalf("failed to create graph: %v", err)
 	}
 	for _, testCase := range testCases {
-		node := graph[testCase.name]
-		if !testCase.set.Equal(node.AncestorNames()) {
+		var node Node
+		switch testCase.nodeType {
+		case Reference:
+			node = graph.References[testCase.name]
+		case Chain:
+			node = graph.Chains[testCase.name]
+		case Workflow:
+			node = graph.Workflows[testCase.name]
+		}
+		if !nodesEqual(node.Ancestors(), testCase.expected) {
 			t.Errorf("%s: ancestor sets not equal", testCase.name)
 		}
 	}
 }
 
-func TestDescendantNames(t *testing.T) {
+func TestDescendants(t *testing.T) {
 	testCases := []struct {
-		name string
-		set  sets.String
+		name     string
+		nodeType Type
+		expected []Node
 	}{{
-		name: ipi,
-		set: sets.String{
-			ipiInstall:                sets.Empty{},
-			ipiInstallInstall:         sets.Empty{},
-			ipiInstallRBAC:            sets.Empty{},
-			ipiDeprovision:            sets.Empty{},
-			ipiDeprovisionMustGather:  sets.Empty{},
-			ipiDeprovisionDeprovision: sets.Empty{},
+		name:     ipi,
+		nodeType: Workflow,
+		expected: []Node{
+			&chainNode{nodeWithName: nodeWithName{name: ipiInstall}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallInstall}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallRBAC}},
+			&chainNode{nodeWithName: nodeWithName{name: ipiDeprovision}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionMustGather}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionDeprovision}},
 		},
 	}, {
-		name: ipiInstall,
-		set: sets.String{
-			ipiInstallInstall: sets.Empty{},
-			ipiInstallRBAC:    sets.Empty{},
+		name:     ipiInstall,
+		nodeType: Chain,
+		expected: []Node{
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallInstall}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallRBAC}},
 		},
 	}, {
-		name: ipiDeprovisionMustGather,
-		set:  sets.String{},
+		name:     ipiDeprovisionMustGather,
+		nodeType: Reference,
+		expected: []Node{},
+	}, {
+		name:     nested,
+		nodeType: Chain,
+		expected: []Node{
+			&chainNode{nodeWithName: nodeWithName{name: ipiInstall}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallInstall}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiInstallRBAC}},
+			&chainNode{nodeWithName: nodeWithName{name: ipiDeprovision}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionMustGather}},
+			&referenceNode{nodeWithName: nodeWithName{name: ipiDeprovisionDeprovision}},
+		},
 	}}
 
 	graph, err := NewGraph(referenceMap, chainMap, workflowMap)
@@ -108,8 +161,16 @@ func TestDescendantNames(t *testing.T) {
 		t.Fatalf("failed to create graph: %v", err)
 	}
 	for _, testCase := range testCases {
-		node := graph[testCase.name]
-		if !testCase.set.Equal(node.DescendantNames()) {
+		var node Node
+		switch testCase.nodeType {
+		case Reference:
+			node = graph.References[testCase.name]
+		case Chain:
+			node = graph.Chains[testCase.name]
+		case Workflow:
+			node = graph.Workflows[testCase.name]
+		}
+		if !nodesEqual(node.Descendants(), testCase.expected) {
 			t.Errorf("%s: descendant sets not equal", testCase.name)
 		}
 	}


### PR DESCRIPTION
This changes the `NodeByName` type in `pkg/registry` to have explicit `References`, `Chains`, and `Workflows` fields as well as fixes a bug in the graphs handling of nested chains.

When the registry graph was first designed, it was assumed that nobody would make a chain and reference that have identical names (the `as` fields). This was not enforced in the release repo, however, and it has now become convention to have both a reference and a chain called `{i|u}pi-conf-cluster_type` for every `cluster_type` we support. This meant that the graph would overwrite references with the same names as chains. This could potentially cause a rehearsal to not occur for jobs that use just the reference with said name instead of the chain for whatever reason. It is also simply not ideal to overwrite data unintentionally anyway.

This also fixes a bug where the graph would only be able to nest one child chain per parent chain, even if there were multiple child chains. A new unit test has been added for this case.

/cc @stevekuznetsov 