### PR TITLE
Improve promotionreconcilers logging

### DIFF
--- a/pkg/controller/promotionreconciler/prowjobreconciler/prowjobreconciler.go
+++ b/pkg/controller/promotionreconciler/prowjobreconciler/prowjobreconciler.go
@@ -166,7 +166,7 @@ func (r *reconciler) reconcile(log *logrus.Entry, request controllerruntime.Requ
 		return fmt.Errorf("failed to create prowjob: %w", err)
 	}
 	r.createdJobsCounter.WithLabelValues(orbc.Org, orbc.Repo, orbc.Branch).Inc()
-	log.WithField("name", pj.Name).Info("Successfully created prowjob")
+	log.WithField("name", pj.Name).WithField("job", pj.Spec.Job).Info("Successfully created prowjob")
 
 	// There is some delay until it gets back to our cache, so block until we can retrieve
 	// it successfully.

--- a/pkg/controller/promotionreconciler/reconciler.go
+++ b/pkg/controller/promotionreconciler/reconciler.go
@@ -166,7 +166,6 @@ func (r *reconciler) reconcile(req controllerruntime.Request, log *logrus.Entry)
 	if err != nil {
 		return controllerutil.TerminalError(fmt.Errorf("failed to get ref for imageStreamTag: %w", err))
 	}
-	log = log.WithField("org", istRef.org).WithField("repo", istRef.repo).WithField("branch", istRef.branch)
 
 	currentHEAD, found, err := r.currentHEADForBranch(istRef, log)
 	if err != nil {
@@ -179,7 +178,9 @@ func (r *reconciler) reconcile(req controllerruntime.Request, log *logrus.Entry)
 	if currentHEAD == istRef.commit {
 		return nil
 	}
+	log = log.WithField("org", istRef.org).WithField("repo", istRef.repo).WithField("branch", istRef.branch).WithField("currentHEAD", currentHEAD)
 
+	log.Info("Requesting prowjob creation")
 	r.enqueueJob(prowjobreconciler.OrgRepoBranchCommit{
 		Org:    istRef.org,
 		Repo:   istRef.repo,


### PR DESCRIPTION
Right now its impossible to get back from a prowjob to the imagestreamtag that triggered its creation which makes debugging hard.