### PR TITLE
Add script to revert ci-operator version

### DIFF
--- a/hack/revert-ci-operator.sh
+++ b/hack/revert-ci-operator.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+
+OLD_LATEST="$(oc --context api.ci get is ci-operator -n ci -o jsonpath={.status.tags[?\(@.tag==\"latest\"\)].items[1].dockerImageReference}|cut -d '@' -f2)"
+
+echo "execute \`oc --context api.ci tag ci/ci-operator@$OLD_LATEST ci/ci-operator:latest\`"


### PR DESCRIPTION
As I don't want to search slack next time this is needed.