### PR TITLE
[ci-secret-bootstrap] make dockerconfigJSON config to get the auth field from attachment instead

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"flag"
@@ -188,13 +189,13 @@ func (o *options) validateCompletedOptions() error {
 			if len(bwContext.DockerConfigJSONData) > 0 {
 				for _, data := range bwContext.DockerConfigJSONData {
 					if data.BWItem == "" {
-						return fmt.Errorf("config[%d].from[%s]: bitwarden item is missing", i, key)
+						return fmt.Errorf("config[%d].from[%s]: bw_item is missing", i, key)
 					}
 					if data.RegistryURLBitwardenField == "" {
-						return fmt.Errorf("config[%d].from[%s]: registry_url field is missing", i, key)
+						return fmt.Errorf("config[%d].from[%s]: registry_url_bw_field is missing", i, key)
 					}
-					if data.AuthBitwardenField == "" {
-						return fmt.Errorf("config[%d].from[%s]: auth field is missing", i, key)
+					if data.AuthBitwardenAttachment == "" {
+						return fmt.Errorf("config[%d].from[%s]: auth_bw_attachment is missing", i, key)
 					}
 					if secretConfig.To[i].Type == "" {
 						secretConfig.To[i].Type = "kubernetes.io/dockerconfigjson"
@@ -262,11 +263,11 @@ func constructDockerConfigJSON(bwClient bitwarden.Client, dockerConfigJSONData [
 
 		}
 
-		authBWField, err := bwClient.GetFieldOnItem(data.BWItem, data.AuthBitwardenField)
+		authBWAttachmentValue, err := bwClient.GetAttachmentOnItem(data.BWItem, data.AuthBitwardenAttachment)
 		if err != nil {
-			return nil, fmt.Errorf("couldn't get the auth field '%s' from bw item %s: %w", data.AuthBitwardenField, data.BWItem, err)
+			return nil, fmt.Errorf("couldn't get attachment '%s' from bw item %s: %w", data.AuthBitwardenAttachment, data.BWItem, err)
 		}
-		authData.Auth = string(authBWField)
+		authData.Auth = string(bytes.TrimSpace(authBWAttachmentValue))
 
 		if data.EmailBitwardenField != "" {
 			emailValue, err := bwClient.GetFieldOnItem(data.BWItem, data.EmailBitwardenField)

--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -28,7 +28,7 @@ type BitWardenContext struct {
 type DockerConfigJSONData struct {
 	BWItem                    string `json:"bw_item"`
 	RegistryURLBitwardenField string `json:"registry_url_bw_field"`
-	AuthBitwardenField        string `json:"auth_bw_field"`
+	AuthBitwardenAttachment   string `json:"auth_bw_attachment"`
 	EmailBitwardenField       string `json:"email_bw_field,omitempty"`
 }
 


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 

Unfortunately, a bitwarden field can't hold more than 1000 characters. Instead, we have to grab the auth token from an attachment.


the new config should look like:

```yaml
secret_configs:
  - from:
      .dockerconfigjson:
        dockerconfigJSON:
        - bw_item: pull-secret-1
          registry_url_bw_field: registry_url
          auth_bw_attachment: auth
          email_bw_field: email
        - bw_item: pull-secret-2
          registry_url_bw_field: registry_url
          auth_bw_attachment: auth
          email_bw_field: email
    to:
      - cluster: app.ci
        namespace: test
        name: pull-secret-test
        type: kubernetes.io/dockerconfigjson
```

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>