### PR TITLE
ci-operator: create a new secret instead of copying

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -276,9 +276,16 @@ func (s *multiStageTestStep) createCredentials() error {
 			if err != nil {
 				return fmt.Errorf("could not read source credential: %v", err)
 			}
-			raw.Namespace = s.jobSpec.Namespace
-			raw.Name = name
-			toCreate[name] = raw
+			toCreate[name] = &coreapi.Secret{
+				TypeMeta: raw.TypeMeta,
+				ObjectMeta: meta.ObjectMeta{
+					Name:      name,
+					Namespace: s.jobSpec.Namespace,
+				},
+				Type:       raw.Type,
+				Data:       raw.Data,
+				StringData: raw.StringData,
+			}
 		}
 	}
 


### PR DESCRIPTION
When copying a secret from one spot to another, we need to be careful to
unset fields like the resource version and self-link. Instead, just copy
over the bits we need and create a new secret.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>