### PR TITLE
Use methods for getting/setting the namespace on jobConfig

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -691,7 +691,7 @@ func (o *options) resolveInputs(steps []api.Step) error {
 	o.namespace = strings.Replace(o.namespace, "{id}", o.inputHash, -1)
 	// TODO: instead of mutating this here, we should pass the parts of graph execution that are resolved
 	// after the graph is created but before it is run down into the run step.
-	o.jobSpec.Namespace = o.namespace
+	o.jobSpec.SetNamespace(o.namespace)
 
 	//If we can resolve the field, use it. If not, don't.
 	if routeGetter, err := routeclientset.NewForConfig(o.clusterConfig); err != nil {
@@ -855,9 +855,9 @@ func (o *options) initializeNamespace() error {
 	}
 
 	// create the image stream or read it to get its uid
-	is, err := imageGetter.ImageStreams(o.jobSpec.Namespace).Create(&imageapi.ImageStream{
+	is, err := imageGetter.ImageStreams(o.jobSpec.Namespace()).Create(&imageapi.ImageStream{
 		ObjectMeta: meta.ObjectMeta{
-			Namespace: o.jobSpec.Namespace,
+			Namespace: o.jobSpec.Namespace(),
 			Name:      api.PipelineImageStream,
 		},
 		Spec: imageapi.ImageStreamSpec{
@@ -869,7 +869,7 @@ func (o *options) initializeNamespace() error {
 		if !kerrors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not set up pipeline imagestream for test: %v", err)
 		}
-		is, _ = imageGetter.ImageStreams(o.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+		is, _ = imageGetter.ImageStreams(o.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 	}
 	if is != nil {
 		isTrue := true

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -124,7 +124,7 @@ func FromConfig(
 	params.Add("JOB_NAME", nil, func() (string, error) { return jobSpec.Job, nil })
 	params.Add("JOB_NAME_HASH", nil, func() (string, error) { return jobSpec.JobNameHash(), nil })
 	params.Add("JOB_NAME_SAFE", nil, func() (string, error) { return strings.Replace(jobSpec.Job, "_", "-", -1), nil })
-	params.Add("NAMESPACE", nil, func() (string, error) { return jobSpec.Namespace, nil })
+	params.Add("NAMESPACE", nil, func() (string, error) { return jobSpec.Namespace(), nil })
 
 	var imageStepLinks []api.StepLink
 	var hasReleaseStep bool

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -127,7 +127,7 @@ func (s *e2eTestStep) run(ctx context.Context, dry bool) error {
 	if dry {
 		return nil
 	}
-	if _, err := s.secretClient.Secrets(s.jobSpec.Namespace).Get(fmt.Sprintf("%s-cluster-profile", s.testConfig.As), meta.GetOptions{}); err != nil {
+	if _, err := s.secretClient.Secrets(s.jobSpec.Namespace()).Get(fmt.Sprintf("%s-cluster-profile", s.testConfig.As), meta.GetOptions{}); err != nil {
 		return results.ForReason("missing_cluster_profile").WithError(err).Errorf("could not find required secret: %v", err)
 	}
 	return s.step.Run(ctx, dry)

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -83,7 +83,7 @@ func (s *inputImageTagStep) run(ctx context.Context, dry bool) error {
 	ist := &imageapi.ImageStreamTag{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.To),
-			Namespace: s.jobSpec.Namespace,
+			Namespace: s.jobSpec.Namespace(),
 		},
 		Tag: &imageapi.TagReference{
 			ReferencePolicy: imageapi.TagReferencePolicy{
@@ -114,14 +114,14 @@ func (s *inputImageTagStep) run(ctx context.Context, dry bool) error {
 		return nil
 	}
 
-	if _, err := s.dstClient.ImageStreamTags(s.jobSpec.Namespace).Create(ist); err != nil && !errors.IsAlreadyExists(err) {
+	if _, err := s.dstClient.ImageStreamTags(s.jobSpec.Namespace()).Create(ist); err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create imagestreamtag for input image: %v", err)
 	}
 	// Wait image is ready
 	importCtx, cancel := context.WithTimeout(ctx, 35*time.Minute)
 	defer cancel()
 	if err := wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		pipeline, err := s.dstClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+		pipeline, err := s.dstClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -72,7 +72,8 @@ func TestInputImageTagStep(t *testing.T) {
 	}
 
 	// Make a step instance
-	jobspec := &api.JobSpec{Namespace: "target-namespace"}
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("target-namespace")
 	dryLogger := &DryLogger{}
 	iits := InputImageTagStep(config, srcClient, dstClient, jobspec, dryLogger)
 
@@ -112,7 +113,7 @@ func TestInputImageTagStep(t *testing.T) {
 	expectedImageStreamTag := &apiimagev1.ImageStreamTag{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      "pipeline:TO",
-			Namespace: jobspec.Namespace,
+			Namespace: jobspec.Namespace(),
 		},
 		Tag: &apiimagev1.TagReference{
 			From: &corev1.ObjectReference{
@@ -126,7 +127,7 @@ func TestInputImageTagStep(t *testing.T) {
 		},
 	}
 
-	targetImageStreamTag, err := dstClient.ImageStreamTags(jobspec.Namespace).Get("pipeline:TO", meta.GetOptions{})
+	targetImageStreamTag, err := dstClient.ImageStreamTags(jobspec.Namespace()).Get("pipeline:TO", meta.GetOptions{})
 	if !equality.Semantic.DeepEqual(expectedImageStreamTag, targetImageStreamTag) {
 		t.Errorf("Different ImageStreamTag 'pipeline:TO' after step execution:\n%s", diff.ObjectReflectDiff(expectedImageStreamTag, targetImageStreamTag))
 	}

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -48,7 +48,7 @@ func (stepNeedsLease) SubTests() []*junit.TestCase {
 func TestLeaseStepForward(t *testing.T) {
 	name := "lease_name"
 	step := stepNeedsLease{}
-	withLease := LeaseStep(nil, name, &step, "", nil)
+	withLease := LeaseStep(nil, name, &step, func() string { return "" }, nil)
 	t.Run("Inputs", func(t *testing.T) {
 		s, err := step.Inputs(false)
 		if err != nil {
@@ -138,7 +138,7 @@ func TestError(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls)
 			s := stepNeedsLease{fail: tc.runFails}
-			if LeaseStep(&client, "rtype", &s, "", nil).Run(ctx, false) == nil {
+			if LeaseStep(&client, "rtype", &s, func() string { return "" }, nil).Run(ctx, false) == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
 			if !reflect.DeepEqual(calls, tc.expected) {
@@ -152,7 +152,7 @@ func TestAcquireRelease(t *testing.T) {
 	var calls []string
 	client := lease.NewFakeClient("owner", "url", 0, nil, &calls)
 	step := stepNeedsLease{}
-	withLease := LeaseStep(&client, "rtype", &step, "", nil)
+	withLease := LeaseStep(&client, "rtype", &step, func() string { return "" }, nil)
 	if err := withLease.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -153,8 +153,8 @@ func TestGeneratePods(t *testing.T) {
 			},
 			Type: "postsubmit",
 		},
-		Namespace: "namespace",
 	}
+	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, nil, nil, nil, "artifact_dir", &jobSpec, nil)
 	env := []coreapi.EnvVar{
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
@@ -385,7 +385,6 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			jobSpec := api.JobSpec{
-				Namespace: "ns",
 				JobSpec: prowdapi.JobSpec{
 					Job:       "job",
 					BuildID:   "build_id",
@@ -393,6 +392,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Type:      prowapi.PeriodicJob,
 				},
 			}
+			jobSpec.SetNamespace("ns")
 			test := []api.LiteralTestStep{tc.test}
 			step := MultiStageTestStep(api.TestStepConfiguration{
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
@@ -507,7 +507,6 @@ func TestRun(t *testing.T) {
 			name := "test"
 			client := fakecs.CoreV1()
 			jobSpec := api.JobSpec{
-				Namespace: "ns",
 				JobSpec: prowdapi.JobSpec{
 					Job:       "job",
 					BuildID:   "build_id",
@@ -515,6 +514,7 @@ func TestRun(t *testing.T) {
 					Type:      prowapi.PeriodicJob,
 				},
 			}
+			jobSpec.SetNamespace("ns")
 			step := MultiStageTestStep(api.TestStepConfiguration{
 				As: name,
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
@@ -527,7 +527,7 @@ func TestRun(t *testing.T) {
 				t.Error(err)
 				return
 			}
-			secrets, err := client.Secrets(jobSpec.Namespace).List(meta.ListOptions{})
+			secrets, err := client.Secrets(jobSpec.Namespace()).List(meta.ListOptions{})
 			if err != nil {
 				t.Error(err)
 				return
@@ -558,7 +558,6 @@ func TestArtifacts(t *testing.T) {
 	executor.AddReactors(fakecs)
 	client := fakecs.CoreV1()
 	jobSpec := api.JobSpec{
-		Namespace: ns,
 		JobSpec: prowdapi.JobSpec{
 			Job:       "job",
 			BuildID:   "build_id",
@@ -566,6 +565,7 @@ func TestArtifacts(t *testing.T) {
 			Type:      prowapi.PeriodicJob,
 		},
 	}
+	jobSpec.SetNamespace(ns)
 	testName := "test"
 	step := MultiStageTestStep(api.TestStepConfiguration{
 		As: testName,

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -38,14 +38,14 @@ func (s *outputImageTagStep) Run(ctx context.Context, dry bool) error {
 
 func (s *outputImageTagStep) run(ctx context.Context, dry bool) error {
 	toNamespace := s.namespace()
-	if string(s.config.From) == s.config.To.Tag && toNamespace == s.jobSpec.Namespace && s.config.To.Name == api.StableImageStream {
+	if string(s.config.From) == s.config.To.Tag && toNamespace == s.jobSpec.Namespace() && s.config.To.Name == api.StableImageStream {
 		log.Printf("Tagging %s into %s", s.config.From, s.config.To.Name)
 	} else {
 		log.Printf("Tagging %s into %s/%s:%s", s.config.From, toNamespace, s.config.To.Name, s.config.To.Tag)
 	}
 	fromImage := "dry-fake"
 	if !dry {
-		from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
+		from, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace()).Get(fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From), meta.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("could not resolve base image: %v", err)
 		}
@@ -123,7 +123,7 @@ func (s *outputImageTagStep) namespace() string {
 	if len(s.config.To.Namespace) != 0 {
 		return s.config.To.Namespace
 	}
-	return s.jobSpec.Namespace
+	return s.jobSpec.Namespace()
 }
 
 func (s *outputImageTagStep) imageStreamTag(fromImage string) *imageapi.ImageStreamTag {
@@ -139,7 +139,7 @@ func (s *outputImageTagStep) imageStreamTag(fromImage string) *imageapi.ImageStr
 			From: &coreapi.ObjectReference{
 				Kind:      "ImageStreamImage",
 				Name:      fmt.Sprintf("%s@%s", api.PipelineImageStream, fromImage),
-				Namespace: s.jobSpec.Namespace,
+				Namespace: s.jobSpec.Namespace(),
 			},
 		},
 	}

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -25,7 +25,8 @@ func TestOutputImageStep(t *testing.T) {
 			Tag:       "configToTag",
 		},
 	}
-	jobspec := &api.JobSpec{Namespace: "job-namespace"}
+	jobspec := &api.JobSpec{}
+	jobspec.SetNamespace("job-namespace")
 	stepSpec := stepExpectation{
 		name: "configToAs",
 		requires: []api.StepLink{
@@ -44,7 +45,7 @@ func TestOutputImageStep(t *testing.T) {
 	}
 
 	pipelineRoot := &imagev1.ImageStreamTag{
-		ObjectMeta: meta.ObjectMeta{Name: "pipeline:root", Namespace: jobspec.Namespace},
+		ObjectMeta: meta.ObjectMeta{Name: "pipeline:root", Namespace: jobspec.Namespace()},
 		Image:      imagev1.Image{ObjectMeta: meta.ObjectMeta{Name: "fromImageName"}},
 	}
 

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -67,7 +67,7 @@ func (s *pipelineImageCacheStep) Provides() (api.ParameterMap, api.StepLink) {
 	}
 	return api.ParameterMap{
 		fmt.Sprintf("LOCAL_IMAGE_%s", strings.ToUpper(strings.Replace(string(s.config.To), "-", "_", -1))): func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
 			}

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -52,8 +52,8 @@ func preparePodStep(t *testing.T, namespace string) (*podStep, stepExpectation, 
 				BaseSHA: "base-sha",
 			},
 		},
-		Namespace: namespace,
 	}
+	jobSpec.SetNamespace(namespace)
 
 	fakecs := ciopTestingClient{
 		kubecs:  fake.NewSimpleClientset(),
@@ -85,7 +85,7 @@ func makeExpectedPod(step *podStep, phaseAfterRun v1.PodPhase) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      step.config.As,
-			Namespace: step.jobSpec.Namespace,
+			Namespace: step.jobSpec.Namespace(),
 			Labels: map[string]string{
 				"build-id":                    step.jobSpec.BuildID,
 				"created-by-ci":               "true",

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -43,7 +43,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context, dry bool) erro
 	if dry {
 		workingDir = "dry-fake"
 	} else {
-		ist, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace).Get(source, meta.GetOptions{})
+		ist, err := s.istClient.ImageStreamTags(s.jobSpec.Namespace()).Get(source, meta.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("could not fetch source ImageStreamTag: %v", err)
 		}
@@ -144,7 +144,7 @@ func (s *projectDirectoryImageBuildStep) Provides() (api.ParameterMap, api.StepL
 	}
 	return api.ParameterMap{
 		fmt.Sprintf("LOCAL_IMAGE_%s", strings.ToUpper(strings.Replace(string(s.config.To), "-", "_", -1))): func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
 			}

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -141,7 +141,7 @@ func setupReleaseImageStream(namespace string, saGetter coreclientset.ServiceAcc
 }
 
 func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
-	releaseImageStreamRepo, err := setupReleaseImageStream(s.jobSpec.Namespace, s.saGetter, s.rbacClient, s.imageClient, s.dryLogger, dry)
+	releaseImageStreamRepo, err := setupReleaseImageStream(s.jobSpec.Namespace(), s.saGetter, s.rbacClient, s.imageClient, s.dryLogger, dry)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
 	importCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 	if err := wait.PollImmediateUntil(10*time.Second, func() (bool, error) {
-		stable, err = s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(streamName, meta.GetOptions{})
+		stable, err = s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(streamName, meta.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -203,7 +203,7 @@ export HOME=/tmp
 oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
 oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
-`, s.jobSpec.Namespace, streamName, cvo, destination, destination, s.name),
+`, s.jobSpec.Namespace(), streamName, cvo, destination, destination, s.name),
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary
@@ -254,7 +254,7 @@ func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
 func providesFor(name string, imageClient imageclientset.ImageV1Interface, spec *api.JobSpec) (api.ParameterMap, api.StepLink) {
 	return api.ParameterMap{
 		EnvVarFor(name): func() (string, error) {
-			is, err := imageClient.ImageStreams(spec.Namespace).Get("release", meta.GetOptions{})
+			is, err := imageClient.ImageStreams(spec.Namespace()).Get("release", meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not retrieve output imagestream: %v", err)
 			}

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -64,7 +64,7 @@ func (s *promotionStep) run(ctx context.Context, dry bool) error {
 
 	log.Printf("Promoting tags to %s: %s", targetName(s.config), strings.Join(names.List(), ", "))
 
-	pipeline, err := s.srcClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+	pipeline, err := s.srcClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("could not resolve pipeline imagestream: %v", err)
 	}

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -60,7 +60,7 @@ func (s *stableImagesTagStep) run(ctx context.Context, dry bool) error {
 		s.dryLogger.AddObject(newIS.DeepCopyObject())
 		return nil
 	}
-	_, err := s.dstClient.ImageStreams(s.jobSpec.Namespace).Create(newIS)
+	_, err := s.dstClient.ImageStreams(s.jobSpec.Namespace()).Create(newIS)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not create stable imagestreamtag: %v", err)
 	}
@@ -214,12 +214,12 @@ func (s *releaseImagesTagStep) run(ctx context.Context, dry bool) error {
 	initialIS := newIS.DeepCopy()
 	initialIS.Name = fmt.Sprintf("%s-initial", api.StableImageStream)
 
-	_, err = s.dstClient.ImageStreams(s.jobSpec.Namespace).Create(newIS)
+	_, err = s.dstClient.ImageStreams(s.jobSpec.Namespace()).Create(newIS)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not copy stable imagestreamtag: %v", err)
 	}
 
-	is, err = s.dstClient.ImageStreams(s.jobSpec.Namespace).Create(initialIS)
+	is, err = s.dstClient.ImageStreams(s.jobSpec.Namespace()).Create(initialIS)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not copy stable-initial imagestreamtag: %v", err)
 	}
@@ -255,12 +255,12 @@ func (s *releaseImagesTagStep) imageFormat() (string, error) {
 		return "REGISTRY", err
 	}
 	registry := strings.SplitN(spec, "/", 2)[0]
-	format := fmt.Sprintf("%s/%s/%s:%s", registry, s.jobSpec.Namespace, fmt.Sprintf("%s%s", s.config.NamePrefix, api.StableImageStream), api.ComponentFormatReplacement)
+	format := fmt.Sprintf("%s/%s/%s:%s", registry, s.jobSpec.Namespace(), fmt.Sprintf("%s%s", s.config.NamePrefix, api.StableImageStream), api.ComponentFormatReplacement)
 	return format, nil
 }
 
 func (s *releaseImagesTagStep) repositoryPullSpec() (string, error) {
-	is, err := s.dstClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+	is, err := s.dstClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -44,7 +44,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context, dry bool) error {
 	if dry {
 		host = "dry-fake"
 	} else {
-		route, err := s.routeClient.Routes(s.jobSpec.Namespace).Get(RPMRepoName, meta.GetOptions{})
+		route, err := s.routeClient.Routes(s.jobSpec.Namespace()).Get(RPMRepoName, meta.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("could not get Route for RPM server: %v", err)
 		}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -258,7 +258,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 	if len(fromTag) > 0 {
 		from = &coreapi.ObjectReference{
 			Kind:      "ImageStreamTag",
-			Namespace: jobSpec.Namespace,
+			Namespace: jobSpec.Namespace(),
 			Name:      fmt.Sprintf("%s:%s", api.PipelineImageStream, fromTag),
 		}
 	}
@@ -269,7 +269,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 	build := &buildapi.Build{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      string(toTag),
-			Namespace: jobSpec.Namespace,
+			Namespace: jobSpec.Namespace(),
 			Labels:    labels,
 			Annotations: map[string]string{
 				JobSpecAnnotation: jobSpec.RawSpec(),
@@ -294,7 +294,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 				Output: buildapi.BuildOutput{
 					To: &coreapi.ObjectReference{
 						Kind:      "ImageStreamTag",
-						Namespace: jobSpec.Namespace,
+						Namespace: jobSpec.Namespace(),
 						Name:      fmt.Sprintf("%s:%s", api.PipelineImageStream, toTag),
 					},
 				},
@@ -626,7 +626,7 @@ func (s *sourceStep) Creates() []api.StepLink {
 func (s *sourceStep) Provides() (api.ParameterMap, api.StepLink) {
 	return api.ParameterMap{
 		"LOCAL_IMAGE_SRC": func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace).Get(api.PipelineImageStream, meta.GetOptions{})
+			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
 			if err != nil {
 				return "", fmt.Errorf("could not get output imagestream: %v", err)
 			}

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -23,6 +23,7 @@ func strP(str string) *string {
 }
 
 func TestCreateBuild(t *testing.T) {
+	t.Parallel()
 	layer := buildapi.ImageOptimizationSkipLayers
 	var testCases = []struct {
 		name            string
@@ -63,7 +64,6 @@ func TestCreateBuild(t *testing.T) {
 						}},
 					},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -163,7 +163,6 @@ RUN git submodule update --init
 						}},
 					},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -270,7 +269,6 @@ RUN git submodule update --init
 						}},
 					},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -376,7 +374,6 @@ RUN git submodule update --init
 						BaseSHA: "masterSHA",
 					}},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -484,7 +481,6 @@ RUN git submodule update --init
 						PathAlias: "this/is/nuts",
 					}},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -590,7 +586,6 @@ RUN git submodule update --init
 						}},
 					},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -710,7 +705,6 @@ RUN rm -f /sshprivatekey
 						}},
 					},
 				},
-				Namespace: "namespace",
 			},
 			clonerefsRef: coreapi.ObjectReference{Kind: "ImageStreamTag", Name: "clonerefs:latest", Namespace: "ci"},
 			resources:    map[string]api.ResourceRequirements{"*": {Requests: map[string]string{"cpu": "200m"}}},
@@ -792,6 +786,7 @@ RUN rm -f /oauth-token
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			testCase.jobSpec.SetNamespace("namespace")
 			if actual, expected := createBuild(testCase.config, testCase.jobSpec, testCase.clonerefsRef, testCase.resources, testCase.cloneAuthConfig, testCase.pullSecret), testCase.expected; !equality.Semantic.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect build: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
 			}


### PR DESCRIPTION
Before, the namespace was a public property of the jobSpec. This lead to
semi-common wrong usage where it was evaluated before it was set,
resulting in bugs.

This PR changes jobSpec to provide getters and setters instead. The
getter will log an error if the namespace was unset, as this is always a
bug. This allows us to easely identify such wrong usages without making
any tests fail due to a potentially non-fatal issue.

Also fixes a bug where the namespace property was used wrongly as
described above.