### PR TITLE
Avoid no-op changes in integration test fixtures

### DIFF
--- a/hack/lib/integration.sh
+++ b/hack/lib/integration.sh
@@ -25,9 +25,17 @@ function os::integration::compare() {
         fi
     fi
 
-    os::cmd::expect_success "diff -Naupr --ignore-matching-lines 'startTime' --ignore-matching-lines 'name: \w\{8\}\(-\w\{4\}\)\{3\}-\w\{12\}' --ignore-matching-lines 'sha: \w\{40\}' ${actual} ${expected}"
+    os::cmd::expect_success "diff -Naupr ${actual} ${expected}"
 }
 readonly -f os::integration::compare
+
+# os::integration::sanitize_prowjob_yaml replaces known variable fields in
+# Kubernetes YAML with static strings in order to make comparisons easy.
+function os::integration::sanitize_prowjob_yaml() {
+    local data="$1"
+    sed -i -E -e 's/sha: .+/sha: test_sha/g' -e 's/[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}/test-prowjob/g' -e 's/startTime: .+/startTime: 2020-06-22T22:25:00Z/g' "${data}"
+}
+readonly -f os::integration::sanitize_prowjob_yaml
 
 __os_integration_configresolver_pid=""
 

--- a/test/integration/cvp-trigger.sh
+++ b/test/integration/cvp-trigger.sh
@@ -16,6 +16,7 @@ os::test::junit::declare_suite_start "integration/cvp-trigger"
 
 actual="${workdir}/output.yaml"
 os::cmd::expect_success "cvp-trigger --bundle-image-ref=git@example.com/org/bundle.git --index-image-ref=git@example.com/org/index.git --prow-config-path=${suite_dir}/config.yaml --job-config-path=${suite_dir}/jobs.yaml --job-name=periodic-ipi-deprovision --ocp-version=4.5 --operator-package-name=package1 --channel=channel1 --target-namespaces=namespace1 --install-namespace=namespace2 --dry-run>${actual}"
+os::integration::sanitize_prowjob_yaml ${actual}
 os::integration::compare "${actual}" "${suite_dir}/periodic-ipi-deprovision.expected"
 
 os::test::junit::declare_suite_end

--- a/test/integration/cvp-trigger/periodic-ipi-deprovision.expected
+++ b/test/integration/cvp-trigger/periodic-ipi-deprovision.expected
@@ -8,7 +8,7 @@ metadata:
     created-by-prow: "true"
     prow.k8s.io/job: periodic-ipi-deprovision
     prow.k8s.io/type: periodic
-  name: d9ee396d-ba30-11ea-9009-8c16450d6013
+  name: test-prowjob
 spec:
   agent: kubernetes
   cluster: default
@@ -89,6 +89,6 @@ spec:
   report: true
   type: periodic
 status:
-  startTime: "2020-06-29T17:49:16Z"
+  startTime: 2020-06-22T22:25:00Z
   state: triggered
 

--- a/test/integration/pj-rehearse.sh
+++ b/test/integration/pj-rehearse.sh
@@ -42,6 +42,7 @@ export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-release-master-reh
 
 actual="${workdir}/rehearsals.yaml"
 os::cmd::expect_success "pj-rehearse --dry-run=true --candidate-path ${repo} --rehearsal-limit 20 > ${actual}"
+os::integration::sanitize_prowjob_yaml ${actual}
 os::integration::compare "${actual}" "${suite_dir}/expected.yaml"
 
 os::test::junit::declare_suite_end

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -303,7 +303,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36aaa1-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -405,18 +405,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -433,7 +433,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a9e2-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -508,18 +508,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -536,7 +536,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a539-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -619,18 +619,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -648,7 +648,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a5f1-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -725,18 +725,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -753,7 +753,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a7f3-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -853,18 +853,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -881,7 +881,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a303-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -958,18 +958,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -986,7 +986,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a3b0-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1086,18 +1086,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1114,7 +1114,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a46c-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1191,18 +1191,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1219,7 +1219,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a6b7-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1319,18 +1319,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1347,7 +1347,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a915-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1447,18 +1447,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1475,7 +1475,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da369cf0-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1552,18 +1552,18 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1580,7 +1580,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da369ebc-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1680,18 +1680,18 @@
         name: job-definition
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1709,7 +1709,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a16b-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -1842,18 +1842,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -1871,7 +1871,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a242-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2004,18 +2004,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2033,7 +2033,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da369fc2-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2132,18 +2132,18 @@
               name: cluster-profile-
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
@@ -2161,7 +2161,7 @@
       prow.k8s.io/refs.pull: "1234"
       prow.k8s.io/refs.repo: release
       prow.k8s.io/type: presubmit
-    name: da36a0a9-ba30-11ea-98cc-8c16450d6013
+    name: test-prowjob
     namespace: test-namespace
     resourceVersion: "1"
   spec:
@@ -2241,17 +2241,17 @@
       serviceAccountName: ci-operator
     refs:
       base_ref: master
-      base_sha: e0f0f81d92d4daca75ec11c9a1716c1d5d9d97d8
+      base_sha: test_sha
       org: openshift
       pulls:
       - author: petr-muller
         number: 1234
-        sha: 56d88af1e30a91530517a16de7de19c5546789bb
+        sha: test_sha
       repo: release
     report: true
     rerun_command: /test pj-rehearse
     type: presubmit
   status:
-    startTime: "2020-06-29T17:49:17Z"
+    startTime: 2020-06-22T22:25:00Z
     state: triggered
 


### PR DESCRIPTION
Currently we filter out certain things during diff time. This PR changes
that to instead replace those fields with a static string before writing
the fixtures in order to reduce review overhead for no-op changes.