### PR TITLE
ci-operator: steps: importing a release creates the stream

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -394,7 +394,7 @@ func (s *importReleaseStep) Requires() []api.StepLink {
 }
 
 func (s *importReleaseStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ReleasePayloadImageLink(s.name)}
+	return []api.StepLink{api.ReleasePayloadImageLink(s.name), api.ReleaseImagesLink(s.name)}
 }
 
 func (s *importReleaseStep) Provides() api.ParameterMap {


### PR DESCRIPTION
Not only does importing a release provide the release payload, but it
also creates all of the imported tags from the payload as well.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>