### PR TITLE
pkg/steps: Configurable activeDeadlineSeconds and terminationGracePeriodSeconds

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -579,11 +579,15 @@ type LiteralTestStep struct {
 	FromImage *ImageStreamTagReference `json:"from_image,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
+	// ActiveDeadlineSeconds is passed directly through to the step's Pod.
+	ActiveDeadlineSeconds *int64 `json:"active_deadline_seconds,omitempty"`
 	// ArtifactDir is the directory from which artifacts will be extracted
 	// when the command finishes. Defaults to "/tmp/artifacts"
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources,omitempty"`
+	// TerminationGracePeriodSeconds is passed directly through to the step's Pod.
+	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty"`
 	// Credentials defines the credentials we'll mount into this step.
 	Credentials []CredentialReference `json:"credentials,omitempty"`
 	// Environment lists parameters that should be set by the test.

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -371,7 +371,10 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 		delete(pod.Labels, ProwJobIdLabel)
 		pod.Annotations[annotationSaveContainerLogs] = "true"
 		pod.Labels[MultiStageTestLabel] = s.name
+		pod.Spec.ActiveDeadlineSeconds = step.ActiveDeadlineSeconds
 		pod.Spec.ServiceAccountName = s.name
+		pod.Spec.TerminationGracePeriodSeconds = step.TerminationGracePeriodSeconds
+
 		addSecretWrapper(pod)
 		container := &pod.Spec.Containers[0]
 		container.Env = append(container.Env, []coreapi.EnvVar{

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -556,7 +556,10 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	if _, err := createOrRestartPod(s.podClient.Pods(s.jobSpec.Namespace()), pod); err != nil {
 		return fmt.Errorf("failed to create or restart %q pod: %w", pod.Name, err)
 	}
-	_, err := waitForPodCompletion(ctx, s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, notifier, false)
+	newPod, err := waitForPodCompletion(ctx, s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, notifier, false)
+	if newPod != nil {
+		pod = newPod
+	}
 	s.subTests = append(s.subTests, notifier.SubTests(fmt.Sprintf("%s - %s ", s.Description(), pod.Name))...)
 	if err != nil {
 		linksText := strings.Builder{}
@@ -565,7 +568,14 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 		if s.config.Metadata.Variant != "" {
 			linksText.WriteString(fmt.Sprintf("&variant=%s", s.config.Metadata.Variant))
 		}
-		return fmt.Errorf("%q pod %q failed: %w\n%s", s.name, pod.Name, err, linksText.String())
+		status := "failed"
+		if pod.Status.Phase == coreapi.PodFailed && pod.Status.Reason == "DeadlineExceeded" {
+			status = "exceeded the configured timeout"
+			if pod.Spec.ActiveDeadlineSeconds != nil {
+				status = fmt.Sprintf("%s activeDeadlineSeconds=%d", status, *pod.Spec.ActiveDeadlineSeconds)
+			}
+		}
+		return fmt.Errorf("%q pod %q %s: %w\n%s", s.name, pod.Name, status, err, linksText.String())
 	}
 	return nil
 }

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -407,7 +407,11 @@ func createOrRestartPod(podClient coreclientset.PodInterface, pod *coreapi.Pod) 
 		return nil, fmt.Errorf("unable to delete completed pod: %w", err)
 	}
 	var created *coreapi.Pod
-	log.Printf("Executing pod %q", pod.Name)
+	if pod.Spec.ActiveDeadlineSeconds == nil {
+		log.Printf("Executing pod %q", pod.Name)
+	} else {
+		log.Printf("Executing pod %q with activeDeadlineSeconds=%d", pod.Name, pod.Spec.ActiveDeadlineSeconds)
+	}
 	// creating a pod in close proximity to namespace creation can result in forbidden errors due to
 	// initializing secrets or policy - use a short backoff to mitigate flakes
 	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Factor: 2, Duration: time.Second}, func() (bool, error) {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -800,6 +800,13 @@ func podLogNewFailedContainers(podClient coreclientset.PodInterface, pod *coreap
 
 		log.Printf("Container %s in pod %s failed, exit code %d, reason %s", status.Name, pod.Name, status.State.Terminated.ExitCode, status.State.Terminated.Reason)
 	}
+	// Workaround for https://github.com/kubernetes/kubernetes/issues/88611
+	// Pods may be terminated with DeadlineExceeded with spec.ActiveDeadlineSeconds is set.
+	// However this doesn't change container statuses, so len(podRunningContainers(pod) is never 0.
+	// Notify the test is complete if ActiveDeadlineSeconds is set and pod has failed.
+	if pod.Status.Phase == coreapi.PodFailed && pod.Spec.ActiveDeadlineSeconds != nil {
+		notifier.Complete(pod.Name)
+	}
 	// if there are no running containers and we're in a terminal state, mark the pod complete
 	if (pod.Status.Phase == coreapi.PodFailed || pod.Status.Phase == coreapi.PodSucceeded) && len(podRunningContainers(pod)) == 0 {
 		notifier.Complete(pod.Name)

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1731,6 +1731,8 @@ const refExample = `ref:
   as: ipi-conf                   # name of the step
   from: base                     # image to run the commands in
   commands: ipi-conf-commands.sh # script file containing the command(s) to be run
+  active_deadline_seconds: 7200  # optional duration in seconds that the step pod may be active before it is killed.
+  termination_grace_period_seconds: 20 # optional duration in seconds the pod needs to terminate gracefully.
   resources:
     requests:
       cpu: 1000m

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -27,7 +27,7 @@ os::cmd::expect_success "ci-operator ${namespace} --secret-dir ${PULL_SECRET_DIR
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
-os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 'DeadlineExceeded Pod was active on the node longer than the specified deadline'
+os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 '"timeout" pod "timeout-timeout" exceeded the configured timeout activeDeadlineSeconds=10: the pod [^ ]* failed after 1[0-5]s \(failed containers: \): DeadlineExceeded Pod was active on the node longer than the specified deadline'
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -27,6 +27,7 @@ os::cmd::expect_success "ci-operator ${namespace} --secret-dir ${PULL_SECRET_DIR
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 'DeadlineExceeded Pod was active on the node longer than the specified deadline'
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -79,6 +79,10 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
+  - as: timeout
+    steps:
+      test:
+        - ref: timeout
 
 zz_generated_metadata:
   branch: master

--- a/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
+++ b/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec sleep 60

--- a/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
+++ b/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
@@ -1,0 +1,11 @@
+ref:
+  as: timeout
+  from: os
+  commands: timeout-commands.sh
+  active_deadline_seconds: 10
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
+  documentation: |-
+    This step will sleep and be killed after active_deadline_seconds.


### PR DESCRIPTION
Sometimes test steps like updates [take a long time][1].  When that happens, something wrapping the workflow may be timed out instead, and the whole thing gets torn down without any post-test gather/teardown steps running.  With this commit, we expose two timeout-related [properties from `PodSpec`][2] to step maintainers to use to control this behavior.  Step maintainers can now set per-step timeouts that are comfortably less than the wrapper timeout, ensuring that slow/hung steps get killed, and the remaining steps have some time to gather details that will explain the delay and perform other teardown.

[1]: https://github.com/openshift/cluster-network-operator/pull/785#issuecomment-698017421
[2]: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core