### PR TITLE
Revert "Add openshift-tests run-resourcewatch to ugprades"

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -322,13 +322,9 @@ objects:
         }
 
         function run-upgrade-tests() {
-          openshift-tests run-resourcewatch &
-          rw_pid=$!
           openshift-tests run-upgrade "${TEST_SUITE}" --to-image "${IMAGE:-${RELEASE_IMAGE_LATEST}}" \
             --options "${TEST_OPTIONS:-}" \
             --provider "${TEST_PROVIDER:-}" -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit
-          kill $rw_pid
-          tar -cf ${ARTIFACT_DIR}/resourcewatch.tar /repository
         }
 
         function run-tests() {


### PR DESCRIPTION
Reverts the changes from https://github.com/openshift/ci-tools/pull/845 until this command can
be made available in the 4.4 openshift-tests binary

In recent runs of the test, we see the following error:
```
Error: unknown command "run-resourcewatch" for ""
Run ' --help' for usage.
error: unknown command "run-resourcewatch" for ""
```
(See build log in https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/25040/pull-ci-openshift-origin-release-4.4-e2e-gcp-upgrade/294/ for one example)

The PR to add this command to 4.4 is open at https://github.com/openshift/origin/pull/25042