### PR TITLE
perform a merge when depth is shallow out and push was still failing

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -379,9 +379,11 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 
 		switch strings.TrimSpace(shallowOut) {
 		case "false":
-			message := "failed to push to destination, no retry possible (already fetched full history)"
-			logger.Error(message)
-			return nil, fmt.Errorf(message)
+			logger.Info("Trying to fetch source and destination full history and perform a merge")
+			if err := mergeRemotesAndPush(logger, g.git, repoDir, srcRemote, dst.branch, destUrl.String(), g.confirm, g.gitName, g.gitEmail); err != nil {
+				return nil, fmt.Errorf("failed to fetch remote and merge: %w", err)
+			}
+			return nil, nil
 		case "true":
 			depth++
 			return makeFetch(logger, repoDir, g.git, srcRemote, src.branch, depth), nil


### PR DESCRIPTION
The problem is described in https://issues.redhat.com/browse/DPTP-1419

It seems that we hit a special case where the commits are less than 8 and the push was still failing.

/cc @openshift/openshift-team-developer-productivity-test-platform @jupierce 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>