### PR TITLE
pkg/steps/clusterinstall/template: Fix resourcewatch jsonpath quote

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -141,7 +141,7 @@ objects:
           while true; do
             [[ ! -f "${KUBECONFIG}" ]] && sleep 1s && continue # make sure we have KUBECONFIG
             echo "== $(date) =="
-            oc get clusteroperators --request-timeout=5s --insecure-skip-tls-verify --ignore-not-found -o jsonpath='{range .items[*]}{"\n"}{.metadata.name} {range .status.conditions[*]}{" "}{.type}={.status}({.reason}[{.message}])
+            oc get clusteroperators --request-timeout=5s --insecure-skip-tls-verify --ignore-not-found -o jsonpath='{range .items[*]}{"\n"}{.metadata.name} {range .status.conditions[*]}{" "}{.type}={.status}({.reason}[{.message}])'
             sleep 5s
           done
         }


### PR DESCRIPTION
[Avoiding][1]:

```
2020/08/20 21:43:28 Running pod e2e-gcp-upgrade
/bin/bash: -c: line 12: unexpected EOF while looking for matching `''
/bin/bash: -c: line 20: syntax error: unexpected end of file
2020/08/20 21:43:31 Container resourcewatch in pod e2e-gcp-upgrade failed, exit code 1, reason Error
```

fixing a typo from 31b8aa1900 (#1131).

[1]: https://storage.googleapis.com/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade/1296562905130471424/build-log.txt