### PR TITLE
[publicize] exit with error if merge won't succeed

### DIFF
--- a/cmd/publicize/server.go
+++ b/cmd/publicize/server.go
@@ -166,8 +166,13 @@ func (s *server) mergeAndPushToRemote(destOrg, destRepo string, sourceRemoteReso
 		return fmt.Errorf("couldn't set config user.name=%s: %w", s.gitEmail, err)
 	}
 
-	if merged, err := repoClient.MergeWithStrategy("FETCH_HEAD", "merge", git.MergeOpt{CommitMessage: mergeMsg}); err != nil && !merged {
-		return fmt.Errorf("couldn't merge FETCH_HEAD: %w", err)
+	merged, err := repoClient.MergeWithStrategy("FETCH_HEAD", "merge", git.MergeOpt{CommitMessage: mergeMsg})
+	if err != nil {
+		return fmt.Errorf("couldn't merge %s/%s, merge --abort failed with reason: %w", destOrg, destRepo, err)
+	}
+
+	if !merged {
+		return fmt.Errorf("couldn't merge %s/%s, possible because of a merge conflict", destOrg, destRepo)
 	}
 
 	if !dry {


### PR DESCRIPTION
On a merge error the upstream code already tries to `merge --abort`, and if that fail to then it returns an error. Otherwise, the error will be nil and the merged bool will be false. The previous implementation caused the tool to continue on a merge error. This PR fixes that.

/cc @openshift/openshift-team-developer-productivity-test-platform @jupierce 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>