### PR TITLE
ci-operator: build oo indices with `--mode semver` 

### DIFF
--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -93,7 +93,7 @@ func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
 		}
 		bundles = append(bundles, fullSpec)
 	}
-	dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["opm", "index", "add", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"]`, strings.Join(bundles, ","), IndexDockerfileName))
+	dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"]`, strings.Join(bundles, ","), IndexDockerfileName))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	buildapi "github.com/openshift/api/build/v1"
+	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
+	coreapi "k8s.io/api/core/v1"
+
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
-	imageclientset "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
-	coreapi "k8s.io/api/core/v1"
 )
 
 type indexGeneratorStep struct {

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	apiimagev1 "github.com/openshift/api/image/v1"
-	"github.com/openshift/ci-tools/pkg/api"
 	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
 )
 
 func TestIndexGenDockerfile(t *testing.T) {

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -38,7 +38,7 @@ func TestIndexGenDockerfile(t *testing.T) {
 	var expectedDockerfileSingleBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
-RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
+RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -62,7 +62,7 @@ COPY --from=builder /database/ database`
 	var expectedDockerfileMultiBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
-RUN ["opm", "index", "add", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
+RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apiimagev1 "github.com/openshift/api/image/v1"
 	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,7 +57,7 @@ COPY --from=builder /database/ database`
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if expectedDockerfileSingleBundle != generatedDockerfile {
-		t.Errorf("Generated opm index dockerfile does not equal expected; generated dockerfile: %s", generatedDockerfile)
+		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileSingleBundle, generatedDockerfile))
 	}
 
 	var expectedDockerfileMultiBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
@@ -80,6 +81,6 @@ COPY --from=builder /database/ database`
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	if expectedDockerfileMultiBundle != generatedDockerfile {
-		t.Errorf("Generated opm index dockerfile does not equal expected; generated dockerfile: %s", generatedDockerfile)
+		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileMultiBundle, generatedDockerfile))
 	}
 }


### PR DESCRIPTION
We are adding custom-build bundles into an ephemeral, empty indices, so
we need `--mode semver` to avoid problems when adding CSVs with
`replaces:` stanzas.

Also, cleanup imports (courtesy of Goland) and improve tests.

/cc @stevekuznetsov @AlexNPavel 