### PR TITLE
rehearse: extract CMManager to rehearse package

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -477,22 +477,22 @@ func setupDependencies(
 				return errors.New(misconfigurationOutput)
 			}
 
-			cmManager := config.NewRehearsalCMManager(prowJobNamespace, cmClient, configUpdaterCfg, prNumber, releaseRepoPath, log)
+			cmManager := rehearse.NewCMManager(prowJobNamespace, cmClient, configUpdaterCfg, prNumber, releaseRepoPath, log)
 
 			cleanupsLock.Lock()
 			cleanups = append(cleanups, func() {
-				if err := cmManager.CleanupCMTemplates(); err != nil {
-					log.WithError(err).Error("failed to clean up temporary template CM")
+				if err := cmManager.Clean(); err != nil {
+					log.WithError(err).Error("failed to clean up temporary ConfigMaps")
 				}
 			})
 			cleanupsLock.Unlock()
 
-			if err := cmManager.CreateCMTemplates(changedTemplates); err != nil {
-				log.WithError(err).Error("couldn't create template configMap")
+			if err := cmManager.CreateTemplates(changedTemplates); err != nil {
+				log.WithError(err).Error("couldn't create temporary template ConfigMaps for rehearsals")
 				return errors.New(failedSetupOutput)
 			}
 			if err := cmManager.CreateClusterProfiles(changedClusterProfiles); err != nil {
-				log.WithError(err).Error("couldn't create cluster profile ConfigMaps")
+				log.WithError(err).Error("couldn't create temporary cluster profile ConfigMaps for rehearsals")
 				return errors.New(failedSetupOutput)
 			}
 

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -41,6 +41,25 @@ const (
 	RegistryPath = "ci-operator/step-registry"
 )
 
+type ConfigMapSource struct {
+	PathInRepo, SHA string
+}
+
+func (s ConfigMapSource) Name() string {
+	base := filepath.Base(s.PathInRepo)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}
+
+func (s ConfigMapSource) CMName(prefix string) string {
+	return prefix + s.Name()
+}
+
+func (s ConfigMapSource) TempCMName(prefix string) string {
+	// Object names can't be too long so we truncate the hash. This increases
+	// chances of collision but we can tolerate it as our input space is tiny.
+	return fmt.Sprintf("rehearse-%s-%s-%s", prefix, s.Name(), s.SHA[:8])
+}
+
 // ReleaseRepoConfig contains all configuration present in release repo (usually openshift/release)
 type ReleaseRepoConfig struct {
 	Prow       *prowconfig.Config


### PR DESCRIPTION
The only purpose of CMManager is to support rehearsals, so it makes
sense for it to live in the `rehearse` package. This makes the
assumptions done by the code correct, and allows to simplify names even
more.

The direction of this change is to lessen the importance of the `ConfigMapSource` struct to make decisions about CM names.
This because the only thing that knows the names is the config-updater config for the production CMs, and the rehearse package can then infer a name from that.