### PR TITLE
Registry replacer: Prune ocp/builder replacements

### DIFF
--- a/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_OCP_builder_pruning_happens.yaml
+++ b/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_OCP_builder_pruning_happens.yaml
@@ -1,0 +1,4 @@
+zz_generated_metadata:
+  branch: ""
+  org: ""
+  repo: ""


### PR DESCRIPTION
Produces https://github.com/openshift/release/pull/10413

Guaranteed to break some ppl once enabled. Its featuregated though.