### PR TITLE
[private-org-sync] don't fail on merge conflict errors, instead print a warning

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -457,7 +457,8 @@ func mergeRemotesAndPush(logger *logrus.Entry, git gitFunc, repoDir, srcRemote, 
 			mergeErrs = append(mergeErrs, fmt.Errorf("failed to perform merge --abort: %w", err))
 		}
 
-		return utilerrors.NewAggregate(mergeErrs)
+		logger.WithError(utilerrors.NewAggregate(mergeErrs)).Warn("error occured while fetching remote and merge")
+		return nil
 	}
 
 	cmd := []string{"push", "--tags"}

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -598,7 +598,6 @@ func TestMirror(t *testing.T) {
 				},
 				{call: "merge --abort"},
 			},
-			expectError: true,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
The request is described in https://issues.redhat.com/browse/DPTP-1426

/cc @openshift/openshift-team-developer-productivity-test-platform @petr-muller @jupierce 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>