### PR TITLE
ci-operator: DRY out the relationships between step links and env

### DIFF
--- a/cmd/cvp-trigger/main.go
+++ b/cmd/cvp-trigger/main.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"os"
 	"path/filepath"
 	"strings"
@@ -210,7 +212,7 @@ func main() {
 		steps.OOChannel: o.channel,
 	}
 	if o.releaseImageRef != "" {
-		envVars[steps.LatestReleaseEnv] = o.releaseImageRef
+		envVars[utils.ReleaseImageEnv(api.LatestStableName)] = o.releaseImageRef
 	}
 	if o.installNamespace != "" {
 		envVars[steps.OOInstallNamespace] = o.installNamespace

--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"strings"
 )
 
@@ -19,7 +20,7 @@ type Step interface {
 	Description() string
 	Requires() []StepLink
 	Creates() []StepLink
-	Provides() (ParameterMap, StepLink)
+	Provides() ParameterMap
 }
 
 type InputDefinition []string
@@ -165,6 +166,14 @@ func StableImageTagLink(name, tag string) StepLink {
 		name: StableStreamFor(name),
 		tag:  tag,
 	}
+}
+
+func Comparer() cmp.Option {
+	return cmp.AllowUnexported(
+		internalImageStreamLink{},
+		internalImageStreamTagLink{},
+		externalImageLink{},
+	)
 }
 
 func StableStreamFor(name string) string {

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -113,7 +113,7 @@ func (f *fakeStep) Creates() []StepLink  { return f.creates }
 func (f *fakeStep) Name() string         { return f.name }
 func (f *fakeStep) Description() string  { return f.name }
 
-func (f *fakeStep) Provides() (ParameterMap, StepLink) { return nil, nil }
+func (f *fakeStep) Provides() ParameterMap { return nil }
 
 func TestBuildGraph(t *testing.T) {
 	root := &fakeStep{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1095,10 +1095,10 @@ const (
 	// the StableImageStream. Images for other versions of
 	// the stream are held in similarly-named streams.
 	LatestStableName = "latest"
-	// InitialStableName is the name of the special stable
+	// InitialImageStream is the name of the special stable
 	// stream we copy at import to keep for upgrade tests.
 	// TODO(skuznets): remove these when they're not implicit
-	InitialStableName = "initial"
+	InitialImageStream = "initial"
 
 	// ReleaseImageStream is the name of the ImageStream
 	// used to hold built or imported release payload images

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -113,8 +113,8 @@ func (s *bundleSourceStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func (s *bundleSourceStep) Provides() (api.ParameterMap, api.StepLink) {
-	return api.ParameterMap{}, api.InternalImageLink(s.config.To)
+func (s *bundleSourceStep) Provides() api.ParameterMap {
+	return api.ParameterMap{}
 }
 
 func (s *bundleSourceStep) Name() string { return string(s.config.To) }

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -3,6 +3,7 @@ package clusterinstall
 import (
 	"context"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -69,14 +70,14 @@ func E2ETestStep(
 		}
 
 		// ensure we depend on the release image
-		name := "RELEASE_IMAGE_INITIAL"
+		name := utils.ReleaseImageEnv(api.InitialImageStream)
 		template.Parameters = append(template.Parameters, templateapi.Parameter{
 			Required: true,
 			Name:     name,
 		})
 
 		// ensure the installer image points to the initial state
-		name = "IMAGE_INSTALLER"
+		name = utils.StableImageEnv("installer")
 		if !params.HasInput(name) {
 			overrides[name] = "stable-initial:installer"
 		}
@@ -141,8 +142,8 @@ func (s *e2eTestStep) Creates() []api.StepLink {
 	return nil
 }
 
-func (s *e2eTestStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *e2eTestStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *e2eTestStep) Name() string { return s.testConfig.As }

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -68,8 +68,8 @@ func (s *gitSourceStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)}
 }
 
-func (s *gitSourceStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *gitSourceStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func determineRefsWorkdir(refs *prowapi.Refs, extraRefs []prowapi.Refs) *prowapi.Refs {

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -26,8 +26,8 @@ func (s *imagesReadyStep) Creates() []api.StepLink {
 	return []api.StepLink{api.ImagesReadyLink()}
 }
 
-func (s *imagesReadyStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *imagesReadyStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *imagesReadyStep) Name() string { return "[images]" }

--- a/pkg/steps/images_ready_test.go
+++ b/pkg/steps/images_ready_test.go
@@ -15,7 +15,6 @@ func TestImagesReadyStep(t *testing.T) {
 		creates:  []api.StepLink{api.ImagesReadyLink()},
 		provides: providesExpectation{
 			params: nil,
-			link:   nil,
 		},
 		inputs: inputsExpectation{
 			values: nil,

--- a/pkg/steps/input_env.go
+++ b/pkg/steps/input_env.go
@@ -56,6 +56,6 @@ func (s *inputEnvironmentStep) Creates() []api.StepLink {
 	return s.links
 }
 
-func (s *inputEnvironmentStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *inputEnvironmentStep) Provides() api.ParameterMap {
+	return nil
 }

--- a/pkg/steps/input_env_test.go
+++ b/pkg/steps/input_env_test.go
@@ -18,7 +18,6 @@ func TestInputEnvironmentStep(t *testing.T) {
 		creates:  links,
 		provides: providesExpectation{
 			params: nil,
-			link:   nil,
 		},
 		inputs: inputsExpectation{
 			values: api.InputDefinition{"another value", "value"},

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -126,8 +126,8 @@ func (s *inputImageTagStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func (s *inputImageTagStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *inputImageTagStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *inputImageTagStep) Name() string { return fmt.Sprintf("[input:%s]", s.config.To) }

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -82,7 +82,6 @@ func TestInputImageTagStep(t *testing.T) {
 		creates:  []api.StepLink{api.InternalImageLink("TO")},
 		provides: providesExpectation{
 			params: nil,
-			link:   nil,
 		},
 		inputs: inputsExpectation{
 			values: api.InputDefinition{"ddc0de"},

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -50,15 +50,15 @@ func (s *leaseStep) Name() string             { return s.wrapped.Name() }
 func (s *leaseStep) Description() string      { return s.wrapped.Description() }
 func (s *leaseStep) Requires() []api.StepLink { return s.wrapped.Requires() }
 func (s *leaseStep) Creates() []api.StepLink  { return s.wrapped.Creates() }
-func (s *leaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	parameters, links := s.wrapped.Provides()
+func (s *leaseStep) Provides() api.ParameterMap {
+	parameters := s.wrapped.Provides()
 	if parameters == nil {
 		parameters = api.ParameterMap{}
 	}
 	parameters[leaseEnv] = func() (string, error) {
 		return s.leasedResource, nil
 	}
-	return parameters, links
+	return parameters
 }
 
 func (s *leaseStep) SubTests() []*junit.TestCase {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -36,10 +36,10 @@ func (stepNeedsLease) Requires() []api.StepLink {
 }
 func (stepNeedsLease) Creates() []api.StepLink { return []api.StepLink{api.ImagesReadyLink()} }
 
-func (stepNeedsLease) Provides() (api.ParameterMap, api.StepLink) {
+func (stepNeedsLease) Provides() api.ParameterMap {
 	return api.ParameterMap{
 		"parameter": func() (string, error) { return "map", nil },
-	}, api.ExternalImageLink(api.ImageStreamTagReference{Name: "test"})
+	}
 }
 
 func (stepNeedsLease) SubTests() []*junit.TestCase {
@@ -85,21 +85,18 @@ func TestLeaseStepForward(t *testing.T) {
 		}
 	})
 	t.Run("Provides", func(t *testing.T) {
-		sParam, sLinks := step.Provides()
+		sParam := step.Provides()
 		sRet, err := sParam["parameter"]()
 		if err != nil {
 			t.Fatal(err)
 		}
-		lParam, lLinks := withLease.Provides()
+		lParam := withLease.Provides()
 		lRet, err := lParam["parameter"]()
 		if err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(lRet, sRet) {
 			t.Errorf("not properly forwarded (param): %s", diff.ObjectDiff(lParam, sParam))
-		}
-		if !reflect.DeepEqual(lLinks, sLinks) {
-			t.Errorf("not properly forwarded (links): %s", diff.ObjectDiff(lLinks, sLinks))
 		}
 	})
 	t.Run("SubTests", func(T *testing.T) {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
 const (
@@ -32,15 +33,14 @@ const (
 	SecretMountEnv = "SHARED_DIR"
 	// ClusterProfileMountEnv is the env we use to expose the cluster profile dir
 	ClusterProfileMountEnv = "CLUSTER_PROFILE_DIR"
-	// InitialReleaseEnv is the environment we use to expose the initial payload
-	InitialReleaseEnv = "RELEASE_IMAGE_INITIAL"
-	// LatestReleaseEnv is the environment we use to expose the latest payload
-	LatestReleaseEnv = "RELEASE_IMAGE_LATEST"
-	// ImageFormatEnv is the environment we use to hold the base pull spec
-	ImageFormatEnv = "IMAGE_FORMAT"
 )
 
-var envForProfile = []string{InitialReleaseEnv, LatestReleaseEnv, leaseEnv, ImageFormatEnv}
+var envForProfile = []string{
+	utils.ReleaseImageEnv(api.InitialImageStream),
+	utils.ReleaseImageEnv(api.LatestStableName),
+	leaseEnv,
+	utils.ImageFormatEnv,
+}
 
 type multiStageTestStep struct {
 	dry     bool
@@ -187,7 +187,9 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 	if s.profile != "" {
 		needsReleasePayload = true
 		for _, env := range envForProfile {
-			ret = append(ret, s.params.Links(env)...)
+			if link, ok := utils.LinkForEnv(env); ok {
+				ret = append(ret, link)
+			}
 		}
 	}
 	if needsReleaseImage && !needsReleasePayload {
@@ -197,8 +199,8 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 }
 
 func (s *multiStageTestStep) Creates() []api.StepLink { return nil }
-func (s *multiStageTestStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *multiStageTestStep) Provides() api.ParameterMap {
+	return nil
 }
 func (s *multiStageTestStep) SubTests() []*junit.TestCase { return s.subTests }
 

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -37,13 +37,19 @@ func TestRequires(t *testing.T) {
 			ClusterProfile: api.ClusterProfileAWS,
 			Test:           []api.LiteralTestStep{{From: "from-release"}},
 		},
-		req: []api.StepLink{},
+		req: []api.StepLink{
+			api.ReleasePayloadImageLink(api.InitialImageStream),
+			api.ReleasePayloadImageLink(api.LatestStableName),
+			api.ImagesReadyLink(),
+		},
 	}, {
 		name: "step needs release images, should have StableImagesLink",
 		steps: api.MultiStageTestConfigurationLiteral{
 			Test: []api.LiteralTestStep{{From: "from-release"}},
 		},
-		req: []api.StepLink{api.StableImagesLink(api.LatestStableName)},
+		req: []api.StepLink{
+			api.StableImagesLink(api.LatestStableName),
+		},
 	}, {
 		name: "step needs images, should have InternalImageLink",
 		config: api.ReleaseBuildConfiguration{
@@ -82,7 +88,7 @@ func TestRequires(t *testing.T) {
 					return
 				}
 			}
-			t.Errorf("incorrect requirements: %s", diff.ObjectReflectDiff(ret, tc.req))
+			t.Errorf("incorrect requirements: %s", cmp.Diff(ret, tc.req, api.Comparer()))
 		})
 	}
 }

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -38,8 +38,7 @@ func TestOutputImageStep(t *testing.T) {
 			api.InternalImageLink("configToAs"),
 		},
 		provides: providesExpectation{
-			params: map[string]string{"IMAGE_CONFIGTOAS": "uri://somewhere:configToTag"},
-			link:   api.ExternalImageLink(config.To),
+			params: map[string]string{"IMAGE_CONFIGTOAS": "uri://somewhere@fromImageName"},
 		},
 		inputs: inputsExpectation{values: nil, err: false},
 	}
@@ -51,7 +50,15 @@ func TestOutputImageStep(t *testing.T) {
 
 	outputImageStream := &imagev1.ImageStream{
 		ObjectMeta: meta.ObjectMeta{Name: config.To.Name, Namespace: config.To.Namespace},
-		Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "uri://somewhere"},
+		Status: imagev1.ImageStreamStatus{
+			PublicDockerImageRepository: "uri://somewhere",
+			Tags: []imagev1.NamedTagEventList{{
+				Tag: "configToTag",
+				Items: []imagev1.TagEvent{{
+					Image: "fromImageName",
+				}},
+			}},
+		},
 	}
 	outputImageStreamTag := &imagev1.ImageStreamTag{
 		ObjectMeta: meta.ObjectMeta{

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -3,16 +3,13 @@ package steps
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
-
 	buildapi "github.com/openshift/api/build/v1"
-	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	coreapi "k8s.io/api/core/v1"
-	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	"strconv"
 )
 
 func rawCommandDockerfile(from api.PipelineImageStreamTagReference, commands string) string {
@@ -60,27 +57,13 @@ func (s *pipelineImageCacheStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func (s *pipelineImageCacheStep) Provides() (api.ParameterMap, api.StepLink) {
+func (s *pipelineImageCacheStep) Provides() api.ParameterMap {
 	if len(s.config.To) == 0 {
-		return nil, nil
+		return nil
 	}
 	return api.ParameterMap{
-		fmt.Sprintf("LOCAL_IMAGE_%s", strings.ToUpper(strings.Replace(string(s.config.To), "-", "_", -1))): func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
-			if err != nil {
-				return "", fmt.Errorf("could not retrieve output imagestream: %w", err)
-			}
-			var registry string
-			if len(is.Status.PublicDockerImageRepository) > 0 {
-				registry = is.Status.PublicDockerImageRepository
-			} else if len(is.Status.DockerImageRepository) > 0 {
-				registry = is.Status.DockerImageRepository
-			} else {
-				return "", fmt.Errorf("image stream %s has no accessible image registry value", s.config.To)
-			}
-			return fmt.Sprintf("%s:%s", registry, s.config.To), nil
-		},
-	}, api.InternalImageLink(s.config.To)
+		utils.PipelineImageEnvFor(s.config.To): utils.ImageDigestFor(s.imageClient, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To)),
+	}
 }
 
 func (s *pipelineImageCacheStep) Name() string { return string(s.config.To) }

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -137,8 +137,8 @@ func (s *podStep) Creates() []api.StepLink {
 	return []api.StepLink{}
 }
 
-func (s *podStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *podStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *podStep) Name() string { return s.config.As }

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -68,7 +68,6 @@ func preparePodStep(t *testing.T, namespace string) (*podStep, stepExpectation, 
 		creates:  []api.StepLink{},
 		provides: providesExpectation{
 			params: nil,
-			link:   nil,
 		},
 		inputs: inputsExpectation{
 			values: nil,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
-
 	buildapi "github.com/openshift/api/build/v1"
 	"github.com/openshift/api/image/docker10"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -154,27 +153,13 @@ func (s *projectDirectoryImageBuildStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func (s *projectDirectoryImageBuildStep) Provides() (api.ParameterMap, api.StepLink) {
+func (s *projectDirectoryImageBuildStep) Provides() api.ParameterMap {
 	if len(s.config.To) == 0 {
-		return nil, nil
+		return nil
 	}
 	return api.ParameterMap{
-		fmt.Sprintf("LOCAL_IMAGE_%s", strings.ToUpper(strings.Replace(string(s.config.To), "-", "_", -1))): func() (string, error) {
-			is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.PipelineImageStream, meta.GetOptions{})
-			if err != nil {
-				return "", fmt.Errorf("could not retrieve output imagestream: %w", err)
-			}
-			var registry string
-			if len(is.Status.PublicDockerImageRepository) > 0 {
-				registry = is.Status.PublicDockerImageRepository
-			} else if len(is.Status.DockerImageRepository) > 0 {
-				registry = is.Status.DockerImageRepository
-			} else {
-				return "", fmt.Errorf("image stream %s has no accessible image registry value", s.config.To)
-			}
-			return fmt.Sprintf("%s:%s", registry, s.config.To), nil
-		},
-	}, api.InternalImageLink(s.config.To)
+		utils.PipelineImageEnvFor(s.config.To): utils.ImageDigestFor(s.imageClient, s.jobSpec.Namespace, api.PipelineImageStream, string(s.config.To)),
+	}
 }
 
 func (s *projectDirectoryImageBuildStep) Name() string { return string(s.config.To) }

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"log"
-	"strings"
 	"time"
 
 	imageapi "github.com/openshift/api/image/v1"
@@ -223,39 +223,10 @@ func (s *assembleReleaseStep) Creates() []api.StepLink {
 	return []api.StepLink{api.ReleasePayloadImageLink(s.name)}
 }
 
-func EnvVarFor(name string) string {
-	return fmt.Sprintf("RELEASE_IMAGE_%s", strings.ToUpper(name))
-}
-
-func (s *assembleReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	return providesFor(s.name, s.imageClient, s.jobSpec)
-}
-
-func providesFor(name string, imageClient imageclientset.ImageV1Interface, spec *api.JobSpec) (api.ParameterMap, api.StepLink) {
+func (s *assembleReleaseStep) Provides() api.ParameterMap {
 	return api.ParameterMap{
-		EnvVarFor(name): func() (string, error) {
-			is, err := imageClient.ImageStreams(spec.Namespace()).Get("release", meta.GetOptions{})
-			if err != nil {
-				return "", fmt.Errorf("could not retrieve output imagestream: %w", err)
-			}
-			var registry string
-			if len(is.Status.PublicDockerImageRepository) > 0 {
-				registry = is.Status.PublicDockerImageRepository
-			} else if len(is.Status.DockerImageRepository) > 0 {
-				registry = is.Status.DockerImageRepository
-			} else {
-				return "", fmt.Errorf("image stream %s has no accessible image registry value", "release")
-			}
-			ref, image := findStatusTag(is, name)
-			if len(image) > 0 {
-				return fmt.Sprintf("%s@%s", registry, image), nil
-			}
-			if ref == nil && findSpecTag(is, name) == nil {
-				return "", nil
-			}
-			return fmt.Sprintf("%s:%s", registry, name), nil
-		},
-	}, api.ReleasePayloadImageLink(name)
+		utils.ReleaseImageEnv(s.name): utils.ImageDigestFor(s.imageClient, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+	}
 }
 
 func (s *assembleReleaseStep) Name() string {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -125,7 +126,7 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 			}
 			if errors.IsForbidden(err) {
 				// the ci-operator expects to have POST /imagestreamimports in the namespace of the job
-				log.Printf("warning: Unable to lock %s to an image digest pull spec, you don't have permission to access the necessary API.", EnvVarFor(s.name))
+				log.Printf("warning: Unable to lock %s to an image digest pull spec, you don't have permission to access the necessary API.", utils.ReleaseImageEnv(s.name))
 				return false, nil
 			}
 			return false, err
@@ -383,8 +384,10 @@ func (s *importReleaseStep) Creates() []api.StepLink {
 	return []api.StepLink{api.ReleasePayloadImageLink(s.name)}
 }
 
-func (s *importReleaseStep) Provides() (api.ParameterMap, api.StepLink) {
-	return providesFor(s.name, s.imageClient, s.jobSpec)
+func (s *importReleaseStep) Provides() api.ParameterMap {
+	return api.ParameterMap{
+		utils.ReleaseImageEnv(s.name): utils.ImageDigestFor(s.imageClient, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+	}
 }
 
 func (s *importReleaseStep) Name() string {

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openshift/ci-tools/pkg/results"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -19,6 +17,8 @@ import (
 	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
 // promotionStep will tag a full release suite
@@ -84,7 +84,7 @@ func (s *promotionStep) run() error {
 			}
 
 			for dst, src := range tags {
-				if valid, _ := findStatusTag(pipeline, src); valid != nil {
+				if valid, _ := utils.FindStatusTag(pipeline, src); valid != nil {
 					is.Spec.Tags = append(is.Spec.Tags, imageapi.TagReference{
 						Name: dst,
 						From: valid,
@@ -104,7 +104,7 @@ func (s *promotionStep) run() error {
 
 	client := s.dstClient.ImageStreamTags(s.config.Namespace)
 	for dst, src := range tags {
-		valid, _ := findStatusTag(pipeline, src)
+		valid, _ := utils.FindStatusTag(pipeline, src)
 		if valid == nil {
 			continue
 		}
@@ -229,8 +229,8 @@ func (s *promotionStep) Creates() []api.StepLink {
 	return []api.StepLink{}
 }
 
-func (s *promotionStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *promotionStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *promotionStep) Name() string { return "" }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -65,8 +65,8 @@ func (s *rpmImageInjectionStep) Creates() []api.StepLink {
 	return []api.StepLink{api.InternalImageLink(s.config.To)}
 }
 
-func (s *rpmImageInjectionStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *rpmImageInjectionStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *rpmImageInjectionStep) Name() string { return string(s.config.To) }

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -365,7 +365,7 @@ func (s *rpmServerStep) rpmRepoURL() (string, error) {
 	return fmt.Sprintf("http://%s", host), nil
 }
 
-func (s *rpmServerStep) Provides() (api.ParameterMap, api.StepLink) {
+func (s *rpmServerStep) Provides() api.ParameterMap {
 	var refs *v1.Refs
 	if s.jobSpec.Refs != nil {
 		refs = s.jobSpec.Refs
@@ -376,9 +376,9 @@ func (s *rpmServerStep) Provides() (api.ParameterMap, api.StepLink) {
 		rpmByOrgAndRepo := strings.Replace(fmt.Sprintf("RPM_REPO_%s_%s", strings.ToUpper(refs.Org), strings.ToUpper(refs.Repo)), "-", "_", -1)
 		return api.ParameterMap{
 			rpmByOrgAndRepo: s.rpmRepoURL,
-		}, api.RPMRepoLink()
+		}
 	}
-	return nil, nil
+	return nil
 }
 
 func (s *rpmServerStep) Name() string { return "[serve:rpms]" }

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -34,7 +34,7 @@ func (f *fakeStep) Creates() []api.StepLink  { return f.creates }
 func (f *fakeStep) Name() string             { return f.name }
 func (f *fakeStep) Description() string      { return f.name }
 
-func (f *fakeStep) Provides() (api.ParameterMap, api.StepLink) { return nil, nil }
+func (f *fakeStep) Provides() api.ParameterMap { return nil }
 
 func TestRunNormalCase(t *testing.T) {
 	root := &fakeStep{

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"io"
 	"log"
 	"os"
@@ -70,7 +71,7 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 
 	for i, p := range s.template.Parameters {
 		if len(p.Value) == 0 {
-			if !s.params.Has(p.Name) && !strings.HasPrefix(p.Name, "IMAGE_") && p.Required {
+			if !s.params.Has(p.Name) && !utils.IsStableImageEnv(p.Name) && p.Required {
 				return fmt.Errorf("template %s has required parameter %s which is not defined", s.template.Name, p.Name)
 			}
 		}
@@ -84,16 +85,13 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 			}
 			continue
 		}
-		if strings.HasPrefix(p.Name, "IMAGE_") {
-			component := strings.ToLower(strings.TrimPrefix(p.Name, "IMAGE_"))
-			if len(component) > 0 {
-				component = strings.Replace(component, "_", "-", -1)
-				format, err := s.params.Get("IMAGE_FORMAT")
-				if err != nil {
-					return fmt.Errorf("could not resolve image format: %w", err)
-				}
-				s.template.Parameters[i].Value = strings.Replace(format, api.ComponentFormatReplacement, component, -1)
+		if utils.IsStableImageEnv(p.Name) {
+			component := utils.StableImageNameFrom(p.Name)
+			format, err := s.params.Get(utils.ImageFormatEnv)
+			if err != nil {
+				return fmt.Errorf("could not resolve image format: %w", err)
 			}
+			s.template.Parameters[i].Value = strings.Replace(format, api.ComponentFormatReplacement, component, -1)
 		}
 	}
 
@@ -250,17 +248,9 @@ func (s *templateExecutionStep) SubTests() []*junit.TestCase {
 
 func (s *templateExecutionStep) Requires() []api.StepLink {
 	var links []api.StepLink
-	var needsRelease bool
 	for _, p := range s.template.Parameters {
-		needsRelease = strings.HasPrefix(p.Name, "RELEASE_IMAGE_") || needsRelease
-		if s.params.Has(p.Name) {
-			paramLinks := s.params.Links(p.Name)
-			links = append(links, paramLinks...)
-			continue
-		}
-		if strings.HasPrefix(p.Name, "IMAGE_") && !needsRelease {
-			links = append(links, api.StableImagesLink(api.LatestStableName))
-			continue
+		if link, ok := utils.LinkForEnv(p.Name); ok {
+			links = append(links, link)
 		}
 	}
 	return links
@@ -270,8 +260,8 @@ func (s *templateExecutionStep) Creates() []api.StepLink {
 	return []api.StepLink{}
 }
 
-func (s *templateExecutionStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *templateExecutionStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *templateExecutionStep) Name() string { return s.template.Name }

--- a/pkg/steps/testing.go
+++ b/pkg/steps/testing.go
@@ -94,7 +94,6 @@ type doneExpectation struct {
 
 type providesExpectation struct {
 	params map[string]string
-	link   api.StepLink
 }
 
 type inputsExpectation struct {
@@ -151,11 +150,12 @@ func examineStep(t *testing.T, step api.Step, expected stepExpectation) {
 		t.Errorf("step.Creates() returned different links:\n%s", diff.ObjectReflectDiff(expected.creates, creates))
 	}
 
-	params, link := step.Provides()
+	params := step.Provides()
 	for expectedKey, expectedValue := range expected.provides.params {
 		getFunc, ok := params[expectedKey]
 		if !ok {
 			t.Errorf("step.Provides: Parameters do not contain '%s' key (expected to return value '%s')", expectedKey, expectedValue)
+			continue
 		}
 		value, err := getFunc()
 		if err != nil {
@@ -163,9 +163,6 @@ func examineStep(t *testing.T, step api.Step, expected stepExpectation) {
 		} else if value != expectedValue {
 			t.Errorf("step.Provides: params[%s]() returned '%s', expected to return '%s'", expectedKey, value, expectedValue)
 		}
-	}
-	if !reflect.DeepEqual(expected.provides.link, link) {
-		t.Errorf("step.Provides returned different link\n%s", diff.ObjectReflectDiff(expected.provides.link, link))
 	}
 
 	inputs, err := step.Inputs()

--- a/pkg/steps/utils/env.go
+++ b/pkg/steps/utils/env.go
@@ -1,0 +1,156 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+const (
+	pipelineEnvPrefix = "LOCAL_"
+	initialEnvPrefix  = "INITIAL_"
+	imageEnvPrefix    = "IMAGE_"
+	releaseEnvPrefix  = "RELEASE_"
+
+	// ImageFormatEnv is the environment we use to hold the base pull spec
+	ImageFormatEnv = "IMAGE_FORMAT"
+)
+
+var knownPrefixes = map[string]string{
+	api.PipelineImageStream: pipelineEnvPrefix + imageEnvPrefix,
+	api.InitialImageStream:  initialEnvPrefix + imageEnvPrefix,
+	api.StableImageStream:   imageEnvPrefix,
+	api.ReleaseImageStream:  releaseEnvPrefix + imageEnvPrefix,
+}
+
+func escapedImageName(name string) string {
+	return strings.ToUpper(strings.Replace(name, "-", "_", -1))
+}
+
+func unescapedImageName(name string) string {
+	return strings.ToLower(strings.Replace(name, "_", "-", -1))
+}
+
+func imageFromEnv(stream, envVar string) (string, bool) {
+	prefix, known := knownPrefixes[stream]
+	if !known {
+		// not a stream we know about, can't unfurl
+		return "", false
+	}
+	if !strings.HasPrefix(envVar, knownPrefixes[stream]) {
+		// improperly formatted env, does not match stream
+		return "", false
+	}
+	return unescapedImageName(strings.TrimPrefix(envVar, prefix)), true
+}
+
+// LinkForEnv determines what step link was required by a user when they
+// added a parameter to their template, if any.
+func LinkForEnv(envVar string) (api.StepLink, bool) {
+	switch {
+	case envVar == ImageFormatEnv:
+		// this is a special case, as we expose this as a specific API
+		// to the user, unlike the rest of these being implicit/computed
+		return api.ImagesReadyLink(), true
+	case IsPipelineImageEnv(envVar):
+		image, ok := imageFromEnv(api.PipelineImageStream, envVar)
+		if !ok {
+			return nil, false
+		}
+		return api.InternalImageLink(api.PipelineImageStreamTagReference(image)), true
+	case IsStableImageEnv(envVar):
+		// we don't know what will produce this parameter,
+		// so we assume it will come from the release import
+		return api.StableImagesLink(api.LatestStableName), true
+	case IsInitialImageEnv(envVar):
+		return api.StableImagesLink(api.InitialImageStream), true
+	case IsReleaseImageEnv(envVar):
+		return api.ReleasePayloadImageLink(ReleaseNameFrom(envVar)), true
+	default:
+		return nil, false
+	}
+}
+
+// EnvVarFor determines the environment variable used to
+// expose a pull spec for an ImageStreamTag in the test
+// namespace to test workloads.
+func EnvVarFor(stream, name string) (string, error) {
+	if _, ok := knownPrefixes[stream]; !ok {
+		return "", fmt.Errorf("stream %q not recognized", stream)
+	}
+	return validatedEnvVarFor(stream, name), nil
+}
+
+// validatedEnvVarFor assumes the caller has checked the validity
+// of the stream name and does not error
+func validatedEnvVarFor(stream, name string) string {
+	return knownPrefixes[stream] + escapedImageName(name)
+}
+
+// PipelineImageEnvFor determines the environment variable
+// used to expose a pull spec for a pipeline ImageStreamTag
+// in the test namespace to test workloads.
+func PipelineImageEnvFor(name api.PipelineImageStreamTagReference) string {
+	return validatedEnvVarFor(api.PipelineImageStream, string(name))
+}
+
+// IsPipelineImageEnv determines if an env var holds a pull
+// spec for a tag under the pipeline image stream
+func IsPipelineImageEnv(envVar string) bool {
+	return strings.HasPrefix(envVar, knownPrefixes[api.PipelineImageStream])
+}
+
+// StableImageEnv determines the environment variable
+// used to expose a pull spec for a stable ImageStreamTag
+// in the test namespace to test workloads.
+func StableImageEnv(name string) string {
+	return validatedEnvVarFor(api.StableImageStream, name)
+}
+
+// IsStableImageEnv determines if an env var holds a pull
+// spec for a tag under the stable image stream
+func IsStableImageEnv(envVar string) bool {
+	return strings.HasPrefix(envVar, knownPrefixes[api.StableImageStream])
+}
+
+// StableImageNameFrom gets an image name from an env name
+func StableImageNameFrom(envVar string) string {
+	// we know that we will be able to unfurl
+	name, _ := imageFromEnv(api.StableImageStream, envVar)
+	return name
+}
+
+// InitialImageEnv determines the environment variable
+// used to expose a pull spec for a initial ImageStreamTag
+// in the test namespace to test workloads.
+func InitialImageEnv(name string) string {
+	return validatedEnvVarFor(api.InitialImageStream, name)
+}
+
+// IsInitialImageEnv determines if an env var holds a pull
+// spec for a tag under the initial image stream
+func IsInitialImageEnv(envVar string) bool {
+	return strings.HasPrefix(envVar, knownPrefixes[api.InitialImageStream])
+}
+
+// ReleaseImageEnv determines the environment variable
+// used to expose a pull spec for a release ImageStreamTag
+// in the test namespace to test workloads.
+func ReleaseImageEnv(name string) string {
+	return validatedEnvVarFor(api.ReleaseImageStream, name)
+}
+
+// IsReleaseImageEnv determines if an env var holds a pull
+// spec for a tag under the release image stream
+func IsReleaseImageEnv(envVar string) bool {
+	return strings.HasPrefix(envVar, knownPrefixes[api.ReleaseImageStream])
+}
+
+// ReleaseNameFrom determines the name of the release payload
+// that the pull spec points to.
+func ReleaseNameFrom(envVar string) string {
+	// we know that we will be able to unfurl
+	name, _ := imageFromEnv(api.ReleaseImageStream, envVar)
+	return name
+}

--- a/pkg/steps/utils/env_test.go
+++ b/pkg/steps/utils/env_test.go
@@ -1,0 +1,162 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestEscaping(t *testing.T) {
+	var testCases = []struct {
+		unescaped, escaped string
+	}{
+		{
+			unescaped: "cluster-api-operator",
+			escaped:   "CLUSTER_API_OPERATOR",
+		},
+		{
+			unescaped: "installer",
+			escaped:   "INSTALLER",
+		},
+	}
+
+	for _, testCase := range testCases {
+		var testPlans = []struct {
+			action          string
+			work            func(string) string
+			input, expected string
+		}{
+			{
+				action:   "escaping",
+				work:     escapedImageName,
+				input:    testCase.unescaped,
+				expected: testCase.escaped,
+			},
+			{
+				action:   "unescaping",
+				work:     unescapedImageName,
+				input:    testCase.escaped,
+				expected: testCase.unescaped,
+			},
+			{
+				action: "round-tripping",
+				work: func(s string) string {
+					return unescapedImageName(escapedImageName(s))
+				},
+				input:    testCase.unescaped,
+				expected: testCase.unescaped,
+			},
+		}
+		for _, test := range testPlans {
+			actual := test.work(test.input)
+			if actual != test.expected {
+				t.Errorf("%s did not yield %s, got %s", test.action, test.expected, actual)
+			}
+		}
+	}
+}
+
+func TestLinkForEnv(t *testing.T) {
+	var testCases = []struct {
+		input  string
+		output api.StepLink
+		valid  bool
+	}{
+		{
+			input:  "unrelated",
+			output: nil,
+			valid:  false,
+		},
+		{
+			input:  "IMAGE_FORMAT",
+			output: api.ImagesReadyLink(),
+			valid:  true,
+		},
+		{
+			input:  "LOCAL_IMAGE_COMPONENT",
+			output: api.InternalImageLink("component"),
+			valid:  true,
+		},
+		{
+			input:  "IMAGE_COMPONENT",
+			output: api.StableImagesLink(api.LatestStableName),
+			valid:  true,
+		},
+		{
+			input:  "INITIAL_IMAGE_COMPONENT",
+			output: api.StableImagesLink(api.InitialImageStream),
+			valid:  true,
+		},
+		{
+			input:  "RELEASE_IMAGE_FOOBAR",
+			output: api.ReleasePayloadImageLink("foobar"),
+			valid:  true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		link, valid := LinkForEnv(testCase.input)
+		if valid != testCase.valid {
+			t.Errorf("didn't determine env validity correctly for %q, expected %v", testCase.input, testCase.valid)
+		}
+		if diff := cmp.Diff(link, testCase.output, api.Comparer()); diff != "" {
+			t.Errorf("got incorrect link for %q: %v", testCase.input, diff)
+		}
+	}
+}
+
+func TestEnvVarFor(t *testing.T) {
+	var testCases = []struct {
+		input, expected string
+		work            func(string) string
+		check           func(string) bool
+		revert          func(string) string
+	}{
+		{
+			input:    "src",
+			expected: "LOCAL_IMAGE_SRC",
+			work: func(s string) string {
+				return PipelineImageEnvFor(api.PipelineImageStreamTagReference(s))
+			},
+			check: IsPipelineImageEnv,
+		},
+		{
+			input:    "cluster-actuator-thing-operator-stuff",
+			expected: "IMAGE_CLUSTER_ACTUATOR_THING_OPERATOR_STUFF",
+			work:     StableImageEnv,
+			check:    IsStableImageEnv,
+			revert:   StableImageNameFrom,
+		},
+		{
+			input:    "whatever",
+			expected: "INITIAL_IMAGE_WHATEVER",
+			work:     InitialImageEnv,
+			check:    IsInitialImageEnv,
+		},
+		{
+			input:    "useful",
+			expected: "RELEASE_IMAGE_USEFUL",
+			work:     ReleaseImageEnv,
+			check:    IsReleaseImageEnv,
+			revert:   ReleaseNameFrom,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actual := testCase.work(testCase.input)
+		if actual != testCase.expected {
+			t.Errorf("got incorrect env %q for %q, wanted %q", actual, testCase.input, testCase.expected)
+		}
+		if !testCase.check(actual) {
+			t.Errorf("check did not pass for %q created from %q", actual, testCase.input)
+		}
+		if testCase.revert != nil {
+			reverted := testCase.revert(actual)
+			if reverted != testCase.input {
+				t.Errorf("failed to round-trip: %q -> %q -> %q", testCase.input, actual, reverted)
+			}
+		}
+	}
+}

--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"fmt"
+
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	imageapi "github.com/openshift/api/image/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+)
+
+func ImageDigestFor(client imageclientset.ImageStreamsGetter, namespace func() string, name, tag string) func() (string, error) {
+	return func() (string, error) {
+		is, err := client.ImageStreams(namespace()).Get(name, meta.GetOptions{})
+		if err != nil {
+			return "", fmt.Errorf("could not retrieve output imagestream: %w", err)
+		}
+		var registry string
+		if len(is.Status.PublicDockerImageRepository) > 0 {
+			registry = is.Status.PublicDockerImageRepository
+		} else if len(is.Status.DockerImageRepository) > 0 {
+			registry = is.Status.DockerImageRepository
+		} else {
+			return "", fmt.Errorf("image stream %s has no accessible image registry value", name)
+		}
+		ref, image := FindStatusTag(is, tag)
+		if len(image) > 0 {
+			return fmt.Sprintf("%s@%s", registry, image), nil
+		}
+		if ref == nil && findSpecTag(is, tag) == nil {
+			return "", fmt.Errorf("image stream %s has no tag %s in spec or status", name, tag)
+		}
+		return fmt.Sprintf("%s:%s", registry, tag), nil
+	}
+}
+
+func findSpecTag(is *imageapi.ImageStream, tag string) *coreapi.ObjectReference {
+	for _, t := range is.Spec.Tags {
+		if t.Name != tag {
+			continue
+		}
+		return t.From
+	}
+	return nil
+}
+
+// FindStatusTag returns an object reference to a tag if
+// it exists in the ImageStream's Spec
+func FindStatusTag(is *imageapi.ImageStream, tag string) (*coreapi.ObjectReference, string) {
+	for _, t := range is.Status.Tags {
+		if t.Tag != tag {
+			continue
+		}
+		if len(t.Items) == 0 {
+			return nil, ""
+		}
+		if len(t.Items[0].Image) == 0 {
+			return &coreapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: t.Items[0].DockerImageReference,
+			}, ""
+		}
+		return &coreapi.ObjectReference{
+			Kind:      "ImageStreamImage",
+			Namespace: is.Namespace,
+			Name:      fmt.Sprintf("%s@%s", is.Name, t.Items[0].Image),
+		}, t.Items[0].Image
+	}
+	return nil, ""
+}

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -51,15 +51,15 @@ func (s *writeParametersStep) run() error {
 }
 
 func (s *writeParametersStep) Requires() []api.StepLink {
-	return s.params.AllLinks()
+	return []api.StepLink{api.AllStepsLink()}
 }
 
 func (s *writeParametersStep) Creates() []api.StepLink {
 	return nil
 }
 
-func (s *writeParametersStep) Provides() (api.ParameterMap, api.StepLink) {
-	return nil, nil
+func (s *writeParametersStep) Provides() api.ParameterMap {
+	return nil
 }
 
 func (s *writeParametersStep) Name() string { return "parameters/write" }

--- a/pkg/steps/write_params_test.go
+++ b/pkg/steps/write_params_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestWriteParamsStep(t *testing.T) {
 	params := api.NewDeferredParameters()
-	params.Add("K1", someStepLink("another-step"), func() (string, error) { return "V1", nil })
-	params.Add("K2", someStepLink("another-step"), func() (string, error) { return "V:2", nil })
+	params.Add("K1", func() (string, error) { return "V1", nil })
+	params.Add("K2", func() (string, error) { return "V:2", nil })
 	paramFile, err := ioutil.TempFile("", "")
 	if err != nil {
 		t.Errorf("Failed to create temporary file: %v", err)
@@ -23,11 +23,10 @@ func TestWriteParamsStep(t *testing.T) {
 
 	specification := stepExpectation{
 		name:     "parameters/write",
-		requires: []api.StepLink{someStepLink("another-step"), someStepLink("another-step")},
+		requires: []api.StepLink{api.AllStepsLink()},
 		creates:  nil,
 		provides: providesExpectation{
 			params: nil,
-			link:   nil,
 		},
 		inputs: inputsExpectation{
 			values: nil,


### PR DESCRIPTION
The logic for interoperating between environment variables and step
links is currently not common, shared or tested. Before we attempt to
expose such a mechanism to users in config, we need to refactor this to
be self-consistent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller 