### PR TITLE
determinize-step-registry: create new tool

### DIFF
--- a/cmd/determinize-step-registry/main.go
+++ b/cmd/determinize-step-registry/main.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+type options struct {
+	stepRegistryDir string
+}
+
+func (o *options) Validate() error {
+	if o.stepRegistryDir == "" {
+		return errors.New("--step-registry-dir is required")
+	}
+	return nil
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.stepRegistryDir, "step-registry-dir", "", "Path to the step registry directory.")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatal("could not parse input")
+	}
+	return o
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("invalid options")
+	}
+
+	if err := filepath.Walk(o.stepRegistryDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info != nil && !info.IsDir() {
+			if filepath.Ext(info.Name()) != ".yaml" {
+				return nil
+			}
+			raw, err := ioutil.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			relpath, err := filepath.Rel(o.stepRegistryDir, path)
+			if err != nil {
+				return fmt.Errorf("failed to determine relative path for %s: %w", path, err)
+			}
+			var output []byte
+			switch {
+			case strings.HasSuffix(path, load.ReferenceSuffix):
+				ref := &api.RegistryReferenceConfig{}
+				err := yaml.Unmarshal(raw, ref)
+				if err != nil {
+					return fmt.Errorf("Unexpected error reading reference file %s: %w", path, err)
+				}
+				ref.Reference.Metadata.ComponentPath = relpath
+				output, err = yaml.Marshal(ref)
+				if err != nil {
+					return fmt.Errorf("Unexpected error marshalling reference file %s: %w", path, err)
+				}
+			case strings.HasSuffix(path, load.ChainSuffix):
+				chain := &api.RegistryChainConfig{}
+				err := yaml.Unmarshal(raw, chain)
+				if err != nil {
+					return fmt.Errorf("Unexpected error reading chain file %s: %w", path, err)
+				}
+				chain.Chain.Metadata.ComponentPath = relpath
+				output, err = yaml.Marshal(chain)
+				if err != nil {
+					return fmt.Errorf("Unexpected error marshalling chain file %s: %w", path, err)
+				}
+			case strings.HasSuffix(path, load.WorkflowSuffix):
+				workflow := &api.RegistryWorkflowConfig{}
+				err := yaml.Unmarshal(raw, workflow)
+				if err != nil {
+					return fmt.Errorf("Unexpected error reading workflow file %s: %w", path, err)
+				}
+				workflow.Workflow.Metadata.ComponentPath = relpath
+				output, err = yaml.Marshal(workflow)
+				if err != nil {
+					return fmt.Errorf("Unexpected error marshalling workflow file %s: %w", path, err)
+				}
+			default:
+				return fmt.Errorf("YAML file %s has an incorrectly formatted filename", path)
+			}
+			if err := ioutil.WriteFile(path, output, 0664); err != nil {
+				return fmt.Errorf("failed to write new step registry file: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		logrus.WithError(err).Errorf("Failed to update step registry files")
+	}
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -488,6 +488,8 @@ type RegistryReference struct {
 	LiteralTestStep `json:",inline"`
 	// Documentation describes what the step being referenced does.
 	Documentation string `json:"documentation,omitempty"`
+	// Metadata contains the RegistryMetadata structure for this component
+	Metadata RegistryMetadata `json:"zz_generated_metadata,omitempty"`
 }
 
 // RegistryChainConfig is the struct that chain references are unmarshalled into.
@@ -506,6 +508,8 @@ type RegistryChain struct {
 	Documentation string `json:"documentation,omitempty"`
 	// Environment lists parameters that should be set by the test.
 	Environment []StepParameter `json:"env,omitempty"`
+	// Metadata contains the RegistryMetadata structure for this component
+	Metadata RegistryMetadata `json:"zz_generated_metadata,omitempty"`
 }
 
 // RegistryWorkflowConfig is the struct that workflow references are unmarshalled into.
@@ -522,6 +526,13 @@ type RegistryWorkflow struct {
 	Steps MultiStageTestConfiguration `json:"steps,omitempty"`
 	// Documentation describes what the workflow does.
 	Documentation string `json:"documentation,omitempty"`
+	// Metadata contains the RegistryMetadata structure for this component
+	Metadata RegistryMetadata `json:"zz_generated_metadata,omitempty"`
+}
+
+type RegistryMetadata struct {
+	// ComponentPath is the relative path of the registry component in the step_registry directory
+	ComponentPath string `json:"component_path,omitempty"`
 }
 
 // LiteralTestStep is the external representation of a test step allowing users

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -11,6 +11,7 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 	pjdwapi "k8s.io/test-infra/prow/pod-utils/downwardapi"
 
+	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
 
@@ -187,16 +188,16 @@ func GetChangedTemplates(path, baseRev string) ([]ConfigMapSource, error) {
 
 func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node, error) {
 	// if a commands script changed, mark reference as changed
-	filename = strings.ReplaceAll(filename, "-commands.sh", "-ref.yaml")
+	filename = strings.ReplaceAll(filename, load.CommandsSuffix, load.ReferenceSuffix)
 	var node registry.Node
 	var ok bool
 	switch {
-	case strings.HasSuffix(filename, "-ref.yaml"):
-		node, ok = graph.References[strings.TrimSuffix(filename, "-ref.yaml")]
-	case strings.HasSuffix(filename, "-chain.yaml"):
-		node, ok = graph.Chains[strings.TrimSuffix(filename, "-chain.yaml")]
-	case strings.HasSuffix(filename, "-workflow.yaml"):
-		node, ok = graph.Workflows[strings.TrimSuffix(filename, "-workflow.yaml")]
+	case strings.HasSuffix(filename, load.ReferenceSuffix):
+		node, ok = graph.References[strings.TrimSuffix(filename, load.ReferenceSuffix)]
+	case strings.HasSuffix(filename, load.ChainSuffix):
+		node, ok = graph.Chains[strings.TrimSuffix(filename, load.ChainSuffix)]
+	case strings.HasSuffix(filename, load.WorkflowSuffix):
+		node, ok = graph.Workflows[strings.TrimSuffix(filename, load.WorkflowSuffix)]
 	default:
 		return nil, fmt.Errorf("invalid step filename: %s", filename)
 	}
@@ -214,7 +215,7 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 		return changes, err
 	}
 	for _, c := range revChanges {
-		if filepath.Ext(c.PathInRepo) == ".yaml" || strings.HasSuffix(c.PathInRepo, "-commands.sh") {
+		if filepath.Ext(c.PathInRepo) == ".yaml" || strings.HasSuffix(c.PathInRepo, load.CommandsSuffix) {
 			node, err := loadRegistryStep(filepath.Base(c.PathInRepo), graph)
 			if err != nil {
 				return changes, err

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -31,10 +31,10 @@ type ResolverInfo struct {
 }
 
 const (
-	refSuffix      = "-ref.yaml"
-	chainSuffix    = "-chain.yaml"
-	workflowSuffix = "-workflow.yaml"
-	commandsSuffix = "-commands.sh"
+	ReferenceSuffix = "-ref.yaml"
+	ChainSuffix     = "-chain.yaml"
+	WorkflowSuffix  = "-workflow.yaml"
+	CommandsSuffix  = "-commands.sh"
 )
 
 // ByOrgRepo maps org --> repo --> list of branched and variant configs
@@ -259,7 +259,7 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 					return fmt.Errorf("ile %s has incorrect prefix. Prefix should be %s", path, prefix)
 				}
 			}
-			if strings.HasSuffix(path, refSuffix) {
+			if strings.HasSuffix(path, ReferenceSuffix) {
 				name, doc, ref, err := loadReference(raw, dir, prefix, flat)
 				if err != nil {
 					return fmt.Errorf("failed to load registry file %s: %w", path, err)
@@ -267,12 +267,12 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && name != prefix {
 					return fmt.Errorf("name of reference in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), refSuffix) != name {
-					return fmt.Errorf("filename %s does not match name of reference; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, refSuffix))
+				if strings.TrimSuffix(filepath.Base(path), ReferenceSuffix) != name {
+					return fmt.Errorf("filename %s does not match name of reference; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, ReferenceSuffix))
 				}
 				references[name] = ref
 				documentation[name] = doc
-			} else if strings.HasSuffix(path, chainSuffix) {
+			} else if strings.HasSuffix(path, ChainSuffix) {
 				var chain api.RegistryChainConfig
 				err := yaml.UnmarshalStrict(raw, &chain)
 				if err != nil {
@@ -281,13 +281,13 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && chain.Chain.As != prefix {
 					return fmt.Errorf("name of chain in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), chainSuffix) != chain.Chain.As {
-					return fmt.Errorf("filename %s does not match name of chain; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, chainSuffix))
+				if strings.TrimSuffix(filepath.Base(path), ChainSuffix) != chain.Chain.As {
+					return fmt.Errorf("filename %s does not match name of chain; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, ChainSuffix))
 				}
 				documentation[chain.Chain.As] = chain.Chain.Documentation
 				chain.Chain.Documentation = ""
 				chains[chain.Chain.As] = chain.Chain
-			} else if strings.HasSuffix(path, workflowSuffix) {
+			} else if strings.HasSuffix(path, WorkflowSuffix) {
 				name, doc, workflow, err := loadWorkflow(raw)
 				if err != nil {
 					return fmt.Errorf("failed to load registry file %s: %w", path, err)
@@ -295,12 +295,12 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && name != prefix {
 					return fmt.Errorf("name of workflow in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), workflowSuffix) != name {
-					return fmt.Errorf("filename %s does not match name of workflow; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, workflowSuffix))
+				if strings.TrimSuffix(filepath.Base(path), WorkflowSuffix) != name {
+					return fmt.Errorf("filename %s does not match name of workflow; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, WorkflowSuffix))
 				}
 				workflows[name] = workflow
 				documentation[name] = doc
-			} else if strings.HasSuffix(path, commandsSuffix) {
+			} else if strings.HasSuffix(path, CommandsSuffix) {
 				// ignore
 			} else {
 				return fmt.Errorf("invalid file name: %s", path)
@@ -322,8 +322,8 @@ func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, str
 	if err != nil {
 		return "", "", api.LiteralTestStep{}, err
 	}
-	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, commandsSuffix) {
-		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, commandsSuffix))
+	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
+		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
 	}
 	command, err := ioutil.ReadFile(filepath.Join(baseDir, step.Reference.Commands))
 	if err != nil {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -739,11 +739,13 @@ func TestRegistry(t *testing.T) {
 						Reference: &installRef,
 					},
 				},
+				Metadata: api.RegistryMetadata{ComponentPath: "ipi/install/ipi-install-chain.yaml"},
 			},
 			"ipi-install-empty-parameter": {
 				As:          "ipi-install-empty-parameter",
 				Steps:       []api.TestStep{{Chain: &installChain}},
 				Environment: []api.StepParameter{{Name: "TEST_PARAMETER", Default: &defaultEmpty}},
+				Metadata:    api.RegistryMetadata{ComponentPath: "ipi/install/empty-parameter/ipi-install-empty-parameter-chain.yaml"},
 			},
 			"ipi-install-with-parameter": api.RegistryChain{
 				As:    "ipi-install-with-parameter",
@@ -752,6 +754,7 @@ func TestRegistry(t *testing.T) {
 					Name:    "TEST_PARAMETER",
 					Default: &chainDefault,
 				}},
+				Metadata: api.RegistryMetadata{ComponentPath: "ipi/install/with-parameter/ipi-install-with-parameter-chain.yaml"},
 			},
 			"ipi-deprovision": api.RegistryChain{
 				As: "ipi-deprovision",
@@ -762,6 +765,7 @@ func TestRegistry(t *testing.T) {
 						Reference: &deprovisionRef,
 					},
 				},
+				Metadata: api.RegistryMetadata{ComponentPath: "ipi/deprovision/ipi-deprovision-chain.yaml"},
 			},
 		}
 

--- a/test/multistage-registry/configmap/..2019_11_15_19_57_20.547184898/ipi-install-install-ref.yaml
+++ b/test/multistage-registry/configmap/..2019_11_15_19_57_20.547184898/ipi-install-install-ref.yaml
@@ -1,13 +1,16 @@
 ref:
   as: ipi-install-install
-  from: installer
   commands: ipi-install-install-commands.sh
+  documentation: The IPI install step runs the OpenShift Installer in order to bring
+    up an OpenShift cluster, using the provided cluster profile to choose a target
+    IaaS platform.
+  env:
+  - default: test parameter default
+    name: TEST_PARAMETER
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  env:
-  - name: TEST_PARAMETER
-    default: test parameter default
-  documentation: |-
-    The IPI install step runs the OpenShift Installer in order to bring up an OpenShift cluster, using the provided cluster profile to choose a target IaaS platform.
+  zz_generated_metadata:
+    component_path: ipi/install/install/ipi-install-install-ref.yaml

--- a/test/multistage-registry/invalid-field/ipi/install/ipi-install-ref.yaml
+++ b/test/multistage-registry/invalid-field/ipi/install/ipi-install-ref.yaml
@@ -1,5 +1,8 @@
 ref:
   as: ipi-install
-  from: installer
   commands: ipi-install-commands.sh
+  from: installer
   invalid_field: bad
+  resources: {}
+  zz_generated_metadata:
+    component_path: ipi/install/ipi-install-ref.yaml

--- a/test/multistage-registry/invalid-filename/ipi/install/ipi-install-install-ref.yaml
+++ b/test/multistage-registry/invalid-filename/ipi/install/ipi-install-install-ref.yaml
@@ -1,4 +1,7 @@
 ref:
   as: ipi-install
-  from: installer
   commands: ipi-install-commands.sh
+  from: installer
+  resources: {}
+  zz_generated_metadata:
+    component_path: ipi/install/ipi-install-install-ref.yaml

--- a/test/multistage-registry/registry/ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml
+++ b/test/multistage-registry/registry/ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-deprovision-deprovision
-  from: installer
   commands: ipi-deprovision-deprovision-commands.sh
+  documentation: The IPI deprovision step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI deprovision step
+  zz_generated_metadata:
+    component_path: ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml

--- a/test/multistage-registry/registry/ipi/deprovision/ipi-deprovision-chain.yaml
+++ b/test/multistage-registry/registry/ipi/deprovision/ipi-deprovision-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-deprovision
+  documentation: The IPI install step chain contains all the individual steps necessary
+    to teardown an OpenShift cluster.
   steps:
   - ref: ipi-deprovision-must-gather
   - ref: ipi-deprovision-deprovision
-  documentation: |-
-    The IPI install step chain contains all the individual steps necessary to teardown an OpenShift cluster.
+  zz_generated_metadata:
+    component_path: ipi/deprovision/ipi-deprovision-chain.yaml

--- a/test/multistage-registry/registry/ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml
+++ b/test/multistage-registry/registry/ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-deprovision-must-gather
-  from: installer
   commands: ipi-deprovision-must-gather-commands.sh
+  documentation: The IPI deprovision gather step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI deprovision gather step
+  zz_generated_metadata:
+    component_path: ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml

--- a/test/multistage-registry/registry/ipi/install/empty-parameter/ipi-install-empty-parameter-chain.yaml
+++ b/test/multistage-registry/registry/ipi/install/empty-parameter/ipi-install-empty-parameter-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-install-empty-parameter
+  env:
+  - default: ""
+    name: TEST_PARAMETER
   steps:
   - chain: ipi-install
-  env:
-  - name: TEST_PARAMETER
-    default: ""
+  zz_generated_metadata:
+    component_path: ipi/install/empty-parameter/ipi-install-empty-parameter-chain.yaml

--- a/test/multistage-registry/registry/ipi/install/install/ipi-install-install-ref.yaml
+++ b/test/multistage-registry/registry/ipi/install/install/ipi-install-install-ref.yaml
@@ -1,13 +1,16 @@
 ref:
   as: ipi-install-install
-  from: installer
   commands: ipi-install-install-commands.sh
+  documentation: The IPI install step runs the OpenShift Installer in order to bring
+    up an OpenShift cluster, using the provided cluster profile to choose a target
+    IaaS platform.
+  env:
+  - default: test parameter default
+    name: TEST_PARAMETER
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  env:
-  - name: TEST_PARAMETER
-    default: test parameter default
-  documentation: |-
-    The IPI install step runs the OpenShift Installer in order to bring up an OpenShift cluster, using the provided cluster profile to choose a target IaaS platform.
+  zz_generated_metadata:
+    component_path: ipi/install/install/ipi-install-install-ref.yaml

--- a/test/multistage-registry/registry/ipi/install/ipi-install-chain.yaml
+++ b/test/multistage-registry/registry/ipi/install/ipi-install-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-install
+  documentation: The IPI install step chain contains all the individual steps necessary
+    to install an OpenShift cluster.
   steps:
   - ref: ipi-install-rbac
   - ref: ipi-install-install
-  documentation: |-
-    The IPI install step chain contains all the individual steps necessary to install an OpenShift cluster.
+  zz_generated_metadata:
+    component_path: ipi/install/ipi-install-chain.yaml

--- a/test/multistage-registry/registry/ipi/install/rbac/ipi-install-rbac-ref.yaml
+++ b/test/multistage-registry/registry/ipi/install/rbac/ipi-install-rbac-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-install-rbac
-  from: installer
   commands: ipi-install-rbac-commands.sh
+  documentation: The IPI install rbac step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI install rbac step
+  zz_generated_metadata:
+    component_path: ipi/install/rbac/ipi-install-rbac-ref.yaml

--- a/test/multistage-registry/registry/ipi/install/with-parameter/ipi-install-with-parameter-chain.yaml
+++ b/test/multistage-registry/registry/ipi/install/with-parameter/ipi-install-with-parameter-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-install-with-parameter
+  env:
+  - default: test parameter set by chain
+    name: TEST_PARAMETER
   steps:
   - chain: ipi-install
-  env:
-  - name: TEST_PARAMETER
-    default: test parameter set by chain
+  zz_generated_metadata:
+    component_path: ipi/install/with-parameter/ipi-install-with-parameter-chain.yaml

--- a/test/multistage-registry/registry/ipi/ipi-workflow.yaml
+++ b/test/multistage-registry/registry/ipi/ipi-workflow.yaml
@@ -1,9 +1,12 @@
 workflow:
   as: ipi
+  documentation: The IPI workflow provides pre- and post- steps that provision and
+    deprovision an OpenShift cluster on a target IaaS platform, allowing job authors
+    to inject their own end-to-end test logic.
   steps:
-    pre:
-    - chain: ipi-install
     post:
     - chain: ipi-deprovision
-  documentation: |-
-    The IPI workflow provides pre- and post- steps that provision and deprovision an OpenShift cluster on a target IaaS platform, allowing job authors to inject their own end-to-end test logic.
+    pre:
+    - chain: ipi-install
+  zz_generated_metadata:
+    component_path: ipi/ipi-workflow.yaml

--- a/test/multistage-registry/registry2/ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml
+++ b/test/multistage-registry/registry2/ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-deprovision-deprovision
-  from: installer
   commands: ipi-deprovision-deprovision-commands.sh
+  documentation: The IPI deprovision step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI deprovision step
+  zz_generated_metadata:
+    component_path: ipi/deprovision/deprovision/ipi-deprovision-deprovision-ref.yaml

--- a/test/multistage-registry/registry2/ipi/deprovision/ipi-deprovision-chain.yaml
+++ b/test/multistage-registry/registry2/ipi/deprovision/ipi-deprovision-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-deprovision
+  documentation: The IPI install step chain contains all the individual steps necessary
+    to teardown an OpenShift cluster.
   steps:
   - ref: ipi-deprovision-must-gather
   - ref: ipi-deprovision-deprovision
-  documentation: |-
-    The IPI install step chain contains all the individual steps necessary to teardown an OpenShift cluster.
+  zz_generated_metadata:
+    component_path: ipi/deprovision/ipi-deprovision-chain.yaml

--- a/test/multistage-registry/registry2/ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml
+++ b/test/multistage-registry/registry2/ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-deprovision-must-gather
-  from: installer
   commands: ipi-deprovision-must-gather-commands.sh
+  documentation: The IPI deprovision gather step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI deprovision gather step
+  zz_generated_metadata:
+    component_path: ipi/deprovision/must-gather/ipi-deprovision-must-gather-ref.yaml

--- a/test/multistage-registry/registry2/ipi/install/install/ipi-install-install-ref.yaml
+++ b/test/multistage-registry/registry2/ipi/install/install/ipi-install-install-ref.yaml
@@ -1,10 +1,13 @@
 ref:
   as: ipi-install-install
-  from: installer
   commands: ipi-install-install-commands.sh
+  documentation: The IPI install step runs the OpenShift Installer in order to bring
+    up an OpenShift cluster, using the provided cluster profile to choose a target
+    IaaS platform.
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI install step runs the OpenShift Installer in order to bring up an OpenShift cluster, using the provided cluster profile to choose a target IaaS platform.
+  zz_generated_metadata:
+    component_path: ipi/install/install/ipi-install-install-ref.yaml

--- a/test/multistage-registry/registry2/ipi/install/ipi-install-chain.yaml
+++ b/test/multistage-registry/registry2/ipi/install/ipi-install-chain.yaml
@@ -1,7 +1,9 @@
 chain:
   as: ipi-install
+  documentation: The IPI install step chain contains all the individual steps necessary
+    to install an OpenShift cluster.
   steps:
   - ref: ipi-install-rbac
   - ref: ipi-install-install
-  documentation: |-
-    The IPI install step chain contains all the individual steps necessary to install an OpenShift cluster.
+  zz_generated_metadata:
+    component_path: ipi/install/ipi-install-chain.yaml

--- a/test/multistage-registry/registry2/ipi/install/rbac/ipi-install-rbac-ref.yaml
+++ b/test/multistage-registry/registry2/ipi/install/rbac/ipi-install-rbac-ref.yaml
@@ -1,10 +1,11 @@
 ref:
   as: ipi-install-rbac
-  from: installer
   commands: ipi-install-rbac-commands.sh
+  documentation: The IPI install rbac step
+  from: installer
   resources:
     requests:
       cpu: 1000m
       memory: 2Gi
-  documentation: |-
-    The IPI install rbac step
+  zz_generated_metadata:
+    component_path: ipi/install/rbac/ipi-install-rbac-ref.yaml

--- a/test/multistage-registry/registry2/ipi/ipi-workflow.yaml
+++ b/test/multistage-registry/registry2/ipi/ipi-workflow.yaml
@@ -1,9 +1,12 @@
 workflow:
   as: ipi
+  documentation: The IPI workflow provides pre- and post- steps that provision and
+    deprovision an OpenShift cluster on a target IaaS platform, allowing job authors
+    to inject their own end-to-end test logic.
   steps:
-    pre:
-    - chain: ipi-install
     post:
     - chain: ipi-deprovision
-  documentation: |-
-    The IPI workflow provides pre- and post- steps that provision and deprovision an OpenShift cluster on a target IaaS platform, allowing job authors to inject their own end-to-end test logic.
+    pre:
+    - chain: ipi-install
+  zz_generated_metadata:
+    component_path: ipi/ipi-workflow.yaml


### PR DESCRIPTION
This PR adds a `determinize-step-registry` tool that performs a similar
task to the other determinize tools in this repo. It also adds a new
metadata field to the registry components that will be used by the web
UI to generate github links and get the OWNERS files for registry
components.

This PR also makes the `XSuffix` consts in the load package public and
replaces all previous hardcoded strings with those consts.