### PR TITLE
registry: keep track of chain stack when resolving

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -362,7 +362,7 @@ func indexConfigsByTestInputImageStramTag(resolver registry.Resolver) agents.Ind
 			if testStep.MultiStageTestConfiguration != nil {
 				// TODO (alvaroalmean): Remove once the deployment was updated
 				if resolver != nil {
-					resolved, err := resolver.Resolve(*testStep.MultiStageTestConfiguration)
+					resolved, err := resolver.Resolve(testStep.As, *testStep.MultiStageTestConfiguration)
 					if err != nil {
 						log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
 					}
@@ -376,7 +376,7 @@ func indexConfigsByTestInputImageStramTag(resolver registry.Resolver) agents.Ind
 			if rawStep.TestStepConfiguration != nil && rawStep.TestStepConfiguration.MultiStageTestConfiguration != nil {
 				// TODO (alvaroalmean): Remove once the deployment was updated
 				if resolver != nil {
-					resolved, err := resolver.Resolve(*rawStep.TestStepConfiguration.MultiStageTestConfiguration)
+					resolved, err := resolver.Resolve(rawStep.TestStepConfiguration.As, *rawStep.TestStepConfiguration.MultiStageTestConfiguration)
 					if err != nil {
 						log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
 					}

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -115,6 +115,6 @@ func (a *registryAgent) loadRegistry() error {
 	return nil
 }
 
-func (a *registryAgent) Resolve(config api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error) {
-	return a.resolver.Resolve(config)
+func (a *registryAgent) Resolve(name string, config api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error) {
+	return a.resolver.Resolve(name, config)
 }

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -723,18 +723,24 @@ func TestRegistry(t *testing.T) {
 		installRBACRef       = `ipi-install-rbac`
 
 		expectedChains = registry.ChainByName{
-			"ipi-install": {
-				{
-					Reference: &installRBACRef,
-				}, {
-					Reference: &installRef,
+			"ipi-install": api.RegistryChain{
+				As: "ipi-install",
+				Steps: []api.TestStep{
+					{
+						Reference: &installRBACRef,
+					}, {
+						Reference: &installRef,
+					},
 				},
 			},
-			"ipi-deprovision": {
-				{
-					Reference: &deprovisionGatherRef,
-				}, {
-					Reference: &deprovisionRef,
+			"ipi-deprovision": api.RegistryChain{
+				As: "ipi-deprovision",
+				Steps: []api.TestStep{
+					{
+						Reference: &deprovisionGatherRef,
+					}, {
+						Reference: &deprovisionRef,
+					},
 				},
 			},
 		}

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -246,7 +246,7 @@ func NewGraph(stepsByName ReferenceByName, chainsByName ChainByName, workflowsBy
 		}
 		chainNodes[name] = node
 		nodesByName.Chains[name] = node
-		for _, step := range chain {
+		for _, step := range chain.Steps {
 			if step.Reference != nil {
 				if _, exists := referenceNodes[*step.Reference]; !exists {
 					return nodesByName, fmt.Errorf("Chain %s contains non-existent reference %s", name, *step.Reference)

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -241,8 +241,8 @@ func TestHasCycles(t *testing.T) {
 	}
 }
 
-func combineChains(map1, map2 map[string][]api.TestStep) map[string][]api.TestStep {
-	newMap := make(map[string][]api.TestStep)
+func combineChains(map1, map2 ChainByName) ChainByName {
+	newMap := make(ChainByName)
 	for k, v := range map1 {
 		newMap[k] = v
 	}

--- a/pkg/registry/graph_test.go
+++ b/pkg/registry/graph_test.go
@@ -28,26 +28,34 @@ var referenceMap = ReferenceByName{
 	ipiConfAWS:                {},
 }
 var chainMap = ChainByName{
-	ipiConfAWS: {{
-		Reference: &ipiConf,
-	}, {
-		Reference: &ipiConfAWS,
-	}},
-	ipiInstall: {{
-		Reference: &ipiInstallInstall,
-	}, {
-		Reference: &ipiInstallRBAC,
-	}},
-	ipiDeprovision: {{
-		Reference: &ipiDeprovisionMustGather,
-	}, {
-		Reference: &ipiDeprovisionDeprovision,
-	}},
-	nested: {{
-		Chain: &ipiInstall,
-	}, {
-		Chain: &ipiDeprovision,
-	}},
+	ipiConfAWS: {
+		Steps: []api.TestStep{{
+			Reference: &ipiConf,
+		}, {
+			Reference: &ipiConfAWS,
+		}},
+	},
+	ipiInstall: {
+		Steps: []api.TestStep{{
+			Reference: &ipiInstallInstall,
+		}, {
+			Reference: &ipiInstallRBAC,
+		}},
+	},
+	ipiDeprovision: {
+		Steps: []api.TestStep{{
+			Reference: &ipiDeprovisionMustGather,
+		}, {
+			Reference: &ipiDeprovisionDeprovision,
+		}},
+	},
+	nested: {
+		Steps: []api.TestStep{{
+			Chain: &ipiInstall,
+		}, {
+			Chain: &ipiDeprovision,
+		}},
+	},
 }
 var workflowMap = WorkflowByName{
 	ipi: {
@@ -294,17 +302,21 @@ func TestNewGraph(t *testing.T) {
 		name:      "Invalid reference in chain",
 		workflows: WorkflowByName{},
 		chains: ChainByName{
-			"ipi-install-2": []api.TestStep{{
-				Reference: &ipiInstall,
-			}},
+			"ipi-install-2": {
+				Steps: []api.TestStep{{
+					Reference: &ipiInstall,
+				}},
+			},
 		},
 	}, {
 		name:      "Invalid chain in chain",
 		workflows: WorkflowByName{},
 		chains: ChainByName{
-			"ipi-install-2": []api.TestStep{{
-				Chain: &ipiInstallInstall,
-			}},
+			"ipi-install-2": {
+				Steps: []api.TestStep{{
+					Chain: &ipiInstallInstall,
+				}},
+			},
 		},
 	}}
 

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -12,7 +12,7 @@ type Resolver interface {
 }
 
 type ReferenceByName map[string]api.LiteralTestStep
-type ChainByName map[string][]api.TestStep
+type ChainByName map[string]api.RegistryChain
 type WorkflowByName map[string]api.MultiStageTestConfiguration
 
 // registry will hold all the registry information needed to convert between the
@@ -113,11 +113,12 @@ func (r *registry) unrollChains(input []api.TestStep) (unrolledSteps []api.TestS
 				return []api.TestStep{}, []error{fmt.Errorf("unknown step chain: %s", *step.Chain)}
 			}
 			// handle nested chains
-			chain, err := r.unrollChains(chain)
+			var err []error
+			chain.Steps, err = r.unrollChains(chain.Steps)
 			if err != nil {
 				errs = append(errs, err...)
 			}
-			unrolledSteps = append(unrolledSteps, chain...)
+			unrolledSteps = append(unrolledSteps, chain.Steps...)
 			continue
 		}
 		unrolledSteps = append(unrolledSteps, step)

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -141,7 +141,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
-		expectedErr: errors.New("invalid step reference: generic-unit-test"),
+		expectedErr: errors.New("test: invalid step reference: generic-unit-test"),
 	}, {
 		name: "Test with chain and reference",
 		config: api.MultiStageTestConfiguration{
@@ -257,7 +257,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
-		expectedErr: errors.New("invalid step reference: install-fips"),
+		expectedErr: errors.New("test: invalid step reference: install-fips"),
 	}, {
 		name: "Test with nested chains",
 		config: api.MultiStageTestConfiguration{
@@ -377,7 +377,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
-		expectedErr: errors.New("nested-chains: duplicate name: ipi-setup"),
+		expectedErr: errors.New("test: nested-chains: duplicate name: ipi-setup"),
 	}, {
 		name: "Full AWS Workflow",
 		config: api.MultiStageTestConfiguration{
@@ -557,7 +557,7 @@ func TestResolve(t *testing.T) {
 		},
 	}} {
 		t.Run(testCase.name, func(t *testing.T) {
-			ret, err := NewResolver(testCase.stepMap, testCase.chainMap, testCase.workflowMap).Resolve(testCase.config)
+			ret, err := NewResolver(testCase.stepMap, testCase.chainMap, testCase.workflowMap).Resolve("test", testCase.config)
 			if testCase.expectedErr == nil {
 				if err != nil {
 					t.Fatalf("%s: expected no error but got: %s", testCase.name, err)

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -165,25 +165,27 @@ func TestResolve(t *testing.T) {
 			}},
 		},
 		chainMap: ChainByName{
-			fipsPreChain: {{
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-install",
-					From:     "installer",
-					Commands: "openshift-cluster install",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "enable-fips",
-					From:     "fips-enabler",
-					Commands: "enable_fips",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
+			fipsPreChain: {
+				Steps: []api.TestStep{{
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-install",
+						From:     "installer",
+						Commands: "openshift-cluster install",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "enable-fips",
+						From:     "fips-enabler",
+						Commands: "enable_fips",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
 		},
 		stepMap: ReferenceByName{
 			teardownRef: {
@@ -243,16 +245,18 @@ func TestResolve(t *testing.T) {
 			}},
 		},
 		chainMap: ChainByName{
-			"broken": {{
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "generic-unit-test-2",
-					From:     "my-image",
-					Commands: "make test/unit",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
+			"broken": {
+				Steps: []api.TestStep{{
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "generic-unit-test-2",
+						From:     "my-image",
+						Commands: "make test/unit",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
 		expectErr:   true,
@@ -265,37 +269,41 @@ func TestResolve(t *testing.T) {
 			}},
 		},
 		chainMap: ChainByName{
-			nestedChains: {{
-				Chain: &chainInstall,
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "enable-fips",
-					From:     "fips-enabler",
-					Commands: "enable_fips",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
-			chainInstall: {{
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-lease",
-					From:     "installer",
-					Commands: "lease",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-setup",
-					From:     "installer",
-					Commands: "openshift-cluster install",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
+			nestedChains: {
+				Steps: []api.TestStep{{
+					Chain: &chainInstall,
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "enable-fips",
+						From:     "fips-enabler",
+						Commands: "enable_fips",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
+			chainInstall: {
+				Steps: []api.TestStep{{
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-lease",
+						From:     "installer",
+						Commands: "lease",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-setup",
+						From:     "installer",
+						Commands: "openshift-cluster install",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{
 			ClusterProfile: api.ClusterProfileAWS,
@@ -335,37 +343,41 @@ func TestResolve(t *testing.T) {
 			}},
 		},
 		chainMap: ChainByName{
-			nestedChains: {{
-				Chain: &chainInstall,
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-setup",
-					From:     "installer",
-					Commands: "openshift-cluster install",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
-			chainInstall: {{
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-lease",
-					From:     "installer",
-					Commands: "lease",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-setup",
-					From:     "installer",
-					Commands: "openshift-cluster install",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
+			nestedChains: {
+				Steps: []api.TestStep{{
+					Chain: &chainInstall,
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-setup",
+						From:     "installer",
+						Commands: "openshift-cluster install",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
+			chainInstall: {
+				Steps: []api.TestStep{{
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-lease",
+						From:     "installer",
+						Commands: "lease",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-setup",
+						From:     "installer",
+						Commands: "openshift-cluster install",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
 		expectErr:   true,
@@ -375,25 +387,27 @@ func TestResolve(t *testing.T) {
 			Workflow: &awsWorkflow,
 		},
 		chainMap: ChainByName{
-			fipsPreChain: {{
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "ipi-install",
-					From:     "installer",
-					Commands: "openshift-cluster install",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}, {
-				LiteralTestStep: &api.LiteralTestStep{
-					As:       "enable-fips",
-					From:     "fips-enabler",
-					Commands: "enable_fips",
-					Resources: api.ResourceRequirements{
-						Requests: api.ResourceList{"cpu": "1000m"},
-						Limits:   api.ResourceList{"memory": "2Gi"},
-					}},
-			}},
+			fipsPreChain: {
+				Steps: []api.TestStep{{
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "ipi-install",
+						From:     "installer",
+						Commands: "openshift-cluster install",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}, {
+					LiteralTestStep: &api.LiteralTestStep{
+						As:       "enable-fips",
+						From:     "fips-enabler",
+						Commands: "enable_fips",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{"cpu": "1000m"},
+							Limits:   api.ResourceList{"memory": "2Gi"},
+						}},
+				}},
+			},
 		},
 		stepMap: ReferenceByName{
 			teardownRef: {

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -377,7 +377,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{},
-		expectedErr: errors.New("duplicate name: ipi-setup"),
+		expectedErr: errors.New("nested-chains: duplicate name: ipi-setup"),
 	}, {
 		name: "Full AWS Workflow",
 		config: api.MultiStageTestConfiguration{

--- a/pkg/webreg/graphviz.go
+++ b/pkg/webreg/graphviz.go
@@ -70,7 +70,7 @@ func addSubgraph(mainGraph graph, name string, root []api.TestStep, chains regis
 		} else if step.Reference != nil {
 			currNode = &node{label: *step.Reference, linkable: true}
 		} else if step.Chain != nil {
-			mainGraph, currSG = addSubgraph(mainGraph, *step.Chain, chains[*step.Chain], chains, !isRoot, true, false)
+			mainGraph, currSG = addSubgraph(mainGraph, *step.Chain, chains[*step.Chain].Steps, chains, !isRoot, true, false)
 		}
 		// create new edge
 		var newIndex int
@@ -172,7 +172,7 @@ func WorkflowGraph(name string, workflows registry.WorkflowByName, chains regist
 }
 
 func chainDotFile(name string, chains registry.ChainByName) string {
-	mainGraph, _ := addSubgraph(graph{}, name, chains[name], chains, false, true, true)
+	mainGraph, _ := addSubgraph(graph{}, name, chains[name].Steps, chains, false, true, true)
 	mainGraph.label = fmt.Sprintf("Chain \"%s\"", name)
 	return writeDotFile(mainGraph)
 }

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -2048,7 +2048,7 @@ func chainHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.R
 	chain := api.RegistryChain{
 		As:            name,
 		Documentation: docs[name],
-		Steps:         chains[name],
+		Steps:         chains[name].Steps,
 	}
 	writePage(w, "Registry Chain Help Page", page, chain)
 }


### PR DESCRIPTION
A requirement for https://github.com/openshift/ci-tools/pull/854.

We are going to need to keep track of the resolution stack to resolve
parameters, so this PR adds that to the existing implementation.  As a nice
side-effect, we can emit error messages with more context.