### PR TITLE
ci-operator: validate operator.substitute.with better

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -366,9 +366,9 @@ func bindOptions(flag *flag.FlagSet) *options {
 func (o *options) Complete() error {
 	if o.artifactDir == "" {
 		// user did not set an artifact dir, but we can default to the Prow dir if set
-		arifactDir, ok := os.LookupEnv(artifactsEnv)
+		artifactDir, ok := os.LookupEnv(artifactsEnv)
 		if ok {
-			o.artifactDir = arifactDir
+			o.artifactDir = artifactDir
 		}
 	}
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -148,9 +148,9 @@ func (config *ReleaseBuildConfiguration) validateTestStepDependencies() []error 
 				}
 
 				if releaseName != "" {
-					implictlyConfigured := (releaseName == InitialReleaseName || releaseName == LatestReleaseName) && config.InputConfiguration.ReleaseTagConfiguration != nil
+					implicitlyConfigured := (releaseName == InitialReleaseName || releaseName == LatestReleaseName) && config.InputConfiguration.ReleaseTagConfiguration != nil
 					_, explicitlyConfigured := config.InputConfiguration.Releases[releaseName]
-					if !(implictlyConfigured || explicitlyConfigured) {
+					if !(implicitlyConfigured || explicitlyConfigured) {
 						errs = append(errs, validationError(fmt.Sprintf("this dependency requires a %q release, which is not configured", releaseName)))
 					}
 				}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -99,8 +99,8 @@ type Metadata struct {
 }
 
 // BuildsImage checks if an image is built by the release configuration.
-func (c ReleaseBuildConfiguration) BuildsImage(name string) bool {
-	for _, i := range c.Images {
+func (config ReleaseBuildConfiguration) BuildsImage(name string) bool {
+	for _, i := range config.Images {
 		if string(i.To) == name {
 			return true
 		}
@@ -110,13 +110,13 @@ func (c ReleaseBuildConfiguration) BuildsImage(name string) bool {
 
 // IsBaseImage checks if `name` will be a tag in the pipeline image stream
 // by virtue of being imported as a base image
-func (c ReleaseBuildConfiguration) IsBaseImage(name string) bool {
-	for i := range c.BaseImages {
+func (config ReleaseBuildConfiguration) IsBaseImage(name string) bool {
+	for i := range config.BaseImages {
 		if i == name {
 			return true
 		}
 	}
-	for i := range c.BaseRPMImages {
+	for i := range config.BaseRPMImages {
 		if i == name {
 			return true
 		}
@@ -125,8 +125,8 @@ func (c ReleaseBuildConfiguration) IsBaseImage(name string) bool {
 }
 
 // IsPipelineImage checks if `name` will be a tag in the pipeline image stream.
-func (c ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
-	if c.IsBaseImage(name) {
+func (config ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
+	if config.IsBaseImage(name) {
 		return true
 	}
 	switch name {

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 
 	buildapi "github.com/openshift/api/build/v1"
@@ -92,7 +93,12 @@ func (s *bundleSourceStep) Requires() []api.StepLink {
 	links := []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)}
 	for _, sub := range s.config.Substitutions {
 		imageStream, name, _ := s.releaseBuildConfig.DependencyParts(api.StepDependency{Name: sub.With})
-		links = append(links, api.LinkForImage(imageStream, name))
+		if link := api.LinkForImage(imageStream, name); link != nil {
+			links = append(links, link)
+		} else {
+			log.Printf("warning: unable to resolve image '%s' to be substituted for '%s'", sub.With, sub.PullSpec)
+		}
+
 	}
 	return links
 }

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -3,13 +3,14 @@ package steps
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"io"
 	"log"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 
 	"k8s.io/test-infra/prow/clonerefs"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
@@ -288,7 +289,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 						From:                    from,
 						ForcePull:               true,
 						NoCache:                 true,
-						Env:                     []coreapi.EnvVar{{Name: "foo", Value: "bar"}}, //workaround https://bugzilla.redhat.com/show_bug.cgi?id=1784163#c8
+						Env:                     []coreapi.EnvVar{{Name: "foo", Value: "bar"}}, // workaround https://bugzilla.redhat.com/show_bug.cgi?id=1784163#c8
 						ImageOptimizationPolicy: &layer,
 					},
 				},


### PR DESCRIPTION
`operator.substitute.with` must be resolvable to a image involved in the
ci-operation execution, otherwise we start using returning `nil`s when
computing step dependencies, leading to `nil` dereference.

Addressed in two places: on validation, and on usage (defensively -- log a
warning. this should not happen with the validation but this way it's more
resilient to changes).

Also took the opportunity and fixed few code style issues.

Fixes: DPTP-1484