### PR TITLE
pkg/steps: add new bundle source step

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -382,6 +382,7 @@ type StepConfiguration struct {
 	InputImageTagStepConfiguration              *InputImageTagStepConfiguration              `json:"input_image_tag_step,omitempty"`
 	PipelineImageCacheStepConfiguration         *PipelineImageCacheStepConfiguration         `json:"pipeline_image_cache_step,omitempty"`
 	SourceStepConfiguration                     *SourceStepConfiguration                     `json:"source_step,omitempty"`
+	BundleSourceStepConfiguration               *BundleSourceStepConfiguration               `json:"bundle_source_step,omitempty"`
 	ProjectDirectoryImageBuildStepConfiguration *ProjectDirectoryImageBuildStepConfiguration `json:"project_directory_image_build_step,omitempty"`
 	RPMImageInjectionStepConfiguration          *RPMImageInjectionStepConfiguration          `json:"rpm_image_injection_step,omitempty"`
 	RPMServeStepConfiguration                   *RPMServeStepConfiguration                   `json:"rpm_serve_step,omitempty"`
@@ -950,6 +951,26 @@ type SourceStepConfiguration struct {
 	ClonerefsPath string `json:"clonerefs_path"`
 }
 
+// BundleSourceStepConfiguration describes a step that performs a set of
+// substitutions on operator manifests in the `src` image so that the
+// pullspecs in the operator manifests point to images inside the CI registry.
+// It is intended to be used as the source image for bundle image builds.
+type BundleSourceStepConfiguration struct {
+	To PipelineImageStreamTagReference `json:"to,omitempty"`
+
+	// ContextDir is the directory in the project
+	// from which this build should be run.
+	ContextDir string `json:"context_dir,omitempty"`
+
+	// OperatorManifests is the subdir of context_dir where optional
+	// operator manifests are stored for operator bundle images.
+	OperatorManifests string `json:"operator_manifests,omitempty"`
+
+	// Substitute contains pullspecs that need to be replaced by images
+	// in the CI cluster for operator bundle images
+	Substitute []PullSpecSubstitution `json:"substitute,omitempty"`
+}
+
 // ProjectDirectoryImageBuildStepConfiguration describes an
 // image build from a directory in a component project.
 type ProjectDirectoryImageBuildStepConfiguration struct {
@@ -974,10 +995,28 @@ type ProjectDirectoryImageBuildInputs struct {
 	// project to run relative to the context_dir.
 	DockerfilePath string `json:"dockerfile_path,omitempty"`
 
+	// OperatorManifests is the subdir of context_dir where optional
+	// operator manifests are stored for operator bundle images.
+	OperatorManifests string `json:"operator_manifests,omitempty"`
+
+	// Substitute contains pullspecs that need to be replaced by images
+	// in the CI cluster for operator bundle images
+	Substitute []PullSpecSubstitution `json:"substitute,omitempty"`
+
 	// Inputs is a map of tag reference name to image input changes
 	// that will populate the build context for the Dockerfile or
 	// alter the input image for a multi-stage build.
 	Inputs map[string]ImageBuildInputs `json:"inputs,omitempty"`
+}
+
+// PullSpecSubstitution contains a name of a pullspec that needs to
+// be substituted with the name of a different pullspec. This is used
+// for generated operator bundle images.
+type PullSpecSubstitution struct {
+	// PullSpec is the pullspec that needs to be replaced
+	PullSpec string `json:"pullspec,omitempty"`
+	// With is the string that the PullSpec is being replaced by
+	With string `json:"with,omitempty"`
 }
 
 // ImageBuildInputs is a subset of the v1 OpenShift Build API object

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -1,0 +1,152 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	buildapi "github.com/openshift/api/build/v1"
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type bundleSourceStep struct {
+	config      api.BundleSourceStepConfiguration
+	resources   api.ResourceConfiguration
+	buildClient BuildClient
+	imageClient imageclientset.ImageStreamsGetter
+	istClient   imageclientset.ImageStreamTagsGetter
+	jobSpec     *api.JobSpec
+	artifactDir string
+	dryLogger   *DryLogger
+	pullSecret  *coreapi.Secret
+}
+
+func (s *bundleSourceStep) Inputs(dry bool) (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *bundleSourceStep) Run(ctx context.Context, dry bool) error {
+	return results.ForReason("building_bundle_source").ForError(s.run(ctx, dry))
+}
+
+func (s *bundleSourceStep) run(ctx context.Context, dry bool) error {
+	source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource)
+	var workingDir string
+	if dry {
+		workingDir = "dry-fake"
+	} else {
+		var err error
+		workingDir, err = getWorkingDir(s.istClient, source, s.jobSpec.Namespace())
+		if err != nil {
+			return fmt.Errorf("failed to get workingDir: %w", err)
+		}
+	}
+	dockerfile, err := s.bundleSourceDockerfile(dry)
+	if err != nil {
+		return err
+	}
+	build := buildFromSource(
+		s.jobSpec, api.PipelineImageStreamTagReferenceSource, s.config.To,
+		buildapi.BuildSource{
+			Type:       buildapi.BuildSourceDockerfile,
+			Dockerfile: &dockerfile,
+			Images: []buildapi.ImageSource{
+				{
+					From: coreapi.ObjectReference{
+						Kind: "ImageStreamTag",
+						Name: source,
+					},
+					Paths: []buildapi.ImageSourcePath{{
+						SourcePath:     fmt.Sprintf("%s/%s/.", workingDir, s.config.ContextDir),
+						DestinationDir: ".",
+					}},
+				},
+			},
+		},
+		"",
+		s.resources,
+		s.pullSecret,
+	)
+	return handleBuild(ctx, s.buildClient, build, dry, s.artifactDir, s.dryLogger)
+}
+
+func replaceCommand(manifestDir, pullSpec, with string) string {
+	return fmt.Sprintf("find %s -type f -exec sed -i 's?%s?%s?g' {} +", manifestDir, pullSpec, with)
+}
+
+func (s *bundleSourceStep) bundleSourceDockerfile(dry bool) (string, error) {
+	var dockerCommands []string
+	dockerCommands = append(dockerCommands, "")
+	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
+	manifestDir := filepath.Join(s.config.ContextDir, s.config.OperatorManifests)
+	for _, sub := range s.config.Substitute {
+		replaceSpec, err := s.getFullPullSpec(sub.With, dry)
+		if err != nil {
+			return "", fmt.Errorf("failed to get replacement imagestream for image tag `%s`", sub.With)
+		}
+		dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["bash", "-c", "%s"]`, replaceCommand(manifestDir, sub.PullSpec, replaceSpec)))
+	}
+	dockerCommands = append(dockerCommands, "")
+	return strings.Join(dockerCommands, "\n"), nil
+}
+
+func (s *bundleSourceStep) getFullPullSpec(tag string, dry bool) (string, error) {
+	if dry {
+		return "dry-registry.ci.openshift.org/namespace/stable:" + tag, nil
+	}
+	is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(api.StableImageStream, meta.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if len(is.Status.PublicDockerImageRepository) > 0 {
+		return is.Status.PublicDockerImageRepository + ":" + tag, nil
+	}
+	if len(is.Status.DockerImageRepository) > 0 {
+		return is.Status.DockerImageRepository + ":" + tag, nil
+	}
+	return "", fmt.Errorf("no pull spec available for image stream %s", api.StableImageStream)
+}
+
+func (s *bundleSourceStep) Requires() []api.StepLink {
+	return []api.StepLink{
+		api.InternalImageLink(api.PipelineImageStreamTagReferenceSource),
+	}
+}
+
+func (s *bundleSourceStep) Creates() []api.StepLink {
+	return []api.StepLink{api.InternalImageLink(s.config.To)}
+}
+
+func (s *bundleSourceStep) Provides() (api.ParameterMap, api.StepLink) {
+	return api.ParameterMap{}, api.InternalImageLink(s.config.To)
+}
+
+func (s *bundleSourceStep) Name() string { return string(s.config.To) }
+
+func (s *bundleSourceStep) Description() string {
+	return fmt.Sprintf("Build image %s from the repository", s.config.To)
+}
+
+func BundleSourceStep(config api.BundleSourceStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, dryLogger *DryLogger, pullSecret *coreapi.Secret) api.Step {
+	return &bundleSourceStep{
+		config:      config,
+		resources:   resources,
+		buildClient: buildClient,
+		imageClient: imageClient,
+		istClient:   istClient,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
+		dryLogger:   dryLogger,
+		pullSecret:  pullSecret,
+	}
+}
+
+// BundleSourceName returns the PipelineImageStreamTagReference for the source image for the given bundle image tag reference
+func BundleSourceName(bundleName api.PipelineImageStreamTagReference) api.PipelineImageStreamTagReference {
+	return api.PipelineImageStreamTagReference(fmt.Sprintf("%s-sub", bundleName))
+}

--- a/pkg/steps/bundle_source_test.go
+++ b/pkg/steps/bundle_source_test.go
@@ -1,0 +1,99 @@
+package steps
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+var subs = []api.PullSpecSubstitution{
+	{
+		PullSpec: "quay.io/openshift/origin-metering-ansible-operator:4.6",
+		With:     "metering-ansible-operator",
+	},
+	{
+		PullSpec: "quay.io/openshift/origin-metering-reporting-operator:4.6",
+		With:     "metering-reporting-operator",
+	},
+	{
+		PullSpec: "quay.io/openshift/origin-metering-presto:4.6",
+		With:     "metering-presto",
+	},
+	{
+		PullSpec: "quay.io/openshift/origin-metering-hive:4.6",
+		With:     "metering-hive",
+	},
+	{
+		PullSpec: "quay.io/openshift/origin-metering-hadoop:4.6",
+		With:     "metering-hadoop",
+	},
+	{
+		PullSpec: "quay.io/openshift/origin-ghostunnel:4.6",
+		With:     "ghostunnel",
+	},
+}
+
+func TestReplaceCommand(t *testing.T) {
+	temp, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory for unit test: %v", err)
+	}
+	if err := exec.Command("cp", "-a", "testdata/4.6", temp).Run(); err != nil {
+		t.Fatalf("Failed to copy testdata to tempdir: %v", err)
+	}
+	for _, sub := range subs {
+		if err := exec.Command("bash", "-c", replaceCommand(temp, sub.PullSpec, "stable:"+sub.With)).Run(); err != nil {
+			t.Fatalf("Failed to run replace command `bash -c \"%s\"`: %v", replaceCommand(temp, sub.PullSpec, sub.With), err)
+		}
+	}
+	files, err := ioutil.ReadDir(filepath.Join(temp, "4.6"))
+	if err != nil {
+		t.Fatalf("Failed to read directory: %v", err)
+	}
+	for _, file := range files {
+		updatedFilename := filepath.Join(temp, "4.6", file.Name())
+		updated, err := ioutil.ReadFile(updatedFilename)
+		if err != nil {
+			t.Fatalf("Failed to read file %s: %v", updatedFilename, err)
+		}
+		expectedFilename := filepath.Join("testdata/4.6-expected", file.Name())
+		expected, err := ioutil.ReadFile(expectedFilename)
+		if err != nil {
+			t.Fatalf("Failed to read file %s: %v", expectedFilename, err)
+		}
+		if !bytes.Equal(updated, expected) {
+			t.Errorf("Updated file %s not equal to expected file %s;\nValue of updated file: %s", updatedFilename, expectedFilename, string(updated))
+		}
+	}
+}
+
+func TestBundleSourceDockerfile(t *testing.T) {
+	var expectedDockerfile = `
+FROM pipeline:src
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-ansible-operator:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-ansible-operator?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-reporting-operator:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-reporting-operator?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-presto:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-presto?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-hive:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-hive?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-hadoop:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-hadoop?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-ghostunnel:4.6?dry-registry.ci.openshift.org/namespace/stable:ghostunnel?g' {} +"]
+`
+
+	s := bundleSourceStep{
+		config: api.BundleSourceStepConfiguration{
+			ContextDir:        "manifests/deploy",
+			OperatorManifests: "4.6",
+			Substitute:        subs,
+		},
+	}
+	generatedDockerfile, err := s.bundleSourceDockerfile(true)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if expectedDockerfile != generatedDockerfile {
+		t.Errorf("Generated bundle source dockerfile does not equal expected; generated dockerfile: %s", generatedDockerfile)
+	}
+}

--- a/pkg/steps/testdata/4.6-expected/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/pkg/steps/testdata/4.6-expected/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -1,0 +1,114 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: metering-operator.v4.6.0
+  namespace: placeholder
+  annotations:
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Monitoring
+    certified: "false"
+    containerImage: stable:metering-ansible-operator
+    createdAt: 2019-01-01T11:59:59Z
+    description: Chargeback and reporting tool to provide accountability for how resources
+      are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.6.0'
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-metering
+    operators.openshift.io/capability: '["fips", "cluster-proxy"]'
+    repository: https://github.com/kube-reporting/metering-operator
+    support: Red Hat, Inc.
+
+spec:
+  displayName: Metering
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: metering-operator
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: metering-operator
+            template:
+              metadata:
+                labels:
+                  app: metering-operator
+                  name: metering-operator
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                - name: ansible
+                  command:
+                  - /opt/ansible/scripts/ansible-logs.sh
+                  - /tmp/ansible-operator/runner
+                  - stdout
+                  image: "stable:metering-ansible-operator"
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                    readOnly: true
+                - name: operator
+                  image: "stable:metering-ansible-operator"
+                  imagePullPolicy: Always
+                  env:
+                  - name: OPERATOR_NAME
+                    value: "metering-operator"
+                  - name: DISABLE_OCP_FEATURES
+                    value: "false"
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: METERING_ANSIBLE_OPERATOR_IMAGE
+                    value: "stable:metering-ansible-operator"
+                  - name: METERING_REPORTING_OPERATOR_IMAGE
+                    value: "stable:metering-reporting-operator"
+                  - name: METERING_PRESTO_IMAGE
+                    value: "stable:metering-presto"
+                  - name: METERING_HIVE_IMAGE
+                    value: "stable:metering-hive"
+                  - name: METERING_HADOOP_IMAGE
+                    value: "stable:metering-hadoop"
+                  - name: GHOSTUNNEL_IMAGE
+                    value: "stable:ghostunnel"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                  resources:
+                    limits:
+                      cpu: 1500m
+                      memory: 500Mi
+                    requests:
+                      cpu: 750m
+                      memory: 400Mi
+
+                volumes:
+                  - name: runner
+                    emptyDir: {}
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                serviceAccount: metering-operator

--- a/pkg/steps/testdata/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/pkg/steps/testdata/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -1,0 +1,114 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: metering-operator.v4.6.0
+  namespace: placeholder
+  annotations:
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Monitoring
+    certified: "false"
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.6
+    createdAt: 2019-01-01T11:59:59Z
+    description: Chargeback and reporting tool to provide accountability for how resources
+      are used across a cluster
+    olm.skipRange: '>=4.2.0 <4.6.0'
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-metering
+    operators.openshift.io/capability: '["fips", "cluster-proxy"]'
+    repository: https://github.com/kube-reporting/metering-operator
+    support: Red Hat, Inc.
+
+spec:
+  displayName: Metering
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: metering-operator
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: metering-operator
+            template:
+              metadata:
+                labels:
+                  app: metering-operator
+                  name: metering-operator
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                - name: ansible
+                  command:
+                  - /opt/ansible/scripts/ansible-logs.sh
+                  - /tmp/ansible-operator/runner
+                  - stdout
+                  image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                    readOnly: true
+                - name: operator
+                  image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  imagePullPolicy: Always
+                  env:
+                  - name: OPERATOR_NAME
+                    value: "metering-operator"
+                  - name: DISABLE_OCP_FEATURES
+                    value: "false"
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: METERING_ANSIBLE_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  - name: METERING_REPORTING_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-reporting-operator:4.6"
+                  - name: METERING_PRESTO_IMAGE
+                    value: "quay.io/openshift/origin-metering-presto:4.6"
+                  - name: METERING_HIVE_IMAGE
+                    value: "quay.io/openshift/origin-metering-hive:4.6"
+                  - name: METERING_HADOOP_IMAGE
+                    value: "quay.io/openshift/origin-metering-hadoop:4.6"
+                  - name: GHOSTUNNEL_IMAGE
+                    value: "quay.io/openshift/origin-ghostunnel:4.6"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                  resources:
+                    limits:
+                      cpu: 1500m
+                      memory: 500Mi
+                    requests:
+                      cpu: 750m
+                      memory: 400Mi
+
+                volumes:
+                  - name: runner
+                    emptyDir: {}
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                serviceAccount: metering-operator

--- a/test/integration/ci-operator/base/config/test-config.yaml
+++ b/test/integration/ci-operator/base/config/test-config.yaml
@@ -50,6 +50,17 @@ images:
       - registry.svc.ci.openshift.org/openshift/origin-v4.0:machine-os-content
       paths: null
   to: machine-os-content
+- dockerfile_path: Dockerfile.bundle
+  context_dir: manifests/deploy/openshift/olm/
+  operator_manifests: "4.6" # this is subdir of context_dir
+  to: metering-reporting-operator-bundle
+  substitute:
+  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.6
+    with: metering-reporting-operator
+  - pullspec: quay.io/openshift/origin-oauth-proxy:4.6
+    with: oauth-proxy
+  - pullspec: quay.io/openshift/origin-hive:4.6
+    with: hive
 promotion:
   additional_images:
     artifacts: artifacts

--- a/test/integration/ci-operator/base/expected_files/expected.json
+++ b/test/integration/ci-operator/base/expected_files/expected.json
@@ -709,6 +709,211 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:metering-reporting-operator-bundle-sub"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "dockerfilePath": "Dockerfile.bundle",
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle-sub",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle-sub",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle-sub",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "\nFROM pipeline:src\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-reporting-operator:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-reporting-operator?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-oauth-proxy:4.6?dry-registry.ci.openshift.org/namespace/stable:oauth-proxy?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-hive:4.6?dry-registry.ci.openshift.org/namespace/stable:hive?g' {} +\"]\n",
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:src",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
         "creates": "rpms",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
         "prow.k8s.io/id": "uuid"
@@ -1351,6 +1556,40 @@
     "metadata": {
       "creationTimestamp": null,
       "name": "stable:machine-os-content",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:metering-reporting-operator-bundle",
       "namespace": "testns"
     },
     "tag": {

--- a/test/integration/ci-operator/base/expected_files/expected_pull_secret.json
+++ b/test/integration/ci-operator/base/expected_files/expected_pull_secret.json
@@ -730,6 +730,217 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:metering-reporting-operator-bundle-sub"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "dockerfilePath": "Dockerfile.bundle",
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle-sub",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle-sub",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle-sub",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "\nFROM pipeline:src\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-reporting-operator:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-reporting-operator?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-oauth-proxy:4.6?dry-registry.ci.openshift.org/namespace/stable:oauth-proxy?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-hive:4.6?dry-registry.ci.openshift.org/namespace/stable:hive?g' {} +\"]\n",
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:src",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true,
+          "pullSecret": {
+            "name": "regcred"
+          }
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
         "creates": "rpms",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
         "prow.k8s.io/id": "uuid"
@@ -1381,6 +1592,40 @@
     "metadata": {
       "creationTimestamp": null,
       "name": "stable:machine-os-content",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:metering-reporting-operator-bundle",
       "namespace": "testns"
     },
     "tag": {

--- a/test/integration/ci-operator/base/expected_files/expected_with_template.json
+++ b/test/integration/ci-operator/base/expected_files/expected_with_template.json
@@ -432,6 +432,211 @@
         "ci.openshift.io/refs.org": "openshift",
         "ci.openshift.io/refs.repo": "ci-tools",
         "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "imageLabels": [
+          {
+            "name": "io.openshift.build.commit.author"
+          },
+          {
+            "name": "io.openshift.build.commit.date"
+          },
+          {
+            "name": "io.openshift.build.commit.id"
+          },
+          {
+            "name": "io.openshift.build.commit.message"
+          },
+          {
+            "name": "io.openshift.build.commit.ref"
+          },
+          {
+            "name": "io.openshift.build.name"
+          },
+          {
+            "name": "io.openshift.build.namespace"
+          },
+          {
+            "name": "io.openshift.build.source-context-dir"
+          },
+          {
+            "name": "io.openshift.build.source-location"
+          },
+          {
+            "name": "vcs-ref"
+          },
+          {
+            "name": "vcs-type"
+          },
+          {
+            "name": "vcs-url"
+          }
+        ],
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:metering-reporting-operator-bundle-sub"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Image"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "dockerfilePath": "Dockerfile.bundle",
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
+        "creates": "metering-reporting-operator-bundle-sub",
+        "job": "pull-ci-openshift-release-master-ci-operator-integration",
+        "prow.k8s.io/id": "uuid"
+      },
+      "name": "metering-reporting-operator-bundle-sub",
+      "namespace": "testns"
+    },
+    "spec": {
+      "nodeSelector": null,
+      "output": {
+        "to": {
+          "kind": "ImageStreamTag",
+          "name": "pipeline:metering-reporting-operator-bundle-sub",
+          "namespace": "testns"
+        }
+      },
+      "postCommit": {},
+      "resources": {
+        "limits": {
+          "memory": "8Gi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "4Gi"
+        }
+      },
+      "serviceAccount": "builder",
+      "source": {
+        "dockerfile": "\nFROM pipeline:src\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-reporting-operator:4.6?dry-registry.ci.openshift.org/namespace/stable:metering-reporting-operator?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-oauth-proxy:4.6?dry-registry.ci.openshift.org/namespace/stable:oauth-proxy?g' {} +\"]\nRUN [\"bash\", \"-c\", \"find manifests/deploy/openshift/olm/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-hive:4.6?dry-registry.ci.openshift.org/namespace/stable:hive?g' {} +\"]\n",
+        "images": [
+          {
+            "as": null,
+            "from": {
+              "kind": "ImageStreamTag",
+              "name": "pipeline:src"
+            },
+            "paths": [
+              {
+                "destinationDir": ".",
+                "sourcePath": "dry-fake/manifests/deploy/openshift/olm//."
+              }
+            ]
+          }
+        ],
+        "type": "Dockerfile"
+      },
+      "strategy": {
+        "dockerStrategy": {
+          "env": [
+            {
+              "name": "foo",
+              "value": "bar"
+            }
+          ],
+          "forcePull": true,
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "pipeline:src",
+            "namespace": "testns"
+          },
+          "imageOptimizationPolicy": "SkipLayers",
+          "noCache": true
+        },
+        "type": "Docker"
+      },
+      "triggeredBy": null
+    },
+    "status": {
+      "output": {},
+      "phase": ""
+    }
+  },
+  {
+    "apiVersion": "build.openshift.io/v1",
+    "kind": "Build",
+    "metadata": {
+      "annotations": {
+        "ci.openshift.io/job-spec": "{\"type\":\"presubmit\",\"job\":\"pull-ci-openshift-release-master-ci-operator-integration\",\"buildid\":\"0\",\"prowjobid\":\"uuid\",\"refs\":{\"org\":\"openshift\",\"repo\":\"ci-tools\",\"base_ref\":\"master\",\"base_sha\":\"af8a90a2faf965eeda949dc1c607c48d3ffcda3e\",\"pulls\":[{\"number\":1234,\"author\":\"droslean\",\"sha\":\"538680dfd2f6cff3b3506c80ca182dcb0dd22a58\"}]}}"
+      },
+      "creationTimestamp": null,
+      "labels": {
+        "build-id": "0",
+        "ci.openshift.io/refs.branch": "master",
+        "ci.openshift.io/refs.org": "openshift",
+        "ci.openshift.io/refs.repo": "ci-tools",
+        "created-by-ci": "true",
         "creates": "rpms",
         "job": "pull-ci-openshift-release-master-ci-operator-integration",
         "prow.k8s.io/id": "uuid"
@@ -1040,6 +1245,40 @@
     "metadata": {
       "creationTimestamp": null,
       "name": "stable:machine-os-content",
+      "namespace": "testns"
+    },
+    "tag": {
+      "annotations": null,
+      "from": {
+        "kind": "ImageStreamImage",
+        "name": "pipeline@dry-fake",
+        "namespace": "testns"
+      },
+      "generation": null,
+      "importPolicy": {},
+      "name": "",
+      "referencePolicy": {
+        "type": "Local"
+      }
+    }
+  },
+  {
+    "apiVersion": "image.openshift.io/v1",
+    "generation": 0,
+    "image": {
+      "dockerImageLayers": null,
+      "dockerImageMetadata": null,
+      "metadata": {
+        "creationTimestamp": null
+      }
+    },
+    "kind": "ImageStreamTag",
+    "lookupPolicy": {
+      "local": false
+    },
+    "metadata": {
+      "creationTimestamp": null,
+      "name": "stable:metering-reporting-operator-bundle",
       "namespace": "testns"
     },
     "tag": {


### PR DESCRIPTION
This commit adds a new `BundleSourceStep` to be used by bundle image
builds. It creates a new image based off of the `pipeline:src` image
and uses `sed` to replace the pullspecs specified in the ci-operator
config with the in-cluster image references.

This is an early WIP and doesn't have tests yet. Those will be added soon.

/cc @petr-muller 