### PR TITLE
Specify registry-config for oc adm release command

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -183,7 +183,7 @@ func FromConfig(
 						return nil, nil, results.ForReason("reading_release").ForError(fmt.Errorf("failed to read input release pullSpec %s: %w", name, err))
 					}
 					log.Printf("Resolved release %s to %s", name, pullSpec)
-					releaseStep = release.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec)
+					releaseStep = release.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, pullSecret)
 				} else {
 					releaseStep = release.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec)
 				}
@@ -221,7 +221,7 @@ func FromConfig(
 				log.Printf("Resolved release %s to %s", resolveConfig.Name, value)
 			}
 
-			step = release.ImportReleaseStep(resolveConfig.Name, value, false, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec)
+			step = release.ImportReleaseStep(resolveConfig.Name, value, false, config.Resources, podClient, imageClient, saGetter, rbacClient, artifactDir, jobSpec, pullSecret)
 		} else if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if test := testStep.MultiStageTestConfigurationLiteral; test != nil {
 				step = steps.MultiStageTestStep(*testStep, config, params, podClient, secretGetter, saGetter, rbacClient, artifactDir, jobSpec)

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -41,7 +41,7 @@ if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
 fi
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:initial] --config ${suite_dir}/dynamic-releases.yaml"
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
-# os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
 os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:pre] --config ${suite_dir}/dynamic-releases.yaml"
 RELEASE_IMAGE_LATEST="$( curl -s -H "Accept: application/json"  "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.4&arch=amd64" | jq --raw-output ".nodes[0].payload" )"
 export RELEASE_IMAGE_LATEST


### PR DESCRIPTION
```
grep -irn "oc adm release" .
./pkg/steps/project_image.go:74:                // oc adm release info tooling
./pkg/steps/release/create_release.go:193:oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q
./pkg/steps/release/create_release.go:194:oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
./pkg/steps/release/import_release.go:156:      // get the CLI image from the payload (since we need it to run oc adm release extract)
./pkg/steps/release/import_release.go:220:oc adm release extract%s --from=%q --file=image-references > /tmp/artifacts/%s
./pkg/steps/clusterinstall/template.go:215:            DIGEST="$(oc adm release info --image-for="${NAME}" | sed 's/.*@//')"
./pkg/steps/clusterinstall/template.go:417:          oc adm release new --from-release ${RELEASE_IMAGE_LATEST} --to-image ${MIRROR_BASE}-scratch:release --mirror ${MIRROR_BASE}-scratch || echo 'ignore: the release could not be reproduced from its inputs'
./pkg/steps/clusterinstall/template.go:418:          oc adm release mirror --from ${MIRROR_BASE}-scratch:release --to ${MIRROR_BASE} --to-release-image ${MIRROR_BASE}:mirrored
```

Another pitfall of `oc adm release` is the one in `template.go`. Is it used in release jobs (we have not moved them yet)?

/cc @openshift/openshift-team-developer-productivity-test-platform 