### PR TITLE
Registry replacer: Update dockerfiles from ocp-build-data

### DIFF
--- a/cmd/registry-replacer/README.md
+++ b/cmd/registry-replacer/README.md
@@ -5,3 +5,6 @@ A small utility used to make sure that all builds use a cluster-local registry. 
 * Finds all ci-operator configs with at least one images directive
 * Downloads the corresponding Dockerfile
 * If it has a reference to the api.ci registry, updates the ci-operator config to replace that with a `base_image`
+* If it has replacements, checks if those apply and if not, removes them
+* Removes all replacements for `ocp/builder` images
+* Updates the `Dockerfile` in the images config to match whats defined in the ocp-build-data repository

--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -8,19 +9,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/api/ocpbuilddata"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/github"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestReplacer(t *testing.T) {
+	majorMinor := ocpbuilddata.MajorMinor{Major: "4", Minor: "6"}
 	testCases := []struct {
-		name                               string
-		config                             *api.ReleaseBuildConfiguration
-		pruneUnusedReplacementsEnabled     bool
-		pruneOCPBuilderReplacementsEnabled bool
-		files                              map[string][]byte
-		expectWrite                        bool
+		name                                         string
+		config                                       *api.ReleaseBuildConfiguration
+		pruneUnusedReplacementsEnabled               bool
+		pruneOCPBuilderReplacementsEnabled           bool
+		ensureCorrectPromotionDockerfile             bool
+		ensureCorrectPromotionDockerfileIngoredRepos sets.String
+		promotionTargetToDockerfileMapping           map[string]dockerfileLocation
+		files                                        map[string][]byte
+		expectWrite                                  bool
 	}{
 		{
 			name: "No dockerfile, does nothing",
@@ -143,6 +149,117 @@ func TestReplacer(t *testing.T) {
 			pruneOCPBuilderReplacementsEnabled: true,
 			expectWrite:                        true,
 		},
+		{
+			name: "Dockerfile gets fixed up",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+				Metadata:               api.Metadata{Branch: "master"},
+			},
+			ensureCorrectPromotionDockerfile:   true,
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {dockerfile: "Dockerfile.rhel"}},
+			expectWrite:                        true,
+		},
+		{
+			name: "Config for non-master branch is ignored",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+			},
+			ensureCorrectPromotionDockerfile:   true,
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {dockerfile: "Dockerfile.rhel"}},
+		},
+		{
+			name: "Dockerfile is correct, nothing to do",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						DockerfilePath: "Dockerfile.rhel",
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+				Metadata:               api.Metadata{Branch: "master"},
+			},
+			ensureCorrectPromotionDockerfile:   true,
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {dockerfile: "Dockerfile.rhel"}},
+		},
+		{
+			name: "Context dir gets fixed up",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						ContextDir:     "some-dir",
+						DockerfilePath: "Dockerfile.rhel",
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+				Metadata:               api.Metadata{Branch: "master"},
+			},
+			ensureCorrectPromotionDockerfile:   true,
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {contextDir: "other_dir", dockerfile: "Dockerfile.rhel"}},
+			expectWrite:                        true,
+		},
+		{
+			name: "Context dir is ncorrect, but ignored",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						ContextDir:     "some-dir",
+						DockerfilePath: "Dockerfile.rhel",
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+				Metadata:               api.Metadata{Branch: "master", Org: "org", Repo: "repo"},
+			},
+			ensureCorrectPromotionDockerfile:             true,
+			ensureCorrectPromotionDockerfileIngoredRepos: sets.NewString("org/repo"),
+			promotionTargetToDockerfileMapping:           map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {contextDir: "other_dir", dockerfile: "Dockerfile.rhel"}},
+		},
+		{
+			name: "Dockerfile+Context dir is correct, nothing to do",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						ContextDir:     "some_dir",
+						DockerfilePath: "Dockerfile.rhel",
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+					To: "promotionTarget",
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp", Name: majorMinor.String()},
+				Metadata:               api.Metadata{Branch: "master"},
+			},
+			ensureCorrectPromotionDockerfile:   true,
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {contextDir: "some_dir", dockerfile: "Dockerfile.rhel"}},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -151,7 +268,16 @@ func TestReplacer(t *testing.T) {
 			t.Parallel()
 
 			fakeWriter := &fakeWriter{}
-			if err := replacer(fakeGithubFileGetterFactory(tc.files), fakeWriter.Write, tc.pruneUnusedReplacementsEnabled, tc.pruneOCPBuilderReplacementsEnabled)(tc.config, &config.Info{}); err != nil {
+			if err := replacer(
+				fakeGithubFileGetterFactory(tc.files),
+				fakeWriter.Write,
+				tc.pruneUnusedReplacementsEnabled,
+				tc.pruneOCPBuilderReplacementsEnabled,
+				tc.ensureCorrectPromotionDockerfile,
+				tc.ensureCorrectPromotionDockerfileIngoredRepos,
+				tc.promotionTargetToDockerfileMapping,
+				majorMinor,
+			)(tc.config, &config.Info{}); err != nil {
 				t.Errorf("replacer failed: %v", err)
 			}
 			if (fakeWriter.data != nil) != tc.expectWrite {

--- a/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Context_dir_gets_fixed_up.yaml
+++ b/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Context_dir_gets_fixed_up.yaml
@@ -1,0 +1,15 @@
+images:
+- context_dir: other_dir
+  dockerfile_path: Dockerfile.rhel
+  inputs:
+    root:
+      as:
+      - ocp/builder:something
+  to: promotionTarget
+promotion:
+  name: "4.6"
+  namespace: ocp
+zz_generated_metadata:
+  branch: master
+  org: ""
+  repo: ""

--- a/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Dockerfile_gets_fixed_up.yaml
+++ b/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Dockerfile_gets_fixed_up.yaml
@@ -1,0 +1,14 @@
+images:
+- dockerfile_path: Dockerfile.rhel
+  inputs:
+    root:
+      as:
+      - ocp/builder:something
+  to: promotionTarget
+promotion:
+  name: "4.6"
+  namespace: ocp
+zz_generated_metadata:
+  branch: master
+  org: ""
+  repo: ""

--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -312,6 +312,10 @@ type MajorMinor struct {
 	Minor string
 }
 
+func (mm MajorMinor) String() string {
+	return mm.Major + "." + mm.Minor
+}
+
 func gatherAllOCPImageConfigs(ocpBuildDataDir string, majorMinor MajorMinor) (map[string]OCPImageConfig, error) {
 	result := map[string]OCPImageConfig{}
 	resultLock := &sync.Mutex{}


### PR DESCRIPTION
The diff this PR produces is here: https://github.com/openshift/release/pull/10799

First commit is pure moving code around, second commit is the actual change.