### PR TITLE
ci-operator: don't wait for release images in templates

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -258,13 +258,15 @@ func (s *templateExecutionStep) SubTests() []*junit.TestCase {
 
 func (s *templateExecutionStep) Requires() []api.StepLink {
 	var links []api.StepLink
+	var needsRelease bool
 	for _, p := range s.template.Parameters {
+		needsRelease = strings.HasPrefix(p.Name, "RELEASE_IMAGE_") || needsRelease
 		if s.params.Has(p.Name) {
 			paramLinks := s.params.Links(p.Name)
 			links = append(links, paramLinks...)
 			continue
 		}
-		if strings.HasPrefix(p.Name, "IMAGE_") {
+		if strings.HasPrefix(p.Name, "IMAGE_") && !needsRelease {
 			links = append(links, api.ReleaseImagesLink())
 			continue
 		}


### PR DESCRIPTION
A template step already knows how to depend on the steps which provide
it with the paramters it needs. Therefore, today templates end up
requiring the release payload steps that create `$RELEASE_IMAGE_foo`.
These steps, in turn, require the suite of release images to be present
if necessary. There is no utlity in requiring those images, again, from
the template itself.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller 