### PR TITLE
webreg: add metadata based info to web UI

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -221,7 +221,7 @@ func rehearseMain() error {
 	var graph registry.NodeByName
 
 	if !o.noRegistry {
-		refs, chains, workflows, _, err = load.Registry(filepath.Join(o.releaseRepoPath, config.RegistryPath), false)
+		refs, chains, workflows, _, _, err = load.Registry(filepath.Join(o.releaseRepoPath, config.RegistryPath), false)
 		if err != nil {
 			logger.WithError(err).Error("could not load step registry")
 			return fmt.Errorf(misconfigurationOutput)

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 	pjdwapi "k8s.io/test-infra/prow/pod-utils/downwardapi"
 
+	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
 
@@ -179,16 +180,16 @@ func GetChangedTemplates(path, baseRev string) ([]string, error) {
 
 func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node, error) {
 	// if a commands script changed, mark reference as changed
-	filename = strings.ReplaceAll(filename, "-commands.sh", "-ref.yaml")
+	filename = strings.ReplaceAll(filename, load.CommandsSuffix, load.RefSuffix)
 	var node registry.Node
 	var ok bool
 	switch {
-	case strings.HasSuffix(filename, "-ref.yaml"):
-		node, ok = graph.References[strings.TrimSuffix(filename, "-ref.yaml")]
-	case strings.HasSuffix(filename, "-chain.yaml"):
-		node, ok = graph.Chains[strings.TrimSuffix(filename, "-chain.yaml")]
-	case strings.HasSuffix(filename, "-workflow.yaml"):
-		node, ok = graph.Workflows[strings.TrimSuffix(filename, "-workflow.yaml")]
+	case strings.HasSuffix(filename, load.RefSuffix):
+		node, ok = graph.References[strings.TrimSuffix(filename, load.RefSuffix)]
+	case strings.HasSuffix(filename, load.ChainSuffix):
+		node, ok = graph.Chains[strings.TrimSuffix(filename, load.ChainSuffix)]
+	case strings.HasSuffix(filename, load.WorkflowSuffix):
+		node, ok = graph.Workflows[strings.TrimSuffix(filename, load.WorkflowSuffix)]
 	default:
 		return nil, fmt.Errorf("invalid step filename: %s", filename)
 	}
@@ -206,7 +207,7 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 		return changes, err
 	}
 	for _, c := range revChanges {
-		if filepath.Ext(c) == ".yaml" || strings.HasSuffix(c, "-commands.sh") {
+		if filepath.Ext(c) == ".yaml" || strings.HasSuffix(c, load.CommandsSuffix) {
 			node, err := loadRegistryStep(filepath.Base(c), graph)
 			if err != nil {
 				return changes, err

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -31,10 +31,10 @@ type ResolverInfo struct {
 }
 
 const (
-	refSuffix      = "-ref.yaml"
-	chainSuffix    = "-chain.yaml"
-	workflowSuffix = "-workflow.yaml"
-	commandsSuffix = "-commands.sh"
+	RefSuffix      = "-ref.yaml"
+	ChainSuffix    = "-chain.yaml"
+	WorkflowSuffix = "-workflow.yaml"
+	CommandsSuffix = "-commands.sh"
 )
 
 // ByOrgRepo maps org --> repo --> list of branched and variant configs
@@ -143,7 +143,7 @@ func Config(path, unresolvedPath, registryPath string, info *ResolverInfo) (*api
 		return nil, fmt.Errorf("invalid configuration: %w\nvalue:\n%s", err, raw)
 	}
 	if registryPath != "" {
-		refs, chains, workflows, _, err := Registry(registryPath, false)
+		refs, chains, workflows, _, _, err := Registry(registryPath, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load registry: %w", err)
 		}
@@ -223,12 +223,12 @@ func literalConfigFromResolver(raw []byte, address string) (*api.ReleaseBuildCon
 
 // Registry takes the path to a registry config directory and returns the full set of references, chains,
 // and workflows that the registry's Resolver needs to resolve a user's MultiStageTestConfiguration
-func Registry(root string, flat bool) (references registry.ReferenceByName, chains registry.ChainByName, workflows registry.WorkflowByName, documentation map[string]string, err error) {
-	references = registry.ReferenceByName{}
-	chains = registry.ChainByName{}
-	workflows = registry.WorkflowByName{}
-	documentation = map[string]string{}
-	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string, *api.RegistryMetadata, error) {
+	references := registry.ReferenceByName{}
+	chains := registry.ChainByName{}
+	workflows := registry.WorkflowByName{}
+	documentation := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info != nil && strings.HasPrefix(info.Name(), "..") {
 			if info.IsDir() {
 				return filepath.SkipDir
@@ -259,7 +259,7 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 					return fmt.Errorf("ile %s has incorrect prefix. Prefix should be %s", path, prefix)
 				}
 			}
-			if strings.HasSuffix(path, refSuffix) {
+			if strings.HasSuffix(path, RefSuffix) {
 				name, doc, ref, err := loadReference(raw, dir, prefix, flat)
 				if err != nil {
 					return fmt.Errorf("failed to load registry file %s: %w", path, err)
@@ -267,12 +267,12 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && name != prefix {
 					return fmt.Errorf("name of reference in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), refSuffix) != name {
-					return fmt.Errorf("filename %s does not match name of reference; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, refSuffix))
+				if strings.TrimSuffix(filepath.Base(path), RefSuffix) != name {
+					return fmt.Errorf("filename %s does not match name of reference; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, RefSuffix))
 				}
 				references[name] = ref
 				documentation[name] = doc
-			} else if strings.HasSuffix(path, chainSuffix) {
+			} else if strings.HasSuffix(path, ChainSuffix) {
 				var chain api.RegistryChainConfig
 				err := yaml.UnmarshalStrict(raw, &chain)
 				if err != nil {
@@ -281,13 +281,13 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && chain.Chain.As != prefix {
 					return fmt.Errorf("name of chain in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), chainSuffix) != chain.Chain.As {
-					return fmt.Errorf("filename %s does not match name of chain; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, chainSuffix))
+				if strings.TrimSuffix(filepath.Base(path), ChainSuffix) != chain.Chain.As {
+					return fmt.Errorf("filename %s does not match name of chain; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, ChainSuffix))
 				}
 				documentation[chain.Chain.As] = chain.Chain.Documentation
 				chain.Chain.Documentation = ""
 				chains[chain.Chain.As] = chain.Chain
-			} else if strings.HasSuffix(path, workflowSuffix) {
+			} else if strings.HasSuffix(path, WorkflowSuffix) {
 				name, doc, workflow, err := loadWorkflow(raw)
 				if err != nil {
 					return fmt.Errorf("failed to load registry file %s: %w", path, err)
@@ -295,12 +295,12 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 				if !flat && name != prefix {
 					return fmt.Errorf("name of workflow in file %s should be %s", path, prefix)
 				}
-				if strings.TrimSuffix(filepath.Base(path), workflowSuffix) != name {
-					return fmt.Errorf("filename %s does not match name of workflow; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, workflowSuffix))
+				if strings.TrimSuffix(filepath.Base(path), WorkflowSuffix) != name {
+					return fmt.Errorf("filename %s does not match name of workflow; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, WorkflowSuffix))
 				}
 				workflows[name] = workflow
 				documentation[name] = doc
-			} else if strings.HasSuffix(path, commandsSuffix) {
+			} else if strings.HasSuffix(path, CommandsSuffix) {
 				// ignore
 			} else {
 				return fmt.Errorf("invalid file name: %s", path)
@@ -309,11 +309,17 @@ func Registry(root string, flat bool) (references registry.ReferenceByName, chai
 		return nil
 	})
 	if err != nil {
-		return references, chains, workflows, documentation, err
+		return nil, nil, nil, nil, nil, err
+	}
+	metadata := &api.RegistryMetadata{}
+	if metadataRaw, err := ioutil.ReadFile(filepath.Join(root, api.RegistryMetadataPath)); err != nil {
+		logrus.WithError(err).Warn("failed to load metadata file")
+	} else if err := json.Unmarshal(metadataRaw, metadata); err != nil {
+		logrus.WithError(err).Warn("failed to parse metadata file")
 	}
 	// create graph to verify that there are no cycles
 	_, err = registry.NewGraph(references, chains, workflows)
-	return references, chains, workflows, documentation, err
+	return references, chains, workflows, documentation, metadata, err
 }
 
 func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, string, api.LiteralTestStep, error) {
@@ -322,8 +328,8 @@ func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, str
 	if err != nil {
 		return "", "", api.LiteralTestStep{}, err
 	}
-	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, commandsSuffix) {
-		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, commandsSuffix))
+	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
+		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
 	}
 	command, err := ioutil.ReadFile(filepath.Join(baseDir, step.Reference.Commands))
 	if err != nil {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -808,23 +808,23 @@ func TestRegistry(t *testing.T) {
 			name:          "Read registry with ref where name and filename don't match",
 			registryDir:   "../../test/multistage-registry/invalid-filename",
 			flatRegistry:  false,
-			references:    registry.ReferenceByName{},
-			chains:        registry.ChainByName{},
-			workflows:     registry.WorkflowByName{},
+			references:    nil,
+			chains:        nil,
+			workflows:     nil,
 			expectedError: true,
 		}, {
 			name:          "Read registry where ref has an extra, invalid field",
 			registryDir:   "../../test/multistage-registry/invalid-field",
 			flatRegistry:  false,
-			references:    registry.ReferenceByName{},
-			chains:        registry.ChainByName{},
-			workflows:     registry.WorkflowByName{},
+			references:    nil,
+			chains:        nil,
+			workflows:     nil,
 			expectedError: true,
 		}}
 	)
 
 	for _, testCase := range testCases {
-		references, chains, workflows, _, err := Registry(testCase.registryDir, testCase.flatRegistry)
+		references, chains, workflows, _, _, err := Registry(testCase.registryDir, testCase.flatRegistry)
 		if err == nil && testCase.expectedError == true {
 			t.Errorf("%s: got no error when error was expected", testCase.name)
 		}
@@ -866,7 +866,7 @@ func TestRegistry(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(path, deprovisionGatherRef), fileData, 0664); err != nil {
 		t.Fatalf("failed to populate temp reference file: %v", err)
 	}
-	_, _, _, _, err = Registry(temp, false)
+	_, _, _, _, _, err = Registry(temp, false)
 	if err == nil {
 		t.Error("got no error when expecting error on incorrect reference name")
 	}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -221,7 +221,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		expectedError: true,
 	}}
 
-	references, chains, workflows, _, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, err := load.Registry(testingRegistry, false)
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 		failToCreate: sets.NewString("rehearse-123-job2"),
 	}}
 
-	references, chains, workflows, _, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, err := load.Registry(testingRegistry, false)
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -505,7 +505,7 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 		},
 	}}
 
-	references, chains, workflows, _, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, err := load.Registry(testingRegistry, false)
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -614,7 +614,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 		},
 	}
 
-	references, chains, workflows, _, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, err := load.Registry(testingRegistry, false)
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}

--- a/pkg/webreg/graphviz_test.go
+++ b/pkg/webreg/graphviz_test.go
@@ -89,7 +89,7 @@ const deprovisionChain = `digraph Webreg {
 }`
 
 func TestChainDotFile(t *testing.T) {
-	_, chains, _, _, err := load.Registry("../../test/multistage-registry/registry", false)
+	_, chains, _, _, _, err := load.Registry("../../test/multistage-registry/registry", false)
 	if err != nil {
 		t.Fatalf("Failed to load registry: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestChainDotFile(t *testing.T) {
 }
 
 func TestWorkflowDotFile(t *testing.T) {
-	_, chains, workflows, _, err := load.Registry("../../test/multistage-registry/registry", false)
+	_, chains, workflows, _, _, err := load.Registry("../../test/multistage-registry/registry", false)
 	if err != nil {
 		t.Fatalf("Failed to load registry: %v", err)
 	}

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1836,13 +1836,15 @@ func githubLink(path string) template.HTML {
 	return template.HTML(fmt.Sprintf("<a href=\"%s\">%s</a>", link, link))
 }
 
-func createHTMLList(items []string) string {
+func createGitHubUserList(items []string) string {
 	var builder strings.Builder
 	builder.WriteString("<ul>")
 	for _, item := range items {
-		builder.WriteString("\n<li>")
+		builder.WriteString("\n<li><a href=\"https://github.com/")
 		builder.WriteString(item)
-		builder.WriteString("</li>")
+		builder.WriteString("\">")
+		builder.WriteString(item)
+		builder.WriteString("</a></li>")
 	}
 	builder.WriteString("</ul>")
 	return builder.String()
@@ -1853,19 +1855,19 @@ func ownersBlock(owners repoowners.Config) template.HTML {
 	builder.WriteString("<h2 id=\"owners\"><a href=\"#owners\">Owners:</a></h2>")
 	if len(owners.Approvers) > 0 {
 		builder.WriteString("<h4 id=\"approvers\"><a href=\"#approvers\">Approvers:</a></h4>\n")
-		builder.WriteString(createHTMLList(owners.Approvers))
+		builder.WriteString(createGitHubUserList(owners.Approvers))
 	}
 	if len(owners.Reviewers) > 0 {
 		builder.WriteString("<h4 id=\"reviewers\"><a href=\"#reviewers\">Reviewers:</a></h4>\n")
-		builder.WriteString(createHTMLList(owners.Reviewers))
+		builder.WriteString(createGitHubUserList(owners.Reviewers))
 	}
 	if len(owners.RequiredReviewers) > 0 {
 		builder.WriteString("<h4 id=\"required_reviewers\"><a href=\"#required_reviewers\">Required Reviewers:</a></h4>\n")
-		builder.WriteString(createHTMLList(owners.RequiredReviewers))
+		builder.WriteString(createGitHubUserList(owners.RequiredReviewers))
 	}
 	if len(owners.Labels) > 0 {
 		builder.WriteString("<h4 id=\"labels\"><a href\"#labels\">Labels:</a></h4>\n")
-		builder.WriteString(createHTMLList(owners.Labels))
+		builder.WriteString(createGitHubUserList(owners.Labels))
 	}
 	return template.HTML(builder.String())
 }

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -15,8 +15,10 @@ import (
 	"github.com/alecthomas/chroma/lexers"
 	"github.com/alecthomas/chroma/styles"
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/repoowners"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/registry"
 )
@@ -157,40 +159,48 @@ const mainPage = `
 `
 
 const referencePage = `
-<h2 id="title"><a href="#title">Step: <nobr style="font-family:monospace">{{ .As }}</nobr></a></h2>
-<p id="documentation">{{ .Documentation }}</p>
-<h2 id="image"><a href="#image">Container image used for this step: <span style="font-family:monospace">{{ .From }}</span></a></h2>
+<h2 id="title"><a href="#title">Step:</a> <nobr style="font-family:monospace">{{ .Reference.As }}</nobr></h2>
+<p id="documentation">{{ .Reference.Documentation }}</p>
+<h2 id="image"><a href="#image">Container image used for this step:</a> <span style="font-family:monospace">{{ .Reference.From }}</span></h2>
 <h2 id="source"><a href="#source">Source Code</a></h2>
-{{ syntaxedSource .Commands }}
+{{ syntaxedSource .Reference.Commands }}
+<h2 id="github"><a href="#github">GitHub Link:</a></h2>{{ githubLink .Metadata.Path }}
+{{ ownersBlock .Metadata.Owners }}
 `
 
 const chainPage = `
-<h2 id="title"><a href="#title">Chains: <nobr style="font-family:monospace">{{ .As }}</nobr></a></h2>
-<p id="documentation">{{ .Documentation }}</p>
+<h2 id="title"><a href="#title">Chains:</a> <nobr style="font-family:monospace">{{ .Chain.As }}</nobr></h2>
+<p id="documentation">{{ .Chain.Documentation }}</p>
 <h2 id="steps" title="Step run by the chain, in runtime order"><a href="#steps">Steps</a></h2>
-{{ template "stepTable" .Steps}}
+{{ template "stepTable" .Chain.Steps}}
 <h2 id="graph" title="Visual representation of steps run by this chain"><a href="#graph">Step Graph</a></h2>
-{{ chainGraph .As }}
+{{ chainGraph .Chain.As }}
+<h2 id="github"><a href="#github">GitHub Link:</a></h2>{{ githubLink .Metadata.Path }}
+{{ ownersBlock .Metadata.Owners }}
 `
 
 // workflowJobPage defines the template for both jobs and workflows
 const workflowJobPage = `
-{{ $type := .Type }}
-<h2 id="title"><a href="#title">{{ $type }}: <nobr style="font-family:monospace">{{ .As }}</nobr></a></h2>
-{{ if .Documentation }}
-	<p id="documentation">{{ .Documentation }}</p>
+{{ $type := .Workflow.Type }}
+<h2 id="title"><a href="#title">{{ $type }}:</a> <nobr style="font-family:monospace">{{ .Workflow.As }}</nobr></h2>
+{{ if .Workflow.Documentation }}
+	<p id="documentation">{{ .Workflow.Documentation }}</p>
 {{ end }}
-{{ if .Steps.ClusterProfile }}
-	<h2 id="cluster_profile"><a href="#cluster_profile">Cluster Profile: <span style="font-family:monospace">{{ .Steps.ClusterProfile }}</span></a></h2>
+{{ if .Workflow.Steps.ClusterProfile }}
+	<h2 id="cluster_profile"><a href="#cluster_profile">Cluster Profile:</a> <span style="font-family:monospace">{{ .Workflow.Steps.ClusterProfile }}</span></h2>
 {{ end }}
 <h2 id="pre" title="Steps run by this {{ toLower $type }} to set up and configure the tests, in runtime order"><a href="#pre">Pre Steps</a></h2>
-{{ template "stepTable" .Steps.Pre }}
+{{ template "stepTable" .Workflow.Steps.Pre }}
 <h2 id="test" title="Steps in the {{ toLower $type }} that run actual tests, in runtime order"><a href="#test">Test Steps</a></h2>
-{{ template "stepTable" .Steps.Test }}
+{{ template "stepTable" .Workflow.Steps.Test }}
 <h2 id="post" title="Steps run by this {{ toLower $type }} to clean up and teardown test resources, in runtime order"><a href="#post">Post Steps</a></h2>
-{{ template "stepTable" .Steps.Post }}
+{{ template "stepTable" .Workflow.Steps.Post }}
 <h2 id="graph" title="Visual representation of steps run by this {{ toLower $type }}"><a href="#graph">Step Graph</a></h2>
-{{ workflowGraph .As .Type }}
+{{ workflowGraph .Workflow.As .Workflow.Type }}
+{{ if eq $type "Workflow" }}
+<h2 id="github"><a href="#github">GitHub Link:</a></h2>{{ githubLink .Metadata.Path }}
+{{ ownersBlock .Metadata.Owners }}
+{{ end }}
 `
 
 const jobSearchPage = `
@@ -1821,6 +1831,45 @@ func orgSpan(o Org, containsVariant bool) int {
 	return rowspan + 1
 }
 
+func githubLink(path string) template.HTML {
+	link := fmt.Sprintf("https://github.com/openshift/release/blob/master/ci-operator/step-registry/%s", path)
+	return template.HTML(fmt.Sprintf("<a href=\"%s\">%s</a>", link, link))
+}
+
+func createHTMLList(items []string) string {
+	var builder strings.Builder
+	builder.WriteString("<ul>")
+	for _, item := range items {
+		builder.WriteString("\n<li>")
+		builder.WriteString(item)
+		builder.WriteString("</li>")
+	}
+	builder.WriteString("</ul>")
+	return builder.String()
+}
+
+func ownersBlock(owners repoowners.Config) template.HTML {
+	var builder strings.Builder
+	builder.WriteString("<h2 id=\"owners\"><a href=\"#owners\">Owners:</a></h2>")
+	if len(owners.Approvers) > 0 {
+		builder.WriteString("<h4 id=\"approvers\"><a href=\"#approvers\">Approvers:</a></h4>\n")
+		builder.WriteString(createHTMLList(owners.Approvers))
+	}
+	if len(owners.Reviewers) > 0 {
+		builder.WriteString("<h4 id=\"reviewers\"><a href=\"#reviewers\">Reviewers:</a></h4>\n")
+		builder.WriteString(createHTMLList(owners.Reviewers))
+	}
+	if len(owners.RequiredReviewers) > 0 {
+		builder.WriteString("<h4 id=\"required_reviewers\"><a href=\"#required_reviewers\">Required Reviewers:</a></h4>\n")
+		builder.WriteString(createHTMLList(owners.RequiredReviewers))
+	}
+	if len(owners.Labels) > 0 {
+		builder.WriteString("<h4 id=\"labels\"><a href\"#labels\">Labels:</a></h4>\n")
+		builder.WriteString(createHTMLList(owners.Labels))
+	}
+	return template.HTML(builder.String())
+}
+
 func getBaseTemplate(workflows registry.WorkflowByName, chains registry.ChainByName, docs map[string]string) *template.Template {
 	base := template.New("baseTemplate").Funcs(
 		template.FuncMap{
@@ -1854,6 +1903,8 @@ func getBaseTemplate(workflows registry.WorkflowByName, chains registry.ChainByN
 			"doubleInc": func(i int) int {
 				return i + 2
 			},
+			"githubLink":  githubLink,
+			"ownersBlock": ownersBlock,
 		},
 	)
 	base, err := base.Parse(templateDefinitions)
@@ -2053,7 +2104,7 @@ func mainPageHandler(agent agents.RegistryAgent, templateString string, w http.R
 	defer func() { logrus.Infof("rendered in %s", time.Since(start)) }()
 
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
-	refs, chains, wfs, docs := agent.GetRegistryComponents()
+	refs, chains, wfs, docs, _ := agent.GetRegistryComponents()
 	page := getBaseTemplate(wfs, chains, docs)
 	page, err := page.Parse(templateString)
 	if err != nil {
@@ -2161,24 +2212,37 @@ func referenceHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *ht
 				}
 				return template.HTML(formatted)
 			},
+			"githubLink":  githubLink,
+			"ownersBlock": ownersBlock,
 		},
 	).Parse(referencePage)
 	if err != nil {
 		writeErrorPage(w, fmt.Errorf("Failed to render page: %w", err), http.StatusInternalServerError)
 		return
 	}
-	refs, _, _, docs := agent.GetRegistryComponents()
+	refs, _, _, docs, metadata := agent.GetRegistryComponents()
 	if _, ok := refs[name]; !ok {
 		writeErrorPage(w, fmt.Errorf("Could not find reference `%s`. If you reached this page via a link provided in the logs of a failed test, the failed step may be a literal defined step, which does not exist in the step registry. Please look at the job info page for the failed test instead.", name), http.StatusNotFound)
 		return
 	}
-	ref := api.RegistryReference{
-		LiteralTestStep: api.LiteralTestStep{
-			As:       name,
-			Commands: refs[name].Commands,
-			From:     refs[name].From,
+	refMetadataName := fmt.Sprint(name, load.RefSuffix)
+	if _, ok := metadata.Metadata[refMetadataName]; !ok {
+		writeErrorPage(w, fmt.Errorf("Could not find metadata for file `%s`. Please contact the Developer Productivity Test Platform.", refMetadataName), http.StatusInternalServerError)
+		return
+	}
+	ref := struct {
+		Reference api.RegistryReference
+		Metadata  api.RegistryInfo
+	}{
+		Reference: api.RegistryReference{
+			LiteralTestStep: api.LiteralTestStep{
+				As:       name,
+				Commands: refs[name].Commands,
+				From:     refs[name].From,
+			},
+			Documentation: docs[name],
 		},
-		Documentation: docs[name],
+		Metadata: metadata.Metadata[refMetadataName],
 	}
 	writePage(w, "Registry Step Help Page", page, ref)
 }
@@ -2189,8 +2253,8 @@ func chainHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.R
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	name := path.Base(req.URL.Path)
 
-	_, chains, wfs, docs := agent.GetRegistryComponents()
-	page := getBaseTemplate(wfs, chains, docs)
+	_, chains, _, docs, metadata := agent.GetRegistryComponents()
+	page := getBaseTemplate(nil, chains, docs)
 	page, err := page.Parse(chainPage)
 	if err != nil {
 		writeErrorPage(w, fmt.Errorf("Failed to render page: %w", err), http.StatusInternalServerError)
@@ -2200,10 +2264,21 @@ func chainHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *http.R
 		writeErrorPage(w, fmt.Errorf("Could not find chain %s", name), http.StatusNotFound)
 		return
 	}
-	chain := api.RegistryChain{
-		As:            name,
-		Documentation: docs[name],
-		Steps:         chains[name].Steps,
+	chainMetadataName := fmt.Sprint(name, load.ChainSuffix)
+	if _, ok := metadata.Metadata[chainMetadataName]; !ok {
+		writeErrorPage(w, fmt.Errorf("Could not find metadata for file `%s`. Please contact the Developer Productivity Test Platform.", chainMetadataName), http.StatusInternalServerError)
+		return
+	}
+	chain := struct {
+		Chain    api.RegistryChain
+		Metadata api.RegistryInfo
+	}{
+		Chain: api.RegistryChain{
+			As:            name,
+			Documentation: docs[name],
+			Steps:         chains[name].Steps,
+		},
+		Metadata: metadata.Metadata[chainMetadataName],
 	}
 	writePage(w, "Registry Chain Help Page", page, chain)
 }
@@ -2214,7 +2289,7 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	name := path.Base(req.URL.Path)
 
-	_, chains, workflows, docs := agent.GetRegistryComponents()
+	_, chains, workflows, docs, metadata := agent.GetRegistryComponents()
 	page := getBaseTemplate(workflows, chains, docs)
 	page, err := page.Parse(workflowJobPage)
 	if err != nil {
@@ -2225,13 +2300,24 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 		writeErrorPage(w, fmt.Errorf("Could not find workflow %s", name), http.StatusNotFound)
 		return
 	}
-	workflow := workflowJob{
-		RegistryWorkflow: api.RegistryWorkflow{
-			As:            name,
-			Documentation: docs[name],
-			Steps:         workflows[name],
-		},
-		Type: workflowType}
+	workflowMetadataName := fmt.Sprint(name, load.WorkflowSuffix)
+	if _, ok := metadata.Metadata[workflowMetadataName]; !ok {
+		writeErrorPage(w, fmt.Errorf("Could not find metadata for file `%s`. Please contact the Developer Productivity Test Platform.", workflowMetadataName), http.StatusInternalServerError)
+		return
+	}
+	workflow := struct {
+		Workflow workflowJob
+		Metadata api.RegistryInfo
+	}{
+		Workflow: workflowJob{
+			RegistryWorkflow: api.RegistryWorkflow{
+				As:            name,
+				Documentation: docs[name],
+				Steps:         workflows[name],
+			},
+			Type: workflowType},
+		Metadata: metadata.Metadata[workflowMetadataName],
+	}
 	writePage(w, "Registry Workflow Help Page", page, workflow)
 }
 
@@ -2310,18 +2396,25 @@ func jobHandler(regAgent agents.RegistryAgent, confAgent agents.ConfigAgent, w h
 	}
 	// TODO(apavel): support jobs other than presubmits
 	name := metadata.JobName("pull", test)
-	_, chains, workflows, docs := regAgent.GetRegistryComponents()
-	workflow, docs := jobToWorkflow(name, config, workflows, docs)
+	_, chains, workflows, docs, _ := regAgent.GetRegistryComponents()
+	jobWorkflow, docs := jobToWorkflow(name, config, workflows, docs)
 	updatedWorkflows := make(registry.WorkflowByName)
 	for k, v := range workflows {
 		updatedWorkflows[k] = v
 	}
-	updatedWorkflows[name] = workflow.Steps
+	updatedWorkflows[name] = jobWorkflow.Steps
 	page := getBaseTemplate(updatedWorkflows, chains, docs)
 	page, err = page.Parse(workflowJobPage)
 	if err != nil {
 		writeErrorPage(w, fmt.Errorf("Failed to render page: %w", err), http.StatusInternalServerError)
 		return
+	}
+	workflow := struct {
+		Workflow workflowJob
+		Metadata api.RegistryInfo
+	}{
+		Workflow: jobWorkflow,
+		Metadata: api.RegistryInfo{},
 	}
 	writePage(w, "Job Test Workflow Help Page", page, workflow)
 }


### PR DESCRIPTION
This PR adds github links and owner information for all registry
components in the `configresolver` web UI using the registry metadata.

This PR also exposes the registry component suffixes and replaces all
hardcoded suffix values across all packages with the exposed consts to
prevent typos and make potential future refactors easier.