### PR TITLE
pkg/api: validate cluster profile unconditionally

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -542,7 +542,7 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 			validationErrors = append(validationErrors, fmt.Errorf("%s: non-literal test found in fully-resolved configuration", fieldRoot))
 		}
 		typeCount++
-		if testConfig.Workflow == nil && testConfig.ClusterProfile != "" {
+		if testConfig.ClusterProfile != "" {
 			validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
 		}
 		seen := sets.NewString()


### PR DESCRIPTION
The condition was added when workflows were first introduced in
66b8344bdfa9510f0e6971be327d902735429db1.  The unresolved configuration
is used to generate ProwJob definitions, so the cluster profile in the
configuration is effectively the one that prevails and must always be
validated.

```
$ sed -i 's/\(cluster_profile: \)azure4$/\1azure/' ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
$ ci-operator-prowgen_master --from-dir ci-operator/config --to-dir ci-operator/jobs |& grep -v level=warning
$ ci-operator-prowgen --from-dir ci-operator/config --to-dir ci-operator/jobs |& grep -v level=warning
time="2020-10-14T11:57:08Z" level=error msg="Failed to load CI Operator configuration" error="invalid ci-operator config: invalid configuration: tests[9]: invalid cluster profile \"azure\"" source-file=ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml
time="2020-10-14T11:57:08Z" level=fatal msg="Failed to generate jobs" error="invalid ci-operator config: invalid configuration: tests[9]: invalid cluster profile \"azure\"" source=ci-operator/config subdir= target=ci-operator/jobs
$ git restore -- .
$ ci-operator-prowgen --from-dir ci-operator/config --to-dir ci-operator/jobs |& grep -v level=warning
```