### PR TITLE
autoowners: allow ignoring full orgs

### DIFF
--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -478,7 +478,7 @@ type loadRepoTestData struct {
 	ConfigSubDirs []string
 	GitHubOrg     string
 	GitHubRepo    string
-	BlackList     sets.String
+	Blocklist     blocklist
 	ExpectedRepos []orgRepo
 }
 
@@ -507,7 +507,7 @@ func TestLoadRepos(t *testing.T) {
 			ConfigSubDirs: []string{"jobs", "config", "templates"},
 			GitHubOrg:     "openshift",
 			GitHubRepo:    "release",
-			BlackList:     sets.NewString("testdata/test2/templates/openshift/installer"),
+			Blocklist:     blocklist{directories: sets.NewString("testdata/test2/templates/openshift/installer")},
 			ExpectedRepos: []orgRepo{
 				{
 					Directories: []string{
@@ -521,7 +521,25 @@ func TestLoadRepos(t *testing.T) {
 					Directories: []string{
 						"testdata/test2/jobs/openshift/installer",
 						"testdata/test2/config/openshift/installer",
-						//"testdata/test2/templates/openshift/installer", // not present due to blacklist
+						// "testdata/test2/templates/openshift/installer", // not present due to blocklist
+					},
+					Organization: "openshift",
+					Repository:   "installer",
+				},
+			},
+		},
+		{
+			TestDirectory: "testdata/test2",
+			ConfigSubDirs: []string{"jobs", "config", "templates"},
+			GitHubOrg:     "openshift",
+			GitHubRepo:    "release",
+			Blocklist:     blocklist{orgs: sets.NewString("kubevirt")},
+			ExpectedRepos: []orgRepo{
+				{
+					Directories: []string{
+						"testdata/test2/jobs/openshift/installer",
+						"testdata/test2/config/openshift/installer",
+						"testdata/test2/templates/openshift/installer",
 					},
 					Organization: "openshift",
 					Repository:   "installer",
@@ -530,7 +548,7 @@ func TestLoadRepos(t *testing.T) {
 		},
 	}
 	for _, data := range loadRepoTestData {
-		repos, err := loadRepos(data.TestDirectory, data.BlackList, data.ConfigSubDirs, data.GitHubOrg, data.GitHubRepo)
+		repos, err := loadRepos(data.TestDirectory, data.Blocklist, data.ConfigSubDirs, data.GitHubOrg, data.GitHubRepo)
 		if err != nil {
 			t.Fatalf("%s: failed to load repos: %v", data.TestDirectory, err)
 		}


### PR DESCRIPTION
I'd like to set up `--ignore-org=openshift-priv` in our autoowners job so that the two jobs stop to flap OWNERS in `openshift-priv/*` repos:

- Here is autoowners creating them: https://github.com/openshift/release/pull/9718/files
- Here is autoconfigbrancher deleting them: https://github.com/openshift/release/pull/9720/files

We do not need OWNERS in `openshift-priv` directories (they are managed purely by automation).

I also took the opportunity to modernize the naming and call the thing `blocklist`.

/cc @hongkailiu @droslean 