### PR TITLE
Revert "ci-operator: explicitly name ephemeral releases"

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -99,7 +99,7 @@ use the following specification:
 
 ```yaml
 tag_specification:
-  name: "4.1"
+  name: origin-v3.11
   namespace: openshift
   tag_overrides: {}
 ```

--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -43,7 +43,7 @@ func TestFromCIOperatorConfigToProwYaml(t *testing.T) {
 			branch:    "branch",
 			configYAML: []byte(`base_images:
   base:
-    name: "4.1"
+    name: origin-v3.11
     namespace: openshift
     tag: base
 build_root:
@@ -61,7 +61,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: "4.1"
+  name: origin-v3.11
   namespace: openshift
   tag: ''
 promotion:
@@ -82,7 +82,7 @@ tests:
 			variant:   "rhel",
 			configYAML: []byte(`base_images:
   base:
-    name: "4.1"
+    name: origin-v3.11
     namespace: openshift
     tag: base
 build_root:
@@ -100,7 +100,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: "4.1"
+  name: origin-v3.11
   namespace: openshift
   tag: ''
 promotion:
@@ -144,7 +144,7 @@ tests:
 			branch:    "branch",
 			configYAML: []byte(`base_images:
   base:
-    name: "4.1"
+    name: origin-v3.11
     namespace: openshift
     tag: base
 images:
@@ -157,7 +157,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: "4.1"
+  name: origin-v3.11
   namespace: openshift
   tag: ''
 promotion:

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -223,18 +223,11 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 	var validationErrors []error
 
 	if len(input.Namespace) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("%s.namespace: must be set", fieldRoot))
+		validationErrors = append(validationErrors, fmt.Errorf("%s: no namespace defined", fieldRoot))
 	}
 
 	if len(input.Name) == 0 {
-		validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be set", fieldRoot))
-	} else {
-		ok, err := regexp.MatchString(`4\.[0-9]+`, input.Name)
-		if err != nil {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be of the form 4.x, failed to parse %q: %w", fieldRoot, input.Name, err))
-		} else if !ok {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be of the form 4.<minor>, not %q", fieldRoot, input.Name))
-		}
+		validationErrors = append(validationErrors, fmt.Errorf("%s: no name defined", fieldRoot))
 	}
 
 	return validationErrors

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -200,7 +200,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			release:       &ReleaseTagConfiguration{Name: "4.1"},
+			release:       &ReleaseTagConfiguration{Name: "origin-v3.11"},
 			expectedValid: true,
 		},
 		{
@@ -941,28 +941,8 @@ func TestValidateReleaseTagConfiguration(t *testing.T) {
 	}{
 		{
 			name:     "valid tag_specification",
-			input:    ReleaseTagConfiguration{Name: "4.3", Namespace: "ocp"},
+			input:    ReleaseTagConfiguration{Name: "test", Namespace: "test"},
 			expected: nil,
-		},
-		{
-			name:     "missing namespace",
-			input:    ReleaseTagConfiguration{Name: "4.3"},
-			expected: []error{errors.New("tag_specification.namespace: must be set")},
-		},
-		{
-			name:     "missing name",
-			input:    ReleaseTagConfiguration{Namespace: "ocp"},
-			expected: []error{errors.New("tag_specification.name: must be set")},
-		},
-		{
-			name:     "missing all",
-			input:    ReleaseTagConfiguration{},
-			expected: []error{errors.New("tag_specification.namespace: must be set"), errors.New("tag_specification.name: must be set")},
-		},
-		{
-			name:     "invalid name",
-			input:    ReleaseTagConfiguration{Name: "test", Namespace: "ocp"},
-			expected: []error{errors.New("tag_specification.name: must be of the form 4.<minor>, not \"test\"")},
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -175,11 +175,6 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		return results.ForReason("missing_release").WithError(err).Errorf("could not resolve imagestream %s: %v", streamName, err)
 	}
 
-	// we want to expose the release payload as a CI version that looks just like
-	// the release versions for nightlies and CI release candidates
-	now := time.Now().UTC().Truncate(time.Second)
-	version := fmt.Sprintf("%s.0-0.test-%s-%s", s.config.Name, now.Format("2006-01-02-150405"), s.jobSpec.Namespace())
-
 	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	log.Printf("Create release image %s", destination)
 	podConfig := steps.PodStepConfiguration{
@@ -195,9 +190,9 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 set -euo pipefail
 export HOME=/tmp
 oc registry login
-oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q --name %q
+oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
 oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
-`, s.jobSpec.Namespace(), streamName, cvo, destination, version, destination, s.name),
+`, s.jobSpec.Namespace(), streamName, cvo, destination, destination, s.name),
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
@@ -1,6 +1,6 @@
 base_images:
   base:
-    name: "4.1"
+    name: origin-v3.11
     namespace: openshift
     tag: base
 build_root:
@@ -23,7 +23,7 @@ resources:
     requests:
       cpu: 10Mi
 tag_specification:
-  name: "4.1"
+  name: origin-v3.11
   namespace: openshift
 tests:
 - as: unit


### PR DESCRIPTION
This reverts commit 97562d95c1bb7fcadc3953db9974b7c1ff4e69d5.

```json
{"component":"dptp-controller-manager","error":"failed to laod config: loading config failed: invalid ci-operator config: invalid configuration: tag_specification.name: must be of the form 4.\u003cminor\u003e, not \"origin-v3.11\"","file":"/go/src/github.com/openshift/ci-tools/cmd/dptp-controller-manager/main.go:190","func":"main.main","level":"fatal","msg":"Failed to construct ci-opeartor config agent","severity":"fatal","time":"2020-08-05T20:44:09Z"}
```

/cc @stevekuznetsov @alvaroaleman 