### PR TITLE
disable the failing custom-release e2e test

### DIFF
--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -41,7 +41,7 @@ if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
 fi
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:initial] --config ${suite_dir}/dynamic-releases.yaml"
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
-os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
+# os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:pre] --config ${suite_dir}/dynamic-releases.yaml"
 RELEASE_IMAGE_LATEST="$( curl -s -H "Accept: application/json"  "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.4&arch=amd64" | jq --raw-output ".nodes[0].payload" )"
 export RELEASE_IMAGE_LATEST


### PR DESCRIPTION
After migrating the e2e job to a build farm, the code that imports releases resolved by release-controller to release payloads in authenticated namespaces on api.ci does not seem to be able to access these images, despite us providing the e2e tests the credentials in https://github.com/openshift/release/pull/10912. This means that either the credentials are not used properly or there is some other problem. This currently blocks unrelated merges to ci-tools, so I propose to disable it temporarily to unblock them.

Immediately after that I will open a revert linked to a card that will make us fix this.