### PR TITLE
Steps: Make errors a bit more helpful

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1356,6 +1356,9 @@ func nodeNames(nodes []*api.StepNode) []string {
 func topologicalSort(nodes []*api.StepNode) ([]*api.StepNode, error) {
 	var sortedNodes []*api.StepNode
 	var satisfied []api.StepLink
+	iterateAllEdges(nodes, sets.String{}, func(inner *api.StepNode) {
+		satisfied = append(satisfied, inner.Step.Creates()...)
+	})
 	seen := make(map[api.Step]struct{})
 	for len(nodes) > 0 {
 		var changed bool
@@ -1373,7 +1376,6 @@ func topologicalSort(nodes []*api.StepNode) ([]*api.StepNode, error) {
 				waiting = append(waiting, node)
 				continue
 			}
-			satisfied = append(satisfied, node.Step.Creates()...)
 			sortedNodes = append(sortedNodes, node)
 			seen[node.Step] = struct{}{}
 			changed = true

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1379,6 +1379,7 @@ func topologicalSort(nodes []*api.StepNode) ([]*api.StepNode, error) {
 			changed = true
 		}
 		if !changed && len(waiting) > 0 {
+			errMessages := sets.String{}
 			for _, node := range waiting {
 				var missing []string
 				for _, link := range node.Step.Requires() {
@@ -1386,7 +1387,11 @@ func topologicalSort(nodes []*api.StepNode) ([]*api.StepNode, error) {
 						missing = append(missing, fmt.Sprintf("<%#v>", link))
 					}
 				}
-				log.Printf("step <%T> is missing dependencies: %s", node.Step, strings.Join(missing, ", "))
+				// De-Duplicate errors
+				errMessages.Insert(fmt.Sprintf("step <%T> is missing dependencies: %s", node.Step, strings.Join(missing, ", ")))
+			}
+			for _, message := range errMessages.List() {
+				log.Print(message)
 			}
 			return nil, errors.New("steps are missing dependencies")
 		}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -391,7 +391,7 @@ func TestBuildPartialGraph(t *testing.T) {
 					fakeimageclientset.NewSimpleClientset(&imagev1.ImageStreamTag{ObjectMeta: metav1.ObjectMeta{Name: ":"}}).ImageV1(),
 					nil,
 				),
-				steps.SourceStep(api.SourceStepConfiguration{}, api.ResourceConfiguration{}, nil, nil, "", &api.JobSpec{}, nil, nil),
+				steps.SourceStep(api.SourceStepConfiguration{From: api.PipelineImageStreamTagReferenceRoot, To: api.PipelineImageStreamTagReferenceSource}, api.ResourceConfiguration{}, nil, nil, "", &api.JobSpec{}, nil, nil),
 				steps.ProjectDirectoryImageBuildStep(
 					api.ProjectDirectoryImageBuildStepConfiguration{
 						From: api.PipelineImageStreamTagReferenceSource,
@@ -417,7 +417,7 @@ func TestBuildPartialGraph(t *testing.T) {
 				t.Fatalf("failed to build graph: %v", err)
 			}
 
-			// Apparently we only conicidentally validate the graph when printing it
+			// Apparently we only coincidentally validate the graph during the topologicalSort we do prior to printing it
 			_, err = topologicalSort(steps)
 			if err == nil {
 				return

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	imagev1 "github.com/openshift/api/image/v1"
+	fakeimageclientset "github.com/openshift/client-go/image/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
@@ -20,6 +23,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps"
 )
 
 func TestProwMetadata(t *testing.T) {
@@ -369,5 +373,58 @@ func TestErrWroteJUnit(t *testing.T) {
 	}
 	if results.FullReason(defaulted) != "something" {
 		t.Errorf(`expected full reason for error to be "something", but got %q"`, results.FullReason(defaulted))
+	}
+}
+
+func TestBuildPartialGraph(t *testing.T) {
+	testCases := []struct {
+		name             string
+		input            []api.Step
+		targetName       string
+		expectedErrorMsg string
+	}{
+		{
+			name: "Missing input image results in human-readable error",
+			input: []api.Step{
+				steps.InputImageTagStep(
+					api.InputImageTagStepConfiguration{To: api.PipelineImageStreamTagReferenceRoot},
+					fakeimageclientset.NewSimpleClientset(&imagev1.ImageStreamTag{ObjectMeta: metav1.ObjectMeta{Name: ":"}}).ImageV1(),
+					nil,
+				),
+				steps.SourceStep(api.SourceStepConfiguration{}, api.ResourceConfiguration{}, nil, nil, "", &api.JobSpec{}, nil, nil),
+				steps.ProjectDirectoryImageBuildStep(
+					api.ProjectDirectoryImageBuildStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceSource,
+						ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+							Inputs: map[string]api.ImageBuildInputs{"cli": {Paths: []api.ImageSourcePath{{DestinationDir: ".", SourcePath: "/usr/bin/oc"}}}},
+						},
+						To: api.PipelineImageStreamTagReference("oc-bin-image"),
+					},
+					api.ResourceConfiguration{}, nil, nil, nil, "", nil, nil,
+				),
+				steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil, nil),
+				steps.ImagesReadyStep(steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil, nil).Creates()),
+			},
+			targetName:       "[images]",
+			expectedErrorMsg: "steps are missing dependencies",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			steps, err := api.BuildPartialGraph(tc.input, []string{tc.targetName})
+			if err != nil {
+				t.Fatalf("failed to build graph: %v", err)
+			}
+
+			// Apparently we only conicidentally validate the graph when printing it
+			_, err = topologicalSort(steps)
+			if err == nil {
+				return
+			}
+			if err.Error() != tc.expectedErrorMsg {
+				t.Errorf("expected error message %q, got %q", tc.expectedErrorMsg, err.Error())
+			}
+		})
 	}
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -132,7 +132,7 @@ func (s *projectDirectoryImageBuildStep) Requires() []api.StepLink {
 		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReferenceIndexImageGenerator))
 	}
 	for name := range s.config.Inputs {
-		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReference(name)))
+		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReference(name), api.StepLinkWithUnsatisfiableErrorMessage(fmt.Sprintf("%q is neither an imported nor a built image", name))))
 	}
 	return links
 }


### PR DESCRIPTION
For https://issues.redhat.com/browse/DPTP-1493

This PR makes errors related to dependency issues in the steps a bit easier to understand by:
* De-Duplicating them
* Avoiding to print steps whose depend on steps that have unfulfilled dependencies by first creating a list of all available dependencies
* Allowing StepLinks to contain an explanation as to why this is needed, print that instead of the raw StepLink and fill it in for the `Inputs` of the `ProjectImage` step

A sample output for a config similiar to whats in the card looks like this:
```
step <*steps.projectDirectoryImageBuildStep> is missing dependencies: "cli" is neither an imported nor a built image
```

This doesn't fully cover the AC, because to do that, we would need to also allow Steps to contain the info where exactly in the config they come from (implying extending the interface) and would need to fill that in for the `projectDirectoryImageBuilderStep`. Since that is a lot of work I have punted on it for now, but if we think its worth the time, I can create a follow-up.

/assign @petr-muller 