### PR TITLE
Dptp-controller-manager: Degrade "no promotionconfig found" to trace

### DIFF
--- a/pkg/controller/promotionreconciler/reconciler.go
+++ b/pkg/controller/promotionreconciler/reconciler.go
@@ -158,7 +158,7 @@ func (r *reconciler) reconcile(req controllerruntime.Request, log *logrus.Entry)
 	}
 	if ciOPConfig == nil {
 		// We don't know how to build this
-		log.Debug("No promotionConfig found")
+		log.Trace("No promotionConfig found")
 		return nil
 	}
 


### PR DESCRIPTION
We log this on each and every imagestreamtag event for which we do not
have a config, e.G. all the imagestreamtags generated during tetsts.

During workdays this generates around 60k lines/30 minutes and its not
useful information, hence degrade to Trace which we don't log by
default.