### PR TITLE
pj-rehearse: stop assuming to run on api.ci

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -166,16 +166,7 @@ func rehearseMain() error {
 				return errors.New(misconfigurationOutput)
 			}
 		}
-		if _, hasAPICIKubeconfig := buildClusterConfigs["api.ci"]; !hasAPICIKubeconfig {
-			apiCIConfig, err := rest.InClusterConfig()
-			if err != nil {
-				logger.WithError(err).Error("could not load cluster clusterConfig")
-				return fmt.Errorf(misconfigurationOutput)
-			}
-			logger.Info("Got api.ci kubeconfig via in-cluster")
-			buildClusterConfigs["api.ci"] = apiCIConfig
-		}
-		prowJobConfig, err = pjKubeconfig(o.prowjobKubeconfig, buildClusterConfigs["api.ci"])
+		prowJobConfig, err = pjKubeconfig(o.prowjobKubeconfig, buildClusterConfigs["app.ci"])
 		if err != nil {
 			logger.WithError(err).Error("Could not load prowjob kubeconfig")
 			return fmt.Errorf(misconfigurationOutput)


### PR DESCRIPTION
We should just provide correct kubeconfigs for all clusters. Also, change the default prowjob cluster to app.ci.