### PR TITLE
 ci-operator: refactor step links to be generic on is or istag

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -140,7 +140,12 @@ func (l *releaseImagesLink) SatisfiedBy(other StepLink) bool {
 		return true
 	default:
 		return false
+func StableStreamFor(name string) string {
+	if name == LatestStableName {
+		return StableImageStream
 	}
+
+	return fmt.Sprintf("%s-%s", StableImageStream, name)
 }
 
 type StepNode struct {

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -33,8 +33,8 @@ func TestMatches(t *testing.T) {
 		},
 		{
 			name:    "release images matches itself",
-			first:   ReleaseImagesLink(),
-			second:  ReleaseImagesLink(),
+			first:   StableImagesLink(LatestStableName),
+			second:  StableImagesLink(LatestStableName),
 			matches: true,
 		},
 		{
@@ -64,7 +64,7 @@ func TestMatches(t *testing.T) {
 		{
 			name:    "internal does not match release images",
 			first:   InternalImageLink(PipelineImageStreamTagReferenceRPMs),
-			second:  ReleaseImagesLink(),
+			second:  StableImagesLink(LatestStableName),
 			matches: false,
 		},
 		{
@@ -76,13 +76,13 @@ func TestMatches(t *testing.T) {
 		{
 			name:    "external does not match release images",
 			first:   ExternalImageLink(ImageStreamTagReference{Namespace: "ns", Name: "name", Tag: "latest"}),
-			second:  ReleaseImagesLink(),
+			second:  StableImagesLink(LatestStableName),
 			matches: false,
 		},
 		{
 			name:    "RPM does not match release images",
 			first:   RPMRepoLink(),
-			second:  ReleaseImagesLink(),
+			second:  StableImagesLink(LatestStableName),
 			matches: false,
 		},
 	}

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -88,7 +88,7 @@ func TestMatches(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		if actual, expected := testCase.first.Matches(testCase.second), testCase.matches; actual != expected {
+		if actual, expected := testCase.first.SatisfiedBy(testCase.second), testCase.matches; actual != expected {
 			message := "not match"
 			if testCase.matches {
 				message = "match"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1054,7 +1054,23 @@ const (
 	// we will serve RPMs after they are built.
 	RPMServeLocation = "/srv/repo"
 
+	// StableImageStream is the ImageStream used to hold
+	// build outputs from the repository under test and
+	// the associated images imported from integration streams
 	StableImageStream = "stable"
+	// LatestStableName is the name of the special latest
+	// stable stream, images in this stream are held in
+	// the StableImageStream. Images for other versions of
+	// the stream are held in similarly-named streams.
+	LatestStableName = "latest"
+	// InitialStableName is the name of the special stable
+	// stream we copy at import to keep for upgrade tests.
+	// TODO(skuznets): remove these when they're not implicit
+	InitialStableName = "initial"
+
+	// ReleaseImageStream is the name of the ImageStream
+	// used to hold built or imported release payload images
+	ReleaseImageStream = "release"
 
 	ComponentFormatReplacement = "${component}"
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -172,7 +172,7 @@ func FromConfig(
 			// as well. For backwards compatibility, we explicitly support
 			// 'initial' and 'latest': if not provided, we will build them.
 			// If a pull spec was provided, however, it will be used.
-			for _, name := range []string{"initial", "latest"} {
+			for _, name := range []string{api.InitialStableName, api.LatestStableName} {
 				var releaseStep api.Step
 				envVar := release.EnvVarFor(name)
 				if params.HasInput(envVar) {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -29,10 +29,12 @@ func (s *stepNeedsLease) Run(ctx context.Context, dry bool) error {
 	return nil
 }
 
-func (stepNeedsLease) Name() string             { return "needs_lease" }
-func (stepNeedsLease) Description() string      { return "this step needs a lease" }
-func (stepNeedsLease) Requires() []api.StepLink { return []api.StepLink{api.ReleaseImagesLink()} }
-func (stepNeedsLease) Creates() []api.StepLink  { return []api.StepLink{api.ImagesReadyLink()} }
+func (stepNeedsLease) Name() string        { return "needs_lease" }
+func (stepNeedsLease) Description() string { return "this step needs a lease" }
+func (stepNeedsLease) Requires() []api.StepLink {
+	return []api.StepLink{api.StableImagesLink(api.LatestStableName)}
+}
+func (stepNeedsLease) Creates() []api.StepLink { return []api.StepLink{api.ImagesReadyLink()} }
 
 func (stepNeedsLease) Provides() (api.ParameterMap, api.StepLink) {
 	return api.ParameterMap{

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -196,7 +196,7 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 		}
 	}
 	if needsReleaseImage && !needsReleasePayload {
-		ret = append(ret, api.ReleaseImagesLink())
+		ret = append(ret, api.StableImagesLink(api.LatestStableName))
 	}
 	return
 }

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -32,18 +32,18 @@ func TestRequires(t *testing.T) {
 		steps  api.MultiStageTestConfigurationLiteral
 		req    []api.StepLink
 	}{{
-		name: "step has a cluster profile and requires a release image, should not have ReleaseImagesLink",
+		name: "step has a cluster profile and requires a release image, should not have StableImagesLink",
 		steps: api.MultiStageTestConfigurationLiteral{
 			ClusterProfile: api.ClusterProfileAWS,
 			Test:           []api.LiteralTestStep{{From: "from-release"}},
 		},
 		req: []api.StepLink{},
 	}, {
-		name: "step needs release images, should have ReleaseImagesLink",
+		name: "step needs release images, should have StableImagesLink",
 		steps: api.MultiStageTestConfigurationLiteral{
 			Test: []api.LiteralTestStep{{From: "from-release"}},
 		},
-		req: []api.StepLink{api.ReleaseImagesLink()},
+		req: []api.StepLink{api.StableImagesLink(api.LatestStableName)},
 	}, {
 		name: "step needs images, should have InternalImageLink",
 		config: api.ReleaseBuildConfiguration{

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -73,7 +73,7 @@ func TestRequires(t *testing.T) {
 			if len(ret) == len(tc.req) {
 				matches := true
 				for i := range ret {
-					if !ret[i].Matches(tc.req[i]) {
+					if !ret[i].SatisfiedBy(tc.req[i]) {
 						matches = false
 						break
 					}

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -72,7 +72,7 @@ func (s *outputImageTagStep) run(ctx context.Context, dry bool) error {
 }
 
 func (s *outputImageTagStep) Requires() []api.StepLink {
-	return []api.StepLink{api.InternalImageLink(s.config.From), api.ReleaseImagesLink()}
+	return []api.StepLink{api.InternalImageLink(s.config.From)}
 }
 
 func (s *outputImageTagStep) Creates() []api.StepLink {

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -31,7 +31,6 @@ func TestOutputImageStep(t *testing.T) {
 		name: "configToAs",
 		requires: []api.StepLink{
 			api.InternalImageLink(config.From),
-			api.ReleaseImagesLink(),
 		},
 		creates: []api.StepLink{
 			api.ExternalImageLink(config.To),

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -227,13 +227,11 @@ func (s *assembleReleaseStep) Requires() []api.StepLink {
 	if s.name == api.LatestStableName {
 		return []api.StepLink{api.ImagesReadyLink()}
 	}
-	return []api.StepLink{api.ReleaseImagesLink()}
+	return []api.StepLink{api.StableImagesLink(s.name)}
 }
 
 func (s *assembleReleaseStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.name))}
-}
-
+	return []api.StepLink{api.ReleasePayloadImageLink(s.name)}
 }
 
 func EnvVarFor(name string) string {
@@ -268,7 +266,7 @@ func providesFor(name string, imageClient imageclientset.ImageV1Interface, spec 
 			}
 			return fmt.Sprintf("%s:%s", registry, name), nil
 		},
-	}, api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(name))
+	}, api.ReleasePayloadImageLink(name)
 }
 
 func (s *assembleReleaseStep) Name() string {

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -149,7 +149,7 @@ func (s *assembleReleaseStep) run(ctx context.Context, dry bool) error {
 		return nil
 	}
 
-	streamName := streamNameFor(s.name)
+	streamName := api.StableStreamFor(s.name)
 	var stable *imageapi.ImageStream
 	var cvo string
 	cvoExists := false
@@ -224,7 +224,7 @@ oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
 }
 
 func (s *assembleReleaseStep) Requires() []api.StepLink {
-	if s.name == "latest" {
+	if s.name == api.LatestStableName {
 		return []api.StepLink{api.ImagesReadyLink()}
 	}
 	return []api.StepLink{api.ReleaseImagesLink()}
@@ -234,13 +234,6 @@ func (s *assembleReleaseStep) Creates() []api.StepLink {
 	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.name))}
 }
 
-func streamNameFor(name string) string {
-	switch name {
-	case "latest":
-		return api.StableImageStream
-	default:
-		return fmt.Sprintf("%s-%s", api.StableImageStream, name)
-	}
 }
 
 func EnvVarFor(name string) string {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -371,7 +371,7 @@ func (s *importReleaseStep) Requires() []api.StepLink {
 		if s.name == api.LatestStableName {
 			return []api.StepLink{api.ImagesReadyLink()}
 		}
-		return []api.StepLink{api.ReleaseImagesLink()}
+		return []api.StepLink{api.StableImagesLink(api.LatestStableName)}
 	}
 	// we don't depend on anything as we will populate
 	// the stable streams with our images.
@@ -379,7 +379,7 @@ func (s *importReleaseStep) Requires() []api.StepLink {
 }
 
 func (s *importReleaseStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleasePayloadImageLink(api.PipelineImageStreamTagReference(s.name))}
+	return []api.StepLink{api.ReleasePayloadImageLink(s.name)}
 }
 
 func (s *importReleaseStep) Provides() (api.ParameterMap, api.StepLink) {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -77,7 +77,7 @@ func (s *importReleaseStep) run(ctx context.Context, dry bool) error {
 		return err
 	}
 
-	streamName := streamNameFor(s.name)
+	streamName := api.StableStreamFor(s.name)
 
 	if dry {
 		return nil
@@ -368,7 +368,7 @@ func (s *importReleaseStep) Requires() []api.StepLink {
 	// users to import images they care about rather than
 	// having two steps overwrite each other on import
 	if s.append {
-		if s.name == "latest" {
+		if s.name == api.LatestStableName {
 			return []api.StepLink{api.ImagesReadyLink()}
 		}
 		return []api.StepLink{api.ReleaseImagesLink()}

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -74,7 +74,8 @@ func (s *stableImagesTagStep) Inputs(dry bool) (api.InputDefinition, error) {
 func (s *stableImagesTagStep) Requires() []api.StepLink { return []api.StepLink{} }
 
 func (s *stableImagesTagStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleaseImagesLink()}
+	// we can only ever create the latest stable image stream with this step
+	return []api.StepLink{api.StableImagesLink(api.LatestStableName)}
 }
 
 func (s *stableImagesTagStep) Provides() (api.ParameterMap, api.StepLink) { return nil, nil }
@@ -214,7 +215,10 @@ func (s *releaseImagesTagStep) Requires() []api.StepLink {
 }
 
 func (s *releaseImagesTagStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleaseImagesLink()}
+	return []api.StepLink{
+		api.StableImagesLink(api.InitialStableName),
+		api.StableImagesLink(api.LatestStableName),
+	}
 }
 
 func (s *releaseImagesTagStep) Provides() (api.ParameterMap, api.StepLink) {

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -163,7 +163,7 @@ func (s *releaseImagesTagStep) run(ctx context.Context, dry bool) error {
 	is.UID = ""
 	newIS := &imageapi.ImageStream{
 		ObjectMeta: meta.ObjectMeta{
-			Name: api.StableImageStream,
+			Name: api.StableStreamFor(api.LatestStableName),
 		},
 		Spec: imageapi.ImageStreamSpec{
 			LookupPolicy: imageapi.ImageLookupPolicy{
@@ -186,7 +186,7 @@ func (s *releaseImagesTagStep) run(ctx context.Context, dry bool) error {
 	}
 
 	initialIS := newIS.DeepCopy()
-	initialIS.Name = fmt.Sprintf("%s-initial", api.StableImageStream)
+	initialIS.Name = api.StableStreamFor(api.InitialStableName)
 
 	_, err = s.client.ImageStreams(s.jobSpec.Namespace()).Create(newIS)
 	if err != nil && !errors.IsAlreadyExists(err) {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -267,7 +267,7 @@ func (s *templateExecutionStep) Requires() []api.StepLink {
 			continue
 		}
 		if strings.HasPrefix(p.Name, "IMAGE_") && !needsRelease {
-			links = append(links, api.ReleaseImagesLink())
+			links = append(links, api.StableImagesLink(api.LatestStableName))
 			continue
 		}
 	}


### PR DESCRIPTION
ci-operator: remove step link equality

This method was unused.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: rename step link method to better reflect usage

The `Matches(other)` function was used to determine if `other` satisfied
the requirements of the link being evaluated. This rename makes that
relationship clear.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: treat latest and initial stable as an API

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: refactor step links to be generic on is or istag

While it remains important to be able to differentiate at the call-site
on whether we're talking about an internal ImageStreamTag, a release
payload image, or other, it's not important to have a plethora of types
under the hood that do nothing special when we're just matching on name
and tag.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @petr-muller @bbguimaraes 