### PR TITLE
CI-Operator: Report lease type when acquiring fails

### DIFF
--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -84,7 +84,7 @@ func (s *leaseStep) run(ctx context.Context, dry bool) error {
 	lease, err := client.Acquire(s.leaseType, ctx, cancel)
 	if err != nil {
 		heartbeatCancel()
-		return results.ForReason("acquiring_lease").WithError(err).Errorf("failed to acquire lease: %v", err)
+		return results.ForReason(results.Reason("acquiring_lease:"+s.leaseType)).WithError(err).Errorf("failed to acquire lease: %v", err)
 	}
 	heartbeatCancel()
 	log.Printf("Acquired lease %q for %q", lease, s.leaseType)


### PR DESCRIPTION
In order to be able to meaningfully alert on lease exhausting we need to know the cloud on which it occured.