### PR TITLE
ci-operator: require stable image stream before creating tags

### DIFF
--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -72,7 +72,17 @@ func (s *outputImageTagStep) run(ctx context.Context, dry bool) error {
 }
 
 func (s *outputImageTagStep) Requires() []api.StepLink {
-	return []api.StepLink{api.InternalImageLink(s.config.From)}
+	return []api.StepLink{
+		api.InternalImageLink(s.config.From),
+		// Release input and import steps do not handle the
+		// case when other steps are publishing tags to the
+		// stable stream. Generally, this is not an issue as
+		// the former run at the start of execution and the
+		// latter only once images are built. However, in
+		// specific configurations, authors may create an
+		// execution graph where we race.
+		api.StableImagesLink(api.LatestStableName),
+	}
 }
 
 func (s *outputImageTagStep) Creates() []api.StepLink {

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -31,6 +31,7 @@ func TestOutputImageStep(t *testing.T) {
 		name: "configToAs",
 		requires: []api.StepLink{
 			api.InternalImageLink(config.From),
+			api.StableImagesLink(api.LatestStableName),
 		},
 		creates: []api.StepLink{
 			api.ExternalImageLink(config.To),


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>