### PR TITLE
Only enq changed imagestreamtags on imagestream update event

### DIFF
--- a/pkg/util/imagestreamtagmapper/imagestreamtagmapper.go
+++ b/pkg/util/imagestreamtagmapper/imagestreamtagmapper.go
@@ -1,0 +1,93 @@
+package imagestreamtagmapper
+
+import (
+	"fmt"
+	"reflect"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// New returns a new ImageStreamTagMapper. Its purpose is to extract all ImageStreamTag events
+// from an ImageStream watch. It ignores unchanged tags on Update events.
+// If no additional filtering/mapping is required, upstream should just return its input.
+func New(upstream func(reconcile.Request) []reconcile.Request) handler.EventHandler {
+	return &imagestreamtagmapper{upstream: upstream}
+}
+
+type imagestreamtagmapper struct {
+	upstream func(reconcile.Request) []reconcile.Request
+}
+
+func (m *imagestreamtagmapper) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+	m.generic(e.Object, e.Meta, q)
+}
+
+func (m *imagestreamtagmapper) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	oldStream, oldOK := e.ObjectOld.(*imagev1.ImageStream)
+	newStream, newOK := e.ObjectNew.(*imagev1.ImageStream)
+	if !oldOK || !newOK {
+		logrus.WithFields(logrus.Fields{
+			"old_type": fmt.Sprintf("%T", e.ObjectOld),
+			"new_type": fmt.Sprintf("%T", e.ObjectNew),
+		}).Error("Got object that was not an *imagev1.ImageStream")
+		return
+	}
+
+	for _, newTag := range newStream.Status.Tags {
+		if namedTagEventListHasElement(oldStream.Status.Tags, newTag) {
+			continue
+		}
+		for _, request := range m.upstream(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: e.MetaNew.GetNamespace(),
+				Name:      e.MetaNew.GetName() + ":" + newTag.Tag,
+			},
+		}) {
+			q.Add(request)
+		}
+	}
+}
+
+func namedTagEventListHasElement(slice []imagev1.NamedTagEventList, element imagev1.NamedTagEventList) bool {
+	for _, item := range slice {
+		if reflect.DeepEqual(item, element) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *imagestreamtagmapper) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	m.generic(e.Object, e.Meta, q)
+}
+
+func (m *imagestreamtagmapper) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+	m.generic(e.Object, e.Meta, q)
+}
+
+func (m *imagestreamtagmapper) generic(o runtime.Object, meta metav1.Object, q workqueue.RateLimitingInterface) {
+	imageStream, ok := o.(*imagev1.ImageStream)
+	if !ok {
+		logrus.WithField("type", fmt.Sprintf("%T", o)).Error("Got object that was not an ImageStram")
+		return
+	}
+
+	for _, imageStreamTag := range imageStream.Status.Tags {
+		for _, request := range m.upstream(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: meta.GetNamespace(),
+				Name:      meta.GetName() + ":" + imageStreamTag.Tag,
+			},
+		}) {
+			q.Add(request)
+		}
+	}
+}

--- a/pkg/util/imagestreamtagmapper/imagestreamtagmapper_test.go
+++ b/pkg/util/imagestreamtagmapper/imagestreamtagmapper_test.go
@@ -1,0 +1,163 @@
+package imagestreamtagmapper_test
+
+import (
+	"testing"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
+)
+
+func TestImageStreamTagMapper(t *testing.T) {
+	upstream := func(r reconcile.Request) []reconcile.Request {
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Namespace: "first_" + r.Namespace, Name: r.Name}},
+			{NamespacedName: types.NamespacedName{Namespace: "second_" + r.Namespace, Name: r.Name}},
+		}
+	}
+	testCases := []struct {
+		name             string
+		event            func() interface{}
+		expectedRequests []string
+	}{
+		{
+			name: "Create returns all tags",
+			event: func() interface{} {
+				imageStream := &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace",
+						Name:      "name",
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{Tag: "1"}, {Tag: "2"}},
+					},
+				}
+				return event.CreateEvent{Meta: imageStream, Object: imageStream}
+			},
+			expectedRequests: []string{
+				"first_namespace/name:1",
+				"first_namespace/name:2",
+				"second_namespace/name:1",
+				"second_namespace/name:2",
+			},
+		},
+		{
+			name: "Update only returns changed tags",
+			event: func() interface{} {
+				imageStreamOld := &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace",
+						Name:      "name",
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{Tag: "1"}, {Tag: "2"}},
+					},
+				}
+
+				ImageStreamNew := imageStreamOld.DeepCopy()
+				ImageStreamNew.Status.Tags[0].Items = []imagev1.TagEvent{{Image: "some-image"}}
+
+				return event.UpdateEvent{
+					MetaOld:   imageStreamOld,
+					ObjectOld: imageStreamOld,
+					MetaNew:   ImageStreamNew,
+					ObjectNew: ImageStreamNew,
+				}
+			},
+			expectedRequests: []string{
+				"first_namespace/name:1",
+				"second_namespace/name:1",
+			},
+		},
+		{
+			name: "Delete returns all tags",
+			event: func() interface{} {
+				imageStream := &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace",
+						Name:      "name",
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{Tag: "1"}, {Tag: "2"}},
+					},
+				}
+				return event.DeleteEvent{Meta: imageStream, Object: imageStream}
+			},
+			expectedRequests: []string{
+				"first_namespace/name:1",
+				"first_namespace/name:2",
+				"second_namespace/name:1",
+				"second_namespace/name:2",
+			},
+		},
+		{
+			name: "Generic returns all tags",
+			event: func() interface{} {
+				ImageStram := &imagev1.ImageStream{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "namespace",
+						Name:      "name",
+					},
+					Status: imagev1.ImageStreamStatus{
+						Tags: []imagev1.NamedTagEventList{{Tag: "1"}, {Tag: "2"}},
+					},
+				}
+				return event.GenericEvent{Meta: ImageStram, Object: ImageStram}
+			},
+			expectedRequests: []string{
+				"first_namespace/name:1",
+				"first_namespace/name:2",
+				"second_namespace/name:1",
+				"second_namespace/name:2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			mapper := imagestreamtagmapper.New(upstream)
+			queue := &trackingWorkqueue{t: t}
+
+			switch e := tc.event().(type) {
+			case event.CreateEvent:
+				mapper.Create(e, queue)
+			case event.UpdateEvent:
+				mapper.Update(e, queue)
+			case event.DeleteEvent:
+				mapper.Delete(e, queue)
+			case event.GenericEvent:
+				mapper.Generic(e, queue)
+			default:
+				t.Fatalf("got type that was not an event but a %T", e)
+			}
+
+			if actual := sets.NewString(tc.expectedRequests...); !actual.Equal(queue.received) {
+				t.Errorf("actual events don't match expected, diff: %v", queue.received.Difference(actual))
+			}
+		})
+	}
+}
+
+type trackingWorkqueue struct {
+	t *testing.T
+	workqueue.RateLimitingInterface
+	received sets.String
+}
+
+func (t *trackingWorkqueue) Add(item interface{}) {
+	request, ok := item.(reconcile.Request)
+	if !ok {
+		t.t.Fatalf("workqueue got item that was not reconcile.Request but %T", item)
+	}
+	if t.received == nil {
+		t.received = sets.String{}
+	}
+	t.received.Insert(request.String())
+}


### PR DESCRIPTION
Currently we have two controllers that care about imagestreamtags but
watch imagestreams because imagestreamtags do not support watching. One
implication of this is that whenever any tag in a given imagestream
changes, all tags in that stream get reconciled, which is very
inefficient.

This PR adds an imagestreamtagmapper which maps imagestreams to images,
giving update events a special treatment by only enqeueing the tags that
have changed.

This mapper is then used in the promotionreconciler and the
test-images-distributor. The usage of this mapper allows the
promotionreconciler to drop request coalescing.

/assign @stevekuznetsov 