### PR TITLE
ocp-build-data-enforcer: cleaup input path

### DIFF
--- a/cmd/ocp-build-data-enforcer/main.go
+++ b/cmd/ocp-build-data-enforcer/main.go
@@ -48,6 +48,7 @@ func gatherOptions() (*options, error) {
 	} else {
 		o.prCreationCeiling = 0
 	}
+	o.ocpBuildDataRepoDir = filepath.Clean(o.ocpBuildDataRepoDir)
 	return o, nil
 }
 


### PR DESCRIPTION
The code in gatherAllOCPImageConfigs relies on the directory path not
having a trailing slash:

https://github.com/openshift/ci-tools/blob/ae31d1102348b34a2cc218c6df66420927bb3b42/pkg/api/ocpbuilddata/types.go#L343

`Clean` cleans the path on input.

