### PR TITLE
Consider a pullspec an input for ImportReleaseStep

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -64,7 +64,7 @@ type importReleaseStep struct {
 }
 
 func (s *importReleaseStep) Inputs(dry bool) (api.InputDefinition, error) {
-	return nil, nil
+	return api.InputDefinition{s.pullSpec}, nil
 }
 
 func (s *importReleaseStep) Run(ctx context.Context, dry bool) error {


### PR DESCRIPTION
The pullspecs can come from two sources: `releases` stanza in the ci-op
config (which is an input on its own, so in this case its a no-op), and
`RELEASE_IMAGE_` variables. In the second case, we need to treat the
value as an input for the namespace to be different for different
release images.

/cc @stevekuznetsov @bbguimaraes 