### PR TITLE
Updates to ci-secret-generator

### DIFF
--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -297,6 +297,12 @@ func main() {
 		logrus.WithError(err).Fatal("failed to complete options.")
 	}
 	var client bitwarden.Client
+	logrus.RegisterExitHandler(func() {
+		if _, err := client.Logout(); err != nil {
+			logrus.WithError(err).Error("failed to logout.")
+		}
+	})
+	defer logrus.Exit(0)
 	if o.dryRun {
 		tmpFile, err := ioutil.TempFile("", "ci-secret-generator")
 		if err != nil {
@@ -316,12 +322,6 @@ func main() {
 			logrus.WithError(err).Fatal("failed to get Bitwarden client.")
 		}
 	}
-	logrus.RegisterExitHandler(func() {
-		if _, err := client.Logout(); err != nil {
-			logrus.WithError(err).Fatal("failed to logout.")
-		}
-	})
-	defer logrus.Exit(0)
 
 	processedBwItems, err := processBwParameters(o.config)
 	if err != nil {

--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -130,9 +130,9 @@ func (o *options) validateCompletedOptions() error {
 }
 
 func executeCommand(command string) ([]byte, error) {
-	out, err := exec.Command("bash", "-c", command).CombinedOutput()
+	out, err := exec.Command("bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c", command).CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("command %q failed, output- %s : %w", command, string(out), err)
+		return nil, fmt.Errorf("%s : %w", string(out), err)
 	}
 	return out, nil
 }

--- a/cmd/ci-secret-generator/main_test.go
+++ b/cmd/ci-secret-generator/main_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/api/secretbootstrap"
 )
 
 func TestProcessBwParameters(t *testing.T) {
@@ -341,5 +343,52 @@ func TestProcessBwParameters(t *testing.T) {
 func equal(t *testing.T, expected, actual interface{}) {
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("actual differs from expected:\n%s", cmp.Diff(expected, actual))
+	}
+}
+
+func TestBitwardenContextsFor(t *testing.T) {
+	var testCases = []struct {
+		in  []bitWardenItem
+		out []secretbootstrap.BitWardenContext
+	}{
+		{
+			in:  []bitWardenItem{},
+			out: nil,
+		},
+		{
+			in: []bitWardenItem{{
+				ItemName: "item1",
+				Fields: []fieldGenerator{{
+					Name: "field1",
+				}, {
+					Name: "field2",
+				}},
+			}, {
+				ItemName: "item2",
+				Attachments: []fieldGenerator{{
+					Name: "attachment1",
+				}},
+				Password: "whatever",
+			}},
+			out: []secretbootstrap.BitWardenContext{{
+				BWItem: "item1",
+				Field:  "field1",
+			}, {
+				BWItem: "item1",
+				Field:  "field2",
+			}, {
+				BWItem:     "item2",
+				Attachment: "attachment1",
+			}, {
+				BWItem:    "item2",
+				Attribute: "password",
+			}},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if diff := cmp.Diff(testCase.out, bitwardenContextsFor(testCase.in)); diff != "" {
+			t.Errorf("got incorrect output: %v", diff)
+		}
 	}
 }

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -1,6 +1,7 @@
 package bitwarden
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -149,7 +150,7 @@ func TestLoginAndListItems(t *testing.T) {
 }`),
 				},
 				"--session not-going-to-tell-you== list items": {
-					err: fmt.Errorf("some unknown error"),
+					err: errors.New("some unknown error"),
 				},
 			},
 			expectedCalls: [][]string{
@@ -157,7 +158,7 @@ func TestLoginAndListItems(t *testing.T) {
 				{"--session", "not-going-to-tell-you==", "list", "items"},
 			},
 			expectedSession: "not-going-to-tell-you==",
-			expectedError:   fmt.Errorf("some unknown error"),
+			expectedError:   errors.New("some unknown error"),
 		},
 		{
 			name:     "u/p not matching",
@@ -169,13 +170,13 @@ func TestLoginAndListItems(t *testing.T) {
   "success": false,
   "message": "Username or password is incorrect. Try again."
 }`),
-					err: fmt.Errorf("failed to login: Username or password is incorrect. Try again"),
+					err: errors.New("Username or password is incorrect. Try again"),
 				},
 			},
 			expectedCalls: [][]string{
 				{"login", "u", "p", "--response"},
 			},
-			expectedError: fmt.Errorf("failed to login: Username or password is incorrect. Try again"),
+			expectedError: errors.New("failed to log in: Username or password is incorrect. Try again"),
 		},
 		{
 			name:     "already logged in",
@@ -187,13 +188,13 @@ func TestLoginAndListItems(t *testing.T) {
   "success": false,
   "message": "You are already logged in as dptp@redhat.com."
 }`),
-					err: fmt.Errorf("failed to login: You are already logged in as dptp@redhat.com"),
+					err: errors.New("You are already logged in as dptp@redhat.com"),
 				},
 			},
 			expectedCalls: [][]string{
 				{"login", "u", "p", "--response"},
 			},
-			expectedError: fmt.Errorf("failed to login: You are already logged in as dptp@redhat.com"),
+			expectedError: errors.New("failed to log in: You are already logged in as dptp@redhat.com"),
 		},
 	}
 	for _, tc := range testCases {
@@ -293,7 +294,7 @@ func TestGetFieldOnItem(t *testing.T) {
 			},
 			itemName:    "no-item",
 			fieldName:   "API Key",
-			expectedErr: fmt.Errorf("failed to find field API Key in item no-item"),
+			expectedErr: errors.New("failed to find field API Key in item no-item"),
 		},
 		{
 			name: "field not found",
@@ -327,7 +328,7 @@ func TestGetFieldOnItem(t *testing.T) {
 			},
 			itemName:    "unsplash.com",
 			fieldName:   "no-field",
-			expectedErr: fmt.Errorf("failed to find field no-field in item unsplash.com"),
+			expectedErr: errors.New("failed to find field no-field in item unsplash.com"),
 		},
 	}
 	for _, tc := range testCases {
@@ -412,7 +413,7 @@ func TestGetPassword(t *testing.T) {
 				},
 			},
 			itemName:    "no-item",
-			expectedErr: fmt.Errorf("failed to find password in item no-item"),
+			expectedErr: errors.New("failed to find password in item no-item"),
 		},
 		{
 			name: "password not found",
@@ -445,7 +446,7 @@ func TestGetPassword(t *testing.T) {
 				},
 			},
 			itemName:    "unsplash.com",
-			expectedErr: fmt.Errorf("failed to find password in item unsplash.com"),
+			expectedErr: errors.New("failed to find password in item unsplash.com"),
 		},
 	}
 	for _, tc := range testCases {
@@ -504,7 +505,7 @@ func TestGetAttachmentOnItemToFile(t *testing.T) {
 			name: "get attachment cmd err",
 			responses: map[string]execResponse{
 				fmt.Sprintf("--session abc get attachment a-id1 --itemid id2 --output %s", file.Name()): {
-					err: fmt.Errorf("some err"),
+					err: errors.New("some err"),
 				},
 			},
 			expectedCalls: [][]string{
@@ -512,21 +513,21 @@ func TestGetAttachmentOnItemToFile(t *testing.T) {
 			},
 			itemName:       "my-credentials",
 			attachmentName: "secret.auto.vars",
-			expectedErr:    fmt.Errorf("some err"),
+			expectedErr:    errors.New("some err"),
 		},
 		{
 			name:           "item not found",
 			expectedCalls:  [][]string{},
 			itemName:       "no-item",
 			attachmentName: "secret.auto.vars",
-			expectedErr:    fmt.Errorf("failed to find attachment secret.auto.vars in item no-item"),
+			expectedErr:    errors.New("failed to find attachment secret.auto.vars in item no-item"),
 		},
 		{
 			name:           "attachment not found",
 			expectedCalls:  [][]string{},
 			itemName:       "my-credentials",
 			attachmentName: "no attachment",
-			expectedErr:    fmt.Errorf("failed to find attachment no attachment in item my-credentials"),
+			expectedErr:    errors.New("failed to find attachment no attachment in item my-credentials"),
 		},
 	}
 	for _, tc := range testCases {
@@ -571,7 +572,7 @@ func TestLogout(t *testing.T) {
 			name: "some err",
 			responses: map[string]execResponse{
 				"logout": {
-					err: fmt.Errorf("some err"),
+					err: errors.New("some err"),
 				},
 			},
 			expectedCalls: [][]string{


### PR DESCRIPTION
ci-secret-generator: run bash commands safely

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-secret-generator: clean up errors

Before, illegible and not useful:
```
INFO[0030] processing attachment                         attachment=build01_ci_reg_auth_value.txt command="oc --as system:adsmin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\"kubernetes.io/dockercfg\") | select(.metadata.annotations[\"kubernetes.io/service-account.name\"]==\"default\") | .data[\".dockercfg\"]' --raw-output | base64 --decode | jq '.[\"docker-registry.default.svc:5000\"].auth' --raw-output | tr -d '\\\\n'" item=build_farm
ERRO[0031] oc --as system:adsmin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type=="kubernetes.io/dockercfg") | select(.metadata.annotations["kubernetes.io/service-account.name"]=="default") | .data[".dockercfg"]' --raw-output | base64 --decode | jq '.["docker-registry.default.svc:5000"].auth' --raw-output | tr -d '\\n': failed to generate attachment  error="command \"oc --as system:adsmin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\\\"kubernetes.io/dockercfg\\\") | select(.metadata.annotations[\\\"kubernetes.io/service-account.name\\\"]==\\\"default\\\") | .data[\\\".dockercfg\\\"]' --raw-output | base64 --decode | jq '.[\\\"docker-registry.default.svc:5000\\\"].auth' --raw-output | tr -d '\\\\\\\\n'\" failed, output- error: the server doesn't have a resource type \"secrets\"\n : exit status 1"
FATA[0031] Failed to update secrets.                     error="bwItem.ItemName: build_farm, bwItem.AttachmentName: build01_ci_reg_auth_value.txt, oc --as system:adsmin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\"kubernetes.io/dockercfg\") | select(.metadata.annotations[\"kubernetes.io/service-account.name\"]==\"default\") | .data[\".dockercfg\"]' --raw-output | base64 --decode | jq '.[\"docker-registry.default.svc:5000\"].auth' --raw-output | tr -d '\\\\n' failed: command \"oc --as system:adsmin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\\\"kubernetes.io/dockercfg\\\") | select(.metadata.annotations[\\\"kubernetes.io/service-account.name\\\"]==\\\"default\\\") | .data[\\\".dockercfg\\\"]' --raw-output | base64 --decode | jq '.[\\\"docker-registry.default.svc:5000\\\"].auth' --raw-output | tr -d '\\\\\\\\n'\" failed, output- error: the server doesn't have a resource type \"secrets\"\n : exit status 1"
```

After:
```
INFO[0000] Dry-Run enabled, writing secrets to /tmp/ci-secret-generator907763598
INFO[0000] processing attachment                         attachment=build01_ci_reg_auth_value.txt command="oc --as systems:admin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\"kubernetes.io/dockercfg\") | select(.metadata.annotations[\"kubernetes.io/service-account.name\"]==\"default\") | .data[\".dockercfg\"]' --raw-output | base64 --decode | jq '.[\"docker-registry.default.svc:5000\"].auth' --raw-output | tr -d '\\\\n'" item=build_farm
ERRO[0000] failed to generate attachment                 attachment=build01_ci_reg_auth_value.txt command="oc --as systems:admin --context api.ci get secrets --namespace ocp -o json | jq '.items[] | select(.type==\"kubernetes.io/dockercfg\") | select(.metadata.annotations[\"kubernetes.io/service-account.name\"]==\"default\") | .data[\".dockercfg\"]' --raw-output | base64 --decode | jq '.[\"docker-registry.default.svc:5000\"].auth' --raw-output | tr -d '\\\\n'" error="Error from server (Forbidden): users \"systems:admin\" is forbidden: User \"stevekuznetsov\" cannot impersonate users at the cluster scope: no RBAC policy matched\n : exit status 1" item=build_farm
FATA[0000] Failed to update secrets.                     error="failed to generate attachment"
```

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-secret-generator: allow validating output

We want to know that the secret values we're about to put into BitWarden
are actually used somewhere - namely, that the ci-secret-bootstrap tool
will read them out and use them in the clusters.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

