### PR TITLE
Prompotionreconciler: Only start once

### DIFF
--- a/pkg/controller/promotionreconciler/prowjobreconciler/prowjobreconciler.go
+++ b/pkg/controller/promotionreconciler/prowjobreconciler/prowjobreconciler.go
@@ -73,9 +73,6 @@ func AddToManager(mgr controllerruntime.Manager, config config.Getter, dryRun bo
 	if err := ctrl.Watch(src, &handler.EnqueueRequestForObject{}); err != nil {
 		return nil, fmt.Errorf("failed to create watch: %w", err)
 	}
-	if err := mgr.Add(ctrl); err != nil {
-		return nil, fmt.Errorf("failed to add controller to manager: %w", err)
-	}
 
 	return enqueuer, nil
 }


### PR DESCRIPTION
Currently, we add the promotionreconciler twice to the manager,
resulting in it getting started twice, resulting in a datarace as we
replace an in-use workqueue and double the configured workers.
