### PR TITLE
Detect failed pods better

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -553,6 +553,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 				continue
 			}
 			if pod.Status.Phase != coreapi.PodRunning && time.Since(pod.CreationTimestamp.Time) > 30*time.Minute {
+				notifier.Complete(name)
 				return false, fmt.Errorf("pod didn't start running within 30 minutes: %s", getReasonsForUnreadyContainers(pod))
 			}
 		case event, ok := <-watcher.ResultChan():

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -552,7 +552,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 				log.Printf("warning: failed to get pod %s: %v", name, err)
 				continue
 			}
-			if !isPodRunning(pod) && time.Since(pod.CreationTimestamp.Time) > 30*time.Minute {
+			if pod.Status.Phase != coreapi.PodRunning && time.Since(pod.CreationTimestamp.Time) > 30*time.Minute {
 				return false, fmt.Errorf("pod didn't start running within 30 minutes: %s", getReasonsForUnreadyContainers(pod))
 			}
 		case event, ok := <-watcher.ResultChan():
@@ -714,15 +714,6 @@ func podJobIsFailed(pod *coreapi.Pod) bool {
 			if s.ExitCode != 0 {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func isPodRunning(pod *coreapi.Pod) bool {
-	for _, condition := range pod.Status.Conditions {
-		if condition.Type == coreapi.PodReady {
-			return condition.Status == coreapi.ConditionTrue
 		}
 	}
 	return false


### PR DESCRIPTION
ci-operator: detect running pods using phase

Looking at conditions made us think that pods were finished when a
single container had exited, so we should look at the overall phase
instead.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: cancel notifier when pod doesn't start

The notifiers that gather logs and write jUnit expect to be triggered
when a Pod terminates, but never are if the Pod never starts in the
first place. Our early-exit code waits on the notifier, so it was
nonfunctional as written.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

