### PR TITLE
ci-operator image: install python2

### DIFF
--- a/images/ci-operator/Dockerfile
+++ b/images/ci-operator/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:8
 LABEL maintainer="skuznets@redhat.com"
 
-RUN yum install -y git
+RUN yum install -y git python2
+RUN alternatives --set python /usr/bin/python2
 ADD ci-operator /usr/bin/ci-operator
 ENTRYPOINT ["/usr/bin/ci-operator"]


### PR DESCRIPTION
Some handcrafted jobs (some of them important upgrade jobs) are doing
`python -c ...` calls. Recently we bumped tools to centos8 which does
not include python by default.

/cc @droslean @deads2k 