### PR TITLE
pkg/steps/lease: fail faster if client not present

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -585,7 +585,9 @@ func (o *options) Run() []error {
 	if err := dumpGraph(o.artifactDir, nodes); err != nil {
 		return []error{fmt.Errorf("failed to dump graph to artifacts dir: %w", err)}
 	}
-
+	if err := api.ValidateGraph(nodes); err != nil {
+		return err
+	}
 	// initialize the namespace if necessary and create any resources that must
 	// exist prior to execution
 	if err := o.initializeNamespace(); err != nil {

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -30,6 +30,8 @@ func (s *bundleSourceStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*bundleSourceStep) Validate() error { return nil }
+
 func (s *bundleSourceStep) Run(ctx context.Context) error {
 	return results.ForReason("building_bundle_source").ForError(s.run(ctx))
 }

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -119,6 +119,8 @@ func (s *e2eTestStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*e2eTestStep) Validate() error { return nil }
+
 func (s *e2eTestStep) Run(ctx context.Context) error {
 	return results.ForReason("installing_cluster").ForError(s.run(ctx))
 }

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -29,6 +29,8 @@ func (s *gitSourceStep) Inputs() (api.InputDefinition, error) {
 	return s.jobSpec.Inputs(), nil
 }
 
+func (*gitSourceStep) Validate() error { return nil }
+
 func (s *gitSourceStep) Run(ctx context.Context) error {
 	return results.ForReason("building_image_from_source").ForError(s.run(ctx))
 }

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -14,6 +14,8 @@ func (s *imagesReadyStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*imagesReadyStep) Validate() error { return nil }
+
 func (s *imagesReadyStep) Run(ctx context.Context) error {
 	return nil
 }

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -33,6 +33,8 @@ func (s *indexGeneratorStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*indexGeneratorStep) Validate() error { return nil }
+
 func (s *indexGeneratorStep) Run(ctx context.Context) error {
 	return results.ForReason("building_index_generator").ForError(s.run(ctx))
 }

--- a/pkg/steps/input_env.go
+++ b/pkg/steps/input_env.go
@@ -35,6 +35,8 @@ func (s *inputEnvironmentStep) Inputs() (api.InputDefinition, error) {
 	return values, nil
 }
 
+func (*inputEnvironmentStep) Validate() error { return nil }
+
 func (s *inputEnvironmentStep) Run(ctx context.Context) error {
 	return nil
 }

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -47,6 +47,8 @@ func (s *inputImageTagStep) Inputs() (api.InputDefinition, error) {
 	return api.InputDefinition{from.Image.Name}, nil
 }
 
+func (*inputImageTagStep) Validate() error { return nil }
+
 func (s *inputImageTagStep) Run(ctx context.Context) error {
 	return results.ForReason("tagging_input_image").ForError(s.run(ctx))
 }

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -46,6 +46,8 @@ func (s *leaseStep) Inputs() (api.InputDefinition, error) {
 	return s.wrapped.Inputs()
 }
 
+func (s *leaseStep) Validate() error { return nil }
+
 func (s *leaseStep) Name() string             { return s.wrapped.Name() }
 func (s *leaseStep) Description() string      { return s.wrapped.Description() }
 func (s *leaseStep) Requires() []api.StepLink { return s.wrapped.Requires() }

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -74,10 +74,10 @@ func (s *leaseStep) Run(ctx context.Context) error {
 
 func (s *leaseStep) run(ctx context.Context) error {
 	log.Printf("Acquiring lease for %q", s.leaseType)
-	client := *s.client
-	if client == nil {
+	if s.client == nil {
 		return results.ForReason("initializing_client").ForError(errors.New("step needs a lease but no lease client provided"))
 	}
+	client := *s.client
 	ctx, cancel := context.WithCancel(ctx)
 	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
 	go heartbeatNamespace(s.namespace, s.namespaceClient, heartbeatCtx)
@@ -85,7 +85,7 @@ func (s *leaseStep) run(ctx context.Context) error {
 	if err != nil {
 		heartbeatCancel()
 		if err == lease.ErrNotFound {
-			printResourceMetrics(*s.client, s.leaseType)
+			printResourceMetrics(client, s.leaseType)
 		}
 		return results.ForReason(results.Reason("acquiring_lease:"+s.leaseType)).WithError(err).Errorf("failed to acquire lease: %v", err)
 	}

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -21,6 +21,7 @@ type stepNeedsLease struct {
 func (stepNeedsLease) Inputs() (api.InputDefinition, error) {
 	return api.InputDefinition{"step", "inputs"}, nil
 }
+func (stepNeedsLease) Validate() error { return nil }
 func (s *stepNeedsLease) Run(ctx context.Context) error {
 	s.ran = true
 	if s.fail {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -121,6 +121,8 @@ func (s *multiStageTestStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*multiStageTestStep) Validate() error { return nil }
+
 func (s *multiStageTestStep) Run(ctx context.Context) error {
 	return results.ForReason("executing_multi_stage_test").ForError(s.run(ctx))
 }

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -30,6 +30,8 @@ func (s *outputImageTagStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*outputImageTagStep) Validate() error { return nil }
+
 func (s *outputImageTagStep) Run(ctx context.Context) error {
 	return results.ForReason("tagging_output_image").ForError(s.run(ctx))
 }

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -31,6 +31,8 @@ func (s *pipelineImageCacheStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*pipelineImageCacheStep) Validate() error { return nil }
+
 func (s *pipelineImageCacheStep) Run(ctx context.Context) error {
 	return results.ForReason("building_cache_image").ForError(s.run(ctx))
 }

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -58,6 +58,8 @@ func (s *podStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*podStep) Validate() error { return nil }
+
 func (s *podStep) Run(ctx context.Context) error {
 	return results.ForReason("running_pod").ForError(s.run(ctx))
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -31,6 +31,8 @@ func (s *projectDirectoryImageBuildStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*projectDirectoryImageBuildStep) Validate() error { return nil }
+
 func (s *projectDirectoryImageBuildStep) Run(ctx context.Context) error {
 	return results.ForReason("building_project_image").ForError(s.run(ctx))
 }

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -60,6 +60,8 @@ func (s *assembleReleaseStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*assembleReleaseStep) Validate() error { return nil }
+
 func (s *assembleReleaseStep) Run(ctx context.Context) error {
 	return results.ForReason("assembling_release").ForError(s.run(ctx))
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -68,6 +68,8 @@ func (s *importReleaseStep) Inputs() (api.InputDefinition, error) {
 	return api.InputDefinition{s.pullSpec}, nil
 }
 
+func (*importReleaseStep) Validate() error { return nil }
+
 func (s *importReleaseStep) Run(ctx context.Context) error {
 	return results.ForReason("importing_release").ForError(s.run(ctx))
 }

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -43,6 +43,8 @@ func (s *promotionStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*promotionStep) Validate() error { return nil }
+
 var promotionRetry = wait.Backoff{
 	Steps:    20,
 	Duration: 10 * time.Millisecond,

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -67,6 +67,8 @@ func (s *stableImagesTagStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*stableImagesTagStep) Validate() error { return nil }
+
 func (s *stableImagesTagStep) Requires() []api.StepLink { return []api.StepLink{} }
 
 func (s *stableImagesTagStep) Creates() []api.StepLink {
@@ -98,6 +100,8 @@ type releaseImagesTagStep struct {
 func (s *releaseImagesTagStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
+
+func (*releaseImagesTagStep) Validate() error { return nil }
 
 func sourceName(config api.ReleaseTagConfiguration) string {
 	return fmt.Sprintf("%s/%s:%s", config.Namespace, config.Name, api.ComponentFormatReplacement)

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -34,6 +34,8 @@ func (s *rpmImageInjectionStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*rpmImageInjectionStep) Validate() error { return nil }
+
 func (s *rpmImageInjectionStep) Run(ctx context.Context) error {
 	return results.ForReason("injecting_rpms").ForError(s.run(ctx))
 }

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -49,6 +49,8 @@ func (s *rpmServerStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*rpmServerStep) Validate() error { return nil }
+
 func (s *rpmServerStep) Run(ctx context.Context) error {
 	return results.ForReason("serving_rpms").ForError(s.run(ctx))
 }

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -20,7 +20,8 @@ type fakeStep struct {
 	numRuns int
 }
 
-func (f *fakeStep) Inputs() (api.InputDefinition, error) { return nil, nil }
+func (*fakeStep) Inputs() (api.InputDefinition, error) { return nil, nil }
+func (*fakeStep) Validate() error                      { return nil }
 
 func (f *fakeStep) Run(ctx context.Context) error {
 	defer f.lock.Unlock()

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -160,6 +160,8 @@ func (s *sourceStep) Inputs() (api.InputDefinition, error) {
 	return s.jobSpec.Inputs(), nil
 }
 
+func (*sourceStep) Validate() error { return nil }
+
 func (s *sourceStep) Run(ctx context.Context) error {
 	return results.ForReason("cloning_source").ForError(s.run(ctx))
 }

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -59,6 +59,8 @@ func (s *templateExecutionStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*templateExecutionStep) Validate() error { return nil }
+
 func (s *templateExecutionStep) Run(ctx context.Context) error {
 	return results.ForReason("executing_template").ForError(s.run(ctx))
 }

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -24,6 +24,8 @@ func (s *writeParametersStep) Inputs() (api.InputDefinition, error) {
 	return nil, nil
 }
 
+func (*writeParametersStep) Validate() error { return nil }
+
 func (s *writeParametersStep) Run(_ context.Context) error {
 	return results.ForReason("writing_parameters").ForError(s.run())
 }


### PR DESCRIPTION
```
2020/09/10 14:07:47 Running [input:root], [release-inputs], src, [images], bin, [release:latest], e2e
2020/09/10 14:07:47 Ran for 1s
error: some steps failed:
  * step "e2e" failed validation: step needs a lease but no lease client provided
  * a lease client was required but none was provided, add the --lease-... arguments
```