### PR TITLE
Enable `make pr-deploy` on app.ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ update-integration:
 .PHONY: update-integration
 
 pr-deploy:
-	oc process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml | oc apply -f - --as system:admin
+	oc process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml --as system:admin | oc apply -f - --as system:admin
 	for cm in ci-operator-master-configs step-registry config; do oc get --export configmap $${cm} -n ci -o json | oc create -f - -n ci-tools-$(PULL_REQUEST) --as system:admin; done
 	echo "server is at https://$$( oc get route server -n ci-tools-$(PULL_REQUEST) -o jsonpath={.spec.host} )"
 .PHONY: pr-deploy

--- a/hack/pr-deploy.yaml
+++ b/hack/pr-deploy.yaml
@@ -64,10 +64,6 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-        from:
-          kind: ImageStreamTag
-          namespace: origin
-          name: centos:8
         imageOptimizationPolicy: SkipLayers
       type: Docker
     triggers:
@@ -89,7 +85,7 @@ objects:
         name: "output:binaries"
     source:
       dockerfile: |
-        FROM api.ci.openshift.org/openshift/release:golang-1.13
+        FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
 
         COPY . .
         RUN go install ./cmd/ci-operator-configresolver/...
@@ -100,10 +96,6 @@ objects:
       type: Git
     strategy:
       dockerStrategy:
-        from:
-          kind: ImageStreamTag
-          namespace: openshift
-          name: "release:golang-1.13"
         imageOptimizationPolicy: SkipLayers
       type: Docker
     triggers:


### PR DESCRIPTION
We recently stopped updating `ci-operator-*-configs` CMs on `api.ci`,
and now I would like to remove them entirely. `make pr-deploy` needs
`ci-operator-master-configs` on the same cluster where it deploys, so
let's allow to deploy it on app.ci. Alternatively, we can change the
script to fetch the CM from `app.ci` with `--context app.ci` or
something similar.

- I was not able to `oc process` on app.ci without `--as system:admin`,
  so adding it.
- The replacement base images' imagestreams are not (yet) migrated to
  app.ci. Rather than figuring out what needs to move and what not, I
  disabled the replacements. This does not run often enough for this
  optimization to be crucial.

/cc @stevekuznetsov @AlexNPavel 