### PR TITLE
promotion: support `main` branch

### DIFF
--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -5,10 +5,11 @@ import (
 	"flag"
 	"fmt"
 
-	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/config"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/flagutil"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
 )
 
 const (
@@ -99,13 +100,14 @@ func IsBumpable(branch, currentRelease string) bool {
 // DetermineReleaseBranch determines the branch that will be used to the future release,
 // based on the branch that is currently promoting to the current release.
 func DetermineReleaseBranch(currentRelease, futureRelease, currentBranch string) (string, error) {
-	if currentBranch == "master" {
+	switch currentBranch {
+	case "master", "main":
 		return fmt.Sprintf("release-%s", futureRelease), nil
-	} else if currentBranch == fmt.Sprintf("openshift-%s", currentRelease) {
+	case fmt.Sprintf("openshift-%s", currentRelease):
 		return fmt.Sprintf("openshift-%s", futureRelease), nil
-	} else if currentBranch == fmt.Sprintf("release-%s", currentRelease) {
+	case fmt.Sprintf("release-%s", currentRelease):
 		return fmt.Sprintf("release-%s", futureRelease), nil
-	} else {
+	default:
 		return "", fmt.Errorf("invalid branch %q promoting to current release", currentBranch)
 	}
 }

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -8,9 +8,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/flagutil"
+
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
-	"k8s.io/test-infra/prow/flagutil"
 )
 
 func TestPromotesOfficialImages(t *testing.T) {
@@ -180,6 +181,14 @@ func TestDetermineReleaseBranches(t *testing.T) {
 			currentRelease:       "4.0",
 			futureRelease:        "4.1",
 			currentBranch:        "master",
+			expectedFutureBranch: "release-4.1",
+			expectedError:        false,
+		},
+		{
+			name:                 "promotion from main makes a release branch",
+			currentRelease:       "4.0",
+			futureRelease:        "4.1",
+			currentBranch:        "main",
 			expectedFutureBranch: "release-4.1",
 			expectedError:        false,
 		},


### PR DESCRIPTION
Fixes:

```console
$ config-brancher --config-dir ./ci-operator/config --current-release=4.7 --future-release=4.8 --confirm
...
ERRO[0000] could not determine future branch that would promote to current imagestream  branch=main error="invalid branch \"main\" promoting to current release" org=openshift repo=osd-metrics-exporter source-file=openshift-osd-metrics-exporter-main.yaml
...
```