### PR TITLE
empty agent jobs are running on k8s

### DIFF
--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -143,8 +143,7 @@ func TestComplete(t *testing.T) {
 
 var (
 	c = dispatcher.Config{
-		Default:       "api.ci",
-		NonKubernetes: "app.ci",
+		Default: "api.ci",
 		BuildFarm: map[dispatcher.CloudProvider]dispatcher.JobGroups{
 			dispatcher.CloudAWS: {
 				dispatcher.ClusterBuild01: {},

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -27,8 +27,6 @@ const (
 type Config struct {
 	// the cluster cluster name if no other condition matches
 	Default ClusterName `json:"default"`
-	// the cluster cluster name for non Kubernetes jobs
-	NonKubernetes ClusterName `json:"nonKubernetes"`
 	// the cluster cluster name for ssh bastion jobs
 	SSHBastion ClusterName `json:"sshBastion"`
 	// Groups maps a group of jobs to a cluster
@@ -85,8 +83,8 @@ func isApplyConfigJob(jobBase prowconfig.JobBase) bool {
 
 // DetermineClusterForJob return the cluster for a prow job and if it can be relocated to a cluster in build farm
 func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path string) (_ ClusterName, mayBeRelocated bool) {
-	if jobBase.Agent != "kubernetes" {
-		return config.NonKubernetes, false
+	if jobBase.Agent != "kubernetes" && jobBase.Agent != "" {
+		return "", false
 	}
 	if strings.Contains(jobBase.Name, "vsphere") && !isApplyConfigJob(jobBase) {
 		return ClusterVSphere, false

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -15,8 +15,7 @@ import (
 
 var (
 	c = Config{
-		Default:       "api.ci",
-		NonKubernetes: "app.ci",
+		Default: "api.ci",
 		Groups: map[ClusterName]Group{
 			"api.ci": {
 				Paths: []string{
@@ -54,8 +53,7 @@ var (
 	}
 
 	configWithBuildFarm = Config{
-		Default:       "api.ci",
-		NonKubernetes: "app.ci",
+		Default: "api.ci",
 		BuildFarm: map[CloudProvider]JobGroups{
 			CloudAWS: {
 				ClusterBuild01: {},
@@ -101,8 +99,7 @@ var (
 	}
 
 	configWithBuildFarmWithJobs = Config{
-		Default:       "api.ci",
-		NonKubernetes: "app.ci",
+		Default: "api.ci",
 		BuildFarm: map[CloudProvider]JobGroups{
 			CloudAWS: {
 				ClusterBuild01: {
@@ -230,11 +227,10 @@ func TestGetClusterForJob(t *testing.T) {
 			expected: "api.ci",
 		},
 		{
-			name:     "some jenkins job",
-			config:   &c,
-			jobBase:  config.JobBase{Agent: "jenkins", Name: "test_branch_wildfly_images"},
-			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
-			expected: "app.ci",
+			name:    "some jenkins job",
+			config:  &c,
+			jobBase: config.JobBase{Agent: "jenkins", Name: "test_branch_wildfly_images"},
+			path:    "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 		},
 	}
 	for _, tc := range testCases {
@@ -278,7 +274,13 @@ func TestDetermineClusterForJob(t *testing.T) {
 			name:     "some jenkins job",
 			jobBase:  config.JobBase{Agent: "jenkins", Name: "test_branch_wildfly_images"},
 			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
-			expected: "app.ci",
+			expected: "",
+		},
+		{
+			name:     "some job without agent",
+			jobBase:  config.JobBase{Name: "no-agent-job"},
+			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
+			expected: "api.ci",
 		},
 		{
 			name:                   "some job in build farm",

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config.yaml
@@ -1,5 +1,4 @@
 default: api.ci
-nonKubernetes: app.ci
 groups:
   "api.ci":
     paths:

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm.yaml
@@ -1,5 +1,4 @@
 default: api.ci
-nonKubernetes: app.ci
 groups:
   "api.ci":
     paths:

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
@@ -1,5 +1,4 @@
 default: api.ci
-nonKubernetes: app.ci
 groups:
   "api.ci":
     paths:

--- a/pkg/dispatcher/testdata/TestLoadConfig/invalid_regex.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/invalid_regex.yaml
@@ -1,5 +1,4 @@
 default: api.ci
-nonKubernetes: api.ci
 groups:
   "default":
     paths:


### PR DESCRIPTION
According to https://github.com/kubernetes/test-infra/blob/6d83fa84beb472a6b3e916a89f371e251b321e84/prow/config/jobs.go#L93-L94

The value of `agent` is "kubernetes".

/cc @stevekuznetsov @alvaroaleman 