### PR TITLE
webreg: allow chains with the same name as a reference be displayed

### DIFF
--- a/pkg/webreg/graphviz.go
+++ b/pkg/webreg/graphviz.go
@@ -203,7 +203,7 @@ func writeSubgraph(mainGraph graph, sg subgraph, index int, indentPrefix string)
 	builder.WriteString(fmt.Sprintf("%slabel=\"%s\";\n", indentPrefix, html.EscapeString(sg.label)))
 	builder.WriteString(fmt.Sprint(indentPrefix, "labeljust=\"l\";\n"))
 	if sg.linkable {
-		builder.WriteString(fmt.Sprintf("%shref=\"/%s/%s\";\n", indentPrefix, "registry", html.EscapeString(sg.label)))
+		builder.WriteString(fmt.Sprintf("%shref=\"/%s/%s\";\n", indentPrefix, "chain", html.EscapeString(sg.label)))
 		builder.WriteString(fmt.Sprint(indentPrefix, bootstrap413monospace, ";\n"))
 	} else {
 		builder.WriteString(fmt.Sprint(indentPrefix, bootstrap413fonts, ";\n"))
@@ -235,7 +235,7 @@ func writeDotFile(mainGraph graph) string {
 	for index, node := range mainGraph.nodes {
 		href := ""
 		if node.linkable {
-			href = fmt.Sprintf(" href=\"/%s/%s\"", "registry", html.EscapeString(node.label))
+			href = fmt.Sprintf(" href=\"/%s/%s\"", "reference", html.EscapeString(node.label))
 		}
 		builder.WriteString(fmt.Sprintf("%s%d [label=\"%s\"%s];\n", indentPrefix, index, node.label, href))
 	}

--- a/pkg/webreg/graphviz_test.go
+++ b/pkg/webreg/graphviz_test.go
@@ -15,11 +15,11 @@ const ipiWorkflow = `digraph Webreg {
 	rankdir=TB;
 	label="Workflow &#34;ipi&#34;";
 
-	0 [label="ipi-install-rbac" href="/registry/ipi-install-rbac"];
-	1 [label="ipi-install-install" href="/registry/ipi-install-install"];
+	0 [label="ipi-install-rbac" href="/reference/ipi-install-rbac"];
+	1 [label="ipi-install-install" href="/reference/ipi-install-install"];
 	2 [label="Intentionally left blank"];
-	3 [label="ipi-deprovision-must-gather" href="/registry/ipi-deprovision-must-gather"];
-	4 [label="ipi-deprovision-deprovision" href="/registry/ipi-deprovision-deprovision"];
+	3 [label="ipi-deprovision-must-gather" href="/reference/ipi-deprovision-must-gather"];
+	4 [label="ipi-deprovision-deprovision" href="/reference/ipi-deprovision-deprovision"];
 
 	0 -> 1 ;
 	3 -> 4 ;
@@ -33,7 +33,7 @@ const ipiWorkflow = `digraph Webreg {
 		subgraph cluster_0 {
 			label="ipi-install";
 			labeljust="l";
-			href="/registry/ipi-install";
+			href="/chain/ipi-install";
 			fontname="SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace";
 			0;
 			1;
@@ -52,7 +52,7 @@ const ipiWorkflow = `digraph Webreg {
 		subgraph cluster_3 {
 			label="ipi-deprovision";
 			labeljust="l";
-			href="/registry/ipi-deprovision";
+			href="/chain/ipi-deprovision";
 			fontname="SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace";
 			3;
 			4;
@@ -67,8 +67,8 @@ const installChain = `digraph Webreg {
 	rankdir=TB;
 	label="Chain &#34;ipi-install&#34;";
 
-	0 [label="ipi-install-rbac" href="/registry/ipi-install-rbac"];
-	1 [label="ipi-install-install" href="/registry/ipi-install-install"];
+	0 [label="ipi-install-rbac" href="/reference/ipi-install-rbac"];
+	1 [label="ipi-install-install" href="/reference/ipi-install-install"];
 
 	0 -> 1 ;
 
@@ -81,8 +81,8 @@ const deprovisionChain = `digraph Webreg {
 	rankdir=TB;
 	label="Chain &#34;ipi-deprovision&#34;";
 
-	0 [label="ipi-deprovision-must-gather" href="/registry/ipi-deprovision-must-gather"];
-	1 [label="ipi-deprovision-deprovision" href="/registry/ipi-deprovision-deprovision"];
+	0 [label="ipi-deprovision-must-gather" href="/reference/ipi-deprovision-must-gather"];
+	1 [label="ipi-deprovision-deprovision" href="/reference/ipi-deprovision-deprovision"];
 
 	0 -> 1 ;
 


### PR DESCRIPTION
This PR fixes an issue where chains with the same name as a reference would not appear in the web UI since the web UI only used names as an identifier.