### PR TITLE
Dptp-controller-manager: Log in-cluster config loading

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -135,6 +135,7 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatalf("--kubeconfig had no context for '%s' and loading InClusterConfig failed", appCIContextName)
 		}
+		logrus.Infof("Loaded %q context from in-cluster config", appCIContextName)
 	}
 
 	ciOPConfigAgent, err := agents.NewConfigAgent(opts.ciOperatorconfigPath, 2*time.Minute, prometheus.NewCounterVec(prometheus.CounterOpts{}, []string{"error"}))


### PR DESCRIPTION
Makes reasoning from the logs a bit easier, we also log the contexts we loaded from explicitly specified kuebconfig