### PR TITLE
pkg/steps/template: Replace context.TODO in waitForPodCompletionOrTimeout

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -510,7 +510,7 @@ func waitForPodCompletion(ctx context.Context, podClient coreclientset.PodInterf
 }
 
 func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.PodInterface, eventClient coreclientset.EventInterface, name string, completed map[string]time.Time, notifier ContainerNotifier, skipLogs bool) (bool, error) {
-	watcher, err := podClient.Watch(context.TODO(), meta.ListOptions{
+	watcher, err := podClient.Watch(ctx, meta.ListOptions{
 		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
 		Watch:         true,
 	})
@@ -519,7 +519,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 	}
 	defer watcher.Stop()
 
-	list, err := podClient.List(context.TODO(), meta.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
+	list, err := podClient.List(ctx, meta.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 	if err != nil {
 		return false, fmt.Errorf("could not list pod: %w", err)
 	}
@@ -552,7 +552,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 			return false, ctx.Err()
 		// Check minutely if we ran into the pod timeout
 		case <-podCheckTicker.C:
-			pod, err := podClient.Get(context.TODO(), name, meta.GetOptions{})
+			pod, err := podClient.Get(ctx, name, meta.GetOptions{})
 			if err != nil {
 				log.Printf("warning: failed to get pod %s: %v", name, err)
 				continue


### PR DESCRIPTION
The TODO are from 0dcdf1090b (#1058).  Possibly they were just `sed`ed in, because the function has taken a Context argument since c242af1190 (#510).

CC @alvaroaleman