### PR TITLE
ci-operator: ensure a one-to-one mapping from Dockerfile to image

### DIFF
--- a/test/integration/pj-rehearse/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/config/super/duper/super-duper-ciop-cfg-change.yaml
@@ -13,6 +13,7 @@ images:
   to: test-image
 - from: base
   to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
+  context_dir: somewhere
 resources:
   '*':
     limits:

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -219,7 +219,8 @@
             images:
             - from: base
               to: test-image
-            - from: base
+            - context_dir: somewhere
+              from: base
               to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
             resources:
               '*':
@@ -339,7 +340,8 @@
             images:
             - from: base
               to: test-image
-            - from: base
+            - context_dir: somewhere
+              from: base
               to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
             resources:
               '*':
@@ -448,7 +450,8 @@
             images:
             - from: base
               to: test-image
-            - from: base
+            - context_dir: somewhere
+              from: base
               to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
             resources:
               '*':
@@ -556,7 +559,8 @@
             images:
             - from: base
               to: test-image
-            - from: base
+            - context_dir: somewhere
+              from: base
               to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
             resources:
               '*':


### PR DESCRIPTION
We cannot allow two unique image names to be promoted after
being built from the same Dockerfile, as that would make it
impossible to take the build configuration in ocp-build-data
and determine the image build in CI that corresponds with it.
Technically, the validation we do here is more stringent --
in the most specific case it could be possible to build two
images from one Dockerfile if both were not promoted. However,
there is no real utility to that complex analysis and it's
easy and simple to enforce the stronger restriction that no
two images are built from the same Dockerfile at all.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>