### PR TITLE
Support multiple build clusters in pj-rehearse

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -55,7 +55,7 @@ func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, err
 	}
 	raw, err := ioutil.ReadFile(o.password)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read file %q: %w", o.password, err)
 	}
 	return &reporter{
 		spec:        spec,

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -143,6 +143,151 @@
       created-by-pj-rehearse: "true"
     name: rehearse-cluster-profile-test-profile-47224c86
     namespace: test-namespace
+- data:
+    test-template.yaml: |
+      kind: Template
+      apiVersion: template.openshift.io/v1
+
+      parameters:
+      - name: JOB_NAME_SAFE
+        required: true
+      - name: JOB_NAME_HASH
+        required: true
+      - name: NAMESPACE
+        required: true
+      - name: IMAGE_FORMAT
+        required: true
+      - name: IMAGE_TESTS
+        required: true
+      - name: CLUSTER_TYPE
+        required: true
+      - name: TEST_COMMAND
+        required: true
+
+      objects:
+
+      # We want the cluster to be able to access these images
+      - kind: RoleBinding
+        apiVersion: authorization.openshift.io/v1
+        metadata:
+          name: ${JOB_NAME_SAFE}-image-puller
+          namespace: ${NAMESPACE}
+        roleRef:
+          name: system:image-puller
+        subjects:
+        - kind: SystemGroup
+          name: system:unauthenticated
+        - kind: SystemGroup
+          name: system:authenticated
+
+      # The e2e pod spins up a cluster, runs e2e tests, and then cleans up the cluster.
+      - kind: Pod
+        apiVersion: v1
+        metadata:
+          name: ${JOB_NAME_SAFE}
+          namespace: ${NAMESPACE}
+          annotations:
+            # we want to gather the teardown logs no matter what
+            ci-operator.openshift.io/wait-for-container-artifacts: teardown
+            ci-operator.openshift.io/save-container-logs: "true"
+        spec:
+          restartPolicy: Never
+          activeDeadlineSeconds: 14400
+          terminationGracePeriodSeconds: 600
+          volumes:
+          - name: artifacts
+            emptyDir: {}
+          - name: shared-tmp
+            emptyDir: {}
+          - name: cluster-profile
+            secret:
+              secretName: ${JOB_NAME_SAFE}-cluster-profile
+
+          containers:
+
+          # Once admin.kubeconfig exists, executes shared tests
+          - name: test
+            image: ${IMAGE_TESTS}
+            terminationMessagePolicy: FallbackToLogsOnError
+            resources:
+              requests:
+                cpu: 1
+                memory: 300Mi
+              limits:
+                memory: 4Gi
+            volumeMounts:
+            - name: shared-tmp
+              mountPath: /tmp/shared
+            - name: cluster-profile
+              mountPath: /tmp/cluster
+            - name: artifacts
+              mountPath: /tmp/artifacts
+            env:
+            - name: HOME
+              value: /tmp/home
+            - name: KUBECONFIG
+              value: /tmp/admin.kubeconfig
+            command:
+            - echo
+            - test
+            - CHANGED
+
+          # Runs an install
+          - name: setup
+            image: ${IMAGE_ANSIBLE}
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - name: shared-tmp
+              mountPath: /tmp
+            - name: cluster-profile
+              mountPath: /usr/share/ansible/openshift-ansible/inventory/dynamic/injected
+            env:
+            - name: INSTANCE_PREFIX
+              value: ${NAMESPACE}-${JOB_NAME_HASH}
+            - name: TYPE
+              value: ${CLUSTER_TYPE}
+            command:
+            - echo
+            - setup
+
+          # Performs cleanup of all created resources
+          - name: teardown
+            image: ${IMAGE_ANSIBLE}
+            terminationMessagePolicy: FallbackToLogsOnError
+            volumeMounts:
+            - name: shared-tmp
+              mountPath: /tmp/shared
+            - name: cluster-profile
+              mountPath: /usr/share/ansible/openshift-ansible/inventory/dynamic/injected
+            - name: artifacts
+              mountPath: /tmp/artifacts
+            env:
+            - name: INSTANCE_PREFIX
+              value: ${NAMESPACE}-${JOB_NAME_HASH}
+            - name: TYPE
+              value: ${CLUSTER_TYPE}
+            command:
+            - echo
+            - teardown
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse-pull: "1234"
+      created-by-pj-rehearse: "true"
+    name: rehearse-template-test-template-4b355dc3
+    namespace: test-namespace
+- data:
+    vars-origin.yaml: |
+      vars-origin.yaml
+    vars.yaml: |
+      changed
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.org/rehearse-pull: "1234"
+      created-by-pj-rehearse: "true"
+    name: rehearse-cluster-profile-test-profile-47224c86
+    namespace: test-namespace
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:
@@ -158,7 +303,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17e239-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304cd45-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -260,18 +405,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -288,7 +433,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17e15e-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304ce19-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -363,18 +508,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -391,7 +536,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17d891-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c924-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -474,18 +619,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -503,7 +648,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17d969-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c9d8-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -580,18 +725,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -608,7 +753,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17daf6-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304cb6a-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -708,18 +853,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -736,7 +881,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17d499-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c6ee-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -813,18 +958,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -841,7 +986,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17d688-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c7a2-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -941,18 +1086,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -969,7 +1114,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17d781-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c864-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1046,18 +1191,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1074,7 +1219,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17da23-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304ca95-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1174,18 +1319,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1202,7 +1347,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17dc0d-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304cc8e-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1302,18 +1447,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1330,7 +1475,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17dcc6-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c10a-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1407,18 +1552,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1435,7 +1580,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17dd99-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c297-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1535,18 +1680,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1564,7 +1709,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17dfcd-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c535-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1697,18 +1842,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1726,7 +1871,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17e0ae-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c63a-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1859,18 +2004,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1888,7 +2033,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17de63-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c392-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1987,18 +2132,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2016,7 +2161,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: ed17df21-ac29-11ea-b112-98fa9bcb3ca2
+    name: d304c46f-af20-11ea-b136-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2096,17 +2241,17 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
+      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
+        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-11T21:24:25Z"
+    startTime: "2020-06-15T15:56:50Z"
     state: triggered
 


### PR DESCRIPTION
This PR updates pj-reherase to support multiple build clusters for the configmap creation. It was done in preparation for https://issues.redhat.com/browse/DPTP-1244 but happens to (mostly) fix https://issues.redhat.com/browse/DPTP-1172

/hold

So I can be present when this gets rolled out.
/assign @petr-muller 