### PR TITLE
pkg/webreg: Normalize "release   :" YAML

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -796,7 +796,7 @@ const ciOperatorReleaseConfig = `releases:
       product: okd
       version: "4.3"
   latest:
-    release   :       # references a version released to customers
+    release:          # references a version released to customers
       channel: stable # configures the release channel to search
       version: "4.4"
   previous:


### PR DESCRIPTION
Make it `release:` instead, to match the rest of the block.  The pre-colon spaces landed with the YAML block in 33c2eaa49b (#839).