### PR TITLE
activeDeadlineSeconds support for workflows

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -465,6 +465,10 @@ type TestStepConfiguration struct {
 	// Commands are the shell commands to run in
 	// the repository root to execute tests.
 	Commands string `json:"commands,omitempty"`
+
+	// ActiveDeadlineSeconds is passed directly through to the step's Pod.
+	ActiveDeadlineSeconds *int64 `json:"active_deadline_seconds,omitempty"`
+
 	// ArtifactDir is an optional directory that contains the
 	// artifacts to upload. If unset, this will default to
 	// "/tmp/artifacts".
@@ -481,6 +485,9 @@ type TestStepConfiguration struct {
 	// You cannot set the Secret and Secrets attributes
 	// at the same time.
 	Secrets []*Secret `json:"secrets,omitempty"`
+
+	// TerminationGracePeriodSeconds is passed directly through to the step's Pod.
+	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty"`
 
 	// Cron is how often the test is expected to run outside
 	// of pull request workflows. Setting this field will
@@ -579,11 +586,15 @@ type LiteralTestStep struct {
 	FromImage *ImageStreamTagReference `json:"from_image,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
+	// ActiveDeadlineSeconds is passed directly through to the step's Pod.
+	ActiveDeadlineSeconds *int64 `json:"active_deadline_seconds,omitempty"`
 	// ArtifactDir is the directory from which artifacts will be extracted
 	// when the command finishes. Defaults to "/tmp/artifacts"
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources,omitempty"`
+	// TerminationGracePeriodSeconds is passed directly through to the step's Pod.
+	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty"`
 	// Credentials defines the credentials we'll mount into this step.
 	Credentials []CredentialReference `json:"credentials,omitempty"`
 	// Environment lists parameters that should be set by the test.

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -371,7 +371,10 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 		delete(pod.Labels, ProwJobIdLabel)
 		pod.Annotations[annotationSaveContainerLogs] = "true"
 		pod.Labels[MultiStageTestLabel] = s.name
+		pod.Spec.ActiveDeadlineSeconds = step.ActiveDeadlineSeconds
 		pod.Spec.ServiceAccountName = s.name
+		pod.Spec.TerminationGracePeriodSeconds = step.TerminationGracePeriodSeconds
+
 		addSecretWrapper(pod)
 		container := &pod.Spec.Containers[0]
 		container.Env = append(container.Env, []coreapi.EnvVar{

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -96,6 +96,8 @@ func TestRequires(t *testing.T) {
 }
 
 func TestGeneratePods(t *testing.T) {
+	activeDeadlineSeconds := int64(10)
+	terminationGracePeriodSeconds := int64(20)
 	config := api.ReleaseBuildConfiguration{
 		Tests: []api.TestStepConfiguration{{
 			As: "test",
@@ -110,6 +112,10 @@ func TestGeneratePods(t *testing.T) {
 					ArtifactDir: "/artifact/dir",
 				}, {
 					As: "step2", From: "stable-initial:installer", Commands: "command2",
+				}, {
+					As: "step3", From: "src", Commands: "command2", ActiveDeadlineSeconds: &activeDeadlineSeconds,
+				}, {
+					As: "step4", From: "src", Commands: "command3", TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 				}},
 			},
 		}},

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -338,3 +338,221 @@
       secret:
         secretName: test
   status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      build-id: build id
+      ci.openshift.io/multi-stage-test: test
+      ci.openshift.io/refs.branch: base ref
+      ci.openshift.io/refs.org: org
+      ci.openshift.io/refs.repo: repo
+      created-by-ci: "true"
+      job: job
+    name: test-step3
+  spec:
+    activeDeadlineSeconds: 10
+    containers:
+    - args:
+      - /bin/bash
+      - -c
+      - |-
+        #!/bin/bash
+        set -eu
+        command2
+      command:
+      - /tmp/secret-wrapper/secret-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    initContainers:
+    - args:
+      - /bin/secret-wrapper
+      - /tmp/secret-wrapper/secret-wrapper
+      command:
+      - cp
+      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      name: cp-secret-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    volumes:
+    - emptyDir: {}
+      name: secret-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      build-id: build id
+      ci.openshift.io/multi-stage-test: test
+      ci.openshift.io/refs.branch: base ref
+      ci.openshift.io/refs.org: org
+      ci.openshift.io/refs.repo: repo
+      created-by-ci: "true"
+      job: job
+    name: test-step4
+  spec:
+    containers:
+    - args:
+      - /bin/bash
+      - -c
+      - |-
+        #!/bin/bash
+        set -eu
+        command3
+      command:
+      - /tmp/secret-wrapper/secret-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    initContainers:
+    - args:
+      - /bin/secret-wrapper
+      - /tmp/secret-wrapper/secret-wrapper
+      command:
+      - cp
+      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      name: cp-secret-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/secret-wrapper
+        name: secret-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 20
+    volumes:
+    - emptyDir: {}
+      name: secret-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1731,6 +1731,8 @@ const refExample = `ref:
   as: ipi-conf                   # name of the step
   from: base                     # image to run the commands in
   commands: ipi-conf-commands.sh # script file containing the command(s) to be run
+  active_deadline_seconds: 7200  # optional duration in seconds that the step pod may be active before it is killed.
+  termination_grace_period_seconds: 20 # optional duration in seconds the pod needs to terminate gracefully.
   resources:
     requests:
       cpu: 1000m

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -27,6 +27,7 @@ os::cmd::expect_success "ci-operator ${namespace} --secret-dir ${PULL_SECRET_DIR
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
+os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 fixme-error-message
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"

--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -27,7 +27,7 @@ os::cmd::expect_success "ci-operator ${namespace} --secret-dir ${PULL_SECRET_DIR
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
-os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 fixme-error-message
+os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 DeadlineExceeded
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -79,6 +79,10 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
+  - as: timeout
+    steps:
+      test:
+        - ref: timeout
 
 zz_generated_metadata:
   branch: master

--- a/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
+++ b/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec sleep 60

--- a/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
+++ b/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
@@ -1,0 +1,11 @@
+ref:
+  as: timeout
+  from: os
+  commands: timeout-commands.sh
+  active_deadline_seconds: 10
+  resources:
+    requests:
+      cpu: 10m
+      memory: 10Mi
+  documentation: |-
+    This step will sleep and be killed after active_deadline_seconds.


### PR DESCRIPTION
Alternative to https://github.com/openshift/ci-tools/pull/1257. It doesn't use additional channels, but notifies the pod has completed if it failed and activeDeadlineSeconds set (not checking for container statuses due to k8s bug)
