### PR TITLE
CI operator: Don't panic when reporting fails

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -121,17 +121,20 @@ func (r *reporter) Report(err error) {
 	data, err := json.Marshal(request)
 	if err != nil {
 		logrus.Tracef("could not marshal request: %v", err)
+		return
 	}
 	logrus.Infof("Reporting job state %q with reason %q", request.State, request.Reason)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/result", r.address), bytes.NewReader(data))
 	if err != nil {
 		logrus.Tracef("could not create report request: %v", err)
+		return
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(r.username, r.password)
 	resp, err := r.client.Do(req)
 	if err != nil {
 		logrus.Tracef("could not send report request: %v", err)
+		return
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {


### PR DESCRIPTION
Sample: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/1030/pull-ci-openshift-ci-tools-master-format/1288132168748371968#1:build-log.txt%3A30

That is this line and it panics because the response is nil: https://github.com/openshift/ci-tools/blob/2f5585541d75db395612b0f63eeb7e561f85105d/pkg/results/report.go#L137

Reporting is always best-effort and should never result in a panic.