### PR TITLE
pj-rehearse code cleanups

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -310,7 +310,7 @@ func rehearseMain() error {
 	toRehearseClusterProfiles := diffs.GetPresubmitsForClusterProfiles(prConfig.Prow, changedClusterProfiles, logger)
 	toRehearse.AddAll(toRehearseClusterProfiles)
 
-	presubmitsWithChangedRegistry := rehearse.AddRandomJobsForChangedRegistry(changedRegistrySteps, graph, prConfig.Prow.JobConfig.PresubmitsStatic, filepath.Join(o.releaseRepoPath, config.CiopConfigInRepoPath), loggers)
+	presubmitsWithChangedRegistry := rehearse.AddRandomJobsForChangedRegistry(changedRegistrySteps, prConfig.Prow.JobConfig.PresubmitsStatic, filepath.Join(o.releaseRepoPath, config.CiopConfigInRepoPath), loggers)
 	toRehearse.AddAll(presubmitsWithChangedRegistry)
 
 	resolver := registry.NewResolver(refs, chains, workflows)

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -106,7 +106,7 @@ pj-rehearse created invalid rehearsal jobs.This is either a pj-rehearse bug, or
 the rehearsed jobs themselves are invalid.`
 )
 
-func loadPluginConfig(releaseRepoPath string) (ret prowplugins.ConfigUpdater, err error) {
+func loadConfigUpdaterCfg(releaseRepoPath string) (ret prowplugins.ConfigUpdater, err error) {
 	agent := prowplugins.ConfigAgent{}
 	if err = agent.Load(filepath.Join(releaseRepoPath, config.PluginConfigInRepoPath), true); err == nil {
 		ret = agent.Config().ConfigUpdater
@@ -183,7 +183,7 @@ func rehearseMain() error {
 	}
 
 	prConfig := config.GetAllConfigs(o.releaseRepoPath, logger)
-	pluginConfig, err := loadPluginConfig(o.releaseRepoPath)
+	configUpdaterCfg, err := loadConfigUpdaterCfg(o.releaseRepoPath)
 	if err != nil {
 		logger.WithError(err).Error("could not load plugin configuration from tested revision of release repo")
 		return fmt.Errorf(misconfigurationOutput)
@@ -373,7 +373,7 @@ func rehearseMain() error {
 		prConfig.Prow.ProwJobNamespace,
 		pjclient,
 		prConfig.Prow.PodNamespace,
-		pluginConfig,
+		configUpdaterCfg,
 		o.releaseRepoPath,
 		o.dryRun,
 		changedTemplates,
@@ -433,7 +433,7 @@ func setupDependencies(
 	prowJobNamespace string,
 	prowJobClient ctrlruntimeclient.Client,
 	podNamespace string,
-	pluginConfig prowplugins.ConfigUpdater,
+	configUpdaterCfg prowplugins.ConfigUpdater,
 	releaseRepoPath string,
 	dryRun bool,
 	changedTemplates []config.ConfigMapSource,
@@ -477,7 +477,7 @@ func setupDependencies(
 				return errors.New(misconfigurationOutput)
 			}
 
-			cmManager := config.NewTemplateCMManager(prowJobNamespace, cmClient, pluginConfig, prNumber, releaseRepoPath, log)
+			cmManager := config.NewRehearsalCMManager(prowJobNamespace, cmClient, configUpdaterCfg, prNumber, releaseRepoPath, log)
 
 			cleanupsLock.Lock()
 			cleanups = append(cleanups, func() {

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -159,7 +159,7 @@ func GetChangedTemplates(path, baseRev string) ([]ConfigMapSource, error) {
 	}
 	var ret []ConfigMapSource
 	for _, c := range changes {
-		if filepath.Ext(c.Filename) == ".yaml" {
+		if filepath.Ext(c.PathInRepo) == ".yaml" {
 			ret = append(ret, c)
 		}
 	}
@@ -195,8 +195,8 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 		return changes, err
 	}
 	for _, c := range revChanges {
-		if filepath.Ext(c.Filename) == ".yaml" || strings.HasSuffix(c.Filename, "-commands.sh") {
-			node, err := loadRegistryStep(filepath.Base(c.Filename), graph)
+		if filepath.Ext(c.PathInRepo) == ".yaml" || strings.HasSuffix(c.PathInRepo, "-commands.sh") {
+			node, err := loadRegistryStep(filepath.Base(c.PathInRepo), graph)
 			if err != nil {
 				return changes, err
 			}
@@ -227,8 +227,8 @@ func getRevChanges(root, path, base string, rec bool) ([]ConfigMapSource, error)
 	var ret []ConfigMapSource
 	for _, l := range strings.Split(strings.TrimSpace(diff), "\n") {
 		ret = append(ret, ConfigMapSource{
-			Filename: filepath.Join(path, l[99:]),
-			SHA:      l[56:96],
+			PathInRepo: filepath.Join(path, l[99:]),
+			SHA:        l[56:96],
 		})
 	}
 	return ret, nil

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -75,11 +75,11 @@ func TestGetChangedTemplates(t *testing.T) {
 > org/repo/README.md
 `
 	expected := []ConfigMapSource{{
-		SHA:      "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-		Filename: filepath.Join(TemplatesPath, "cluster-launch-top-level.yaml"),
+		SHA:        "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		PathInRepo: filepath.Join(TemplatesPath, "cluster-launch-top-level.yaml"),
 	}, {
-		SHA:      "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-		Filename: filepath.Join(TemplatesPath, "org/repo/cluster-launch-subdir.yaml"),
+		SHA:        "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+		PathInRepo: filepath.Join(TemplatesPath, "org/repo/cluster-launch-subdir.yaml"),
 	}}
 	compareChanges(t, TemplatesPath, files, cmd, GetChangedTemplates, expected)
 }
@@ -100,20 +100,20 @@ git mv renameme/file renamed/file
 > dir/dir/file
 `
 	expected := []ConfigMapSource{{
-		SHA:      "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078",
-		Filename: filepath.Join(ClusterProfilesPath, "changeme"),
+		SHA:        "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "changeme"),
 	}, {
-		SHA:      "b4c3cc91598b6469bf7036502b8ca2bd563b0d0a",
-		Filename: filepath.Join(ClusterProfilesPath, "dir"),
+		SHA:        "b4c3cc91598b6469bf7036502b8ca2bd563b0d0a",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "dir"),
 	}, {
-		SHA:      "03b9d461447abb84264053a440b4c715842566bb",
-		Filename: filepath.Join(ClusterProfilesPath, "moveme"),
+		SHA:        "03b9d461447abb84264053a440b4c715842566bb",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "moveme"),
 	}, {
-		SHA:      "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078",
-		Filename: filepath.Join(ClusterProfilesPath, "new"),
+		SHA:        "df2b8fc99e1c1d4dbc0a854d9f72157f1d6ea078",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "new"),
 	}, {
-		SHA:      "9bbab5dcf83793f9edc258136426678cccce940e",
-		Filename: filepath.Join(ClusterProfilesPath, "renamed"),
+		SHA:        "9bbab5dcf83793f9edc258136426678cccce940e",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "renamed"),
 	}}
 	compareChanges(t, ClusterProfilesPath, files, cmd, GetChangedClusterProfiles, expected)
 }

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -186,12 +186,12 @@ func TestCreateClusterProfiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	cms, err := client.List(metav1.ListOptions{})
-	sort.Slice(cms.Items, func(i, j int) bool {
-		return cms.Items[i].Name < cms.Items[j].Name
-	})
 	if err != nil {
 		t.Fatal(err)
 	}
+	sort.Slice(cms.Items, func(i, j int) bool {
+		return cms.Items[i].Name < cms.Items[j].Name
+	})
 	expected := []v1.ConfigMap{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rehearse-cluster-profile-profile0-e92d4a59",

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -38,7 +38,7 @@ func TestValidateConfigMaps(t *testing.T) {
 	}
 	client := fake.NewSimpleClientset().CoreV1().ConfigMaps("ns")
 	config.SetDefaults()
-	manager := NewTemplateCMManager("ns", client, config, 0, "/", logrus.NewEntry(logrus.New()))
+	manager := NewRehearsalCMManager("ns", client, config, 0, "/", logrus.NewEntry(logrus.New()))
 	if err := manager.validateChanges(changes); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -60,8 +60,8 @@ func TestCreateCleanupCMTemplates(t *testing.T) {
 	testTemplatePath := filepath.Join(TemplatesPath, "subdir/test-template.yaml")
 	ns := "test-namespace"
 	ciTemplates := []ConfigMapSource{{
-		Filename: testTemplatePath,
-		SHA:      "hd9sxk615lkcwx2kj226g3r3lvwkftyjif2pczm5dq3l0h13p35t",
+		PathInRepo: testTemplatePath,
+		SHA:        "hd9sxk615lkcwx2kj226g3r3lvwkftyjif2pczm5dq3l0h13p35t",
 	}}
 	contents, err := ioutil.ReadFile(filepath.Join(testRepoPath, testTemplatePath))
 	if err != nil {
@@ -95,16 +95,16 @@ func TestCreateCleanupCMTemplates(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	cs.Fake.PrependReactor("delete-collection", "configmaps", func(action coretesting.Action) (bool, runtime.Object, error) {
 		deleteAction := action.(coretesting.DeleteCollectionAction)
-		listRestricitons := deleteAction.GetListRestrictions()
+		listRestrictions := deleteAction.GetListRestrictions()
 
-		if !reflect.DeepEqual(listRestricitons.Labels, expectedListRestricitons.Labels) {
-			t.Fatalf("Labels:\nExpected:%#v\nFound: %#v", expectedListRestricitons.Labels, listRestricitons.Labels)
+		if !reflect.DeepEqual(listRestrictions.Labels, expectedListRestricitons.Labels) {
+			t.Fatalf("Labels:\nExpected:%#v\nFound: %#v", expectedListRestricitons.Labels, listRestrictions.Labels)
 		}
 
 		return true, nil, nil
 	})
 	client := cs.CoreV1().ConfigMaps(ns)
-	cmManager := NewTemplateCMManager(ns, client, configUpdaterCfg, 1234, testRepoPath, logrus.NewEntry(logrus.New()))
+	cmManager := NewRehearsalCMManager(ns, client, configUpdaterCfg, 1234, testRepoPath, logrus.NewEntry(logrus.New()))
 	if err := cmManager.CreateCMTemplates(ciTemplates); err != nil {
 		t.Fatalf("CreateCMTemplates() returned error: %v", err)
 	}
@@ -140,21 +140,21 @@ func TestCreateClusterProfiles(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	profiles := []ConfigMapSource{{
-		SHA:      "e92d4a5996a8a977bd7916b65488371331681f9d",
-		Filename: filepath.Join(ClusterProfilesPath, "profile0"),
+		SHA:        "e92d4a5996a8a977bd7916b65488371331681f9d",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "profile0"),
 	}, {
-		SHA:      "a8c99ffc996128417ef1062f9783730a8c864586",
-		Filename: filepath.Join(ClusterProfilesPath, "profile1"),
+		SHA:        "a8c99ffc996128417ef1062f9783730a8c864586",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "profile1"),
 	}, {
-		SHA:      "8012ff51a005eaa8ed8f4c08ccdce580f462fff6",
-		Filename: filepath.Join(ClusterProfilesPath, "unchanged"),
+		SHA:        "8012ff51a005eaa8ed8f4c08ccdce580f462fff6",
+		PathInRepo: filepath.Join(ClusterProfilesPath, "unchanged"),
 	}}
 	for _, p := range profiles {
-		path := filepath.Join(dir, p.Filename)
+		path := filepath.Join(dir, p.PathInRepo)
 		if err := os.MkdirAll(path, 0775); err != nil {
 			t.Fatal(err)
 		}
-		content := []byte(filepath.Base(p.Filename) + " content")
+		content := []byte(filepath.Base(p.PathInRepo) + " content")
 		if err := ioutil.WriteFile(filepath.Join(path, "file"), content, 0664); err != nil {
 			t.Fatal(err)
 		}
@@ -181,7 +181,7 @@ func TestCreateClusterProfiles(t *testing.T) {
 	configUpdaterCfg.SetDefaults()
 	cs := fake.NewSimpleClientset()
 	client := cs.CoreV1().ConfigMaps(ns)
-	m := NewTemplateCMManager(ns, client, configUpdaterCfg, pr, dir, logrus.NewEntry(logrus.New()))
+	m := NewRehearsalCMManager(ns, client, configUpdaterCfg, pr, dir, logrus.NewEntry(logrus.New()))
 	if err := m.CreateClusterProfiles(profiles); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -738,7 +738,7 @@ func TestGetPresubmitsForClusterProfiles(t *testing.T) {
 		id:  "empty",
 		cfg: &prowconfig.Config{},
 		profiles: []config.ConfigMapSource{{
-			Filename: filepath.Join(config.ClusterProfilesPath, "test-profile"),
+			PathInRepo: filepath.Join(config.ClusterProfilesPath, "test-profile"),
 		}},
 	}, {
 		id: "not a kubernetes job",
@@ -752,7 +752,7 @@ func TestGetPresubmitsForClusterProfiles(t *testing.T) {
 			},
 		},
 		profiles: []config.ConfigMapSource{{
-			Filename: filepath.Join(config.ClusterProfilesPath, "test-profile"),
+			PathInRepo: filepath.Join(config.ClusterProfilesPath, "test-profile"),
 		}},
 	}, {
 		id: "job doesn't use cluster profiles",
@@ -766,7 +766,7 @@ func TestGetPresubmitsForClusterProfiles(t *testing.T) {
 			},
 		},
 		profiles: []config.ConfigMapSource{{
-			Filename: filepath.Join(config.ClusterProfilesPath, "test-profile"),
+			PathInRepo: filepath.Join(config.ClusterProfilesPath, "test-profile"),
 		}},
 	}, {
 		id: "job doesn't use the cluster profile",
@@ -780,7 +780,7 @@ func TestGetPresubmitsForClusterProfiles(t *testing.T) {
 			},
 		},
 		profiles: []config.ConfigMapSource{{
-			Filename: filepath.Join(config.ClusterProfilesPath, "test-profile"),
+			PathInRepo: filepath.Join(config.ClusterProfilesPath, "test-profile"),
 		}},
 	}, {
 		id: "multiple jobs, one uses cluster the profile",
@@ -798,7 +798,7 @@ func TestGetPresubmitsForClusterProfiles(t *testing.T) {
 			},
 		},
 		profiles: []config.ConfigMapSource{{
-			Filename: filepath.Join(config.ClusterProfilesPath, "test-profile"),
+			PathInRepo: filepath.Join(config.ClusterProfilesPath, "test-profile"),
 		}},
 		expected: []string{"uses-cluster-profile"},
 	}} {

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -356,7 +356,7 @@ func NewJobConfigurer(ciopConfigs config.DataByFilename, resolver registry.Resol
 func fillTemplateMap(templates []config.ConfigMapSource) map[string]string {
 	templateMap := make(map[string]string, len(templates))
 	for _, t := range templates {
-		templateMap[filepath.Base(t.Filename)] = t.TempCMName("template")
+		templateMap[filepath.Base(t.PathInRepo)] = t.TempCMName("template")
 	}
 	return templateMap
 }
@@ -493,7 +493,7 @@ func AddRandomJobsForChangedTemplates(templates []config.ConfigMapSource, toBeRe
 	rehearsals := make(config.Presubmits)
 
 	for _, template := range templates {
-		templateFile := filepath.Base(template.Filename)
+		templateFile := filepath.Base(template.PathInRepo)
 		for _, clusterType := range clusterTypes {
 			if isAlreadyRehearsed(toBeRehearsed, clusterType, templateFile) {
 				continue

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -614,7 +614,7 @@ func getAllAncestors(changed []registry.Node) []registry.Node {
 	return ancestors
 }
 
-func AddRandomJobsForChangedRegistry(regSteps []registry.Node, graph registry.NodeByName, prConfigPresubmits map[string][]prowconfig.Presubmit, configPath string, loggers Loggers) config.Presubmits {
+func AddRandomJobsForChangedRegistry(regSteps []registry.Node, prConfigPresubmits map[string][]prowconfig.Presubmit, configPath string, loggers Loggers) config.Presubmits {
 	configsByFilename, err := config.LoadDataByFilename(configPath)
 	if err != nil {
 		loggers.Debug.Errorf("Failed to load config by filename in AddRandomJobsForChangedRegistry: %v", err)

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -189,10 +189,10 @@ func TestReplaceClusterProfiles(t *testing.T) {
 
 	profiles := []config.ConfigMapSource{{
 		SHA:      "47f520ef9c2662fc9a2675f1dd4f02d5082b2776",
-		Filename: filepath.Join(config.ClusterProfilesPath, "changed-profile0"),
+		PathInRepo: filepath.Join(config.ClusterProfilesPath, "changed-profile0"),
 	}, {
 		SHA:      "85c627078710b8beee65d06d0cf157094fc46b03",
-		Filename: filepath.Join(config.ClusterProfilesPath, "changed-profile1"),
+		PathInRepo: filepath.Join(config.ClusterProfilesPath, "changed-profile1"),
 	}}
 
 	for _, tc := range testCases {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -188,10 +188,10 @@ func TestReplaceClusterProfiles(t *testing.T) {
 	}
 
 	profiles := []config.ConfigMapSource{{
-		SHA:      "47f520ef9c2662fc9a2675f1dd4f02d5082b2776",
+		SHA:        "47f520ef9c2662fc9a2675f1dd4f02d5082b2776",
 		PathInRepo: filepath.Join(config.ClusterProfilesPath, "changed-profile0"),
 	}, {
-		SHA:      "85c627078710b8beee65d06d0cf157094fc46b03",
+		SHA:        "85c627078710b8beee65d06d0cf157094fc46b03",
 		PathInRepo: filepath.Join(config.ClusterProfilesPath, "changed-profile1"),
 	}}
 


### PR DESCRIPTION
Part of why pj-rehearse is annoying is that the names are often wrong (things contain something entirely different than their names suggests). Cleanups were extracted from https://github.com/openshift/ci-tools/pull/992 to reduce the size of the actual funcionality code change. There is no actual functionality change.

Various names changed to match their actual content:

- plugin config -> config updater config
- Template CM Manager -> Rehearsal CM Manager
- ConfigMapSource.Filename -> PathInRepo
- typos

Removed unused parameters and misplaced nil check.