### PR TITLE
Private prow configs mirror: Ignore non-openshift orgs

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -119,7 +119,13 @@ func getOrgReposWithOfficialImages(releaseRepoPath string, whitelist map[string]
 	}
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
+
 		if !promotion.BuildsOfficialImages(c) {
+			return nil
+		}
+
+		if i.Org != "openshift" {
+			logrus.WithField("org", i.Org).WithField("repo", i.Repo).Warn("Dropping repo in non-openshift org, this is currently not supported")
 			return nil
 		}
 


### PR DESCRIPTION
We identify repo by name which means if a different org has the same
repo as its in the openshift org, we will flap based on map ordering.

This tool was never intended to handle non-openshift orgs anyways.