### PR TITLE
prowgen: add support for generating postsubmits

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -341,8 +341,11 @@ func validateTestStepConfiguration(fieldRoot string, input []TestStepConfigurati
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `commands`, `steps`, and `literal_steps` are mutually exclusive", fieldRootN))
 		}
 
-		// Validate Secret/Secrets
+		if test.Postsubmit && test.Cron != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `cron` and `postsubmit` are mututally exclusive", fieldRootN))
+		}
 
+		// Validate Secret/Secrets
 		if test.Secret != nil && test.Secrets != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("test.Secret and test.Secrets cannot both be set"))
 		}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestValidateTests(t *testing.T) {
+	cronString := "0 0 * * 1"
 	for _, tc := range []struct {
 		id            string
 		release       *ReleaseTagConfiguration
@@ -370,6 +371,19 @@ func TestValidateTests(t *testing.T) {
 					MultiStageTestConfiguration: &MultiStageTestConfiguration{},
 				},
 			},
+		},
+		{
+			id: "cron and postsubmit together are invalid",
+			tests: []TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &ContainerTestConfiguration{From: "ignored"},
+					Cron:                       &cronString,
+					Postsubmit:                 true,
+				},
+			},
+			expectedValid: false,
 		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -477,6 +477,9 @@ type TestStepConfiguration struct {
 	// create a periodic job instead of a presubmit
 	Cron *string `json:"cron,omitempty"`
 
+	// Postsubmit configures prowgen to generate the job as a postsubmit rather than a presubmit
+	Postsubmit bool `json:"postsubmit,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
 	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -404,6 +404,18 @@ func TestGenerateJobs(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
+		}, {
+			id: "two tests and empty Images with one test configured as a postsubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}},
+					{As: "leTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}, Postsubmit: true}},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
 		},
 	}
 

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
@@ -1,0 +1,13 @@
+postsubmits:
+  organization/repository:
+  - labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-leTest
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-derTest

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -710,8 +710,23 @@ them (by declaring container image builds with <code>images</code> and the desti
 for them to be published with <code>promotion</code>), a <i>post-submit</i> test will
 exist. A post-submit test executes after code is merged to the target repository;
 this sort of test type is a good fit for publication of new artifacts after changes to
-source code. It is not possible to configure any additional post-submit tests
-at this time using <code>ci-operator</code> configuration.
+source code.
+</p>
+<p>
+Adding a custom postsubmit to a repository via the ci-operator config is
+supported. To do so, add the <code>postsubmit</code> field to a ci-operator
+test config and set it to <code>true</code>. The following example configures
+a ci-operator test to run as a postsubmit:
+</p>
+<code>ci-operator</code> configuration:
+{{ yamlSyntax (index . "ciOperatorPostsubmitTestConfig") }}
+
+<p>
+One important thing to note is that, unlike presubmit jobs, the postsubmit
+tests are configured to not be rehearsable. This means that when the test is
+being added or modified by a PR in the <code>openshift/release</code> repo,
+the job will not be automatically run against the change in the PR. This is
+done to prevent accidental publication of artifacts by rehearsals.
 </p>
 
 <h5 id="periodic"><a href="#periodic">Periodic Tests</a></h5>
@@ -947,6 +962,14 @@ const depsPropagation = `tests:
       dependencies:
       - name: "pipeline:bin" # the original definition of ${DEP}
         env: "DEP"
+`
+
+const ciOperatorPostsubmitTestConfig = `tests:
+- as: "upload-results"               # names this test "upload-results"
+  commands: "make upload-results"    # declares which commands to run
+  container:
+    from: "bin"                      # runs the commands in "pipeline:bin"
+  postsubmit: true                   # schedule the job to be run as a postsubmit
 `
 
 const ciOperatorPeriodicTestConfig = `tests:
@@ -2255,6 +2278,7 @@ func helpHandler(subPath string, w http.ResponseWriter, _ *http.Request) {
 		data["ciOperatorTagSpecificationConfig"] = ciOperatorTagSpecificationConfig
 		data["ciOperatorReleaseConfig"] = ciOperatorReleaseConfig
 		data["ciOperatorContainerTestConfig"] = ciOperatorContainerTestConfig
+		data["ciOperatorPostsubmitTestConfig"] = ciOperatorPostsubmitTestConfig
 		data["ciOperatorPeriodicTestConfig"] = ciOperatorPeriodicTestConfig
 		data["ciOperatorContainerTestWithDependenciesConfig"] = ciOperatorContainerTestWithDependenciesConfig
 		data["depsPropagation"] = depsPropagation

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -37,6 +37,11 @@ tests:
   commands: make test-unit
   container:
     from: src
+- as: upload-results
+  commands: make upload-results
+  container:
+    from: src
+  postsubmit: true
 - as: lint
   commands: make test-lint
   container:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -55,6 +55,46 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-super-duper-master-upload-results
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-password-file=/etc/report/password.txt
+        - --report-username=ci
+        - --target=upload-results
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: regcred
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/prowgen-controlled: "true"
       ci-operator.openshift.io/variant: variant


### PR DESCRIPTION
This PR allows users to generate postsubmits from a test defined
in ci-operator by adding a `postsubmit` field to the TestStepConfiguration
type.