### PR TITLE
E2E test: Print ci-operator output

### DIFF
--- a/hack/lib/cmd.sh
+++ b/hack/lib/cmd.sh
@@ -2,6 +2,15 @@
 # This utility file contains functions that wrap commands to be tested. All wrapper functions run commands
 # in a sub-shell and redirect all output. Tests in test-cmd *must* use these functions for testing.
 
+function os::cmd::redirect-to-stdout-wrapper() {
+    echo "$@ &>/dev/stdout"
+}
+
+function os::cmd::expect_success_print_output() {
+  cmd="$(os::cmd::redirect-to-stdout-wrapper $@)"
+  os::cmd::expect_success "$cmd"
+}
+
 # expect_success runs the cmd and expects an exit code of 0
 function os::cmd::expect_success() {
     if [[ $# -ne 1 ]]; then echo "os::cmd::expect_success expects only one argument, got $#"; return 1; fi
@@ -10,6 +19,11 @@ function os::cmd::expect_success() {
     os::cmd::internal::expect_exit_code_run_grep "${cmd}"
 }
 readonly -f os::cmd::expect_success
+
+function os::cmd::expect_failure_print_output(){
+  cmd="$(os::cmd::redirect-to-stdout-wrapper $@)"
+  os::cmd::expect_failure "$cmd"
+}
 
 # expect_failure runs the cmd and expects a non-zero exit code
 function os::cmd::expect_failure() {

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -14,10 +14,10 @@ os::test::junit::declare_suite_start "e2e/multi-stage"
 
 export JOB_SPEC='{"type":"presubmit","job":"pull-ci-test-test-master-success","buildid":"0","prowjobid":"uuid","refs":{"org":"test","repo":"test","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[{"number":1234,"author":"droslean","sha":"538680dfd2f6cff3b3506c80ca182dcb0dd22a58"}]}}'
 os::integration::configresolver::start "${suite_dir}/configs" "${suite_dir}/registry" "${OS_ROOT}/test/integration/ci-operator-configresolver/config.yaml" "true"
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target success"
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_success_print_output "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target success"
+os::cmd::expect_success_print_output "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_success_print_output "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_success_print_output "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"
@@ -30,6 +30,6 @@ os::test::junit::declare_suite_start "e2e/multi-stage/dependencies"
 # This test validates the ci-operator can amend the graph with user input
 
 export JOB_SPEC='{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]}}'
-os::cmd::expect_success "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-dependencies --unresolved-config ${suite_dir}/dependencies.yaml"
+os::cmd::expect_success_print_output "ci-operator --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-dependencies --unresolved-config ${suite_dir}/dependencies.yaml"
 os::integration::configresolver::check_log
 os::test::junit::declare_suite_end

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -15,9 +15,9 @@ os::test::junit::declare_suite_start "e2e/simple"
 # This test validates the ci-operator exit codes
 
 export JOB_SPEC='{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]}}'
-os::cmd::expect_success "ci-operator --target success --config ${suite_dir}/config.yaml"
-os::cmd::expect_failure "ci-operator --target success --target failure --config ${suite_dir}/config.yaml"
-os::cmd::expect_failure "ci-operator --target failure --config ${suite_dir}/config.yaml"
+os::cmd::expect_success_print_output "ci-operator --target success --config ${suite_dir}/config.yaml"
+os::cmd::expect_failure_print_output "ci-operator --target success --target failure --config ${suite_dir}/config.yaml"
+os::cmd::expect_failure_print_output "ci-operator --target failure --config ${suite_dir}/config.yaml"
 
 cluster_profile="${workdir}/cluster-profile"
 mkdir -p "${cluster_profile}"
@@ -25,7 +25,7 @@ touch "${cluster_profile}/data"
 artifact_dir="${workdir}/artifacts"
 mkdir -p "${artifact_dir}"
 unset NAMESPACE JOB_NAME_SAFE # set by the job running us, override
-os::cmd::expect_success "CLUSTER_TYPE=something TEST_COMMAND=executable ci-operator --template ${suite_dir}/template.yaml --target template --config ${suite_dir}/template-config.yaml --secret-dir ${cluster_profile} --artifact-dir=${artifact_dir}"
+os::cmd::expect_success "$(os::cmd::redirect-to-stdout-wrapper CLUSTER_TYPE=something TEST_COMMAND=executable ci-operator --template ${suite_dir}/template.yaml --target template --config ${suite_dir}/template-config.yaml --secret-dir ${cluster_profile} --artifact-dir=${artifact_dir})"
 os::integration::compare "${artifact_dir}/template" "${suite_dir}/artifacts/template"
 sed -i 's/time=".*"/time="whatever"/g' "${artifact_dir}/junit_operator.xml"
 os::integration::compare "${artifact_dir}/junit_operator.xml" "${suite_dir}/artifacts/junit_operator.xml"
@@ -39,13 +39,13 @@ export JOB_SPEC='{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master
 if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
   os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-secret -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
 fi
-os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:initial] --config ${suite_dir}/dynamic-releases.yaml"
-os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
-os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
-os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:pre] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success_print_output "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:initial] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success_print_output "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success_print_output "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --secret-dir ${PULL_SECRET_DIR} --target [release:custom] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success_print_output "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:pre] --config ${suite_dir}/dynamic-releases.yaml"
 RELEASE_IMAGE_LATEST="$( curl -s -H "Accept: application/json"  "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-4.4&arch=amd64" | jq --raw-output ".nodes[0].payload" )"
 export RELEASE_IMAGE_LATEST
-os::cmd::expect_success "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
+os::cmd::expect_success_print_output "ci-operator --secret-dir ${PULL_SECRET_DIR} --target [release:latest] --config ${suite_dir}/dynamic-releases.yaml"
 unset RELEASE_IMAGE_LATEST
 os::test::junit::declare_suite_end
 
@@ -60,5 +60,5 @@ if [[ -z "${PULL_PULL_SHA:-}" ]]; then
   os::log::fatal "\$PULL_PULL_SHA must be set for this test"
 fi
 export JOB_SPEC='{"type":"presubmit","job":"pull-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"'${PULL_BASE_SHA}'","pulls":[{"number":'${PULL_NUMBER}',"author":"AlexNPavel","sha":"'${PULL_PULL_SHA}'"}]}}'
-os::cmd::expect_success "ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --target [images] --target ci-index --config ${suite_dir}/optional-operators.yaml"
+os::cmd::expect_success_print_output "os::cmd::redirect-to-stdout-wrapper ci-operator --image-import-pull-secret ${PULL_SECRET_DIR}/.dockerconfigjson --target [images] --target ci-index --config ${suite_dir}/optional-operators.yaml"
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Currently this is redirected to a file, which makes it impossible to
debug these tests on timeout.
