### PR TITLE
Promotionreconciler: Stop retrying on requests that get a 404 from GH

### DIFF
--- a/hack/run-dptp-controller-manager.sh
+++ b/hack/run-dptp-controller-manager.sh
@@ -6,7 +6,6 @@ cd $(dirname $0)/..
 CGO_ENABLED=0 go build -v -o /tmp/dptp-cm ./cmd/dptp-controller-manager
 /tmp/dptp-cm \
   --leader-election-namespace=ci \
-  --promotionreconcilerOptions.ignored-github-organization=openshift-priv \
   --ci-operator-config-path="$(go env GOPATH)/src/github.com/openshift/release/ci-operator/config" \
   --config-path="$(go env GOPATH)/src/github.com/openshift/release/core-services/prow/02_config/_config.yaml" \
   --job-config-path="$(go env GOPATH)/src/github.com/openshift/release/ci-operator/jobs" \


### PR DESCRIPTION
The 404 means that either:
* The repo/branch was deleted, so this request can not be reconciled
* We do not have access to this repo, which also means we can not
  reconcile it

The PR also removes the `ignoredGitHubOrganizations`, we instead try
everything and just stop retrying on the 404.

Fixes https://github.com/openshift/release/issues/9283