### PR TITLE
[prowgen] replace ci-pull-credentials to ci-pull-credentials-pack secret

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -256,7 +256,7 @@ func generatePodSpecMultiStage(info *ProwgenInfo, test *cioperatorapi.TestStepCo
 		// and that is OK. We just need it to exist in the test namespace so
 		// that the image import controller can use it.
 		secrets = append(secrets, &cioperatorapi.Secret{
-			Name: "ci-pull-credentials",
+			Name: "ci-pull-credentials-pack",
 		})
 	}
 	podSpec := generateCiOperatorPodSpec(info, secrets, []string{test.As})

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage.yaml
@@ -4,7 +4,7 @@ containers:
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
   - --target=test
-  - --secret-dir=/secrets/ci-pull-credentials
+  - --secret-dir=/secrets/ci-pull-credentials-pack
   - --secret-dir=/usr/local/test-cluster-profile
   - --lease-server-password-file=/etc/boskos/password
   command:
@@ -22,8 +22,8 @@ containers:
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/ci-pull-credentials
-    name: ci-pull-credentials
+  - mountPath: /secrets/ci-pull-credentials-pack
+    name: ci-pull-credentials-pack
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
@@ -38,9 +38,9 @@ volumes:
 - name: result-aggregator
   secret:
     secretName: result-aggregator
-- name: ci-pull-credentials
+- name: ci-pull-credentials-pack
   secret:
-    secretName: ci-pull-credentials
+    secretName: ci-pull-credentials-pack
 - name: cluster-profile
   projected:
     sources:

--- a/test/e2e/lease.sh
+++ b/test/e2e/lease.sh
@@ -2,7 +2,7 @@
 source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
 
 if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
-  os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-credentials -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
+  os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-credentials-pack -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
 fi
 if [[ -z "${IMPORT_SECRET_DIR:-}" ]]; then
   os::log::fatal "\$IMPORT_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-secret -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "

--- a/test/e2e/simple.sh
+++ b/test/e2e/simple.sh
@@ -5,7 +5,7 @@ if [[ -z "${PULL_SECRET_DIR:-}" ]]; then
   os::log::fatal "\$PULL_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret registry-pull-credentials -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
 fi
 if [[ -z "${IMPORT_SECRET_DIR:-}" ]]; then
-  os::log::fatal "\$IMPORT_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-credentials -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
+  os::log::fatal "\$IMPORT_SECRET_DIR must point to a valid registry pull secret dir. Get the data with: oc --context api.ci --as system:admin --namespace ci get secret ci-pull-credentials-pack -o jsonpath={.data.\.dockerconfigjson} | base64 --decode "
 fi
 PARENT_JOBSPEC="${JOB_SPEC}"
 if [[ -z "${PARENT_JOBSPEC:-}" ]]; then

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -236,7 +236,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
-        - --secret-dir=/secrets/ci-pull-credentials
+        - --secret-dir=/secrets/ci-pull-credentials-pack
         - --target=steps
         command:
         - ci-operator
@@ -247,8 +247,8 @@ presubmits:
           requests:
             cpu: 10m
         volumeMounts:
-        - mountPath: /secrets/ci-pull-credentials
-          name: ci-pull-credentials
+        - mountPath: /secrets/ci-pull-credentials-pack
+          name: ci-pull-credentials-pack
           readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
@@ -258,9 +258,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: ci-pull-credentials
+      - name: ci-pull-credentials-pack
         secret:
-          secretName: ci-pull-credentials
+          secretName: ci-pull-credentials-pack
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials


### PR DESCRIPTION
/hold

`ci-pull-credentials` will be deprecated and it will be replaced with `ci-pull-credentials-pack`

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>