### PR TITLE
Prowgen: Stop setting the kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,7 @@ verify-gen: generate
 		git diff; \
 		echo "generated files are out of date, run make generate"; exit 1; \
 	fi
+
+update-unit:
+	UPDATE=true go test ./...
+.PHONY: update-unit

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -35,7 +35,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -49,9 +48,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -60,12 +56,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -38,7 +38,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -53,9 +52,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -64,12 +60,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/postsubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
@@ -15,7 +15,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -29,9 +28,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -40,12 +36,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -30,9 +29,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -71,7 +61,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -84,9 +73,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -95,12 +81,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_Using_a_variant_config,_one_test_and_images,_one_existing_job._Expect_one_presubmit,_pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -32,9 +31,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -43,12 +39,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -74,7 +64,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -88,9 +77,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -99,12 +85,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/presubmit-TestFromCIOperatorConfigToProwYaml_one_test_and_images,_no_previous_jobs._Expect_test_presubmit_+_pre_post_submit_images_jobs.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -30,9 +29,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -71,7 +61,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -84,9 +73,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -95,12 +81,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/hack/tools.go
+++ b/hack/tools.go
@@ -1,4 +1,5 @@
 // +build tools
+
 package hack
 
 // Add tools that hack scripts depend on here, to ensure they are vendored.

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -35,11 +35,6 @@ type ProwgenInfo struct {
 func generatePodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secret) *corev1.PodSpec {
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      "apici-ci-operator-credentials",
-			MountPath: "/etc/apici",
-			ReadOnly:  true,
-		},
-		{
 			Name:      "pull-secret",
 			MountPath: "/etc/pull-secret",
 			ReadOnly:  true,
@@ -52,20 +47,6 @@ func generatePodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secret) *corev1
 	}
 
 	volumes := []corev1.Volume{
-		{
-			Name: "apici-ci-operator-credentials",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "apici-ci-operator-credentials",
-					Items: []corev1.KeyToPath{
-						{
-							Key:  "sa.ci-operator.apici.config",
-							Path: "kubeconfig",
-						},
-					},
-				},
-			},
-		},
 		{
 			Name: "pull-secret",
 			VolumeSource: corev1.VolumeSource{
@@ -214,7 +195,6 @@ func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secre
 	ret := generatePodSpec(info, secrets)
 	ret.Containers[0].Command = []string{"ci-operator"}
 	ret.Containers[0].Args = append([]string{
-		"--kubeconfig=/etc/apici/kubeconfig",
 		"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 		"--report-username=ci",
 		"--report-password-file=/etc/report/password.txt",

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -1,30 +1,19 @@
 package prowgen
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
-	"reflect"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/resource"
-	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	ciop "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
-
-var unexportedFields = []cmp.Option{
-	cmpopts.IgnoreUnexported(prowconfig.Presubmit{}),
-	cmpopts.IgnoreUnexported(prowconfig.Periodic{}),
-	cmpopts.IgnoreUnexported(prowconfig.Brancher{}),
-	cmpopts.IgnoreUnexported(prowconfig.RegexpChangeMatcher{}),
-}
 
 func TestGeneratePodSpec(t *testing.T) {
 	tests := []struct {
@@ -33,111 +22,17 @@ func TestGeneratePodSpec(t *testing.T) {
 		secrets        []*ciop.Secret
 		targets        []string
 		additionalArgs []string
-
-		expected *corev1.PodSpec
 	}{
 		{
 			description: "standard use case",
 			info:        &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			secrets:     nil,
 			targets:     []string{"target"},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=target",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-					},
-				}},
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-				},
-			},
 		},
 		{
 			description:    "additional args are included in podspec",
 			info:           &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			secrets:        nil,
 			targets:        []string{"target"},
 			additionalArgs: []string{"--promote", "--some=thing"},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--promote",
-						"--some=thing",
-						"--target=target",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-					},
-				}},
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-				},
-			},
 		},
 		{
 			description:    "additional args and secret are included in podspec",
@@ -145,113 +40,11 @@ func TestGeneratePodSpec(t *testing.T) {
 			secrets:        []*ciop.Secret{{Name: "secret-name", MountPath: "/usr/local/test-secret"}},
 			targets:        []string{"target"},
 			additionalArgs: []string{"--promote", "--some=thing"},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--promote",
-						"--some=thing",
-						"--target=target",
-						"--secret-dir=/secrets/secret-name",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "secret-name", MountPath: "/secrets/secret-name", ReadOnly: true},
-					},
-				}},
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "secret-name",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "secret-name"},
-						},
-					},
-				},
-			},
 		},
 		{
 			description: "multiple targets",
 			info:        &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			secrets:     nil,
 			targets:     []string{"target", "more", "and-more"},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=target",
-						"--target=more",
-						"--target=and-more",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-					},
-				}},
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-				},
-			},
 		},
 		{
 			description: "private job",
@@ -259,75 +52,13 @@ func TestGeneratePodSpec(t *testing.T) {
 				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 				Config:   config.Prowgen{Private: true},
 			},
-			secrets: nil,
 			targets: []string{"target"},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Containers: []corev1.Container{
-					{
-						Image:           "ci-operator:latest",
-						ImagePullPolicy: corev1.PullAlways,
-						Command:         []string{"ci-operator"},
-						Args: []string{
-							"--kubeconfig=/etc/apici/kubeconfig",
-							"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-							"--report-username=ci",
-							"--report-password-file=/etc/report/password.txt",
-							"--target=target",
-							"--oauth-token-path=/usr/local/github-credentials/oauth",
-						},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-						},
-						VolumeMounts: []corev1.VolumeMount{
-							{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-							{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-							{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-							{
-								Name:      "github-credentials-openshift-ci-robot-private-git-cloner",
-								MountPath: "/usr/local/github-credentials",
-								ReadOnly:  true,
-							},
-						},
-					},
-				},
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "github-credentials-openshift-ci-robot-private-git-cloner",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "github-credentials-openshift-ci-robot-private-git-cloner"},
-						},
-					},
-				},
-			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			podSpec := generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, tc.additionalArgs...)
-			if !equality.Semantic.DeepEqual(podSpec, tc.expected) {
-				t.Errorf("%s: expected PodSpec diff:\n%s", tc.description, cmp.Diff(tc.expected, podSpec, unexportedFields...))
-			}
+			testhelper.CompareWithFixture(t, generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, tc.additionalArgs...))
 		})
 	}
 }
@@ -340,81 +71,8 @@ func TestGeneratePodSpecMultiStage(t *testing.T) {
 			ClusterProfile: ciop.ClusterProfileAWS,
 		},
 	}
-	expected := corev1.PodSpec{
-		ServiceAccountName: "ci-operator",
-		Volumes: []corev1.Volume{{
-			Name: "apici-ci-operator-credentials",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-			},
-		}, {
-			Name: "pull-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-			},
-		}, {
-			Name: "result-aggregator",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-			},
-		}, {
-			Name: "ci-pull-credentials",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: "ci-pull-credentials"},
-			},
-		}, {
-			Name: "cluster-profile",
-			VolumeSource: corev1.VolumeSource{
-				Projected: &corev1.ProjectedVolumeSource{
-					Sources: []corev1.VolumeProjection{{
-						Secret: &corev1.SecretProjection{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: "cluster-secrets-aws",
-							},
-						},
-					}},
-				},
-			},
-		}, {
-			Name: "boskos",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: "boskos-credentials",
-					Items:      []corev1.KeyToPath{{Key: "password", Path: "password"}},
-				},
-			},
-		}},
-		Containers: []corev1.Container{{
-			Image:           "ci-operator:latest",
-			ImagePullPolicy: corev1.PullAlways,
-			Command:         []string{"ci-operator"},
-			Args: []string{
-				"--kubeconfig=/etc/apici/kubeconfig",
-				"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-				"--report-username=ci",
-				"--report-password-file=/etc/report/password.txt",
-				"--target=test",
-				"--secret-dir=/secrets/ci-pull-credentials",
-				"--secret-dir=/usr/local/test-cluster-profile",
-				"--lease-server-password-file=/etc/boskos/password",
-			},
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-				{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-				{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-				{Name: "ci-pull-credentials", ReadOnly: true, MountPath: "/secrets/ci-pull-credentials"},
-				{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-				{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-			},
-		}},
-	}
-	podSpec := *generatePodSpecMultiStage(&info, &test, true)
-	if !equality.Semantic.DeepEqual(&podSpec, &expected) {
-		t.Errorf("expected PodSpec diff:\n%s", cmp.Diff(expected, podSpec, unexportedFields...))
-	}
+
+	testhelper.CompareWithFixture(t, generatePodSpecMultiStage(&info, &test, true))
 }
 
 func TestGeneratePodSpecTemplate(t *testing.T) {
@@ -422,8 +80,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 		info    *ProwgenInfo
 		release string
 		test    ciop.TestStepConfiguration
-
-		expected *corev1.PodSpec
 	}{
 		{
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
@@ -435,93 +91,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 				},
 			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-e2e",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-gcp",
-											},
-										},
-									},
-									{
-										ConfigMap: &corev1.ConfigMapProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-profile-gcp",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test"},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "gcp"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "RPM_REPO_OPENSHIFT_ORIGIN", Value: "https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-e2e.yaml"},
-					},
-				}},
-			},
 		},
 		{
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
@@ -532,94 +101,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerClusterTestConfiguration: &ciop.OpenshiftInstallerClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "aws"},
 				},
-			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-installer-e2e",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-aws",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "boskos",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "boskos-credentials", Items: []corev1.KeyToPath{{Key: "password", Path: "password"}}},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test",
-						"--lease-server-password-file=/etc/boskos/password",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "aws"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-e2e.yaml"},
-					},
-				}},
 			},
 		},
 		{
@@ -635,104 +116,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					NestedVirtImage:          "nested-virt-image-name",
 				},
 			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-installer-custom-test-image",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-gcp",
-											},
-										},
-									},
-									{
-										ConfigMap: &corev1.ConfigMapProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-profile-gcp",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "boskos",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "boskos-credentials", Items: []corev1.KeyToPath{{Key: "password", Path: "password"}}},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test",
-						"--lease-server-password-file=/etc/boskos/password",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "gcp"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "true"},
-						{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: "nested-virt-image-name"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-custom-test-image.yaml"},
-					},
-				}},
-			},
 		},
 		{
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
@@ -745,103 +128,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					From:                     "pipeline:kubevirt-test",
 					EnableNestedVirt:         true,
 				},
-			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-installer-custom-test-image",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-gcp",
-											},
-										},
-									},
-									{
-										ConfigMap: &corev1.ConfigMapProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-profile-gcp",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "boskos",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "boskos-credentials", Items: []corev1.KeyToPath{{Key: "password", Path: "password"}}},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test",
-						"--lease-server-password-file=/etc/boskos/password",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "gcp"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-						{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: "true"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-custom-test-image.yaml"},
-					},
-				}},
 			},
 		},
 		{
@@ -857,102 +143,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					EnableNestedVirt:         false,
 				},
 			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-installer-custom-test-image",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-gcp",
-											},
-										},
-									},
-									{
-										ConfigMap: &corev1.ConfigMapProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-profile-gcp",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "boskos",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "boskos-credentials", Items: []corev1.KeyToPath{{Key: "password", Path: "password"}}},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test",
-						"--lease-server-password-file=/etc/boskos/password",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "gcp"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-custom-test-image.yaml"},
-					},
-				}},
-			},
 		},
 		{
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
@@ -965,268 +155,68 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 					From:                     "pipeline:kubevirt-test",
 				},
 			},
-
-			expected: &corev1.PodSpec{
-				ServiceAccountName: "ci-operator",
-				Volumes: []corev1.Volume{
-					{
-						Name: "apici-ci-operator-credentials",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "apici-ci-operator-credentials", Items: []corev1.KeyToPath{{Key: "sa.ci-operator.apici.config", Path: "kubeconfig"}}},
-						},
-					},
-					{
-						Name: "pull-secret",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
-						},
-					},
-					{
-						Name: "result-aggregator",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
-						},
-					},
-					{
-						Name: "job-definition",
-						VolumeSource: corev1.VolumeSource{
-							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{
-									Name: "prow-job-cluster-launch-installer-custom-test-image",
-								},
-							},
-						},
-					},
-					{
-						Name: "cluster-profile",
-						VolumeSource: corev1.VolumeSource{
-							Projected: &corev1.ProjectedVolumeSource{
-								Sources: []corev1.VolumeProjection{
-									{
-										Secret: &corev1.SecretProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-secrets-gcp",
-											},
-										},
-									},
-									{
-										ConfigMap: &corev1.ConfigMapProjection{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: "cluster-profile-gcp",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Name: "boskos",
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{SecretName: "boskos-credentials", Items: []corev1.KeyToPath{{Key: "password", Path: "password"}}},
-						},
-					},
-				},
-				Containers: []corev1.Container{{
-					Image:           "ci-operator:latest",
-					ImagePullPolicy: corev1.PullAlways,
-					Command:         []string{"ci-operator"},
-					Args: []string{
-						"--kubeconfig=/etc/apici/kubeconfig",
-						"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
-						"--report-username=ci",
-						"--report-password-file=/etc/report/password.txt",
-						"--target=test",
-						"--secret-dir=/usr/local/test-cluster-profile",
-						"--template=/usr/local/test",
-						"--lease-server-password-file=/etc/boskos/password",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
-					},
-					Env: []corev1.EnvVar{
-						{Name: "CLUSTER_TYPE", Value: "gcp"},
-						{Name: "JOB_NAME_SAFE", Value: "test"},
-						{Name: "TEST_COMMAND", Value: "commands"},
-						{Name: "TEST_IMAGESTREAM_TAG", Value: "pipeline:kubevirt-test"},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-
-						{Name: "apici-ci-operator-credentials", ReadOnly: true, MountPath: "/etc/apici"},
-						{Name: "pull-secret", ReadOnly: true, MountPath: "/etc/pull-secret"},
-						{Name: "result-aggregator", ReadOnly: true, MountPath: "/etc/report"},
-						{Name: "boskos", ReadOnly: true, MountPath: "/etc/boskos"},
-						{Name: "cluster-profile", MountPath: "/usr/local/test-cluster-profile"},
-						{Name: "job-definition", MountPath: "/usr/local/test", SubPath: "cluster-launch-installer-custom-test-image.yaml"},
-					},
-				}},
-			},
 		},
 	}
 
-	for _, tc := range tests {
-		podSpec := generatePodSpecTemplate(tc.info, tc.release, &tc.test)
-		if !equality.Semantic.DeepEqual(podSpec, tc.expected) {
-			t.Errorf("expected PodSpec diff:\n%s", cmp.Diff(tc.expected, podSpec, unexportedFields...))
-		}
+	for idx, tc := range tests {
+		t.Run(fmt.Sprintf("testcase-%d", idx), func(t *testing.T) {
+			testhelper.CompareWithFixture(t, generatePodSpecTemplate(tc.info, tc.release, &tc.test))
+		})
 	}
 }
 
 func TestGeneratePresubmitForTest(t *testing.T) {
-	newTrue := true
-
 	tests := []struct {
 		description string
 
 		test     string
 		repoInfo *ProwgenInfo
-		expected *prowconfig.Presubmit
 	}{{
 		description: "presubmit for standard test",
 		test:        "testname",
 		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-
-		expected: &prowconfig.Presubmit{
-			JobBase: prowconfig.JobBase{
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-					"pj-rehearse.openshift.io/can-be-rehearsed":   "true",
-				},
-				Name: "pull-ci-org-repo-branch-testname",
-				UtilityConfig: prowconfig.UtilityConfig{
-					DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-					Decorate:         ptrBool(true),
-				},
-			},
-			AlwaysRun: true,
-			Brancher:  prowconfig.Brancher{Branches: []string{"branch"}},
-			Reporter: prowconfig.Reporter{
-				Context: "ci/prow/testname",
-			},
-			RerunCommand: "/test testname",
-			Trigger:      `(?m)^/test( | .* )testname,?($|\s.*)`,
-		},
 	},
 		{
 			description: "presubmit for a test in a variant config",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
-
-			expected: &prowconfig.Presubmit{
-				JobBase: prowconfig.JobBase{
-					Agent: "kubernetes",
-					Labels: map[string]string{
-						"ci-operator.openshift.io/prowgen-controlled": "true",
-						"ci-operator.openshift.io/variant":            "also",
-						"pj-rehearse.openshift.io/can-be-rehearsed":   "true",
-					},
-					Name: "pull-ci-org-repo-branch-also-testname",
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         ptrBool(true),
-					},
-				},
-				AlwaysRun: true,
-				Brancher:  prowconfig.Brancher{Branches: []string{"branch"}},
-				Reporter: prowconfig.Reporter{
-					Context: "ci/prow/also-testname",
-				},
-				RerunCommand: "/test also-testname",
-				Trigger:      `(?m)^/test( | .* )also-testname,?($|\s.*)`,
-			},
 		},
 	}
 	for _, tc := range tests {
-		presubmit := generatePresubmitForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, true, nil) // podSpec tested in generatePodSpec
-		if !equality.Semantic.DeepEqual(presubmit, tc.expected) {
-			t.Errorf("expected presubmit diff:\n%s", cmp.Diff(tc.expected, presubmit, unexportedFields...))
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, true, nil)) // podSpec tested in generatePodSpec
+		})
 	}
 }
 
 func TestGeneratePeriodicForTest(t *testing.T) {
-	newTrue := true
-
 	tests := []struct {
 		description string
 
 		test     string
 		repoInfo *ProwgenInfo
-		expected *prowconfig.Periodic
 	}{{
 		description: "periodic for standard test",
 		test:        "testname",
 		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-
-		expected: &prowconfig.Periodic{
-			Cron: "@yearly",
-			JobBase: prowconfig.JobBase{
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-					"pj-rehearse.openshift.io/can-be-rehearsed":   "true",
-				},
-				Name: "periodic-ci-org-repo-branch-testname",
-				UtilityConfig: prowconfig.UtilityConfig{
-					DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-					Decorate:         ptrBool(true),
-					ExtraRefs: []prowv1.Refs{{
-						Org:     "org",
-						Repo:    "repo",
-						BaseRef: "branch",
-					}},
-				},
-			},
-		},
 	},
 		{
 			description: "periodic for a test in a variant config",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
-			expected: &prowconfig.Periodic{
-				Cron: "@yearly",
-				JobBase: prowconfig.JobBase{
-					Agent: "kubernetes",
-					Labels: map[string]string{
-						"ci-operator.openshift.io/prowgen-controlled": "true",
-						"ci-operator.openshift.io/variant":            "also",
-						"pj-rehearse.openshift.io/can-be-rehearsed":   "true",
-					},
-					Name: "periodic-ci-org-repo-branch-also-testname",
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         ptrBool(true),
-						ExtraRefs: []prowv1.Refs{{
-							Org:     "org",
-							Repo:    "repo",
-							BaseRef: "branch",
-						}},
-					},
-				},
-			},
 		},
 	}
 	for _, tc := range tests {
-		periodic := generatePeriodicForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, true, "@yearly", nil) // podSpec tested in generatePodSpec
-		// Periodic has unexported fields on which DeepEqual panics, so we need to compare member-wise
-		if !equality.Semantic.DeepEqual(periodic.JobBase, tc.expected.JobBase) {
-			t.Errorf("expected periodic diff:\n%s", cmp.Diff(tc.expected.JobBase, periodic.JobBase, unexportedFields...))
-		}
-		if periodic.Cron != tc.expected.Cron {
-			t.Errorf("expected periodic cron diff:\n%s", cmp.Diff(tc.expected.Cron, periodic.Cron, unexportedFields...))
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			testhelper.CompareWithFixture(t, generatePeriodicForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, true, "@yearly", nil)) // podSpec tested in generatePodSpec
+		})
 	}
 }
 
 func TestGeneratePostSubmitForTest(t *testing.T) {
-	newTrue := true
-	standardJobLabels := map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"}
 	tests := []struct {
 		name     string
 		repoInfo *ProwgenInfo
-
-		expected *prowconfig.Postsubmit
 	}{
 		{
 			name: "name",
@@ -1235,20 +225,6 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-
-			expected: &prowconfig.Postsubmit{
-				JobBase: prowconfig.JobBase{
-					Agent:  "kubernetes",
-					Labels: standardJobLabels,
-					Name:   "branch-ci-organization-repository-branch-name",
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         ptrBool(true),
-					},
-				},
-
-				Brancher: prowconfig.Brancher{Branches: []string{"^branch$"}},
-			},
 		},
 		{
 			name: "Name",
@@ -1257,18 +233,6 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "Repository",
 				Branch: "Branch",
 			}},
-
-			expected: &prowconfig.Postsubmit{
-				JobBase: prowconfig.JobBase{
-					Agent:  "kubernetes",
-					Name:   "branch-ci-Organization-Repository-Branch-Name",
-					Labels: map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"},
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         ptrBool(true),
-					}},
-				Brancher: prowconfig.Brancher{Branches: []string{"^Branch$"}},
-			},
 		},
 		{
 			name: "name",
@@ -1277,39 +241,20 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "Repository",
 				Branch: "Branch",
 			}},
-
-			expected: &prowconfig.Postsubmit{
-				JobBase: prowconfig.JobBase{
-					Agent:  "kubernetes",
-					Name:   "branch-ci-Organization-Repository-Branch-name",
-					Labels: map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true"},
-					UtilityConfig: prowconfig.UtilityConfig{
-						DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &newTrue},
-						Decorate:         ptrBool(true),
-					}},
-				Brancher: prowconfig.Brancher{Branches: []string{"^Branch$"}},
-			},
 		},
 	}
 	for _, tc := range tests {
-		postsubmit := generatePostsubmitForTest(tc.name, tc.repoInfo, jobconfig.Generated, nil, nil) // podSpec tested in TestGeneratePodSpec
-		if !equality.Semantic.DeepEqual(postsubmit, tc.expected) {
-			t.Errorf("expected postsubmit diff:\n%s", cmp.Diff(tc.expected, postsubmit, unexportedFields...))
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			testhelper.CompareWithFixture(t, generatePostsubmitForTest(tc.name, tc.repoInfo, jobconfig.Generated, nil, nil)) // podSpec tested in TestGeneratePodSpec
+		})
 	}
 }
 
 func TestGenerateJobs(t *testing.T) {
-	standardPresubmitJobLabels := map[string]string{
-		"ci-operator.openshift.io/prowgen-controlled": "true",
-		"pj-rehearse.openshift.io/can-be-rehearsed":   "true"}
-	standardPostsubmitJobLabels := map[string]string{"ci-operator.openshift.io/prowgen-controlled": "true", "ci-operator.openshift.io/is-promotion": "true"}
-
 	tests := []struct {
 		id       string
 		config   *ciop.ReleaseBuildConfiguration
 		repoInfo *ProwgenInfo
-		expected *prowconfig.JobConfig
 	}{
 		{
 			id: "two tests and empty Images so only two test presubmits are generated",
@@ -1323,19 +268,6 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-derTest",
-						Labels: standardPresubmitJobLabels,
-					}}, {
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-leTest",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-				PostsubmitsStatic: map[string][]prowconfig.Postsubmit{},
-			},
 		}, {
 			id: "two tests and nonempty Images so two test presubmits and images pre/postsubmits are generated ",
 			config: &ciop.ReleaseBuildConfiguration{
@@ -1350,29 +282,6 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-derTest",
-						Labels: standardPresubmitJobLabels,
-					}}, {
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-leTest",
-						Labels: standardPresubmitJobLabels,
-					}}, {
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-				PostsubmitsStatic: map[string][]prowconfig.Postsubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:           "branch-ci-organization-repository-branch-images",
-						Labels:         standardPostsubmitJobLabels,
-						MaxConcurrency: 1,
-					}},
-				}},
-			},
 		}, {
 			id: "template test",
 			config: &ciop.ReleaseBuildConfiguration{
@@ -1392,14 +301,6 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-oTeste",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-			},
 		}, {
 			id: "template test which doesn't require `tag_specification`",
 			config: &ciop.ReleaseBuildConfiguration{
@@ -1415,14 +316,6 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-oTeste",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-			},
 		}, {
 			id: "Promotion configuration causes --promote job",
 			config: &ciop.ReleaseBuildConfiguration{
@@ -1435,21 +328,6 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-				PostsubmitsStatic: map[string][]prowconfig.Postsubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:           "branch-ci-organization-repository-branch-images",
-						Labels:         standardPostsubmitJobLabels,
-						MaxConcurrency: 1,
-					}},
-				}},
-			},
 		}, {
 			id: "no Promotion configuration has no branch job",
 			config: &ciop.ReleaseBuildConfiguration{
@@ -1464,31 +342,20 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			expected: &prowconfig.JobConfig{
-				PresubmitsStatic: map[string][]prowconfig.Presubmit{"organization/repository": {{
-					JobBase: prowconfig.JobBase{
-						Name:   "pull-ci-organization-repository-branch-images",
-						Labels: standardPresubmitJobLabels,
-					}},
-				}},
-			},
 		},
 	}
 
 	log.SetOutput(ioutil.Discard)
 	for _, tc := range tests {
-		jobConfig := GenerateJobs(tc.config, tc.repoInfo, jobconfig.Generated)
-
-		pruneForTests(jobConfig) // prune the fields that are tested in TestGeneratePre/PostsubmitForTest
-
-		if !equality.Semantic.DeepEqual(jobConfig, tc.expected) {
-			t.Errorf("testcase: %s\nexpected job config diff:\n%s", tc.id, cmp.Diff(tc.expected, jobConfig, unexportedFields...))
-		}
+		t.Run(tc.id, func(t *testing.T) {
+			jobConfig := GenerateJobs(tc.config, tc.repoInfo, jobconfig.Generated)
+			pruneForTests(jobConfig) // prune the fields that are tested in TestGeneratePre/PostsubmitForTest
+			testhelper.CompareWithFixture(t, jobConfig)
+		})
 	}
 }
 
 func TestGenerateJobBase(t *testing.T) {
-	yes := true
 	path := "/some/where"
 	var testCases = []struct {
 		testName    string
@@ -1499,7 +366,6 @@ func TestGenerateJobBase(t *testing.T) {
 		podSpec     *corev1.PodSpec
 		rehearsable bool
 		pathAlias   *string
-		expected    prowconfig.JobBase
 	}{
 		{
 			testName: "no special options",
@@ -1508,15 +374,6 @@ func TestGenerateJobBase(t *testing.T) {
 			info:     &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			label:    jobconfig.Generated,
 			podSpec:  &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-			},
 		},
 		{
 			testName:    "rehearsable",
@@ -1526,16 +383,6 @@ func TestGenerateJobBase(t *testing.T) {
 			label:       jobconfig.Generated,
 			podSpec:     &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			rehearsable: true,
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-					"pj-rehearse.openshift.io/can-be-rehearsed":   "true",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-			},
 		},
 		{
 			testName: "config variant",
@@ -1544,16 +391,6 @@ func TestGenerateJobBase(t *testing.T) {
 			info:     &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "whatever"}},
 			label:    jobconfig.Generated,
 			podSpec:  &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-whatever-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-					"ci-operator.openshift.io/variant":            "whatever",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-			},
 		},
 		{
 			testName:  "path alias",
@@ -1563,16 +400,6 @@ func TestGenerateJobBase(t *testing.T) {
 			label:     jobconfig.Generated,
 			podSpec:   &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			pathAlias: &path,
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-whatever-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-					"ci-operator.openshift.io/variant":            "whatever",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}, PathAlias: "/some/where"},
-			},
 		},
 		{
 			testName: "hidden job for private repos",
@@ -1584,16 +411,6 @@ func TestGenerateJobBase(t *testing.T) {
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-				Hidden:        true,
-			},
 		},
 		{
 			testName: "expose job for private repos with public results",
@@ -1605,16 +422,6 @@ func TestGenerateJobBase(t *testing.T) {
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-				Hidden:        false,
-			},
 		},
 		{
 			testName: "expose option set but not private",
@@ -1626,23 +433,12 @@ func TestGenerateJobBase(t *testing.T) {
 			},
 			label:   jobconfig.Generated,
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-			expected: prowconfig.JobBase{
-				Name:  "pull-ci-org-repo-branch-test",
-				Agent: "kubernetes",
-				Labels: map[string]string{
-					"ci-operator.openshift.io/prowgen-controlled": "true",
-				},
-				Spec:          &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
-				UtilityConfig: prowconfig.UtilityConfig{Decorate: ptrBool(true), DecorationConfig: &prowv1.DecorationConfig{SkipCloning: &yes}},
-			},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.testName, func(t *testing.T) {
-			if actual, expected := generateJobBase(testCase.name, testCase.prefix, testCase.info, testCase.label, testCase.podSpec, testCase.rehearsable, testCase.pathAlias), testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: got incorrect job base: %v", testCase.testName, cmp.Diff(actual, expected, unexportedFields...))
-			}
+			testhelper.CompareWithFixture(t, generateJobBase(testCase.name, testCase.prefix, testCase.info, testCase.label, testCase.podSpec, testCase.rehearsable, testCase.pathAlias))
 		})
 	}
 }
@@ -1668,8 +464,4 @@ func pruneForTests(jobConfig *prowconfig.JobConfig) {
 			jobConfig.PostsubmitsStatic[repo][i].UtilityConfig = prowconfig.UtilityConfig{}
 		}
 	}
-}
-
-func ptrBool(b bool) *bool {
-	return &b
 }

--- a/pkg/prowgen/testdata/TestGenerateJobBase_config_variant.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_config_variant.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/variant: whatever
+name: pull-ci-org-repo-branch-whatever-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
@@ -1,0 +1,11 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_expose_option_set_but_not_private.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_expose_option_set_but_not_private.yaml
@@ -1,0 +1,11 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_hidden_job_for_private_repos.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_hidden_job_for_private_repos.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+hidden: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_no_special_options.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_no_special_options.yaml
@@ -1,0 +1,11 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_path_alias.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_path_alias.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/variant: whatever
+name: pull-ci-org-repo-branch-whatever-test
+path_alias: /some/where
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobBase_rehearsable.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobBase_rehearsable.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/TestGenerateJobs_Promotion_configuration_causes_--promote_job.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_Promotion_configuration_causes_--promote_job.yaml
@@ -1,0 +1,14 @@
+postsubmits:
+  organization/repository:
+  - labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/TestGenerateJobs_template_test.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_template_test.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-oTeste

--- a/pkg/prowgen/testdata/TestGenerateJobs_template_test_which_doesn't_require_`tag_specification`.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_template_test_which_doesn't_require_`tag_specification`.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-oTeste

--- a/pkg/prowgen/testdata/TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
@@ -1,0 +1,12 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-derTest
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-leTest

--- a/pkg/prowgen/testdata/TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
+++ b/pkg/prowgen/testdata/TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  organization/repository:
+  - labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-derTest
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-leTest
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
@@ -1,0 +1,14 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/variant: also
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-also-testname

--- a/pkg/prowgen/testdata/TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/TestGeneratePodSpecMultiStage.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecMultiStage.yaml
@@ -1,0 +1,64 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/secrets/ci-pull-credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /secrets/ci-pull-credentials
+    name: ci-pull-credentials
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- name: ci-pull-credentials
+  secret:
+    secretName: ci-pull-credentials
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-aws
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecMultiStage.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecMultiStage.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -17,9 +16,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -36,12 +32,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate.yaml
@@ -1,0 +1,75 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: TEST_IMAGESTREAM_TAG
+    value: pipeline:kubevirt-test
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-0.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-0.yaml
@@ -1,0 +1,65 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: RPM_REPO_OPENSHIFT_ORIGIN
+    value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-e2e.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-e2e
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-0.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-0.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -25,9 +24,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -41,12 +37,6 @@ containers:
     subPath: cluster-launch-e2e.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-1.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-1.yaml
@@ -1,0 +1,71 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: aws
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-e2e.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-e2e
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-aws
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-1.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-1.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -24,9 +23,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -43,12 +39,6 @@ containers:
     subPath: cluster-launch-installer-e2e.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-2.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-2.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -30,9 +29,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -49,12 +45,6 @@ containers:
     subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-2.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-2.yaml
@@ -1,0 +1,79 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: TEST_IMAGESTREAM_TAG
+    value: pipeline:kubevirt-test
+  - name: CLUSTER_ENABLE_NESTED_VIRT
+    value: "true"
+  - name: CLUSTER_NESTED_VIRT_IMAGE
+    value: nested-virt-image-name
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-3.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-3.yaml
@@ -1,0 +1,77 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: TEST_IMAGESTREAM_TAG
+    value: pipeline:kubevirt-test
+  - name: CLUSTER_ENABLE_NESTED_VIRT
+    value: "true"
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-3.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-3.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -28,9 +27,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -47,12 +43,6 @@ containers:
     subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-4.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-4.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -26,9 +25,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -45,12 +41,6 @@ containers:
     subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-4.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-4.yaml
@@ -1,0 +1,75 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: TEST_IMAGESTREAM_TAG
+    value: pipeline:kubevirt-test
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-5.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-5.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -26,9 +25,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -45,12 +41,6 @@ containers:
     subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-5.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpecTemplate_testcase-5.yaml
@@ -1,0 +1,75 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=test
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --template=/usr/local/test
+  - --lease-server-password-file=/etc/boskos/password
+  command:
+  - ci-operator
+  env:
+  - name: CLUSTER_TYPE
+    value: gcp
+  - name: JOB_NAME_SAFE
+    value: test
+  - name: TEST_COMMAND
+    value: commands
+  - name: TEST_IMAGESTREAM_TAG
+    value: pipeline:kubevirt-test
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-gcp
+    - configMap:
+        name: cluster-profile-gcp
+- name: boskos
+  secret:
+    items:
+    - key: password
+      path: password
+    secretName: boskos-credentials

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -17,9 +16,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -31,12 +27,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
@@ -1,0 +1,48 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --promote
+  - --some=thing
+  - --target=target
+  - --secret-dir=/secrets/secret-name
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /secrets/secret-name
+    name: secret-name
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- name: secret-name
+  secret:
+    secretName: secret-name

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
@@ -1,0 +1,41 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --promote
+  - --some=thing
+  - --target=target
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -16,9 +15,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -27,12 +23,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_multiple_targets.yaml
@@ -1,0 +1,41 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=target
+  - --target=more
+  - --target=and-more
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_multiple_targets.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -16,9 +15,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -27,12 +23,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_private_job.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_private_job.yaml
@@ -1,0 +1,46 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=target
+  - --oauth-token-path=/usr/local/github-credentials/oauth
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /usr/local/github-credentials
+    name: github-credentials-openshift-ci-robot-private-git-cloner
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- name: github-credentials-openshift-ci-robot-private-git-cloner
+  secret:
+    secretName: github-credentials-openshift-ci-robot-private-git-cloner

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_private_job.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_private_job.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -15,9 +14,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -29,12 +25,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_standard_use_case.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_standard_use_case.yaml
@@ -1,0 +1,39 @@
+containers:
+- args:
+  - --kubeconfig=/etc/apici/kubeconfig
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-username=ci
+  - --report-password-file=/etc/report/password.txt
+  - --target=target
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/apici
+    name: apici-ci-operator-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: apici-ci-operator-credentials
+  secret:
+    items:
+    - key: sa.ci-operator.apici.config
+      path: kubeconfig
+    secretName: apici-ci-operator-credentials
+- name: pull-secret
+  secret:
+    secretName: regcred
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/TestGeneratePodSpec_standard_use_case.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePodSpec_standard_use_case.yaml
@@ -1,6 +1,5 @@
 containers:
 - args:
-  - --kubeconfig=/etc/apici/kubeconfig
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
@@ -14,9 +13,6 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/apici
-    name: apici-ci-operator-credentials
-    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -25,12 +21,6 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: apici-ci-operator-credentials
-  secret:
-    items:
-    - key: sa.ci-operator.apici.config
-      path: kubeconfig
-    secretName: apici-ci-operator-credentials
 - name: pull-secret
   secret:
     secretName: regcred

--- a/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_Name.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_Name.yaml
@@ -1,0 +1,9 @@
+agent: kubernetes
+branches:
+- ^Branch$
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: branch-ci-Organization-Repository-Branch-Name

--- a/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_name#01.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_name#01.yaml
@@ -1,0 +1,9 @@
+agent: kubernetes
+branches:
+- ^Branch$
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: branch-ci-Organization-Repository-Branch-name

--- a/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_name.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePostSubmitForTest_name.yaml
@@ -1,0 +1,9 @@
+agent: kubernetes
+branches:
+- ^branch$
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: branch-ci-organization-repository-branch-name

--- a/pkg/prowgen/testdata/TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -1,0 +1,15 @@
+agent: kubernetes
+always_run: true
+branches:
+- branch
+context: ci/prow/also-testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/variant: also
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-also-testname
+rerun_command: /test also-testname
+trigger: (?m)^/test( | .* )also-testname,?($|\s.*)

--- a/pkg/prowgen/testdata/TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -1,0 +1,14 @@
+agent: kubernetes
+always_run: true
+branches:
+- branch
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -1,0 +1,79 @@
+package testhelper
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"sigs.k8s.io/yaml"
+)
+
+type Options struct {
+	Prefix string
+}
+
+type Option func(*Options)
+
+func WithPrefix(prefix string) Option {
+	return func(o *Options) {
+		o.Prefix = prefix
+	}
+}
+
+// CompareWithFixture will compare output with a test fixture and allows to automatically update them
+// by setting the UPDATE env var.
+// If output is not a []byte or string, it will get serialized as yaml prior to the comparison.
+// The fixtures are stored in $PWD/testdata/prefix${testName}.yaml
+func CompareWithFixture(t *testing.T, output interface{}, opts ...Option) {
+	options := &Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	var serializedOutput []byte
+	switch v := output.(type) {
+	case []byte:
+		serializedOutput = v
+	case string:
+		serializedOutput = []byte(v)
+	default:
+		serialized, err := yaml.Marshal(v)
+		if err != nil {
+			t.Fatalf("failed to yaml marshal output of type %T: %v", output, err)
+		}
+		serializedOutput = serialized
+	}
+
+	golden, err := filepath.Abs(filepath.Join("testdata", strings.ReplaceAll(options.Prefix+t.Name(), "/", "_")+".yaml"))
+	if err != nil {
+		t.Fatalf("failed to get absolute path to testdata file: %v", err)
+	}
+	if os.Getenv("UPDATE") != "" {
+		if err := ioutil.WriteFile(golden, serializedOutput, 0644); err != nil {
+			t.Fatalf("failed to write updated fixture: %v", err)
+		}
+	}
+	expected, err := ioutil.ReadFile(golden)
+	if err != nil {
+		t.Fatalf("failed to read testdata file: %v", err)
+	}
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(expected)),
+		B:        difflib.SplitLines(string(serializedOutput)),
+		FromFile: "Fixture",
+		ToFile:   "Current",
+		Context:  3,
+	}
+	diffStr, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diffStr != "" {
+		t.Errorf("got diff between expected and actual result: \n%s\n\nIf this is expected, re-run the test with `UPDATE=true go test ./...` to update the fixtures.", diffStr)
+	}
+}

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -32,9 +31,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
@@ -46,12 +42,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -17,7 +17,6 @@ periodics:
     containers:
     - args:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --kubeconfig=/etc/apici/kubeconfig
       - --oauth-token-path=/usr/local/github-credentials/oauth
       - --report-password-file=/etc/report/password.txt
       - --report-username=ci
@@ -42,9 +41,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/apici
-        name: apici-ci-operator-credentials
-        readOnly: true
       - mountPath: /usr/local/e2e-nightly-cluster-profile
         name: cluster-profile
       - mountPath: /usr/local/github-credentials
@@ -61,12 +57,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: apici-ci-operator-credentials
-      secret:
-        items:
-        - key: sa.ci-operator.apici.config
-          path: kubeconfig
-        secretName: apici-ci-operator-credentials
     - name: cluster-profile
       projected:
         sources:

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -16,7 +16,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --promote
         - --report-password-file=/etc/report/password.txt
@@ -31,9 +30,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
@@ -45,12 +41,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -43,9 +42,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/e2e-cluster-profile
           name: cluster-profile
         - mountPath: /usr/local/github-credentials
@@ -62,12 +58,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: cluster-profile
         projected:
           sources:
@@ -106,7 +96,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -121,9 +110,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
@@ -135,12 +121,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
@@ -169,7 +149,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --oauth-token-path=/usr/local/github-credentials/oauth
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -183,9 +162,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
@@ -197,12 +173,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=test
@@ -30,9 +29,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -16,7 +16,6 @@ periodics:
     containers:
     - args:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --kubeconfig=/etc/apici/kubeconfig
       - --report-password-file=/etc/report/password.txt
       - --report-username=ci
       - --secret-dir=/usr/local/e2e-aws-nightly-cluster-profile
@@ -40,9 +39,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/apici
-        name: apici-ci-operator-credentials
-        readOnly: true
       - mountPath: /usr/local/e2e-aws-nightly-cluster-profile
         name: cluster-profile
       - mountPath: /usr/local/e2e-aws-nightly
@@ -56,12 +52,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: apici-ci-operator-credentials
-      secret:
-        items:
-        - key: sa.ci-operator.apici.config
-          path: kubeconfig
-        secretName: apici-ci-operator-credentials
     - name: cluster-profile
       projected:
         sources:
@@ -93,7 +83,6 @@ periodics:
     containers:
     - args:
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --kubeconfig=/etc/apici/kubeconfig
       - --report-password-file=/etc/report/password.txt
       - --report-username=ci
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
@@ -117,9 +106,6 @@ periodics:
         requests:
           cpu: 10m
       volumeMounts:
-      - mountPath: /etc/apici
-        name: apici-ci-operator-credentials
-        readOnly: true
       - mountPath: /usr/local/e2e-nightly-cluster-profile
         name: cluster-profile
       - mountPath: /usr/local/e2e-nightly
@@ -133,12 +119,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: apici-ci-operator-credentials
-      secret:
-        items:
-        - key: sa.ci-operator.apici.config
-          path: kubeconfig
-        secretName: apici-ci-operator-credentials
     - name: cluster-profile
       projected:
         sources:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -15,7 +15,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -29,9 +28,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -40,12 +36,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -75,7 +65,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -90,9 +79,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -101,12 +87,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --secret-dir=/usr/local/e2e-cluster-profile
@@ -41,9 +40,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /usr/local/e2e-cluster-profile
           name: cluster-profile
         - mountPath: /usr/local/e2e
@@ -57,12 +53,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: cluster-profile
         projected:
           sources:
@@ -101,7 +91,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -115,9 +104,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -126,12 +112,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -166,7 +146,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=lint
@@ -179,9 +158,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -190,12 +166,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -220,7 +190,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --secret-dir=/secrets/ci-pull-credentials
@@ -234,9 +203,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /secrets/ci-pull-credentials
           name: ci-pull-credentials
           readOnly: true
@@ -248,12 +214,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: ci-pull-credentials
         secret:
           secretName: ci-pull-credentials
@@ -281,7 +241,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -294,9 +253,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -305,12 +261,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -337,7 +287,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -352,9 +301,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -363,12 +309,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -395,7 +335,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -409,9 +348,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -420,12 +356,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -30,9 +29,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -15,7 +15,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -30,9 +29,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -17,7 +17,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -31,9 +30,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,12 +38,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -82,7 +72,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=lint
@@ -95,9 +84,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -106,12 +92,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -136,7 +116,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -149,9 +128,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -160,12 +136,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/pj-rehearse-integration/expected.yaml
+++ b/test/pj-rehearse-integration/expected.yaml
@@ -303,7 +303,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304cd45-af20-11ea-b136-8c16450d6013
+    name: 1a6b36ac-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -405,18 +405,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -433,7 +433,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304ce19-af20-11ea-b136-8c16450d6013
+    name: 1a6b3792-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -508,18 +508,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -536,7 +536,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c924-af20-11ea-b136-8c16450d6013
+    name: 1a6b2d0f-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -619,18 +619,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -648,7 +648,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c9d8-af20-11ea-b136-8c16450d6013
+    name: 1a6b2e02-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -725,18 +725,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -753,7 +753,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304cb6a-af20-11ea-b136-8c16450d6013
+    name: 1a6b2fd4-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -853,18 +853,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -881,7 +881,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c6ee-af20-11ea-b136-8c16450d6013
+    name: 1a6b29c6-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -958,18 +958,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -986,7 +986,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c7a2-af20-11ea-b136-8c16450d6013
+    name: 1a6b2b5c-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1086,18 +1086,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1114,7 +1114,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c864-af20-11ea-b136-8c16450d6013
+    name: 1a6b2c50-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1191,18 +1191,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1219,7 +1219,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304ca95-af20-11ea-b136-8c16450d6013
+    name: 1a6b2ef7-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1319,18 +1319,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1347,7 +1347,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304cc8e-af20-11ea-b136-8c16450d6013
+    name: 1a6b3141-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1447,18 +1447,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1475,7 +1475,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c10a-af20-11ea-b136-8c16450d6013
+    name: 1a6b3225-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1552,18 +1552,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1580,7 +1580,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c297-af20-11ea-b136-8c16450d6013
+    name: 1a6b32d9-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1680,18 +1680,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1709,7 +1709,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c535-af20-11ea-b136-8c16450d6013
+    name: 1a6b352d-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1842,18 +1842,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1871,7 +1871,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c63a-af20-11ea-b136-8c16450d6013
+    name: 1a6b35f0-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2004,18 +2004,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2033,7 +2033,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c392-af20-11ea-b136-8c16450d6013
+    name: 1a6b33a1-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2132,18 +2132,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2161,7 +2161,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: d304c46f-af20-11ea-b136-8c16450d6013
+    name: 1a6b3467-af3f-11ea-a8ac-8c16450d6013
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2241,17 +2241,17 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: fd599648f34f3aa5c51afe58f099d61076cbeb2a
+      base_sha: b03cfb38a1f17f60d58ee4af7fad6145c196f73c
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 4f835a2d0d378d3c4cab317a8959b3c557126557
+        sha: ef76c0888113af3d1dc25b8f04ce798ad4010fd5
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-15T15:56:50Z"
+    startTime: "2020-06-15T19:33:34Z"
     state: triggered
 

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -16,7 +16,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -30,9 +29,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,12 +37,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -31,9 +30,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,12 +38,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -73,7 +63,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -86,9 +75,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -97,12 +83,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -16,7 +16,6 @@ postsubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --promote
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -31,9 +30,6 @@ postsubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,12 +38,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
@@ -33,9 +32,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -44,12 +40,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -75,7 +65,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -88,9 +77,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -99,12 +85,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -19,7 +19,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -32,9 +31,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -43,12 +39,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred

--- a/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/repo-init-integration/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -18,7 +18,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=cmd
@@ -31,9 +30,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,12 +38,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -73,7 +63,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -96,9 +85,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
@@ -115,12 +101,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: boskos
         secret:
           items:
@@ -160,7 +140,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --lease-server-password-file=/etc/boskos/password
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
@@ -183,9 +162,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
@@ -202,12 +178,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: boskos
         secret:
           items:
@@ -247,7 +217,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=race
@@ -260,9 +229,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -271,12 +237,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred
@@ -302,7 +262,6 @@ presubmits:
       containers:
       - args:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --kubeconfig=/etc/apici/kubeconfig
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
@@ -315,9 +274,6 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /etc/apici
-          name: apici-ci-operator-credentials
-          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -326,12 +282,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: apici-ci-operator-credentials
-        secret:
-          items:
-          - key: sa.ci-operator.apici.config
-            path: kubeconfig
-          secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
           secretName: regcred


### PR DESCRIPTION
This PR changes the prowgen tool to not set the kubeconfig arg on the ci-operator anymore. It does not have any effect anymore and just exists for compatibility reasons.

This PR is best reviewed commit by commit, the first one makes prowgen use fixtures as reference so updating tests is less tedious and the second commit is the actual change.

o/release pr: https://github.com/openshift/release/pull/9670