### PR TITLE
pkg/steps: Add a finalizer for pod collection

### DIFF
--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -205,6 +205,7 @@ func generateBasePod(
 				JobSpecAnnotation:                     jobSpec.RawSpec(),
 				annotationContainersForSubTestResults: containerName,
 			},
+			Finalizers: []string{finalizer}, // ensure we notice before the pod is deleted
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: coreapi.RestartPolicyNever,

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -4,6 +4,8 @@
       ci-operator.openshift.io/save-container-logs: "true"
       ci.openshift.io/job-spec: ""
     creationTimestamp: null
+    finalizers:
+    - ci.openshift.io/read-final-status
     labels:
       OPENSHIFT_CI: "true"
       build-id: build id
@@ -112,6 +114,8 @@
       ci-operator.openshift.io/save-container-logs: "true"
       ci.openshift.io/job-spec: ""
     creationTimestamp: null
+    finalizers:
+    - ci.openshift.io/read-final-status
     labels:
       OPENSHIFT_CI: "true"
       build-id: build id
@@ -236,6 +240,8 @@
       ci-operator.openshift.io/save-container-logs: "true"
       ci.openshift.io/job-spec: ""
     creationTimestamp: null
+    finalizers:
+    - ci.openshift.io/read-final-status
     labels:
       OPENSHIFT_CI: "true"
       build-id: build id

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -3,6 +3,8 @@ metadata:
     ci-operator.openshift.io/container-sub-tests: StepName
     ci.openshift.io/job-spec: ""
   creationTimestamp: null
+  finalizers:
+  - ci.openshift.io/read-final-status
   labels:
     OPENSHIFT_CI: "true"
     build-id: test-build-id

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -3,6 +3,8 @@ metadata:
     ci-operator.openshift.io/container-sub-tests: StepName
     ci.openshift.io/job-spec: ""
   creationTimestamp: null
+  finalizers:
+  - ci.openshift.io/read-final-status
   labels:
     OPENSHIFT_CI: "true"
     build-id: test-build-id


### PR DESCRIPTION
And, when we see that finalizer in the pod and are no longer interested in watching it, remove the finalizer so the deletion can go through.

This should avoid cases where the parallel Delete (e.g. the one in `podStep.run()`) removes the pod, the change somehow slips through the watch, and we [lose track of the pod][1]:

    2020/10/06 23:04:25 error: could not wait for pod 'timeout-timeout': it is no longer present on the cluster (usually a result of a race or resource pressure. re-running the job should help)

Spun out of #1257.

/assign @alvaroaleman

[1]: https://github.com/openshift/ci-tools/pull/1257#issuecomment-704613892