### PR TITLE
pkg/steps: Return Pod from waitForPodCompletion

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -554,7 +554,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	if _, err := createOrRestartPod(s.podClient.Pods(s.jobSpec.Namespace()), pod); err != nil {
 		return fmt.Errorf("failed to create or restart %q pod: %w", pod.Name, err)
 	}
-	err := waitForPodCompletion(ctx, s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, notifier, false)
+	_, err := waitForPodCompletion(ctx, s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, notifier, false)
 	s.subTests = append(s.subTests, notifier.SubTests(fmt.Sprintf("%s - %s ", s.Description(), pod.Name))...)
 	if err != nil {
 		linksText := strings.Builder{}

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -118,7 +118,7 @@ func (s *podStep) run(ctx context.Context) error {
 		s.subTests = testCaseNotifier.SubTests(s.Description() + " - ")
 	}()
 
-	if err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
+	if _, err := waitForPodCompletion(context.TODO(), s.podClient.Pods(s.jobSpec.Namespace()), s.eventClient.Events(s.jobSpec.Namespace()), pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
 		return fmt.Errorf("%s %q failed: %w", s.name, pod.Name, err)
 	}
 	return nil
@@ -292,10 +292,10 @@ func getSecretVolumeMountFromSecret(secretMountPath string) []coreapi.VolumeMoun
 // PodStep and is intended for other steps that may need to run transient actions.
 // This pod will not be able to gather artifacts, nor will it report log messages
 // unless it fails.
-func RunPod(ctx context.Context, podClient PodClient, eventClient coreclientset.EventsGetter, pod *coreapi.Pod) error {
+func RunPod(ctx context.Context, podClient PodClient, eventClient coreclientset.EventsGetter, pod *coreapi.Pod) (*coreapi.Pod, error) {
 	pod, err := createOrRestartPod(podClient.Pods(pod.Namespace), pod)
 	if err != nil {
-		return err
+		return pod, err
 	}
 	return waitForPodCompletion(ctx, podClient.Pods(pod.Namespace), eventClient.Events(pod.Namespace), pod.Name, nil, true)
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -160,7 +160,7 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 	// get the CLI image from the payload (since we need it to run oc adm release extract)
 	target := fmt.Sprintf("release-images-%s", s.name)
 	targetCLI := fmt.Sprintf("%s-cli", target)
-	if err := steps.RunPod(context.TODO(), s.podClient, s.eventClient, &coreapi.Pod{
+	if _, err := steps.RunPod(context.TODO(), s.podClient, s.eventClient, &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      targetCLI,
 			Namespace: s.jobSpec.Namespace(),


### PR DESCRIPTION
To allow future callers to switch on particular pod states when explaining error messages.  For example, we may want to say something about the configured `activeDeadlineSeconds` if we see a pod that failed with `DeadlineExceeded` (#1257).