### PR TITLE
Add main branch support.

### DIFF
--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -87,7 +87,7 @@ var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9
 
 func FlavorForBranch(branch string) string {
 	var flavor string
-	if branch == "master" {
+	if branch == "master" || branch == "main" {
 		flavor = "master"
 	} else if threeXBranches.MatchString(branch) {
 		flavor = "3.x"

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -102,6 +102,11 @@ func TestMetadata_ConfigMapName(t *testing.T) {
 			expected: "ci-operator-master-configs",
 		},
 		{
+			name:     "main branch goes to master configmap",
+			branch:   "main",
+			expected: "ci-operator-master-configs",
+		},
+		{
 			name:     "enterprise 3.6 branch goes to 3.x configmap",
 			branch:   "enterprise-3.6",
 			expected: "ci-operator-3.x-configs",


### PR DESCRIPTION
Main branches are now supported by the ci-operator. For now, they're
basically just aliases of the master branch.