### PR TITLE
Fix mountPath vs mount_path in README

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1455,7 +1455,7 @@ const credentialExample = `ref:
   credentials:
   - namespace: test-credentials # this entry injects the custom credential
     name: my-data
-    mountPath: /var/run/my-data
+    mount_path: /var/run/my-data
   documentation: |-
 	The step runs with custom credentials injected.`
 const chainExample = `chain:


### PR DESCRIPTION
It seems that it is mountPath in volumeMounts: but mount_path in credentials:

Signed-off-by: Johnny Bieren <jbieren@redhat.com>