### PR TITLE
CI secret boostrap: Allow targeting a named group of clusters

### DIFF
--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -1,7 +1,11 @@
 package secretbootstrap
 
 import (
+	"encoding/json"
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 type AttributeType string
@@ -18,10 +22,17 @@ type BitWardenContext struct {
 }
 
 type SecretContext struct {
-	Cluster   string            `json:"cluster"`
-	Namespace string            `json:"namespace"`
-	Name      string            `json:"name"`
-	Type      corev1.SecretType `json:"type,omitempty"`
+	// A cluster to target. Mutually exclusive with 'ClusterGroups'
+	Cluster string `json:"cluster"`
+	// A list of clusterGroups to target. Mutually exclusive with 'cluster'
+	ClusterGroups []string          `json:"cluster_groups,omitempty"`
+	Namespace     string            `json:"namespace"`
+	Name          string            `json:"name"`
+	Type          corev1.SecretType `json:"type,omitempty"`
+}
+
+func (sc SecretContext) String() string {
+	return sc.Namespace + "/" + sc.Name + " in cluster " + sc.Cluster
 }
 
 type SecretConfig struct {
@@ -29,5 +40,56 @@ type SecretConfig struct {
 	To   []SecretContext             `json:"to"`
 }
 
-// Config is what we version in our repository.
-type Config []SecretConfig
+// Config is what we version in our repository
+type Config struct {
+	ClusterGroups map[string][]string `json:"cluster_groups,omitempty"`
+	Secrets       []SecretConfig      `json:"secret_configs"`
+}
+
+type configWithoutUnmarshaler Config
+
+func (c *Config) UnmarshalJSON(d []byte) error {
+	var target configWithoutUnmarshaler
+	if err := json.Unmarshal(d, &target); err != nil {
+		return err
+	}
+	*c = Config(target)
+	return c.resolve()
+}
+
+func (c *Config) resolve() error {
+	var errs []error
+
+	for idx, secret := range c.Secrets {
+		var newTo []SecretContext
+		for jdx, to := range secret.To {
+			if to.Cluster != "" && len(to.ClusterGroups) != 0 {
+				errs = append(errs, fmt.Errorf("item secrets.%d.to.%d has both cluster and cluster_groups set, those are mutually exclusive", idx, jdx))
+				continue
+			}
+			if to.Cluster != "" {
+				newTo = append(newTo, to)
+				continue
+			}
+			for _, clusterGroupName := range to.ClusterGroups {
+				clusters, groupExists := c.ClusterGroups[clusterGroupName]
+				if !groupExists {
+					errs = append(errs, fmt.Errorf("item secrets.%d.to.%d references inexistent cluster_group %s", idx, jdx, clusterGroupName))
+					continue
+				}
+				for _, cluster := range clusters {
+					newTo = append(newTo, SecretContext{
+						Cluster:   cluster,
+						Namespace: to.Namespace,
+						Name:      to.Name,
+						Type:      to.Type,
+					})
+				}
+			}
+		}
+
+		c.Secrets[idx].To = newTo
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/api/secretbootstrap/secretboostrap_test.go
+++ b/pkg/api/secretbootstrap/secretboostrap_test.go
@@ -1,0 +1,88 @@
+package secretbootstrap
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestResolving(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         Config
+		expectedError  string
+		expectedConfig Config
+	}{
+		{
+			name:          "Both cluster and cluster_groups set, error",
+			config:        Config{Secrets: []SecretConfig{{To: []SecretContext{{Cluster: "cl", ClusterGroups: []string{"a"}}}}}},
+			expectedError: "item secrets.0.to.0 has both cluster and cluster_groups set, those are mutually exclusive",
+		},
+		{
+			name: "Cluster groups get resolved",
+			config: Config{
+				ClusterGroups: map[string][]string{
+					"group-a": {"a"},
+					"group-b": {"b"},
+				},
+				Secrets: []SecretConfig{{
+					To: []SecretContext{{
+						ClusterGroups: []string{"group-a", "group-b"},
+						Namespace:     "namspace",
+						Name:          "name",
+						Type:          corev1.SecretTypeBasicAuth,
+					}},
+				}},
+			},
+			expectedConfig: Config{
+				ClusterGroups: map[string][]string{
+					"group-a": {"a"},
+					"group-b": {"b"},
+				},
+				Secrets: []SecretConfig{{
+					To: []SecretContext{
+						{
+							Cluster:   "a",
+							Namespace: "namspace",
+							Name:      "name",
+							Type:      corev1.SecretTypeBasicAuth,
+						},
+						{
+							Cluster:   "b",
+							Namespace: "namspace",
+							Name:      "name",
+							Type:      corev1.SecretTypeBasicAuth,
+						},
+					},
+				}},
+			},
+		},
+		{
+			name:          "Inexistent ClusterGroups, error",
+			config:        Config{Secrets: []SecretConfig{{To: []SecretContext{{ClusterGroups: []string{"a"}}}}}},
+			expectedError: "item secrets.0.to.0 references inexistent cluster_group a",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			var errMsg string
+			err := tc.config.resolve()
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != tc.expectedError {
+				t.Fatalf("got error %s, expected error %s", errMsg, tc.expectedError)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expectedConfig, tc.config); diff != "" {
+				t.Errorf("expected config differs from actual config: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/secretsyncer/secretsyncer.go
+++ b/pkg/controller/secretsyncer/secretsyncer.go
@@ -250,7 +250,7 @@ func (s boostrapSecretConfigTarget) String() string {
 
 func filterFromConfig(cfg secretbootstrap.Config) filter {
 	forbidden := sets.String{}
-	for _, cfg := range cfg {
+	for _, cfg := range cfg.Secrets {
 		for _, target := range cfg.To {
 			for from := range cfg.From {
 				forbidden.Insert(boostrapSecretConfigTarget{cluster: target.Cluster, namespace: target.Namespace, name: target.Name, key: from}.String())

--- a/pkg/controller/secretsyncer/secretsyncer_test.go
+++ b/pkg/controller/secretsyncer/secretsyncer_test.go
@@ -147,12 +147,12 @@ func TestFilter(t *testing.T) {
 	}{
 		{
 			name: "forbidden",
-			cfg: secretbootstrap.Config{{
+			cfg: secretbootstrap.Config{Secrets: []secretbootstrap.SecretConfig{{
 				From: map[string]secretbootstrap.BitWardenContext{target.key: {}},
 				To: []secretbootstrap.SecretContext{
 					{Cluster: target.cluster, Namespace: target.namespace, Name: target.name},
 				},
-			}},
+			}}},
 			expectedResult: false,
 		},
 		{


### PR DESCRIPTION
This PR allows defining and targeting a named group of clusters via ci-secret-bootstrap.

The resolving is implemented as part of a custom unmarshaler, which makes this completely transparent for consumers.

This PR breaks the config format, which means after we merge it, we need to adjust the config in o/release to have the secret configs below the `secret_configs` as seen in the testcase changes.

Its recommended to review this PR with whitespace changes disabled.