### PR TITLE
Imagebuild: connection reset by peer is a transient failure

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -446,7 +446,8 @@ func hintsAtInfraReason(logSnippet string) bool {
 		strings.Contains(logSnippet, "Error: Failed to synchronize cache for repo") ||
 		strings.Contains(logSnippet, "Could not resolve host: ") ||
 		strings.Contains(logSnippet, "net/http: TLS handshake timeout") ||
-		strings.Contains(logSnippet, "All mirrors were tried")
+		strings.Contains(logSnippet, "All mirrors were tried") ||
+		strings.Contains(logSnippet, "connection reset by peer")
 }
 
 func waitForBuild(ctx context.Context, buildClient BuildClient, namespace, name string) error {


### PR DESCRIPTION
Sample: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/1185/pull-ci-openshift-ci-tools-master-images/1300548570507644928