### PR TITLE
peribolos sync: add --only-org

### DIFF
--- a/cmd/autoperibolossync/main.go
+++ b/cmd/autoperibolossync/main.go
@@ -37,6 +37,7 @@ type options struct {
 	peribolosConfig string
 	releaseRepoPath string
 	whitelist       string
+	onlyOrg         string
 
 	flagutil.GitHubOptions
 }
@@ -54,6 +55,7 @@ func parseOptions() options {
 	fs.StringVar(&o.peribolosConfig, "peribolos-config", "", "The peribolos configuration to be updated. Assuming that the file exists in the working directory.")
 	fs.StringVar(&o.releaseRepoPath, "release-repo-path", "", "Path to a openshift/release repository directory")
 	fs.StringVar(&o.whitelist, "whitelist-file", "", "Path to a whitelisted repositories file")
+	fs.StringVar(&o.onlyOrg, "only-org", "", "Only dump config of repos belonging to this organization.")
 
 	o.AddFlags(fs)
 	o.AllowAnonymous = true
@@ -106,6 +108,10 @@ func main() {
 	if o.whitelist != "" {
 		args = append(args, "--whitelist-file")
 		args = append(args, o.whitelist)
+	}
+
+	if o.onlyOrg != "" {
+		args = append(args, "--only-org", o.onlyOrg)
 	}
 
 	stdout := bumper.HideSecretsWriter{Delegate: os.Stdout, Censor: sa}


### PR DESCRIPTION
Successful Peribolos dump relies on having admin access on the target
repository, which we can now only guarantee in the `openshift` org. The
remaining pieces of the `openshift-priv` tooling already have (and use)
the same parameter. Non-openshift orgs are currently out of scope.

Will fix the following in https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/logs/periodic-org-sync/1274094822981898240, caused by an invalid dump of the https://github.com/code-ready/crc repo for which our bot does not have `admin` permissions. Non-openshift repositories are currently out of scope for the openshift-priv tooling.

```
{"component":"peribolos","file":"prow/cmd/peribolos/main.go:201","func":"main.main","level":"fatal","msg":"Configuration failed: failed to configure openshift-priv repos: status code 422 not one of [201], body: {\"message\":\"Repository creation failed.\",\"errors\":[{\"resource\":\"Repository\",\"code\":\"custom\",\"message\":\"Either :allow_merge_commit, :allow_squash_merge or :allow_rebase_merge must be true.\"}],\"documentation_url\":\"https://developer.github.com/v3/repos/#create\"}","severity":"fatal","time":"2020-06-19T21:57:19Z"}
```


/cc @droslean @stevekuznetsov 