### PR TITLE
Add allow-list as input to testgrid

### DIFF
--- a/cmd/testgrid-config-generator/README.md
+++ b/cmd/testgrid-config-generator/README.md
@@ -38,7 +38,7 @@ Now run testgrid-config-generator.
 
 Assuming you have all your repos rooted at the same toplevel dir, you can run the following command from the `github.com/openshift/ci-tools/cmd/testgrid-config-generator` directory, otherwise you will need to specify the correct paths to the repos/subdirs:
 ```console
-$ ./testgrid-config-generator -testgrid-config ../../../../kubernetes/test-infra/config/testgrids/openshift -release-config ../../../release/core-services/release-controller/_releases -prow-jobs-dir ../../../release/ci-operator/jobs
+$ ./testgrid-config-generator -testgrid-config ../../../../kubernetes/test-infra/config/testgrids/openshift -release-config ../../../release/core-services/release-controller/_releases -prow-jobs-dir ../../../release/ci-operator/jobs -allow-list=../../../release/core-services/testgrid-config-generator/_allow-list.yaml
 ````
 Verify that changes were made by checking your local `test-infra` repo. For example:
 ```console

--- a/cmd/testgrid-config-generator/main_test.go
+++ b/cmd/testgrid-config-generator/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetAllowList(t *testing.T) {
+	testcases := []struct {
+		name          string
+		input         string
+		expectedOut   map[string]string
+		expectedError error
+	}{
+		{
+			name: "Release type blocking",
+			input: `
+key1: informing
+key2: blocking
+`,
+			expectedError: fmt.Errorf("release_type \"blocking\" not permitted in the allow-list for key2, blocking jobs must be in the release controller configuration"),
+		},
+		{
+			name: "Release type blocking",
+			input: `
+key1: informing
+key2: informing
+`,
+			expectedOut: map[string]string{
+				"key1": "informing",
+				"key2": "informing",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		data := tc.input
+		allowList, err := getAllowList([]byte(data))
+		equal(t, tc.expectedOut, allowList)
+		equalError(t, tc.expectedError, err)
+	}
+
+}
+
+func equalError(t *testing.T, expected, actual error) {
+	if expected != nil && actual == nil || expected == nil && actual != nil {
+		t.Errorf("expecting error \"%v\", got \"%v\"", expected, actual)
+	}
+	if expected != nil && actual != nil && expected.Error() != actual.Error() {
+		t.Errorf("expecting error msg %q, got %q", expected.Error(), actual.Error())
+	}
+}
+
+func equal(t *testing.T, expected, actual interface{}) {
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("actual differs from expected:\n%s", cmp.Diff(expected, actual))
+	}
+}

--- a/test/integration/testgrid-config-generator.sh
+++ b/test/integration/testgrid-config-generator.sh
@@ -15,7 +15,7 @@ cp -a "${suite_dir}/config/testgrid/"* "${workdir}"
 os::test::junit::declare_suite_start "integration/testgrid-config-generator"
 # This test validates the testgrid-config-generator tool
 
-os::cmd::expect_success "testgrid-config-generator --release-config ${suite_dir}/config/release --testgrid-config ${workdir} --prow-jobs-dir ${suite_dir}/config/jobs"
+os::cmd::expect_success "testgrid-config-generator --release-config ${suite_dir}/config/release --testgrid-config ${workdir} --prow-jobs-dir ${suite_dir}/config/jobs --allow-list ${suite_dir}/config/_allow-list.yaml"
 os::integration::compare "${workdir}" "${suite_dir}/expected"
 
 os::test::junit::declare_suite_end

--- a/test/integration/testgrid-config-generator/config/_allow-list.yaml
+++ b/test/integration/testgrid-config-generator/config/_allow-list.yaml
@@ -1,0 +1,4 @@
+release-openshift-origin-job-from-allow-list: informing
+release-openshift-origin-job: informing
+release-openshift-origin-job-without-release-label-broken: broken
+release-openshift-ocp-job: informing

--- a/test/integration/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
+++ b/test/integration/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
@@ -70,3 +70,9 @@ periodics:
   decorate: true
   interval: 2h
   name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    job-release: "4.2"
+  name: release-openshift-origin-job-from-allow-list

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -108,6 +108,33 @@ dashboards:
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-job
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-job-from-allow-list
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-job-from-allow-list
   name: redhat-openshift-ocp-release-4.2-informing
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
@@ -120,3 +147,6 @@ test_groups:
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-job
   name: release-openshift-origin-job
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-job-from-allow-list
+  name: release-openshift-origin-job-from-allow-list


### PR DESCRIPTION
This change allows the release-type to be specified in the allowed
list thereby deprecating the need to add the release-type annotation.