### PR TITLE
Kubeconfig loading: Error if env var has not found kubeconfig

### DIFF
--- a/pkg/util/client.go
+++ b/pkg/util/client.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -46,6 +47,9 @@ func LoadKubeConfigs(kubeconfig string) (map[string]*rest.Config, string, error)
 		}
 		configs[context] = contextCfg
 		logrus.Infof("Parsed kubeconfig context: %s", context)
+	}
+	if kubeconfigsFromEnv := strings.Split(os.Getenv("KUBECONFIG"), ":"); len(kubeconfigsFromEnv) > 0 && len(kubeconfigsFromEnv) != len(configs) {
+		errs = append(errs, fmt.Errorf("KUBECONFIG env var with value %s had %d elements but only got %d kubeconfigs", os.Getenv("KUBECONFIG"), len(kubeconfigsFromEnv), len(configs)))
 	}
 	return configs, cfg.CurrentContext, utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
We had a case where the dptp-controller-manager got a KUBECONFIG submitted via env var that was not actually in the secret mounted there. This error got silently swallowed. After this PR, we will fail startup instead, preventing silently defunct binaries.