### PR TITLE
rename regcred secret to registry-pull-credentials

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -58,7 +58,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -62,7 +62,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -38,7 +38,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -39,7 +39,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -83,7 +83,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -41,7 +41,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -87,7 +87,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -39,7 +39,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -83,7 +83,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/ci-tools-presubmits.yaml
+++ b/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/ci-tools-presubmits.yaml
@@ -51,7 +51,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -106,7 +106,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -161,7 +161,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -216,7 +216,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -271,7 +271,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -354,7 +354,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -409,7 +409,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/cluster-api-provider-gcp-presubmits.yaml
+++ b/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/cluster-api-provider-gcp-presubmits.yaml
@@ -84,7 +84,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -175,7 +175,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -230,7 +230,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -285,7 +285,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -341,7 +341,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -396,7 +396,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/cluster-etcd-operator-master-presubmits.yaml
+++ b/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/cluster-etcd-operator-master-presubmits.yaml
@@ -68,7 +68,7 @@ presubmits:
               name: cluster-secrets-aws
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -157,7 +157,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -245,7 +245,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -334,7 +334,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -409,7 +409,7 @@ presubmits:
               name: cluster-profile-gcp
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -485,7 +485,7 @@ presubmits:
               name: cluster-profile-packet
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -541,7 +541,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -596,7 +596,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -651,7 +651,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -706,7 +706,7 @@ presubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/wildfly-operator-presubmits.yaml
+++ b/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/wildfly-operator-presubmits.yaml
@@ -49,7 +49,7 @@ postsubmits:
           secretName: apici-ci-operator-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -51,7 +51,7 @@ func generatePodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secret) *corev1
 		{
 			Name: "pull-secret",
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: "regcred"},
+				Secret: &corev1.SecretVolumeSource{SecretName: "registry-pull-credentials"},
 			},
 		},
 		{

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -39,7 +39,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -85,7 +85,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage.yaml
@@ -34,7 +34,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_0.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_0.yaml
@@ -39,7 +39,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_1.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_1.yaml
@@ -41,7 +41,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
@@ -47,7 +47,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
@@ -45,7 +45,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_4.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_4.yaml
@@ -43,7 +43,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_5.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_5.yaml
@@ -43,7 +43,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
@@ -29,7 +29,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
@@ -25,7 +25,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_multiple_targets.yaml
@@ -25,7 +25,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
@@ -27,7 +27,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_standard_use_case.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_standard_use_case.yaml
@@ -23,7 +23,7 @@ serviceAccountName: ci-operator
 volumes:
 - name: pull-secret
   secret:
-    secretName: regcred
+    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -48,7 +48,7 @@ const (
 
 	OauthSecretKey = "oauth-token"
 
-	PullSecretName = "regcred"
+	PullSecretName = "registry-pull-credentials"
 )
 
 type CloneAuthType string

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -71,7 +71,7 @@ spec:
       imageOptimizationPolicy: SkipLayers
       noCache: true
       pullSecret:
-        name: regcred
+        name: registry-pull-credentials
     type: Docker
 status:
   output: {}

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -38,7 +38,7 @@ os::test::junit::declare_suite_start "e2e/simple/dynamic-release"
 
 export JOB_SPEC='{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]}}'
 if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
-  os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret regcred -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
+  os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret registry-pull-credentials -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
 fi
 if [[ -z "${IMPORT_SECRET_DIR:-}" ]]; then
   os::log::fatal "\$IMPORT_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-secret -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -47,7 +47,7 @@ presubmits:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -72,7 +72,7 @@ periodics:
       name: job-definition
     - name: pull-secret
       secret:
-        secretName: regcred
+        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -46,7 +46,7 @@ postsubmits:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -73,7 +73,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -126,7 +126,7 @@ presubmits:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -178,7 +178,7 @@ presubmits:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
@@ -39,7 +39,7 @@ periodics:
     volumes:
     - name: pull-secret
       secret:
-        secretName: regcred
+        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -62,7 +62,7 @@ periodics:
       name: job-definition
     - name: pull-secret
       secret:
-        secretName: regcred
+        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -131,7 +131,7 @@ periodics:
       name: job-definition
     - name: pull-secret
       secret:
-        secretName: regcred
+        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -38,7 +38,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -84,7 +84,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -129,7 +129,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -109,7 +109,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -158,7 +158,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -212,7 +212,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -263,7 +263,7 @@ presubmits:
           secretName: ci-pull-credentials
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -307,7 +307,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -355,7 +355,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -402,7 +402,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -39,7 +39,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -94,7 +94,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -138,7 +138,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -39,7 +39,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -85,7 +85,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -40,7 +40,7 @@ postsubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -42,7 +42,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -87,7 +87,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -40,7 +40,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -117,7 +117,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -194,7 +194,7 @@ presubmits:
         name: job-definition
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -239,7 +239,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -284,7 +284,7 @@ presubmits:
       volumes:
       - name: pull-secret
         secret:
-          secretName: regcred
+          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 

/hold This PR needs the corresponding changes in `openshift/release` 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>