### PR TITLE
pkg/steps/lease: Split leased resource on '--'

### DIFF
--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"strings"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -61,7 +62,8 @@ func (s *leaseStep) Provides() api.ParameterMap {
 		parameters = api.ParameterMap{}
 	}
 	parameters[leaseEnv] = func() (string, error) {
-		return s.leasedResource, nil
+		chunks := strings.SplitN(s.leasedResource, "--", 2)
+		return chunks[0], nil
 	}
 	return parameters
 }

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -85,7 +85,7 @@ func TestLeaseStepForward(t *testing.T) {
 			t.Errorf("not properly forwarded: %s", diff.ObjectDiff(l, s))
 		}
 	})
-	t.Run("Provides", func(t *testing.T) {
+	t.Run("Provides includes parameters from wrapped step", func(t *testing.T) {
 		sParam := step.Provides()
 		sRet, err := sParam["parameter"]()
 		if err != nil {
@@ -98,6 +98,19 @@ func TestLeaseStepForward(t *testing.T) {
 		}
 		if !reflect.DeepEqual(lRet, sRet) {
 			t.Errorf("not properly forwarded (param): %s", diff.ObjectDiff(lParam, sParam))
+		}
+	})
+	t.Run("Provides includes sanitized lease name", func(t *testing.T) {
+		rawLeaseStep := withLease.(*leaseStep)
+		rawLeaseStep.leasedResource = "whatever--01"
+		expected := "whatever"
+		lParam := withLease.Provides()
+		actual, err := lParam[leaseEnv]()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual != expected {
+			t.Errorf("got %q for %s, expected %q", actual, leaseEnv, expected)
 		}
 	})
 	t.Run("SubTests", func(T *testing.T) {


### PR DESCRIPTION
To allow for the suffixed lease names from openshift/release#12589 without exposing the suffixes to consuming steps.