### PR TITLE
ci-operator: add option for read-only shared dir

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -599,6 +599,9 @@ type LiteralTestStep struct {
 	// flag is set to true in MultiStageTestConfiguration. This option is
 	// applicable to `post` steps.
 	OptionalOnSuccess *bool `json:"optional_on_success,omitempty"`
+	// ReadonlySharedDir reduces the run time of steps that do not update the
+	// shared directory.
+	ReadonlySharedDir bool `json:"readonly_shared_dir,omitempty"`
 	// Cli is the (optional) name of the release from which the `oc` binary
 	// will be injected into this step.
 	Cli string `json:"cli,omitempty"`

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -401,7 +401,9 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 			pod.Spec.Containers[idx].VolumeMounts = append(pod.Spec.Containers[idx].VolumeMounts, coreapi.VolumeMount{Name: homeVolumeName, MountPath: "/alabama"})
 		}
 
-		addSecretWrapper(pod)
+		if !step.ReadonlySharedDir {
+			addSecretWrapper(pod)
+		}
 		container := &pod.Spec.Containers[0]
 		container.Env = append(container.Env, []coreapi.EnvVar{
 			{Name: "NAMESPACE", Value: s.jobSpec.Namespace()},

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -218,6 +218,43 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 	}
 }
 
+func TestGeneratePodReadonly(t *testing.T) {
+	config := api.ReleaseBuildConfiguration{
+		Tests: []api.TestStepConfiguration{{
+			As: "test",
+			MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+				Test: []api.LiteralTestStep{{
+					As:                "step0",
+					From:              "src",
+					Commands:          "command0",
+					ReadonlySharedDir: true,
+				}},
+			},
+		}},
+	}
+	jobSpec := api.JobSpec{
+		JobSpec: prowdapi.JobSpec{
+			Job:       "job",
+			BuildID:   "build id",
+			ProwJobID: "prow job id",
+			Refs: &prowapi.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "base ref",
+				BaseSHA: "base sha",
+			},
+			Type: "postsubmit",
+		},
+	}
+	jobSpec.SetNamespace("namespace")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, nil, nil, nil, nil, nil, "artifact_dir", &jobSpec)
+	ret, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testhelper.CompareWithFixture(t, ret)
+}
+
 type fakePodExecutor struct {
 	failures sets.String
 	pods     []*coreapi.Pod

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePodReadonly.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePodReadonly.yaml
@@ -1,0 +1,78 @@
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      build-id: build id
+      ci.openshift.io/multi-stage-test: test
+      ci.openshift.io/refs.branch: base ref
+      ci.openshift.io/refs.org: org
+      ci.openshift.io/refs.repo: repo
+      created-by-ci: "true"
+      job: job
+    name: test-step0
+  spec:
+    containers:
+    - command:
+      - /bin/bash
+      - -c
+      - |-
+        #!/bin/bash
+        set -eu
+        if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi
+        if ! [[ -d ${HOME:-} ]]; then export HOME=/alabama; fi
+        command0
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /alabama
+        name: home
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    restartPolicy: Never
+    serviceAccountName: test
+    volumes:
+    - emptyDir: {}
+      name: home
+    - name: test
+      secret:
+        secretName: test
+  status: {}


### PR DESCRIPTION
Add a configuration option in multi-stage steps to not add the
`secret-wrapper` to the test process.  Results in noticeably faster
tests when a read-only version of the directory is sufficient.