### PR TITLE
Keep ssh bastion jobs on api.ci

### DIFF
--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -363,3 +363,40 @@ func TestMatchingPathRegEx(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSSHBastionJob(t *testing.T) {
+	testCases := []struct {
+		name     string
+		base     prowconfig.JobBase
+		expected bool
+	}{
+		{
+			name: "matching label: false",
+			base: prowconfig.JobBase{
+				Name: "some-job",
+				Labels: map[string]string{
+					"dptp.openshift.io/non-ssh-bastion": "true",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "matching label: true",
+			base: prowconfig.JobBase{
+				Name: "some-job",
+				Labels: map[string]string{
+					"dptp.openshift.io/ssh-bastion": "true",
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := isSSHBastionJob(tc.base)
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expected, actual))
+			}
+		})
+	}
+}

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -24,6 +24,7 @@ type ProwgenLabel string
 const (
 	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
 	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
+	SSHBastionLabel                    = "dptp.openshift.io/ssh-bastion"
 	ProwJobLabelVariant                = "ci-operator.openshift.io/variant"
 	Generated             ProwgenLabel = "true"
 	New                   ProwgenLabel = "newly-generated"


### PR DESCRIPTION
After merge (this should not be a breaking change), I will contact authors of each bastion in https://github.com/openshift/release/tree/master/core-services/sshd-bastion/ to ask them add the label `"dptp.openshift.io/ssh-bastion": "true"` to the jobs which uses the bastions.

/cc @stevekuznetsov @alvaroaleman @bbguimaraes 