### PR TITLE
Enable allow_skip_on_success also for non-literal MultiStageTestConfi…

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -614,7 +614,7 @@ type MultiStageTestConfiguration struct {
 	// AllowSkipOnSuccess defines if any steps can be skipped when
 	// all previous `pre` and `test` steps were successful. The given step must explicitly
 	// ask for being skipped by setting the OptionalOnSuccess flag to true.
-	AllowSkipOnSuccess bool `json:"allow_skip_on_success,omitempty"`
+	AllowSkipOnSuccess *bool `json:"allow_skip_on_success,omitempty"`
 }
 
 // MultiStageTestConfigurationLiteral is a form of the MultiStageTestConfiguration that does not include
@@ -635,7 +635,7 @@ type MultiStageTestConfigurationLiteral struct {
 	// AllowSkipOnSuccess defines if any steps can be skipped when
 	// all previous `pre` and `test` steps were successful. The given step must explicitly
 	// ask for being skipped by setting the OptionalOnSuccess flag to true.
-	AllowSkipOnSuccess bool `json:"allow_skip_on_success,omitempty"`
+	AllowSkipOnSuccess *bool `json:"allow_skip_on_success,omitempty"`
 }
 
 // TestEnvironment has the values of parameters for multi-stage tests.

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -59,9 +59,13 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 				config.Environment[k] = v
 			}
 		}
+		if config.AllowSkipOnSuccess == nil {
+			config.AllowSkipOnSuccess = workflow.AllowSkipOnSuccess
+		}
 	}
 	expandedFlow := api.MultiStageTestConfigurationLiteral{
-		ClusterProfile: config.ClusterProfile,
+		ClusterProfile:     config.ClusterProfile,
+		AllowSkipOnSuccess: config.AllowSkipOnSuccess,
 	}
 	rec := stackRecordForTest(name, config.Environment)
 	stack := []stackRecord{rec}

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -18,6 +18,7 @@ func TestResolve(t *testing.T) {
 	nestedChains := "nested-chains"
 	chainInstall := "install-chain"
 	awsWorkflow := "ipi-aws"
+	yes := true
 	for _, testCase := range []struct {
 		name        string
 		config      api.MultiStageTestConfiguration
@@ -30,7 +31,8 @@ func TestResolve(t *testing.T) {
 		// This is a full config that should not change (other than struct) when passed to the Resolver
 		name: "Full AWS IPI",
 		config: api.MultiStageTestConfiguration{
-			ClusterProfile: api.ClusterProfileAWS,
+			ClusterProfile:     api.ClusterProfileAWS,
+			AllowSkipOnSuccess: &yes,
 			Pre: []api.TestStep{{
 				LiteralTestStep: &api.LiteralTestStep{
 					As:       "ipi-install",
@@ -63,7 +65,8 @@ func TestResolve(t *testing.T) {
 			}},
 		},
 		expectedRes: api.MultiStageTestConfigurationLiteral{
-			ClusterProfile: api.ClusterProfileAWS,
+			ClusterProfile:     api.ClusterProfileAWS,
+			AllowSkipOnSuccess: &yes,
 			Pre: []api.LiteralTestStep{{
 				As:       "ipi-install",
 				From:     "installer",

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -58,7 +58,7 @@ type multiStageTestStep struct {
 	jobSpec            *api.JobSpec
 	pre, test, post    []api.LiteralTestStep
 	subTests           []*junit.TestCase
-	allowSkipOnSuccess bool
+	allowSkipOnSuccess *bool
 }
 
 func MultiStageTestStep(
@@ -327,7 +327,9 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 	var ret []coreapi.Pod
 	var errs []error
 	for _, step := range steps {
-		if s.allowSkipOnSuccess && step.OptionalOnSuccess != nil && *step.OptionalOnSuccess && !hasPrevErrs {
+		if s.allowSkipOnSuccess != nil && *s.allowSkipOnSuccess &&
+			step.OptionalOnSuccess != nil && *step.OptionalOnSuccess &&
+			!hasPrevErrs {
 			continue
 		}
 		image := step.From

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -472,6 +472,7 @@ func (e *fakePodExecutor) AddReactors(cs *fake.Clientset) {
 }
 
 func TestRun(t *testing.T) {
+	yes := true
 	for _, tc := range []struct {
 		name     string
 		failures sets.String
@@ -527,8 +528,8 @@ func TestRun(t *testing.T) {
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
 					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: func(b bool) *bool { return &b }(true)}},
-					AllowSkipOnSuccess: true,
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: &yes}},
+					AllowSkipOnSuccess: &yes,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), "", &jobSpec)
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -45,14 +45,21 @@ tests:
       post:
         - as: skip-on-success-post-step
           optional_on_success: true
-          commands: touch ${ARTIFACT_DIR}/file
+          commands: touch ${ARTIFACT_DIR}/skipped
           from: os
           resources:
             requests:
               cpu: 100m
               memory: 200Mi
-        - as: check-skipped-step
-          commands: test ! -f ${ARTIFACT_DIR}/file
+        - as: always-run-post-step
+          commands: touch ${ARTIFACT_DIR}/alwaysrun
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        - as: check-skipped-and-always-run-steps
+          commands: test ! -f ${ARTIFACT_DIR}/skipped -a -f ${ARTIFACT_DIR}/alwaysrun
           from: os
           resources:
             requests:

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -58,8 +58,15 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
-        - as: check-skipped-and-always-run-steps
-          commands: test ! -f ${ARTIFACT_DIR}/skipped -a -f ${ARTIFACT_DIR}/alwaysrun
+        - as: check-skipped-step
+          commands: test ! -f ${ARTIFACT_DIR}/skipped
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+        - as: check-always-run-step
+          commands: test -f ${ARTIFACT_DIR}/alwaysrun
           from: os
           resources:
             requests:

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -45,28 +45,28 @@ tests:
       post:
         - as: skip-on-success-post-step
           optional_on_success: true
-          commands: touch ${ARTIFACT_DIR}/skipped
+          commands: echo > ${SHARED_DIR}/skipped
           from: os
           resources:
             requests:
               cpu: 100m
               memory: 200Mi
         - as: always-run-post-step
-          commands: touch ${ARTIFACT_DIR}/alwaysrun
+          commands: echo > ${SHARED_DIR}/alwaysrun
           from: os
           resources:
             requests:
               cpu: 100m
               memory: 200Mi
         - as: check-skipped-step
-          commands: test ! -f ${ARTIFACT_DIR}/skipped
+          commands: test ! -f ${SHARED_DIR}/skipped
           from: os
           resources:
             requests:
               cpu: 100m
               memory: 200Mi
         - as: check-always-run-step
-          commands: test -f ${ARTIFACT_DIR}/alwaysrun
+          commands: test -f ${SHARED_DIR}/alwaysrun
           from: os
           resources:
             requests:


### PR DESCRIPTION
…guration

* also make this argument optional for literal
MultiStageTestConfiguration

The test on https://github.com/openshift/ci-tools/blob/master/test/e2e/multi-stage/config.yaml#L34 was passing because the optional step was NOT skipped but it failed to create the file via `touch ${ARTIFACT_DIR}/file`. I've changed that to use `echo` and $SHARED_DIR and separated the test to check both conditions.