### PR TITLE
ci-operator: remove uses of top-level context

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -519,7 +519,7 @@ func waitForPodCompletion(ctx context.Context, podClient coreclientset.PodInterf
 }
 
 func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.PodInterface, eventClient coreclientset.EventInterface, name string, completed map[string]time.Time, notifier ContainerNotifier, skipLogs bool) (*coreapi.Pod, bool, error) {
-	watcher, err := podClient.Watch(ctx, meta.ListOptions{
+	watcher, err := podClient.Watch(context.Background(), meta.ListOptions{
 		FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String(),
 		Watch:         true,
 	})
@@ -528,7 +528,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 	}
 	defer watcher.Stop()
 
-	list, err := podClient.List(ctx, meta.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
+	list, err := podClient.List(context.Background(), meta.ListOptions{FieldSelector: fields.Set{"metadata.name": name}.AsSelector().String()})
 	if err != nil {
 		return nil, false, fmt.Errorf("could not list pod: %w", err)
 	}
@@ -561,7 +561,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient coreclientset.
 			return pod, false, ctx.Err()
 		// Check minutely if we ran into the pod timeout
 		case <-podCheckTicker.C:
-			newPod, err := podClient.Get(ctx, name, meta.GetOptions{})
+			newPod, err := podClient.Get(context.Background(), name, meta.GetOptions{})
 			if err != nil {
 				log.Printf("warning: failed to get pod %s: %v", name, err)
 				continue


### PR DESCRIPTION
Calling these functions with a cancelled context causes them to fail and
return an error (debugging output included):

```
^CINFO[0050] Received signal.                              signal=interrupt
2020/10/08 12:11:33 error: Process interrupted with signal interrupt, cancelling execution...
debug: event: watch.Event{Type:"ERROR", Object:(*v1.Status)(0xc0008d8000)}, ok: true
2020/10/08 12:11:33 error: Unrecognized event in watch: ERROR &v1.Status{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ListMeta:v1.ListMeta{SelfLink:"", ResourceVersion:"", Continue:"", RemainingItemCount:(*int64)(nil)}, Status:"Failure", Message:"an error on the server (\"unable to decode an event from the watch stream: context canceled\") has prevented the request from succeeding", Reason:"InternalError", Details:(*v1.StatusDetails)(0xc0003d4000), Code:500}
debug: event: watch.Event{Type:"", Object:runtime.Object(nil)}, ok: false
2020/10/08 12:11:33 cleanup: Deleting pods with label ci.openshift.io/multi-stage-test=success
2020/10/08 12:11:34 No custom metadata found and prow metadata already exists. Not updating the metadata.
2020/10/08 12:11:34 Ran for 51s
error: some steps failed:
  * could not run steps: execution cancelled
  * could not run steps: step success failed: "success" test steps failed: ["success" pod "success-test" failed: could not create watcher for pod: Get "https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/pods
?fieldSelector=metadata.name%3Dsuccess-test&watch=true": context canceled
```

Using the top-level test context affects the loop in several ways:
- the `select` statement is now non-deterministic on interruptions,
  since it waits on two channels that depend on the same context
  (`ctx.Done()` and `watcher.ResultChan`)
- if the watch wins the race, we get an event without a Pod, which
  invalidates the subsequent assertion
- the execution is immediately cancelled with an error because the
  context is cancelled, resulting in no test artifacts

@alvaroaleman @wking