### PR TITLE
ci-operator: parameterize names of release steps

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -274,7 +274,7 @@ func (s *assembleReleaseStep) Name() string {
 }
 
 func (s *assembleReleaseStep) Description() string {
-	return "Create the release image containing all images built by this job"
+	return fmt.Sprintf("Create the release image %q containing all images built by this job", s.name)
 }
 
 // AssembleReleaseStep builds a new update payload image based on the cluster version operator

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -391,7 +391,7 @@ func (s *importReleaseStep) Name() string {
 }
 
 func (s *importReleaseStep) Description() string {
-	return "Import a release payload from an external source"
+	return fmt.Sprintf("Import the release payload %q from an external source", s.name)
 }
 
 // ImportReleaseStep imports an existing update payload image


### PR DESCRIPTION
These names are used in the generation of jUnit test cases and should
therefore be unique.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 