### PR TITLE
Revert "validateLiteralTestStepCommon: allow using imagestreamtag references"

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -666,16 +666,8 @@ func validateLiteralTestStepCommon(fieldRoot string, step LiteralTestStep, seen 
 		if step.FromImage.Tag == "" {
 			ret = append(ret, fmt.Errorf("%s.from_image: `tag` is required", fieldRoot))
 		}
-	} else {
-		imageParts := strings.Split(step.From, ":")
-		if len(imageParts) > 2 {
-			ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid imagestream reference", fieldRoot, step.From))
-		}
-		for _, obj := range imageParts {
-			if len(validation.IsDNS1123Subdomain(obj)) != 0 {
-				ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, obj))
-			}
-		}
+	} else if len(validation.IsDNS1123Subdomain(step.From)) != 0 {
+		ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, step.From))
 	}
 	if len(step.Commands) == 0 {
 		ret = append(ret, fmt.Errorf("%s: `commands` is required", fieldRoot))

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -632,27 +632,17 @@ func TestValidateTestSteps(t *testing.T) {
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'docker.io/library/centos' is not a valid Kubernetes object name")},
+		errs: []error{errors.New("test[0].from: 'docker.io/library/centos:7' is not a valid Kubernetes object name")},
 	}, {
 		name: "invalid image 1",
 		steps: []TestStep{{
 			LiteralTestStep: &LiteralTestStep{
 				As:        "as",
-				From:      "stable>initial:base",
+				From:      "stable:base",
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'stable>initial' is not a valid Kubernetes object name")},
-	}, {
-		name: "invalid image 2",
-		steps: []TestStep{{
-			LiteralTestStep: &LiteralTestStep{
-				As:        "as",
-				From:      "stable:initial:base",
-				Commands:  "commands",
-				Resources: resources},
-		}},
-		errs: []error{errors.New("test[0].from: 'stable:initial:base' is not a valid imagestream reference")},
+		errs: []error{errors.New("test[0].from: 'stable:base' is not a valid Kubernetes object name")},
 	}, {
 		name: "no commands",
 		steps: []TestStep{{


### PR DESCRIPTION
Reverts openshift/ci-tools#1230

Just removing the validation does not seem to be sufficient, IST references need to be processed differently later. Right now ci-operator spawns invalid pods, and then image-registry operator chokes on them:

```
The following objects have invalid references:

  Pod[ci-op-2cq11w99/e2e-azure-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-5hr1jn9h/e2e-gcp-image-ecosystem-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-7gyk1rg4/e2e-ovn-hybrid-step-registry-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-9rkqc2x8/e2e-operator-with-custom-vxlan-port-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-b6ddjmcv/e2e-ovn-step-registry-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-sv6g320c/e2e-windows-hybrid-network-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-sxltbxjz/e2e-aws-sdn-multi-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
  Pod[ci-op-ypvwxw58/e2e-aws-sdn-single-ipi-install-install]: invalid container image reference "stable:stable-initial:installer": invalid reference format
```

FYI @vrutkovs 