### PR TITLE
cmd/ipi-deprovision: Fall back to assuming us-east1 for GCP

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -36,8 +36,7 @@ for network in $( gcloud --project=openshift-gce-devel-ci compute networks list 
   infraID="${network%"-network"}"
   region="$( gcloud --project=openshift-gce-devel-ci compute networks describe "${network}" --format="value(subnetworks[0])" | grep -Po "(?<=regions/)[^/]+" || true )"
   if [[ -z "${region:-}" ]]; then
-    echo "could not determine region for cluster ${infraID}, ignoring ..."
-    continue
+    region=us-east1
   fi
   workdir="/tmp/deprovision/${infraID}"
   mkdir -p "${workdir}"


### PR DESCRIPTION
We've had the "could not determine region" bail-out since d9ba62b1d2 (#380).  But we only [run GCP CI in us-east1][1] today.  Falling back to us-east1 will allow us to clean up clusters which die in setup after creating the network but before creating any subnets, like:

```console
$ gcloud --project=openshift-gce-devel-ci compute networks describe ci-op-pb0tz84t-d2203-tgjwj-network
autoCreateSubnetworks: false
creationTimestamp: '2020-07-09T11:21:51.305-07:00'
id: ...
kind: compute#network
name: ci-op-pb0tz84t-d2203-tgjwj-network
routingConfig:
  routingMode: REGIONAL
selfLink: https://www.googleapis.com/compute/v1/projects/openshift-gce-devel-ci/global/networks/ci-op-pb0tz84t-d2203-tgjwj-network
x_gcloud_bgp_routing_mode: REGIONAL
x_gcloud_subnet_mode: CUSTOM
```

Before we shard out to multiple GCP regions, we'll want to either adjust this further to iterate over all sharded regions, or find an alternative channel for transmitting region information (an annotation on the network itself?  Some other regioned resource?).

[1]: https://github.com/openshift/release/blob/83db5513ea453cfdc18f9fae2dd522b0ea3de201/ci-operator/step-registry/ipi/conf/gcp/ipi-conf-gcp-commands.sh#L11