### PR TITLE
applyconfig: handle properly the relative path of a symlink

### DIFF
--- a/cmd/applyconfig/applyconfig.go
+++ b/cmd/applyconfig/applyconfig.go
@@ -211,15 +211,13 @@ func applyConfig(rootDir string, o *options) error {
 		// oc-cli works with the symlinks targeting files
 		// here we need to handle symlinks targeting folders recursively
 		if info.Mode()&os.ModeSymlink != 0 {
-			target, err := os.Readlink(path)
+			target, err := filepath.EvalSymlinks(path)
 			if err != nil {
-				logrus.WithError(err).Errorf("failed to readlink: %s", path)
-				failures = true
+				return fmt.Errorf("failed to readlink %s: %w", path, err)
 			}
 			targetFileInfo, err := os.Stat(target)
 			if err != nil {
-				logrus.WithError(err).Errorf("failed to Stat: %s", target)
-				failures = true
+				return fmt.Errorf("failed to Stat %s: %w", target, err)
 			}
 			if targetFileInfo.IsDir() {
 				logrus.Infof("replace the symlink folder %s with the target %s", path, target)


### PR DESCRIPTION
ref. https://stackoverflow.com/questions/18062026/resolve-symlinks-in-go/28249042
and also tested locally with the folder in release repo (i should have done this in the last round)

Fix https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/10545/pull-ci-openshift-release-master-vsphere-dry/1288841842586030080#1:build-log.txt%3A28

/cc @alvaroaleman @stevekuznetsov 