### PR TITLE
template-deprecator: add new tool

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -142,11 +142,6 @@ func isStale(job prowconfig.JobBase) bool {
 	return generated && genLabel != string(jc.New)
 }
 
-func isGenerated(job prowconfig.JobBase) bool {
-	_, generated := job.Labels[jc.ProwJobLabelGenerated]
-	return generated
-}
-
 func prune(jobConfig *prowconfig.JobConfig) *prowconfig.JobConfig {
 	var pruned prowconfig.JobConfig
 
@@ -156,7 +151,7 @@ func prune(jobConfig *prowconfig.JobConfig) *prowconfig.JobConfig {
 				continue
 			}
 
-			if isGenerated(job.JobBase) {
+			if prowgen.IsGenerated(job.JobBase) {
 				job.Labels[jc.ProwJobLabelGenerated] = string(jc.Generated)
 			}
 
@@ -173,9 +168,8 @@ func prune(jobConfig *prowconfig.JobConfig) *prowconfig.JobConfig {
 			if isStale(job.JobBase) {
 				continue
 			}
-			if isGenerated(job.JobBase) {
+			if prowgen.IsGenerated(job.JobBase) {
 				job.Labels[jc.ProwJobLabelGenerated] = string(jc.Generated)
-
 			}
 			if pruned.PostsubmitsStatic == nil {
 				pruned.PostsubmitsStatic = map[string][]prowconfig.Postsubmit{}
@@ -189,9 +183,8 @@ func prune(jobConfig *prowconfig.JobConfig) *prowconfig.JobConfig {
 		if isStale(job.JobBase) {
 			continue
 		}
-		if isGenerated(job.JobBase) {
+		if prowgen.IsGenerated(job.JobBase) {
 			job.Labels[jc.ProwJobLabelGenerated] = string(jc.Generated)
-
 		}
 
 		pruned.Periodics = append(pruned.Periodics, job)

--- a/cmd/template-deprecator/README.md
+++ b/cmd/template-deprecator/README.md
@@ -1,0 +1,14 @@
+# Template Deprecator
+
+This tool maintains the allowlist that drives the template deprecation
+(see https://docs.ci.openshift.org/docs/how-tos/migrating-template-jobs-to-multistage/ 
+for more information) and enforces the current desired state of the repository.
+
+The tool loads the current allowlist first. Then it processes the Prow configuration
+and detects all jobs that use a test template, updating the allowlist during the
+process. The tool validates the changed allowlist and fails if it contains some
+undesirable item, like a job that uses a fully deprecated template or other
+configuration that should simply not be added to the repository.
+
+If no undesirable configuration is detected, the tool saves the modified allowlist
+to the original location.

--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	prowconfig "k8s.io/test-infra/prow/config"
+	prowplugins "k8s.io/test-infra/prow/plugins"
+
+	"github.com/openshift/ci-tools/pkg/deprecatetemplates"
+)
+
+type options struct {
+	prowJobConfigDir     string
+	prowConfigPath       string
+	prowPluginConfigPath string
+	allowlistPath        string
+
+	help bool
+}
+
+func bindOptions(fs *flag.FlagSet) *options {
+	opt := &options{}
+
+	fs.StringVar(&opt.prowJobConfigDir, "prow-jobs-dir", "", "Path to a root of directory structure with Prow job config files (ci-operator/jobs in openshift/release)")
+	fs.StringVar(&opt.prowConfigPath, "prow-config-path", "", "Path to the Prow configuration file")
+	fs.StringVar(&opt.prowPluginConfigPath, "prow-plugin-config-path", "", "Path to the Prow plugin configuration file")
+	fs.StringVar(&opt.allowlistPath, "allowlist-path", "", "Path to template deprecation allowlist")
+
+	return opt
+}
+
+func (o *options) validate() error {
+	for param, value := range map[string]string{
+		"--prow-jobs-dir":           o.prowJobConfigDir,
+		"--prow-config-path":        o.prowConfigPath,
+		"--prow-plugin-config-path": o.prowPluginConfigPath,
+		"--allowlist-path":          o.allowlistPath,
+	} {
+		if value == "" {
+			return fmt.Errorf("mandatory argument %s was not set", param)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	opt := bindOptions(flag.CommandLine)
+	flag.Parse()
+
+	if opt.help {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	if err := opt.validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid parameters")
+	}
+
+	agent := prowplugins.ConfigAgent{}
+	if err := agent.Load(opt.prowPluginConfigPath, true); err != nil {
+		logrus.WithError(err).Fatal("Failed to read Prow plugin configuration")
+	}
+	pluginCfg := agent.Config().ConfigUpdater
+
+	prowCfg, err := prowconfig.Load(opt.prowConfigPath, opt.prowJobConfigDir)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to load Prow configuration")
+	}
+
+	enforcer, err := deprecatetemplates.NewEnforcer(opt.allowlistPath)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to initialize template deprecator")
+	}
+
+	enforcer.LoadTemplates(pluginCfg)
+	enforcer.ProcessJobs(prowCfg)
+
+	if err := enforcer.SaveAllowlist(opt.allowlistPath); err != nil {
+		logrus.WithError(err).Fatal("Failed to save template deprecation allowlist")
+	}
+}

--- a/pkg/deprecatetemplates/allowlist.go
+++ b/pkg/deprecatetemplates/allowlist.go
@@ -1,0 +1,148 @@
+package deprecatetemplates
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+
+	jc "github.com/openshift/ci-tools/pkg/jobconfig"
+)
+
+const (
+	release = "release"
+	unknown = "unknown"
+)
+
+func isGenerated(job config.JobBase) bool {
+	_, generated := job.Labels[jc.ProwJobLabelGenerated]
+	return generated
+}
+
+func getKind(job config.JobBase) string {
+	if strings.HasPrefix(job.Name, "pull-ci") {
+		return string(prowv1.PresubmitJob)
+	} else if strings.HasPrefix(job.Name, "branch-ci-") {
+		return string(prowv1.PostsubmitJob)
+	} else if strings.HasPrefix(job.Name, "release-") {
+		return release
+	} else if strings.HasPrefix(job.Name, "periodic-") {
+		return string(prowv1.PeriodicJob)
+	}
+
+	// this is fine, it is best effort
+	// the allowlist does not need to be 100% precise category-wise
+	return unknown
+}
+
+type blockedJob struct {
+	Generated bool   `json:"generated"`
+	Kind      string `json:"kind"`
+}
+
+type blockedJobs map[string]blockedJob
+
+func (b blockedJobs) Has(job config.JobBase) bool {
+	_, has := b[job.Name]
+	return has
+}
+
+func (b blockedJobs) Insert(job config.JobBase) {
+	b[job.Name] = blockedJob{
+		Generated: isGenerated(job),
+		Kind:      getKind(job),
+	}
+}
+
+func (b blockedJobs) Union(other blockedJobs) blockedJobs {
+	union := blockedJobs{}
+	for k, v := range b {
+		union[k] = v
+	}
+	for k, v := range other {
+		union[k] = v
+	}
+	return union
+}
+
+type deprecatedTemplateBlocker struct {
+	Description string      `json:"description"`
+	Jobs        blockedJobs `json:"jobs"`
+}
+
+type deprecatedTemplate struct {
+	Name           string                               `json:"template_name"`
+	UnknownBlocker deprecatedTemplateBlocker            `json:"unknown_blocker"`
+	Blockers       map[string]deprecatedTemplateBlocker `json:"blockers,omitempty"`
+}
+
+func (d deprecatedTemplate) insert(job config.JobBase) {
+	for _, blocker := range d.Blockers {
+		if blocker.Jobs.Has(job) {
+			return
+		}
+	}
+	d.UnknownBlocker.Jobs.Insert(job)
+}
+
+type Allowlist interface {
+	Insert(job config.JobBase, template string)
+	Save(path string) error
+}
+
+type allowlist struct {
+	Templates map[string]deprecatedTemplate `json:"templates"`
+}
+
+func (a *allowlist) Insert(job config.JobBase, template string) {
+	if a.Templates == nil {
+		a.Templates = map[string]deprecatedTemplate{}
+	}
+
+	if _, ok := a.Templates[template]; !ok {
+		a.Templates[template] = deprecatedTemplate{
+			Name: template,
+			UnknownBlocker: deprecatedTemplateBlocker{
+				Description: "unknown",
+				Jobs:        blockedJobs{},
+			},
+		}
+	}
+
+	a.Templates[template].insert(job)
+}
+
+func loadAllowlist(allowlistPath string) (Allowlist, error) {
+	var allowlist allowlist
+
+	raw, err := ioutil.ReadFile(allowlistPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	if err == nil {
+		err := yaml.Unmarshal(raw, &allowlist)
+		return &allowlist, err
+	}
+
+	logrus.Warn("template deprecation allowlist does not exist, will populate a new one")
+	return &allowlist, nil
+}
+
+func (a allowlist) Save(path string) error {
+	raw, err := yaml.Marshal(a)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(path, raw, 0644); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/deprecatetemplates/allowlist.go
+++ b/pkg/deprecatetemplates/allowlist.go
@@ -11,18 +11,13 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 
-	jc "github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/prowgen"
 )
 
 const (
 	release = "release"
 	unknown = "unknown"
 )
-
-func isGenerated(job config.JobBase) bool {
-	_, generated := job.Labels[jc.ProwJobLabelGenerated]
-	return generated
-}
 
 func getKind(job config.JobBase) string {
 	if strings.HasPrefix(job.Name, "pull-ci") {
@@ -54,7 +49,7 @@ func (b blockedJobs) Has(job config.JobBase) bool {
 
 func (b blockedJobs) Insert(job config.JobBase) {
 	b[job.Name] = blockedJob{
-		Generated: isGenerated(job),
+		Generated: prowgen.IsGenerated(job),
 		Kind:      getKind(job),
 	}
 }

--- a/pkg/deprecatetemplates/allowlist.go
+++ b/pkg/deprecatetemplates/allowlist.go
@@ -72,7 +72,7 @@ func (b blockedJobs) Union(other blockedJobs) blockedJobs {
 
 type deprecatedTemplateBlocker struct {
 	Description string      `json:"description"`
-	Jobs        blockedJobs `json:"jobs"`
+	Jobs        blockedJobs `json:"jobs,omitempty"`
 }
 
 type deprecatedTemplate struct {

--- a/pkg/deprecatetemplates/allowlist_test.go
+++ b/pkg/deprecatetemplates/allowlist_test.go
@@ -1,0 +1,169 @@
+package deprecatetemplates
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestDeprecatedTemplateInsert(t *testing.T) {
+	job := "inserted-job"
+
+	testCases := []struct {
+		description string
+		existingDT  deprecatedTemplate
+		expectedDT  deprecatedTemplate
+	}{
+		{
+			description: "new job is added to unknown blockers",
+			existingDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{}},
+			},
+			expectedDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
+			},
+		},
+		{
+			description: "job with a known blocker is not added to unknown blockers",
+			existingDT: deprecatedTemplate{
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"DPTP-1235": {
+						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+					},
+				},
+			},
+			expectedDT: deprecatedTemplate{
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"DPTP-1235": {
+						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+					},
+				},
+			},
+		},
+		{
+			description: "adding job already in unknown blockers is a nop",
+			existingDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
+			},
+			expectedDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.existingDT.insert(config.JobBase{Name: job})
+			if diff := cmp.Diff(tc.existingDT, tc.expectedDT); diff != "" {
+				t.Errorf("%s: deprecated template record differs from expected:\n%s", tc.description, diff)
+			}
+		})
+	}
+}
+
+func TestAllowlistInsert(t *testing.T) {
+	template := "template"
+	job := "job"
+	anotherJob := "another-job"
+
+	testCases := []struct {
+		description   string
+		before        map[string]deprecatedTemplate
+		expectedAfter map[string]deprecatedTemplate
+	}{
+		{
+			description: "add job to new template record",
+			expectedAfter: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					UnknownBlocker: deprecatedTemplateBlocker{
+						Description: "unknown",
+						Jobs:        blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+					},
+				},
+			},
+		},
+		{
+			description: "add job to existing template record",
+			before: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					UnknownBlocker: deprecatedTemplateBlocker{
+						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+					},
+				},
+			},
+			expectedAfter: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					UnknownBlocker: deprecatedTemplateBlocker{
+						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+					},
+					Blockers: nil,
+				},
+			},
+		},
+		{
+			description: "add job to existing template record, already known blocker",
+			before: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					Blockers: map[string]deprecatedTemplateBlocker{
+						"DPTP-1234": {
+							Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+						},
+					},
+				},
+			},
+			expectedAfter: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					Blockers: map[string]deprecatedTemplateBlocker{
+						"DPTP-1234": {
+							Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "add job to existing template record, already unknown blocker",
+			before: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					UnknownBlocker: deprecatedTemplateBlocker{
+						Jobs: blockedJobs{
+							job:        blockedJob{Generated: false, Kind: "unknown"},
+							anotherJob: blockedJob{Generated: false, Kind: "unknown"},
+						},
+					},
+				},
+			},
+			expectedAfter: map[string]deprecatedTemplate{
+				template: {
+					Name: template,
+					UnknownBlocker: deprecatedTemplateBlocker{
+						Jobs: blockedJobs{
+							job:        blockedJob{Generated: false, Kind: "unknown"},
+							anotherJob: blockedJob{Generated: false, Kind: "unknown"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := allowlist{Templates: tc.before}
+			actual.Insert(config.JobBase{Name: job}, template)
+			expected := allowlist{Templates: tc.expectedAfter}
+			if diff := cmp.Diff(&expected, &actual, cmpopts.IgnoreUnexported(allowlist{})); diff != "" {
+				t.Errorf("%s: allowlist differs from expected:\n%s", tc.description, diff)
+			}
+		})
+	}
+}

--- a/pkg/deprecatetemplates/enforcer.go
+++ b/pkg/deprecatetemplates/enforcer.go
@@ -1,0 +1,84 @@
+package deprecatetemplates
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
+	prowplugins "k8s.io/test-infra/prow/plugins"
+
+	"github.com/openshift/ci-tools/pkg/rehearse"
+)
+
+// Enforcer manages all necessary data to decide if the state of
+// openshift/release is valid (and therefore, if a PR to openshift/release
+// does not diverge it from the valid state)
+type Enforcer struct {
+	existingTemplates sets.String
+	allowlist         Allowlist
+}
+
+// NewEnforcer initializes a new enforcer instance. The enforcer will be
+// initialized with an allowlist from the given location. If the allowlist
+// does not exist, the enforcer will have an empty allowlist.
+func NewEnforcer(allowlistPath string) (*Enforcer, error) {
+	allowlist, err := loadAllowlist(allowlistPath)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to load template deprecating allowlist from %q", allowlistPath)
+	}
+	return &Enforcer{
+		allowlist:         allowlist,
+		existingTemplates: sets.NewString(),
+	}, nil
+}
+
+// LoadTemplates detects all existing templates from config updater configuration
+func (e *Enforcer) LoadTemplates(cuCfg prowplugins.ConfigUpdater) {
+	templates := sets.NewString()
+	templatePathPrefix := "ci-operator/templates/"
+	for pattern, cmSpec := range cuCfg.Maps {
+		if strings.HasPrefix(pattern, templatePathPrefix) {
+			templates.Insert(cmSpec.Name)
+		}
+	}
+
+	e.existingTemplates = templates
+}
+
+type jobconfig interface {
+	AllStaticPostsubmits(repos []string) []prowconfig.Postsubmit
+	AllStaticPresubmits(repos []string) []prowconfig.Presubmit
+	AllPeriodics() []prowconfig.Periodic
+}
+
+// ProcessJobs reads all existing Prow jobs and makes sure all jobs that use
+// one of the existing templates are present in the allowlist.
+func (e *Enforcer) ProcessJobs(jobConfig jobconfig) {
+
+	for _, job := range jobConfig.AllStaticPresubmits(nil) {
+		e.ingest(job.JobBase)
+	}
+
+	for _, job := range jobConfig.AllStaticPostsubmits(nil) {
+		e.ingest(job.JobBase)
+	}
+
+	for _, job := range jobConfig.AllPeriodics() {
+		e.ingest(job.JobBase)
+	}
+
+}
+
+func (e *Enforcer) ingest(job prowconfig.JobBase) {
+	for template := range e.existingTemplates {
+		if rehearse.UsesConfigMap(job, template) {
+			e.allowlist.Insert(job, template)
+		}
+	}
+}
+
+// SaveAllowlist dumps the allowlist to the given location
+func (e *Enforcer) SaveAllowlist(path string) error {
+	return e.allowlist.Save(path)
+}

--- a/pkg/deprecatetemplates/enforcer_test.go
+++ b/pkg/deprecatetemplates/enforcer_test.go
@@ -1,0 +1,159 @@
+package deprecatetemplates
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+func TestLoadTemplates(t *testing.T) {
+	testcases := []struct {
+		description string
+		updaterCfg  plugins.ConfigUpdater
+		expected    sets.String
+	}{
+		{
+			description: "template is detected",
+			updaterCfg: plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"ci-operator/templates/this-is-a-template.yaml": {Name: "template"},
+				},
+			},
+			expected: sets.NewString("template"),
+		},
+		{
+			description: "not a template is ignored",
+			updaterCfg: plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"ci-operator/config/this/is-not/a-template.yaml": {Name: "not-a-template"},
+				},
+			},
+			expected: sets.NewString(),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			enforcer := Enforcer{}
+			enforcer.LoadTemplates(tc.updaterCfg)
+			if diff := cmp.Diff(tc.expected, enforcer.existingTemplates); diff != "" {
+				t.Errorf("%s: templates differ from expected:\n%s", tc.description, diff)
+			}
+		})
+	}
+}
+
+type mockAllowlist struct {
+	jobs map[string]sets.String
+}
+
+func (m *mockAllowlist) Insert(job config.JobBase, template string) {
+	if _, ok := m.jobs[template]; !ok {
+		m.jobs[template] = sets.NewString()
+	}
+	m.jobs[template].Insert(job.Name)
+}
+
+func (m *mockAllowlist) Save(_ string) error {
+	panic("this should never be called")
+}
+
+type mockJobConfig struct {
+	presubmits  []config.Presubmit
+	postsubmits []config.Postsubmit
+	periodics   []config.Periodic
+}
+
+func (m *mockJobConfig) AllStaticPostsubmits(_ []string) []config.Postsubmit {
+	return append([]config.Postsubmit{}, m.postsubmits...)
+}
+func (m *mockJobConfig) AllStaticPresubmits(_ []string) []config.Presubmit {
+	return append([]config.Presubmit{}, m.presubmits...)
+}
+func (m *mockJobConfig) AllPeriodics() []config.Periodic {
+	return append([]config.Periodic{}, m.periodics...)
+}
+
+func cmVolume(name, cmName string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+			},
+		},
+	}
+}
+
+func TestProcessJobs(t *testing.T) {
+	template := "template"
+	jobWithTemplate := config.JobBase{
+		Name: "job-with-template",
+		Spec: &corev1.PodSpec{
+			Volumes: []corev1.Volume{cmVolume("volume", template)},
+		},
+	}
+	jobWithoutTemplate := config.JobBase{
+		Name: "job-without-template",
+		Spec: &corev1.PodSpec{},
+	}
+
+	testcases := []struct {
+		description string
+		presubmits  []config.Presubmit
+		postsubmits []config.Postsubmit
+		periodics   []config.Periodic
+
+		inserted sets.String
+	}{
+		{
+			description: "presubmit using template is added",
+			presubmits:  []config.Presubmit{{JobBase: jobWithTemplate}},
+			inserted:    sets.NewString("job-with-template"),
+		},
+		{
+			description: "postsubmit using template is added",
+			postsubmits: []config.Postsubmit{{JobBase: jobWithTemplate}},
+			inserted:    sets.NewString("job-with-template"),
+		},
+		{
+			description: "periodics using template is added",
+			periodics:   []config.Periodic{{JobBase: jobWithTemplate}},
+			inserted:    sets.NewString("job-with-template"),
+		},
+		{
+			description: "jobs not using template are ignored",
+			presubmits:  []config.Presubmit{{JobBase: jobWithTemplate}, {JobBase: jobWithoutTemplate}},
+			postsubmits: []config.Postsubmit{{JobBase: jobWithoutTemplate}},
+			periodics:   []config.Periodic{{JobBase: jobWithoutTemplate}},
+			inserted:    sets.NewString("job-with-template"),
+		},
+	}
+
+	for _, tc := range testcases {
+		mock := mockAllowlist{jobs: map[string]sets.String{}}
+		mockJobs := &mockJobConfig{
+			presubmits:  tc.presubmits,
+			postsubmits: tc.postsubmits,
+			periodics:   tc.periodics,
+		}
+		t.Run(tc.description, func(t *testing.T) {
+			enforcer := Enforcer{
+				existingTemplates: sets.NewString(template),
+				allowlist:         &mock,
+			}
+			enforcer.ProcessJobs(mockJobs)
+
+			if jobs, ok := mock.jobs[template]; !ok {
+				t.Errorf("%s: no record added for template '%s'", tc.description, template)
+			} else if diff := cmp.Diff(jobs, tc.inserted); diff != "" {
+				t.Errorf("%s: inserted jobs differ:\n%s", tc.description, diff)
+			}
+		})
+	}
+}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -568,3 +568,8 @@ func makeBranchExplicit(branch string) string {
 	}
 	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
 }
+
+func IsGenerated(job prowconfig.JobBase) bool {
+	_, generated := job.Labels[jc.ProwJobLabelGenerated]
+	return generated
+}

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -570,3 +570,32 @@ func pruneForTests(jobConfig *prowconfig.JobConfig) {
 		}
 	}
 }
+
+func TestIsGenerated(t *testing.T) {
+	testCases := []struct {
+		description string
+		labels      map[string]string
+		expected    bool
+	}{
+		{
+			description: "job without any labels is not generated",
+		},
+		{
+			description: "job without the generated label is not generated",
+			labels:      map[string]string{"some-label": "some-value"},
+		},
+		{
+			description: "job with the generated label is generated",
+			labels:      map[string]string{jobconfig.ProwJobLabelGenerated: "any-value"},
+			expected:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if generated := IsGenerated(prowconfig.JobBase{Labels: tc.labels}); generated != tc.expected {
+				t.Errorf("%s: expected %t, got %t", tc.description, tc.expected, generated)
+			}
+		})
+	}
+}

--- a/pkg/slack/events/joblink/link.go
+++ b/pkg/slack/events/joblink/link.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/prowgen"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 	"github.com/openshift/ci-tools/pkg/slack/events"
 )
@@ -195,19 +196,19 @@ func contextFor(logger *logrus.Entry, infos []jobInfo, config JobGetter, gcsClie
 		if job.presubmit != nil {
 			spec = pjutil.PresubmitSpec(*job.presubmit, prowapi.Refs{})
 			options = job.presubmit.DecorationConfig.GCSConfiguration
-			_, generated = job.presubmit.Labels[jobconfig.ProwJobLabelGenerated]
+			generated = prowgen.IsGenerated(job.presubmit.JobBase)
 			job.metadata.Variant = rehearse.VariantFromLabels(job.presubmit.Labels)
 			prefix = jobconfig.PresubmitPrefix
 		} else if job.postsubmit != nil {
 			spec = pjutil.PostsubmitSpec(*job.postsubmit, prowapi.Refs{})
 			options = job.postsubmit.DecorationConfig.GCSConfiguration
-			_, generated = job.postsubmit.Labels[jobconfig.ProwJobLabelGenerated]
+			generated = prowgen.IsGenerated(job.postsubmit.JobBase)
 			job.metadata.Variant = rehearse.VariantFromLabels(job.postsubmit.Labels)
 			prefix = jobconfig.PostsubmitPrefix
 		} else if job.periodic != nil {
 			spec = pjutil.PeriodicSpec(*job.periodic)
 			options = job.periodic.DecorationConfig.GCSConfiguration
-			_, generated = job.periodic.Labels[jobconfig.ProwJobLabelGenerated]
+			generated = prowgen.IsGenerated(job.periodic.JobBase)
 			job.metadata.Variant = rehearse.VariantFromLabels(job.periodic.Labels)
 			prefix = jobconfig.PeriodicPrefix
 		} else {

--- a/test/integration/template-deprecator.sh
+++ b/test/integration/template-deprecator.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+function cleanup() {
+    os::test::junit::reconcile_output
+    os::cleanup::processes
+}
+trap "cleanup" EXIT
+
+suite_dir="${OS_ROOT}/test/integration/template-deprecator/"
+workdir="${BASETMPDIR}/template-deprecator"
+mkdir -p "${workdir}"
+cp -a "${suite_dir}/"* "${workdir}"
+inputs="${workdir}/input"
+allowlist="${workdir}/allowlist.yaml"
+
+os::test::junit::declare_suite_start "integration/template-deprecator"
+
+# this invocation will generate a new allowlist
+os::cmd::expect_success "template-deprecator --prow-jobs-dir ${inputs}/jobs --prow-config-path ${inputs}/config.yaml --prow-plugin-config-path ${inputs}/plugins.yaml --allowlist-path ${allowlist}"
+os::integration::compare "${allowlist}" "${suite_dir}/expected/allowlist.yaml"
+
+# this invocation will grow an existing allowlist
+cp "${inputs}/partial-allowlist.yaml" "${allowlist}"
+os::cmd::expect_success "template-deprecator --prow-jobs-dir ${inputs}/jobs --prow-config-path ${inputs}/config.yaml --prow-plugin-config-path ${inputs}/plugins.yaml --allowlist-path ${allowlist}"
+os::integration::compare "${allowlist}" "${suite_dir}/expected/allowlist.yaml"
+
+# this invocation will respect the blockers already present in allowlist
+cp "${inputs}/blockered-allowlist.yaml" "${allowlist}"
+os::cmd::expect_success "template-deprecator --prow-jobs-dir ${inputs}/jobs --prow-config-path ${inputs}/config.yaml --prow-plugin-config-path ${inputs}/plugins.yaml --allowlist-path ${allowlist}"
+os::integration::compare "${allowlist}" "${suite_dir}/expected/blockered-allowlist.yaml"
+
+os::test::junit::declare_suite_end

--- a/test/integration/template-deprecator/expected/allowlist.yaml
+++ b/test/integration/template-deprecator/expected/allowlist.yaml
@@ -1,0 +1,12 @@
+templates:
+  testing-template:
+    template_name: testing-template
+    unknown_blocker:
+      description: unknown
+      jobs:
+        periodic-job-1:
+          generated: false
+          kind: periodic
+        periodic-job-2:
+          generated: false
+          kind: periodic

--- a/test/integration/template-deprecator/expected/blockered-allowlist.yaml
+++ b/test/integration/template-deprecator/expected/blockered-allowlist.yaml
@@ -1,0 +1,15 @@
+templates:
+  testing-template:
+    blockers:
+      DPTP-1234:
+        description: serious problem
+        jobs:
+          periodic-job-1:
+            generated: false
+            kind: periodic
+          periodic-job-2:
+            generated: false
+            kind: periodic
+    template_name: testing-template
+    unknown_blocker:
+      description: unknown

--- a/test/integration/template-deprecator/input/blockered-allowlist.yaml
+++ b/test/integration/template-deprecator/input/blockered-allowlist.yaml
@@ -1,0 +1,15 @@
+templates:
+  testing-template:
+    blockers:
+      DPTP-1234:
+        description: "serious problem"
+        jobs:
+          periodic-job-1:
+            generated: false
+            kind: periodic
+          periodic-job-2:
+            generated: false
+            kind: periodic
+    template_name: testing-template
+    unknown_blocker:
+      description: unknown

--- a/test/integration/template-deprecator/input/config.yaml
+++ b/test/integration/template-deprecator/input/config.yaml
@@ -1,0 +1,22 @@
+plank:
+  default_decoration_configs:
+    '*':
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20200128-8b3c11f53
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20200128-8b3c11f53
+        initupload: gcr.io/k8s-prow/initupload:v20200128-8b3c11f53
+        sidecar: gcr.io/k8s-prow/sidecar:v20200128-8b3c11f53
+tide:
+  queries:
+  - includedBranches:
+    - master
+    - release-4.2
+    repos:
+    - openshift/installer
+    - super/trooper

--- a/test/integration/template-deprecator/input/jobs/periodics.yaml
+++ b/test/integration/template-deprecator/input/jobs/periodics.yaml
@@ -1,0 +1,55 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 4h
+  labels:
+    job-release: "4.8"
+  name: periodic-job-1
+  spec:
+    containers:
+    - args:
+      - do-stuff
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+    serviceAccountName: ci-operator
+    volumes:
+    - configMap:
+        name: testing-template
+      name: job-definition
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 4h
+  labels:
+    job-release: "4.8"
+  name: periodic-job-2
+  spec:
+    containers:
+    - args:
+      - do-stuff
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+    serviceAccountName: ci-operator
+    volumes:
+    - configMap:
+        name: testing-template
+      name: job-definition

--- a/test/integration/template-deprecator/input/partial-allowlist.yaml
+++ b/test/integration/template-deprecator/input/partial-allowlist.yaml
@@ -1,0 +1,9 @@
+templates:
+  testing-template:
+    template_name: testing-template
+    unknown_blocker:
+      description: unknown
+      jobs:
+        periodic-job-2:
+          generated: false
+          kind: periodic

--- a/test/integration/template-deprecator/input/plugins.yaml
+++ b/test/integration/template-deprecator/input/plugins.yaml
@@ -1,0 +1,7 @@
+config_updater:
+  maps:
+    ci-operator/templates/template.yaml:
+      clusters:
+        app.ci:
+        - ci
+      name: testing-template


### PR DESCRIPTION
~This code makes `sanitize-prow-jobs` _optionally_ read config-updater config, get a list of all existing templates, and compile an allowlist of all jobs that currently use these templates. This allowlist is merged with a previously saved one~.

I made the second iteration a separate binary, because the functionality did not really fit into `sanitize-prow-jobs` in the end (it would become a totally modal tool, wiith separate options etc). Also, we may want to make interaction with the allowllist easier for users via the tool, and an explicit tool is better for that.


This is how the allowlist looks like:

```yaml
templates:
  prow-job-cluster-launch-e2e:
    blockers:
      JIRA-1234:
        description: "Things do not thing the way they should thing"
        jobs:
          periodic-ci-openshift-origin-release-3.11-e2e-gcp:
            generated: false
            kind: periodic
          pull-ci-image-registry-e2e-3.10:
            generated: false
            kind: presubmit
    template_name: prow-job-cluster-launch-e2e
    unknown_blocker:
      description: unknown
      jobs:
        pull-ci-openshift-image-registry-release-3.11-e2e-gcp:
          generated: true
          kind: presubmit
```

By default, new jobs are always added to the `unknown_blocker` list. From there, humans can (currenlty only manually) move the jobs to the `blockers` list, keyed by Jira numbers. If a job is in a known blocker list for a template, it will not be added to the unknown blocker list anymore.

/cc @openshift/openshift-team-developer-productivity-test-platform 