### PR TITLE
multistage: handle imagestream references in From

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -671,9 +671,15 @@ func validateLiteralTestStepCommon(fieldRoot string, step LiteralTestStep, seen 
 		if len(imageParts) > 2 {
 			ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid imagestream reference", fieldRoot, step.From))
 		}
-		for _, obj := range imageParts {
+		for i, obj := range imageParts {
 			if len(validation.IsDNS1123Subdomain(obj)) != 0 {
 				ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, obj))
+			} else if i == 0 && len(imageParts) == 2 {
+				switch obj {
+				case PipelineImageStream, ReleaseStreamFor(LatestReleaseName), ReleaseStreamFor(InitialReleaseName), ReleaseImageStream:
+				default:
+					ret = append(ret, fmt.Errorf("%s.from: unknown imagestream '%s'", fieldRoot, imageParts[0]))
+				}
 			}
 		}
 	}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -666,8 +666,16 @@ func validateLiteralTestStepCommon(fieldRoot string, step LiteralTestStep, seen 
 		if step.FromImage.Tag == "" {
 			ret = append(ret, fmt.Errorf("%s.from_image: `tag` is required", fieldRoot))
 		}
-	} else if len(validation.IsDNS1123Subdomain(step.From)) != 0 {
-		ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, step.From))
+	} else {
+		imageParts := strings.Split(step.From, ":")
+		if len(imageParts) > 2 {
+			ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid imagestream reference", fieldRoot, step.From))
+		}
+		for _, obj := range imageParts {
+			if len(validation.IsDNS1123Subdomain(obj)) != 0 {
+				ret = append(ret, fmt.Errorf("%s.from: '%s' is not a valid Kubernetes object name", fieldRoot, obj))
+			}
+		}
 	}
 	if len(step.Commands) == 0 {
 		ret = append(ret, fmt.Errorf("%s: `commands` is required", fieldRoot))

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -632,17 +632,27 @@ func TestValidateTestSteps(t *testing.T) {
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'docker.io/library/centos:7' is not a valid Kubernetes object name")},
+		errs: []error{errors.New("test[0].from: 'docker.io/library/centos' is not a valid Kubernetes object name")},
 	}, {
 		name: "invalid image 1",
 		steps: []TestStep{{
 			LiteralTestStep: &LiteralTestStep{
 				As:        "as",
-				From:      "stable:base",
+				From:      "stable>initial:base",
 				Commands:  "commands",
 				Resources: resources},
 		}},
-		errs: []error{errors.New("test[0].from: 'stable:base' is not a valid Kubernetes object name")},
+		errs: []error{errors.New("test[0].from: 'stable>initial' is not a valid Kubernetes object name")},
+	}, {
+		name: "invalid image 2",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:        "as",
+				From:      "stable:initial:base",
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from: 'stable:initial:base' is not a valid imagestream reference")},
 	}, {
 		name: "no commands",
 		steps: []TestStep{{

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -654,6 +654,16 @@ func TestValidateTestSteps(t *testing.T) {
 		}},
 		errs: []error{errors.New("test[0].from: 'stable:initial:base' is not a valid imagestream reference")},
 	}, {
+		name: "invalid image 3",
+		steps: []TestStep{{
+			LiteralTestStep: &LiteralTestStep{
+				As:        "as",
+				From:      "no-such-imagestream:base",
+				Commands:  "commands",
+				Resources: resources},
+		}},
+		errs: []error{errors.New("test[0].from: unknown imagestream 'no-such-imagestream'")},
+	}, {
 		name: "no commands",
 		steps: []TestStep{{
 			LiteralTestStep: &LiteralTestStep{

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -353,11 +353,9 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 		if link, ok := step.FromImageTag(); ok {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, link)
 		} else {
-			parts := strings.Split(image, ":")
-			if len(parts) == 1 {
-				stream, _ := s.config.ImageStreamFor(image)
-				image = fmt.Sprintf("%s:%s", stream, image)
-			}
+			dep := api.StepDependency{Name: image}
+			stream, tag, _ := s.config.DependencyParts(dep)
+			image = fmt.Sprintf("%s:%s", stream, tag)
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -353,8 +353,11 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 		if link, ok := step.FromImageTag(); ok {
 			image = fmt.Sprintf("%s:%s", api.PipelineImageStream, link)
 		} else {
-			stream, _ := s.config.ImageStreamFor(image)
-			image = fmt.Sprintf("%s:%s", stream, image)
+			parts := strings.Split(image, ":")
+			if len(parts) == 1 {
+				stream, _ := s.config.ImageStreamFor(image)
+				image = fmt.Sprintf("%s:%s", stream, image)
+			}
 		}
 		resources, err := resourcesFor(step.Resources)
 		if err != nil {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -108,6 +108,8 @@ func TestGeneratePods(t *testing.T) {
 					From:        "image1",
 					Commands:    "command1",
 					ArtifactDir: "/artifact/dir",
+				}, {
+					As: "step2", From: "stable-initial:installer", Commands: "command2",
 				}},
 			},
 		}},

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -230,3 +230,111 @@
       secret:
         secretName: test
   status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      build-id: build id
+      ci.openshift.io/multi-stage-test: test
+      ci.openshift.io/refs.branch: base ref
+      ci.openshift.io/refs.org: org
+      ci.openshift.io/refs.repo: repo
+      created-by-ci: "true"
+      job: job
+    name: test-step2
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -c
+      - |-
+        #!/bin/bash
+        set -eu
+        command2
+      command:
+      - /tmp/secret-wrapper/secret-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: stable-initial:installer
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    initContainers:
+    - args:
+      - /bin/secret-wrapper
+      - /tmp/secret-wrapper/secret-wrapper
+      command:
+      - cp
+      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      name: cp-secret-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    volumes:
+    - emptyDir: {}
+      name: secret-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -27,6 +27,13 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
+        - as: step-with-imagestreamtag
+          commands: test $( cat ${SHARED_DIR}/file ) = message
+          from: pipeline:os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
   - as: with-references
     steps:
       test:


### PR DESCRIPTION
Resubmit of https://github.com/openshift/ci-tools/pull/1230 (reverted by https://github.com/openshift/ci-tools/pull/1238).

If multistage "from" contains imagestreamtag it would be used in the pod. This is useful for upgrade jobs, which require installer to be used from "stable-initial:installer" imagstreamtag. 