### PR TITLE
multi_stage: add link to registry info page for failed steps

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -533,7 +533,13 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	err := waitForPodCompletion(ctx, s.podClient.Pods(s.jobSpec.Namespace()), pod.Name, notifier, false)
 	s.subTests = append(s.subTests, notifier.SubTests(fmt.Sprintf("%s - %s ", s.Description(), pod.Name))...)
 	if err != nil {
-		return fmt.Errorf("%q pod %q failed: %w", s.name, pod.Name, err)
+		linksText := strings.Builder{}
+		linksText.WriteString(fmt.Sprintf("Link to step on registry info site: https://steps.ci.openshift.org/reference/%s", strings.TrimPrefix(pod.Name, s.name+"-")))
+		linksText.WriteString(fmt.Sprintf("\nLink to job on registry info site: https://steps.ci.openshift.org/job?org=%s&repo=%s&branch=%s&test=%s", s.config.Metadata.Org, s.config.Metadata.Repo, s.config.Metadata.Branch, s.name))
+		if s.config.Metadata.Variant != "" {
+			linksText.WriteString(fmt.Sprintf("&variant=%s", s.config.Metadata.Variant))
+		}
+		return fmt.Errorf("%q pod %q failed: %w\n%s", s.name, pod.Name, err, linksText.String())
 	}
 	return nil
 }

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -2122,7 +2122,7 @@ func referenceHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *ht
 	}
 	refs, _, _, docs := agent.GetRegistryComponents()
 	if _, ok := refs[name]; !ok {
-		writeErrorPage(w, fmt.Errorf("Could not find reference %s: %w", name, err), http.StatusNotFound)
+		writeErrorPage(w, fmt.Errorf("Could not find reference `%s`. If you reached this page via a link provided in the logs of a failed test, the failed step may be a literal defined step, which does not exist in the step registry. Please look at the job info page for the failed test instead.", name), http.StatusNotFound)
 		return
 	}
 	ref := api.RegistryReference{
@@ -2150,7 +2150,7 @@ func chainHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.R
 		return
 	}
 	if _, ok := chains[name]; !ok {
-		writeErrorPage(w, fmt.Errorf("Could not find chain %s: %w", name, err), http.StatusNotFound)
+		writeErrorPage(w, fmt.Errorf("Could not find chain %s", name), http.StatusNotFound)
 		return
 	}
 	chain := api.RegistryChain{
@@ -2175,7 +2175,7 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 		return
 	}
 	if _, ok := workflows[name]; !ok {
-		writeErrorPage(w, fmt.Errorf("Could not find workflow %s: %w", name, err), http.StatusNotFound)
+		writeErrorPage(w, fmt.Errorf("Could not find workflow %s", name), http.StatusNotFound)
 		return
 	}
 	workflow := workflowJob{


### PR DESCRIPTION
This PR adds a link to the step registry info page for failed multistage
steps in the test logs. This makes it easier to debug failing tests.

This also makes the 404 error page for non-existent registry components
more verbose. Since it is possible for users to be running a job that
has an embedded literal step in the test config, this error page may be
hit more often so it was made a bit more verbose.