### PR TITLE
Fix race in configagents

### DIFF
--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -191,6 +191,7 @@ func (a *configAgent) AddIndex(indexName string, indexFunc IndexFn) error {
 
 // loadFilenameToConfig generates a new filenameToConfig map.
 func (a *configAgent) loadFilenameToConfig() error {
+	a.lock.Lock()
 	logrus.Debug("Reloading configs")
 	startTime := time.Now()
 	configs, err := load.FromPathByOrgRepo(a.configPath)
@@ -198,7 +199,6 @@ func (a *configAgent) loadFilenameToConfig() error {
 		return fmt.Errorf("loading config failed: %w", err)
 	}
 
-	a.lock.Lock()
 	indexes := a.buildIndexes(configs)
 	a.configs = configs
 	a.generation++

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -118,6 +118,7 @@ func (a *registryAgent) GetRegistryComponents() (registry.ReferenceByName, regis
 }
 
 func (a *registryAgent) loadRegistry() error {
+	a.lock.Lock()
 	logrus.Debug("Reloading registry")
 	startTime := time.Now()
 	references, chains, workflows, documentation, metadata, err := load.Registry(a.registryPath, a.flatRegistry)
@@ -125,7 +126,6 @@ func (a *registryAgent) loadRegistry() error {
 		a.recordError("failed to load ci-operator registry")
 		return fmt.Errorf("failed to load ci-operator registry (%w)", err)
 	}
-	a.lock.Lock()
 	a.references = references
 	a.chains = chains
 	a.workflows = workflows


### PR DESCRIPTION
We need to hold the lock during loading, otherwise:
1. Routine A loads
2. A new event comes in, routine B loads as well
3. Routine b finishes, acquires lock, sets config, releases lock
4. Routine a finishes, acquires lock, sets config, releases lock

We now have an outdated config.

/assign @bbguimaraes 