### PR TITLE
Make sure build labels are always set correctly

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -279,9 +279,8 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 		},
 		Spec: buildapi.BuildSpec{
 			CommonSpec: buildapi.CommonSpec{
-				Resources:      buildResources,
-				ServiceAccount: "builder", // TODO: remove when build cluster has https://github.com/openshift/origin/pull/17668
-				Source:         source,
+				Resources: buildResources,
+				Source:    source,
 				Strategy: buildapi.BuildStrategy{
 					Type: buildapi.DockerBuildStrategyType,
 					DockerStrategy: &buildapi.DockerBuildStrategy{

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -17,6 +17,19 @@ metadata:
 spec:
   nodeSelector: null
   output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src
@@ -25,7 +38,6 @@ spec:
   resources:
     requests:
       cpu: 200m
-  serviceAccount: builder
   source:
     dockerfile: |2
 


### PR DESCRIPTION
Before this commit, we set the build labels like vcs ref identifier in the
projectDirectoryImageBuildStep but nowhere else. This means that all the
other images will either not have these labels or inherit them from
their base.

When such an image without correct labels gets promoted, the
promotionreconciler and possibly other automation that relies on the
correctness on them doesn't work properly anymore.