### PR TITLE
pkg/steps/lease: print resource metrics on failure

### DIFF
--- a/pkg/lease/fake.go
+++ b/pkg/lease/fake.go
@@ -54,3 +54,7 @@ func (c *fakeClient) ReleaseOne(name, dest string) error {
 func (c *fakeClient) ReleaseAll(dest string) error {
 	return c.addCall("releaseall", dest)
 }
+
+func (*fakeClient) Metric(rtype string) (common.Metric, error) {
+	return common.NewMetric(rtype), nil
+}


### PR DESCRIPTION
The upstream client and server errors are confusing because both
non-existent and exhausted resources result in an HTTP 404 error.

We often receive support requests because the error message (`failed to
acquire lease: resources not found`) can give the false impression that
the test infrastructure is at fault.

Sample output:

```
2020/09/04 18:08:42 Acquiring lease for "aws-quota-slice"
2020/09/04 18:08:47 warning: Failed to acquire resource, current capacity: 0 free, 1 leased
2020/09/04 18:08:47 Ran for 2m17s
error: some steps failed:
  * could not run steps: step test failed: failed to acquire lease: resources not found
```