### PR TITLE
prowgen: add support for generating ci-index presubmit

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -330,6 +330,8 @@ func validateTestStepConfiguration(fieldRoot string, input []TestStepConfigurati
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: is required", fieldRootN))
 		} else if test.As == "images" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'images' because it gets confused with '[images]' target", fieldRootN))
+		} else if test.As == "ci-index" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'ci-index' because it gets confused with 'ci-index' target", fieldRootN))
 		} else if len(validation.IsDNS1123Subdomain(test.As)) != 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' is not a valid Kubernetes object name", fieldRootN, test.As))
 		}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -41,6 +41,17 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			id: `ReleaseBuildConfiguration{Tests: {As: "ci-index"}}`,
+			tests: []TestStepConfiguration{
+				{
+					As:                         "ci-index",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
+				},
+			},
+			expectedValid: false,
+		},
+		{
 			id: "No test type",
 			tests: []TestStepConfiguration{
 				{

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -191,7 +191,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, true, nil, tc.jobRelease)) // podSpec tested in generatePodSpec
+			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, jobconfig.Generated, nil, nil, tc.jobRelease)) // podSpec tested in generatePodSpec
 		})
 	}
 }
@@ -381,6 +381,22 @@ func TestGenerateJobs(t *testing.T) {
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
 				InputConfiguration: ciop.InputConfiguration{
 					ReleaseTagConfiguration: &ciop.ReleaseTagConfiguration{Namespace: "openshift"},
+				},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		}, {
+			id: "operator section creates ci-index presubmit job",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{},
+				Operator: &ciop.OperatorStepConfiguration{
+					Bundles: []ciop.Bundle{{
+						DockerfilePath: "bundle.Dockerfile",
+						ContextDir:     "manifests",
+					}},
 				},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-ci-index

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -11,6 +11,10 @@ build_root:
 images:
 - from: base
   to: test-image
+operator:
+  bundles:
+  - dockerfile_path: bundle.Dockerfile
+    context_dir: manifests
 promotion:
   name: other
   namespace: ocp

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -4,6 +4,50 @@ presubmits:
     always_run: true
     branches:
     - master
+    context: ci/prow/ci-index
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-super-duper-master-ci-index
+    rerun_command: /test ci-index
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-password-file=/etc/report/password.txt
+        - --report-username=ci
+        - --target=ci-index
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: regcred
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ci-index,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
     context: ci/prow/e2e
     decorate: true
     decoration_config:


### PR DESCRIPTION
This PR adds support for automatically generating a `ci-index`
targetting presubmit for any config that contains an `operator` section.

/cc @petr-muller 