### PR TITLE
ipi-deprovision: send SIGQUIT to installer on timeout

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -53,7 +53,7 @@ EOF
 done
 
 for workdir in $( find /tmp/deprovision -mindepth 1 -type d | shuf ); do
-  timeout 30m openshift-install --dir "${workdir}" --log-level debug destroy cluster
+  timeout --signal=SIGQUIT 30m openshift-install --dir "${workdir}" --log-level debug destroy cluster
 done
 
 gcs_bucket_age_cutoff="$(TZ="GMT" date --date="${CLUSTER_TTL}-4 hours" '+%a, %d %b %Y %H:%M:%S GMT')"


### PR DESCRIPTION
In order to see what the installer is up to, we should send SIGQUIT on
timeout so that the Go runtime prints the active stack trace.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>