### PR TITLE
ci-operator: evaluate namespace at runtime

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -59,9 +59,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/load"
-	"github.com/openshift/ci-tools/pkg/release/candidate"
-	"github.com/openshift/ci-tools/pkg/release/official"
-	"github.com/openshift/ci-tools/pkg/release/prerelease"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/util"
@@ -415,31 +412,6 @@ func (o *options) Complete() error {
 		log.Printf("Resolved configuration:\n%s", string(config))
 		job, _ := json.Marshal(o.jobSpec)
 		log.Printf("Resolved job spec:\n%s", string(job))
-	}
-
-	// resolve releases we're asked to resolve and propagate their values
-	for name, release := range o.configSpec.Releases {
-		env := fmt.Sprintf("RELEASE_IMAGE_%s", strings.ToUpper(name))
-		if current := os.Getenv(env); current != "" {
-			return results.ForReason("exposing_release").ForError(fmt.Errorf("could not resolve release and set to %s, as that environment was already provided", env))
-		}
-		var value string
-		var err error
-		switch {
-		case release.Candidate != nil:
-			value, err = candidate.ResolvePullSpec(*release.Candidate)
-		case release.Release != nil:
-			value, err = official.ResolvePullSpec(*release.Release)
-		case release.Prerelease != nil:
-			value, err = prerelease.ResolvePullSpec(*release.Prerelease)
-		}
-		if err != nil {
-			return results.ForReason("resolving_release").ForError(fmt.Errorf("failed to resolve release %s: %v", name, err))
-		}
-		log.Printf("Resolved release %s to %s", name, value)
-		if err := os.Setenv(env, value); err != nil {
-			return results.ForReason("exposing_release").ForError(fmt.Errorf("failed to expose release %s as %s: %v", name, env, err))
-		}
 	}
 
 	var refs []prowapi.Refs

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -352,6 +352,7 @@ type ReleaseTagConfiguration struct {
 // release dependencies.
 type ReleaseConfiguration struct {
 	Name string `json:"name"`
+	UnresolvedRelease
 }
 
 // PromotionConfiguration describes where images created by this

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -248,13 +248,13 @@ func EnvVarFor(name string) string {
 }
 
 func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	return providesFor(s.name, s.imageClient, s.jobSpec.Namespace)
+	return providesFor(s.name, s.imageClient, s.jobSpec)
 }
 
-func providesFor(name string, imageClient imageclientset.ImageV1Interface, namespace string) (api.ParameterMap, api.StepLink) {
+func providesFor(name string, imageClient imageclientset.ImageV1Interface, spec *api.JobSpec) (api.ParameterMap, api.StepLink) {
 	return api.ParameterMap{
 		EnvVarFor(name): func() (string, error) {
-			is, err := imageClient.ImageStreams(namespace).Get("release", meta.GetOptions{})
+			is, err := imageClient.ImageStreams(spec.Namespace).Get("release", meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
 			}

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -2,28 +2,21 @@ package release
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/openshift/ci-tools/pkg/results"
-	"io/ioutil"
 	"log"
-	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	rbacclientset "k8s.io/client-go/kubernetes/typed/rbac/v1"
-	"k8s.io/client-go/util/retry"
-
-	imageapi "github.com/openshift/api/image/v1"
-	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/steps"
@@ -53,8 +46,6 @@ import (
 type assembleReleaseStep struct {
 	config      *api.ReleaseTagConfiguration
 	name        string
-	params      api.Parameters
-	releaseSpec string
 	resources   api.ResourceConfiguration
 	imageClient imageclientset.ImageV1Interface
 	podClient   steps.PodClient
@@ -66,9 +57,6 @@ type assembleReleaseStep struct {
 }
 
 func (s *assembleReleaseStep) Inputs(dry bool) (api.InputDefinition, error) {
-	if val, _ := s.params.Get(s.envVar()); len(val) > 0 {
-		return api.InputDefinition{val}, nil
-	}
 	return nil, nil
 }
 
@@ -76,18 +64,18 @@ func (s *assembleReleaseStep) Run(ctx context.Context, dry bool) error {
 	return results.ForReason("assembling_release").ForError(s.run(ctx, dry))
 }
 
-func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
+func setupReleaseImageStream(namespace string, saGetter coreclientset.ServiceAccountsGetter, rbacClient rbacclientset.RbacV1Interface, imageClient imageclientset.ImageV1Interface, dryLogger *steps.DryLogger, dry bool) (string, error) {
 	sa := &coreapi.ServiceAccount{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "ci-operator",
-			Namespace: s.jobSpec.Namespace,
+			Namespace: namespace,
 		},
 	}
 
 	role := &rbacapi.Role{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "ci-operator-image",
-			Namespace: s.jobSpec.Namespace,
+			Namespace: namespace,
 		},
 		Rules: []rbacapi.PolicyRule{
 			{
@@ -106,9 +94,9 @@ func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
 	roleBinding := &rbacapi.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "ci-operator-image",
-			Namespace: s.jobSpec.Namespace,
+			Namespace: namespace,
 		},
-		Subjects: []rbacapi.Subject{{Kind: "ServiceAccount", Name: "ci-operator", Namespace: s.jobSpec.Namespace}},
+		Subjects: []rbacapi.Subject{{Kind: "ServiceAccount", Name: "ci-operator", Namespace: namespace}},
 		RoleRef: rbacapi.RoleRef{
 			Kind: "Role",
 			Name: "ci-operator-image",
@@ -116,59 +104,52 @@ func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
 	}
 
 	if dry {
-		s.dryLogger.AddObject(sa.DeepCopyObject())
-		s.dryLogger.AddObject(role.DeepCopyObject())
-		s.dryLogger.AddObject(roleBinding.DeepCopyObject())
-		return nil
+		dryLogger.AddObject(sa.DeepCopyObject())
+		dryLogger.AddObject(role.DeepCopyObject())
+		dryLogger.AddObject(roleBinding.DeepCopyObject())
+		return "", nil
 	}
 
-	if _, err := s.saGetter.ServiceAccounts(s.jobSpec.Namespace).Create(sa); err != nil && !errors.IsAlreadyExists(err) {
-		return results.ForReason("creating_service_account").WithError(err).Errorf("could not create service account 'ci-operator' for: %v", err)
+	if _, err := saGetter.ServiceAccounts(namespace).Create(sa); err != nil && !errors.IsAlreadyExists(err) {
+		return "", results.ForReason("creating_service_account").WithError(err).Errorf("could not create service account 'ci-operator' for: %v", err)
 	}
 
-	if _, err := s.rbacClient.Roles(s.jobSpec.Namespace).Create(role); err != nil && !errors.IsAlreadyExists(err) {
-		return results.ForReason("creating_roles").WithError(err).Errorf("could not create role 'ci-operator-image' for: %v", err)
+	if _, err := rbacClient.Roles(namespace).Create(role); err != nil && !errors.IsAlreadyExists(err) {
+		return "", results.ForReason("creating_roles").WithError(err).Errorf("could not create role 'ci-operator-image' for: %v", err)
 	}
 
-	if _, err := s.rbacClient.RoleBindings(s.jobSpec.Namespace).Create(roleBinding); err != nil && !errors.IsAlreadyExists(err) {
-		return results.ForReason("binding_roles").WithError(err).Errorf("could not create role binding 'ci-operator-image' for: %v", err)
+	if _, err := rbacClient.RoleBindings(namespace).Create(roleBinding); err != nil && !errors.IsAlreadyExists(err) {
+		return "", results.ForReason("binding_roles").WithError(err).Errorf("could not create role binding 'ci-operator-image' for: %v", err)
 	}
-
-	tag := s.tag()
-	streamName := s.streamName()
 
 	// ensure the image stream exists
-	release, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Create(&imageapi.ImageStream{
+	release, err := imageClient.ImageStreams(namespace).Create(&imageapi.ImageStream{
 		ObjectMeta: meta.ObjectMeta{
 			Name: "release",
 		},
 	})
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return err
+			return "", err
 		}
-		release, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Get("release", meta.GetOptions{})
+		release, err = imageClient.ImageStreams(namespace).Get("release", meta.GetOptions{})
 		if err != nil {
-			return results.ForReason("creating_release_stream").ForError(err)
+			return "", results.ForReason("creating_release_stream").ForError(err)
 		}
 	}
+	return release.Status.PublicDockerImageRepository, nil
+}
 
-	// if the user specified an input env var, we tag it in instead of generating it
-	if s.params.HasInput(s.envVar()) {
-		providedImage, err := s.params.Get(s.envVar())
-		if err != nil {
-			return fmt.Errorf("cannot retrieve %s: %v", s.envVar(), err)
-		}
-		if len(providedImage) == 0 {
-			log.Printf("No %s release image necessary because empty input variable provided", tag)
-			return nil
-		}
-		if len(s.releaseSpec) > 0 {
-			providedImage = s.releaseSpec
-		}
-		return results.ForReason("importing_release").ForError(s.importFromReleaseImage(ctx, dry, providedImage))
+func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
+	releaseImageStreamRepo, err := setupReleaseImageStream(s.jobSpec.Namespace, s.saGetter, s.rbacClient, s.imageClient, s.dryLogger, dry)
+	if err != nil {
+		return err
+	}
+	if dry {
+		return nil
 	}
 
+	streamName := streamNameFor(s.name)
 	var stable *imageapi.ImageStream
 	var cvo string
 	cvoExists := false
@@ -194,22 +175,22 @@ func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
 			if !cliExists {
 				return results.ForReason("missing_cli").WithError(err).Errorf("no 'cli' image was tagged into the %s stream, that image is required for building a release", streamName)
 			}
-			log.Printf("No %s release image necessary, %s image stream does not include a cluster-version-operator image", tag, streamName)
+			log.Printf("No %s release image necessary, %s image stream does not include a cluster-version-operator image", s.name, streamName)
 			return nil
 		} else if errors.IsNotFound(err) {
 			// if a user sets IMAGE_FORMAT=... we skip importing the image stream contents, which prevents us from
 			// generating a release image.
-			log.Printf("No %s release image can be generated when the %s image stream was skipped", tag, streamName)
+			log.Printf("No %s release image can be generated when the %s image stream was skipped", s.name, streamName)
 			return nil
 		}
 		return results.ForReason("missing_release").WithError(err).Errorf("could not resolve imagestream %s: %v", streamName, err)
 	}
 
-	destination := fmt.Sprintf("%s:%s", release.Status.PublicDockerImageRepository, tag)
+	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	log.Printf("Create release image %s", destination)
 	podConfig := steps.PodStepConfiguration{
 		SkipLogs: true,
-		As:       fmt.Sprintf("release-%s", tag),
+		As:       fmt.Sprintf("release-%s", s.name),
 		From: api.ImageStreamTagReference{
 			Name: streamName,
 			Tag:  "cli",
@@ -222,7 +203,7 @@ export HOME=/tmp
 oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
 oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
-`, s.jobSpec.Namespace, streamName, cvo, destination, destination, tag),
+`, s.jobSpec.Namespace, streamName, cvo, destination, destination, s.name),
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary
@@ -242,304 +223,7 @@ oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
 	return results.ForReason("creating_release").ForError(step.Run(ctx, dry))
 }
 
-// importFromReleaseImage uses the provided release image and updates the stable / release streams as
-// appropriate with the contents of the payload so that downstream components are using the correct images.
-// The most common case is to use the correct installer image, tests, and cli commands.
-func (s *assembleReleaseStep) importFromReleaseImage(ctx context.Context, dry bool, providedImage string) error {
-	tag := s.tag()
-	streamName := s.streamName()
-
-	if dry {
-		return nil
-	}
-
-	log.Printf("Importing release image %s", tag)
-
-	// create the stable image stream with lookup policy so we have a place to put our imported images
-	_, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Create(&imageapi.ImageStream{
-		ObjectMeta: meta.ObjectMeta{
-			Name: streamName,
-		},
-		Spec: imageapi.ImageStreamSpec{
-			LookupPolicy: imageapi.ImageLookupPolicy{
-				Local: true,
-			},
-		},
-	})
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("could not create stable imagestreamtag: %v", err)
-	}
-	// tag the release image in and let it import
-	var pullSpec string
-
-	// retry importing the image a few times because we might race against establishing credentials/roles
-	// and be unable to import images on the same cluster
-	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Duration: 1 * time.Second, Factor: 2}, func() (bool, error) {
-		result, err := s.imageClient.ImageStreamImports(s.jobSpec.Namespace).Create(&imageapi.ImageStreamImport{
-			ObjectMeta: meta.ObjectMeta{
-				Name: "release",
-			},
-			Spec: imageapi.ImageStreamImportSpec{
-				Import: true,
-				Images: []imageapi.ImageImportSpec{
-					{
-						To: &coreapi.LocalObjectReference{
-							Name: tag,
-						},
-						From: coreapi.ObjectReference{
-							Kind: "DockerImage",
-							Name: providedImage,
-						},
-					},
-				},
-			},
-		})
-		if err != nil {
-			if errors.IsConflict(err) {
-				return false, nil
-			}
-			if errors.IsForbidden(err) {
-				// the ci-operator expects to have POST /imagestreamimports in the namespace of the job
-				log.Printf("warning: Unable to lock %s to an image digest pull spec, you don't have permission to access the necessary API.", s.envVar())
-				return false, nil
-			}
-			return false, err
-		}
-		image := result.Status.Images[0]
-		if image.Image == nil {
-			return false, nil
-		}
-		pullSpec = result.Status.Images[0].Image.DockerImageReference
-		return true, nil
-	}); err != nil {
-		return fmt.Errorf("unable to import %s release image: %v", tag, err)
-	}
-
-	// override anything in stable with the contents of the release image
-	// TODO: should we allow underride for things we built in pipeline?
-	artifactDir := s.artifactDir
-	if len(artifactDir) == 0 {
-		var err error
-		artifactDir, err = ioutil.TempDir("", "payload-images")
-		if err != nil {
-			return fmt.Errorf("unable to create temporary artifact dir for payload extraction")
-		}
-	}
-
-	// get the CLI image from the payload (since we need it to run oc adm release extract)
-	target := fmt.Sprintf("release-images-%s", tag)
-	targetCLI := fmt.Sprintf("%s-cli", target)
-	if err := steps.RunPod(context.TODO(), s.podClient, &coreapi.Pod{
-		ObjectMeta: meta.ObjectMeta{
-			Name:      targetCLI,
-			Namespace: s.jobSpec.Namespace,
-		},
-		Spec: coreapi.PodSpec{
-			RestartPolicy: coreapi.RestartPolicyNever,
-			Containers: []coreapi.Container{
-				{
-					Name:    "release",
-					Image:   pullSpec,
-					Command: []string{"/bin/sh", "-c", "cluster-version-operator image cli > /dev/termination-log"},
-				},
-			},
-		},
-	}); err != nil {
-		return fmt.Errorf("unable to find the 'cli' image in the provided release image: %v", err)
-	}
-	pod, err := s.podClient.Pods(s.jobSpec.Namespace).Get(targetCLI, meta.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to extract the 'cli' image from the release image: %v", err)
-	}
-	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
-		return fmt.Errorf("unable to extract the 'cli' image from the release image: %v", err)
-	}
-	cliImage := pod.Status.ContainerStatuses[0].State.Terminated.Message
-
-	// tag the cli image into stable so we use the correct pull secrets from the namespace
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		_, err := s.imageClient.ImageStreamTags(s.jobSpec.Namespace).Update(&imageapi.ImageStreamTag{
-			ObjectMeta: meta.ObjectMeta{
-				Name: fmt.Sprintf("%s:cli", streamName),
-			},
-			Tag: &imageapi.TagReference{
-				ReferencePolicy: imageapi.TagReferencePolicy{
-					Type: imageapi.LocalTagReferencePolicy,
-				},
-				From: &coreapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: cliImage,
-				},
-			},
-		})
-		return err
-	}); err != nil {
-		return fmt.Errorf("unable to tag the 'cli' image into the stable stream: %v", err)
-	}
-
-	// run adm release extract and grab the raw image-references from the payload
-	podConfig := steps.PodStepConfiguration{
-		SkipLogs: true,
-		As:       target,
-		From: api.ImageStreamTagReference{
-			Name: streamName,
-			Tag:  "cli",
-		},
-		ServiceAccountName: "ci-operator",
-		ArtifactDir:        "/tmp/artifacts",
-		Commands: fmt.Sprintf(`
-set -euo pipefail
-export HOME=/tmp
-oc registry login
-oc adm release extract --from=%q --file=image-references > /tmp/artifacts/%s
-`, pullSpec, target),
-	}
-
-	// set an explicit default for release-latest resources, but allow customization if necessary
-	resources := s.resources
-	if _, ok := resources[podConfig.As]; !ok {
-		copied := make(api.ResourceConfiguration)
-		for k, v := range resources {
-			copied[k] = v
-		}
-		// max cpu observed at 0.1 core, most memory ~ 420M
-		copied[podConfig.As] = api.ResourceRequirements{Requests: api.ResourceList{"cpu": "50m", "memory": "400Mi"}}
-		resources = copied
-	}
-	step := steps.PodStep("release", podConfig, resources, s.podClient, artifactDir, s.jobSpec, s.dryLogger)
-	if err := step.Run(ctx, false); err != nil {
-		return err
-	}
-
-	// read the contents from the artifacts directory
-	isContents, err := ioutil.ReadFile(filepath.Join(artifactDir, podConfig.As, target))
-	if err != nil {
-		return fmt.Errorf("unable to read release image stream: %v", err)
-	}
-	var releaseIS imageapi.ImageStream
-	if err := json.Unmarshal(isContents, &releaseIS); err != nil {
-		return fmt.Errorf("unable to decode release image stream: %v", err)
-	}
-	if releaseIS.Kind != "ImageStream" || releaseIS.APIVersion != "image.openshift.io/v1" {
-		return fmt.Errorf("unexpected image stream contents: %v", err)
-	}
-
-	// update the stable image stream to have all of the tags from the payload
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		stable, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(streamName, meta.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("could not resolve imagestream %s: %v", streamName, err)
-		}
-
-		existing := sets.NewString()
-		tags := make([]imageapi.TagReference, 0, len(releaseIS.Spec.Tags)+len(stable.Spec.Tags))
-		for _, tag := range releaseIS.Spec.Tags {
-			existing.Insert(tag.Name)
-			tag.ReferencePolicy.Type = imageapi.LocalTagReferencePolicy
-			tags = append(tags, tag)
-		}
-		for _, tag := range stable.Spec.Tags {
-			if existing.Has(tag.Name) {
-				continue
-			}
-			existing.Insert(tag.Name)
-			tag.ReferencePolicy.Type = imageapi.LocalTagReferencePolicy
-			tags = append(tags, tag)
-		}
-		stable.Spec.Tags = tags
-
-		_, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Update(stable)
-		return err
-	}); err != nil {
-		return fmt.Errorf("unable to update stable image stream with release tags: %v", err)
-	}
-
-	// loop until we observe all images have successfully imported, kicking import if a particular
-	// tag fails
-	var waiting map[string]int64
-	if err := wait.Poll(3*time.Second, 15*time.Minute, func() (bool, error) {
-		stable, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(streamName, meta.GetOptions{})
-		if err != nil {
-			return false, fmt.Errorf("could not resolve imagestream %s: %v", streamName, err)
-		}
-		generations := make(map[string]int64)
-		for _, tag := range stable.Spec.Tags {
-			if tag.Generation == nil || *tag.Generation == 0 {
-				continue
-			}
-			generations[tag.Name] = *tag.Generation
-		}
-		updates := false
-		for _, event := range stable.Status.Tags {
-			gen, ok := generations[event.Tag]
-			if !ok {
-				continue
-			}
-			if len(event.Items) > 0 && event.Items[0].Generation >= gen {
-				delete(generations, event.Tag)
-				continue
-			}
-			if hasFailedImportCondition(event.Conditions, gen) {
-				zero := int64(0)
-				findSpecTagReference(stable, event.Tag).Generation = &zero
-				updates = true
-			}
-		}
-		if updates {
-			_, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Update(stable)
-			if err != nil {
-				log.Printf("error requesting re-import of failed release image stream: %v", err)
-			}
-			return false, nil
-		}
-		if len(generations) == 0 {
-			return true, nil
-		}
-		waiting = generations
-		return false, nil
-	}); err != nil {
-		if len(waiting) == 0 || err != wait.ErrWaitTimeout {
-			return fmt.Errorf("unable to import image stream %s: %v", streamName, err)
-		}
-		var tags []string
-		for tag := range waiting {
-			tags = append(tags, tag)
-		}
-		sort.Strings(tags)
-		return fmt.Errorf("the following tags from the release could not be imported to %s after five minutes: %s", streamName, strings.Join(tags, ", "))
-	}
-
-	log.Printf("Imported release %s created at %s with %d images to tag release:%s", releaseIS.Name, releaseIS.CreationTimestamp, len(releaseIS.Spec.Tags), tag)
-	return nil
-}
-
-func findSpecTagReference(is *imageapi.ImageStream, tag string) *imageapi.TagReference {
-	for i, t := range is.Spec.Tags {
-		if t.Name != tag {
-			continue
-		}
-		return &is.Spec.Tags[i]
-	}
-	return nil
-}
-
-func hasFailedImportCondition(conditions []imageapi.TagEventCondition, generation int64) bool {
-	for _, condition := range conditions {
-		if condition.Generation >= generation && condition.Type == imageapi.ImportSuccess && condition.Status == coreapi.ConditionFalse {
-			return true
-		}
-	}
-	return false
-}
-
 func (s *assembleReleaseStep) Requires() []api.StepLink {
-	// if our prereq is provided, we don't depend on anything as
-	// we will populate the stable streams with our images. However,
-	// if there is a tag_specification, we currently allow carry-forward
-	// images from that stream to exist, so we need to wait on them
-	if s.params.HasInput(s.envVar()) && s.config == nil {
-		return []api.StepLink{}
-	}
 	if s.name == "latest" {
 		return []api.StepLink{api.ImagesReadyLink()}
 	}
@@ -547,31 +231,30 @@ func (s *assembleReleaseStep) Requires() []api.StepLink {
 }
 
 func (s *assembleReleaseStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.tag()))}
+	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.name))}
 }
 
-func (s *assembleReleaseStep) tag() string {
-	return s.name
-}
-
-func (s *assembleReleaseStep) streamName() string {
-	switch s.name {
+func streamNameFor(name string) string {
+	switch name {
 	case "latest":
 		return api.StableImageStream
 	default:
-		return fmt.Sprintf("%s-%s", api.StableImageStream, s.name)
+		return fmt.Sprintf("%s-%s", api.StableImageStream, name)
 	}
 }
 
-func (s *assembleReleaseStep) envVar() string {
-	return fmt.Sprintf("RELEASE_IMAGE_%s", strings.ToUpper(s.tag()))
+func EnvVarFor(name string) string {
+	return fmt.Sprintf("RELEASE_IMAGE_%s", strings.ToUpper(name))
 }
 
 func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	tag := s.tag()
+	return providesFor(s.name, s.imageClient, s.jobSpec.Namespace)
+}
+
+func providesFor(name string, imageClient imageclientset.ImageV1Interface, namespace string) (api.ParameterMap, api.StepLink) {
 	return api.ParameterMap{
-		s.envVar(): func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get("release", meta.GetOptions{})
+		EnvVarFor(name): func() (string, error) {
+			is, err := imageClient.ImageStreams(namespace).Get("release", meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
 			}
@@ -583,20 +266,20 @@ func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
 			} else {
 				return "", fmt.Errorf("image stream %s has no accessible image registry value", "release")
 			}
-			ref, image := findStatusTag(is, tag)
+			ref, image := findStatusTag(is, name)
 			if len(image) > 0 {
 				return fmt.Sprintf("%s@%s", registry, image), nil
 			}
-			if ref == nil && findSpecTag(is, tag) == nil {
+			if ref == nil && findSpecTag(is, name) == nil {
 				return "", nil
 			}
-			return fmt.Sprintf("%s:%s", registry, tag), nil
+			return fmt.Sprintf("%s:%s", registry, name), nil
 		},
-	}, api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(tag))
+	}, api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(name))
 }
 
 func (s *assembleReleaseStep) Name() string {
-	return fmt.Sprintf("[release:%s]", s.tag())
+	return fmt.Sprintf("[release:%s]", s.name)
 }
 
 func (s *assembleReleaseStep) Description() string {
@@ -605,13 +288,12 @@ func (s *assembleReleaseStep) Description() string {
 
 // AssembleReleaseStep builds a new update payload image based on the cluster version operator
 // and the operators defined in the release configuration.
-func AssembleReleaseStep(name string, config *api.ReleaseTagConfiguration, params api.Parameters, resources api.ResourceConfiguration,
+func AssembleReleaseStep(name string, config *api.ReleaseTagConfiguration, resources api.ResourceConfiguration,
 	podClient steps.PodClient, imageClient imageclientset.ImageV1Interface, saGetter coreclientset.ServiceAccountsGetter,
 	rbacClient rbacclientset.RbacV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *steps.DryLogger) api.Step {
 	return &assembleReleaseStep{
 		config:      config,
 		name:        name,
-		params:      params,
 		resources:   resources,
 		podClient:   podClient,
 		imageClient: imageClient,

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -1,0 +1,401 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacclientset "k8s.io/client-go/kubernetes/typed/rbac/v1"
+	"k8s.io/client-go/util/retry"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps"
+)
+
+// importReleaseStep is responsible for importing release images from
+// external image streams for use with tests that need to install or
+// upgrade a cluster. It uses the `cli` image within the image stream to
+// create the image and pushes it to a `release` image stream. As output
+// it provides the environment variable RELEASE_IMAGE_<name> which can be
+// used by tests that invoke the installer.
+//
+// Since release images describe a set of images, when we import a release
+// image, we treat it's contents as inputs we must expand into the `stable-<name>`
+// image stream. This is because our test scenarios need access not
+// just to the release image, but also to the images in that release image
+// like installer, cli, or tests. To make it easy for a CI job to install from
+// an older release image, we need to extract the 'installer' image into the
+// same location that we would expect if it came from a tag_specification.
+// The images inside of a release image override any images built or imported
+// into the job, which allows you to have an empty tag_specification and
+// inject the images from a known historic release for the purposes of building
+// branches of those releases.
+type importReleaseStep struct {
+	// name is the name of the release we're importing, like 'latest'
+	name string
+	// pullSpec is the fully-resolved pull spec of the release payload image we are importing
+	pullSpec    string
+	resources   api.ResourceConfiguration
+	imageClient imageclientset.ImageV1Interface
+	podClient   steps.PodClient
+	saGetter    coreclientset.ServiceAccountsGetter
+	rbacClient  rbacclientset.RbacV1Interface
+	artifactDir string
+	jobSpec     *api.JobSpec
+	dryLogger   *steps.DryLogger
+}
+
+func (s *importReleaseStep) Inputs(dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *importReleaseStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("importing_release").ForError(s.run(ctx, dry))
+}
+
+func (s *importReleaseStep) run(ctx context.Context, dry bool) error {
+	_, err := setupReleaseImageStream(s.jobSpec.Namespace, s.saGetter, s.rbacClient, s.imageClient, s.dryLogger, dry)
+	if err != nil {
+		return err
+	}
+
+	streamName := streamNameFor(s.name)
+
+	if dry {
+		return nil
+	}
+
+	log.Printf("Importing release image %s", s.name)
+
+	// create the stable image stream with lookup policy so we have a place to put our imported images
+	_, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Create(&imageapi.ImageStream{
+		ObjectMeta: meta.ObjectMeta{
+			Name: streamName,
+		},
+		Spec: imageapi.ImageStreamSpec{
+			LookupPolicy: imageapi.ImageLookupPolicy{
+				Local: true,
+			},
+		},
+	})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return fmt.Errorf("could not create stable imagestreamtag: %v", err)
+	}
+	// tag the release image in and let it import
+	var pullSpec string
+
+	// retry importing the image a few times because we might race against establishing credentials/roles
+	// and be unable to import images on the same cluster
+	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Duration: 1 * time.Second, Factor: 2}, func() (bool, error) {
+		result, err := s.imageClient.ImageStreamImports(s.jobSpec.Namespace).Create(&imageapi.ImageStreamImport{
+			ObjectMeta: meta.ObjectMeta{
+				Name: "release",
+			},
+			Spec: imageapi.ImageStreamImportSpec{
+				Import: true,
+				Images: []imageapi.ImageImportSpec{
+					{
+						To: &coreapi.LocalObjectReference{
+							Name: s.name,
+						},
+						From: coreapi.ObjectReference{
+							Kind: "DockerImage",
+							Name: s.pullSpec,
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			if errors.IsConflict(err) {
+				return false, nil
+			}
+			if errors.IsForbidden(err) {
+				// the ci-operator expects to have POST /imagestreamimports in the namespace of the job
+				log.Printf("warning: Unable to lock %s to an image digest pull spec, you don't have permission to access the necessary API.", EnvVarFor(s.name))
+				return false, nil
+			}
+			return false, err
+		}
+		image := result.Status.Images[0]
+		if image.Image == nil {
+			return false, nil
+		}
+		pullSpec = result.Status.Images[0].Image.DockerImageReference
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("unable to import %s release image: %v", s.name, err)
+	}
+
+	// override anything in stable with the contents of the release image
+	// TODO: should we allow underride for things we built in pipeline?
+	artifactDir := s.artifactDir
+	if len(artifactDir) == 0 {
+		var err error
+		artifactDir, err = ioutil.TempDir("", "payload-images")
+		if err != nil {
+			return fmt.Errorf("unable to create temporary artifact dir for payload extraction")
+		}
+	}
+
+	// get the CLI image from the payload (since we need it to run oc adm release extract)
+	target := fmt.Sprintf("release-images-%s", s.name)
+	targetCLI := fmt.Sprintf("%s-cli", target)
+	if err := steps.RunPod(context.TODO(), s.podClient, &coreapi.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      targetCLI,
+			Namespace: s.jobSpec.Namespace,
+		},
+		Spec: coreapi.PodSpec{
+			RestartPolicy: coreapi.RestartPolicyNever,
+			Containers: []coreapi.Container{
+				{
+					Name:    "release",
+					Image:   pullSpec,
+					Command: []string{"/bin/sh", "-c", "cluster-version-operator image cli > /dev/termination-log"},
+				},
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("unable to find the 'cli' image in the provided release image: %v", err)
+	}
+	pod, err := s.podClient.Pods(s.jobSpec.Namespace).Get(targetCLI, meta.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to extract the 'cli' image from the release image: %v", err)
+	}
+	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
+		return fmt.Errorf("unable to extract the 'cli' image from the release image: %v", err)
+	}
+	cliImage := pod.Status.ContainerStatuses[0].State.Terminated.Message
+
+	// tag the cli image into stable so we use the correct pull secrets from the namespace
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err := s.imageClient.ImageStreamTags(s.jobSpec.Namespace).Update(&imageapi.ImageStreamTag{
+			ObjectMeta: meta.ObjectMeta{
+				Name: fmt.Sprintf("%s:cli", streamName),
+			},
+			Tag: &imageapi.TagReference{
+				ReferencePolicy: imageapi.TagReferencePolicy{
+					Type: imageapi.LocalTagReferencePolicy,
+				},
+				From: &coreapi.ObjectReference{
+					Kind: "DockerImage",
+					Name: cliImage,
+				},
+			},
+		})
+		return err
+	}); err != nil {
+		return fmt.Errorf("unable to tag the 'cli' image into the stable stream: %v", err)
+	}
+
+	// run adm release extract and grab the raw image-references from the payload
+	podConfig := steps.PodStepConfiguration{
+		SkipLogs: true,
+		As:       target,
+		From: api.ImageStreamTagReference{
+			Name: streamName,
+			Tag:  "cli",
+		},
+		ServiceAccountName: "ci-operator",
+		ArtifactDir:        "/tmp/artifacts",
+		Commands: fmt.Sprintf(`
+set -euo pipefail
+export HOME=/tmp
+oc registry login
+oc adm release extract --from=%q --file=image-references > /tmp/artifacts/%s
+`, pullSpec, target),
+	}
+
+	// set an explicit default for release-latest resources, but allow customization if necessary
+	resources := s.resources
+	if _, ok := resources[podConfig.As]; !ok {
+		copied := make(api.ResourceConfiguration)
+		for k, v := range resources {
+			copied[k] = v
+		}
+		// max cpu observed at 0.1 core, most memory ~ 420M
+		copied[podConfig.As] = api.ResourceRequirements{Requests: api.ResourceList{"cpu": "50m", "memory": "400Mi"}}
+		resources = copied
+	}
+	step := steps.PodStep("release", podConfig, resources, s.podClient, artifactDir, s.jobSpec, s.dryLogger)
+	if err := step.Run(ctx, false); err != nil {
+		return err
+	}
+
+	// read the contents from the artifacts directory
+	isContents, err := ioutil.ReadFile(filepath.Join(artifactDir, podConfig.As, target))
+	if err != nil {
+		return fmt.Errorf("unable to read release image stream: %v", err)
+	}
+	var releaseIS imageapi.ImageStream
+	if err := json.Unmarshal(isContents, &releaseIS); err != nil {
+		return fmt.Errorf("unable to decode release image stream: %v", err)
+	}
+	if releaseIS.Kind != "ImageStream" || releaseIS.APIVersion != "image.openshift.io/v1" {
+		return fmt.Errorf("unexpected image stream contents: %v", err)
+	}
+
+	// update the stable image stream to have all of the tags from the payload
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		stable, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(streamName, meta.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("could not resolve imagestream %s: %v", streamName, err)
+		}
+
+		existing := sets.NewString()
+		tags := make([]imageapi.TagReference, 0, len(releaseIS.Spec.Tags)+len(stable.Spec.Tags))
+		for _, tag := range releaseIS.Spec.Tags {
+			existing.Insert(tag.Name)
+			tag.ReferencePolicy.Type = imageapi.LocalTagReferencePolicy
+			tags = append(tags, tag)
+		}
+		for _, tag := range stable.Spec.Tags {
+			if existing.Has(tag.Name) {
+				continue
+			}
+			existing.Insert(tag.Name)
+			tag.ReferencePolicy.Type = imageapi.LocalTagReferencePolicy
+			tags = append(tags, tag)
+		}
+		stable.Spec.Tags = tags
+
+		_, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Update(stable)
+		return err
+	}); err != nil {
+		return fmt.Errorf("unable to update stable image stream with release tags: %v", err)
+	}
+
+	// loop until we observe all images have successfully imported, kicking import if a particular
+	// tag fails
+	var waiting map[string]int64
+	if err := wait.Poll(3*time.Second, 15*time.Minute, func() (bool, error) {
+		stable, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(streamName, meta.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("could not resolve imagestream %s: %v", streamName, err)
+		}
+		generations := make(map[string]int64)
+		for _, tag := range stable.Spec.Tags {
+			if tag.Generation == nil || *tag.Generation == 0 {
+				continue
+			}
+			generations[tag.Name] = *tag.Generation
+		}
+		updates := false
+		for _, event := range stable.Status.Tags {
+			gen, ok := generations[event.Tag]
+			if !ok {
+				continue
+			}
+			if len(event.Items) > 0 && event.Items[0].Generation >= gen {
+				delete(generations, event.Tag)
+				continue
+			}
+			if hasFailedImportCondition(event.Conditions, gen) {
+				zero := int64(0)
+				findSpecTagReference(stable, event.Tag).Generation = &zero
+				updates = true
+			}
+		}
+		if updates {
+			_, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Update(stable)
+			if err != nil {
+				log.Printf("error requesting re-import of failed release image stream: %v", err)
+			}
+			return false, nil
+		}
+		if len(generations) == 0 {
+			return true, nil
+		}
+		waiting = generations
+		return false, nil
+	}); err != nil {
+		if len(waiting) == 0 || err != wait.ErrWaitTimeout {
+			return fmt.Errorf("unable to import image stream %s: %v", streamName, err)
+		}
+		var tags []string
+		for tag := range waiting {
+			tags = append(tags, tag)
+		}
+		sort.Strings(tags)
+		return fmt.Errorf("the following tags from the release could not be imported to %s after five minutes: %s", streamName, strings.Join(tags, ", "))
+	}
+
+	log.Printf("Imported release %s created at %s with %d images to tag release:%s", releaseIS.Name, releaseIS.CreationTimestamp, len(releaseIS.Spec.Tags), s.name)
+	return nil
+}
+
+func findSpecTagReference(is *imageapi.ImageStream, tag string) *imageapi.TagReference {
+	for i, t := range is.Spec.Tags {
+		if t.Name != tag {
+			continue
+		}
+		return &is.Spec.Tags[i]
+	}
+	return nil
+}
+
+func hasFailedImportCondition(conditions []imageapi.TagEventCondition, generation int64) bool {
+	for _, condition := range conditions {
+		if condition.Generation >= generation && condition.Type == imageapi.ImportSuccess && condition.Status == coreapi.ConditionFalse {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *importReleaseStep) Requires() []api.StepLink {
+	// we don't depend on anything as we will populate
+	// the stable streams with our images.
+	return []api.StepLink{}
+}
+
+func (s *importReleaseStep) Creates() []api.StepLink {
+	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.name))}
+}
+
+func (s *importReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
+	return providesFor(s.name, s.imageClient, s.jobSpec.Namespace)
+}
+
+func (s *importReleaseStep) Name() string {
+	return fmt.Sprintf("[release:%s]", s.name)
+}
+
+func (s *importReleaseStep) Description() string {
+	return "Import a release payload from an external source"
+}
+
+// ImportReleaseStep imports an existing update payload image
+func ImportReleaseStep(name, pullSpec string, resources api.ResourceConfiguration,
+	podClient steps.PodClient, imageClient imageclientset.ImageV1Interface, saGetter coreclientset.ServiceAccountsGetter,
+	rbacClient rbacclientset.RbacV1Interface, artifactDir string, jobSpec *api.JobSpec, dryLogger *steps.DryLogger) api.Step {
+	return &importReleaseStep{
+		name:        name,
+		pullSpec:    pullSpec,
+		resources:   resources,
+		podClient:   podClient,
+		imageClient: imageClient,
+		saGetter:    saGetter,
+		rbacClient:  rbacClient,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
+	}
+}

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -371,7 +371,7 @@ func (s *importReleaseStep) Creates() []api.StepLink {
 }
 
 func (s *importReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	return providesFor(s.name, s.imageClient, s.jobSpec.Namespace)
+	return providesFor(s.name, s.imageClient, s.jobSpec)
 }
 
 func (s *importReleaseStep) Name() string {


### PR DESCRIPTION
Revert "Merge pull request #874 from alvaroaleman/revert-5"

This reverts commit 6eb6b2b8cd9b98e792f83a8d541f1c48696105bf, reversing
changes made to c91af1cc534203c646bc5707197ad5bbaf1ac6a3.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: evaluate namespace at runtime

When we construct the step and determine the list of parameters it
provides, we have not yet determined the inputs to the graph or created
a namespace, so we need to read that value at run-time when the
parameters are evaluated.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

