### PR TITLE
ci-operator: correctly wrap errors from steps

### DIFF
--- a/pkg/results/error.go
+++ b/pkg/results/error.go
@@ -104,6 +104,7 @@ func (e *BuilderWithReason) ForError(err error) error {
 	if err == nil {
 		return nil
 	}
+	e.wrapped = err
 	e.message = err.Error()
 	return &e.Error
 }

--- a/pkg/results/error_test.go
+++ b/pkg/results/error_test.go
@@ -46,3 +46,25 @@ func TestError(t *testing.T) {
 		t.Errorf("got incorrect reason for unchanged error; expected %s, got %v", expected, actual)
 	}
 }
+
+func TestComplexError(t *testing.T) {
+	work := func() error {
+		return errors.New("root error")
+	}
+
+	do := func() error {
+		if err := work(); err != nil {
+			return ForReason("root_thing").WithError(err).Errorf("failed to do root thing: %v", err)
+		}
+		return nil
+	}
+
+	run := func() error {
+		return ForReason("higher_level_thing").ForError(do())
+	}
+
+	err := run()
+	if actual, expected := FullReason(err), "higher_level_thing:root_thing"; actual != expected {
+		t.Errorf("got incorrect reason for top-level error; expected %s, got %v", expected, actual)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

generated with

```
$ perl -i -p0e 's/return results.ForReason\(("[a-z_]+")\).ForError\(s.run\(ctx, dry\)\)/err := s.run(ctx, dry)\n\treturn results.ForReason(\1).WithError(err).Errorf(err.Error())/s' $( git grep -l 'ForError(..run' )
```