### PR TITLE
blocking-issue-creator: block merges to current-release too

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -25,7 +25,7 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	if err := o.Options.Validate(); err != nil {
+	if err := o.FutureOptions.Validate(); err != nil {
 		return err
 	}
 	if o.username == "" {


### PR DESCRIPTION
This change makes blocking-issue-creator consistent with how other tools
(repo-brancher, mainly) treat the `--current-release` option. The
current release is considered a "future-release" and therefore blocking
issue is created for it.

Consistently, repo-brancher (the tool that performs the fast forwarding)
will fast-forward code to the release branch for the current release,
which implies the necessity to have that blocker issue.

The gist here is that `FutureOptions.Validate` does the backfill from
`--current-release`, whereas `Options.Validate` does not:

https://github.com/openshift/ci-tools/blob/ae10a83be7627796abe322a12672a365a294e9bb/pkg/promotion/promotion.go#L85-L98

/cc @stevekuznetsov 
/cc @openshift/openshift-team-developer-productivity-test-platform 