### PR TITLE
webreg: fix broken chain table on homepage

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -293,7 +293,7 @@ const templateDefinitions = `
 				<tr>
 					<td>{{ template "nameWithLinkChain" $name }}</td>
 					<td>{{ docsForName $name }}</td>
-					<td>{{ template "stepList" $config }}</td>
+					<td>{{ template "stepList" $config.Steps }}</td>
 				</tr>
 			{{ end }}
 		</tbody>


### PR DESCRIPTION
The `chainTable` template definition had a minor mistake that broke the homepage below the first chain. This fixes that.