### PR TITLE
Private config mirror: Remove stale plugin configs

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -184,7 +184,7 @@ func injectPrivateTideOrgContextPolicy(contextOptions prowconfig.TideContextPoli
 	}
 }
 
-func injectPrivateReposTideQueries(tideQueries []prowconfig.TideQuery, orgRepos orgReposWithOfficialImages) {
+func setPrivateReposTideQueries(tideQueries []prowconfig.TideQuery, orgRepos orgReposWithOfficialImages) {
 	logrus.Info("Processing...")
 
 	for index, tideQuery := range tideQueries {
@@ -196,6 +196,8 @@ func injectPrivateReposTideQueries(tideQueries []prowconfig.TideQuery, orgRepos 
 
 				logrus.WithField("repo", repo).Info("Found")
 				repos.Insert(privateOrgRepo(repo))
+			} else if strings.HasPrefix(orgRepo, openshiftPrivOrg) {
+				repos.Delete(orgRepo)
 			}
 		}
 
@@ -422,7 +424,7 @@ func main() {
 	injectPrivateBranchProtection(prowConfig.BranchProtection, orgRepos)
 	injectPrivateTideOrgContextPolicy(prowConfig.Tide.ContextOptions, orgRepos)
 	injectPrivateMergeType(prowConfig.Tide.MergeType, orgRepos)
-	injectPrivateReposTideQueries(prowConfig.Tide.Queries, orgRepos)
+	setPrivateReposTideQueries(prowConfig.Tide.Queries, orgRepos)
 	injectPrivatePRStatusBaseURLs(prowConfig.Tide.PRStatusBaseURLs, orgRepos)
 	injectPrivatePlankDefaultDecorationConfigs(prowConfig.Plank.DefaultDecorationConfigs, orgRepos)
 	injectPrivateJobURLPrefixConfig(prowConfig.Plank.JobURLPrefixConfig, orgRepos)

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -209,7 +209,7 @@ func TestInjectPrivateReposTideQueries(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.id, func(t *testing.T) {
-			injectPrivateReposTideQueries(tc.tideQueries, orgRepos)
+			setPrivateReposTideQueries(tc.tideQueries, orgRepos)
 			if !reflect.DeepEqual(tc.tideQueries, tc.expected) {
 				t.Fatal(cmp.Diff(tc.tideQueries, tc.expected))
 			}


### PR DESCRIPTION
The fact that we don't do this today currently results in invalid config, because there are duplicate plugins in now-unmanaged openshift/priv repos that are also set at the org level, see for example here: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/13103/pull-ci-openshift-release-master-config/1319700661008338944

Result of this PR is here: https://github.com/openshift/release/pull/13107