### PR TITLE
Test images distributor: use imagestream.status to find all tags

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -105,8 +105,8 @@ func TestRegistryClusterHandlerFactory(t *testing.T) {
 					Name:      streamName,
 					Namespace: namespace,
 				},
-				Spec: imagev1.ImageStreamSpec{
-					Tags: []imagev1.TagReference{{Name: tagName}},
+				Status: imagev1.ImageStreamStatus{
+					Tags: []imagev1.NamedTagEventList{{Tag: tagName}},
 				},
 			}
 			event := event.CreateEvent{Meta: obj, Object: obj}


### PR DESCRIPTION
Needed because for some imagestreams, there is no `.spec.tags` set, even though there are imagestreamtags in them, for example:
```
apiVersion: image.openshift.io/v1
kind: ImageStream
metadata:
  annotations:
    hello: world
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"image.openshift.io/v1","kind":"ImageStream","metadata":{"annotations":{},"name":"cli-jq","namespace":"ocp"}}
  creationTimestamp: "2020-03-19T21:53:21Z"
  generation: 1
  name: cli-jq
  namespace: ocp
  resourceVersion: "744318274"
  selfLink: /apis/image.openshift.io/v1/namespaces/ocp/imagestreams/cli-jq
  uid: 0cb0d0c7-6a2c-11ea-a71e-42010a8e0003
spec:
  lookupPolicy:
    local: false
status:
  dockerImageRepository: docker-registry.default.svc:5000/ocp/cli-jq
  publicDockerImageRepository: registry.svc.ci.openshift.org/ocp/cli-jq
  tags:
  - items:
    - created: "2020-03-19T21:55:31Z"
      dockerImageReference: docker-registry.default.svc:5000/ocp/cli-jq@sha256:03e6a8145c85cb86739017a9b2c1b244e81eeddc77ffe102c21ef3982aec162f
      generation: 1
      image: sha256:03e6a8145c85cb86739017a9b2c1b244e81eeddc77ffe102c21ef3982aec162f
    tag: latest
```