### PR TITLE
Delete attachment from local bw mirror after running bw cmd

### DIFF
--- a/pkg/bitwarden/cli.go
+++ b/pkg/bitwarden/cli.go
@@ -359,11 +359,11 @@ func (c *cliClient) SetAttachmentOnItem(itemName, attachmentName string, fileCon
 		if bytes.Equal(fileContents, existingFileContents) {
 			return nil
 		}
-		targetItem.Attachments = append(targetItem.Attachments[:targetAttachmentIndex], targetItem.Attachments[targetAttachmentIndex+1:]...)
 		// If attachment exists delete it
 		if err := c.deleteAttachment(targetAttachment.ID, targetItem.ID); err != nil {
 			return fmt.Errorf("failed to set new attachment on item")
 		}
+		targetItem.Attachments = append(targetItem.Attachments[:targetAttachmentIndex], targetItem.Attachments[targetAttachmentIndex+1:]...)
 
 	}
 	newAttachment := &Attachment{}

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -998,6 +998,66 @@ func TestSetAttachment(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			name: "replace an existing attachment when multiple attachments exist",
+			client: &cliClient{
+				savedItems: []Item{
+					{
+						ID:   "id1",
+						Name: "unsplash.com",
+						Type: 1,
+						Attachments: []Attachment{
+							{
+								ID:       "attachmentID1",
+								FileName: "File1",
+							},
+							{
+								ID:       "attachmentID2",
+								FileName: "File2",
+							},
+						},
+					},
+				},
+				session: "my-session",
+			},
+			bwCliResponses: map[string]execResponse{
+				"--session my-session get attachment attachmentID1 --itemid id1 --output ": {
+					out: []byte(`dont-care`),
+				},
+				"--session my-session delete attachment attachmentID1 --itemid id1": {
+					out: []byte(`{result:"true"}`),
+				},
+				"--session my-session create attachment --itemid id1 --file ": {
+					out: []byte(`{"object":"attachment","id":"attachmentID3","filename":"File1"}`),
+				},
+			},
+			expectedCalls: [][]string{
+				{"--session", "my-session", "get", "attachment", "attachmentID1", "--itemid", "id1", "--output"},
+				{"--session", "my-session", "delete", "attachment", "attachmentID1", "--itemid", "id1"},
+				{"--session", "my-session", "create", "attachment", "--itemid", "id1", "--file"},
+			},
+			itemName:     "unsplash.com",
+			fileName:     "File1",
+			fileContents: []byte("new_file_contents"),
+			expectedSavedItems: []Item{
+				{
+					ID:   "id1",
+					Name: "unsplash.com",
+					Type: 1,
+					Attachments: []Attachment{
+						{
+							ID:       "attachmentID2",
+							FileName: "File2",
+						},
+						{
+							ID:       "attachmentID3",
+							FileName: "File1",
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Since the bw delete command was being called after the item was removed from the list, we were actually deleting the element which occurs after intended element - since the pointer points to the item at that index.
This change would move the delete from the list after the call to bw delete