### PR TITLE
validateLiteralTestStepCommon: allow using imagestreamtag references

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -666,8 +666,16 @@ func validateLiteralTestStepCommon(fieldRoot string, step LiteralTestStep, seen 
 		if step.FromImage.Tag == "" {
 			ret = append(ret, fmt.Errorf("%s.from_image: `tag` is required", fieldRoot))
 		}
-	} else if len(validation.IsDNS1123Subdomain(step.From)) != 0 {
-		ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, step.From))
+	} else {
+		imageParts := strings.Split(step.From, ":")
+		if len(imageParts) > 2 {
+			ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid imagestream reference", fieldRoot, step.From))
+		}
+		for _, obj := range imageParts {
+			if len(validation.IsDNS1123Subdomain(obj)) != 0 {
+				ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, obj))
+			}
+		}
 	}
 	if len(step.Commands) == 0 {
 		ret = append(ret, fmt.Errorf("%s: `commands` is required", fieldRoot))

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -632,17 +632,27 @@ func TestValidateTestSteps(t *testing.T) {
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'docker.io/library/centos:7' is not a valid Kubernetes object name")},
+		errs: []error{errors.New("test[0].from: 'docker.io/library/centos' is not a valid Kubernetes object name")},
 	}, {
 		name: "invalid image 1",
 		steps: []TestStep{{
 			LiteralTestStep: &LiteralTestStep{
 				As:        "as",
-				From:      "stable:base",
+				From:      "stable>initial:base",
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'stable:base' is not a valid Kubernetes object name")},
+		errs: []error{errors.New("test[0].from: 'stable>initial' is not a valid Kubernetes object name")},
+	}, {
+		name: "invalid image 2",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:        "as",
+				From:      "stable:initial:base",
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from: 'stable:initial:base' is not a valid imagestream reference")},
 	}, {
 		name: "no commands",
 		steps: []TestStep{{


### PR DESCRIPTION
Rework test From validation to allow imagestreamtag references (i.e. `stable-initial:installer`) instead of plain tag names.

Ref: https://issues.redhat.com/browse/DPTP-1518