### PR TITLE
pkg/steps/lease: add support for multiple leases

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -617,6 +617,16 @@ type StepDependency struct {
 	Env string `json:"env"`
 }
 
+// StepLease defines a resource that needs to be acquired prior to execution.
+// The resource name will be exposed to the step via the specificed environment
+// variable.
+type StepLease struct {
+	// ResourceType is the type of resource that will be leased.
+	ResourceType string `json:"resource_type"`
+	// Env is the environment variable that will contain the resource name.
+	Env string `json:"env"`
+}
+
 // FromImageTag returns the internal name for the image tag that will be used
 // for this step, if one is configured.
 func (s *LiteralTestStep) FromImageTag() (PipelineImageStreamTagReference, bool) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -230,7 +230,11 @@ func FromConfig(
 			if test := testStep.MultiStageTestConfigurationLiteral; test != nil {
 				step = steps.MultiStageTestStep(*testStep, config, params, podClient, eventClient, secretGetter, saGetter, rbacClient, imageClient, artifactDir, jobSpec)
 				if test.ClusterProfile != "" {
-					step = steps.LeaseStep(leaseClient, test.ClusterProfile.LeaseType(), step, jobSpec.Namespace, namespaceClient)
+					leases := []api.StepLease{{
+						ResourceType: test.ClusterProfile.LeaseType(),
+						Env:          steps.DefaultLeaseEnv,
+					}}
+					step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace, namespaceClient)
 				}
 				for _, subStep := range append(append(test.Pre, test.Test...), test.Post...) {
 					if link, ok := subStep.FromImageTag(); ok {
@@ -248,7 +252,11 @@ func FromConfig(
 					if err != nil {
 						return nil, nil, fmt.Errorf("unable to create end to end test step: %w", err)
 					}
-					step = steps.LeaseStep(leaseClient, test.ClusterProfile.LeaseType(), step, jobSpec.Namespace, namespaceClient)
+					leases := []api.StepLease{{
+						ResourceType: test.ClusterProfile.LeaseType(),
+						Env:          steps.DefaultLeaseEnv,
+					}}
+					step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace, namespaceClient)
 				}
 			} else {
 				step = steps.TestStep(*testStep, config.Resources, podClient, eventClient, artifactDir, jobSpec)
@@ -281,7 +289,11 @@ func FromConfig(
 				if err != nil {
 					return nil, nil, fmt.Errorf("cannot resolve lease type from cluster type: %w", err)
 				}
-				step = steps.LeaseStep(leaseClient, lease, step, jobSpec.Namespace, namespaceClient)
+				leases := []api.StepLease{{
+					ResourceType: lease,
+					Env:          steps.DefaultLeaseEnv,
+				}}
+				step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace, namespaceClient)
 				break
 			}
 		}

--- a/pkg/lease/client_test.go
+++ b/pkg/lease/client_test.go
@@ -25,7 +25,7 @@ func TestAcquire(t *testing.T) {
 	}
 	expected = []string{
 		"acquire owner rtype free leased random",
-		"updateone owner rtype0 leased 0",
+		"updateone owner rtype_0 leased 0",
 	}
 	if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("wrong calls to the boskos client: %v", diff.ObjectDiff(calls, expected))
@@ -34,7 +34,7 @@ func TestAcquire(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected = []string{"rtype0"}
+	expected = []string{"rtype_0"}
 	if !reflect.DeepEqual(list, expected) {
 		t.Fatalf("wrong list: %v", diff.ObjectDiff(list, expected))
 	}
@@ -43,7 +43,7 @@ func TestAcquire(t *testing.T) {
 func TestHeartbeatCancel(t *testing.T) {
 	ctx := context.Background()
 	var calls []string
-	client := NewFakeClient("owner", "url", 0, sets.NewString("updateone owner rtype0 leased 0"), &calls)
+	client := NewFakeClient("owner", "url", 0, sets.NewString("updateone owner rtype_0 leased 0"), &calls)
 	var called bool
 	if _, err := client.Acquire("rtype", ctx, func() { called = true }); err != nil {
 		t.Fatal(err)
@@ -67,36 +67,36 @@ func TestHeartbeatRetries(t *testing.T) {
 		requests: 3,
 		success:  true,
 		failures: []string{
-			"updateone owner rtype0 leased 0",
-			"updateone owner rtype0 leased 1",
+			"updateone owner rtype_0 leased 0",
+			"updateone owner rtype_0 leased 1",
 		},
 	}, {
 		name:     "requests < retries, should fail",
 		requests: 3,
 		failures: []string{
-			"updateone owner rtype0 leased 0",
-			"updateone owner rtype0 leased 1",
-			"updateone owner rtype0 leased 2",
+			"updateone owner rtype_0 leased 0",
+			"updateone owner rtype_0 leased 1",
+			"updateone owner rtype_0 leased 2",
 		},
 	}, {
 		name:     "requests > retries with intermittent failures, should succeed",
 		success:  true,
 		requests: 6,
 		failures: []string{
-			"updateone owner rtype0 leased 0",
-			"updateone owner rtype0 leased 1",
-			"updateone owner rtype0 leased 3",
-			"updateone owner rtype0 leased 4",
+			"updateone owner rtype_0 leased 0",
+			"updateone owner rtype_0 leased 1",
+			"updateone owner rtype_0 leased 3",
+			"updateone owner rtype_0 leased 4",
 		},
 	}, {
 		name:     "requests <= retries with intermittent failures, should fail",
 		requests: 6,
 		failures: []string{
-			"updateone owner rtype0 leased 0",
-			"updateone owner rtype0 leased 1",
-			"updateone owner rtype0 leased 3",
-			"updateone owner rtype0 leased 4",
-			"updateone owner rtype0 leased 5",
+			"updateone owner rtype_0 leased 0",
+			"updateone owner rtype_0 leased 1",
+			"updateone owner rtype_0 leased 3",
+			"updateone owner rtype_0 leased 4",
+			"updateone owner rtype_0 leased 5",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/lease/fake.go
+++ b/pkg/lease/fake.go
@@ -45,7 +45,7 @@ func (c *fakeClient) addCall(call string, args ...string) error {
 
 func (c *fakeClient) AcquireWaitWithPriority(ctx context.Context, rtype, state, dest, requestID string) (*common.Resource, error) {
 	err := c.addCall("acquire", rtype, state, dest, requestID)
-	return &common.Resource{Name: fmt.Sprintf("%s%d", rtype, len(*c.calls)-1)}, err
+	return &common.Resource{Name: fmt.Sprintf("%s_%d", rtype, len(*c.calls)-1)}, err
 }
 
 func (c *fakeClient) UpdateOne(name, dest string, _ *common.UserData) error {

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -18,30 +18,37 @@ import (
 	"github.com/openshift/ci-tools/pkg/results"
 )
 
-const leaseEnv = "LEASED_RESOURCE"
+const DefaultLeaseEnv = "LEASED_RESOURCE"
 
 var NoLeaseClientErr = errors.New("step needs a lease but no lease client provided")
 
-// leaseStep wraps another step and acquires/releases a lease.
+type stepLease struct {
+	api.StepLease
+	resource string
+}
+
+// leaseStep wraps another step and acquires/releases one or more leases.
 type leaseStep struct {
-	client         *lease.Client
-	leaseType      string
-	leasedResource string
-	wrapped        api.Step
+	client  *lease.Client
+	leases  []stepLease
+	wrapped api.Step
 
 	// for sending heartbeats during lease acquisition
 	namespace       func() string
 	namespaceClient coreclientset.NamespaceInterface
 }
 
-func LeaseStep(client *lease.Client, lease string, wrapped api.Step, namespace func() string, namespaceClient coreclientset.NamespaceInterface) api.Step {
-	return &leaseStep{
+func LeaseStep(client *lease.Client, leases []api.StepLease, wrapped api.Step, namespace func() string, namespaceClient coreclientset.NamespaceInterface) api.Step {
+	ret := leaseStep{
 		client:          client,
-		leaseType:       lease,
 		wrapped:         wrapped,
 		namespace:       namespace,
 		namespaceClient: namespaceClient,
 	}
+	for _, l := range leases {
+		ret.leases = append(ret.leases, stepLease{StepLease: l})
+	}
+	return &ret
 }
 
 func (s *leaseStep) Inputs() (api.InputDefinition, error) {
@@ -64,8 +71,10 @@ func (s *leaseStep) Provides() api.ParameterMap {
 	if parameters == nil {
 		parameters = api.ParameterMap{}
 	}
-	parameters[leaseEnv] = func() (string, error) {
-		return s.leasedResource, nil
+	for _, l := range s.leases {
+		parameters[l.Env] = func() (string, error) {
+			return l.resource, nil
+		}
 	}
 	return parameters
 }
@@ -82,25 +91,22 @@ func (s *leaseStep) Run(ctx context.Context) error {
 }
 
 func (s *leaseStep) run(ctx context.Context) error {
-	log.Printf("Acquiring lease for %q", s.leaseType)
+	log.Printf("Acquiring leases for %q", s.Name())
 	client := *s.client
 	ctx, cancel := context.WithCancel(ctx)
 	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
 	go heartbeatNamespace(s.namespace, s.namespaceClient, heartbeatCtx)
-	resource, err := client.Acquire(s.leaseType, ctx, cancel)
-	if err != nil {
+	if err := acquireLeases(client, ctx, cancel, s.leases); err != nil {
 		heartbeatCancel()
-		if err == lease.ErrNotFound {
-			printResourceMetrics(client, s.leaseType)
+		if err := releaseLeases(client, s.leases); err != nil {
+			log.Printf("failed to release leases after acquisition failure: %v", err)
 		}
-		return results.ForReason(results.Reason("acquiring_lease:"+s.leaseType)).WithError(err).Errorf("failed to acquire lease: %v", err)
+		return err
 	}
 	heartbeatCancel()
-	log.Printf("Acquired lease %q for %q", resource, s.leaseType)
-	s.leasedResource = resource
 	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
-	log.Printf("Releasing lease for %q", s.leaseType)
-	releaseErr := results.ForReason("releasing_lease").ForError(client.Release(resource))
+	log.Printf("Releasing leases for %q", s.Name())
+	releaseErr := results.ForReason("releasing_lease").ForError(releaseLeases(client, s.leases))
 
 	// we want a sensible output error for reporting, so we bubble up these individually
 	//if we can, as this is the only step that can have multiple errors
@@ -111,6 +117,41 @@ func (s *leaseStep) run(ctx context.Context) error {
 	} else {
 		return utilerrors.NewAggregate([]error{wrappedErr, releaseErr})
 	}
+}
+
+func acquireLeases(
+	client lease.Client,
+	ctx context.Context,
+	cancel context.CancelFunc,
+	leases []stepLease,
+) error {
+	for i, l := range leases {
+		log.Printf("Acquiring lease for %q", l.ResourceType)
+		name, err := client.Acquire(l.ResourceType, ctx, cancel)
+		if err != nil {
+			if err == lease.ErrNotFound {
+				printResourceMetrics(client, l.ResourceType)
+			}
+			return results.ForReason(results.Reason("acquiring_lease:"+l.ResourceType)).WithError(err).Errorf("failed to acquire lease: %v", err)
+		}
+		log.Printf("Acquired lease %q for %q", name, l.ResourceType)
+		leases[i].resource = name
+	}
+	return nil
+}
+
+func releaseLeases(client lease.Client, leases []stepLease) error {
+	var errs []error
+	for _, l := range leases {
+		if l.resource == "" {
+			continue
+		}
+		log.Printf("Releasing lease %q for %q", l.resource, l.ResourceType)
+		if err := client.Release(l.resource); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return utilerrors.NewAggregate(errs)
 }
 
 func heartbeatNamespace(namespace func() string, client coreclientset.NamespaceInterface, ctx context.Context) {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -49,9 +49,9 @@ func (stepNeedsLease) SubTests() []*junit.TestCase {
 }
 
 func TestLeaseStepForward(t *testing.T) {
-	name := "lease_name"
+	leases := []api.StepLease{{ResourceType: "lease_name"}}
 	step := stepNeedsLease{}
-	withLease := LeaseStep(nil, name, &step, func() string { return "" }, nil)
+	withLease := LeaseStep(nil, leases, &step, func() string { return "" }, nil)
 	t.Run("Inputs", func(t *testing.T) {
 		s, err := step.Inputs()
 		if err != nil {
@@ -109,6 +109,10 @@ func TestLeaseStepForward(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
+	leases := []api.StepLease{
+		{ResourceType: "rtype0"},
+		{ResourceType: "rtype1"},
+	}
 	ctx := context.Background()
 	for _, tc := range []struct {
 		name     string
@@ -116,29 +120,50 @@ func TestError(t *testing.T) {
 		failures sets.String
 		expected []string
 	}{{
-		name:     "acquire fails",
-		failures: sets.NewString("acquire owner rtype free leased random"),
-		expected: []string{"acquire owner rtype free leased random"},
+		name:     "first acquire fails",
+		failures: sets.NewString("acquire owner rtype0 free leased random"),
+		expected: []string{"acquire owner rtype0 free leased random"},
 	}, {
-		name:     "release fails",
-		failures: sets.NewString("releaseone owner rtype_0 free"),
+		name:     "second acquire fails",
+		failures: sets.NewString("acquire owner rtype1 free leased random"),
 		expected: []string{
-			"acquire owner rtype free leased random",
-			"releaseone owner rtype_0 free",
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+		},
+	}, {
+		name:     "first release fails",
+		failures: sets.NewString("releaseone owner rtype0_0 free"),
+		expected: []string{
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+			"releaseone owner rtype1_1 free",
+		},
+	}, {
+		name:     "second release fails",
+		failures: sets.NewString("releaseone owner rtype1_1 free"),
+		expected: []string{
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+			"releaseone owner rtype1_1 free",
 		},
 	}, {
 		name:     "run fails",
 		runFails: true,
 		expected: []string{
-			"acquire owner rtype free leased random",
-			"releaseone owner rtype_0 free",
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+			"releaseone owner rtype1_1 free",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls)
 			s := stepNeedsLease{fail: tc.runFails}
-			if LeaseStep(&client, "rtype", &s, func() string { return "" }, nil).Run(ctx) == nil {
+			if LeaseStep(&client, leases, &s, func() string { return "" }, nil).Run(ctx) == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
 			if !reflect.DeepEqual(calls, tc.expected) {
@@ -151,8 +176,9 @@ func TestError(t *testing.T) {
 func TestAcquireRelease(t *testing.T) {
 	var calls []string
 	client := lease.NewFakeClient("owner", "url", 0, nil, &calls)
+	leases := []api.StepLease{{ResourceType: "rtype0"}, {ResourceType: "rtype1"}}
 	step := stepNeedsLease{}
-	withLease := LeaseStep(&client, "rtype", &step, func() string { return "" }, nil)
+	withLease := LeaseStep(&client, leases, &step, func() string { return "" }, nil)
 	if err := withLease.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -161,7 +187,9 @@ func TestAcquireRelease(t *testing.T) {
 	}
 	expected := []string{
 		"acquire owner rtype0 free leased random",
+		"acquire owner rtype1 free leased random",
 		"releaseone owner rtype0_0 free",
+		"releaseone owner rtype1_1 free",
 	}
 	if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("wrong calls to the lease client: %s", diff.ObjectDiff(calls, expected))

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -121,17 +121,17 @@ func TestError(t *testing.T) {
 		expected: []string{"acquire owner rtype free leased random"},
 	}, {
 		name:     "release fails",
-		failures: sets.NewString("releaseone owner rtype0 free"),
+		failures: sets.NewString("releaseone owner rtype_0 free"),
 		expected: []string{
 			"acquire owner rtype free leased random",
-			"releaseone owner rtype0 free",
+			"releaseone owner rtype_0 free",
 		},
 	}, {
 		name:     "run fails",
 		runFails: true,
 		expected: []string{
 			"acquire owner rtype free leased random",
-			"releaseone owner rtype0 free",
+			"releaseone owner rtype_0 free",
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -160,8 +160,8 @@ func TestAcquireRelease(t *testing.T) {
 		t.Fatal("step was not executed")
 	}
 	expected := []string{
-		"acquire owner rtype free leased random",
-		"releaseone owner rtype0 free",
+		"acquire owner rtype0 free leased random",
+		"releaseone owner rtype0_0 free",
 	}
 	if !reflect.DeepEqual(calls, expected) {
 		t.Fatalf("wrong calls to the lease client: %s", diff.ObjectDiff(calls, expected))

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -38,7 +38,7 @@ const (
 
 var envForProfile = []string{
 	utils.ReleaseImageEnv(api.LatestReleaseName),
-	leaseEnv,
+	DefaultLeaseEnv,
 	utils.ImageFormatEnv,
 }
 


### PR DESCRIPTION
An internal change that should not have any externally observable behavior
change (other than a few log messages).  Required to support multiple
leases per test in the future.

/hold

Reviewable, but I'll work on adding tests for the existing code tomorrow.