### PR TITLE
ci-operator: explicitly name ephemeral releases

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -99,7 +99,7 @@ use the following specification:
 
 ```yaml
 tag_specification:
-  name: origin-v3.11
+  name: "4.1"
   namespace: openshift
   tag_overrides: {}
 ```

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -43,7 +43,7 @@ func TestFromCIOperatorConfigToProwYaml(t *testing.T) {
 			branch:    "branch",
 			configYAML: []byte(`base_images:
   base:
-    name: origin-v3.11
+    name: "4.1"
     namespace: openshift
     tag: base
 build_root:
@@ -61,7 +61,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: origin-v3.11
+  name: "4.1"
   namespace: openshift
   tag: ''
 promotion:
@@ -82,7 +82,7 @@ tests:
 			variant:   "rhel",
 			configYAML: []byte(`base_images:
   base:
-    name: origin-v3.11
+    name: "4.1"
     namespace: openshift
     tag: base
 build_root:
@@ -100,7 +100,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: origin-v3.11
+  name: "4.1"
   namespace: openshift
   tag: ''
 promotion:
@@ -144,7 +144,7 @@ tests:
 			branch:    "branch",
 			configYAML: []byte(`base_images:
   base:
-    name: origin-v3.11
+    name: "4.1"
     namespace: openshift
     tag: base
 images:
@@ -157,7 +157,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: origin-v3.11
+  name: "4.1"
   namespace: openshift
   tag: ''
 promotion:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -223,11 +223,18 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 	var validationErrors []error
 
 	if len(input.Namespace) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("%s: no namespace defined", fieldRoot))
+		validationErrors = append(validationErrors, fmt.Errorf("%s.namespace: must be set", fieldRoot))
 	}
 
 	if len(input.Name) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("%s: no name defined", fieldRoot))
+		validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be set", fieldRoot))
+	} else {
+		ok, err := regexp.MatchString(`4\.[0-9]+`, input.Name)
+		if err != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be of the form 4.x, failed to parse %q: %w", fieldRoot, input.Name, err))
+		} else if !ok {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be of the form 4.<minor>, not %q", fieldRoot, input.Name))
+		}
 	}
 
 	return validationErrors

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -200,7 +200,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
+			release:       &ReleaseTagConfiguration{Name: "4.1"},
 			expectedValid: true,
 		},
 		{
@@ -941,8 +941,28 @@ func TestValidateReleaseTagConfiguration(t *testing.T) {
 	}{
 		{
 			name:     "valid tag_specification",
-			input:    ReleaseTagConfiguration{Name: "test", Namespace: "test"},
+			input:    ReleaseTagConfiguration{Name: "4.3", Namespace: "ocp"},
 			expected: nil,
+		},
+		{
+			name:     "missing namespace",
+			input:    ReleaseTagConfiguration{Name: "4.3"},
+			expected: []error{errors.New("tag_specification.namespace: must be set")},
+		},
+		{
+			name:     "missing name",
+			input:    ReleaseTagConfiguration{Namespace: "ocp"},
+			expected: []error{errors.New("tag_specification.name: must be set")},
+		},
+		{
+			name:     "missing all",
+			input:    ReleaseTagConfiguration{},
+			expected: []error{errors.New("tag_specification.namespace: must be set"), errors.New("tag_specification.name: must be set")},
+		},
+		{
+			name:     "invalid name",
+			input:    ReleaseTagConfiguration{Name: "test", Namespace: "ocp"},
+			expected: []error{errors.New("tag_specification.name: must be of the form 4.<minor>, not \"test\"")},
 		},
 	}
 	for _, testCase := range testCases {

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
@@ -1,6 +1,6 @@
 base_images:
   base:
-    name: origin-v3.11
+    name: "4.1"
     namespace: openshift
     tag: base
 build_root:
@@ -23,7 +23,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: origin-v3.11
+  name: "4.1"
   namespace: openshift
 tests:
 - as: unit


### PR DESCRIPTION
In order to allow users to inspect the version of the cluster that they
are interacting with, we use the MAJOR.MINOR version from the imported
release context in order to create a test-specific version that follows
the format used for production versions, nightlies, and CI candidates.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>


```
$ oc adm release info registry.svc.ci.openshift.org/ci-op-kh0zrk59/release:latest
Name:      4.5.0-0.test-2020-08-05-191240-ci-op-kh0zrk59
Digest:    sha256:225640962cefbb1a9c5a842287de3d054838a684442f5e04017365d1883b8002
Created:   2020-08-05T19:12:53Z
OS/Arch:   linux/amd64
Manifests: 419

Pull From: registry.svc.ci.openshift.org/ci-op-kh0zrk59/release@sha256:225640962cefbb1a9c5a842287de3d054838a684442f5e04017365d1883b8002

Release Metadata:
  Version:  4.5.0-0.test-2020-08-05-191240-ci-op-kh0zrk59
  Upgrades: <none>

Component Versions:
  Kubernetes 1.18.3
  Machine Os 45.82.202008010929-0

Images:
  NAME                                           DIGEST
  aws-machine-controllers                        sha256:36956f93b880f07a02676a327a0156e74a4dd81e89569df8fe9d3a20a39dcbb4
...
```