### PR TITLE
Pass leaseClient as interface, not as pointer to interface

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -539,7 +539,7 @@ func (o *options) Run() []error {
 
 	dryLogger := steps.NewDryLogger(o.determinizeOutput)
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, &o.leaseClient, o.targets.values, dryLogger, o.cloneAuthConfig, o.pullSecret)
+	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, o.leaseClient, o.targets.values, dryLogger, o.cloneAuthConfig, o.pullSecret)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -41,7 +41,7 @@ func FromConfig(
 	paramFile, artifactDir string,
 	promote bool,
 	clusterConfig *rest.Config,
-	leaseClient *lease.Client,
+	leaseClient lease.Client,
 	requiredTargets []string,
 	dryLogger *steps.DryLogger,
 	cloneAuthConfig *steps.CloneAuthConfig,

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -22,7 +22,7 @@ const leaseEnv = "LEASED_RESOURCE"
 
 // leaseStep wraps another step and acquires/releases a lease.
 type leaseStep struct {
-	client         *lease.Client
+	client         lease.Client
 	leaseType      string
 	leasedResource string
 	wrapped        api.Step
@@ -32,7 +32,7 @@ type leaseStep struct {
 	namespaceClient coreclientset.NamespaceInterface
 }
 
-func LeaseStep(client *lease.Client, lease string, wrapped api.Step, namespace func() string, namespaceClient coreclientset.NamespaceInterface) api.Step {
+func LeaseStep(client lease.Client, lease string, wrapped api.Step, namespace func() string, namespaceClient coreclientset.NamespaceInterface) api.Step {
 	return &leaseStep{
 		client:          client,
 		leaseType:       lease,
@@ -74,7 +74,7 @@ func (s *leaseStep) Run(ctx context.Context, dry bool) error {
 
 func (s *leaseStep) run(ctx context.Context, dry bool) error {
 	log.Printf("Acquiring lease for %q", s.leaseType)
-	client := *s.client
+	client := s.client
 	if client == nil {
 		return results.ForReason("initializing_client").ForError(errors.New("step needs a lease but no lease client provided"))
 	}

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -140,7 +140,7 @@ func TestError(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls)
 			s := stepNeedsLease{fail: tc.runFails}
-			if LeaseStep(&client, "rtype", &s, func() string { return "" }, nil).Run(ctx, false) == nil {
+			if LeaseStep(client, "rtype", &s, func() string { return "" }, nil).Run(ctx, false) == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
 			if !reflect.DeepEqual(calls, tc.expected) {
@@ -154,7 +154,7 @@ func TestAcquireRelease(t *testing.T) {
 	var calls []string
 	client := lease.NewFakeClient("owner", "url", 0, nil, &calls)
 	step := stepNeedsLease{}
-	withLease := LeaseStep(&client, "rtype", &step, func() string { return "" }, nil)
+	withLease := LeaseStep(client, "rtype", &step, func() string { return "" }, nil)
 	if err := withLease.Run(context.Background(), false); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
@bbguimaraes you did this in 78ee4642d why? We do not have a public implementation of this so it should always be nil without needing the (de-)referencing to prevent ppl to accidentally add type info that would make it non-nil?