### PR TITLE
ci-operator: allow steps to reference external images

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -429,8 +429,20 @@ func validateLiteralTestStep(fieldRoot string, step LiteralTestStep, seen sets.S
 	} else {
 		seen.Insert(step.As)
 	}
-	if len(step.From) == 0 {
-		ret = append(ret, fmt.Errorf("%s: `from` is required", fieldRoot))
+	if len(step.From) == 0 && step.FromImage == nil {
+		ret = append(ret, fmt.Errorf("%s: `from` or `from_image` is required", fieldRoot))
+	} else if len(step.From) != 0 && step.FromImage != nil {
+		ret = append(ret, fmt.Errorf("%s: `from` and `from_image` cannot be set together", fieldRoot))
+	} else if step.FromImage != nil {
+		if step.FromImage.Namespace == "" {
+			ret = append(ret, fmt.Errorf("%s.from_image: `namespace` is required", fieldRoot))
+		}
+		if step.FromImage.Name == "" {
+			ret = append(ret, fmt.Errorf("%s.from_image: `name` is required", fieldRoot))
+		}
+		if step.FromImage.Tag == "" {
+			ret = append(ret, fmt.Errorf("%s.from_image: `tag` is required", fieldRoot))
+		}
 	} else if len(validation.IsDNS1123Subdomain(step.From)) != 0 {
 		ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, step.From))
 	}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -554,7 +554,61 @@ func TestValidateTestSteps(t *testing.T) {
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0]: `from` is required")},
+		errs: []error{errors.New("test[0]: `from` or `from_image` is required")},
+	}, {
+		name: "two images",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:   "no_image",
+				From: "something",
+				FromImage: &ImageStreamTagReference{
+					Namespace: "ns",
+					Name:      "name",
+					Tag:       "tag",
+				},
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0]: `from` and `from_image` cannot be set together")},
+	}, {
+		name: "from_image missing namespace",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As: "no_image",
+				FromImage: &ImageStreamTagReference{
+					Name: "name",
+					Tag:  "tag",
+				},
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from_image: `namespace` is required")},
+	}, {
+		name: "from_image missing name",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As: "no_image",
+				FromImage: &ImageStreamTagReference{
+					Namespace: "ns",
+					Tag:       "tag",
+				},
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from_image: `name` is required")},
+	}, {
+		name: "from_image missing tag",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As: "no_image",
+				FromImage: &ImageStreamTagReference{
+					Namespace: "ns",
+					Name:      "name",
+				},
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from_image: `tag` is required")},
 	}, {
 		name: "invalid image 0",
 		steps: []TestStep{{

--- a/pkg/api/helper/imageextraction_test.go
+++ b/pkg/api/helper/imageextraction_test.go
@@ -30,9 +30,12 @@ func TestGetAllImageStreamTagReturnsAllImageStreamTags(t *testing.T) {
 				// fuzzer a bit from creating unreadable output.
 				func(_ *string, _ fuzz.Continue) {},
 				func(_ *api.ClusterProfile, _ fuzz.Continue) {},
+				// These methods are for reading config from disk, so we can ignore fields
+				// that are only set once the configuration has been resolved by a server
+				func(_ *api.MultiStageTestConfigurationLiteral, _ fuzz.Continue) {},
 			).
 				// Using something else messes up the result, apparently the fuzzer sometimes overwrites the whole
-				// map/slice after insering into it.
+				// map/slice after inserting into it.
 				NumElements(1, 1)
 
 			cfg := load.ByOrgRepo{}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -438,6 +438,8 @@ type LiteralTestStep struct {
 	As string `json:"as,omitempty"`
 	// From is the container image that will be used for this step.
 	From string `json:"from,omitempty"`
+	// FromImage is a literal ImageStreamTag reference to use for this step.
+	FromImage *ImageStreamTagReference `json:"from_image,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
 	// ArtifactDir is the directory from which artifacts will be extracted
@@ -457,6 +459,15 @@ type CredentialReference struct {
 	Name string `json:"name"`
 	// MountPath is where the secret should be mounted.
 	MountPath string `json:"mount_path"`
+}
+
+// FromImageTag returns the internal name for the image tag that will be used
+// for this step, if one is configured.
+func (s *LiteralTestStep) FromImageTag() (PipelineImageStreamTagReference, bool) {
+	if s.FromImage == nil {
+		return "", false
+	}
+	return PipelineImageStreamTagReference(fmt.Sprintf("%s-%s-%s", s.FromImage.Namespace, s.FromImage.Name, s.FromImage.Tag)), true
 }
 
 // TestStep is the struct that a user's configuration gets unmarshalled into.

--- a/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
+++ b/test/ci-operator-integration/multi-stage/configs/master/openshift-hyperkube-master.yaml
@@ -106,6 +106,17 @@ tests:
           memory: "7"
         requests:
           memory: "7"
+    - as: post2
+      from_image:
+        namespace: "ns"
+        name: "image"
+        tag: "latest"
+      commands: post2 command
+      resources:
+        limits:
+          memory: "8"
+        requests:
+          memory: "8"
 zz_generated_metadata:
   org: openshift
   repo: hyperkube

--- a/test/ci-operator-integration/multi-stage/expected/hyperkube.json
+++ b/test/ci-operator-integration/multi-stage/expected/hyperkube.json
@@ -376,6 +376,40 @@
     },
     "metadata": {
       "creationTimestamp": null,
+      "name": "pipeline:ns-image-latest",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "image@",
+        "namespace": "ns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
       "name": "pipeline:root",
       "namespace": "testns"
     },
@@ -756,6 +790,201 @@
             },
             "requests": {
               "memory": "7"
+            }
+          },
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            },
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            },
+            {
+              "mountPath": "/var/run/secrets/ci.openshift.io/multi-stage",
+              "name": "multi-stage"
+            }
+          ]
+        },
+        {
+          "command": [
+            "/bin/sh",
+            "-c",
+            "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
+          ],
+          "image": "busybox",
+          "name": "artifacts",
+          "resources": {},
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/artifacts",
+              "name": "artifacts"
+            }
+          ]
+        }
+      ],
+      "initContainers": [
+        {
+          "args": [
+            "/bin/secret-wrapper",
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "command": [
+            "cp"
+          ],
+          "image": "registry.svc.ci.openshift.org/ci/secret-wrapper:latest",
+          "name": "cp-secret-wrapper",
+          "resources": {},
+          "terminationMessagePolicy": "FallbackToLogsOnError",
+          "volumeMounts": [
+            {
+              "mountPath": "/tmp/secret-wrapper",
+              "name": "secret-wrapper"
+            }
+          ]
+        }
+      ],
+      "restartPolicy": "Never",
+      "serviceAccountName": "multi-stage",
+      "volumes": [
+        {
+          "emptyDir": {},
+          "name": "artifacts"
+        },
+        {
+          "emptyDir": {},
+          "name": "secret-wrapper"
+        },
+        {
+          "name": "multi-stage",
+          "secret": {
+            "secretName": "multi-stage"
+          }
+        }
+      ]
+    },
+    "status": {}
+  },
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "metadata": {
+      "annotations": {
+        "ci-operator.openshift.io/container-sub-tests": "test",
+        "ci-operator.openshift.io/save-container-logs": "true",
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/multi-stage-test": "multi-stage",
+        "ci.openshift.io/refs.branch": "release-4.2",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "installer",
+        "created-by-ci": "true",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration"
+      },
+      "name": "multi-stage-post2"
+    },
+    "spec": {
+      "containers": [
+        {
+          "args": [
+            "/bin/bash",
+            "-c",
+            "#!/bin/bash\nset -eu\npost2 command"
+          ],
+          "command": [
+            "/tmp/secret-wrapper/secret-wrapper"
+          ],
+          "env": [
+            {
+              "name": "BUILD_ID",
+              "value": "0"
+            },
+            {
+              "name": "CI",
+              "value": "true"
+            },
+            {
+              "name": "JOB_NAME",
+              "value": "pull-ci-openshift-release-master-ci-operator-integration"
+            },
+            {
+              "name": "JOB_SPEC",
+              "value": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"installer\",\"base_ref\":\"release-4.2\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+            },
+            {
+              "name": "JOB_TYPE",
+              "value": "presubmit"
+            },
+            {
+              "name": "OPENSHIFT_CI",
+              "value": "true"
+            },
+            {
+              "name": "PROW_JOB_ID",
+              "value": "uuid"
+            },
+            {
+              "name": "PULL_BASE_REF",
+              "value": "release-4.2"
+            },
+            {
+              "name": "PULL_BASE_SHA",
+              "value": "af8a90a2faf965eeda949dc1c607c48d3ffcda3e"
+            },
+            {
+              "name": "PULL_NUMBER",
+              "value": "1234"
+            },
+            {
+              "name": "PULL_PULL_SHA",
+              "value": "538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "PULL_REFS",
+              "value": "release-4.2:af8a90a2faf965eeda949dc1c607c48d3ffcda3e,1234:538680dfd2f6cff3b3506c80ca182dcb0dd22a58"
+            },
+            {
+              "name": "REPO_NAME",
+              "value": "installer"
+            },
+            {
+              "name": "REPO_OWNER",
+              "value": "openshift"
+            },
+            {
+              "name": "ARTIFACT_DIR",
+              "value": "/tmp/artifacts"
+            },
+            {
+              "name": "NAMESPACE",
+              "value": "testns"
+            },
+            {
+              "name": "JOB_NAME_SAFE",
+              "value": "multi-stage"
+            },
+            {
+              "name": "JOB_NAME_HASH",
+              "value": "41093"
+            },
+            {
+              "name": "SHARED_DIR",
+              "value": "/var/run/secrets/ci.openshift.io/multi-stage"
+            }
+          ],
+          "image": "pipeline:ns-image-latest",
+          "name": "test",
+          "resources": {
+            "limits": {
+              "memory": "8"
+            },
+            "requests": {
+              "memory": "8"
             }
           },
           "terminationMessagePolicy": "FallbackToLogsOnError",


### PR DESCRIPTION
A test step from the registry needs to be able to reference an external
image so that it can ship together with the dependencies it needs.
Otherwise, every test configuration that ends up using that test step
will need to update its' `base_images` stanza, which is terrible for UX.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>