### PR TITLE
[wip] e2e: add a test that mounts and validates a credential

### DIFF
--- a/test/e2e/credentials.sh
+++ b/test/e2e/credentials.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+function cleanup() {
+    os::test::junit::reconcile_output
+    os::cleanup::processes
+}
+trap "cleanup" EXIT
+
+suite_dir="${OS_ROOT}/test/e2e/credentials"
+cp "${suite_dir}/config.yaml" "${BASETMPDIR}"
+
+os::test::junit::declare_suite_start "e2e/credentials"
+# This test validates the ci-operator can mount credentials
+
+export JOB_SPEC='{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]}}'
+# we need to create a credential to mount, and we know we can
+# access secrets in our current namespace, so we'll place it
+# in here for now
+current_namespace="$( oc project --short )"
+sed -i "s/CHANGE_ME/${current_namespace}/" "${BASETMPDIR}/config.yaml"
+os::cmd::expect_success "oc --namespace ${current_namespace} create secret generic credential --from-literal key=value"
+os::cmd::expect_success "ci-operator --target multi-stage-with-credentials --config ${BASETMPDIR}/config.yaml"
+
+os::test::junit::declare_suite_end

--- a/test/e2e/credentials/config.yaml
+++ b/test/e2e/credentials/config.yaml
@@ -1,0 +1,38 @@
+base_images:
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: openshift
+    tag: '7'
+resources:
+  '*':
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 10m  
+tests:
+  - as: multi-stage-with-credentials
+    steps:
+      test:
+        - as: read-and-share
+          commands: cat /credential/key > ${SHARED_DIR}/key
+          credentials:
+            - mountPath: /credential
+              name: credential
+              namespace: CHANGE_ME
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        - as: consume-and-validate
+          commands: test $( cat ${SHARED_DIR}/key ) = value
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+zz_generated_metadata:
+  branch: master
+  org: test
+  repo: test


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Things we need to get this to work:

 - [x] dynamic resolution of user-specified config at runtime https://github.com/openshift/ci-tools/pull/835
 - [ ] `oc` in the e2e test image