### PR TITLE
[ci-secret-bootstrap] add the ability to validate the usage of the bitwarden items

### DIFF
--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -1,6 +1,8 @@
 package bitwarden
 
-import "os"
+import (
+	"os"
+)
 
 // Field represents a field in BitWarden
 type Field struct {
@@ -35,6 +37,7 @@ type Item struct {
 // Client is used to communicate with BitWarden
 type Client interface {
 	GetFieldOnItem(itemName, fieldName string) ([]byte, error)
+	GetAllItems() []Item
 	GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error)
 	GetPassword(itemName string) ([]byte, error)
 	Logout() ([]byte, error)

--- a/pkg/bitwarden/cli.go
+++ b/pkg/bitwarden/cli.go
@@ -142,6 +142,10 @@ func (c *cliClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
 	return nil, fmt.Errorf("failed to find field %s in item %s", fieldName, itemName)
 }
 
+func (c *cliClient) GetAllItems() []Item {
+	return c.savedItems
+}
+
 func (c *cliClient) GetAttachmentOnItem(itemName, attachmentName string) (bytes []byte, retErr error) {
 	file, err := ioutil.TempFile("", "attachmentName")
 	if err != nil {
@@ -442,6 +446,11 @@ type dryRunCliClient struct {
 func (d *dryRunCliClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
 	return nil, nil
 }
+
+func (d *dryRunCliClient) GetAllItems() []Item {
+	return nil
+}
+
 func (d *dryRunCliClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/bitwarden/fake.go
+++ b/pkg/bitwarden/fake.go
@@ -23,6 +23,9 @@ func (c fakeClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
 	return nil, fmt.Errorf("failed to find field %s in item %s", fieldName, itemName)
 }
 
+func (f fakeClient) GetAllItems() []Item {
+	return f.items
+}
 func (c fakeClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
 	for _, item := range c.items {
 		if itemName == item.Name {


### PR DESCRIPTION
This commit includes:

- A way how to compare the bitwarden vs config items
- flag `--validate-bitwarden-items-usage` to enable the validation
- flag `--bw-allow-unused` to allow bitwarden items to existing without being used
- unittests


[DPTP-1547](https://issues.redhat.com/browse/DPTP-1547)
/cc @openshift/openshift-team-developer-productivity-test-platform 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>