### PR TITLE
Remove unused openshift_installer_random template

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -569,9 +569,6 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 			validationErrors = append(validationErrors, validateLiteralTestStepPost(fieldRootI, s, seen, testConfig.Environment)...)
 		}
 	}
-	if test.OpenshiftInstallerRandomClusterTestConfiguration != nil {
-		typeCount++
-	}
 	if typeCount == 0 {
 		validationErrors = append(validationErrors, fmt.Errorf("%s has no type, you may want to specify 'container' for a container based test", fieldRoot))
 	} else if typeCount == 1 {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -504,7 +504,6 @@ type TestStepConfiguration struct {
 	OpenshiftInstallerUPIClusterTestConfiguration             *OpenshiftInstallerUPIClusterTestConfiguration             `json:"openshift_installer_upi,omitempty"`
 	OpenshiftInstallerUPISrcClusterTestConfiguration          *OpenshiftInstallerUPISrcClusterTestConfiguration          `json:"openshift_installer_upi_src,omitempty"`
 	OpenshiftInstallerConsoleClusterTestConfiguration         *OpenshiftInstallerConsoleClusterTestConfiguration         `json:"openshift_installer_console,omitempty"`
-	OpenshiftInstallerRandomClusterTestConfiguration          *OpenshiftInstallerRandomClusterTestConfiguration          `json:"openshift_installer_random,omitempty"`
 	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
 }
 


### PR DESCRIPTION
The only reference in o/release is this:
```
$ rg openshift_installer_random
core-services/iaas-e2e-config/README.md
3:This ConfigMap is used by the IaaS-agnostic tests (`openshift_installer_random`
```