### PR TITLE
slack-bot: expose interaction flows in messages

### DIFF
--- a/hack/local-slack-bot.sh
+++ b/hack/local-slack-bot.sh
@@ -53,4 +53,4 @@ os::log::info "Sending production traffic from Slack to the reverse proxy..."
 ssh -N -T root@127.0.0.1 -p 2222 -R "8888:127.0.0.1:8888" &
 
 os::log::info "Running the slack-bot server..."
-http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 --slack-token-path "${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" --jira-username=skuznets --jira-password-file="${data}/password" --jira-endpoint https://issues.redhat.com --log-level=trace
+http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 --slack-token-path "${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" --jira-username=dptp-bot --jira-password-file="${data}/password" --jira-endpoint https://issues.redhat.com --log-level=trace

--- a/pkg/slack/events/handler.go
+++ b/pkg/slack/events/handler.go
@@ -1,0 +1,93 @@
+package events
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack/slackevents"
+)
+
+// Handler knows how to handle an event callback.
+type Handler interface {
+	Handle(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error
+	Identifier() string
+}
+
+type handler struct {
+	handle     func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error
+	identifier string
+}
+
+func (h *handler) Handle(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error {
+	return h.handle(callback, logger)
+}
+func (h *handler) Identifier() string {
+	return h.identifier
+}
+
+// HandlerFunc returns a Handler for a handling func
+func HandlerFunc(identifier string, handle func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error) Handler {
+	return &handler{
+		handle:     handle,
+		identifier: identifier,
+	}
+}
+
+// PartialHandler is a Handler that exposes whether it handled
+// a callback, consuming it, or if another Handler should have
+// the chance to handle it instead.
+type PartialHandler interface {
+	Handle(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error)
+	Identifier() string
+}
+
+type partialHandler struct {
+	handle     func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error)
+	identifier string
+}
+
+func (h *partialHandler) Handle(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
+	return h.handle(callback, logger)
+}
+func (h *partialHandler) Identifier() string {
+	return h.identifier
+}
+
+// PartialHandlerFunc returns a PartialHandler for a handling func
+func PartialHandlerFunc(identifier string, handle func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error)) PartialHandler {
+	return &partialHandler{
+		handle:     handle,
+		identifier: identifier,
+	}
+}
+
+// HandlerFromPartial adapts a partial handler to a singleton
+// when there is just one handler for a callback
+func HandlerFromPartial(handler PartialHandler) Handler {
+	return HandlerFunc(handler.Identifier(), func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error {
+		_, err := handler.Handle(callback, logger)
+		return err
+	})
+}
+
+// PartialFromHandler adapts a handler to a partial
+// and always expects that the handler consumes the callback
+func PartialFromHandler(handler Handler) PartialHandler {
+	return PartialHandlerFunc(handler.Identifier(), func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
+		err = handler.Handle(callback, logger)
+		return true, err
+	})
+}
+
+// MultiHandler sends the callback to a chain of partial handlers,
+// greedily allowing them to consume and respond to it.
+func MultiHandler(handlers ...PartialHandler) Handler {
+	return HandlerFunc("multi_handler", func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) error {
+		for _, handler := range handlers {
+			logger = logger.WithField("handler", handler.Identifier())
+			handled, err := handler.Handle(callback, logger)
+			if handled {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/pkg/slack/events/mention/mention.go
+++ b/pkg/slack/events/mention/mention.go
@@ -1,0 +1,137 @@
+package mention
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/openshift/ci-tools/pkg/slack/events"
+	"github.com/openshift/ci-tools/pkg/slack/modals"
+	"github.com/openshift/ci-tools/pkg/slack/modals/bug"
+	"github.com/openshift/ci-tools/pkg/slack/modals/consultation"
+	"github.com/openshift/ci-tools/pkg/slack/modals/enhancement"
+	"github.com/openshift/ci-tools/pkg/slack/modals/helpdesk"
+	"github.com/openshift/ci-tools/pkg/slack/modals/incident"
+	"github.com/openshift/ci-tools/pkg/slack/modals/triage"
+)
+
+type messagePoster interface {
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+}
+
+// Handler returns a handler that knows how to respond to
+// new messages that mention the robot by showing users
+// which interactive workflows they might be interested in,
+// based on the phrasing that they used to mention the bot.
+func Handler(client messagePoster) events.PartialHandler {
+	return events.PartialHandlerFunc("mention", func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
+		if callback.Type != slackevents.CallbackEvent {
+			return false, nil
+		}
+		event, ok := callback.InnerEvent.Data.(*slackevents.AppMentionEvent)
+		if !ok {
+			return false, nil
+		}
+		logger.Info("Handling app mention...")
+		timestamp := event.TimeStamp
+		if event.ThreadTimeStamp != "" {
+			timestamp = event.ThreadTimeStamp
+		}
+		responseChannel, responseTimestamp, err := client.PostMessage(event.Channel, slack.MsgOptionBlocks(responseFor(event.Text)...), slack.MsgOptionTS(timestamp))
+		if err != nil {
+			logger.WithError(err).Warn("Failed to post response to app mention")
+		} else {
+			logger.Infof("Posted response to app mention in channel %s at %s", responseChannel, responseTimestamp)
+		}
+		return true, err
+	})
+}
+
+func responseFor(message string) []slack.Block {
+	type interaction struct {
+		identifier              modals.Identifier
+		description, buttonText string
+	}
+	interactions := []interaction{
+		{
+			identifier:  bug.Identifier,
+			description: "Record a defect in the test infrastructure, providing a reproducer where possible.",
+			buttonText:  "File a Bug",
+		},
+		{
+			identifier:  consultation.Identifier,
+			description: "Ask for input from the Test Platform team to aid in achieving some goal.",
+			buttonText:  "Request a Consultation",
+		},
+		{
+			identifier:  enhancement.Identifier,
+			description: "Explain how a new feature or infrastructure component could improve your productivity.",
+			buttonText:  "Describe an Enhancement",
+		},
+		{
+			identifier:  helpdesk.Identifier,
+			description: "Request clarification on best practices for using the test infrastructure.",
+			buttonText:  "Ask a Question",
+		},
+		{
+			identifier:  incident.Identifier,
+			description: "File a tracking issue for an ongoing operational incident with the test infrastructure.",
+			buttonText:  "Track an Incident",
+		},
+		{
+			identifier:  triage.Identifier,
+			description: "Contact the on-call Test Platform engineer to alert them of an outage.",
+			buttonText:  "Report an Outage",
+		},
+	}
+
+	block := func(identifier, description, buttonText string) slack.Block {
+		return &slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: fmt.Sprintf("*%s*\n%s", buttonText, description),
+			},
+			Accessory: &slack.Accessory{
+				ButtonElement: &slack.ButtonBlockElement{
+					Type:  slack.METButton,
+					Text:  &slack.TextBlockObject{Type: slack.PlainTextType, Text: buttonText},
+					Value: identifier,
+				},
+			},
+		}
+	}
+
+	var blocks []slack.Block
+	for _, interaction := range interactions {
+		if strings.Contains(message, string(interaction.identifier)) {
+			blocks = append(blocks, &slack.DividerBlock{
+				Type: slack.MBTDivider,
+			})
+			blocks = append(blocks, block(string(interaction.identifier), interaction.description, interaction.buttonText))
+		}
+	}
+
+	if len(blocks) == 0 {
+		blocks = append(blocks, &slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{
+				Type: slack.PlainTextType,
+				Text: "Sorry, I don't know how to help with that.",
+			},
+		})
+	} else {
+		blocks = append([]slack.Block{&slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{
+				Type: slack.PlainTextType,
+				Text: "It looks like you're trying to do one of the following:",
+			},
+		}}, blocks...)
+	}
+
+	return blocks
+}

--- a/pkg/slack/events/mention/mention_test.go
+++ b/pkg/slack/events/mention/mention_test.go
@@ -1,0 +1,33 @@
+package mention
+
+import (
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestRespnseFor(t *testing.T) {
+	var testCases = []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "unrelated text gets a sad response",
+			message: "who is the president?",
+		},
+		{
+			name:    "one keyword gets a button block",
+			message: "help me file a bug",
+		},
+		{
+			name:    "many keywords get many button block",
+			message: "help me file a bug and request a consultation",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := responseFor(testCase.message)
+			testhelper.CompareWithFixture(t, actual)
+		})
+	}
+}

--- a/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_many_keywords_get_many_button_block.yaml
+++ b/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_many_keywords_get_many_button_block.yaml
@@ -1,0 +1,30 @@
+- text:
+    text: 'It looks like you''re trying to do one of the following:'
+    type: plain_text
+  type: section
+- type: divider
+- accessory:
+    text:
+      text: File a Bug
+      type: plain_text
+    type: button
+    value: bug
+  text:
+    text: |-
+      *File a Bug*
+      Record a defect in the test infrastructure, providing a reproducer where possible.
+    type: mrkdwn
+  type: section
+- type: divider
+- accessory:
+    text:
+      text: Request a Consultation
+      type: plain_text
+    type: button
+    value: consultation
+  text:
+    text: |-
+      *Request a Consultation*
+      Ask for input from the Test Platform team to aid in achieving some goal.
+    type: mrkdwn
+  type: section

--- a/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_one_keyword_gets_a_button_block.yaml
+++ b/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_one_keyword_gets_a_button_block.yaml
@@ -1,0 +1,17 @@
+- text:
+    text: 'It looks like you''re trying to do one of the following:'
+    type: plain_text
+  type: section
+- type: divider
+- accessory:
+    text:
+      text: File a Bug
+      type: plain_text
+    type: button
+    value: bug
+  text:
+    text: |-
+      *File a Bug*
+      Record a defect in the test infrastructure, providing a reproducer where possible.
+    type: mrkdwn
+  type: section

--- a/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_unrelated_text_gets_a_sad_response.yaml
+++ b/pkg/slack/events/mention/testdata/zz_fixture_TestRespnseFor_unrelated_text_gets_a_sad_response.yaml
@@ -1,0 +1,4 @@
+- text:
+    text: Sorry, I don't know how to help with that.
+    type: plain_text
+  type: section

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -1,0 +1,16 @@
+package router
+
+import (
+	"github.com/slack-go/slack"
+
+	"github.com/openshift/ci-tools/pkg/slack/events"
+	"github.com/openshift/ci-tools/pkg/slack/events/mention"
+)
+
+// ForEvents returns a Handler that appropriately routes
+// event callbacks for the handlers we know about
+func ForEvents(client *slack.Client) events.Handler {
+	return events.MultiHandler(
+		mention.Handler(client),
+	)
+}

--- a/pkg/slack/interactions/router/router_test.go
+++ b/pkg/slack/interactions/router/router_test.go
@@ -1,1 +1,39 @@
 package router
+
+import (
+	"testing"
+
+	"github.com/slack-go/slack"
+
+	"github.com/openshift/ci-tools/pkg/slack/modals/modaltesting"
+)
+
+func TestIsMessageButtonPress(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		expected bool
+	}{
+		{
+			name:     "button press in a message",
+			expected: true,
+		},
+		{
+			name:     "button press in a modal",
+			expected: false,
+		},
+		{
+			name:     "not a button press",
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var callback slack.InteractionCallback
+			modaltesting.ReadCallbackFixture(t, &callback)
+			if actual, expected := isMessageButtonPress(&callback), testCase.expected; actual != expected {
+				t.Errorf("%s: did not correctly determine if callback was a button press in a message, expected %v", testCase.name, expected)
+			}
+		})
+	}
+}

--- a/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_button_press_in_a_message_callback.yaml
+++ b/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_button_press_in_a_message_callback.yaml
@@ -1,0 +1,14 @@
+actions:
+- action_id: zm/x
+  action_ts: "1602718811.967465"
+  block_id: 9SYKg
+  type: button
+  value: incident
+message:
+  text: This content can't be displayed.
+  ts: "1602718788.001800"
+  type: message
+  user: U01BVNGTY4Q
+token: Rn1sVT099UjUeKclB3PkLT8t
+trigger_id: 1453277082384.1377252349923.284fae7a31c31795c67c87d6603044b0
+type: block_actions

--- a/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_button_press_in_a_modal_callback.yaml
+++ b/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_button_press_in_a_modal_callback.yaml
@@ -1,0 +1,46 @@
+actions:
+- action_id: uHi
+  action_ts: "1602721077.927021"
+  block_id: ReiWk
+  type: button
+  value: question
+token: Rn1sVT099UjUeKclB3PkLT8t
+trigger_id: 1414746070679.1377252349923.d013e2bf51ca9cd492f125285356c8ec
+type: block_actions
+view:
+  app_id: A01BJF00CAD
+  bot_id: B01B63T6ZFD
+  hash: 1602721048.8I2Iugsv
+  id: V01D03D0257
+  private_metadata: bug
+  root_view_id: V01D03D0257
+  state:
+    values:
+      category:
+        BtO:
+          type: static_select
+          value: ""
+      expected:
+        uE2k:
+          type: plain_text_input
+          value: ""
+      impact:
+        Au7:
+          type: plain_text_input
+          value: ""
+      optional:
+        v5u/:
+          type: plain_text_input
+          value: ""
+      reproduction:
+        m1dJb:
+          type: plain_text_input
+          value: ""
+      symptom:
+        UsOZt:
+          type: plain_text_input
+          value: ""
+      title:
+        3Gi:
+          type: plain_text_input
+          value: ""

--- a/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_not_a_button_press_callback.yaml
+++ b/pkg/slack/interactions/router/testdata/zz_fixture_TestIsMessageButtonPress_not_a_button_press_callback.yaml
@@ -1,0 +1,5 @@
+action_ts: "1602721047.606675"
+callback_id: bug
+token: Rn1sVT099UjUeKclB3PkLT8t
+trigger_id: 1429692656371.1377252349923.c727cd573983e889f95ea1eee26199ce
+type: shortcut

--- a/pkg/slack/modals/bug/view_test.go
+++ b/pkg/slack/modals/bug/view_test.go
@@ -39,7 +39,8 @@ func TestValidateSubmissionHandler(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			callback := modaltesting.ReadCallbackFixture(t)
+			var callback slack.InteractionCallback
+			modaltesting.ReadCallbackFixture(t, &callback)
 			handled, out, err := validateSubmissionHandler().Handle(&callback, logrus.WithField("test", testCase.name))
 			if expected, actual := testCase.expectedHandled, handled; expected != actual {
 				t.Errorf("%s: expected handled %v but got %v", testCase.name, expected, actual)

--- a/pkg/slack/modals/modaltesting/issueparameters.go
+++ b/pkg/slack/modals/modaltesting/issueparameters.go
@@ -45,7 +45,8 @@ type ProcessTestCase struct {
 func ValidateParameterProcessing(t *testing.T, parameters modals.JiraIssueParameters, testCases []ProcessTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			callback := ReadCallbackFixture(t)
+			var callback slack.InteractionCallback
+			ReadCallbackFixture(t, &callback)
 			title, body, err := parameters.Process(&callback)
 			if diff := cmp.Diff(testCase.ExpectedTitle, title); diff != "" {
 				t.Errorf("%s: got incorrect title: %v", testCase.Name, diff)
@@ -76,13 +77,9 @@ func WriteCallbackFixture(t *testing.T, data []byte) {
 	testhelper.WriteToFixture(t, "_callback", data)
 }
 
-func ReadCallbackFixture(t *testing.T) slack.InteractionCallback {
+func ReadCallbackFixture(t *testing.T, callback interface{}) {
 	data := testhelper.ReadFromFixture(t, "_callback")
-	var callback slack.InteractionCallback
-	if err := yaml.Unmarshal(data, &callback); err != nil {
+	if err := yaml.Unmarshal(data, callback); err != nil {
 		t.Errorf("failed to unmarshal payload: %v", err)
-		return callback
 	}
-
-	return callback
 }

--- a/pkg/slack/modals/modaltesting/submission.go
+++ b/pkg/slack/modals/modaltesting/submission.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 
 	"github.com/openshift/ci-tools/pkg/jira"
 	"github.com/openshift/ci-tools/pkg/slack/interactions"
@@ -24,7 +25,8 @@ type SubmissionTestCase struct {
 func ValidateSubmission(t *testing.T, handler interactions.Handler, testCases ...SubmissionTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			callback := ReadCallbackFixture(t)
+			var callback slack.InteractionCallback
+			ReadCallbackFixture(t, &callback)
 			out, err := handler.Handle(&callback, logrus.WithField("test", testCase.Name))
 			select {
 			case <-time.After(1 * time.Second):


### PR DESCRIPTION
Nobody wants to go to the "lightning bolt menu" and find the interaction
shortcut buttons for the bot, so now we can just mention the bot in a
conversation and it will respond with a button that starts a flow.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @alvaroaleman 

As always feel free to test it out on the robot-testing workspace.
![Screenshot from 2020-10-14 17-50-20](https://user-images.githubusercontent.com/7328370/96060661-ffad1e80-0e45-11eb-87e3-96bd1aadd56a.png)
