### PR TITLE
Builds: Consider DNS errors to be transient

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -445,7 +445,9 @@ func isInfraReason(reason buildapi.StatusReason) bool {
 func hintsAtInfraReason(logSnippet string) bool {
 	return strings.Contains(logSnippet, "error: build error: no such image") ||
 		strings.Contains(logSnippet, "[Errno 256] No more mirrors to try.") ||
-		strings.Contains(logSnippet, "Error: Failed to synchronize cache for repo")
+		strings.Contains(logSnippet, "Error: Failed to synchronize cache for repo") ||
+		strings.Contains(logSnippet, "Could not resolve host: ") ||
+		strings.Contains(logSnippet, "net/http: TLS handshake timeout")
 }
 
 func waitForBuild(ctx context.Context, buildClient BuildClient, namespace, name string) error {


### PR DESCRIPTION
Samples: 

* https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/955/pull-ci-openshift-ci-tools-master-images/1277668136862093312#1:build-log.txt%3A88
* https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gcs/origin-ci-test/pr-logs/pull/openshift_ci-tools/963/pull-ci-openshift-ci-tools-master-images/1277694810026676224#1:build-log.txt%3A199