### PR TITLE
Change uppercase OSUOSL to lowercas

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -449,7 +449,7 @@ func validateReleaseTagConfiguration(fieldRoot string, input ReleaseTagConfigura
 
 func validateClusterProfile(fieldRoot string, p ClusterProfile) []error {
 	switch p {
-	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileLibvirtPpc64le, ClusterProfileLibvirtS390x, ClusterProfileOpenStack, ClusterProfileOpenStackOSUOSL, ClusterProfileOpenStackVexxhost, ClusterProfileOpenStackPpc64le, ClusterProfileOvirt, ClusterProfilePacket, ClusterProfileVSphere:
+	case ClusterProfileAWS, ClusterProfileAWSAtomic, ClusterProfileAWSCentos, ClusterProfileAWSCentos40, ClusterProfileAWSGluster, ClusterProfileAzure4, ClusterProfileGCP, ClusterProfileGCP40, ClusterProfileGCPHA, ClusterProfileGCPCRIO, ClusterProfileGCPLogging, ClusterProfileGCPLoggingJournald, ClusterProfileGCPLoggingJSONFile, ClusterProfileGCPLoggingCRIO, ClusterProfileLibvirtPpc64le, ClusterProfileLibvirtS390x, ClusterProfileOpenStack, ClusterProfileOpenStackOsuosl, ClusterProfileOpenStackVexxhost, ClusterProfileOpenStackPpc64le, ClusterProfileOvirt, ClusterProfilePacket, ClusterProfileVSphere:
 		return nil
 	}
 	return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -760,7 +760,7 @@ const (
 	ClusterProfileLibvirtPpc64le     ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtS390x       ClusterProfile = "libvirt-s390x"
 	ClusterProfileOpenStack          ClusterProfile = "openstack"
-	ClusterProfileOpenStackOSUOSL    ClusterProfile = "openstack-OSUOSL"
+	ClusterProfileOpenStackOsuosl    ClusterProfile = "openstack-osuosl"
 	ClusterProfileOpenStackVexxhost  ClusterProfile = "openstack-vexxhost"
 	ClusterProfileOpenStackPpc64le   ClusterProfile = "openstack-ppc64le"
 	ClusterProfileOvirt              ClusterProfile = "ovirt"
@@ -788,7 +788,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtS390x,
 		ClusterProfileOpenStack,
-		ClusterProfileOpenStackOSUOSL,
+		ClusterProfileOpenStackOsuosl,
 		ClusterProfileOpenStackVexxhost,
 		ClusterProfileOpenStackPpc64le,
 		ClusterProfileOvirt,
@@ -825,8 +825,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-s390x"
 	case ClusterProfileOpenStack:
 		return "openstack"
-	case ClusterProfileOpenStackOSUOSL:
-		return "openstack-OSUOSL"
+	case ClusterProfileOpenStackOsuosl:
+		return "openstack-osuosl"
 	case ClusterProfileOpenStackVexxhost:
 		return "openstack-vexxhost"
 	case ClusterProfileOpenStackPpc64le:
@@ -870,8 +870,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "libvirt-s390x-quota-slice"
 	case ClusterProfileOpenStack:
 		return "openstack-quota-slice"
-	case ClusterProfileOpenStackOSUOSL:
-		return "openstack-OSUOSL-quota-slice"
+	case ClusterProfileOpenStackOsuosl:
+		return "openstack-osuosl-quota-slice"
 	case ClusterProfileOpenStackVexxhost:
 		return "openstack-vexxhost-quota-slice"
 	case ClusterProfileOpenStackPpc64le:
@@ -890,7 +890,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "azure4", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-OSUOSL", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet":
+	case "aws", "azure4", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -470,7 +470,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzure4,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileOpenStack,
-		cioperatorapi.ClusterProfileOpenStackOSUOSL,
+		cioperatorapi.ClusterProfileOpenStackOsuosl,
 		cioperatorapi.ClusterProfileOpenStackVexxhost,
 		cioperatorapi.ClusterProfileOpenStackPpc64le,
 		cioperatorapi.ClusterProfileVSphere:


### PR DESCRIPTION
This fixes the following error:
{"component":"boskos","error":"[ResourceObject.boskos.k8s.io "openstack-OSUOSL-02" is invalid: metadata.name: Invalid value: "openstack-OSUOSL-02": a DNS-1123 subdomain must consist of lower case alphanumeric characters,...