### PR TITLE
ci-operator: create imagestreams with local reference policy

### DIFF
--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -137,8 +137,9 @@ func (s *releaseImagesTagStep) run(ctx context.Context) error {
 	for _, tag := range is.Spec.Tags {
 		if valid, _ := utils.FindStatusTag(is, tag.Name); valid != nil {
 			newIS.Spec.Tags = append(newIS.Spec.Tags, imageapi.TagReference{
-				Name: tag.Name,
-				From: valid,
+				Name:            tag.Name,
+				From:            valid,
+				ReferencePolicy: imageapi.TagReferencePolicy{Type: imageapi.LocalTagReferencePolicy},
 			})
 		}
 	}


### PR DESCRIPTION
We want users of these ImageStreams to refer to their content with the
local registry's domain, not wherever their content might be sourced
during pull-through.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>