### PR TITLE
Add run-resourcewatch (back) to upgrade tests

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -322,9 +322,13 @@ objects:
         }
 
         function run-upgrade-tests() {
+          REPOSITORY_PATH=/resourcewatch openshift-tests run-resourcewatch --kubeconfig=${KUBECONFIG} --namespace=ci-operator-monitor &
+          rw_pid=$!
           openshift-tests run-upgrade "${TEST_SUITE}" --to-image "${IMAGE:-${RELEASE_IMAGE_LATEST}}" \
             --options "${TEST_OPTIONS:-}" \
             --provider "${TEST_PROVIDER:-}" -o /tmp/artifacts/e2e.log --junit-dir /tmp/artifacts/junit
+          kill $rw_pid
+          tar -cf ${ARTIFACT_DIR}/resourcewatch.tar /resourcewatch
         }
 
         function run-tests() {


### PR DESCRIPTION
Now that `run-resourcewatch` is available in 4.4 (https://github.com/openshift/origin/pull/25042), we should be able to add back the changes from https://github.com/openshift/ci-tools/pull/845 (reverted by https://github.com/openshift/ci-tools/pull/860) and get the git monitoring tool running in upgrade tests