### PR TITLE
[ci-secret-bootstrap] stop forcing the secret type on dockerconfigJSON configuration

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -200,13 +200,6 @@ func (o *options) validateCompletedOptions() error {
 					if data.AuthBitwardenAttachment == "" {
 						return fmt.Errorf("config[%d].from[%s]: auth_bw_attachment is missing", i, key)
 					}
-					for j, to := range o.config.Secrets[i].To {
-						if to.Type == "" {
-							o.config.Secrets[i].To[j].Type = "kubernetes.io/dockerconfigjson"
-						} else if to.Type != "kubernetes.io/dockerconfigjson" {
-							return fmt.Errorf("config[%d].to[%d]: key: '%s' is a dockerconfigJSON config and it should be a 'kubernetes.io/dockerconfigjson' type secret", i, j, key)
-						}
-					}
 				}
 			} else if bwContext.BWItem != "" {
 				switch bwContext.Attribute {

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1043,45 +1043,6 @@ func TestValidateCompletedOptions(t *testing.T) {
 			},
 			expected: fmt.Errorf("config[0].from[key-name-1]: either registry_url_bw_field or registry_url must be set"),
 		},
-		{
-			name: "dockerconfigJSON configuration with wrong secret type in the destination secret",
-			given: options{
-				logLevel:   "info",
-				bwPassword: "topSecret",
-				config: secretbootstrap.Config{
-					Secrets: []secretbootstrap.SecretConfig{
-						{
-							From: map[string]secretbootstrap.BitWardenContext{
-								"key-name-1": {
-									DockerConfigJSONData: []secretbootstrap.DockerConfigJSONData{
-										{
-											BWItem:                    "bitwarden-item",
-											RegistryURLBitwardenField: "registryURL",
-											AuthBitwardenAttachment:   "auth",
-										},
-										{
-											BWItem:                    "bitwarden-item2",
-											RegistryURLBitwardenField: "registryURL",
-											AuthBitwardenAttachment:   "auth",
-											EmailBitwardenField:       "email",
-										},
-									},
-								},
-							},
-							To: []secretbootstrap.SecretContext{
-								{
-									Cluster:   "default",
-									Name:      "docker-config-json-secret",
-									Namespace: "namespace-1",
-									Type:      "wrong-type",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: fmt.Errorf("config[0].to[0]: key: 'key-name-1' is a dockerconfigJSON config and it should be a 'kubernetes.io/dockerconfigjson' type secret"),
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 

Currently we are defaulting the secret type to be `kubernetes.io/dockerconfigjson` when there is a `dockerconfigJSON` configuration included. This doesn't make any sense because there are secrets that are using this as simple key in their secrets with `opaque` secret type. 
Therefore, we don't want to default it or validate it.

Fixes: https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/log?job=periodic-ci-secret-bootstrap&id=1320692848172994560

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>