### PR TITLE
Define AllowSkipOnSuccess and OptionalOnSuccess flags

### DIFF
--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -477,6 +477,7 @@ func TestValidateTestSteps(t *testing.T) {
 	// string pointers in golang are annoying
 	myReference := "my-reference"
 	asReference := "as"
+	yes := true
 	for _, tc := range []struct {
 		name  string
 		steps []TestStep
@@ -678,7 +679,7 @@ func TestValidateTestSteps(t *testing.T) {
 				From:              "from",
 				Commands:          "commands",
 				Resources:         resources,
-				OptionalOnSuccess: func(b bool) *bool { return &b }(true)},
+				OptionalOnSuccess: &yes},
 		}},
 		errs: []error{
 			errors.New("test[0]: `optional_on_success` is only allowed for Post steps"),
@@ -702,6 +703,7 @@ func TestValidatePostSteps(t *testing.T) {
 		Requests: ResourceList{"cpu": "1"},
 		Limits:   ResourceList{"memory": "1m"},
 	}
+	yes := true
 	for _, tc := range []struct {
 		name  string
 		steps []TestStep
@@ -716,7 +718,7 @@ func TestValidatePostSteps(t *testing.T) {
 				From:              "from",
 				Commands:          "commands",
 				Resources:         resources,
-				OptionalOnSuccess: func(b bool) *bool { return &b }(true)},
+				OptionalOnSuccess: &yes},
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -669,13 +669,62 @@ func TestValidateTestSteps(t *testing.T) {
 		errs: []error{
 			errors.New("test[1].ref: duplicated name \"as\""),
 		},
+	}, {
+		name: "Test step with forbidden parameter",
+
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:                "as",
+				From:              "from",
+				Commands:          "commands",
+				Resources:         resources,
+				OptionalOnSuccess: func(b bool) *bool { return &b }(true)},
+		}},
+		errs: []error{
+			errors.New("test[0]: `optional_on_success` is only allowed for Post steps"),
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			seen := tc.seen
 			if seen == nil {
 				seen = sets.NewString()
 			}
-			ret := validateTestSteps("test", tc.steps, seen, nil)
+			ret := validateTestStepsTest("test", tc.steps, seen, nil)
+			if !errListMessagesEqual(ret, tc.errs) {
+				t.Fatal(diff.ObjectReflectDiff(ret, tc.errs))
+			}
+		})
+	}
+}
+
+func TestValidatePostSteps(t *testing.T) {
+	resources := ResourceRequirements{
+		Requests: ResourceList{"cpu": "1"},
+		Limits:   ResourceList{"memory": "1m"},
+	}
+	for _, tc := range []struct {
+		name  string
+		steps []TestStep
+		seen  sets.String
+		errs  []error
+	}{{
+		name: "Valid Post steps",
+
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:                "as",
+				From:              "from",
+				Commands:          "commands",
+				Resources:         resources,
+				OptionalOnSuccess: func(b bool) *bool { return &b }(true)},
+		}},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			seen := tc.seen
+			if seen == nil {
+				seen = sets.NewString()
+			}
+			ret := validateTestStepsPost("test", tc.steps, seen, nil)
 			if !errListMessagesEqual(ret, tc.errs) {
 				t.Fatal(diff.ObjectReflectDiff(ret, tc.errs))
 			}
@@ -706,7 +755,7 @@ func TestValidateParameters(t *testing.T) {
 		err:    []error{errors.New("test: unresolved parameter(s): [TEST1]")},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateLiteralTestStep("test", LiteralTestStep{
+			err := validateLiteralTestStepTest("test", LiteralTestStep{
 				As:       "as",
 				From:     "from",
 				Commands: "commands",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -548,7 +548,7 @@ type LiteralTestStep struct {
 	// OptionalOnSuccess defines if this step should be skipped as long
 	// as all `pre` and `test` steps were successful and AllowSkipOnSuccess
 	// flag is set to true in MultiStageTestConfiguration.
-	OptionalOnSuccess bool `json:"optional_on_success,omitempty"`
+	OptionalOnSuccess *bool `json:"optional_on_success,omitempty"`
 }
 
 // StepParameter is a variable set by the test, with an optional default.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -545,6 +545,10 @@ type LiteralTestStep struct {
 	Credentials []CredentialReference `json:"credentials,omitempty"`
 	// Environment lists parameters that should be set by the test.
 	Environment []StepParameter `json:"env,omitempty"`
+	// OptionalOnSuccess defines if this step should be skipped as long
+	// as all `pre` and `test` steps were successful and AllowSkipOnSuccess
+	// flag is set to true in MultiStageTestConfiguration.
+	OptionalOnSuccess bool `json:"optional_on_success,omitempty"`
 }
 
 // StepParameter is a variable set by the test, with an optional default.
@@ -598,7 +602,8 @@ type MultiStageTestConfiguration struct {
 	// Test is the array of test steps that define the actual test.
 	Test []TestStep `json:"test,omitempty"`
 	// Post is the array of test steps run after the tests finish and teardown/deprovision resources.
-	// Post steps always run, even if previous steps fail.
+	// Post steps always run, even if previous steps fail. However, they have an option to skip
+	// execution if previous Pre and Test steps passed.
 	Post []TestStep `json:"post,omitempty"`
 	// Workflow is the name of the workflow to be used for this configuration. For fields defined in both
 	// the config and the workflow, the fields from the config will override what is set in Workflow.
@@ -622,6 +627,10 @@ type MultiStageTestConfigurationLiteral struct {
 	Post []LiteralTestStep `json:"post,omitempty"`
 	// Environment has the values of parameters for the steps.
 	Environment TestEnvironment `json:"env,omitempty"`
+	// AllowSkipOnSuccess defines if any steps can be skipped when
+	// all previous `pre` and `test` steps were successful. The given step must explicitly
+	// ask for being skipped by setting the OptionalOnSuccess flag to true.
+	AllowSkipOnSuccess bool `json:"allow_skip_on_success,omitempty"`
 }
 
 // TestEnvironment has the values of parameters for multi-stage tests.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -547,7 +547,8 @@ type LiteralTestStep struct {
 	Environment []StepParameter `json:"env,omitempty"`
 	// OptionalOnSuccess defines if this step should be skipped as long
 	// as all `pre` and `test` steps were successful and AllowSkipOnSuccess
-	// flag is set to true in MultiStageTestConfiguration.
+	// flag is set to true in MultiStageTestConfiguration. This option is
+	// applicable to `post` steps.
 	OptionalOnSuccess *bool `json:"optional_on_success,omitempty"`
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -610,6 +610,10 @@ type MultiStageTestConfiguration struct {
 	Workflow *string `json:"workflow,omitempty"`
 	// Environment has the values of parameters for the steps.
 	Environment TestEnvironment `json:"env,omitempty"`
+	// AllowSkipOnSuccess defines if any steps can be skipped when
+	// all previous `pre` and `test` steps were successful. The given step must explicitly
+	// ask for being skipped by setting the OptionalOnSuccess flag to true.
+	AllowSkipOnSuccess bool `json:"allow_skip_on_success,omitempty"`
 }
 
 // MultiStageTestConfigurationLiteral is a form of the MultiStageTestConfiguration that does not include

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -346,7 +346,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 	var ret []coreapi.Pod
 	var errs []error
 	for _, step := range steps {
-		if s.allowSkipOnSuccess && step.OptionalOnSuccess && !hasPrevErrs {
+		if s.allowSkipOnSuccess && step.OptionalOnSuccess != nil && *step.OptionalOnSuccess && !hasPrevErrs {
 			continue
 		}
 		image := step.From

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -49,16 +49,17 @@ type multiStageTestStep struct {
 	profile api.ClusterProfile
 	config  *api.ReleaseBuildConfiguration
 	// params exposes getters for variables created by other steps
-	params          api.Parameters
-	env             api.TestEnvironment
-	podClient       PodClient
-	secretClient    coreclientset.SecretsGetter
-	saClient        coreclientset.ServiceAccountsGetter
-	rbacClient      rbacclientset.RbacV1Interface
-	artifactDir     string
-	jobSpec         *api.JobSpec
-	pre, test, post []api.LiteralTestStep
-	subTests        []*junit.TestCase
+	params             api.Parameters
+	env                api.TestEnvironment
+	podClient          PodClient
+	secretClient       coreclientset.SecretsGetter
+	saClient           coreclientset.ServiceAccountsGetter
+	rbacClient         rbacclientset.RbacV1Interface
+	artifactDir        string
+	jobSpec            *api.JobSpec
+	pre, test, post    []api.LiteralTestStep
+	subTests           []*junit.TestCase
+	allowSkipOnSuccess bool
 }
 
 func MultiStageTestStep(
@@ -93,21 +94,22 @@ func newMultiStageTestStep(
 	}
 	ms := testConfig.MultiStageTestConfigurationLiteral
 	return &multiStageTestStep{
-		logger:       logger,
-		name:         testConfig.As,
-		profile:      ms.ClusterProfile,
-		config:       config,
-		params:       params,
-		env:          ms.Environment,
-		podClient:    podClient,
-		secretClient: secretClient,
-		saClient:     saClient,
-		rbacClient:   rbacClient,
-		artifactDir:  artifactDir,
-		jobSpec:      jobSpec,
-		pre:          ms.Pre,
-		test:         ms.Test,
-		post:         ms.Post,
+		logger:             logger,
+		name:               testConfig.As,
+		profile:            ms.ClusterProfile,
+		config:             config,
+		params:             params,
+		env:                ms.Environment,
+		podClient:          podClient,
+		secretClient:       secretClient,
+		saClient:           saClient,
+		rbacClient:         rbacClient,
+		artifactDir:        artifactDir,
+		jobSpec:            jobSpec,
+		pre:                ms.Pre,
+		test:               ms.Test,
+		post:               ms.Post,
+		allowSkipOnSuccess: ms.AllowSkipOnSuccess,
 	}
 }
 
@@ -156,13 +158,13 @@ func (s *multiStageTestStep) run(ctx context.Context, dry bool) error {
 		return fmt.Errorf("failed to create RBAC objects: %w", err)
 	}
 	var errs []error
-	if err := s.runSteps(ctx, s.pre, env, true); err != nil {
-		errs = append(errs, fmt.Errorf("%q pre steps failed: %w", s.name, err))
-	} else if err := s.runSteps(ctx, s.test, env, true); err != nil {
-		errs = append(errs, fmt.Errorf("%q test steps failed: %w", s.name, err))
+	if err := s.runSteps(ctx, s.pre, env, true, errs); err != nil {
+		errs = append(errs, fmt.Errorf("%q pre steps failed: %v", s.name, err))
+	} else if err := s.runSteps(ctx, s.test, env, true, errs); err != nil {
+		errs = append(errs, fmt.Errorf("%q test steps failed: %v", s.name, err))
 	}
-	if err := s.runSteps(context.Background(), s.post, env, false); err != nil {
-		errs = append(errs, fmt.Errorf("%q post steps failed: %w", s.name, err))
+	if err := s.runSteps(context.Background(), s.post, env, false, errs); err != nil {
+		errs = append(errs, fmt.Errorf("%q post steps failed: %v", s.name, err))
 	}
 	return utilerrors.NewAggregate(errs)
 }
@@ -314,8 +316,9 @@ func (s *multiStageTestStep) runSteps(
 	steps []api.LiteralTestStep,
 	env []coreapi.EnvVar,
 	shortCircuit bool,
+	prevErrs []error,
 ) error {
-	pods, err := s.generatePods(steps, env)
+	pods, err := s.generatePods(steps, env, prevErrs)
 	if err != nil {
 		return err
 	}
@@ -338,10 +341,14 @@ func (s *multiStageTestStep) runSteps(
 	return utilerrors.NewAggregate(errs)
 }
 
-func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []coreapi.EnvVar) ([]coreapi.Pod, error) {
+func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []coreapi.EnvVar,
+	prevErrs []error) ([]coreapi.Pod, error) {
 	var ret []coreapi.Pod
 	var errs []error
 	for _, step := range steps {
+		if s.allowSkipOnSuccess && step.OptionalOnSuccess && len(prevErrs) == 0 {
+			continue
+		}
 		image := step.From
 		if link, ok := step.FromImageTag(); ok {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, link)

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -159,12 +159,12 @@ func (s *multiStageTestStep) run(ctx context.Context, dry bool) error {
 	}
 	var errs []error
 	if err := s.runSteps(ctx, s.pre, env, true, errs); err != nil {
-		errs = append(errs, fmt.Errorf("%q pre steps failed: %v", s.name, err))
+		errs = append(errs, fmt.Errorf("%q pre steps failed: %w", s.name, err))
 	} else if err := s.runSteps(ctx, s.test, env, true, errs); err != nil {
-		errs = append(errs, fmt.Errorf("%q test steps failed: %v", s.name, err))
+		errs = append(errs, fmt.Errorf("%q test steps failed: %w", s.name, err))
 	}
 	if err := s.runSteps(context.Background(), s.post, env, false, errs); err != nil {
-		errs = append(errs, fmt.Errorf("%q post steps failed: %v", s.name, err))
+		errs = append(errs, fmt.Errorf("%q post steps failed: %w", s.name, err))
 	}
 	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -520,7 +520,7 @@ func TestRun(t *testing.T) {
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
 					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: true}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: func(b bool) *bool { return &b }(true)}},
 					AllowSkipOnSuccess: true,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), "", &jobSpec, nil)

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -161,7 +161,7 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},
 		{Name: "LEASED_RESOURCE", Value: "uuid"},
 	}
-	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, []error{})
+	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Environment: tc.env,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, nil, nil, nil, nil, "", &jobSpec, nil)
-			pods, err := step.(*multiStageTestStep).generatePods(test, nil, []error{})
+			pods, err := step.(*multiStageTestStep).generatePods(test, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -161,7 +161,7 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},
 		{Name: "LEASED_RESOURCE", Value: "uuid"},
 	}
-	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env)
+	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, []error{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Environment: tc.env,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, nil, nil, nil, nil, "", &jobSpec, nil)
-			pods, err := step.(*multiStageTestStep).generatePods(test, nil)
+			pods, err := step.(*multiStageTestStep).generatePods(test, nil, []error{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -474,7 +474,7 @@ func TestRun(t *testing.T) {
 		expected: []string{
 			"test-pre0", "test-pre1",
 			"test-test0", "test-test1",
-			"test-post0", "test-post1",
+			"test-post0",
 		},
 	}, {
 		name:     "failure in a pre step, test should not run, post should",
@@ -497,7 +497,7 @@ func TestRun(t *testing.T) {
 		expected: []string{
 			"test-pre0", "test-pre1",
 			"test-test0", "test-test1",
-			"test-post0", "test-post1",
+			"test-post0",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -518,9 +518,10 @@ func TestRun(t *testing.T) {
 			step := MultiStageTestStep(api.TestStepConfiguration{
 				As: name,
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
-					Pre:  []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
-					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: true}},
+					AllowSkipOnSuccess: true,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), "", &jobSpec, nil)
 			if err := step.Run(context.Background(), false); tc.failures == nil && err != nil {

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1156,13 +1156,15 @@ The configuration can also override a workflow field with a <a href="#step">full
 
 {{ yamlSyntax (index . "configExample3") }}
 
-<h3 id="allow-skip-on-success"><a href="#allow-skip-on-success">Optional skipping of post steps</a></h3>
+<h2 id="allow-skip-on-success"><a href="#allow-skip-on-success">Options to Change Control Flow</a></h2>
 <p>
-There is an option to skip arbitrary <code>post</code> steps when all <code>test</code>
-steps pass. For example, it might be useful to skip gathering artifacts when all tests have passed and save 
-some time at the end of the multistage test. In order to skip a <code>post</code> step, the individual step
-has to define an <code>optional_on_success</code> field. Skipping the step is then enabled by adding
-an <code>allow_skip_on_success</code> field to the <code>steps</code> configuration. This is an example:
+<code>ci-operator</code> can be configured to skip some or all <code>post</code> steps
+when all <code>test</code> steps pass.
+Skipping a <code>post</code> step when all tests have passed may be useful to skip
+gathering artifacts and save some time at the end of the multistage test.
+In order to allow steps to be skipped in a test, the <code>allow_skip_on_success</code> field must
+be set in the <code>steps</code> configuration. Individual <code>post</code> steps opt
+into being skipped by setting the <code>optional_on_success</code> field. This is an example:
 </p>
 
 {{ yamlSyntax (index . "configExample4") }}
@@ -1349,7 +1351,7 @@ const configExample3 = `tests:
 const configExample4 = `tests:
 - as: e2e-steps # test name
   steps:
-    allow_skip_on_success: true
+    allow_skip_on_success: true      # allows steps to be skipped in this test
     test:
     - as: successful-test-step
       commands: echo Success

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1156,6 +1156,17 @@ The configuration can also override a workflow field with a <a href="#step">full
 
 {{ yamlSyntax (index . "configExample3") }}
 
+<h3 id="allow-skip-on-success"><a href="#allow-skip-on-success">Optional skipping of post steps</a></h3>
+<p>
+There is an option to skip arbitrary <code>post</code> steps when all <code>test</code>
+steps pass. For example, it might be useful to skip gathering artifacts when all tests have passed and save 
+some time at the end of the multistage test. In order to skip a <code>post</code> step, the individual step
+has to define an <code>optional_on_success</code> field. Skipping the step is then enabled by adding
+an <code>allow_skip_on_success</code> field to the <code>steps</code> configuration. This is an example:
+</p>
+
+{{ yamlSyntax (index . "configExample4") }}
+
 <h3 id="layout"><a href="#layout">Registry Layout and Naming Convention</a></h3>
 <p>
 To prevent naming collisions between all the registry components, the step
@@ -1335,6 +1346,27 @@ const configExample3 = `tests:
         requests:
           cpu: 100m
           memory: 200Mi`
+const configExample4 = `tests:
+- as: e2e-steps # test name
+  steps:
+    allow_skip_on_success: true
+    test:
+    - as: successful-test-step
+      commands: echo Success
+      from: os
+      resources:
+        requests:
+          cpu: 100m
+          memory: 200Mi
+    post:
+    - as: gather-must-gather         # this step will be skipped as the successful-test-step passes
+      optional_on_success: true
+      from: cli
+      commands: gather-must-gather-commands.sh
+      resources:
+        requests:
+          cpu: 300m
+          memory: 300Mi`
 const paramsExample = `ref:
   as: openshift-e2e-test
   from: tests
@@ -1960,6 +1992,7 @@ func helpHandler(subPath string, w http.ResponseWriter, _ *http.Request) {
 		data["configExample1"] = configExample1
 		data["configExample2"] = configExample2
 		data["configExample3"] = configExample3
+		data["configExample4"] = configExample4
 		data["paramsExample"] = paramsExample
 		data["paramsPropagation"] = paramsPropagation
 		data["paramsRequired"] = paramsRequired

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -20,6 +20,7 @@ os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-add
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"
+os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success"
 unset UNRESOLVED_CONFIG
 os::integration::configresolver::check_log
 

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -17,10 +17,10 @@ os::integration::configresolver::start "${suite_dir}/configs" "${suite_dir}/regi
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target success"
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success"
 unset UNRESOLVED_CONFIG
 os::integration::configresolver::check_log
 

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -31,6 +31,34 @@ tests:
     steps:
       test:
         - ref: step
+  - as: skip-on-success
+    steps:
+      allow_skip_on_success: true
+      test:
+        - as: successful-test-step
+          commands: echo Success
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+      post:
+        - as: skip-on-success-post-step
+          optional_on_success: true
+          commands: touch ${ARTIFACT_DIR}/file
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        - as: check-skipped-step
+          commands: test ! -f ${ARTIFACT_DIR}/file
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+
 zz_generated_metadata:
   branch: master
   org: test


### PR DESCRIPTION
* allow_skip_on_success is an umbrella flag being set inside the "steps" element,
  it gives a signal to all steps that define optional_on_success to be
skipped
* optional_on_success is being set inside individual step

If both are set to true and all previous `pre` and `test` steps were
successful, the given step will be skipped. If the step is a `post` step it will be skipped in this case even if previous `post` steps failed but all `pre` and `test` steps passed.