### PR TITLE
ci-operator configs: omitempty images.from

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -953,7 +953,7 @@ type SourceStepConfiguration struct {
 // ProjectDirectoryImageBuildStepConfiguration describes an
 // image build from a directory in a component project.
 type ProjectDirectoryImageBuildStepConfiguration struct {
-	From PipelineImageStreamTagReference `json:"from"`
+	From PipelineImageStreamTagReference `json:"from,omitempty"`
 	To   PipelineImageStreamTagReference `json:"to"`
 
 	ProjectDirectoryImageBuildInputs `json:",inline"`


### PR DESCRIPTION
Empty `from` means we do not substitute a `FROM` in the repo's
Dockerfile, which makes sense in some cases.

Hit while building an optional operator bundle image which is built from
scratch.