### PR TITLE
Disable forcing applyconfig jobs on vphere

### DIFF
--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/test-infra/prow/config"
 	prowconfig "k8s.io/test-infra/prow/config"
 )
@@ -290,6 +291,17 @@ func TestDetermineClusterForJob(t *testing.T) {
 			name:     "Vsphere job",
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "yalayala-vsphere"},
 			expected: "vsphere",
+		},
+		{
+			name: "applyconfig job for vsphere",
+			jobBase: config.JobBase{Agent: "kubernetes", Name: "pull-ci-openshift-release-master-vsphere-dry", Spec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{Image: "registry.svc.ci.openshift.org/ci/applyconfig:latest"},
+				},
+			},
+			},
+			expected:               "api.ci",
+			expectedCanBeRelocated: true,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Those are admin jobs.

According to https://issues.redhat.com/browse/DPTP-1505, they should be on app.ci

And we have our config to do so.
https://github.com/openshift/release/blob/06c181cf669b68cf9bf04d0c26ddc1c4dded51a7/core-services/sanitize-prow-jobs/_config.yaml#L1614-L1615

This PR is a breaking change. The fix is https://github.com/openshift/release/pull/12104

/cc @alvaroaleman 
