### PR TITLE
[ci-secret-bootstrap] introduce the dockerconfigJSON configuration

### DIFF
--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 
 	"sigs.k8s.io/yaml"
@@ -375,7 +376,7 @@ func validateContexts(contexts []secretbootstrap.BitWardenContext, config secret
 		var found bool
 		for _, secret := range config.Secrets {
 			for _, haystack := range secret.From {
-				if needle == haystack {
+				if reflect.DeepEqual(needle, haystack) {
 					found = true
 				}
 			}

--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+
 	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,10 +18,27 @@ const (
 )
 
 type BitWardenContext struct {
-	BWItem     string        `json:"bw_item"`
-	Field      string        `json:"field,omitempty"`
-	Attachment string        `json:"attachment,omitempty"`
-	Attribute  AttributeType `json:"attribute,omitempty"`
+	BWItem               string                 `json:"bw_item"`
+	Field                string                 `json:"field,omitempty"`
+	Attachment           string                 `json:"attachment,omitempty"`
+	Attribute            AttributeType          `json:"attribute,omitempty"`
+	DockerConfigJSONData []DockerConfigJSONData `json:"dockerconfigJSON,omitempty"`
+}
+
+type DockerConfigJSONData struct {
+	BWItem                    string `json:"bw_item"`
+	RegistryURLBitwardenField string `json:"registry_url_bw_field"`
+	AuthBitwardenField        string `json:"auth_bw_field"`
+	EmailBitwardenField       string `json:"email_bw_field,omitempty"`
+}
+
+type DockerConfigJSON struct {
+	Auths map[string]DockerAuth `json:"auths"`
+}
+
+type DockerAuth struct {
+	Auth  string `json:"auth"`
+	Email string `json:"email,omitempty"`
 }
 
 type SecretContext struct {


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-1496

Keeping backward compatibility, this PR adds a specific case of configuration to generate a single docker config JSON secret from multiple bitwarden values.


example config:
```yaml
secret_configs:
  - from:
      .dockerconfigjson:
        dockerconfigJSON:
        - bw_item: pull-secret-0
          registry_url_bw_field: registryURL
          auth_bw_field: auth
          email_bw_field: email
        - bw_item: pull-secret-1
          registry_url_bw_field: registryURL
          auth_bw_field: auth
    to:
      - cluster: app.ci
        namespace: test
        name: pull-secret-test
        type: kubernetes.io/dockerconfigjson
```

example output with some comments for better understanding.
```
{
  "auths": {
    "cloud.openshift.com": { // registry_url field
      "auth": "123456789", // auth field
      "email": "test@test.com" // email field
    },
    "registry.connect.redhat.com": {  // registry_url field
      "auth": "1234567890" // auth field
    }
  }
}

```
/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>