### PR TITLE
Prowgen should handle duplicate targets

### DIFF
--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -1,0 +1,92 @@
+postsubmits:
+  organization/repository:
+  - agent: kubernetes
+    branches:
+    - ^branch$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-username=ci
+        - --report-password-file=/etc/report/password.txt
+        - --promote
+        - --target=[images]
+        - --target=out-1
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: regcred
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+presubmits:
+  organization/repository:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - branch
+    context: ci/prow/images
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images
+    rerun_command: /test images
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-username=ci
+        - --report-password-file=/etc/report/password.txt
+        - --target=[images]
+        - --target=out-1
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: regcred
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )images,?($|\s.*)


### PR DESCRIPTION
If additionalImages is specified where two output names exist for
the same image, then prowgen can generate duplicate targets which
causes an error on ci-operator parsing (`--target=foo --target=foo`
is invalid).

Fix the generator so that

```
promotion:
  additional_images:
    base: base-7
    base-7: base-7
    base-8: base-8
```

does not generate

```
- --target=base-7
- --target=base-7
- --target=base-8
```

Blocks openshift/release#9949 which needs to publish `base`, `base-7`, and `base-8` from `base-7` and `base-8`

@stevekuznetsov