### PR TITLE
[pkg/report] fix result's report message

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -123,7 +123,13 @@ func (r *reporter) Report(err error) {
 		logrus.Tracef("could not marshal request: %v", err)
 		return
 	}
-	logrus.Infof("Reporting job state %q with reason %q", request.State, request.Reason)
+
+	reportMsg := fmt.Sprintf("Reporting job state '%s'", request.State)
+	if state != StateSucceeded {
+		reportMsg = fmt.Sprintf("Reporting job state '%s' with reason '%s'", request.State, request.Reason)
+	}
+
+	logrus.Infof(reportMsg)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/result", r.address), bytes.NewReader(data))
 	if err != nil {
 		logrus.Tracef("could not create report request: %v", err)


### PR DESCRIPTION
before
```
level=info msg="Reporting job state \"succeeded\" with reason \"unknown\""
```

after
```
level=info msg="Reporting job state 'succeeded'"
level=info msg="Reporting job state 'failed' with reason 'something'"
```

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>