### PR TITLE
prowgen: keep image-mirror-push-secret if existing

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -434,6 +434,25 @@ func mergePostsubmits(old, new *prowconfig.Postsubmit) prowconfig.Postsubmit {
 
 	if _, ok := merged.Labels[cioperatorapi.PromotionJobLabelKey]; !ok {
 		merged.MaxConcurrency = old.MaxConcurrency
+	} else {
+		var oldHas, mergedHas bool
+		if old.Spec != nil && len(old.Spec.Containers) > 0 {
+			for _, arg := range old.Spec.Containers[0].Args {
+				if arg == "--image-mirror-push-secret=/etc/push-secret/.dockerconfigjson" {
+					oldHas = true
+				}
+			}
+		}
+		if merged.Spec != nil && len(merged.Spec.Containers) > 0 {
+			for _, arg := range merged.Spec.Containers[0].Args {
+				if arg == "--image-mirror-push-secret=/etc/push-secret/.dockerconfigjson" {
+					mergedHas = true
+				}
+			}
+			if oldHas && !mergedHas {
+				merged.Spec.Containers[0].Args = append(merged.Spec.Containers[0].Args, "--image-mirror-push-secret=/etc/push-secret/.dockerconfigjson")
+			}
+		}
 	}
 	if old.Cluster != "" {
 		merged.Cluster = old.Cluster


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1603894425209800?thread_ts=1603817965.189700&cid=GB7NB0CUC

Have tested with https://github.com/openshift/release/pull/13204

/hold

Need to see if this one does NOT introduce any breaking changes.

/cc @alvaroaleman @stevekuznetsov 