### PR TITLE
ci-operator: add support for building operator index images

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -302,18 +302,13 @@ func validateImages(fieldRoot string, input []ProjectDirectoryImageBuildStepConf
 
 func validateOperator(fieldRoot string, input *OperatorStepConfiguration) []error {
 	var validationErrors []error
-	if len(input.Substitutions) > 0 {
-		if len(input.Manifests) == 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.substitute: %s.operator_manifests must also be set", fieldRoot, fieldRoot))
+	for num, sub := range input.Substitutions {
+		fieldRootN := fmt.Sprintf("%s.substitute[%d]", fieldRoot, num)
+		if sub.PullSpec == "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.pullspec: must be set", fieldRootN))
 		}
-		for num, sub := range input.Substitutions {
-			fieldRootN := fmt.Sprintf("%s.substitute[%d]", fieldRoot, num)
-			if sub.PullSpec == "" {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.pullspec: must be set", fieldRootN))
-			}
-			if sub.With == "" {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.with: must be set", fieldRootN))
-			}
+		if sub.With == "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.with: must be set", fieldRootN))
 		}
 	}
 	return validationErrors

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1536,7 +1536,6 @@ func TestValidateOperator(t *testing.T) {
 	}{{
 		name: "missing a substitution.pullspec and a substitution.with",
 		input: &OperatorStepConfiguration{
-			Manifests: []string{"manifests"},
 			Substitutions: []PullSpecSubstitution{{
 				PullSpec: "original",
 				With:     "substitute",
@@ -1549,17 +1548,6 @@ func TestValidateOperator(t *testing.T) {
 		output: []error{
 			errors.New("operator.substitute[1].with: must be set"),
 			errors.New("operator.substitute[2].pullspec: must be set"),
-		},
-	}, {
-		name: "substitution set without manifests",
-		input: &OperatorStepConfiguration{
-			Substitutions: []PullSpecSubstitution{{
-				PullSpec: "original",
-				With:     "substitute",
-			}},
-		},
-		output: []error{
-			errors.New("operator.substitute: operator.operator_manifests must also be set"),
 		},
 	}}
 	for _, testCase := range testCases {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -394,6 +394,7 @@ type StepConfiguration struct {
 	PipelineImageCacheStepConfiguration         *PipelineImageCacheStepConfiguration         `json:"pipeline_image_cache_step,omitempty"`
 	SourceStepConfiguration                     *SourceStepConfiguration                     `json:"source_step,omitempty"`
 	BundleSourceStepConfiguration               *BundleSourceStepConfiguration               `json:"bundle_source_step,omitempty"`
+	IndexGeneratorStepConfiguration             *IndexGeneratorStepConfiguration             `json:"index_generator_step,omitempty"`
 	ProjectDirectoryImageBuildStepConfiguration *ProjectDirectoryImageBuildStepConfiguration `json:"project_directory_image_build_step,omitempty"`
 	RPMImageInjectionStepConfiguration          *RPMImageInjectionStepConfiguration          `json:"rpm_image_injection_step,omitempty"`
 	RPMServeStepConfiguration                   *RPMServeStepConfiguration                   `json:"rpm_serve_step,omitempty"`
@@ -1002,6 +1003,17 @@ type SourceStepConfiguration struct {
 	// ClonerefsPath is the path in the above image where the
 	// clonerefs tool is placed
 	ClonerefsPath string `json:"clonerefs_path"`
+}
+
+// IndexGeneratorStepConfiguration describes a step that creates an index database and
+// Dockerfile to build an operator index that uses the generated database based on
+// bundle names provided in OperatorIndex
+type IndexGeneratorStepConfiguration struct {
+	To PipelineImageStreamTagReference `json:"to,omitempty"`
+
+	// OperatorIndex is a list of the names of the bundle images that the
+	// index will contain in its database.
+	OperatorIndex []string `json:"operator_index,omitempty"`
 }
 
 // BundleSourceStepConfiguration describes a step that performs a set of

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1012,15 +1012,17 @@ type SourceStepConfiguration struct {
 // bundle build dockerfiles, and images the operator(s) depends on that must
 // be substituted to run in a CI test cluster
 type OperatorStepConfiguration struct {
-	// DockerfilePath describes the path(s) to the dockerfile(s) that builds the operator bundle
-	DockerfilePath []string `json:"dockerfile_path,omitempty"`
-
-	// Manifests describes the path(s) of the operator manifests that the bundle(s) requires
-	Manifests []string `json:"manifests,omitempty"`
+	// Bundles define a dockerfile and build context to build a bundle
+	Bundles []Bundle `json:"bundles,omitempty"`
 
 	// Substitutions describes the pullspecs in the operator manifests that must be subsituted
 	// with the pull specs of the images in the CI registry
 	Substitutions []PullSpecSubstitution `json:"substitutions,omitempty"`
+}
+
+type Bundle struct {
+	DockerfilePath string `json:"dockerfile_path,omitempty"`
+	ContextDir     string `json:"context_dir,omitempty"`
 }
 
 // IndexGeneratorStepConfiguration describes a step that creates an index database and
@@ -1041,17 +1043,13 @@ const IndexImageGeneratorName = "ci-index-gen"
 const IndexImageName = "ci-index"
 
 // BundleSourceStepConfiguration describes a step that performs a set of
-// substitutions on operator manifests in the `src` image so that the
+// substitutions on all yaml files in the `src` image so that the
 // pullspecs in the operator manifests point to images inside the CI registry.
 // It is intended to be used as the source image for bundle image builds.
 type BundleSourceStepConfiguration struct {
-	// Manifests is the subdir of context_dir where optional
-	// operator manifests are stored for operator bundle images.
-	Manifests []string `json:"operator_manifests,omitempty"`
-
-	// Substitute contains pullspecs that need to be replaced by images
+	// Substitutions contains pullspecs that need to be replaced by images
 	// in the CI cluster for operator bundle images
-	Substitute []PullSpecSubstitution `json:"substitute,omitempty"`
+	Substitutions []PullSpecSubstitution `json:"substitutions,omitempty"`
 }
 
 // BundleSourceName is the name of the bundle source image built by the CI

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -64,6 +64,9 @@ type ReleaseBuildConfiguration struct {
 	// and can be used to build only a specific image.
 	Images []ProjectDirectoryImageBuildStepConfiguration `json:"images,omitempty"`
 
+	// Operator describes the operator bundle(s) that is built by the project
+	Operator *OperatorStepConfiguration `json:"operator,omitempty"`
+
 	// Tests describes the tests to run inside of built images.
 	// The images launched as pods but have no explicit access to
 	// the cluster they are running on.
@@ -1005,6 +1008,21 @@ type SourceStepConfiguration struct {
 	ClonerefsPath string `json:"clonerefs_path"`
 }
 
+// OperatorStepConfiguration describes the locations of operator bundle information,
+// bundle build dockerfiles, and images the operator(s) depends on that must
+// be substituted to run in a CI test cluster
+type OperatorStepConfiguration struct {
+	// DockerfilePath describes the path(s) to the dockerfile(s) that builds the operator bundle
+	DockerfilePath []string `json:"dockerfile_path,omitempty"`
+
+	// Manifests describes the path(s) of the operator manifests that the bundle(s) requires
+	Manifests []string `json:"manifests,omitempty"`
+
+	// Substitutions describes the pullspecs in the operator manifests that must be subsituted
+	// with the pull specs of the images in the CI registry
+	Substitutions []PullSpecSubstitution `json:"substitutions,omitempty"`
+}
+
 // IndexGeneratorStepConfiguration describes a step that creates an index database and
 // Dockerfile to build an operator index that uses the generated database based on
 // bundle names provided in OperatorIndex
@@ -1016,25 +1034,31 @@ type IndexGeneratorStepConfiguration struct {
 	OperatorIndex []string `json:"operator_index,omitempty"`
 }
 
+// IndexImageGeneratorName is the name of the index image generator built by ci-operator
+const IndexImageGeneratorName = "ci-index-gen"
+
+// IndexImageName is the name of the index image built by ci-operator
+const IndexImageName = "ci-index"
+
 // BundleSourceStepConfiguration describes a step that performs a set of
 // substitutions on operator manifests in the `src` image so that the
 // pullspecs in the operator manifests point to images inside the CI registry.
 // It is intended to be used as the source image for bundle image builds.
 type BundleSourceStepConfiguration struct {
-	To PipelineImageStreamTagReference `json:"to,omitempty"`
-
-	// ContextDir is the directory in the project
-	// from which this build should be run.
-	ContextDir string `json:"context_dir,omitempty"`
-
-	// OperatorManifests is the subdir of context_dir where optional
+	// Manifests is the subdir of context_dir where optional
 	// operator manifests are stored for operator bundle images.
-	OperatorManifests string `json:"operator_manifests,omitempty"`
+	Manifests []string `json:"operator_manifests,omitempty"`
 
 	// Substitute contains pullspecs that need to be replaced by images
 	// in the CI cluster for operator bundle images
 	Substitute []PullSpecSubstitution `json:"substitute,omitempty"`
 }
+
+// BundleSourceName is the name of the bundle source image built by the CI
+const BundleSourceName = "src-bundle"
+
+// BundlePrefix is the prefix used by ci-operator for bundle images
+const BundlePrefix = "ci-bundle"
 
 // ProjectDirectoryImageBuildStepConfiguration describes an
 // image build from a directory in a component project.
@@ -1059,14 +1083,6 @@ type ProjectDirectoryImageBuildInputs struct {
 	// DockerfilePath is the path to a Dockerfile in the
 	// project to run relative to the context_dir.
 	DockerfilePath string `json:"dockerfile_path,omitempty"`
-
-	// OperatorManifests is the subdir of context_dir where optional
-	// operator manifests are stored for operator bundle images.
-	OperatorManifests string `json:"operator_manifests,omitempty"`
-
-	// Substitute contains pullspecs that need to be replaced by images
-	// in the CI cluster for operator bundle images
-	Substitute []PullSpecSubstitution `json:"substitute,omitempty"`
 
 	// Inputs is a map of tag reference name to image input changes
 	// that will populate the build context for the Dockerfile or

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -422,12 +422,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 						ImageStreamTagReference: &api.ImageStreamTagReference{Tag: "manual"},
 					},
 				},
-				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
-					To: "operator-bundle",
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-						OperatorManifests: "4.6",
-					},
-				}},
+				Operator: &api.OperatorStepConfiguration{
+					DockerfilePath: []string{"manifests/olm/bundle.Dockerfile"},
+					Manifests:      []string{"manifests/olm/4.6"},
+				},
 			},
 			jobSpec: &api.JobSpec{
 				JobSpec: downwardapi.JobSpec{
@@ -440,13 +438,12 @@ func TestStepConfigsForBuild(t *testing.T) {
 			},
 			output: []api.StepConfiguration{{
 				BundleSourceStepConfiguration: &api.BundleSourceStepConfiguration{
-					To:                "operator-bundle-sub",
-					OperatorManifests: "4.6",
+					Manifests: []string{"manifests/olm/4.6"},
 				},
 			}, {
 				IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
 					To:            "ci-index-gen",
-					OperatorIndex: []string{"operator-bundle"},
+					OperatorIndex: []string{"ci-bundle0"},
 				},
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
@@ -460,8 +457,11 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			}, {
 				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
-					To:                               "operator-bundle",
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{OperatorManifests: "4.6"},
+					To: "ci-bundle0",
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						ContextDir:     "manifests/olm",
+						DockerfilePath: "bundle.Dockerfile",
+					},
 				},
 			}, {
 				SourceStepConfiguration: &api.SourceStepConfiguration{

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -423,8 +423,14 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 				Operator: &api.OperatorStepConfiguration{
-					DockerfilePath: []string{"manifests/olm/bundle.Dockerfile"},
-					Manifests:      []string{"manifests/olm/4.6"},
+					Bundles: []api.Bundle{{
+						ContextDir:     "manifests/olm",
+						DockerfilePath: "bundle.Dockerfile",
+					}},
+					Substitutions: []api.PullSpecSubstitution{{
+						PullSpec: "quay.io/origin/oc",
+						With:     "pipeline:oc",
+					}},
 				},
 			},
 			jobSpec: &api.JobSpec{
@@ -438,7 +444,10 @@ func TestStepConfigsForBuild(t *testing.T) {
 			},
 			output: []api.StepConfiguration{{
 				BundleSourceStepConfiguration: &api.BundleSourceStepConfiguration{
-					Manifests: []string{"manifests/olm/4.6"},
+					Substitutions: []api.PullSpecSubstitution{{
+						PullSpec: "quay.io/origin/oc",
+						With:     "pipeline:oc",
+					}},
 				},
 			}, {
 				IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{

--- a/pkg/steps/bundle_source_test.go
+++ b/pkg/steps/bundle_source_test.go
@@ -9,7 +9,7 @@ import (
 
 	apiimagev1 "github.com/openshift/api/image/v1"
 	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
 )
@@ -84,6 +84,12 @@ RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/op
 RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-hive:4.6?some-reg/target-namespace/stable:metering-hive?g' {} +"]
 RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-metering-hadoop:4.6?some-reg/target-namespace/stable:metering-hadoop?g' {} +"]
 RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/openshift/origin-ghostunnel:4.6?some-reg/target-namespace/stable:ghostunnel?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-metering-ansible-operator:4.6?some-reg/target-namespace/stable:metering-ansible-operator?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-metering-reporting-operator:4.6?some-reg/target-namespace/stable:metering-reporting-operator?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-metering-presto:4.6?some-reg/target-namespace/stable:metering-presto?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-metering-hive:4.6?some-reg/target-namespace/stable:metering-hive?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-metering-hadoop:4.6?some-reg/target-namespace/stable:metering-hadoop?g' {} +"]
+RUN ["bash", "-c", "find manifests/deploy/4.6-alt -type f -exec sed -i 's?quay.io/openshift/origin-ghostunnel:4.6?some-reg/target-namespace/stable:ghostunnel?g' {} +"]
 `
 
 	fakeClientSet := ciopTestingClient{
@@ -101,9 +107,11 @@ RUN ["bash", "-c", "find manifests/deploy/4.6 -type f -exec sed -i 's?quay.io/op
 
 	s := bundleSourceStep{
 		config: api.BundleSourceStepConfiguration{
-			ContextDir:        "manifests/deploy",
-			OperatorManifests: "4.6",
-			Substitute:        subs,
+			Manifests: []string{
+				"manifests/deploy/4.6",
+				"manifests/deploy/4.6-alt",
+			},
+			Substitute: subs,
 		},
 		jobSpec:     &api.JobSpec{},
 		imageClient: fakeClientSet.ImageV1(),

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -1,0 +1,148 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	buildapi "github.com/openshift/api/build/v1"
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/util"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type indexGeneratorStep struct {
+	config      api.IndexGeneratorStepConfiguration
+	resources   api.ResourceConfiguration
+	buildClient BuildClient
+	imageClient imageclientset.ImageStreamsGetter
+	istClient   imageclientset.ImageStreamTagsGetter
+	jobSpec     *api.JobSpec
+	artifactDir string
+	pullSecret  *coreapi.Secret
+}
+
+const IndexDataDirectory = "/index-data"
+const IndexDockerfileName = "index.Dockerfile"
+const IndexImageName = "ci-index"
+
+func (s *indexGeneratorStep) Inputs() (api.InputDefinition, error) {
+	return nil, nil
+}
+
+func (s *indexGeneratorStep) Run(ctx context.Context) error {
+	return results.ForReason("building_index_generator").ForError(s.run(ctx))
+}
+
+func (s *indexGeneratorStep) run(ctx context.Context) error {
+	source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource)
+	workingDir, err := getWorkingDir(s.istClient, source, s.jobSpec.Namespace())
+	if err != nil {
+		return fmt.Errorf("failed to get workingDir: %w", err)
+	}
+	dockerfile, err := s.indexGenDockerfile()
+	if err != nil {
+		return err
+	}
+	build := buildFromSource(
+		s.jobSpec, api.PipelineImageStreamTagReferenceSource, s.config.To,
+		buildapi.BuildSource{
+			Type:       buildapi.BuildSourceDockerfile,
+			Dockerfile: &dockerfile,
+			Images: []buildapi.ImageSource{
+				{
+					From: coreapi.ObjectReference{
+						Kind: "ImageStreamTag",
+						Name: source,
+					},
+					Paths: []buildapi.ImageSourcePath{{
+						SourcePath:     fmt.Sprintf("%s/.", workingDir),
+						DestinationDir: ".",
+					}},
+				},
+			},
+			Secrets: []buildapi.SecretBuildSource{{
+				Secret: coreapi.LocalObjectReference{Name: s.pullSecret.Name},
+			}},
+		},
+		"",
+		s.resources,
+		s.pullSecret,
+	)
+	err = handleBuild(ctx, s.buildClient, build, s.artifactDir)
+	if err != nil && strings.Contains(err.Error(), "error checking provided apis") {
+		return results.ForReason("generating_index").WithError(err).Errorf("failed to generate operator index due to invalid bundle info: %v", err)
+	}
+	return err
+}
+
+func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
+	var dockerCommands []string
+	dockerCommands = append(dockerCommands, "")
+	dockerCommands = append(dockerCommands, "FROM quay.io/operator-framework/upstream-opm-builder AS builder")
+	// pull secret is needed for opm command
+	dockerCommands = append(dockerCommands, "COPY .dockerconfigjson .")
+	dockerCommands = append(dockerCommands, "RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json")
+	var bundles []string
+	is, err := s.imageClient.ImageStreams(s.jobSpec.Namespace()).Get(context.TODO(), api.PipelineImageStream, meta.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get pipeline imagestream: %w", err)
+	}
+	for _, bundleName := range s.config.OperatorIndex {
+		fullSpec, exists := util.ResolvePullSpec(is, bundleName, false)
+		if !exists {
+			return "", fmt.Errorf("failed to get full pull spec for bundle `%s`", bundleName)
+		}
+		bundles = append(bundles, fullSpec)
+	}
+	dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["opm", "index", "add", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"]`, strings.Join(bundles, ","), IndexDockerfileName))
+	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
+	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
+	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))
+	dockerCommands = append(dockerCommands, ("COPY --from=builder /database/ database"))
+	dockerCommands = append(dockerCommands, "")
+	return strings.Join(dockerCommands, "\n"), nil
+}
+
+func (s *indexGeneratorStep) Requires() []api.StepLink {
+	var links []api.StepLink
+	for _, bundle := range s.config.OperatorIndex {
+		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReference(bundle)))
+	}
+	return links
+}
+
+func (s *indexGeneratorStep) Creates() []api.StepLink {
+	return []api.StepLink{api.InternalImageLink(s.config.To)}
+}
+
+func (s *indexGeneratorStep) Provides() api.ParameterMap {
+	return api.ParameterMap{}
+}
+
+func (s *indexGeneratorStep) Name() string { return string(s.config.To) }
+
+func (s *indexGeneratorStep) Description() string {
+	return fmt.Sprintf("Build image %s from the repository", s.config.To)
+}
+
+func IndexGeneratorStep(config api.IndexGeneratorStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, imageClient imageclientset.ImageStreamsGetter, istClient imageclientset.ImageStreamTagsGetter, artifactDir string, jobSpec *api.JobSpec, pullSecret *coreapi.Secret) api.Step {
+	return &indexGeneratorStep{
+		config:      config,
+		resources:   resources,
+		buildClient: buildClient,
+		imageClient: imageClient,
+		istClient:   istClient,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
+		pullSecret:  pullSecret,
+	}
+}
+
+// IndexGeneratorName returns the PipelineImageStreamTagReference for the generation image for the given index image tag reference
+func IndexGeneratorName(indexName api.PipelineImageStreamTagReference) api.PipelineImageStreamTagReference {
+	return api.PipelineImageStreamTagReference(fmt.Sprintf("%s-gen", indexName))
+}

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -27,7 +27,6 @@ type indexGeneratorStep struct {
 
 const IndexDataDirectory = "/index-data"
 const IndexDockerfileName = "index.Dockerfile"
-const IndexImageName = "ci-index"
 
 func (s *indexGeneratorStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
@@ -140,9 +139,4 @@ func IndexGeneratorStep(config api.IndexGeneratorStepConfiguration, resources ap
 		jobSpec:     jobSpec,
 		pullSecret:  pullSecret,
 	}
-}
-
-// IndexGeneratorName returns the PipelineImageStreamTagReference for the generation image for the given index image tag reference
-func IndexGeneratorName(indexName api.PipelineImageStreamTagReference) api.PipelineImageStreamTagReference {
-	return api.PipelineImageStreamTagReference(fmt.Sprintf("%s-gen", indexName))
 }

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -27,7 +27,7 @@ func TestIndexGenDockerfile(t *testing.T) {
 FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
-RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:test", "--out-dockerfile", "index.Dockerfile", "--generate"]
+RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -35,7 +35,7 @@ COPY --from=builder /database/ database
 `
 	stepSingleBundle := indexGeneratorStep{
 		config: api.IndexGeneratorStepConfiguration{
-			OperatorIndex: []string{"test"},
+			OperatorIndex: []string{"ci-bundle0"},
 		},
 		jobSpec:     &api.JobSpec{},
 		imageClient: fakeClientSet.ImageV1(),
@@ -53,7 +53,7 @@ COPY --from=builder /database/ database
 FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
-RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:test,some-reg/target-namespace/stable:another-bundle", "--out-dockerfile", "index.Dockerfile", "--generate"]
+RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:ci-bundle0,some-reg/target-namespace/stable:ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -61,7 +61,7 @@ COPY --from=builder /database/ database
 `
 	stepMultiBundle := indexGeneratorStep{
 		config: api.IndexGeneratorStepConfiguration{
-			OperatorIndex: []string{"test", "another-bundle"},
+			OperatorIndex: []string{"ci-bundle0", "ci-bundle1"},
 		},
 		jobSpec:     &api.JobSpec{},
 		imageClient: fakeClientSet.ImageV1(),

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -1,0 +1,77 @@
+package steps
+
+import (
+	"testing"
+
+	apiimagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/ci-tools/pkg/api"
+	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIndexGenDockerfile(t *testing.T) {
+	fakeClientSet := ciopTestingClient{
+		imagecs: fakeimageclientset.NewSimpleClientset(&apiimagev1.ImageStream{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "target-namespace",
+				Name:      api.PipelineImageStream,
+			},
+			Status: apiimagev1.ImageStreamStatus{
+				PublicDockerImageRepository: "some-reg/target-namespace/stable",
+			},
+		}),
+		t: t,
+	}
+
+	var expectedDockerfileSingleBundle = `
+FROM quay.io/operator-framework/upstream-opm-builder AS builder
+COPY .dockerconfigjson .
+RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
+RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:test", "--out-dockerfile", "index.Dockerfile", "--generate"]
+FROM pipeline:src
+WORKDIR /index-data
+COPY --from=builder index.Dockerfile index.Dockerfile
+COPY --from=builder /database/ database
+`
+	stepSingleBundle := indexGeneratorStep{
+		config: api.IndexGeneratorStepConfiguration{
+			OperatorIndex: []string{"test"},
+		},
+		jobSpec:     &api.JobSpec{},
+		imageClient: fakeClientSet.ImageV1(),
+	}
+	stepSingleBundle.jobSpec.SetNamespace("target-namespace")
+	generatedDockerfile, err := stepSingleBundle.indexGenDockerfile()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if expectedDockerfileSingleBundle != generatedDockerfile {
+		t.Errorf("Generated opm index dockerfile does not equal expected; generated dockerfile: %s", generatedDockerfile)
+	}
+
+	var expectedDockerfileMultiBundle = `
+FROM quay.io/operator-framework/upstream-opm-builder AS builder
+COPY .dockerconfigjson .
+RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
+RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/stable:test,some-reg/target-namespace/stable:another-bundle", "--out-dockerfile", "index.Dockerfile", "--generate"]
+FROM pipeline:src
+WORKDIR /index-data
+COPY --from=builder index.Dockerfile index.Dockerfile
+COPY --from=builder /database/ database
+`
+	stepMultiBundle := indexGeneratorStep{
+		config: api.IndexGeneratorStepConfiguration{
+			OperatorIndex: []string{"test", "another-bundle"},
+		},
+		jobSpec:     &api.JobSpec{},
+		imageClient: fakeClientSet.ImageV1(),
+	}
+	stepMultiBundle.jobSpec.SetNamespace("target-namespace")
+	generatedDockerfile, err = stepMultiBundle.indexGenDockerfile()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if expectedDockerfileMultiBundle != generatedDockerfile {
+		t.Errorf("Generated opm index dockerfile does not equal expected; generated dockerfile: %s", generatedDockerfile)
+	}
+}

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -60,5 +60,5 @@ if [[ -z "${PULL_PULL_SHA:-}" ]]; then
   os::log::fatal "\$PULL_PULL_SHA must be set for this test"
 fi
 export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"'${PULL_BASE_SHA}'","pulls":[{"number":'${PULL_NUMBER}',"author":"AlexNPavel","sha":"'${PULL_PULL_SHA}'"}]}}'
-os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --target ci-index --config ${suite_dir}/optional-operators.yaml"
+os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --target [images] --target ci-index --config ${suite_dir}/optional-operators.yaml"
 os::test::junit::declare_suite_end

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -10,6 +10,7 @@ trap "cleanup" EXIT
 suite_dir="${OS_ROOT}/test/e2e/simple"
 workdir="${BASETMPDIR}/e2e/simple"
 mkdir -p "${workdir}"
+JOB_SPEC_TEST="${JOB_SPEC}"
 
 os::test::junit::declare_suite_start "e2e/simple"
 # This test validates the ci-operator exit codes
@@ -47,5 +48,12 @@ RELEASE_IMAGE_LATEST="$( curl -s -H "Accept: application/json"  "https://api.ope
 export RELEASE_IMAGE_LATEST
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
 unset RELEASE_IMAGE_LATEST
+os::test::junit::declare_suite_end
 
+os::test::junit::declare_suite_start "e2e/simple/optional-operator"
+export JOB_SPEC="${JOB_SPEC_TEST}"
+if [[ -z "${JOB_SPEC:-}" ]]; then
+  os::log::fatal "\$JOB_SPEC must be set for this test"
+fi
+os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --target [images] --config ${suite_dir}/optional-operators.yaml"
 os::test::junit::declare_suite_end

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -15,10 +15,9 @@ resources:
     requests:
       cpu: 10m
 operator:
-  dockerfile_path:
-  - "test/manifests/bundle.Dockerfile"
-  manifests:
-  - "test/manifests/4.6"
+  bundles:
+  - context_dir: "test/manifests"
+    dockerfile_path: "bundle.Dockerfile"
   substitutions:
   - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.5
     with: metering-reporting-operator # another `images:` list item
@@ -26,6 +25,9 @@ operator:
     with: oauth-proxy # OCP component
   - pullspec: quay.io/openshift/origin-hive:4.5
     with: hive # operand image, must be present in `stable` imagestream
+tag_specification:
+  namespace: ocp
+  name: "4.6"
 # need a test or image field to be valid ci-operator config
 tests:
 - as: success

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -1,0 +1,28 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: '7'
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.14
+resources:
+  '*':
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 10m
+images:
+- dockerfile_path: bundle.Dockerfile
+  context_dir: test/manifests
+  operator_manifests: "4.6" # this is subdir of context_dir
+  to: metering-reporting-operator-bundle
+  substitute:
+  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.5
+    with: metering-reporting-operator # another `images:` list item
+  - pullspec: quay.io/openshift/origin-oauth-proxy:4.5
+    with: oauth-proxy # OCP component
+  - pullspec: quay.io/openshift/origin-hive:4.5
+    with: hive # operand image, must be present in `stable` imagestream

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -14,15 +14,21 @@ resources:
       cpu: 500m
     requests:
       cpu: 10m
-images:
-- dockerfile_path: bundle.Dockerfile
-  context_dir: test/manifests
-  operator_manifests: "4.6" # this is subdir of context_dir
-  to: metering-reporting-operator-bundle
-  substitute:
+operator:
+  dockerfile_path:
+  - "test/manifests/bundle.Dockerfile"
+  manifests:
+  - "test/manifests/4.6"
+  substitutions:
   - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.5
     with: metering-reporting-operator # another `images:` list item
   - pullspec: quay.io/openshift/origin-oauth-proxy:4.5
     with: oauth-proxy # OCP component
   - pullspec: quay.io/openshift/origin-hive:4.5
     with: hive # operand image, must be present in `stable` imagestream
+# need a test or image field to be valid ci-operator config
+tests:
+- as: success
+  commands: exit 0
+  container:
+    from: os

--- a/test/manifests/4.6/hive.crd.yaml
+++ b/test/manifests/4.6/hive.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hivetables.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: hivetables
+    singular: hivetable
+    kind: HiveTable
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Table Name
+      type: string
+      jsonPath: .status.tableName

--- a/test/manifests/4.6/image-references
+++ b/test/manifests/4.6/image-references
@@ -1,0 +1,34 @@
+# vi: ft=yaml
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-metering-ansible-operator:4.6
+    name: metering-ansible-operator
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-metering-reporting-operator:4.6
+    name: metering-reporting-operator
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-metering-presto:4.6
+    name: metering-presto
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-metering-hive:4.6
+    name: metering-hive
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-metering-hadoop:4.6
+    name: metering-hadoop
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ghostunnel:4.6
+    name: ghostunnel
+  - from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-oauth-proxy:4.6
+    name: oauth-proxy
+

--- a/test/manifests/4.6/meteringconfig.crd.yaml
+++ b/test/manifests/4.6/meteringconfig.crd.yaml
@@ -1,0 +1,18 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: meteringconfigs.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    kind: MeteringConfig
+    listKind: MeteringConfigList
+    plural: meteringconfigs
+    singular: meteringconfig
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/test/manifests/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
+++ b/test/manifests/4.6/meteringoperator.v4.6.0.clusterserviceversion.yaml
@@ -1,0 +1,347 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: metering-operator.v4.6.0
+  namespace: placeholder
+  annotations:
+    olm.skipRange: ">=4.3.0 <4.6.0"
+    capabilities: Seamless Upgrades
+    categories: OpenShift Optional, Monitoring
+    certified: "false"
+    containerImage: quay.io/openshift/origin-metering-ansible-operator:4.6
+    createdAt: 2019-01-01T11:59:59Z
+    description: Chargeback and reporting tool to provide accountability for how resources
+      are used across a cluster
+    operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/suggested-namespace: openshift-metering
+    operators.openshift.io/capability: '["fips", "cluster-proxy"]'
+    repository: https://github.com/kube-reporting/metering-operator
+    support: Red Hat, Inc.
+
+spec:
+  displayName: Metering
+  description: |
+    The Metering Operator is a chargeback and reporting tool to provide accountability for how resources are used across a cluster. Cluster admins can schedule reports based on historical usage data by Pod, Namespace, and Cluster wide. The Metering Operator is a part of the [Kubernetes Reporting organization](https://coreos.com/blog/introducing-operator-framework-metering).
+
+    Read the user guide for more details on [running and viewing your first report](https://docs.openshift.com/container-platform/4.6/metering/metering-using-metering.html).
+  keywords: [metering metrics reporting prometheus chargeback]
+  version: "4.6.0"
+  minKubeVersion: "1.18.0"
+  maturity: stable
+  maintainers:
+    - email: sd-operator-metering@redhat.com
+      name: Red Hat
+
+  links:
+    - name: Documentation
+      url: https://docs.openshift.com/container-platform/4.6/metering/metering-about-metering.html
+
+  provider:
+    name: Red Hat
+
+  labels:
+    operator-metering: "true"
+
+  selector:
+    matchLabels:
+      operator-metering: "true"
+
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: metering-operator
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - services/finalizers
+            - deployments/finalizers
+            verbs:
+            - update
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - proxies
+            verbs:
+            - list
+            - get
+          - apiGroups:
+            - config.openshift.io
+            resources:
+            - networks
+            verbs:
+            - list
+            - get
+          - apiGroups:
+            - authorization.k8s.io
+            resources:
+            - subjectaccessreviews
+            verbs:
+            - create
+          - apiGroups:
+            - authentication.k8s.io
+            resources:
+            - tokenreviews
+            verbs:
+            - create
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            resources:
+            - clusterrolebindings
+            - clusterroles
+            verbs:
+            - '*'
+
+      permissions:
+        - serviceAccountName: metering-operator
+          rules:
+          - apiGroups:
+            - metering.openshift.io
+            resources:
+            - '*'
+            verbs:
+            - '*'
+          - apiGroups:
+            - monitoring.coreos.com
+            resources:
+            - servicemonitors
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - pods/attach
+            - pods/exec
+            - pods/portforward
+            - pods/proxy
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - configmaps
+            - endpoints
+            - persistentvolumeclaims
+            - secrets
+            - serviceaccounts
+            - services
+            - services/proxy
+            verbs:
+            - '*'
+          - apiGroups:
+            - ""
+            resources:
+            - events
+            - namespaces/status
+            - pods/log
+            - pods/status
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - ""
+            resources:
+            - events
+            verbs:
+            - create
+            - update
+            - patch
+          - apiGroups:
+            - ""
+            resources:
+            - namespaces
+            verbs:
+            - get
+            - list
+            - watch
+          - apiGroups:
+            - apps
+            resources:
+            - daemonsets
+            - deployments
+            - deployments/finalizers
+            - deployments/rollback
+            - deployments/scale
+            - replicasets
+            - replicasets/scale
+            - statefulsets
+            verbs:
+            - '*'
+          - apiGroups:
+            - batch
+            resources:
+            - cronjobs
+            - jobs
+            verbs:
+            - '*'
+          - apiGroups:
+            - extensions
+            resources:
+            - daemonsets
+            - deployments
+            - deployments/rollback
+            - deployments/scale
+            - replicasets
+            - replicasets/scale
+            verbs:
+            - '*'
+          - apiGroups:
+            - rbac.authorization.k8s.io
+            - authorization.openshift.io
+            resources:
+            - rolebindings
+            - roles
+            verbs:
+            - '*'
+          - apiGroups:
+            - route.openshift.io
+            resources:
+            - routes
+            verbs:
+            - '*'
+
+      deployments:
+        - name: metering-operator
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: metering-operator
+            template:
+              metadata:
+                labels:
+                  app: metering-operator
+                  name: metering-operator
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                - name: ansible
+                  command:
+                  - /opt/ansible/scripts/ansible-logs.sh
+                  - /tmp/ansible-operator/runner
+                  - stdout
+                  image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  imagePullPolicy: Always
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                    readOnly: true
+                - name: operator
+                  image: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  imagePullPolicy: Always
+                  env:
+                  - name: OPERATOR_NAME
+                    value: "metering-operator"
+                  - name: DISABLE_OCP_FEATURES
+                    value: "false"
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.annotations['olm.targetNamespaces']
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: METERING_ANSIBLE_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-ansible-operator:4.6"
+                  - name: METERING_REPORTING_OPERATOR_IMAGE
+                    value: "quay.io/openshift/origin-metering-reporting-operator:4.6"
+                  - name: METERING_PRESTO_IMAGE
+                    value: "quay.io/openshift/origin-metering-presto:4.6"
+                  - name: METERING_HIVE_IMAGE
+                    value: "quay.io/openshift/origin-metering-hive:4.6"
+                  - name: METERING_HADOOP_IMAGE
+                    value: "quay.io/openshift/origin-metering-hadoop:4.6"
+                  - name: GHOSTUNNEL_IMAGE
+                    value: "quay.io/openshift/origin-ghostunnel:4.6"
+                  - name: OAUTH_PROXY_IMAGE
+                    value: "quay.io/openshift/origin-oauth-proxy:4.6"
+                  ports:
+                  - name: http-metrics
+                    containerPort: 8383
+                  - name: cr-metrics
+                    containerPort: 8686
+                  volumeMounts:
+                  - mountPath: /tmp/ansible-operator/runner
+                    name: runner
+                  resources:
+                    limits:
+                      cpu: 1500m
+                      memory: 500Mi
+                    requests:
+                      cpu: 750m
+                      memory: 400Mi
+
+                volumes:
+                  - name: runner
+                    emptyDir: {}
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                serviceAccount: metering-operator
+
+  customresourcedefinitions:
+    owned:
+    - description: An instance of Metering with high-level configuration
+      displayName: Metering Configuration
+      kind: MeteringConfig
+      name: meteringconfigs.metering.openshift.io
+      version: v1
+    - description: A scheduled or on-off Metering Report summarizes data based on the
+        query specified.
+      displayName: Metering Report
+      kind: Report
+      name: reports.metering.openshift.io
+      version: v1
+    - description: A SQL query used by Metering to generate reports.
+      displayName: Metering Report Query
+      kind: ReportQuery
+      name: reportqueries.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource representing a database table in Presto.
+        Used by ReportQueries to determine what tables exist, and by the HTTP API to determine
+        how to query a table.
+      displayName: Metering Data Source
+      kind: ReportDataSource
+      name: reportdatasources.metering.openshift.io
+      version: v1
+    - description: Represents a configurable storage location for Metering to store metering
+        and report data.
+      displayName: Metering Storage Location
+      kind: StorageLocation
+      name: storagelocations.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource describing a source of data for usage
+        by Report Queries.
+      displayName: Metering Presto Table
+      kind: PrestoTable
+      name: prestotables.metering.openshift.io
+      version: v1
+    - description: Used under-the-hood. A resource representing a database table in Hive.
+      displayName: Metering Hive Table
+      kind: HiveTable
+      name: hivetables.metering.openshift.io
+      version: v1
+

--- a/test/manifests/4.6/prestotable.crd.yaml
+++ b/test/manifests/4.6/prestotable.crd.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: prestotables.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: prestotables
+    singular: prestotable
+    kind: PrestoTable
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Table Name
+      type: string
+      jsonPath: .status.tableName

--- a/test/manifests/4.6/report.crd.yaml
+++ b/test/manifests/4.6/report.crd.yaml
@@ -1,0 +1,34 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reports.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reports
+    singular: report
+    kind: Report
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Query
+      type: string
+      jsonPath: .spec.query
+    - name: Schedule
+      type: string
+      jsonPath: .spec.schedule.period
+    - name: Running
+      type: string
+      jsonPath: .status.conditions[?(@.type=="Running")].reason
+    - name: Failed
+      type: string
+      jsonPath: .status.conditions[?(@.type=="Failure")].reason
+    - name: Last Report Time
+      type: string
+      jsonPath: .status.lastReportTime
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp

--- a/test/manifests/4.6/reportdatasource.crd.yaml
+++ b/test/manifests/4.6/reportdatasource.crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reportdatasources.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reportdatasources
+    singular: reportdatasource
+    kind: ReportDataSource
+    shortNames:
+    - datasource
+    - datasources
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Earliest Metric
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.earliestImportedMetricTime
+    - name: Newest Metric
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.newestImportedMetricTime
+    - name: Import Start
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.importDataStartTime
+    - name: Import End
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.importDataEndTime
+    - name: Last Import Time
+      type: string
+      jsonPath: .status.prometheusMetricsImportStatus.lastImportTime
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp

--- a/test/manifests/4.6/reportquery.crd.yaml
+++ b/test/manifests/4.6/reportquery.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: reportqueries.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: reportqueries
+    singular: reportquery
+    kind: ReportQuery
+    shortNames:
+    - rq
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    additionalPrinterColumns:
+    - name: Age
+      type: date
+      jsonPath: .metadata.creationTimestamp

--- a/test/manifests/4.6/storagelocation.crd.yaml
+++ b/test/manifests/4.6/storagelocation.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: storagelocations.metering.openshift.io
+spec:
+  group: metering.openshift.io
+  scope: Namespaced
+  names:
+    plural: storagelocations
+    singular: storagelocation
+    kind: StorageLocation
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/test/manifests/bundle.Dockerfile
+++ b/test/manifests/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=metering-ocp
+LABEL operators.operatorframework.io.bundle.channels.v1=4.6
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6
+
+COPY 4.6/*.yaml /manifests/
+COPY metadata /metadata/

--- a/test/manifests/metadata/annotations.yaml
+++ b/test/manifests/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: "4.6"
+  operators.operatorframework.io.bundle.channels.v1: "4.6"
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: metering-ocp


### PR DESCRIPTION
This PR adds support for building operator index images by adding an
`operator_index` field for images. The process is handled in a similar
manner to the bundle images, which require 2 steps, with the first step
involving building a new image to be used as a source image.

First, an image build is made that runs the `opm` command that generates
the `index.db` file and a dockerfile to build the corresponding index
image.

Second, a build is made with the previous build's image as its source,
using the dockerfile generated by `opm`.

This PR also adds validation for the `images` section of the config as
both `operator_manifests` and `operator_index` add potential for user
error.