### PR TITLE
pkg/steps/template: Push "Executing pod..." logging into createOrRestartPod

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -522,7 +522,6 @@ func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, sh
 	namePrefix := s.name + "-"
 	var errs []error
 	for _, pod := range pods {
-		log.Printf("Executing %q", pod.Name)
 		var notifier ContainerNotifier = NopNotifier
 		for _, c := range pod.Spec.Containers {
 			if c.Name == "artifacts" {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -407,6 +407,7 @@ func createOrRestartPod(podClient coreclientset.PodInterface, pod *coreapi.Pod) 
 		return nil, fmt.Errorf("unable to delete completed pod: %w", err)
 	}
 	var created *coreapi.Pod
+	log.Printf("Executing pod %q", pod.Name)
 	// creating a pod in close proximity to namespace creation can result in forbidden errors due to
 	// initializing secrets or policy - use a short backoff to mitigate flakes
 	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 4, Factor: 2, Duration: time.Second}, func() (bool, error) {


### PR DESCRIPTION
This seems generically useful, and not something that needs to be restricted to multi-step, where it has been since 8cf5f87d55 (#100).