### PR TITLE
Reporter: Remove error if -report-password-file is not set

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -50,11 +50,8 @@ func (o *Options) Validate() error {
 
 // Client returns an HTTP or HTTPs client, based on the options
 func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, error) {
-	if o.address == "" {
+	if o.address == "" || o.password == "" {
 		return &noopReporter{}, nil
-	}
-	if o.password == "" {
-		return nil, errors.New("mandatory flag -report-password-file is unset")
 	}
 	raw, err := ioutil.ReadFile(o.password)
 	if err != nil {


### PR DESCRIPTION
If we can't report due to missing info it should be a no-op reporter and the user should see no error.