### PR TITLE
rehearse: verify the test exists when inlining

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -245,6 +245,9 @@ func getResolvedConfigForTest(ciopConfigs config.DataByFilename, resolver regist
 			break
 		}
 	}
+	if len(ciopCopy.Configuration.Tests) == 0 {
+		return "", nil, fmt.Errorf("test %q not found in the ci-operator configuration file: %s", testname, filename)
+	}
 	ciopConfigResolved, err := registry.ResolveConfig(resolver, ciopCopy.Configuration)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed resolve ReleaseBuildConfiguration: %w", err)

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -215,6 +215,12 @@ func TestInlineCiopConfig(t *testing.T) {
 		configs:     config.DataByFilename{"filename": {Info: config.Info{Metadata: testCiopConfigInfo}, Configuration: testCiopConfig}},
 		expectedEnv: []v1.EnvVar{{Name: "T", Value: string(testCiopConfigContentTest2)}},
 	}, {
+		description:   "CM reference to ci-operator-configs with invalid test",
+		testname:      "non-existent",
+		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
+		configs:       config.DataByFilename{"filename": {Info: config.Info{Metadata: testCiopConfigInfo}, Configuration: testCiopConfig}},
+		expectedError: true,
+	}, {
 		description:   "bad CM key is handled",
 		sourceEnv:     []v1.EnvVar{{Name: "T", ValueFrom: makeCMReference(testCiopConfigInfo.ConfigMapName(), "filename")}},
 		configs:       config.DataByFilename{},


### PR DESCRIPTION
Should not happen with generated jobs, but it is an open interface so it
was just a matter of time:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/10191/pull-ci-openshift-release-master-pj-rehearse/1288013504346853376