### PR TITLE
rpm_server: Should use overwrite and not append for script creation

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -114,7 +114,7 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 
 if which python3 2> /dev/null; then
 	# If python3 is available, use it
-	cat <<END >>/tmp/serve.py
+	cat <<END >/tmp/serve.py
 import time, threading, socket, socketserver, http, http.server
 
 # Create socket
@@ -144,7 +144,7 @@ END
 	python3 /tmp/serve.py
 else
 	# Else, fallback to python2
-	cat <<END >>/tmp/serve.py
+	cat <<END >/tmp/serve.py
 import time, threading, socket, SocketServer, BaseHTTPServer, SimpleHTTPServer
 # Create socket
 addr = ('', 8080)


### PR DESCRIPTION
The use of the `>>` append redirect for the python serving script
meant that subsequent executions would not update the contents.
While this is unlikely to impact the pod, someone debugging the
script would never see their changes to the script reflected
because the new version would be appended to the python script
after a blocking function (so the updated code would never run).

Correct the typo so no other copy and paste mistakes occur.

Found while adapting https://github.com/openshift/release-controller/pull/222