### PR TITLE
ipi-deprovision: skip 3.11 clusters on GCP based on network's autoCreateSubnetwork

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -31,13 +31,8 @@ echo "deprovisioning clusters with a creationTimestamp before ${gce_cluster_age_
 export CLOUDSDK_CONFIG=/tmp/gcloudconfig
 mkdir -p "${CLOUDSDK_CONFIG}"
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND name~'ci-*'"
+export FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND autoCreateSubnetworks=false AND name~'ci-'"
 for network in $( gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}" --format "value(name)" ); do
-  infraID="${network%"-network"}"
-  if [[ "${#infraID}" -gt 12 ]]; then
-    echo "cluster ${infraID} is a 3.11 cluster, ignoring..."
-    continue
-  fi
   region="$( gcloud --project=openshift-gce-devel-ci compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" || true )"
   if [[ -z "${region:-}" ]]; then
     echo "could not determine region for cluster ${infraID}, ignoring ..."


### PR DESCRIPTION
openshift 4, creates newtorks with autoCreateSubnetworks false, i.e Subnet Mode as Manual where the installer will create the subnets for the cluster.
openshift 3 CI, uses the networks in auto subnet mode automatically createing networks in all the regions.

Filter all the expired Openshift 4 clusters
```
$ FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND autoCreateSubnetworks=false AND name~'ci-'"
$ gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}"
NAME                              SUBNET_MODE  BGP_ROUTING_MODE  IPV4_RANGE  GATEWAY_IPV4
ci-ln-vrrr4pk-f76d1-hxtnc-network   CUSTOM       REGIONAL
ci-op-d8lfy7cb-8eb03-wmtd8-network  CUSTOM       REGIONAL
ci-op-gvj98-network                 CUSTOM       REGIONAL
ci-op-jt9t528f-29898-g5ph9-network  CUSTOM       REGIONAL
ci-op-l5fd9-network                 CUSTOM       REGIONAL
ci-op-lz6icv0p-e18e6                CUSTOM       REGIONAL
ci-op-n7ls5t0i-8eb03-jzgts-network  CUSTOM       REGIONAL
ci-op-rs2db6s9-8eb03-92vnr-network  CUSTOM       REGIONAL
ci-op-vfdth-network                 CUSTOM       REGIONAL
ci-op-vmndxjjf-a5752-ddn8b-network  CUSTOM       REGIONAL
ci-op-vqh9xfzn-92b62-c42wd-network  CUSTOM       REGIONAL
ci-op-vswt4-network                 CUSTOM       REGIONAL
ci-op-wpn4znzs-15937-jvq89-network  CUSTOM       REGIONAL
```

Filter all the expired Openshift 3 clusters
```
$ FILTER="creationTimestamp.date('%Y-%m-%dT%H:%M%z')<${gce_cluster_age_cutoff} AND autoCreateSubnetworks=true AND name~'ci-'"
$ gcloud --project=openshift-gce-devel-ci compute networks list --filter "${FILTER}"
NAME                          SUBNET_MODE  BGP_ROUTING_MODE  IPV4_RANGE  GATEWAY_IPV4
ci-op-jr736pgg-7a04a-network  AUTO         REGIONAL
ci-op-zc17bzy3-7a04a-network  AUTO         REGIONAL
```