### PR TITLE
Allow specifying build_root_image in the repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,11 +160,13 @@ update-integration:
 	UPDATE=true make integration
 .PHONY: update-integration
 
+kubeExport := "jq 'del(.metadata.namespace,.metadata.resourceVersion,.metadata.uid,.metadata.creationTimestamp)'"
+
 pr-deploy-configresolver:
 	$(eval USER=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.user.login))
 	$(eval BRANCH=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.ref))
 	oc --context app.ci --as system:admin process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml | oc  --context app.ci --as system:admin apply -f -
-	for cm in ci-operator-master-configs step-registry config; do oc  --context app.ci --as system:admin get --export configmap $${cm} -n ci -o json | oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST); done
+	for cm in ci-operator-master-configs step-registry config; do oc  --context app.ci --as system:admin get configmap $${cm} -n ci -o json | eval $(kubeExport)|oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST); done
 	echo "server is at https://$$( oc  --context app.ci --as system:admin get route server -n ci-tools-$(PULL_REQUEST) -o jsonpath={.spec.host} )"
 .PHONY: pr-deploy
 
@@ -172,8 +174,8 @@ pr-deploy-backporter:
 	$(eval USER=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.user.login))
 	$(eval BRANCH=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.ref))
 	oc --context app.ci --as system:admin process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy-backporter.yaml | oc  --context app.ci --as system:admin apply -f -
-	oc  --context app.ci --as system:admin get --export configmap plugins -n ci -o json | oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST)
-	oc  --context app.ci --as system:admin get --export secret bugzilla-credentials-openshift-bugzilla-robot -n ci -o json | oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST)
+	oc  --context app.ci --as system:admin get configmap plugins -n ci -o json | eval $(kubeExport) | oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST)
+	oc  --context app.ci --as system:admin get secret bugzilla-credentials-openshift-bugzilla-robot -n ci -o json | eval $(kubeExport) | oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST)
 	echo "server is at https://$$( oc  --context app.ci --as system:admin get route bp-server -n ci-tools-$(PULL_REQUEST) -o jsonpath={.spec.host} )"
 .PHONY: pr-deploy-backporter
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -273,7 +273,7 @@ func (config *ReleaseBuildConfiguration) DependencyParts(dependency StepDependen
 func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImageConfiguration, hasImages bool) error {
 	if input == nil {
 		if hasImages {
-			return errors.New("when 'images' are specified 'build_root' is required and must have image_stream_tag or project_image")
+			return errors.New("when 'images' are specified 'build_root' is required and must have image_stream_tag, project_image or from_repository set")
 		}
 		return nil
 	}

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -68,7 +68,7 @@ func (config *ReleaseBuildConfiguration) validate(org, repo string, resolved boo
 	var validationErrors []error
 
 	validationErrors = append(validationErrors, validateReleaseBuildConfiguration(config, org, repo)...)
-	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage, len(config.Images) > 0)...)
+	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage, len(config.Images) > 0))
 	validationErrors = append(validationErrors, validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration, resolved)...)
 
 	// this validation brings together a large amount of data from separate
@@ -270,21 +270,27 @@ func (config *ReleaseBuildConfiguration) DependencyParts(dependency StepDependen
 	}
 }
 
-func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImageConfiguration, hasImages bool) []error {
+func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImageConfiguration, hasImages bool) error {
 	if input == nil {
 		if hasImages {
-			return []error{errors.New("when 'images' are specified 'build_root' is required and must have image_stream_tag or project_image")}
+			return errors.New("when 'images' are specified 'build_root' is required and must have image_stream_tag or project_image")
 		}
 		return nil
 	}
 
-	var validationErrors []error
 	if input.ProjectImageBuild != nil && input.ImageStreamTagReference != nil {
-		validationErrors = append(validationErrors, fmt.Errorf("%s: both image_stream_tag and project_image cannot be set", fieldRoot))
-	} else if input.ProjectImageBuild == nil && input.ImageStreamTagReference == nil {
-		validationErrors = append(validationErrors, fmt.Errorf("%s: you have to specify either image_stream_tag or project_image", fieldRoot))
+		return fmt.Errorf("%s: image_stream_tag and project_image are mutually exclusive", fieldRoot)
 	}
-	return validationErrors
+	if input.ProjectImageBuild != nil && input.FromRepository {
+		return fmt.Errorf("%s: project_image and from_repository are mutually exclusive", fieldRoot)
+	}
+	if input.FromRepository && input.ImageStreamTagReference != nil {
+		return fmt.Errorf("%s: from_repository and image_stream_tag are mutually exclusive", fieldRoot)
+	}
+	if input.ProjectImageBuild == nil && input.ImageStreamTagReference == nil && !input.FromRepository {
+		return fmt.Errorf("%s: you have to specify one of project_image, image_stream_tag or from_repository", fieldRoot)
+	}
+	return nil
 }
 
 func validateImages(fieldRoot string, input []ProjectDirectoryImageBuildStepConfiguration) []error {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -305,6 +305,10 @@ const (
 	ReleaseChannelStable    ReleaseChannel = "stable"
 	ReleaseChannelFast      ReleaseChannel = "fast"
 	ReleaseChannelCandidate ReleaseChannel = "candidate"
+
+	// BuildRootImageFileName is the name of the file that contains the build root images
+	// pullspec.
+	BuildRootImageFileName = ".build_root_image"
 )
 
 // BuildRootImageConfiguration holds the two ways of using a base image
@@ -312,6 +316,8 @@ const (
 type BuildRootImageConfiguration struct {
 	ImageStreamTagReference *ImageStreamTagReference          `json:"image_stream_tag,omitempty"`
 	ProjectImageBuild       *ProjectDirectoryImageBuildInputs `json:"project_image,omitempty"`
+	// If the BuildRoot images pullspec should be read from a file in the repository (BuildRootImageFileName).
+	FromRepository bool `json:"from_repository"`
 }
 
 // ImageStreamTagReference identifies an ImageStreamTag

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -321,7 +321,7 @@ type BuildRootImageConfiguration struct {
 	ImageStreamTagReference *ImageStreamTagReference          `json:"image_stream_tag,omitempty"`
 	ProjectImageBuild       *ProjectDirectoryImageBuildInputs `json:"project_image,omitempty"`
 	// If the BuildRoot images pullspec should be read from a file in the repository (BuildRootImageFileName).
-	FromRepository bool `json:"from_repository"`
+	FromRepository bool `json:"from_repository,omitempty"`
 }
 
 // ImageStreamTagReference identifies an ImageStreamTag

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -306,10 +306,14 @@ const (
 	ReleaseChannelFast      ReleaseChannel = "fast"
 	ReleaseChannelCandidate ReleaseChannel = "candidate"
 
-	// BuildRootImageFileName is the name of the file that contains the build root images
+	// CIOperatorInrepoConfigFileName is the name of the file that contains the build root images
 	// pullspec.
-	BuildRootImageFileName = ".build_root_image"
+	CIOperatorInrepoConfigFileName = ".ci-operator.yaml"
 )
+
+type CIOperatorInrepoConfig struct {
+	BuildRootImage ImageStreamTagReference `json:"build_root_image"`
+}
 
 // BuildRootImageConfiguration holds the two ways of using a base image
 // that the pipeline will caches on.

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -95,50 +95,13 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			}},
 			readFile: func(filename string) ([]byte, error) {
-				if filename != ".build_root_image" {
-					return nil, fmt.Errorf("expected '.build_root_image' as file for the build_root_image, got %s", filename)
+				if filename != ".ci-operator.yaml" {
+					return nil, fmt.Errorf("expected '.ci-operator.yaml' as file for the build_root_image, got %s", filename)
 				}
-				return []byte("stream-namespace/stream-name:stream-tag"), nil
-			},
-		},
-		{
-			name: "minimal information provided with build_root_image from repo, tag gets defaulted",
-			input: &api.ReleaseBuildConfiguration{
-				InputConfiguration: api.InputConfiguration{
-					BuildRootImage: &api.BuildRootImageConfiguration{
-						FromRepository: true,
-					},
-				},
-			},
-			jobSpec: &api.JobSpec{
-				JobSpec: downwardapi.JobSpec{
-					Refs: &prowapi.Refs{
-						Org:  "org",
-						Repo: "repo",
-					},
-				},
-				BaseNamespace: "base-1",
-			},
-			output: []api.StepConfiguration{{
-				SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
-					From: api.PipelineImageStreamTagReferenceRoot,
-					To:   api.PipelineImageStreamTagReferenceSource,
-				}),
-			}, {
-				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
-					BaseImage: api.ImageStreamTagReference{
-						Namespace: "stream-namespace",
-						Name:      "stream-name",
-						Tag:       "latest",
-					},
-					To: api.PipelineImageStreamTagReferenceRoot,
-				},
-			}},
-			readFile: func(filename string) ([]byte, error) {
-				if filename != ".build_root_image" {
-					return nil, fmt.Errorf("expected '.build_root_image' as file for the build_root_image, got %s", filename)
-				}
-				return []byte("stream-namespace/stream-name"), nil
+				return []byte(`build_root_image:
+  namespace: stream-namespace
+  name: stream-name
+  tag: stream-tag`), nil
 			},
 		},
 		{

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private_with_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private_with_clone__true.yaml
@@ -1,0 +1,9 @@
+agent: kubernetes
+decorate: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_and_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_and_clone__true.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
@@ -6,4 +6,4 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/prowgen-controlled: "true"
-name: branch-ci-organization-repository-branch-first
+name: branch-ci-organization-repository-branch-Lowercase org repo and branch

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch_with_release.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch_with_release.yaml
@@ -7,4 +7,4 @@ decoration_config:
 labels:
   ci-operator.openshift.io/prowgen-controlled: "true"
   job-release: "4.6"
-name: branch-ci-organization-repository-branch-fourth
+name: branch-ci-organization-repository-branch-Lowercase org repo and branch with release

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
@@ -6,4 +6,4 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/prowgen-controlled: "true"
-name: branch-ci-Organization-Repository-Branch-second
+name: branch-ci-Organization-Repository-Branch-Uppercase org, repo and branch

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch_with_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch_with_clone__true.yaml
@@ -2,8 +2,6 @@ agent: kubernetes
 branches:
 - ^Branch$
 decorate: true
-decoration_config:
-  skip_cloning: true
 labels:
   ci-operator.openshift.io/prowgen-controlled: "true"
-name: branch-ci-Organization-Repository-Branch-third
+name: 'branch-ci-Organization-Repository-Branch-Uppercase org, repo and branch with clone: true'

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+always_run: true
+branches:
+- branch
+context: ci/prow/testname
+decorate: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: "true"
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -753,6 +753,22 @@ current <code>HEAD</code> of the given branch, even if ci-operator runs in the
 context of a PR that updates that <code>Dockerfile</code>.
 </p>
 
+<p>
+A third option is to configure the <code>build_root</code> in your repo
+alongside the code instead of inside the <code>ci-operator</code> config. The main advantage
+of this is that it allows to atomically change both code and the <code>build_root</code>.
+To do so, set the <code>from_repo: true</code> in your <code>ci-operator</code> config:
+</p>
+
+{{ yamlSyntax (index . "ciOperatorBuildRootFromRepo") }}
+
+<p>
+Afterwards, create a file named <code>.ci-operator.yaml</code> in your repository
+that contains the imagestream you want to use for your <code>build_root</code>:
+</p>
+
+{{ yamlSyntax (index . "ciOperatorBuildRootInRepo" ) }}
+
 <h4 id="artifacts"><a href="#artifacts">Building Artifacts</a></h4>
 
 <p>
@@ -1098,18 +1114,15 @@ environment variable in the <code>test</code> step to point to the pull specific
 
 const ciOperatorInputConfig = `base_images:
   base: # provides the OpenShift universal base image for other builds to use when they reference "base"
-    cluster: "https://api.ci.openshift.org"
     name: "4.5"
     namespace: "ocp"
     tag: "base"
   cli: # provides an image with the OpenShift CLI for other builds to use when they reference "cli"
-    cluster: "https://api.ci.openshift.org"
     name: "4.5"
     namespace: "ocp"
     tag: "cli"
 build_root: # declares that the release:golang-1.13 image has the build-time dependencies
   image_stream_tag:
-    cluster: "https://api.ci.openshift.org"
     name: "release"
     namespace: "openshift"
     tag: "golang-1.13"
@@ -1252,6 +1265,16 @@ const ciOperatorPeriodicTestConfig = `tests:
 const ciOperatorProjectImageBuildroot = `build_root:
   project_image:
     dockerfile_path: images/build-root/Dockerfile # Dockerfile for building the build root image
+`
+
+const ciOperatorBuildRootFromRepo = `build_root:
+  from_repo: true
+`
+
+const ciOperatorBuildRootInRepo = `build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.15
 `
 
 const gettingStartedPage = `
@@ -3047,6 +3070,8 @@ func helpHandler(subPath string, w http.ResponseWriter, _ *http.Request) {
 		data["ciOperatorPostsubmitTestConfig"] = ciOperatorPostsubmitTestConfig
 		data["ciOperatorPeriodicTestConfig"] = ciOperatorPeriodicTestConfig
 		data["ciOperatorProjectImageBuildroot"] = ciOperatorProjectImageBuildroot
+		data["ciOperatorBuildRootFromRepo"] = ciOperatorBuildRootFromRepo
+		data["ciOperatorBuildRootInRepo"] = ciOperatorBuildRootInRepo
 		data["ciOperatorContainerTestWithDependenciesConfig"] = ciOperatorContainerTestWithDependenciesConfig
 		data["depsPropagation"] = depsPropagation
 	case "/leases":


### PR DESCRIPTION
This PR allows to specify the `build_root_image` inside the repository by setting `build_root.from_repository: true`. If this is set, we will:
* Enable cloning on all prowjobs that are based off of that ci-operator config (We might optimize this later on to only do so when we actually have that image in our graph, but that requires some bigger refacotoring of the ci-operator and prowgen)
* Read the imagestream from a file named `.build_root_image` in the repo

/assign @stevekuznetsov 
/cc @marun 

/label tide/merge-method-squash