### PR TITLE
slack-bot: add context to job links

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ replace (
 )
 
 require (
+	cloud.google.com/go/storage v1.10.0
 	github.com/GoogleCloudPlatform/testgrid v0.0.13
 	github.com/alecthomas/chroma v0.7.1
 	github.com/andygrunwald/go-jira v1.12.0
@@ -52,6 +53,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	google.golang.org/api v0.29.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	k8s.io/api v0.18.7-rc.0
 	k8s.io/apimachinery v0.18.7-rc.0

--- a/hack/local-slack-bot.sh
+++ b/hack/local-slack-bot.sh
@@ -16,6 +16,10 @@ function cleanup() {
 }
 trap "cleanup" EXIT
 
+if [[ -z "${RELEASE_REPO_DIR:-}" ]]; then
+  os::log::fatal "\$RELEASE_REPO_DIR is required"
+fi
+
 data="${BASETMPDIR}/data"
 mkdir -p "${data}"
 
@@ -53,4 +57,4 @@ os::log::info "Sending production traffic from Slack to the reverse proxy..."
 ssh -N -T root@127.0.0.1 -p 2222 -R "8888:127.0.0.1:8888" &
 
 os::log::info "Running the slack-bot server..."
-http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 --slack-token-path "${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" --jira-username=dptp-bot --jira-password-file="${data}/password" --jira-endpoint https://issues.redhat.com --log-level=trace
+http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 --slack-token-path "${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" --jira-username=dptp-bot --jira-password-file="${data}/password" --jira-endpoint https://issues.redhat.com --log-level=trace --prow-config-path="${RELEASE_REPO_DIR}/core-services/prow/02_config/_config.yaml" --prow-job-config-path="${RELEASE_REPO_DIR}/ci-operator/jobs"

--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -20,6 +20,7 @@ const (
 	ServiceRPMs     Service = "rpms"
 	ServiceProw     Service = "prow"
 	ServiceConfig   Service = "config"
+	ServiceGCSWeb   Service = "gcsweb-ci"
 )
 
 // URLForService returns the URL for the service including scheme
@@ -31,7 +32,7 @@ func URLForService(service Service) string {
 func DomainForService(service Service) string {
 	var serviceDomain string
 	switch service {
-	case ServiceBoskos:
+	case ServiceBoskos, ServiceGCSWeb:
 		serviceDomain = ServiceDomainAPPCI
 	case ServiceRPMs, ServiceRegistry:
 		serviceDomain = ServiceDomainAPICI

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -100,9 +100,8 @@ func CompletePrimaryRefs(refs pjapi.Refs, jb prowconfig.JobBase) *pjapi.Refs {
 	return &refs
 }
 
-func getTrimmedBranch(branches []string) string {
+func BranchFromRegexes(branches []string) string {
 	return strings.TrimPrefix(strings.TrimSuffix(branches[0], "$"), "^")
-
 }
 
 func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber int, refs *pjapi.Refs) (*prowconfig.Presubmit, error) {
@@ -117,7 +116,7 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	var context string
 
 	if len(source.Branches) > 0 {
-		branch = getTrimmedBranch(source.Branches)
+		branch = BranchFromRegexes(source.Branches)
 		if len(repo) > 0 {
 			orgRepo := strings.Split(repo, "/")
 			jobOrg := orgRepo[0]
@@ -351,7 +350,7 @@ func NewJobConfigurer(ciopConfigs config.DataByFilename, resolver registry.Resol
 	}
 }
 
-func variantFromLabels(labels map[string]string) string {
+func VariantFromLabels(labels map[string]string) string {
 	variant := ""
 	if variantLabel, ok := labels[jobconfig.ProwJobLabelVariant]; ok {
 		variant = variantLabel
@@ -368,7 +367,7 @@ func (jc *JobConfigurer) ConfigurePeriodicRehearsals(periodics config.Periodics)
 	for _, job := range filteredPeriodics {
 		jobLogger := jc.loggers.Job.WithField("target-job", job.Name)
 		metadata := api.Metadata{
-			Variant: variantFromLabels(job.Labels),
+			Variant: VariantFromLabels(job.Labels),
 		}
 		if len(job.ExtraRefs) != 0 {
 			metadata.Org = job.ExtraRefs[0].Org
@@ -411,8 +410,8 @@ func (jc *JobConfigurer) ConfigurePresubmitRehearsals(presubmits config.Presubmi
 			metadata := api.Metadata{
 				Org:     splitOrgRepo[0],
 				Repo:    splitOrgRepo[1],
-				Branch:  getTrimmedBranch(job.Branches),
-				Variant: variantFromLabels(job.Labels),
+				Branch:  BranchFromRegexes(job.Branches),
+				Variant: VariantFromLabels(job.Labels),
 			}
 			testname := metadata.TestNameFromJobName(job.Name, jobconfig.PresubmitPrefix)
 

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1112,7 +1112,7 @@ func TestGetTrimmedBranch(t *testing.T) {
 		expected: "release-4.2",
 	}}
 	for _, testCase := range testCases {
-		branch := getTrimmedBranch(testCase.input)
+		branch := BranchFromRegexes(testCase.input)
 		if branch != testCase.expected {
 			t.Errorf("%s: getTrimmedBranches returned %s, expected %s", testCase.name, branch, testCase.expected)
 		}
@@ -1143,9 +1143,9 @@ func TestVariantFromLabels(t *testing.T) {
 		expected: "v2",
 	}}
 	for _, testCase := range testCases {
-		variant := variantFromLabels(testCase.input)
+		variant := VariantFromLabels(testCase.input)
 		if variant != testCase.expected {
-			t.Errorf("%s: variantFromLabels returned %s, expected %s", testCase.name, variant, testCase.expected)
+			t.Errorf("%s: VariantFromLabels returned %s, expected %s", testCase.name, variant, testCase.expected)
 		}
 	}
 }

--- a/pkg/slack/events/joblink/link.go
+++ b/pkg/slack/events/joblink/link.go
@@ -1,0 +1,387 @@
+package joblink
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	gcsutil "k8s.io/test-infra/prow/pod-utils/gcs"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/rehearse"
+	"github.com/openshift/ci-tools/pkg/slack/events"
+)
+
+// job abstracts the types of Prow jobs. Only one field can be non-nil
+type job struct {
+	metadata   api.Metadata
+	presubmit  *config.Presubmit
+	postsubmit *config.Postsubmit
+	periodic   *config.Periodic
+}
+
+// JobGetter knows how to retrieve job details for a job by name
+type JobGetter interface {
+	JobForName(name string) *job
+}
+
+// NewJobGetter exposes a simplified interface from the Prow configuration
+func NewJobGetter(config config.Getter) JobGetter {
+	return &getter{
+		config: config,
+	}
+}
+
+type getter struct {
+	config config.Getter
+}
+
+func metadataFromConfig(orgRepo string, job config.JobBase, brancher config.Brancher) api.Metadata {
+	parts := strings.Split(orgRepo, "/")
+	if len(parts) != 2 {
+		return api.Metadata{}
+	}
+	return api.Metadata{
+		Org:     parts[0],
+		Repo:    parts[1],
+		Branch:  rehearse.BranchFromRegexes(brancher.Branches),
+		Variant: rehearse.VariantFromLabels(job.Labels),
+	}
+}
+
+func (g *getter) JobForName(name string) *job {
+	var found job
+
+	for orgRepo, presubmits := range g.config().PresubmitsStatic {
+		parts := strings.Split(orgRepo, "/")
+		if len(parts) != 2 {
+			continue
+		}
+		for _, presubmit := range presubmits {
+			if presubmit.Name == name {
+				found.presubmit = &presubmit
+				found.metadata = metadataFromConfig(orgRepo, presubmit.JobBase, presubmit.Brancher)
+				return &found
+			}
+		}
+	}
+
+	for orgRepo, postsubmits := range g.config().PostsubmitsStatic {
+		parts := strings.Split(orgRepo, "/")
+		if len(parts) != 2 {
+			continue
+		}
+		for _, postsubmit := range postsubmits {
+			if postsubmit.Name == name {
+				found.postsubmit = &postsubmit
+				found.metadata = metadataFromConfig(orgRepo, postsubmit.JobBase, postsubmit.Brancher)
+				return &found
+			}
+		}
+	}
+
+	for _, periodic := range g.config().Periodics {
+		if periodic.Name == name {
+			found.periodic = &periodic
+			if len(periodic.ExtraRefs) > 0 {
+				found.metadata = api.Metadata{
+					Org:     periodic.ExtraRefs[0].Org,
+					Repo:    periodic.ExtraRefs[0].Repo,
+					Branch:  periodic.ExtraRefs[0].BaseRef,
+					Variant: rehearse.VariantFromLabels(periodic.Labels),
+				}
+			}
+			return &found
+		}
+	}
+
+	return &found
+}
+
+type messagePoster interface {
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+}
+
+// Handler returns a handler that knows how to respond to
+// messages that mention job details by adding context to
+// them and providing commonly-needed information.
+func Handler(client messagePoster, config JobGetter, gcsClient *storage.Client) events.PartialHandler {
+	return events.PartialHandlerFunc("joblink", func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
+		if callback.Type != slackevents.CallbackEvent {
+			return false, nil
+		}
+		event, ok := callback.InnerEvent.Data.(*slackevents.MessageEvent)
+		if !ok {
+			return false, nil
+		}
+		infos, err := extractInfo(callback)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to parse event data")
+			return false, err
+		}
+		if len(infos) == 0 {
+			return false, nil
+		}
+		logger.Info("Handling new message with job links...")
+		timestamp := event.TimeStamp
+		if event.ThreadTimeStamp != "" {
+			timestamp = event.ThreadTimeStamp
+		}
+		responseChannel, responseTimestamp, err := client.PostMessage(event.Channel, slack.MsgOptionBlocks(contextFor(logger, infos, config, gcsClient)...), slack.MsgOptionTS(timestamp))
+		if err != nil {
+			logger.WithError(err).Warn("Failed to post response to comment")
+		} else {
+			logger.Infof("Posted response to comment in channel %s at %s", responseChannel, responseTimestamp)
+		}
+		return true, err
+	})
+}
+
+func contextFor(logger *logrus.Entry, infos []*jobInfo, config JobGetter, gcsClient *storage.Client) []slack.Block {
+	blocks := []slack.Block{&slack.SectionBlock{
+		Type: slack.MBTSection,
+		Text: &slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: "It looks like you mentioned a job result in your message. Here is some helpful information:",
+		},
+	}}
+
+	for _, info := range infos {
+		logger = logger.WithFields(logrus.Fields{
+			"job": info.Name,
+			"id":  info.Id,
+		})
+		job := config.JobForName(info.Name)
+		if job == nil {
+			continue
+		}
+		var spec prowapi.ProwJobSpec
+		var options *prowapi.GCSConfiguration
+		var generated bool
+		var prefix string
+		// we do not want to do a bunch of parsing of URLs to get
+		// at the refs that were used to trigger the job, and we
+		// can just look up the alias path in GCS anyway so we don't
+		// need to do any work to get the right artifact path anyway
+		if job.presubmit != nil {
+			spec = pjutil.PresubmitSpec(*job.presubmit, prowapi.Refs{})
+			options = job.presubmit.DecorationConfig.GCSConfiguration
+			_, generated = job.presubmit.Labels[jobconfig.ProwJobLabelGenerated]
+			job.metadata.Variant = rehearse.VariantFromLabels(job.presubmit.Labels)
+			prefix = jobconfig.PresubmitPrefix
+		} else if job.postsubmit != nil {
+			spec = pjutil.PostsubmitSpec(*job.postsubmit, prowapi.Refs{})
+			options = job.postsubmit.DecorationConfig.GCSConfiguration
+			_, generated = job.postsubmit.Labels[jobconfig.ProwJobLabelGenerated]
+			job.metadata.Variant = rehearse.VariantFromLabels(job.postsubmit.Labels)
+			prefix = jobconfig.PostsubmitPrefix
+		} else if job.periodic != nil {
+			spec = pjutil.PeriodicSpec(*job.periodic)
+			options = job.periodic.DecorationConfig.GCSConfiguration
+			_, generated = job.periodic.Labels[jobconfig.ProwJobLabelGenerated]
+			job.metadata.Variant = rehearse.VariantFromLabels(job.periodic.Labels)
+			prefix = jobconfig.PeriodicPrefix
+		} else {
+			// should not happen with non-nil job
+			logger.Warn("No job was found but a non-nil job was returned.")
+			continue
+		}
+		text := bytes.Buffer{}
+		text.WriteString("*" + job.metadata.TestNameFromJobName(info.Name, prefix) + ":*")
+		if generated {
+			text.WriteString("\n - `ci-operator` <https://github.com/openshift/release/tree/master/ci-operator/config/" + job.metadata.RelativePath() + "|config>.")
+		} else {
+			text.WriteString("\n - This job is not generated from `ci-operator` configuration; DPTP may not be able to support questions for it.")
+		}
+
+		if info.Id != "" {
+			var path string
+			dspec := downwardapi.NewJobSpec(spec, info.Id, "")
+			if alias := gcsutil.AliasForSpec(&dspec); alias != "" {
+				logger = logger.WithField("path", alias)
+				logger.Debug("Resolving path from alias.")
+				prefix := fmt.Sprintf("gs://%s", options.Bucket)
+				// dereference alias to get the path
+				var p gcs.Path
+				if err := p.Set(fmt.Sprintf("%s/%s", prefix, alias)); err != nil {
+					logger.WithError(err).Warn("Could not set path for alias read.")
+					continue
+				}
+				if p.Object() == "" {
+					logger.Warn("Alias read found empty object name.")
+					continue
+				}
+				reader, err := gcsClient.Bucket(p.Bucket()).Object(p.Object()).NewReader(context.Background())
+				if err != nil {
+					logger.WithError(err).Warn("Could not open alias for read.")
+					continue
+				}
+				symlink, err := ioutil.ReadAll(reader)
+				if err != nil {
+					logger.WithError(err).Warn("Could not read alias.")
+					continue
+				}
+				path = strings.TrimPrefix(string(symlink), prefix)
+			} else {
+				_, path, _ = gcsupload.PathsForJob(options, &dspec, "")
+			}
+			logger.WithField("path", path).Debug("Resolved full GCS path.")
+			text.WriteString("\n - Job result <https://prow.ci.openshift.org/view/gs/" + options.Bucket + "/" + path + "|link>.")
+		}
+
+		blocks = append(blocks, &slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: text.String(),
+			},
+		})
+	}
+	return blocks
+}
+
+type jobInfo struct {
+	// our jobs have globally unique names so we can
+	// get away with identifying them with this minimal
+	// set of information
+	Name, Id string
+	Line     int
+}
+
+// extractInfo extracts information about any jobs that were
+// linked in a comment body on Slack
+func extractInfo(event *slackevents.EventsAPIEvent) ([]*jobInfo, error) {
+	raw, ok := event.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok {
+		return nil, errors.New("could not get raw event content")
+	}
+	type blocks struct {
+		Blocks []struct {
+			Elements []struct {
+				Elements []struct {
+					Url string `json:"url"`
+				} `json:"elements"`
+			} `json:"elements"`
+		} `json:"blocks"`
+	}
+	var data blocks
+	if err := json.Unmarshal(*raw.InnerEvent, &data); err != nil {
+		return nil, errors.New("could not get blocks from event data")
+	}
+
+	var infos []*jobInfo
+	for _, block := range data.Blocks {
+		for _, element := range block.Elements {
+			for _, subElement := range element.Elements {
+				if subElement.Url != "" {
+					if url, err := url.Parse(subElement.Url); err == nil {
+						infos = append(infos, infoFromUrl(url))
+					}
+				}
+			}
+		}
+	}
+
+	return infos, nil
+}
+
+func infoFromUrl(url *url.URL) *jobInfo {
+	var info jobInfo
+	switch url.Host {
+	case api.DomainForService(api.ServiceProw):
+		switch strings.Split(url.Path, "/")[1] {
+		case "job-history":
+			return infoForJobHistory(url)
+		case "log":
+			return infoForJobLog(url)
+		case "view":
+			return infoForJobView(url)
+		}
+	case api.DomainForService(api.ServiceGCSWeb):
+		return infoForArtifact(url)
+	}
+	return &info
+}
+
+// infoForJobHistory handles URLs like:
+// https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.7?buildId=1234123123
+func infoForJobHistory(url *url.URL) *jobInfo {
+	parts := strings.Split(url.Path, "/")
+	if len(parts) < 1 {
+		return nil
+	}
+	return &jobInfo{
+		Name: parts[len(parts)-1],
+		Id:   url.Query().Get("buildId"),
+	}
+}
+
+// infoForJobLog handles URLs like:
+// https://prow.ci.openshift.org/log?job=pull-ci-openshift-installer-release-4.6-e2e-metal-ipi&id=1319125780608847872
+func infoForJobLog(url *url.URL) *jobInfo {
+	return &jobInfo{
+		Name: url.Query().Get("job"),
+		Id:   url.Query().Get("id"),
+	}
+}
+
+// infoForJobView handles URLs like:
+// https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/12371/rehearse-12371-periodic-ci-kubevirt-kubevirt-master-e2e-nested-virt/1318930182802771968
+func infoForJobView(url *url.URL) *jobInfo {
+	parts := strings.Split(url.Path, "/")
+	if len(parts) < 2 {
+		return nil
+	}
+	var line int
+	if fragment := strings.Split(url.Fragment, ":"); len(fragment) == 3 {
+		if l, err := strconv.Atoi(fragment[2]); err == nil {
+			line = l
+		}
+	}
+	return &jobInfo{
+		Name: parts[len(parts)-2],
+		Id:   parts[len(parts)-1],
+		Line: line,
+	}
+}
+
+// infoForArtifact handles URLs like:
+// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt
+func infoForArtifact(url *url.URL) *jobInfo {
+	parts := strings.Split(url.Path, "/")
+	// the last fully numeric path part before user-provided
+	// artifacts will be the job ID
+	index := -1
+	for i, part := range parts {
+		if part == "artifacts" {
+			break
+		}
+		if _, err := strconv.Atoi(part); err == nil {
+			index = i
+		}
+	}
+	if index == -1 {
+		return nil
+	}
+	return &jobInfo{
+		Name: parts[index-1],
+		Id:   parts[index],
+	}
+}

--- a/pkg/slack/events/joblink/link_test.go
+++ b/pkg/slack/events/joblink/link_test.go
@@ -1,0 +1,66 @@
+package joblink
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestExtractInfo(t *testing.T) {
+	var testCases = []struct {
+		link     string
+		expected *jobInfo
+	}{
+		{
+			link:     "https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.7",
+			expected: &jobInfo{Name: "release-openshift-origin-installer-e2e-gcp-upgrade-4.7", Id: ""},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/log?job=pull-ci-openshift-installer-release-4.6-e2e-metal-ipi&id=1319125780608847872",
+			expected: &jobInfo{Name: "pull-ci-openshift-installer-release-4.6-e2e-metal-ipi", Id: "1319125780608847872"},
+		},
+		{
+			link:     "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
+		},
+		{
+			link:     "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/artifacts/123/123123/123/12/312/3/1",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/12371/rehearse-12371-periodic-ci-kubevirt-kubevirt-master-e2e-nested-virt/1318930182802771968",
+			expected: &jobInfo{Name: "rehearse-12371-periodic-ci-kubevirt-kubevirt-master-e2e-nested-virt", Id: "1318930182802771968"},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_tektoncd-pipeline-operator/495/pull-ci-openshift-tektoncd-pipeline-operator-release-next-4.4-csv/1319068241137504256#1:build-log.txt%3A58",
+			expected: &jobInfo{Name: "pull-ci-openshift-tektoncd-pipeline-operator-release-next-4.4-csv", Id: "1319068241137504256", Line: 58},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-openshift-library-import/1319699861964066816",
+			expected: &jobInfo{Name: "periodic-openshift-library-import", Id: "1319699861964066816"},
+		},
+		{
+			link:     "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-openshift-library-import/1319699861964066816/clone-records.json",
+			expected: &jobInfo{Name: "periodic-openshift-library-import", Id: "1319699861964066816"},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/batch/pull-ci-openshift-origin-release-4.5-unit/1319699245074223104",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-release-4.5-unit", Id: "1319699245074223104"},
+		},
+		{
+			link:     "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-k8s-prometheus-adapter-release-4.8-images/1319705916215398400",
+			expected: &jobInfo{Name: "branch-ci-openshift-k8s-prometheus-adapter-release-4.8-images", Id: "1319705916215398400"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		url, err := url.Parse(testCase.link)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(testCase.expected, infoFromUrl(url)); diff != "" {
+			t.Errorf("%s: got incorrect info: %v", testCase.link, diff)
+		}
+	}
+}

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -1,16 +1,20 @@
 package router
 
 import (
+	"cloud.google.com/go/storage"
 	"github.com/slack-go/slack"
+	"k8s.io/test-infra/prow/config"
 
 	"github.com/openshift/ci-tools/pkg/slack/events"
+	"github.com/openshift/ci-tools/pkg/slack/events/joblink"
 	"github.com/openshift/ci-tools/pkg/slack/events/mention"
 )
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client) events.Handler {
+func ForEvents(client *slack.Client, config config.Getter, gcsClient *storage.Client) events.Handler {
 	return events.MultiHandler(
 		mention.Handler(client),
+		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),
 	)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -7,6 +7,7 @@ cloud.google.com/go/internal/optional
 cloud.google.com/go/internal/trace
 cloud.google.com/go/internal/version
 # cloud.google.com/go/storage v1.10.0
+## explicit
 cloud.google.com/go/storage
 # github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
 github.com/Azure/go-ansiterm
@@ -531,6 +532,7 @@ golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.1.0
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/api v0.29.0
+## explicit
 google.golang.org/api/googleapi
 google.golang.org/api/googleapi/transport
 google.golang.org/api/internal


### PR DESCRIPTION
When a user pastes a link to a job or artifact, we often want to see the
full Spyglass link and the ci-operator configuration that gave rise to
the job in the first place. Instead of asking them for this information
we can just calculate it and post a reply.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>