### PR TITLE
Improve failed pod output

### DIFF
--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -40,6 +40,7 @@ func E2ETestStep(
 	testConfig api.TestStepConfiguration,
 	params api.Parameters,
 	podClient steps.PodClient,
+	eventClient coreclientset.EventsGetter,
 	templateClient steps.TemplateClient,
 	secretClient coreclientset.SecretsGetter,
 	artifactDir string,
@@ -97,7 +98,7 @@ func E2ETestStep(
 		params = api.NewOverrideParameters(params, overrides)
 	}
 
-	step := steps.TemplateExecutionStep(template, params, podClient, templateClient, artifactDir, jobSpec, resources)
+	step := steps.TemplateExecutionStep(template, params, podClient, eventClient, templateClient, artifactDir, jobSpec, resources)
 	subTests, ok := step.(nestedSubTests)
 	if !ok {
 		return nil, fmt.Errorf("unexpected %T", step)

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -76,7 +76,7 @@ func TestRequires(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			step := MultiStageTestStep(api.TestStepConfiguration{
 				MultiStageTestConfigurationLiteral: &tc.steps,
-			}, &tc.config, api.NewDeferredParameters(), nil, nil, nil, nil, nil, "", nil)
+			}, &tc.config, api.NewDeferredParameters(), nil, nil, nil, nil, nil, nil, "", nil)
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true
@@ -128,7 +128,7 @@ func TestGeneratePods(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, nil, nil, nil, nil, "artifact_dir", &jobSpec)
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, nil, nil, nil, nil, nil, "artifact_dir", &jobSpec)
 	env := []coreapi.EnvVar{
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},
@@ -198,7 +198,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Test:        test,
 					Environment: tc.env,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, nil, nil, nil, nil, nil, "", &jobSpec)
+			}, &api.ReleaseBuildConfiguration{}, nil, nil, nil, nil, nil, nil, nil, "", &jobSpec)
 			pods, err := step.(*multiStageTestStep).generatePods(test, nil, false)
 			if err != nil {
 				t.Fatal(err)
@@ -323,7 +323,7 @@ func TestRun(t *testing.T) {
 					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: &yes}},
 					AllowSkipOnSuccess: &yes,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), nil, "", &jobSpec)
+			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, client, fakecs.RbacV1(), nil, "", &jobSpec)
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {
 				t.Error(err)
 				return
@@ -379,7 +379,7 @@ func TestArtifacts(t *testing.T) {
 				{As: "test1", ArtifactDir: "/path/to/artifacts"},
 			},
 		},
-	}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), nil, tmp, &jobSpec)
+	}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, client, fakecs.RbacV1(), nil, tmp, &jobSpec)
 	if err := step.Run(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -456,7 +456,7 @@ func TestJUnit(t *testing.T) {
 					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
 					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, fakecs.RbacV1(), nil, "/dev/null", &jobSpec)
+			}, &api.ReleaseBuildConfiguration{}, nil, &fakePodClient{NewPodClient(client, nil, nil)}, client, client, client, fakecs.RbacV1(), nil, "/dev/null", &jobSpec)
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {
 				t.Error(err)
 				return

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -3,9 +3,12 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/results"
 	"log"
 	"path/filepath"
+
+	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/openshift/ci-tools/pkg/results"
 
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -48,6 +51,7 @@ type podStep struct {
 	config      PodStepConfiguration
 	resources   api.ResourceConfiguration
 	podClient   PodClient
+	eventClient coreclientset.EventsGetter
 	artifactDir string
 	jobSpec     *api.JobSpec
 
@@ -114,7 +118,7 @@ func (s *podStep) run(ctx context.Context) error {
 		s.subTests = testCaseNotifier.SubTests(s.Description() + " - ")
 	}()
 
-	if err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace()), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
+	if err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
 		return fmt.Errorf("%s %q failed: %w", s.name, pod.Name, err)
 	}
 	return nil
@@ -149,7 +153,7 @@ func (s *podStep) Description() string {
 	return fmt.Sprintf("Run test %s", s.config.As)
 }
 
-func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, eventClient coreclientset.EventsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return PodStep(
 		"test",
 		PodStepConfiguration{
@@ -162,17 +166,19 @@ func TestStep(config api.TestStepConfiguration, resources api.ResourceConfigurat
 		},
 		resources,
 		podClient,
+		eventClient,
 		artifactDir,
 		jobSpec,
 	)
 }
 
-func PodStep(name string, config PodStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, artifactDir string, jobSpec *api.JobSpec) api.Step {
+func PodStep(name string, config PodStepConfiguration, resources api.ResourceConfiguration, podClient PodClient, eventClient coreclientset.EventsGetter, artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &podStep{
 		name:        name,
 		config:      config,
 		resources:   resources,
 		podClient:   podClient,
+		eventClient: eventClient,
 		artifactDir: artifactDir,
 		jobSpec:     jobSpec,
 	}
@@ -286,10 +292,10 @@ func getSecretVolumeMountFromSecret(secretMountPath string) []coreapi.VolumeMoun
 // PodStep and is intended for other steps that may need to run transient actions.
 // This pod will not be able to gather artifacts, nor will it report log messages
 // unless it fails.
-func RunPod(ctx context.Context, podClient PodClient, pod *coreapi.Pod) error {
+func RunPod(ctx context.Context, podClient PodClient, eventClient coreclientset.EventsGetter, pod *coreapi.Pod) error {
 	pod, err := createOrRestartPod(podClient.Pods(pod.Namespace), pod)
 	if err != nil {
 		return err
 	}
-	return waitForPodCompletion(ctx, podClient.Pods(pod.Namespace), pod.Name, nil, true)
+	return waitForPodCompletion(ctx, podClient.Pods(pod.Namespace), eventClient.Events(pod.Namespace), pod.Name, nil, true)
 }

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -58,7 +58,7 @@ func preparePodStep(t *testing.T, namespace string) (*podStep, stepExpectation, 
 		t:       t,
 	}
 	client := NewPodClient(fakecs.Core(), nil, nil)
-	ps := PodStep(stepName, config, resources, client, artifactDir, jobSpec)
+	ps := PodStep(stepName, config, resources, client, fakecs.kubecs.CoreV1(), artifactDir, jobSpec)
 
 	specification := stepExpectation{
 		name:     podName,

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -693,7 +693,10 @@ func getReasonsForUnreadyContainers(p *coreapi.Pod) string {
 			reason = "unknown"
 			message = "unknown"
 		}
-		_, _ = builder.WriteString(fmt.Sprintf("\n* Container %s is not ready with reason %s and message %s", c.Name, reason, message))
+		if message != "" {
+			message = fmt.Sprintf(" and message %s", message)
+		}
+		_, _ = builder.WriteString(fmt.Sprintf("\n* Container %s is not ready with reason %s%s", c.Name, reason, message))
 	}
 	return builder.String()
 }


### PR DESCRIPTION
ci-operator: expose message only when there is one

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: spew events for pods that fail to start

In almost all cases, the PodStatus does not contain enough information
and until we have a better way to show off the output of a job, we
should put the event data into the output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

