### PR TITLE
pkg/load: partially validate registry contents

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -200,8 +200,6 @@ func main() {
 	}
 	level, _ := logrus.ParseLevel(o.logLevel)
 	logrus.SetLevel(level)
-	health := pjutil.NewHealth()
-	metrics.ExposeMetrics("ci-operator-configresolver", prowConfig.PushGateway{}, flagutil.DefaultMetricsPort)
 
 	configAgent, err := agents.NewConfigAgent(o.configPath, agents.WithConfigMetrics(configresolverMetrics.ErrorRate))
 	if err != nil {
@@ -216,7 +214,8 @@ func main() {
 	if o.validateOnly {
 		os.Exit(0)
 	}
-
+	health := pjutil.NewHealth()
+	metrics.ExposeMetrics("ci-operator-configresolver", prowConfig.PushGateway{}, flagutil.DefaultMetricsPort)
 	simplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root
 		l("config"),
 		l("resolve"),

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -329,7 +329,10 @@ func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainB
 		logrus.WithError(err).Warn("failed to parse metadata file")
 	}
 	// create graph to verify that there are no cycles
-	_, err = registry.NewGraph(references, chains, workflows)
+	if _, err = registry.NewGraph(references, chains, workflows); err != nil {
+		return nil, nil, nil, nil, nil, err
+	}
+	err = registry.Validate(references, chains, workflows)
 	return references, chains, workflows, documentation, metadata, err
 }
 

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -91,6 +91,9 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 		AllowSkipOnSuccess: config.AllowSkipOnSuccess,
 	}
 	stack := stackForTest(name, config.Environment)
+	if config.Workflow != nil {
+		stack.push(stackRecordForTest(*config.Workflow, nil))
+	}
 	pre, errs := r.process(config.Pre, sets.NewString(), stack)
 	expandedFlow.Pre = append(expandedFlow.Pre, pre...)
 	resolveErrors = append(resolveErrors, errs...)

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -67,8 +67,7 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 		ClusterProfile:     config.ClusterProfile,
 		AllowSkipOnSuccess: config.AllowSkipOnSuccess,
 	}
-	rec := stackRecordForTest(name, config.Environment)
-	stack := []stackRecord{rec}
+	stack := stackForTest(name, config.Environment)
 	pre, errs := r.process(config.Pre, sets.NewString(), stack)
 	expandedFlow.Pre = append(expandedFlow.Pre, pre...)
 	resolveErrors = append(resolveErrors, errs...)
@@ -80,13 +79,51 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 	post, errs := r.process(config.Post, sets.NewString(), stack)
 	expandedFlow.Post = append(expandedFlow.Post, post...)
 	resolveErrors = append(resolveErrors, errs...)
-	for u := range rec.unused {
-		resolveErrors = append(resolveErrors, stackErrorf(stack, "no step declares parameter %q", u))
-	}
+	resolveErrors = append(resolveErrors, stack.records[0].checkUnused(&stack)...)
 	if resolveErrors != nil {
 		return api.MultiStageTestConfigurationLiteral{}, errors.NewAggregate(resolveErrors)
 	}
 	return expandedFlow, nil
+}
+
+type stack struct {
+	records []stackRecord
+}
+
+func stackForTest(name string, env api.TestEnvironment) stack {
+	return stack{records: []stackRecord{stackRecordForTest(name, env)}}
+}
+
+func (s *stack) push(r stackRecord) {
+	s.records = append(s.records, r)
+}
+
+func (s *stack) pop() {
+	s.records = s.records[:len(s.records)-1]
+}
+
+func (s *stack) errorf(format string, args ...interface{}) error {
+	var b strings.Builder
+	for i := range s.records {
+		b.WriteString(s.records[i].name)
+		b.WriteString(": ")
+	}
+	args = append([]interface{}{b.String()}, args...)
+	return fmt.Errorf("%s"+format, args...)
+}
+
+func (s *stack) resolve(name string) *string {
+	for _, r := range s.records {
+		for j, e := range r.env {
+			if e.Name == name {
+				for _, r := range s.records {
+					r.unused.Delete(e.Name)
+				}
+				return r.env[j].Default
+			}
+		}
+	}
+	return nil
 }
 
 type stackRecord struct {
@@ -112,17 +149,14 @@ func stackRecordForTest(name string, env api.TestEnvironment) stackRecord {
 	return stackRecordForStep(name, params)
 }
 
-func stackErrorf(s []stackRecord, format string, args ...interface{}) error {
-	var b strings.Builder
-	for i := range s {
-		b.WriteString(s[i].name)
-		b.WriteString(": ")
+func (r *stackRecord) checkUnused(s *stack) (ret []error) {
+	for u := range r.unused {
+		ret = append(ret, s.errorf("no step declares parameter %q", u))
 	}
-	args = append([]interface{}{b.String()}, args...)
-	return fmt.Errorf("%s"+format, args...)
+	return
 }
 
-func (r *registry) process(steps []api.TestStep, seen sets.String, stack []stackRecord) (ret []api.LiteralTestStep, errs []error) {
+func (r *registry) process(steps []api.TestStep, seen sets.String, stack stack) (ret []api.LiteralTestStep, errs []error) {
 	for _, step := range steps {
 		if step.Chain != nil {
 			steps, err := r.processChain(&step, seen, stack)
@@ -139,65 +173,50 @@ func (r *registry) process(steps []api.TestStep, seen sets.String, stack []stack
 	return
 }
 
-func (r *registry) processChain(step *api.TestStep, seen sets.String, stack []stackRecord) ([]api.LiteralTestStep, []error) {
+func (r *registry) processChain(step *api.TestStep, seen sets.String, stack stack) ([]api.LiteralTestStep, []error) {
 	name := *step.Chain
 	chain, ok := r.chainsByName[name]
 	if !ok {
-		return nil, []error{stackErrorf(stack, "unknown step chain: %s", name)}
+		return nil, []error{stack.errorf("unknown step chain: %s", name)}
 	}
 	rec := stackRecordForStep(name, chain.Environment)
-	stack = append(stack, rec)
+	stack.push(rec)
+	defer stack.pop()
 	ret, err := r.process(chain.Steps, seen, stack)
-	for u := range rec.unused {
-		err = append(err, stackErrorf(stack, "no step declares parameter %q", u))
-	}
+	err = append(err, rec.checkUnused(&stack)...)
 	return ret, err
 }
 
-func (r *registry) processStep(step *api.TestStep, seen sets.String, stack []stackRecord) (ret api.LiteralTestStep, err []error) {
+func (r *registry) processStep(step *api.TestStep, seen sets.String, stack stack) (ret api.LiteralTestStep, err []error) {
 	if ref := step.Reference; ref != nil {
 		var ok bool
 		ret, ok = r.stepsByName[*ref]
 		if !ok {
-			return api.LiteralTestStep{}, []error{stackErrorf(stack, "invalid step reference: %s", *ref)}
+			return api.LiteralTestStep{}, []error{stack.errorf("invalid step reference: %s", *ref)}
 		}
 	} else if step.LiteralTestStep != nil {
 		ret = *step.LiteralTestStep
 	} else {
-		return api.LiteralTestStep{}, []error{stackErrorf(stack, "encountered TestStep where both `Reference` and `LiteralTestStep` are nil")}
+		return api.LiteralTestStep{}, []error{stack.errorf("encountered TestStep where both `Reference` and `LiteralTestStep` are nil")}
 	}
 	if seen.Has(ret.As) {
-		return api.LiteralTestStep{}, []error{stackErrorf(stack, "duplicate name: %s", ret.As)}
+		return api.LiteralTestStep{}, []error{stack.errorf("duplicate name: %s", ret.As)}
 	}
 	seen.Insert(ret.As)
 	var errs []error
 	if ret.Environment != nil {
 		env := make([]api.StepParameter, 0, len(ret.Environment))
 		for _, e := range ret.Environment {
-			if v := resolveVariable(e.Name, stack); v != nil {
+			if v := stack.resolve(e.Name); v != nil {
 				e.Default = v
 			} else if e.Default == nil {
-				errs = append(errs, stackErrorf(stack, "%s: unresolved parameter: %s", ret.As, e.Name))
+				errs = append(errs, stack.errorf("%s: unresolved parameter: %s", ret.As, e.Name))
 			}
 			env = append(env, e)
 		}
 		ret.Environment = env
 	}
 	return ret, errs
-}
-
-func resolveVariable(name string, stack []stackRecord) *string {
-	for _, r := range stack {
-		for j, e := range r.env {
-			if e.Name == name {
-				for _, r := range stack {
-					r.unused.Delete(e.Name)
-				}
-				return r.env[j].Default
-			}
-		}
-	}
-	return nil
 }
 
 // ResolveConfig uses a resolver to resolve an entire ci-operator config

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -618,7 +618,7 @@ func TestResolve(t *testing.T) {
 				},
 			},
 		},
-		expectedErr:           errors.New(`test: no step declares parameter "NOT_THE_STEP_ENV"`),
+		expectedErr:           errors.New(`test: ipi-aws: no step declares parameter "NOT_THE_STEP_ENV"`),
 		expectedValidationErr: errors.New(`ipi-aws: no step declares parameter "NOT_THE_STEP_ENV"`),
 	}} {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/test/integration/ci-operator-configresolver.sh
+++ b/test/integration/ci-operator-configresolver.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
-rsync_tmp_dir=$(mktemp -d)
 function cleanup() {
-    rm -rf $rsync_tmp_dir
     os::test::junit::reconcile_output
     os::integration::configresolver::check_log
     os::cleanup::processes


### PR DESCRIPTION
Full validation can only be done in the presence of test configurations,
but many useful validations can be performed when the registry is initially
loaded.

There is probably a more efficient algorithm, but this way we maintain a
single execution path for all validation phases.  Validating the entire
step registry in `openshift/release` still stays below 1s on my machine and
I don't see any change in total execution time.

The original bug report has been added as an integration tests.  I've also
verified that the new code correctly identifies the error:

```
$ cd openshift/release/
$ git checkout --quiet 67cb826934
$ ci-operator-configresolver --validate-only …
INFO[0000] Configs reloaded                             duration=683.772282ms
FATA[0000] Failed to get registry agent: Failed to load registry: failed to load ci-operator registry ([openshift-e2e-aws-loki: duplicate name: manifests, openshift-e2e-gcp-loki: duplicate name: manifests])
```

***

/hold

Opening for review, but I want to fix the bug that is causing integration tests
to fail intermittently first.  Some of these commits may be moved to separate
PRs in the process.