### PR TITLE
ci-operator: wait 15m for pending pods

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -555,8 +555,9 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 				log.Printf("warning: failed to get pod %s: %v", name, err)
 				continue
 			}
-			if !podHasStarted(pod) && time.Since(pod.CreationTimestamp.Time) > 10*time.Minute {
-				message := fmt.Sprintf("pod didn't start running within 10 minutes: %s", getReasonsForUnreadyContainers(pod))
+			timeout := 15 * time.Minute
+			if !podHasStarted(pod) && time.Since(pod.CreationTimestamp.Time) > timeout {
+				message := fmt.Sprintf("pod didn't start running within %s: %s", timeout, getReasonsForUnreadyContainers(pod))
 				log.Print(message)
 				notifier.Complete(name)
 				return false, errors.New(message)


### PR DESCRIPTION
We've frequently seen image pulls take 10m (!), e.g.:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_cluster-kube-controller-manager-operator/449/pull-ci-openshift-cluster-kube-controller-manager-operator-master-e2e-aws-operator/1306162734701744128

```
2020-09-16T09:29:58Z pulling image "docker-registry.default.svc:5000/ci-op-dftcl0f8/stable@sha256:e4f935c038e45a58ca4d2e46233930dc1f0354027249690297d766f24a86f7a2"
2020-09-16T09:39:13Z Successfully pulled image "docker-registry.default.svc:5000/ci-op-dftcl0f8/stable@sha256:e4f935c038e45a58ca4d2e46233930dc1f0354027249690297d766f24a86f7a2"
```

/shrug