### PR TITLE
ci-operator: expose ephemeral cluster versions based on parents

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
@@ -175,6 +176,21 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		return results.ForReason("missing_release").WithError(err).Errorf("could not resolve imagestream %s: %v", streamName, err)
 	}
 
+	// we want to expose the release payload as a CI version that looks just like
+	// the release versions for nightlies and CI release candidates
+	prefix := "0.0.1-0"
+	if raw, ok := stable.ObjectMeta.Annotations[releaseConfigAnnotation]; ok {
+		var releaseConfig struct {
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal([]byte(raw), &releaseConfig); err != nil {
+			return results.ForReason("invalid_release").WithError(err).Errorf("could not resolve release configuration on imagestream %s: %v", streamName, err)
+		}
+		prefix = releaseConfig.Name
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	version := fmt.Sprintf("%s.test-%s-%s", prefix, now.Format("2006-01-02-150405"), s.jobSpec.Namespace())
+
 	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	log.Printf("Create release image %s", destination)
 	podConfig := steps.PodStepConfiguration{
@@ -190,9 +206,9 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 set -euo pipefail
 export HOME=/tmp
 oc registry login
-oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
+oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q --name %q
 oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
-`, s.jobSpec.Namespace(), streamName, cvo, destination, destination, s.name),
+`, s.jobSpec.Namespace(), streamName, cvo, destination, version, destination, s.name),
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary


### PR DESCRIPTION
When we import a release from a stream that's configured to have a name
and be released in some way, we can piggy-back off of that name to
create a name for our release that clearly labels us as a derivative
while also uniquely identifying the test configuration that is running.
All of this is best-effort and will no-op if no release config is
present, allowing us to still mark the cluster version as one udner test
but not identifying the parent release.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @smarterclayton 