### PR TITLE
Config Agent: Fix data race

### DIFF
--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -188,9 +188,8 @@ func (a *configAgent) loadFilenameToConfig() error {
 		return fmt.Errorf("loading config failed: %w", err)
 	}
 
-	indexes := a.buildIndexes(configs)
-
 	a.lock.Lock()
+	indexes := a.buildIndexes(configs)
 	a.configs = configs
 	a.generation++
 	a.indexes = indexes


### PR DESCRIPTION
We need to hold the lock when building the index, otherwise a different
routine might manipulate the index map while we are still iterator over
it.

Sample:
==================
WARNING: DATA RACE
Read at 0x00c0002fe808 by goroutine 54:
  github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).buildIndexes()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:206 +0x6c
  github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).loadFilenameToConfig()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:191 +0x230
  github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).loadFilenameToConfig-fm()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:183 +0x44
  github.com/openshift/ci-tools/pkg/coalescer.(*coalescer).Run.func1()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/coalescer/coalescer.go:40 +0xb2
  sync.(*Once).doSlow()
      /usr/local/go/src/sync/once.go:66 +0x109
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:57 +0x68
  github.com/openshift/ci-tools/pkg/coalescer.(*coalescer).Run()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/coalescer/coalescer.go:34 +0xb8
  github.com/openshift/ci-tools/pkg/load/agents.NewConfigAgent.func1()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:90 +0x4a
  k8s.io/test-infra/prow/interrupts.Tick.func1()
      /home/alvaro/git/golang/pkg/mod/k8s.io/test-infra@v0.0.0-20200725055416-2388ca759f42/prow/interrupts/interrupts.go:221 +0xa5

Previous write at 0x00c0002fe808 by main goroutine:
  github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).AddIndex.func1()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:164 +0x2e9
  github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).AddIndex()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/pkg/load/agents/configAgent.go:171 +0x69
  main.pullSpecForOrgRepoBranchDockerfileFactory()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/cmd/ocp-build-data-enforcer/ci_op.go:19 +0x81
  main.main()
      /home/alvaro/git/golang/src/github.com/openshift/ci-tools/cmd/ocp-build-data-enforcer/main.go:50 +0x2a4