### PR TITLE
Registry replacer: Fix self-approve option

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -317,7 +317,7 @@ func githubFileGetterFactory(org, repo, branch string) githubFileGetter {
 	}
 }
 
-func upsertPR(gc github.Client, dir, githubUsername, tokenFilePath string, pruneUnusedReplacements, selfApprove bool) error {
+func upsertPR(gc github.Client, dir, githubUsername, tokenFilePath string, selfApprove, pruneUnusedReplacements bool) error {
 	if err := os.Chdir(dir); err != nil {
 		return fmt.Errorf("failed to chdir into %s: %w", dir, err)
 	}


### PR DESCRIPTION
Self-approve is the first boolean arg, not the second: https://github.com/openshift/ci-tools/blob/584bfc8c8a36b2b533bee2b6d03368b0a975e532/cmd/registry-replacer/main.go#L122