### PR TITLE
Revert "Test image distribution controller: Only allow certain regist…

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -211,15 +211,10 @@ func (r *reconciler) reconcile(req reconcile.Request, log *logrus.Entry) error {
 	sourceImageStreamTag := &imagev1.ImageStreamTag{}
 	if err := r.registryClient.Get(r.ctx, decoded, sourceImageStreamTag); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Trace("Source imageStreamTag not found")
+			log.Debug("Source imageStreamTag not found")
 			return nil
 		}
 		return fmt.Errorf("failed to get imageStreamTag %s from registry cluster: %w", decoded.String(), err)
-	}
-	*log = *log.WithField("docker_image_reference", sourceImageStreamTag.Image.DockerImageReference)
-	if !isImportAllowed(sourceImageStreamTag.Image.DockerImageReference) {
-		log.Debug("Import not allowed, ignoring")
-		return nil
 	}
 
 	if err := client.Get(r.ctx, types.NamespacedName{Name: decoded.Namespace}, &corev1.Namespace{}); err != nil {
@@ -552,20 +547,4 @@ func upsertObject(ctx context.Context, c ctrlruntimeclient.Client, obj crcontrol
 		log.Info("Upsert succeeded")
 	}
 	return err
-}
-
-var allowedRegistries = sets.NewString("registry.svc.ci.openshift.org",
-	"docker-registry.default.svc:5000",
-	"registry.access.redhat.com",
-	"quay.io",
-	"gcr.io",
-	"docker.io",
-)
-
-func isImportAllowed(pullSpec string) bool {
-	i := strings.Index(pullSpec, "/")
-	if i == -1 {
-		return false
-	}
-	return allowedRegistries.Has(pullSpec[:i])
 }

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -170,12 +170,6 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
-	imageStreamTagWithBuild01PullSpec := func() *imagev1.ImageStreamTag {
-		copy := referenceImageStreamTag.DeepCopy()
-		copy.Image.DockerImageReference = "registry.build01.ci.openshift.org/ci-op-hbtwhrrm/pipeline@sha256:328d0a90295ef5f5932807bcab8f230007afeb1572d1d7878ab8bdae671dfa8b"
-		return copy
-	}
-
 	outdatedImageStreamTag := func() *imagev1.ImageStreamTag {
 		copy := referenceImageStreamTag.DeepCopy()
 		copy.Image.Name = "old"
@@ -378,28 +372,6 @@ func TestReconcile(t *testing.T) {
 				}
 				if err := controllerutil.SwallowIfTerminal(err); err != nil {
 					return fmt.Errorf("error %v is not terminal", err)
-				}
-				return nil
-			},
-		},
-		{
-			name: "ImageStreamTag with build01 reference, no import is created",
-			request: types.NamespacedName{
-				Namespace: "01_" + referenceImageStreamTag.Namespace,
-				Name:      referenceImageStreamTag.Name,
-			},
-			registryClient:      fakeclient.NewFakeClient(imageStreamTagWithBuild01PullSpec()),
-			buildClusterClients: map[string]ctrlruntimeclient.Client{"01": fakeclient.NewFakeClient()},
-			verify: func(rc ctrlruntimeclient.Client, bc map[string]ctrlruntimeclient.Client, err error) error {
-				if err != nil {
-					return fmt.Errorf("unexpected error: %w", err)
-				}
-				name := types.NamespacedName{
-					Namespace: referenceImageStreamTag.Namespace,
-					Name:      referenceImageStreamTag.Name,
-				}
-				if err := bc["01"].Get(ctx, name, &imagev1.ImageStreamImport{}); !apierrors.IsNotFound(err) {
-					return fmt.Errorf("expected to get not found err, but got %v", err)
 				}
 				return nil
 			},


### PR DESCRIPTION
…ries"

This reverts commit f3012533231b795c4bc2c8b3e01ac6fc9028d9eb.

There is the issue that even if an image is pullable without an ImageStreamTag, there might be code that expects an imagestreamtag.

This was originally built to avoid errors when we import from a build cluster because an imagestreamtag that originates in a build cluster is present on api.ci and it happens to fall in one of the static allow lists. We need to find another way to cope with that:
* Manually remove those
* Add a denylst that limits the allowlist