### PR TITLE
clusterinstall: fix template

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -33,6 +33,10 @@ parameters:
   required: false
 - name: CLUSTER_VARIANT
 - name: USE_LEASE_CLIENT
+- name: BRANCH
+  required: true
+- name: PROW_JOB_ID
+  required: true
 
 objects:
 
@@ -126,11 +130,6 @@ objects:
     # annotate the information about this job so that the release controller adds it to the upgrade graph
     - name: annotate	
       image: ${IMAGE_CLI}
-      env:
-      - name: RELEASE_IMAGE_INITIAL
-      - name: RELEASE_IMAGE_LATEST
-      - name: BRANCH
-      - name: PROW_JOB_ID
       command:
       - /bin/bash
       - -c


### PR DESCRIPTION
Environment variables on the Pod's contents are entirely unnecessary
unless you need to expose it to something in the script, then you also
need to explcitly have the value replaced, otherwise what LOOKS like an
environment variable dereference by bash actually is bash reading a
literal string that's injected at template instance render time.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>