### PR TITLE
rehearse: fix `wait.Poll` return value

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -855,15 +855,12 @@ func (e *Executor) waitForJobs(jobs sets.String, selector ctrlruntimeclient.List
 			}
 			jobs.Delete(pj.Name)
 			if jobs.Len() == 0 {
-				return success, nil
+				return true, nil
 			}
 		}
 
 		return false, nil
 	}); err != nil {
-		if err == wait.ErrWaitTimeout {
-			return false, nil
-		}
 		return false, fmt.Errorf("failed waiting for prowjobs to finish: %w", err)
 	}
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/DPTP-1377.