### PR TITLE
Add openshift-tests run-resourcewatch to ugprades

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -322,9 +322,13 @@ objects:
         }
 
         function run-upgrade-tests() {
+          openshift-tests run-resourcewatch &
+          rw_pid=$!
           openshift-tests run-upgrade "${TEST_SUITE}" --to-image "${IMAGE:-${RELEASE_IMAGE_LATEST}}" \
             --options "${TEST_OPTIONS:-}" \
             --provider "${TEST_PROVIDER:-}" -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit
+          kill $rw_pid
+          tar -cf ${ARTIFACT_DIR}/resourcewatch.tar /repository
         }
 
         function run-tests() {


### PR DESCRIPTION
Copied from https://github.com/openshift/release/pull/9198, we want to run this in 4.x upgrade tests