### PR TITLE
ci-operator: multi-stage: require release images only without payload

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -171,13 +171,13 @@ func (s *multiStageTestStep) Description() string {
 }
 
 func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
-	var needsRelease bool
+	var needsReleaseImage, needsReleasePayload bool
 	internalLinks := map[api.PipelineImageStreamTagReference]struct{}{}
 	for _, step := range append(append(s.pre, s.test...), s.post...) {
 		if s.config.IsPipelineImage(step.From) || s.config.BuildsImage(step.From) {
 			internalLinks[api.PipelineImageStreamTagReference(step.From)] = struct{}{}
 		} else {
-			needsRelease = true
+			needsReleaseImage = true
 		}
 
 		if link, ok := step.FromImageTag(); ok {
@@ -188,12 +188,12 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 		ret = append(ret, api.InternalImageLink(link))
 	}
 	if s.profile != "" {
-		needsRelease = true
+		needsReleasePayload = true
 		for _, env := range envForProfile {
 			ret = append(ret, s.params.Links(env)...)
 		}
 	}
-	if needsRelease {
+	if needsReleaseImage && !needsReleasePayload {
 		ret = append(ret, api.ReleaseImagesLink())
 	}
 	return

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -32,11 +32,12 @@ func TestRequires(t *testing.T) {
 		steps  api.MultiStageTestConfigurationLiteral
 		req    []api.StepLink
 	}{{
-		name: "step has a cluster profile, should have ReleaseImagesLink",
+		name: "step has a cluster profile and requires a release image, should not have ReleaseImagesLink",
 		steps: api.MultiStageTestConfigurationLiteral{
 			ClusterProfile: api.ClusterProfileAWS,
+			Test:           []api.LiteralTestStep{{From: "from-release"}},
 		},
-		req: []api.StepLink{api.ReleaseImagesLink()},
+		req: []api.StepLink{},
 	}, {
 		name: "step needs release images, should have ReleaseImagesLink",
 		steps: api.MultiStageTestConfigurationLiteral{


### PR DESCRIPTION
When we require a full release payload, we are guaranteed to get the
release images, as well. We do not need to require both in this case.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>