### PR TITLE
images/generate-registry-metadata: install diffutils

### DIFF
--- a/images/generate-registry-metadata/Dockerfile
+++ b/images/generate-registry-metadata/Dockerfile
@@ -1,5 +1,9 @@
 FROM centos:8
 LABEL maintainer="apavel@redhat.com"
 
+RUN yum install -y diffutils && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
 ADD generate-registry-metadata /usr/bin/generate-registry-metadata
 ENTRYPOINT ["/usr/bin/generate-registry-metadata"]


### PR DESCRIPTION
Apparently, diff isn't included by default in the centos:8 image so
diffutils needs to be installed.