### PR TITLE
image distributor: use local image reference policy

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	apihelper "github.com/openshift/ci-tools/pkg/api/helper"
@@ -272,6 +273,9 @@ func (r *reconciler) reconcile(req reconcile.Request, log *logrus.Entry) error {
 					Name: publicURLForImage(sourceImageStreamTag.Image.DockerImageReference),
 				},
 				To: &corev1.LocalObjectReference{Name: imageTag},
+				ReferencePolicy: imagev1.TagReferencePolicy{
+					Type: imagev1.LocalTagReferencePolicy,
+				},
 			}},
 		},
 	}
@@ -383,6 +387,9 @@ func imagestream(namespace, name string) (*imagev1.ImageStream, crcontrollerutil
 	}
 	return stream, func() error {
 		stream.Spec.LookupPolicy.Local = true
+		for i := range stream.Spec.Tags {
+			stream.Spec.Tags[i].ReferencePolicy.Type = imagev1.LocalTagReferencePolicy
+		}
 		return nil
 	}
 }

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -292,7 +292,8 @@ func TestReconcile(t *testing.T) {
 						Kind: "DockerImage",
 						Name: "registry.svc.ci.openshift.org/ocp/4.4@sha256:a273f5ac7f1ad8f7ffab45205ac36c8dff92d9107ef3ae429eeb135fa8057b8b",
 					},
-					To: &corev1.LocalObjectReference{Name: "Question"},
+					To:              &corev1.LocalObjectReference{Name: "Question"},
+					ReferencePolicy: imagev1.TagReferencePolicy{Type: "Local"},
 				}},
 			},
 			Status: imagev1.ImageStreamImportStatus{


### PR DESCRIPTION
When users query for an image on a build cluster, we want them to pull
from the internal registry of that cluster. This will force the internal
registry to use pull-through and cache the image layers, which was the
point of distributing the images in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 