### PR TITLE
ci-operator: allow waiting before importing a release

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -186,7 +186,7 @@ func FromConfig(
 						return nil, nil, results.ForReason("reading_release").ForError(fmt.Errorf("failed to read input release pullSpec %s: %v", name, err))
 					}
 					log.Printf("Resolved release %s to %s", name, pullSpec)
-					releaseStep = release.ImportReleaseStep(name, pullSpec, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
+					releaseStep = release.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
 				} else {
 					releaseStep = release.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
 				}
@@ -224,7 +224,7 @@ func FromConfig(
 			}
 			log.Printf("Resolved release %s to %s", resolveConfig.Name, value)
 
-			step = release.ImportReleaseStep(resolveConfig.Name, value, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
+			step = release.ImportReleaseStep(resolveConfig.Name, value, false, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, dryLogger)
 			addProvidesForStep(step, params)
 		} else if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if test := testStep.MultiStageTestConfigurationLiteral; test != nil {


### PR DESCRIPTION
Today, some jobs are using the following workflow:

 - build an image or set `tag_specification`
 - also provide `$RELEASE_IMAGE_LATEST`

With the previous implementation, two separate steps would create images
to fill out the stable stream and overwrite each other's work. The
effect was that the jobs could end up with images in the stable stream
that were not in the imported release from the env var, as they would be
created by the image steps and not be overwritten.

By allowing an explicit configuration for the import step, we can wait
on these other steps in the cases where we'd do in the past and continue
to provide the same user experience. This is not ideal and we need to
provide a clear way for users to simply import images they are
interested in, since the combination of `tag_specification` and a
`$RELEASE_IAMGE_LATEST` is nonsensical, as they are nominally both means
to configure which release of OpenShift is being tested.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>