### PR TITLE
ci-operator: expose `base_images` to templates

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
@@ -129,7 +130,10 @@ func (s *inputImageTagStep) Creates() []api.StepLink {
 }
 
 func (s *inputImageTagStep) Provides() api.ParameterMap {
-	return nil
+	tag := s.config.To
+	return api.ParameterMap{
+		utils.PipelineImageEnvFor(tag): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, string(tag)),
+	}
 }
 
 func (s *inputImageTagStep) Name() string { return fmt.Sprintf("[input:%s]", s.config.To) }


### PR DESCRIPTION
AFAICT, this was an omission.  I'm wary of adding features to templates,
but this allows for more reliable and much simpler and faster E2E tests
(e.g. https://github.com/openshift/ci-tools/pull/1258), which will still
be required for as long as we support templates.