### PR TITLE
Github FileGetter: Retry to not choke on transient errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.0
 	github.com/google/gofuzz v1.1.0
+	github.com/hashicorp/go-retryablehttp v0.6.6
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23
 	github.com/mattn/go-zglob v0.0.2
 	github.com/montanaflynn/stats v0.6.3


### PR DESCRIPTION
Like it for example happened here: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-registry-replacer/1316499184521580544#1:build-log.txt%3A86