### PR TITLE
ci-operator: create Pods with resolved refs

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -249,7 +249,7 @@ func FromConfig(
 					step = steps.LeaseStep(leaseClient, test.ClusterProfile.LeaseType(), step, jobSpec.Namespace, namespaceClient)
 				}
 			} else {
-				step = steps.TestStep(*testStep, config.Resources, podClient, artifactDir, jobSpec)
+				step = steps.TestStep(*testStep, config.Resources, podClient, imageClient, artifactDir, jobSpec)
 			}
 		}
 		if !isReleaseStep {

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -3,10 +3,10 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"path/filepath"
 
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -16,6 +16,8 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
 const (
@@ -48,6 +50,7 @@ type podStep struct {
 	config      PodStepConfiguration
 	resources   api.ResourceConfiguration
 	podClient   PodClient
+	imageClient imageclientset.ImageV1Interface
 	artifactDir string
 	jobSpec     *api.JobSpec
 
@@ -74,7 +77,10 @@ func (s *podStep) run(ctx context.Context) error {
 	if len(s.config.From.Namespace) > 0 {
 		return fmt.Errorf("pod step does not support an image stream tag reference outside the namespace")
 	}
-	image := fmt.Sprintf("%s:%s", s.config.From.Name, s.config.From.Tag)
+	image, err := utils.ImageDigestFor(s.imageClient, s.jobSpec.Namespace, s.config.From.Name, s.config.From.Tag)()
+	if err != nil {
+		return results.ForReason("resolving_image").ForError(err)
+	}
 
 	pod, err := s.generatePodForStep(image, containerResources)
 	if err != nil {
@@ -147,7 +153,7 @@ func (s *podStep) Description() string {
 	return fmt.Sprintf("Run test %s", s.config.As)
 }
 
-func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return PodStep(
 		"test",
 		PodStepConfiguration{
@@ -160,17 +166,19 @@ func TestStep(config api.TestStepConfiguration, resources api.ResourceConfigurat
 		},
 		resources,
 		podClient,
+		imageClient,
 		artifactDir,
 		jobSpec,
 	)
 }
 
-func PodStep(name string, config PodStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func PodStep(name string, config PodStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, imageClient imageclientset.ImageV1Interface, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &podStep{
 		name:        name,
 		config:      config,
 		resources:   resources,
 		podClient:   podClient,
+		imageClient: imageClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -223,7 +223,7 @@ oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
 		resources = copied
 	}
 
-	step := steps.PodStep("release", podConfig, resources, s.podClient, s.artifactDir, s.jobSpec)
+	step := steps.PodStep("release", podConfig, resources, s.podClient, s.imageClient, s.artifactDir, s.jobSpec)
 
 	return results.ForReason("creating_release").ForError(step.Run(ctx))
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -245,7 +245,7 @@ oc adm release extract%s --from=%q --file=image-references > /tmp/artifacts/%s
 		copied[podConfig.As] = api.ResourceRequirements{Requests: api.ResourceList{"cpu": "50m", "memory": "400Mi"}}
 		resources = copied
 	}
-	step := steps.PodStep("release", podConfig, resources, s.podClient, artifactDir, s.jobSpec)
+	step := steps.PodStep("release", podConfig, resources, s.podClient, s.imageClient, artifactDir, s.jobSpec)
 	if err := step.Run(ctx); err != nil {
 		return err
 	}

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -52,7 +52,7 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
-    image: somename:sometag
+    image: some-reg/TestNamespace/somename@sha256:47e2f82dbede8ff990e6e240f82d78830e7558f7b30df7bd8c0693992018b1e3
     name: StepName
     resources: {}
     terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -52,7 +52,7 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
-    image: somename:sometag
+    image: some-reg/TestNamespace/somename@sha256:47e2f82dbede8ff990e6e240f82d78830e7558f7b30df7bd8c0693992018b1e3
     name: StepName
     resources: {}
     terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
The built-in ImageStreamTag resolution process in OpenShift is arcane
and very difficult to understand in conjuction with all of the different
levels of image imports and distribution we have. We always want to pull
from the local registry when we're creating a Pod with an ImageStreamTag
so we can just do the digest resolution ourselves and use the resolved
pull specification in the Pod's configuration. If that ends up being
pull-through with the central registry as the source, that's fine, but
opaque to the end-user ci-operator process.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 
/cc @bparees 