### PR TITLE
ci-operator: immediately print when a Pod fails to start

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -553,8 +554,10 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 				continue
 			}
 			if pod.Status.Phase != coreapi.PodRunning && time.Since(pod.CreationTimestamp.Time) > 30*time.Minute {
+				message := fmt.Sprintf("pod didn't start running within 30 minutes: %s", getReasonsForUnreadyContainers(pod))
+				log.Print(message)
 				notifier.Complete(name)
-				return false, fmt.Errorf("pod didn't start running within 30 minutes: %s", getReasonsForUnreadyContainers(pod))
+				return false, errors.New(message)
 			}
 		case event, ok := <-watcher.ResultChan():
 			if !ok {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"io"
 	"log"
 	"os"
@@ -15,7 +14,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +31,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
 const (
@@ -121,7 +121,7 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 		opt := meta.DeleteOptions{
 			PropagationPolicy: &policy,
 		}
-		if err := s.templateClient.TemplateInstances(s.jobSpec.Namespace()).Delete(ctx, s.template.Name, opt); err != nil && !errors.IsNotFound(err) {
+		if err := s.templateClient.TemplateInstances(s.jobSpec.Namespace()).Delete(ctx, s.template.Name, opt); err != nil && !kerrors.IsNotFound(err) {
 			log.Printf("error: Could not delete template instance: %v", err)
 		}
 	}()
@@ -329,7 +329,7 @@ func createOrRestartTemplateInstance(templateClient templateclientset.TemplateIn
 		return nil, fmt.Errorf("unable to delete completed template instance: %w", err)
 	}
 	created, err := templateClient.Create(context.TODO(), instance, meta.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return nil, fmt.Errorf("unable to create template instance: %w", err)
 	}
 	if err != nil {
@@ -344,7 +344,7 @@ func createOrRestartTemplateInstance(templateClient templateclientset.TemplateIn
 
 func waitForCompletedTemplateInstanceDeletion(templateClient templateclientset.TemplateInstanceInterface, podClient coreclientset.PodInterface, name string) error {
 	instance, err := templateClient.Get(context.TODO(), name, meta.GetOptions{})
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		log.Printf("Template instance %s already deleted, do not need to wait any longer", name)
 		return nil
 	}
@@ -356,7 +356,7 @@ func waitForCompletedTemplateInstanceDeletion(templateClient templateclientset.T
 		PropagationPolicy: &policy,
 		Preconditions:     &meta.Preconditions{UID: &uid},
 	})
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		log.Printf("After initial existence check, a delete of template %s and instance %s received a not found error ",
 			name, string(instance.UID))
 		return nil
@@ -367,7 +367,7 @@ func waitForCompletedTemplateInstanceDeletion(templateClient templateclientset.T
 
 	for i := 0; ; i++ {
 		instance, err := templateClient.Get(context.TODO(), name, meta.GetOptions{})
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			break
 		}
 		if err != nil {
@@ -407,11 +407,11 @@ func createOrRestartPod(podClient coreclientset.PodInterface, pod *coreapi.Pod) 
 	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Factor: 2, Duration: time.Second}, func() (bool, error) {
 		newPod, err := podClient.Create(context.TODO(), pod, meta.CreateOptions{})
 		if err != nil {
-			if errors.IsForbidden(err) {
+			if kerrors.IsForbidden(err) {
 				log.Printf("Unable to create pod %s, may be temporary: %v", pod.Name, err)
 				return false, nil
 			}
-			if !errors.IsAlreadyExists(err) {
+			if !kerrors.IsAlreadyExists(err) {
 				return false, err
 			}
 			newPod, err = podClient.Get(context.TODO(), pod.Name, meta.GetOptions{})
@@ -431,7 +431,7 @@ func waitForPodDeletion(podClient coreclientset.PodInterface, name string, uid t
 	timeout := 600
 	for i := 0; i < timeout; i += 2 {
 		pod, err := podClient.Get(context.TODO(), name, meta.GetOptions{})
-		if errors.IsNotFound(err) {
+		if kerrors.IsNotFound(err) {
 			return nil
 		}
 		if err != nil {
@@ -449,7 +449,7 @@ func waitForPodDeletion(podClient coreclientset.PodInterface, name string, uid t
 
 func waitForCompletedPodDeletion(podClient coreclientset.PodInterface, name string) error {
 	pod, err := podClient.Get(context.TODO(), name, meta.GetOptions{})
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		return nil
 	}
 	// running pods are left to run, we just wait for them to finish
@@ -460,7 +460,7 @@ func waitForCompletedPodDeletion(podClient coreclientset.PodInterface, name stri
 	// delete the pod we expect, otherwise another user has relaunched this pod
 	uid := pod.UID
 	err = podClient.Delete(context.TODO(), name, meta.DeleteOptions{Preconditions: &meta.Preconditions{UID: &uid}})
-	if errors.IsNotFound(err) {
+	if kerrors.IsNotFound(err) {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
ci-operator: add an import alias for k8s errors

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: immediately print when a Pod fails to start

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
