### PR TITLE
OpenshiftInstallerCustomTest template: Remove unused nested virt properties

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -995,9 +995,7 @@ type OpenshiftInstallerCustomTestImageClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
 	// From defines the imagestreamtag that will be used to run the
 	// provided test command.  e.g. stable:console-test
-	From             string `json:"from"`
-	EnableNestedVirt bool   `json:"enable_nested_virt,omitempty"`
-	NestedVirtImage  string `json:"nested_virt_image,omitempty"`
+	From string `json:"from"`
 }
 
 // OpenshiftInstallerGCPNestedVirtCustomTestImageClusterTestConfiguration describes a

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -384,18 +383,6 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 				Value: conf.PreviousRPMDeps},
 			corev1.EnvVar{Name: "PREVIOUS_RPM_REPO",
 				Value: fmt.Sprintf("%s/openshift-origin-v%s/", cioperatorapi.URLForService(cioperatorapi.ServiceRPMs), conf.PreviousVersion)})
-	}
-	if conf := test.OpenshiftInstallerCustomTestImageClusterTestConfiguration; conf != nil {
-		if conf.EnableNestedVirt {
-			container.Env = append(
-				container.Env,
-				corev1.EnvVar{Name: "CLUSTER_ENABLE_NESTED_VIRT", Value: strconv.FormatBool(conf.EnableNestedVirt)})
-			if conf.NestedVirtImage != "" {
-				container.Env = append(
-					container.Env,
-					corev1.EnvVar{Name: "CLUSTER_NESTED_VIRT_IMAGE", Value: conf.NestedVirtImage})
-			}
-		}
 	}
 	return podSpec
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -112,8 +112,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
-					EnableNestedVirt:         true,
-					NestedVirtImage:          "nested-virt-image-name",
 				},
 			},
 		},
@@ -126,7 +124,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
-					EnableNestedVirt:         true,
 				},
 			},
 		},
@@ -139,8 +136,6 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
-					NestedVirtImage:          "",
-					EnableNestedVirt:         false,
 				},
 			},
 		},

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
@@ -18,10 +18,6 @@ containers:
     value: commands
   - name: TEST_IMAGESTREAM_TAG
     value: pipeline:kubevirt-test
-  - name: CLUSTER_ENABLE_NESTED_VIRT
-    value: "true"
-  - name: CLUSTER_NESTED_VIRT_IMAGE
-    value: nested-virt-image-name
   image: ci-operator:latest
   imagePullPolicy: Always
   name: ""

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
@@ -18,8 +18,6 @@ containers:
     value: commands
   - name: TEST_IMAGESTREAM_TAG
     value: pipeline:kubevirt-test
-  - name: CLUSTER_ENABLE_NESTED_VIRT
-    value: "true"
   image: ci-operator:latest
   imagePullPolicy: Always
   name: ""


### PR DESCRIPTION
```
[2020-10-23-15:00]:[build01@ci-op-fwfg97yy][master]~/.../openshift/release
$ rg 'enable_nested_virt|nested_virt_image'
```

Yields no result