### PR TITLE
config-brancher: always update all affected versions

### DIFF
--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -27,7 +27,7 @@ func (o *options) Validate() error {
 		return fmt.Errorf("future releases %v do not contain bump release %v", futureReleases.List(), o.BumpRelease)
 	}
 
-	return o.Options.Validate()
+	return o.FutureOptions.Validate()
 }
 
 func (o *options) Bind(fs *flag.FlagSet) {

--- a/test/integration/ci-operator-config-mirror.sh
+++ b/test/integration/ci-operator-config-mirror.sh
@@ -3,24 +3,23 @@ source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 trap os::test::junit::reconcile_output EXIT
 
 suite_dir="${OS_ROOT}/test/integration/ci-operator-config-mirror"
-cp -r "${suite_dir}/input" "${BASETMPDIR}"
-cp -r "${suite_dir}/input-to-clean" "${BASETMPDIR}"
-
-actual="${BASETMPDIR}/input"
-actual_to_clean="${BASETMPDIR}/input-to-clean"
-
-expected="${suite_dir}/output"
+workdir="${BASETMPDIR}/ci-operator-config-mirror"
+mkdir -p "${workdir}"
+cp -a "${suite_dir}/"* "${workdir}"
 
 os::test::junit::declare_suite_start "integration/ci-operator-config-mirror"
 # This test validates the ci-operator-config-mirror tool
 
+actual="${workdir}/input"
 os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual} --clean=false --whitelist-file ${suite_dir}/whitelist.yaml"
-os::integration::compare "${actual}" "${expected}"
+os::integration::compare "${actual}" "${suite_dir}/output"
 
-os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual_to_clean} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
-os::integration::compare "${actual_to_clean}" "${expected}"
+actual="${workdir}/input-to-clean"
+os::cmd::expect_success "ci-operator-config-mirror --to-org super-priv --config-path ${actual} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
+os::integration::compare "${actual}" "${suite_dir}/output"
 
-os::cmd::expect_success "ci-operator-config-mirror --only-org super --to-org super-priv --config-path ${actual_to_clean} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
-os::integration::compare "${actual_to_clean}" "${suite_dir}/output-only-super"
+actual="${workdir}/input-to-clean"
+os::cmd::expect_success "ci-operator-config-mirror --only-org super --to-org super-priv --config-path ${actual} --clean=true --whitelist-file ${suite_dir}/whitelist.yaml"
+os::integration::compare "${actual}" "${suite_dir}/output-only-super"
 
 os::test::junit::declare_suite_end

--- a/test/integration/config-brancher.sh
+++ b/test/integration/config-brancher.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+function cleanup() {
+    os::test::junit::reconcile_output
+    os::cleanup::processes
+}
+trap "cleanup" EXIT
+
+suite_dir="${OS_ROOT}/test/integration/config-brancher/"
+workdir="${BASETMPDIR}/config-brancher"
+mkdir -p "${workdir}"
+cp -a "${suite_dir}/"* "${workdir}"
+actual="${workdir}/input"
+
+os::test::junit::declare_suite_start "integration/config-brancher"
+# This test validates the config-brancher tool
+
+# this invocation will branch a config from a source dev config
+os::cmd::expect_success "config-brancher --org org --repo new --config-dir ${actual} --current-release=4.5 --future-release=4.6 --confirm"
+# this invocation will branch, and bump the dev config
+os::cmd::expect_success "config-brancher --org org --repo bump --config-dir ${actual} --current-release=4.5 --future-release=4.6 --bump-release=4.6 --confirm"
+# this invocation will edit config in place while bumping
+os::cmd::expect_success "config-brancher --org org --repo existing --config-dir ${actual} --current-release=4.5 --future-release=4.6 --bump-release=4.6 --confirm"
+os::integration::compare "${actual}" "${suite_dir}/expected"
+
+os::test::junit::declare_suite_end

--- a/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.6"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: bump

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.5
+  org: org
+  repo: bump

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
@@ -1,0 +1,38 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  disabled: true
+  name: "4.6"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.6
+  org: org
+  repo: bump

--- a/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.6"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.5
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
@@ -1,0 +1,38 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  disabled: true
+  name: "4.6"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.6
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/expected/org/new/org-new-master.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: new

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
@@ -1,0 +1,38 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  disabled: true
+  name: "4.5"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.5
+  org: org
+  repo: new

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.6"
+  namespace: ocp
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+rpm_build_commands: make rpms
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: release-4.6
+  org: org
+  repo: new

--- a/test/integration/config-brancher/input/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/input/org/bump/org-bump-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: bump

--- a/test/integration/config-brancher/input/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/input/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-release-4.5.yaml
@@ -1,0 +1,38 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+  disabled: true
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/input/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-release-4.6.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.6"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.6"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.6"
+  namespace: ocp
+tag_specification:
+  name: "4.6"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: existing

--- a/test/integration/config-brancher/input/org/new/org-new-master.yaml
+++ b/test/integration/config-brancher/input/org/new/org-new-master.yaml
@@ -1,0 +1,37 @@
+base_images:
+  tools:
+    name: "4.5"
+    namespace: ocp
+    tag: tools
+base_rpm_images:
+  installer:
+    name: "4.5"
+    namespace: ocp
+    tag: installer
+rpm_build_commands: make rpms
+build_root:
+  image_stream_tag:
+    name: "4.5"
+    namespace: ocp
+    tag: base
+promotion:
+  name: "4.5"
+  namespace: ocp
+tag_specification:
+  name: "4.5"
+  namespace: ocp
+tests:
+  - as: unit
+    commands: make test-unit
+    container:
+      from: src
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: org
+  repo: new

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -158,7 +158,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d9077-aa6f-11ea-9327-8c16450d6013
+    name: ed17e239-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -260,18 +260,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -288,7 +288,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d9141-aa6f-11ea-9327-8c16450d6013
+    name: ed17e15e-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -363,18 +363,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -391,7 +391,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d87ea-aa6f-11ea-9327-8c16450d6013
+    name: ed17d891-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -474,18 +474,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -503,7 +503,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d88a9-aa6f-11ea-9327-8c16450d6013
+    name: ed17d969-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -580,18 +580,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -608,7 +608,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8a26-aa6f-11ea-9327-8c16450d6013
+    name: ed17daf6-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -708,18 +708,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -736,7 +736,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d83c5-aa6f-11ea-9327-8c16450d6013
+    name: ed17d499-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -813,18 +813,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -841,7 +841,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8612-aa6f-11ea-9327-8c16450d6013
+    name: ed17d688-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -941,18 +941,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -969,7 +969,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d870f-aa6f-11ea-9327-8c16450d6013
+    name: ed17d781-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1046,18 +1046,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1074,7 +1074,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d895d-aa6f-11ea-9327-8c16450d6013
+    name: ed17da23-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1174,18 +1174,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1202,7 +1202,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8b41-aa6f-11ea-9327-8c16450d6013
+    name: ed17dc0d-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1302,18 +1302,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1330,7 +1330,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8c12-aa6f-11ea-9327-8c16450d6013
+    name: ed17dcc6-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1407,18 +1407,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1435,7 +1435,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8cc5-aa6f-11ea-9327-8c16450d6013
+    name: ed17dd99-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1535,18 +1535,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1564,7 +1564,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8f06-aa6f-11ea-9327-8c16450d6013
+    name: ed17dfcd-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1697,18 +1697,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1726,7 +1726,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8fc8-aa6f-11ea-9327-8c16450d6013
+    name: ed17e0ae-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1859,18 +1859,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1888,7 +1888,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8d90-aa6f-11ea-9327-8c16450d6013
+    name: ed17de63-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1987,18 +1987,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2016,7 +2016,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: 7f5d8e4f-aa6f-11ea-9327-8c16450d6013
+    name: ed17df21-ac29-11ea-b112-98fa9bcb3ca2
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2096,17 +2096,17 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: f31e1750910c4cfbf8ffa6aafe660985f87a662b
+      base_sha: 8ca31a8ec364ff7e94592eba9d6998182ac7cd76
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 6ec7984752286cfc9355750974e26d0004f7c641
+        sha: 526593bc9f8c28b8f442203321a3b1a141595b7f
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-09T16:37:24Z"
+    startTime: "2020-06-11T21:24:25Z"
     state: triggered
 


### PR DESCRIPTION
The config-brancher tool works across a number of different versions:
 - the current version devs are working on
 - future versions we've created in advance
 - the version we are bumping the dev version to

Originally, you only had to specify a version in one of these three
fields to ensure that the config for that version was updated when the
tool was run. At some point that regressed, so for instance when you
configured a current version, future versions and a bump version, unless
you specifically listed the bump version as a future version, the bump
version would not be updated. This is problematic as when we do a bump,
the dev configuration is changed to the bump version, and the branch for
that bump version must also be changed to no longer publish images, or
we'd have two branches racing to publish to the same image tag. This
change fixes the bug and adds in a set of integration tests to verify
it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @droslean 