### PR TITLE
[ci-operator-config-mirror] Add the ability to mirror the configs from a specific organization

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -151,7 +151,7 @@ func main() {
 		{
 			command: "/usr/bin/ci-operator-config-mirror",
 			arguments: func() []string {
-				args := []string{"--config-path", o.ConfigDir, "--to-org", "openshift-priv"}
+				args := []string{"--config-path", o.ConfigDir, "--to-org", "openshift-priv", "--only-org", "openshift"}
 				if o.whitelist != "" {
 					args = append(args, []string{"--whitelist-file", o.whitelist}...)
 				}

--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -28,6 +28,7 @@ type options struct {
 
 	configDir string
 	toOrg     string
+	onlyOrg   string
 
 	clean bool
 }
@@ -38,6 +39,7 @@ func gatherOptions() options {
 
 	fs.StringVar(&o.configDir, "config-path", "", "Path to directory containing ci-operator configurations")
 	fs.StringVar(&o.toOrg, "to-org", "", "Name of the organization which the ci-operator configuration files will be mirrored")
+	fs.StringVar(&o.onlyOrg, "only-org", "", "Mirror only ci-operator configuration from this organization")
 
 	fs.BoolVar(&o.clean, "clean", true, "If the `to-org` folder already exists, then delete all subdirectories")
 
@@ -106,6 +108,11 @@ func main() {
 		logger := logrus.WithFields(logrus.Fields{"org": repoInfo.Org, "repo": repoInfo.Repo, "branch": repoInfo.Branch})
 
 		if repoInfo.Org == o.toOrg {
+			return nil
+		}
+
+		if len(o.onlyOrg) > 0 && repoInfo.Org != o.onlyOrg {
+			logger.Warnf("Skipping... This repo doesn't belong in %s organization", o.onlyOrg)
 			return nil
 		}
 

--- a/test/integration/ci-operator-config-mirror.sh
+++ b/test/integration/ci-operator-config-mirror.sh
@@ -20,5 +20,7 @@ os::integration::compare "${actual}" "${expected}"
 os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual_to_clean} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
 os::integration::compare "${actual_to_clean}" "${expected}"
 
+os::cmd::expect_success "ci-operator-config-mirror --only-org super --to-org super-priv --config-path ${actual_to_clean} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
+os::integration::compare "${actual_to_clean}" "${suite_dir}/output-only-super"
 
 os::test::junit::declare_suite_end

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/bar/foo-bar-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/bar/foo-bar-master.yaml
@@ -1,0 +1,34 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: foo
+  repo: bar

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-master.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10    
+images:
+- from: base
+  to: test-image
+promotion:
+  name: satin-soul  
+  namespace: non-ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official.yaml
@@ -1,0 +1,33 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    namespace: openshift
+    name: release
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: 4.5
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
@@ -1,0 +1,43 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: ocp
+    tag: os
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/duper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: duper

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/trooper
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other-priv
+  namespace: ocp-private
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: trooper

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
@@ -1,0 +1,42 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+  os:
+    cluster: https://api.ci.openshift.org
+    name: centos
+    namespace: ocp
+    tag: os
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/trooper/super-trooper-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  base:
+    cluster: https://api.ci.openshift.org
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  name: other
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: trooper


### PR DESCRIPTION
Introduces the `--only-org` flag. Give the tool the ability to mirror the ci-operator configurations that belong in a specified organization.

/cc @stevekuznetsov @petr-muller 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>