### PR TITLE
Step registry ui: Add handler for ci-operator config reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ verify:
 #   make lint
 lint:
 	./hack/lint.sh
-	make validate-ci-operator-reference
 .PHONY: lint
 
 # Run unit tests.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 #   build: Build code.
 #   test: Run all tests.
 #   clean: Clean up.
+#
+SHELL = /bin/bash
 
 OUT_DIR = _output
 OS_OUTPUT_GOPATH ?= 1
@@ -52,6 +54,7 @@ verify:
 #   make lint
 lint:
 	./hack/lint.sh
+	make validate-ci-operator-reference
 .PHONY: lint
 
 # Run unit tests.
@@ -186,6 +189,7 @@ check-breaking-changes:
 .PHONY: generate
 generate:
 	hack/update-codegen.sh
+	hack/generate-ci-op-reference.sh
 
 .PHONY: verify-gen
 verify-gen: generate

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -28,9 +28,9 @@ func main() {
 	// We have to go through this hassle because its not possible to escape backticks in a backtick literal string
 	reference = strings.ReplaceAll(reference, `"`, `\"`)
 	referenceLines := strings.Split(reference, "\n")
-	reference = "package webreg\n\nconst ciOperatorReferenceYaml = \"" + strings.Join(referenceLines, "\" + \n	\"") + `"`
+	reference = "package webreg\n\nconst ciOperatorReferenceYaml = \"" + strings.Join(referenceLines, "\\n\" +\n\"") + `"`
 
 	if err := ioutil.WriteFile("./pkg/webreg/zz_generated.ci_operator_reference.go", []byte(reference), 0644); err != nil {
-		logrus.WithError(err).Fatal("Failed to write generated file: %v", err)
+		logrus.WithError(err).Fatalf("Failed to write generated file: %v", err)
 	}
 }

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/pkg/genyaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func main() {
+	files, err := filepath.Glob("./pkg/api/*.go")
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to resolve filepath")
+	}
+	commentMap, err := genyaml.NewCommentMap(files...)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to construct commentMap")
+	}
+	reference, err := commentMap.GenYaml(genyaml.PopulateStruct(&api.ReleaseBuildConfiguration{}))
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to generate reference yaml")
+	}
+
+	// We have to go through this hassle because its not possible to escape backticks in a backtick literal string
+	reference = strings.ReplaceAll(reference, `"`, `\"`)
+	referenceLines := strings.Split(reference, "\n")
+	reference = "package webreg\n\nconst ciOperatorReferenceYaml = \"" + strings.Join(referenceLines, "\" + \n	\"") + `"`
+
+	if err := ioutil.WriteFile("./pkg/webreg/zz_generated.ci_operator_reference.go", []byte(reference), 0644); err != nil {
+		logrus.WithError(err).Fatal("Failed to write generated file: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	k8s.io/api v0.18.7-rc.0
 	k8s.io/apimachinery v0.18.7-rc.0
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
-	k8s.io/test-infra v0.0.0-20201026133301-f7d653694b18
+	k8s.io/test-infra v0.0.0-20201029180605-20aad120bf8a
 	k8s.io/utils v0.0.0-20200603063816-c1c6865ac451
 	sigs.k8s.io/boskos v0.0.0-20200617235605-f289ba6555ba
 	sigs.k8s.io/controller-runtime v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -2100,8 +2100,8 @@ k8s.io/test-infra v0.0.0-20200407001919-bc7f71ef65b8/go.mod h1:/WpJWcaDvuykB322W
 k8s.io/test-infra v0.0.0-20200514184223-ba32c8aae783/go.mod h1:bW6thaPZfL2hW7ecjx2WYwlP9KQLM47/xIJyttkVk5s=
 k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20200630233406-1dca6122872e/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
-k8s.io/test-infra v0.0.0-20201026133301-f7d653694b18 h1:XsV54KOjJMKmLrSdUMi5ESWXn/8ksBW9kIhDcaqBgNA=
-k8s.io/test-infra v0.0.0-20201026133301-f7d653694b18/go.mod h1:0cyHeX6hFHM8fNxumHp9kEXVjJmULd6PQJh4HYIxvcQ=
+k8s.io/test-infra v0.0.0-20201029180605-20aad120bf8a h1:xPN9N/Gmmwf8H4dXyZ7f7pgeEf6GVw104jDiYKo+tv8=
+k8s.io/test-infra v0.0.0-20201029180605-20aad120bf8a/go.mod h1:0cyHeX6hFHM8fNxumHp9kEXVjJmULd6PQJh4HYIxvcQ=
 k8s.io/utils v0.0.0-20181019225348-5e321f9a457c/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20190907131718-3d4f5b7dea0b/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/hack/generate-ci-op-reference.sh
+++ b/hack/generate-ci-op-reference.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+
+go run ./cmd/docgen
+gofmt -s -w pkg/webreg/zz_generated.ci_operator_reference.go

--- a/hack/run-step-registry.sh
+++ b/hack/run-step-registry.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+go install ./cmd/ci-operator-configresolver/
+echo "UI is available on http://127.0.0.1:8082"
+ci-operator-configresolver \
+ -config=../release/ci-operator/config \
+ -registry=../release/ci-operator/step-registry \
+ -prow-config=../release/core-services/prow/02_config/_config.yaml

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1,0 +1,1210 @@
+package webreg
+
+const ciOperatorReferenceYaml = "# The list of base images describe" +
+	"# which images are going to be necessary outside" +
+	"# of the pipeline. The key will be the alias that other" +
+	"# steps use to refer to this image." +
+	"base_images:" +
+	"    \"\":" +
+	"        # As is an optional string to use as the intermediate name for this reference." +
+	"        as: ' '" +
+	"        name: ' '" +
+	"        namespace: ' '" +
+	"        tag: ' '" +
+	"# BaseRPMImages is a list of the images and their aliases that will" +
+	"# have RPM repositories injected into them for downstream" +
+	"# image builds that require built project RPMs." +
+	"base_rpm_images:" +
+	"    \"\":" +
+	"        # As is an optional string to use as the intermediate name for this reference." +
+	"        as: ' '" +
+	"        name: ' '" +
+	"        namespace: ' '" +
+	"        tag: ' '" +
+	"# BinaryBuildCommands will create a \"bin\" image based on \"src\" that" +
+	"# contains the output of this command. This allows reuse of binary artifacts" +
+	"# across other steps. If empty, no \"bin\" image will be created." +
+	"binary_build_commands: ' '" +
+	"# BuildRootImage supports two ways to get the image that" +
+	"# the pipeline will caches on. The one way is to take the reference" +
+	"# from an image stream, and the other from a dockerfile." +
+	"build_root:" +
+	"    image_stream_tag:" +
+	"        # As is an optional string to use as the intermediate name for this reference." +
+	"        as: ' '" +
+	"        name: ' '" +
+	"        namespace: ' '" +
+	"        tag: ' '" +
+	"    project_image:" +
+	"        # ContextDir is the directory in the project" +
+	"        # from which this build should be run." +
+	"        context_dir: ' '" +
+	"        # DockerfilePath is the path to a Dockerfile in the" +
+	"        # project to run relative to the context_dir." +
+	"        dockerfile_path: ' '" +
+	"        # Inputs is a map of tag reference name to image input changes" +
+	"        # that will populate the build context for the Dockerfile or" +
+	"        # alter the input image for a multi-stage build." +
+	"        inputs:" +
+	"            \"\":" +
+	"                # As is a list of multi-stage step names or image names that will" +
+	"                # be replaced by the image reference from this step. For instance," +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
+	"                # image with the pipeline input." +
+	"                as:" +
+	"                  - \"\"" +
+	"                # Paths is a list of paths to copy out of this image and into the" +
+	"                # context directory." +
+	"                paths:" +
+	"                  - # DestinationDir is the directory in the destination image to copy" +
+	"                    # to." +
+	"                    destination_dir: ' '" +
+	"                    # SourcePath is a file or directory in the source image to copy from." +
+	"                    source_path: ' '" +
+	"# CanonicalGoRepository is a directory path that represents" +
+	"# the desired location of the contents of this repository in" +
+	"# Go. If specified the location of the repository we are" +
+	"# cloning from is ignored." +
+	"canonical_go_repository: \"\"" +
+	"# Images describes the images that are built" +
+	"# baseImage the project as part of the release" +
+	"# process. The name of each image is its \"to\" value" +
+	"# and can be used to build only a specific image." +
+	"images:" +
+	"  - # ContextDir is the directory in the project" +
+	"    # from which this build should be run." +
+	"    context_dir: ' '" +
+	"    # DockerfilePath is the path to a Dockerfile in the" +
+	"    # project to run relative to the context_dir." +
+	"    dockerfile_path: ' '" +
+	"    from: ' '" +
+	"    # Inputs is a map of tag reference name to image input changes" +
+	"    # that will populate the build context for the Dockerfile or" +
+	"    # alter the input image for a multi-stage build." +
+	"    inputs:" +
+	"        \"\":" +
+	"            # As is a list of multi-stage step names or image names that will" +
+	"            # be replaced by the image reference from this step. For instance," +
+	"            # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
+	"            # either \"nginx:latest\" or \"base\" in this array will replace that" +
+	"            # image with the pipeline input." +
+	"            as:" +
+	"              - \"\"" +
+	"            # Paths is a list of paths to copy out of this image and into the" +
+	"            # context directory." +
+	"            paths:" +
+	"              - # DestinationDir is the directory in the destination image to copy" +
+	"                # to." +
+	"                destination_dir: ' '" +
+	"                # SourcePath is a file or directory in the source image to copy from." +
+	"                source_path: ' '" +
+	"    to: ' '" +
+	"# Operator describes the operator bundle(s) that is built by the project" +
+	"operator:" +
+	"    # Bundles define a dockerfile and build context to build a bundle" +
+	"    bundles:" +
+	"      - context_dir: ' '" +
+	"        dockerfile_path: ' '" +
+	"    # Substitutions describes the pullspecs in the operator manifests that must be subsituted" +
+	"    # with the pull specs of the images in the CI registry" +
+	"    substitutions:" +
+	"      - # PullSpec is the pullspec that needs to be replaced" +
+	"        pullspec: ' '" +
+	"        # With is the string that the PullSpec is being replaced by" +
+	"        with: ' '" +
+	"# PromotionConfiguration determines how images are promoted" +
+	"# by this command. It is ignored unless promotion has specifically" +
+	"# been requested. Promotion is performed after all other steps" +
+	"# have been completed so that tests can be run prior to promotion." +
+	"# If no promotion is defined, it is defaulted from the ReleaseTagConfiguration." +
+	"promotion:" +
+	"    # AdditionalImages is a mapping of images to promote. The" +
+	"    # images will be taken from the pipeline image stream. The" +
+	"    # key is the name to promote as and the value is the source" +
+	"    # name. If you specify a tag that does not exist as the source" +
+	"    # the destination tag will not be created." +
+	"    additional_images:" +
+	"        \"\": \"\"" +
+	"    # ExcludedImages are image names that will not be promoted." +
+	"    # Exclusions are made before additional_images are included." +
+	"    # Use exclusions when you want to build images for testing" +
+	"    # but not promote them afterwards." +
+	"    excluded_images:" +
+	"      - \"\"" +
+	"    # Name is an optional image stream name to use that" +
+	"    # contains all component tags. If specified, tag is" +
+	"    # ignored." +
+	"    name: ' '" +
+	"    # NamePrefix is prepended to the final output image name" +
+	"    # if specified." +
+	"    name_prefix: ' '" +
+	"    # Namespace identifies the namespace to which the built" +
+	"    # artifacts will be published to." +
+	"    namespace: ' '" +
+	"    # Tag is the ImageStreamTag tagged in for each" +
+	"    # build image's ImageStream." +
+	"    tag: ' '" +
+	"# RawSteps are literal Steps that should be" +
+	"# included in the final pipeline." +
+	"raw_steps:" +
+	"  - bundle_source_step:" +
+	"        # Substitutions contains pullspecs that need to be replaced by images" +
+	"        # in the CI cluster for operator bundle images" +
+	"        substitutions:" +
+	"          - # PullSpec is the pullspec that needs to be replaced" +
+	"            pullspec: ' '" +
+	"            # With is the string that the PullSpec is being replaced by" +
+	"            with: ' '" +
+	"    index_generator_step:" +
+	"        # OperatorIndex is a list of the names of the bundle images that the" +
+	"        # index will contain in its database." +
+	"        operator_index:" +
+	"          - \"\"" +
+	"        to: ' '" +
+	"    input_image_tag_step:" +
+	"        base_image:" +
+	"            # As is an optional string to use as the intermediate name for this reference." +
+	"            as: ' '" +
+	"            name: ' '" +
+	"            namespace: ' '" +
+	"            tag: ' '" +
+	"        to: ' '" +
+	"    output_image_tag_step:" +
+	"        from: ' '" +
+	"        # Optional means the output step is not built, published, or" +
+	"        # promoted unless explicitly targeted. Use for builds which" +
+	"        # are invoked only when testing certain parts of the repo." +
+	"        optional: false" +
+	"        to:" +
+	"            # As is an optional string to use as the intermediate name for this reference." +
+	"            as: ' '" +
+	"            name: ' '" +
+	"            namespace: ' '" +
+	"            tag: ' '" +
+	"    pipeline_image_cache_step:" +
+	"        # Commands are the shell commands to run in" +
+	"        # the repository root to create the cached" +
+	"        # content." +
+	"        commands: ' '" +
+	"        from: ' '" +
+	"        to: ' '" +
+	"    project_directory_image_build_inputs:" +
+	"        # ContextDir is the directory in the project" +
+	"        # from which this build should be run." +
+	"        context_dir: ' '" +
+	"        # DockerfilePath is the path to a Dockerfile in the" +
+	"        # project to run relative to the context_dir." +
+	"        dockerfile_path: ' '" +
+	"        # Inputs is a map of tag reference name to image input changes" +
+	"        # that will populate the build context for the Dockerfile or" +
+	"        # alter the input image for a multi-stage build." +
+	"        inputs:" +
+	"            \"\":" +
+	"                # As is a list of multi-stage step names or image names that will" +
+	"                # be replaced by the image reference from this step. For instance," +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
+	"                # image with the pipeline input." +
+	"                as:" +
+	"                  - \"\"" +
+	"                # Paths is a list of paths to copy out of this image and into the" +
+	"                # context directory." +
+	"                paths:" +
+	"                  - # DestinationDir is the directory in the destination image to copy" +
+	"                    # to." +
+	"                    destination_dir: ' '" +
+	"                    # SourcePath is a file or directory in the source image to copy from." +
+	"                    source_path: ' '" +
+	"    project_directory_image_build_step:" +
+	"        # ContextDir is the directory in the project" +
+	"        # from which this build should be run." +
+	"        context_dir: ' '" +
+	"        # DockerfilePath is the path to a Dockerfile in the" +
+	"        # project to run relative to the context_dir." +
+	"        dockerfile_path: ' '" +
+	"        from: ' '" +
+	"        # Inputs is a map of tag reference name to image input changes" +
+	"        # that will populate the build context for the Dockerfile or" +
+	"        # alter the input image for a multi-stage build." +
+	"        inputs:" +
+	"            \"\":" +
+	"                # As is a list of multi-stage step names or image names that will" +
+	"                # be replaced by the image reference from this step. For instance," +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
+	"                # image with the pipeline input." +
+	"                as:" +
+	"                  - \"\"" +
+	"                # Paths is a list of paths to copy out of this image and into the" +
+	"                # context directory." +
+	"                paths:" +
+	"                  - # DestinationDir is the directory in the destination image to copy" +
+	"                    # to." +
+	"                    destination_dir: ' '" +
+	"                    # SourcePath is a file or directory in the source image to copy from." +
+	"                    source_path: ' '" +
+	"        to: ' '" +
+	"    release_images_tag_step:" +
+	"        # Name is the image stream name to use that contains all" +
+	"        # component tags." +
+	"        name: ' '" +
+	"        # NamePrefix is prepended to the final output image name" +
+	"        # if specified." +
+	"        name_prefix: ' '" +
+	"        # Namespace identifies the namespace from which" +
+	"        # all release artifacts not built in the current" +
+	"        # job are tagged from." +
+	"        namespace: ' '" +
+	"    resolved_release_images_step:" +
+	"        candidate:" +
+	"            architecture: ' '" +
+	"            product: ' '" +
+	"            stream: ' '" +
+	"            version: ' '" +
+	"        name: ' '" +
+	"        prerelease:" +
+	"            architecture: ' '" +
+	"            product: ' '" +
+	"            version_bounds:" +
+	"                lower: ' '" +
+	"                upper: ' '" +
+	"        release:" +
+	"            architecture: ' '" +
+	"            channel: ' '" +
+	"            version: ' '" +
+	"    rpm_image_injection_step:" +
+	"        from: ' '" +
+	"        to: ' '" +
+	"    rpm_serve_step:" +
+	"        from: ' '" +
+	"    source_step:" +
+	"        # ClonerefsImage is the image where we get the clonerefs tool" +
+	"        clonerefs_image:" +
+	"            # As is an optional string to use as the intermediate name for this reference." +
+	"            as: ' '" +
+	"            name: ' '" +
+	"            namespace: ' '" +
+	"            tag: ' '" +
+	"        # ClonerefsPath is the path in the above image where the" +
+	"        # clonerefs tool is placed" +
+	"        clonerefs_path: ' '" +
+	"        from: ' '" +
+	"        to: ' '" +
+	"    test_step:" +
+	"        # ArtifactDir is an optional directory that contains the" +
+	"        # artifacts to upload. If unset, this will default to" +
+	"        # \"/tmp/artifacts\"." +
+	"        artifact_dir: ' '" +
+	"        # As is the name of the test." +
+	"        as: ' '" +
+	"        # Commands are the shell commands to run in" +
+	"        # the repository root to execute tests." +
+	"        commands: ' '" +
+	"        # Only one of the following can be not-null." +
+	"        container:" +
+	"            # From is the image stream tag in the pipeline to run this" +
+	"            # command in." +
+	"            from: ' '" +
+	"            # MemoryBackedVolume mounts a volume of the specified size into" +
+	"            # the container at /tmp/volume." +
+	"            memory_backed_volume:" +
+	"                # Size is the requested size of the volume as a Kubernetes" +
+	"                # quantity, i.e. \"1Gi\" or \"500M\"" +
+	"                size: ' '" +
+	"        # Cron is how often the test is expected to run outside" +
+	"        # of pull request workflows. Setting this field will" +
+	"        # create a periodic job instead of a presubmit" +
+	"        cron: \"\"" +
+	"        literal_steps:" +
+	"            # AllowSkipOnSuccess defines if any steps can be skipped when" +
+	"            # all previous `pre` and `test` steps were successful. The given step must explicitly" +
+	"            # ask for being skipped by setting the OptionalOnSuccess flag to true." +
+	"            allow_skip_on_success: false" +
+	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
+	"            cluster_profile: ' '" +
+	"            # Dependencies holds override values for dependency parameters." +
+	"            dependencies:" +
+	"                \"\": \"\"" +
+	"            # Environment has the values of parameters for the steps." +
+	"            env:" +
+	"                \"\": \"\"" +
+	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
+	"            # Post steps always run, even if previous steps fail." +
+	"            post:" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"                active_deadline_seconds: 0" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"                artifact_dir: ' '" +
+	"                # As is the name of the LiteralTestStep." +
+	"                as: ' '" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                # Commands is the command(s) that will be run inside the image." +
+	"                commands: ' '" +
+	"                # Credentials defines the credentials we'll mount into this step." +
+	"                credentials:" +
+	"                  - # MountPath is where the secret should be mounted." +
+	"                    mount_path: ' '" +
+	"                    # Names is which source secret to mount." +
+	"                    name: ' '" +
+	"                    # Namespace is where the source secret exists." +
+	"                    namespace: ' '" +
+	"                # Dependencies lists images which must be available before the test runs" +
+	"                # and the environment variables which are used to expose their pull specs." +
+	"                dependencies:" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                    env: ' '" +
+	"                    # Name is the tag or stream:tag that this dependency references" +
+	"                    name: ' '" +
+	"                # Environment lists parameters that should be set by the test." +
+	"                env:" +
+	"                  - # Default if not set, optional, makes the parameter not required if set." +
+	"                    default: \"\"" +
+	"                    # Documentation is a textual description of the parameter." +
+	"                    documentation: ' '" +
+	"                    # Name of the environment variable." +
+	"                    name: ' '" +
+	"                # From is the container image that will be used for this step." +
+	"                from: ' '" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"                from_image:" +
+	"                    # As is an optional string to use as the intermediate name for this reference." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"                # applicable to `post` steps." +
+	"                optional_on_success: false" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    limits:" +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        \"\": \"\"" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"                termination_grace_period_seconds: 0" +
+	"            # Pre is the array of test steps run to set up the environment for the test." +
+	"            pre:" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"                active_deadline_seconds: 0" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"                artifact_dir: ' '" +
+	"                # As is the name of the LiteralTestStep." +
+	"                as: ' '" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                # Commands is the command(s) that will be run inside the image." +
+	"                commands: ' '" +
+	"                # Credentials defines the credentials we'll mount into this step." +
+	"                credentials:" +
+	"                  - # MountPath is where the secret should be mounted." +
+	"                    mount_path: ' '" +
+	"                    # Names is which source secret to mount." +
+	"                    name: ' '" +
+	"                    # Namespace is where the source secret exists." +
+	"                    namespace: ' '" +
+	"                # Dependencies lists images which must be available before the test runs" +
+	"                # and the environment variables which are used to expose their pull specs." +
+	"                dependencies:" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                    env: ' '" +
+	"                    # Name is the tag or stream:tag that this dependency references" +
+	"                    name: ' '" +
+	"                # Environment lists parameters that should be set by the test." +
+	"                env:" +
+	"                  - # Default if not set, optional, makes the parameter not required if set." +
+	"                    default: \"\"" +
+	"                    # Documentation is a textual description of the parameter." +
+	"                    documentation: ' '" +
+	"                    # Name of the environment variable." +
+	"                    name: ' '" +
+	"                # From is the container image that will be used for this step." +
+	"                from: ' '" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"                from_image:" +
+	"                    # As is an optional string to use as the intermediate name for this reference." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"                # applicable to `post` steps." +
+	"                optional_on_success: false" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    limits:" +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        \"\": \"\"" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"                termination_grace_period_seconds: 0" +
+	"            # Test is the array of test steps that define the actual test." +
+	"            test:" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"                active_deadline_seconds: 0" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"                artifact_dir: ' '" +
+	"                # As is the name of the LiteralTestStep." +
+	"                as: ' '" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                # Commands is the command(s) that will be run inside the image." +
+	"                commands: ' '" +
+	"                # Credentials defines the credentials we'll mount into this step." +
+	"                credentials:" +
+	"                  - # MountPath is where the secret should be mounted." +
+	"                    mount_path: ' '" +
+	"                    # Names is which source secret to mount." +
+	"                    name: ' '" +
+	"                    # Namespace is where the source secret exists." +
+	"                    namespace: ' '" +
+	"                # Dependencies lists images which must be available before the test runs" +
+	"                # and the environment variables which are used to expose their pull specs." +
+	"                dependencies:" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                    env: ' '" +
+	"                    # Name is the tag or stream:tag that this dependency references" +
+	"                    name: ' '" +
+	"                # Environment lists parameters that should be set by the test." +
+	"                env:" +
+	"                  - # Default if not set, optional, makes the parameter not required if set." +
+	"                    default: \"\"" +
+	"                    # Documentation is a textual description of the parameter." +
+	"                    documentation: ' '" +
+	"                    # Name of the environment variable." +
+	"                    name: ' '" +
+	"                # From is the container image that will be used for this step." +
+	"                from: ' '" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"                from_image:" +
+	"                    # As is an optional string to use as the intermediate name for this reference." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"                # applicable to `post` steps." +
+	"                optional_on_success: false" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    limits:" +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        \"\": \"\"" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"                termination_grace_period_seconds: 0" +
+	"        openshift_ansible:" +
+	"            cluster_profile: ' '" +
+	"        openshift_ansible_40:" +
+	"            cluster_profile: ' '" +
+	"        openshift_ansible_custom:" +
+	"            cluster_profile: ' '" +
+	"        openshift_ansible_src:" +
+	"            cluster_profile: ' '" +
+	"        openshift_ansible_upgrade:" +
+	"            cluster_profile: ' '" +
+	"            previous_rpm_deps: ' '" +
+	"            previous_version: ' '" +
+	"        openshift_installer:" +
+	"            cluster_profile: ' '" +
+	"        openshift_installer_console:" +
+	"            cluster_profile: ' '" +
+	"        openshift_installer_custom_test_image:" +
+	"            cluster_profile: ' '" +
+	"            # From defines the imagestreamtag that will be used to run the" +
+	"            # provided test command. e.g. stable:console-test" +
+	"            from: ' '" +
+	"        openshift_installer_src:" +
+	"            cluster_profile: ' '" +
+	"        openshift_installer_upi:" +
+	"            cluster_profile: ' '" +
+	"        openshift_installer_upi_src:" +
+	"            cluster_profile: ' '" +
+	"        # Secret is an optional secret object which" +
+	"        # will be mounted inside the test container." +
+	"        # You cannot set the Secret and Secrets attributes" +
+	"        # at the same time." +
+	"        secret:" +
+	"            # Secret mount path. Defaults to /usr/test-secret" +
+	"            mount_path: ' '" +
+	"            # Secret name, used inside test containers" +
+	"            name: ' '" +
+	"        # Secrets is an optional array of secret objects" +
+	"        # which will be mounted inside the test container." +
+	"        # You cannot set the Secret and Secrets attributes" +
+	"        # at the same time." +
+	"        secrets:" +
+	"          - # Secret mount path. Defaults to /usr/test-secret" +
+	"            mount_path: ' '" +
+	"            # Secret name, used inside test containers" +
+	"            name: ' '" +
+	"        steps:" +
+	"            # AllowSkipOnSuccess defines if any steps can be skipped when" +
+	"            # all previous `pre` and `test` steps were successful. The given step must explicitly" +
+	"            # ask for being skipped by setting the OptionalOnSuccess flag to true." +
+	"            allow_skip_on_success: false" +
+	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
+	"            cluster_profile: ' '" +
+	"            # Dependencies holds override values for dependency parameters." +
+	"            dependencies:" +
+	"                \"\": \"\"" +
+	"            # Environment has the values of parameters for the steps." +
+	"            env:" +
+	"                \"\": \"\"" +
+	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
+	"            # Post steps always run, even if previous steps fail. However, they have an option to skip" +
+	"            # execution if previous Pre and Test steps passed." +
+	"            post:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - active_deadline_seconds: 0" +
+	"                artifact_dir: ' '" +
+	"                as: ' '" +
+	"                # Chain is the name of a step chain reference." +
+	"                chain: \"\"" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                commands: ' '" +
+	"                credentials:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - mount_path: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                dependencies:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - env: ' '" +
+	"                    name: ' '" +
+	"                env:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - default: \"\"" +
+	"                    documentation: ' '" +
+	"                    name: ' '" +
+	"                from: ' '" +
+	"                from_image:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                optional_on_success: false" +
+	"                # Reference is the name of a step reference." +
+	"                ref: \"\"" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    limits:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                termination_grace_period_seconds: 0" +
+	"            # Pre is the array of test steps run to set up the environment for the test." +
+	"            pre:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - active_deadline_seconds: 0" +
+	"                artifact_dir: ' '" +
+	"                as: ' '" +
+	"                # Chain is the name of a step chain reference." +
+	"                chain: \"\"" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                commands: ' '" +
+	"                credentials:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - mount_path: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                dependencies:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - env: ' '" +
+	"                    name: ' '" +
+	"                env:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - default: \"\"" +
+	"                    documentation: ' '" +
+	"                    name: ' '" +
+	"                from: ' '" +
+	"                from_image:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                optional_on_success: false" +
+	"                # Reference is the name of a step reference." +
+	"                ref: \"\"" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    limits:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                termination_grace_period_seconds: 0" +
+	"            # Test is the array of test steps that define the actual test." +
+	"            test:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - active_deadline_seconds: 0" +
+	"                artifact_dir: ' '" +
+	"                as: ' '" +
+	"                # Chain is the name of a step chain reference." +
+	"                chain: \"\"" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary" +
+	"                # will be injected into this step." +
+	"                cli: ' '" +
+	"                commands: ' '" +
+	"                credentials:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - mount_path: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                dependencies:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - env: ' '" +
+	"                    name: ' '" +
+	"                env:" +
+	"                  # LiteralTestStep is a full test step definition." +
+	"                  - default: \"\"" +
+	"                    documentation: ' '" +
+	"                    name: ' '" +
+	"                from: ' '" +
+	"                from_image:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    as: ' '" +
+	"                    name: ' '" +
+	"                    namespace: ' '" +
+	"                    tag: ' '" +
+	"                optional_on_success: false" +
+	"                # Reference is the name of a step reference." +
+	"                ref: \"\"" +
+	"                # Resources defines the resource requirements for the step." +
+	"                resources:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    limits:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                    requests:" +
+	"                        # LiteralTestStep is a full test step definition." +
+	"                        \"\": \"\"" +
+	"                termination_grace_period_seconds: 0" +
+	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both" +
+	"            # the config and the workflow, the fields from the config will override what is set in Workflow." +
+	"            workflow: \"\"" +
+	"# Releases maps semantic release payload identifiers" +
+	"# to the names that they will be exposed under. For" +
+	"# instance, an 'initial' name will be exposed as" +
+	"# $RELEASE_IMAGE_INITIAL. The 'latest' key is special" +
+	"# and cannot co-exist with 'tag_specification', as" +
+	"# they result in the same output." +
+	"releases:" +
+	"    \"\":" +
+	"        # Candidate describes a candidate release payload" +
+	"        candidate:" +
+	"            # Architecture is the architecture for the product." +
+	"            # Defaults to amd64." +
+	"            architecture: ' '" +
+	"            # Product is the name of the product being released" +
+	"            product: ' '" +
+	"            # ReleaseStream is the stream from which we pick the latest candidate" +
+	"            stream: ' '" +
+	"            # Version is the minor version to search for" +
+	"            version: ' '" +
+	"        # Prerelease describes a yet-to-be released payload" +
+	"        prerelease:" +
+	"            # Architecture is the architecture for the product." +
+	"            # Defaults to amd64." +
+	"            architecture: ' '" +
+	"            # Product is the name of the product being released" +
+	"            product: ' '" +
+	"            # VersionBounds describe the allowable version bounds to search in" +
+	"            version_bounds:" +
+	"                lower: ' '" +
+	"                upper: ' '" +
+	"        # Release describes a released payload" +
+	"        release:" +
+	"            # Architecture is the architecture for the release." +
+	"            # Defaults to amd64." +
+	"            architecture: ' '" +
+	"            # Channel is the release channel to search in" +
+	"            channel: ' '" +
+	"            # Version is the minor version to search for" +
+	"            version: ' '" +
+	"# Resources is a set of resource requests or limits over the" +
+	"# input types. The special name '*' may be used to set default" +
+	"# requests and limits." +
+	"resources:" +
+	"    \"\":" +
+	"        limits:" +
+	"            \"\": \"\"" +
+	"        requests:" +
+	"            \"\": \"\"" +
+	"# RpmBuildCommands will create an \"rpms\" image from \"bin\" (or \"src\", if no" +
+	"# binary build commands were specified) that contains the output of this" +
+	"# command. The created RPMs will then be served via HTTP to the \"base\" image" +
+	"# via an injected rpm.repo in the standard location at /etc/yum.repos.d." +
+	"rpm_build_commands: ' '" +
+	"# RpmBuildLocation is where RPms are deposited after being built. If" +
+	"# unset, this will default under the repository root to" +
+	"# _output/local/releases/rpms/." +
+	"rpm_build_location: ' '" +
+	"# ReleaseTagConfiguration determines how the" +
+	"# full release is assembled." +
+	"tag_specification:" +
+	"    # Name is the image stream name to use that contains all" +
+	"    # component tags." +
+	"    name: ' '" +
+	"    # NamePrefix is prepended to the final output image name" +
+	"    # if specified." +
+	"    name_prefix: ' '" +
+	"    # Namespace identifies the namespace from which" +
+	"    # all release artifacts not built in the current" +
+	"    # job are tagged from." +
+	"    namespace: ' '" +
+	"# TestBinaryBuildCommands will create a \"test-bin\" image based on \"src\" that" +
+	"# contains the output of this command. This allows reuse of binary artifacts" +
+	"# across other steps. If empty, no \"test-bin\" image will be created." +
+	"test_binary_build_commands: ' '" +
+	"# Tests describes the tests to run inside of built images." +
+	"# The images launched as pods but have no explicit access to" +
+	"# the cluster they are running on." +
+	"tests:" +
+	"  - # ArtifactDir is an optional directory that contains the" +
+	"    # artifacts to upload. If unset, this will default to" +
+	"    # \"/tmp/artifacts\"." +
+	"    artifact_dir: ' '" +
+	"    # As is the name of the test." +
+	"    as: ' '" +
+	"    # Commands are the shell commands to run in" +
+	"    # the repository root to execute tests." +
+	"    commands: ' '" +
+	"    # Only one of the following can be not-null." +
+	"    container:" +
+	"        # From is the image stream tag in the pipeline to run this" +
+	"        # command in." +
+	"        from: ' '" +
+	"        # MemoryBackedVolume mounts a volume of the specified size into" +
+	"        # the container at /tmp/volume." +
+	"        memory_backed_volume:" +
+	"            # Size is the requested size of the volume as a Kubernetes" +
+	"            # quantity, i.e. \"1Gi\" or \"500M\"" +
+	"            size: ' '" +
+	"    # Cron is how often the test is expected to run outside" +
+	"    # of pull request workflows. Setting this field will" +
+	"    # create a periodic job instead of a presubmit" +
+	"    cron: \"\"" +
+	"    literal_steps:" +
+	"        # AllowSkipOnSuccess defines if any steps can be skipped when" +
+	"        # all previous `pre` and `test` steps were successful. The given step must explicitly" +
+	"        # ask for being skipped by setting the OptionalOnSuccess flag to true." +
+	"        allow_skip_on_success: false" +
+	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
+	"        cluster_profile: ' '" +
+	"        # Dependencies holds override values for dependency parameters." +
+	"        dependencies:" +
+	"            \"\": \"\"" +
+	"        # Environment has the values of parameters for the steps." +
+	"        env:" +
+	"            \"\": \"\"" +
+	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
+	"        # Post steps always run, even if previous steps fail." +
+	"        post:" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"            active_deadline_seconds: 0" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"            artifact_dir: ' '" +
+	"            # As is the name of the LiteralTestStep." +
+	"            as: ' '" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            # Commands is the command(s) that will be run inside the image." +
+	"            commands: ' '" +
+	"            # Credentials defines the credentials we'll mount into this step." +
+	"            credentials:" +
+	"              - # MountPath is where the secret should be mounted." +
+	"                mount_path: ' '" +
+	"                # Names is which source secret to mount." +
+	"                name: ' '" +
+	"                # Namespace is where the source secret exists." +
+	"                namespace: ' '" +
+	"            # Dependencies lists images which must be available before the test runs" +
+	"            # and the environment variables which are used to expose their pull specs." +
+	"            dependencies:" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                env: ' '" +
+	"                # Name is the tag or stream:tag that this dependency references" +
+	"                name: ' '" +
+	"            # Environment lists parameters that should be set by the test." +
+	"            env:" +
+	"              - # Default if not set, optional, makes the parameter not required if set." +
+	"                default: \"\"" +
+	"                # Documentation is a textual description of the parameter." +
+	"                documentation: ' '" +
+	"                # Name of the environment variable." +
+	"                name: ' '" +
+	"            # From is the container image that will be used for this step." +
+	"            from: ' '" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"            from_image:" +
+	"                # As is an optional string to use as the intermediate name for this reference." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"            # applicable to `post` steps." +
+	"            optional_on_success: false" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                limits:" +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    \"\": \"\"" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"            termination_grace_period_seconds: 0" +
+	"        # Pre is the array of test steps run to set up the environment for the test." +
+	"        pre:" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"            active_deadline_seconds: 0" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"            artifact_dir: ' '" +
+	"            # As is the name of the LiteralTestStep." +
+	"            as: ' '" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            # Commands is the command(s) that will be run inside the image." +
+	"            commands: ' '" +
+	"            # Credentials defines the credentials we'll mount into this step." +
+	"            credentials:" +
+	"              - # MountPath is where the secret should be mounted." +
+	"                mount_path: ' '" +
+	"                # Names is which source secret to mount." +
+	"                name: ' '" +
+	"                # Namespace is where the source secret exists." +
+	"                namespace: ' '" +
+	"            # Dependencies lists images which must be available before the test runs" +
+	"            # and the environment variables which are used to expose their pull specs." +
+	"            dependencies:" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                env: ' '" +
+	"                # Name is the tag or stream:tag that this dependency references" +
+	"                name: ' '" +
+	"            # Environment lists parameters that should be set by the test." +
+	"            env:" +
+	"              - # Default if not set, optional, makes the parameter not required if set." +
+	"                default: \"\"" +
+	"                # Documentation is a textual description of the parameter." +
+	"                documentation: ' '" +
+	"                # Name of the environment variable." +
+	"                name: ' '" +
+	"            # From is the container image that will be used for this step." +
+	"            from: ' '" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"            from_image:" +
+	"                # As is an optional string to use as the intermediate name for this reference." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"            # applicable to `post` steps." +
+	"            optional_on_success: false" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                limits:" +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    \"\": \"\"" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"            termination_grace_period_seconds: 0" +
+	"        # Test is the array of test steps that define the actual test." +
+	"        test:" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
+	"            active_deadline_seconds: 0" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
+	"            artifact_dir: ' '" +
+	"            # As is the name of the LiteralTestStep." +
+	"            as: ' '" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            # Commands is the command(s) that will be run inside the image." +
+	"            commands: ' '" +
+	"            # Credentials defines the credentials we'll mount into this step." +
+	"            credentials:" +
+	"              - # MountPath is where the secret should be mounted." +
+	"                mount_path: ' '" +
+	"                # Names is which source secret to mount." +
+	"                name: ' '" +
+	"                # Namespace is where the source secret exists." +
+	"                namespace: ' '" +
+	"            # Dependencies lists images which must be available before the test runs" +
+	"            # and the environment variables which are used to expose their pull specs." +
+	"            dependencies:" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with" +
+	"                env: ' '" +
+	"                # Name is the tag or stream:tag that this dependency references" +
+	"                name: ' '" +
+	"            # Environment lists parameters that should be set by the test." +
+	"            env:" +
+	"              - # Default if not set, optional, makes the parameter not required if set." +
+	"                default: \"\"" +
+	"                # Documentation is a textual description of the parameter." +
+	"                documentation: ' '" +
+	"                # Name of the environment variable." +
+	"                name: ' '" +
+	"            # From is the container image that will be used for this step." +
+	"            from: ' '" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
+	"            from_image:" +
+	"                # As is an optional string to use as the intermediate name for this reference." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
+	"            # applicable to `post` steps." +
+	"            optional_on_success: false" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                limits:" +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    \"\": \"\"" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
+	"            termination_grace_period_seconds: 0" +
+	"    openshift_ansible:" +
+	"        cluster_profile: ' '" +
+	"    openshift_ansible_40:" +
+	"        cluster_profile: ' '" +
+	"    openshift_ansible_custom:" +
+	"        cluster_profile: ' '" +
+	"    openshift_ansible_src:" +
+	"        cluster_profile: ' '" +
+	"    openshift_ansible_upgrade:" +
+	"        cluster_profile: ' '" +
+	"        previous_rpm_deps: ' '" +
+	"        previous_version: ' '" +
+	"    openshift_installer:" +
+	"        cluster_profile: ' '" +
+	"    openshift_installer_console:" +
+	"        cluster_profile: ' '" +
+	"    openshift_installer_custom_test_image:" +
+	"        cluster_profile: ' '" +
+	"        # From defines the imagestreamtag that will be used to run the" +
+	"        # provided test command. e.g. stable:console-test" +
+	"        from: ' '" +
+	"    openshift_installer_src:" +
+	"        cluster_profile: ' '" +
+	"    openshift_installer_upi:" +
+	"        cluster_profile: ' '" +
+	"    openshift_installer_upi_src:" +
+	"        cluster_profile: ' '" +
+	"    # Secret is an optional secret object which" +
+	"    # will be mounted inside the test container." +
+	"    # You cannot set the Secret and Secrets attributes" +
+	"    # at the same time." +
+	"    secret:" +
+	"        # Secret mount path. Defaults to /usr/test-secret" +
+	"        mount_path: ' '" +
+	"        # Secret name, used inside test containers" +
+	"        name: ' '" +
+	"    # Secrets is an optional array of secret objects" +
+	"    # which will be mounted inside the test container." +
+	"    # You cannot set the Secret and Secrets attributes" +
+	"    # at the same time." +
+	"    secrets:" +
+	"      - # Secret mount path. Defaults to /usr/test-secret" +
+	"        mount_path: ' '" +
+	"        # Secret name, used inside test containers" +
+	"        name: ' '" +
+	"    steps:" +
+	"        # AllowSkipOnSuccess defines if any steps can be skipped when" +
+	"        # all previous `pre` and `test` steps were successful. The given step must explicitly" +
+	"        # ask for being skipped by setting the OptionalOnSuccess flag to true." +
+	"        allow_skip_on_success: false" +
+	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
+	"        cluster_profile: ' '" +
+	"        # Dependencies holds override values for dependency parameters." +
+	"        dependencies:" +
+	"            \"\": \"\"" +
+	"        # Environment has the values of parameters for the steps." +
+	"        env:" +
+	"            \"\": \"\"" +
+	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
+	"        # Post steps always run, even if previous steps fail. However, they have an option to skip" +
+	"        # execution if previous Pre and Test steps passed." +
+	"        post:" +
+	"          # LiteralTestStep is a full test step definition." +
+	"          - active_deadline_seconds: 0" +
+	"            artifact_dir: ' '" +
+	"            as: ' '" +
+	"            # Chain is the name of a step chain reference." +
+	"            chain: \"\"" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            commands: ' '" +
+	"            credentials:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - mount_path: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"            dependencies:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - env: ' '" +
+	"                name: ' '" +
+	"            env:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - default: \"\"" +
+	"                documentation: ' '" +
+	"                name: ' '" +
+	"            from: ' '" +
+	"            from_image:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            optional_on_success: false" +
+	"            # Reference is the name of a step reference." +
+	"            ref: \"\"" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                limits:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"            termination_grace_period_seconds: 0" +
+	"        # Pre is the array of test steps run to set up the environment for the test." +
+	"        pre:" +
+	"          # LiteralTestStep is a full test step definition." +
+	"          - active_deadline_seconds: 0" +
+	"            artifact_dir: ' '" +
+	"            as: ' '" +
+	"            # Chain is the name of a step chain reference." +
+	"            chain: \"\"" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            commands: ' '" +
+	"            credentials:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - mount_path: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"            dependencies:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - env: ' '" +
+	"                name: ' '" +
+	"            env:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - default: \"\"" +
+	"                documentation: ' '" +
+	"                name: ' '" +
+	"            from: ' '" +
+	"            from_image:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            optional_on_success: false" +
+	"            # Reference is the name of a step reference." +
+	"            ref: \"\"" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                limits:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"            termination_grace_period_seconds: 0" +
+	"        # Test is the array of test steps that define the actual test." +
+	"        test:" +
+	"          # LiteralTestStep is a full test step definition." +
+	"          - active_deadline_seconds: 0" +
+	"            artifact_dir: ' '" +
+	"            as: ' '" +
+	"            # Chain is the name of a step chain reference." +
+	"            chain: \"\"" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary" +
+	"            # will be injected into this step." +
+	"            cli: ' '" +
+	"            commands: ' '" +
+	"            credentials:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - mount_path: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"            dependencies:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - env: ' '" +
+	"                name: ' '" +
+	"            env:" +
+	"              # LiteralTestStep is a full test step definition." +
+	"              - default: \"\"" +
+	"                documentation: ' '" +
+	"                name: ' '" +
+	"            from: ' '" +
+	"            from_image:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                as: ' '" +
+	"                name: ' '" +
+	"                namespace: ' '" +
+	"                tag: ' '" +
+	"            optional_on_success: false" +
+	"            # Reference is the name of a step reference." +
+	"            ref: \"\"" +
+	"            # Resources defines the resource requirements for the step." +
+	"            resources:" +
+	"                # LiteralTestStep is a full test step definition." +
+	"                limits:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"                requests:" +
+	"                    # LiteralTestStep is a full test step definition." +
+	"                    \"\": \"\"" +
+	"            termination_grace_period_seconds: 0" +
+	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both" +
+	"        # the config and the workflow, the fields from the config will override what is set in Workflow." +
+	"        workflow: \"\"" +
+	"zz_generated_metadata:" +
+	"    branch: ' '" +
+	"    org: ' '" +
+	"    repo: ' '" +
+	"    variant: ' '" +
+	""

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1,1210 +1,1210 @@
 package webreg
 
-const ciOperatorReferenceYaml = "# The list of base images describe" +
-	"# which images are going to be necessary outside" +
-	"# of the pipeline. The key will be the alias that other" +
-	"# steps use to refer to this image." +
-	"base_images:" +
-	"    \"\":" +
-	"        # As is an optional string to use as the intermediate name for this reference." +
-	"        as: ' '" +
-	"        name: ' '" +
-	"        namespace: ' '" +
-	"        tag: ' '" +
-	"# BaseRPMImages is a list of the images and their aliases that will" +
-	"# have RPM repositories injected into them for downstream" +
-	"# image builds that require built project RPMs." +
-	"base_rpm_images:" +
-	"    \"\":" +
-	"        # As is an optional string to use as the intermediate name for this reference." +
-	"        as: ' '" +
-	"        name: ' '" +
-	"        namespace: ' '" +
-	"        tag: ' '" +
-	"# BinaryBuildCommands will create a \"bin\" image based on \"src\" that" +
-	"# contains the output of this command. This allows reuse of binary artifacts" +
-	"# across other steps. If empty, no \"bin\" image will be created." +
-	"binary_build_commands: ' '" +
-	"# BuildRootImage supports two ways to get the image that" +
-	"# the pipeline will caches on. The one way is to take the reference" +
-	"# from an image stream, and the other from a dockerfile." +
-	"build_root:" +
-	"    image_stream_tag:" +
-	"        # As is an optional string to use as the intermediate name for this reference." +
-	"        as: ' '" +
-	"        name: ' '" +
-	"        namespace: ' '" +
-	"        tag: ' '" +
-	"    project_image:" +
-	"        # ContextDir is the directory in the project" +
-	"        # from which this build should be run." +
-	"        context_dir: ' '" +
-	"        # DockerfilePath is the path to a Dockerfile in the" +
-	"        # project to run relative to the context_dir." +
-	"        dockerfile_path: ' '" +
-	"        # Inputs is a map of tag reference name to image input changes" +
-	"        # that will populate the build context for the Dockerfile or" +
-	"        # alter the input image for a multi-stage build." +
-	"        inputs:" +
-	"            \"\":" +
-	"                # As is a list of multi-stage step names or image names that will" +
-	"                # be replaced by the image reference from this step. For instance," +
-	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
-	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
-	"                # image with the pipeline input." +
-	"                as:" +
-	"                  - \"\"" +
-	"                # Paths is a list of paths to copy out of this image and into the" +
-	"                # context directory." +
-	"                paths:" +
-	"                  - # DestinationDir is the directory in the destination image to copy" +
-	"                    # to." +
-	"                    destination_dir: ' '" +
-	"                    # SourcePath is a file or directory in the source image to copy from." +
-	"                    source_path: ' '" +
-	"# CanonicalGoRepository is a directory path that represents" +
-	"# the desired location of the contents of this repository in" +
-	"# Go. If specified the location of the repository we are" +
-	"# cloning from is ignored." +
-	"canonical_go_repository: \"\"" +
-	"# Images describes the images that are built" +
-	"# baseImage the project as part of the release" +
-	"# process. The name of each image is its \"to\" value" +
-	"# and can be used to build only a specific image." +
-	"images:" +
-	"  - # ContextDir is the directory in the project" +
-	"    # from which this build should be run." +
-	"    context_dir: ' '" +
-	"    # DockerfilePath is the path to a Dockerfile in the" +
-	"    # project to run relative to the context_dir." +
-	"    dockerfile_path: ' '" +
-	"    from: ' '" +
-	"    # Inputs is a map of tag reference name to image input changes" +
-	"    # that will populate the build context for the Dockerfile or" +
-	"    # alter the input image for a multi-stage build." +
-	"    inputs:" +
-	"        \"\":" +
-	"            # As is a list of multi-stage step names or image names that will" +
-	"            # be replaced by the image reference from this step. For instance," +
-	"            # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
-	"            # either \"nginx:latest\" or \"base\" in this array will replace that" +
-	"            # image with the pipeline input." +
-	"            as:" +
-	"              - \"\"" +
-	"            # Paths is a list of paths to copy out of this image and into the" +
-	"            # context directory." +
-	"            paths:" +
-	"              - # DestinationDir is the directory in the destination image to copy" +
-	"                # to." +
-	"                destination_dir: ' '" +
-	"                # SourcePath is a file or directory in the source image to copy from." +
-	"                source_path: ' '" +
-	"    to: ' '" +
-	"# Operator describes the operator bundle(s) that is built by the project" +
-	"operator:" +
-	"    # Bundles define a dockerfile and build context to build a bundle" +
-	"    bundles:" +
-	"      - context_dir: ' '" +
-	"        dockerfile_path: ' '" +
-	"    # Substitutions describes the pullspecs in the operator manifests that must be subsituted" +
-	"    # with the pull specs of the images in the CI registry" +
-	"    substitutions:" +
-	"      - # PullSpec is the pullspec that needs to be replaced" +
-	"        pullspec: ' '" +
-	"        # With is the string that the PullSpec is being replaced by" +
-	"        with: ' '" +
-	"# PromotionConfiguration determines how images are promoted" +
-	"# by this command. It is ignored unless promotion has specifically" +
-	"# been requested. Promotion is performed after all other steps" +
-	"# have been completed so that tests can be run prior to promotion." +
-	"# If no promotion is defined, it is defaulted from the ReleaseTagConfiguration." +
-	"promotion:" +
-	"    # AdditionalImages is a mapping of images to promote. The" +
-	"    # images will be taken from the pipeline image stream. The" +
-	"    # key is the name to promote as and the value is the source" +
-	"    # name. If you specify a tag that does not exist as the source" +
-	"    # the destination tag will not be created." +
-	"    additional_images:" +
-	"        \"\": \"\"" +
-	"    # ExcludedImages are image names that will not be promoted." +
-	"    # Exclusions are made before additional_images are included." +
-	"    # Use exclusions when you want to build images for testing" +
-	"    # but not promote them afterwards." +
-	"    excluded_images:" +
-	"      - \"\"" +
-	"    # Name is an optional image stream name to use that" +
-	"    # contains all component tags. If specified, tag is" +
-	"    # ignored." +
-	"    name: ' '" +
-	"    # NamePrefix is prepended to the final output image name" +
-	"    # if specified." +
-	"    name_prefix: ' '" +
-	"    # Namespace identifies the namespace to which the built" +
-	"    # artifacts will be published to." +
-	"    namespace: ' '" +
-	"    # Tag is the ImageStreamTag tagged in for each" +
-	"    # build image's ImageStream." +
-	"    tag: ' '" +
-	"# RawSteps are literal Steps that should be" +
-	"# included in the final pipeline." +
-	"raw_steps:" +
-	"  - bundle_source_step:" +
-	"        # Substitutions contains pullspecs that need to be replaced by images" +
-	"        # in the CI cluster for operator bundle images" +
-	"        substitutions:" +
-	"          - # PullSpec is the pullspec that needs to be replaced" +
-	"            pullspec: ' '" +
-	"            # With is the string that the PullSpec is being replaced by" +
-	"            with: ' '" +
-	"    index_generator_step:" +
-	"        # OperatorIndex is a list of the names of the bundle images that the" +
-	"        # index will contain in its database." +
-	"        operator_index:" +
-	"          - \"\"" +
-	"        to: ' '" +
-	"    input_image_tag_step:" +
-	"        base_image:" +
-	"            # As is an optional string to use as the intermediate name for this reference." +
-	"            as: ' '" +
-	"            name: ' '" +
-	"            namespace: ' '" +
-	"            tag: ' '" +
-	"        to: ' '" +
-	"    output_image_tag_step:" +
-	"        from: ' '" +
-	"        # Optional means the output step is not built, published, or" +
-	"        # promoted unless explicitly targeted. Use for builds which" +
-	"        # are invoked only when testing certain parts of the repo." +
-	"        optional: false" +
-	"        to:" +
-	"            # As is an optional string to use as the intermediate name for this reference." +
-	"            as: ' '" +
-	"            name: ' '" +
-	"            namespace: ' '" +
-	"            tag: ' '" +
-	"    pipeline_image_cache_step:" +
-	"        # Commands are the shell commands to run in" +
-	"        # the repository root to create the cached" +
-	"        # content." +
-	"        commands: ' '" +
-	"        from: ' '" +
-	"        to: ' '" +
-	"    project_directory_image_build_inputs:" +
-	"        # ContextDir is the directory in the project" +
-	"        # from which this build should be run." +
-	"        context_dir: ' '" +
-	"        # DockerfilePath is the path to a Dockerfile in the" +
-	"        # project to run relative to the context_dir." +
-	"        dockerfile_path: ' '" +
-	"        # Inputs is a map of tag reference name to image input changes" +
-	"        # that will populate the build context for the Dockerfile or" +
-	"        # alter the input image for a multi-stage build." +
-	"        inputs:" +
-	"            \"\":" +
-	"                # As is a list of multi-stage step names or image names that will" +
-	"                # be replaced by the image reference from this step. For instance," +
-	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
-	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
-	"                # image with the pipeline input." +
-	"                as:" +
-	"                  - \"\"" +
-	"                # Paths is a list of paths to copy out of this image and into the" +
-	"                # context directory." +
-	"                paths:" +
-	"                  - # DestinationDir is the directory in the destination image to copy" +
-	"                    # to." +
-	"                    destination_dir: ' '" +
-	"                    # SourcePath is a file or directory in the source image to copy from." +
-	"                    source_path: ' '" +
-	"    project_directory_image_build_step:" +
-	"        # ContextDir is the directory in the project" +
-	"        # from which this build should be run." +
-	"        context_dir: ' '" +
-	"        # DockerfilePath is the path to a Dockerfile in the" +
-	"        # project to run relative to the context_dir." +
-	"        dockerfile_path: ' '" +
-	"        from: ' '" +
-	"        # Inputs is a map of tag reference name to image input changes" +
-	"        # that will populate the build context for the Dockerfile or" +
-	"        # alter the input image for a multi-stage build." +
-	"        inputs:" +
-	"            \"\":" +
-	"                # As is a list of multi-stage step names or image names that will" +
-	"                # be replaced by the image reference from this step. For instance," +
-	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying" +
-	"                # either \"nginx:latest\" or \"base\" in this array will replace that" +
-	"                # image with the pipeline input." +
-	"                as:" +
-	"                  - \"\"" +
-	"                # Paths is a list of paths to copy out of this image and into the" +
-	"                # context directory." +
-	"                paths:" +
-	"                  - # DestinationDir is the directory in the destination image to copy" +
-	"                    # to." +
-	"                    destination_dir: ' '" +
-	"                    # SourcePath is a file or directory in the source image to copy from." +
-	"                    source_path: ' '" +
-	"        to: ' '" +
-	"    release_images_tag_step:" +
-	"        # Name is the image stream name to use that contains all" +
-	"        # component tags." +
-	"        name: ' '" +
-	"        # NamePrefix is prepended to the final output image name" +
-	"        # if specified." +
-	"        name_prefix: ' '" +
-	"        # Namespace identifies the namespace from which" +
-	"        # all release artifacts not built in the current" +
-	"        # job are tagged from." +
-	"        namespace: ' '" +
-	"    resolved_release_images_step:" +
-	"        candidate:" +
-	"            architecture: ' '" +
-	"            product: ' '" +
-	"            stream: ' '" +
-	"            version: ' '" +
-	"        name: ' '" +
-	"        prerelease:" +
-	"            architecture: ' '" +
-	"            product: ' '" +
-	"            version_bounds:" +
-	"                lower: ' '" +
-	"                upper: ' '" +
-	"        release:" +
-	"            architecture: ' '" +
-	"            channel: ' '" +
-	"            version: ' '" +
-	"    rpm_image_injection_step:" +
-	"        from: ' '" +
-	"        to: ' '" +
-	"    rpm_serve_step:" +
-	"        from: ' '" +
-	"    source_step:" +
-	"        # ClonerefsImage is the image where we get the clonerefs tool" +
-	"        clonerefs_image:" +
-	"            # As is an optional string to use as the intermediate name for this reference." +
-	"            as: ' '" +
-	"            name: ' '" +
-	"            namespace: ' '" +
-	"            tag: ' '" +
-	"        # ClonerefsPath is the path in the above image where the" +
-	"        # clonerefs tool is placed" +
-	"        clonerefs_path: ' '" +
-	"        from: ' '" +
-	"        to: ' '" +
-	"    test_step:" +
-	"        # ArtifactDir is an optional directory that contains the" +
-	"        # artifacts to upload. If unset, this will default to" +
-	"        # \"/tmp/artifacts\"." +
-	"        artifact_dir: ' '" +
-	"        # As is the name of the test." +
-	"        as: ' '" +
-	"        # Commands are the shell commands to run in" +
-	"        # the repository root to execute tests." +
-	"        commands: ' '" +
-	"        # Only one of the following can be not-null." +
-	"        container:" +
-	"            # From is the image stream tag in the pipeline to run this" +
-	"            # command in." +
-	"            from: ' '" +
-	"            # MemoryBackedVolume mounts a volume of the specified size into" +
-	"            # the container at /tmp/volume." +
-	"            memory_backed_volume:" +
-	"                # Size is the requested size of the volume as a Kubernetes" +
-	"                # quantity, i.e. \"1Gi\" or \"500M\"" +
-	"                size: ' '" +
-	"        # Cron is how often the test is expected to run outside" +
-	"        # of pull request workflows. Setting this field will" +
-	"        # create a periodic job instead of a presubmit" +
-	"        cron: \"\"" +
-	"        literal_steps:" +
-	"            # AllowSkipOnSuccess defines if any steps can be skipped when" +
-	"            # all previous `pre` and `test` steps were successful. The given step must explicitly" +
-	"            # ask for being skipped by setting the OptionalOnSuccess flag to true." +
-	"            allow_skip_on_success: false" +
-	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
-	"            cluster_profile: ' '" +
-	"            # Dependencies holds override values for dependency parameters." +
-	"            dependencies:" +
-	"                \"\": \"\"" +
-	"            # Environment has the values of parameters for the steps." +
-	"            env:" +
-	"                \"\": \"\"" +
-	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
-	"            # Post steps always run, even if previous steps fail." +
-	"            post:" +
-	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"                active_deadline_seconds: 0" +
-	"                # ArtifactDir is the directory from which artifacts will be extracted" +
-	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"                artifact_dir: ' '" +
-	"                # As is the name of the LiteralTestStep." +
-	"                as: ' '" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                # Commands is the command(s) that will be run inside the image." +
-	"                commands: ' '" +
-	"                # Credentials defines the credentials we'll mount into this step." +
-	"                credentials:" +
-	"                  - # MountPath is where the secret should be mounted." +
-	"                    mount_path: ' '" +
-	"                    # Names is which source secret to mount." +
-	"                    name: ' '" +
-	"                    # Namespace is where the source secret exists." +
-	"                    namespace: ' '" +
-	"                # Dependencies lists images which must be available before the test runs" +
-	"                # and the environment variables which are used to expose their pull specs." +
-	"                dependencies:" +
-	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                    env: ' '" +
-	"                    # Name is the tag or stream:tag that this dependency references" +
-	"                    name: ' '" +
-	"                # Environment lists parameters that should be set by the test." +
-	"                env:" +
-	"                  - # Default if not set, optional, makes the parameter not required if set." +
-	"                    default: \"\"" +
-	"                    # Documentation is a textual description of the parameter." +
-	"                    documentation: ' '" +
-	"                    # Name of the environment variable." +
-	"                    name: ' '" +
-	"                # From is the container image that will be used for this step." +
-	"                from: ' '" +
-	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"                from_image:" +
-	"                    # As is an optional string to use as the intermediate name for this reference." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                # OptionalOnSuccess defines if this step should be skipped as long" +
-	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"                # applicable to `post` steps." +
-	"                optional_on_success: false" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    limits:" +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        \"\": \"\"" +
-	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"                termination_grace_period_seconds: 0" +
-	"            # Pre is the array of test steps run to set up the environment for the test." +
-	"            pre:" +
-	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"                active_deadline_seconds: 0" +
-	"                # ArtifactDir is the directory from which artifacts will be extracted" +
-	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"                artifact_dir: ' '" +
-	"                # As is the name of the LiteralTestStep." +
-	"                as: ' '" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                # Commands is the command(s) that will be run inside the image." +
-	"                commands: ' '" +
-	"                # Credentials defines the credentials we'll mount into this step." +
-	"                credentials:" +
-	"                  - # MountPath is where the secret should be mounted." +
-	"                    mount_path: ' '" +
-	"                    # Names is which source secret to mount." +
-	"                    name: ' '" +
-	"                    # Namespace is where the source secret exists." +
-	"                    namespace: ' '" +
-	"                # Dependencies lists images which must be available before the test runs" +
-	"                # and the environment variables which are used to expose their pull specs." +
-	"                dependencies:" +
-	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                    env: ' '" +
-	"                    # Name is the tag or stream:tag that this dependency references" +
-	"                    name: ' '" +
-	"                # Environment lists parameters that should be set by the test." +
-	"                env:" +
-	"                  - # Default if not set, optional, makes the parameter not required if set." +
-	"                    default: \"\"" +
-	"                    # Documentation is a textual description of the parameter." +
-	"                    documentation: ' '" +
-	"                    # Name of the environment variable." +
-	"                    name: ' '" +
-	"                # From is the container image that will be used for this step." +
-	"                from: ' '" +
-	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"                from_image:" +
-	"                    # As is an optional string to use as the intermediate name for this reference." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                # OptionalOnSuccess defines if this step should be skipped as long" +
-	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"                # applicable to `post` steps." +
-	"                optional_on_success: false" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    limits:" +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        \"\": \"\"" +
-	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"                termination_grace_period_seconds: 0" +
-	"            # Test is the array of test steps that define the actual test." +
-	"            test:" +
-	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"                active_deadline_seconds: 0" +
-	"                # ArtifactDir is the directory from which artifacts will be extracted" +
-	"                # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"                artifact_dir: ' '" +
-	"                # As is the name of the LiteralTestStep." +
-	"                as: ' '" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                # Commands is the command(s) that will be run inside the image." +
-	"                commands: ' '" +
-	"                # Credentials defines the credentials we'll mount into this step." +
-	"                credentials:" +
-	"                  - # MountPath is where the secret should be mounted." +
-	"                    mount_path: ' '" +
-	"                    # Names is which source secret to mount." +
-	"                    name: ' '" +
-	"                    # Namespace is where the source secret exists." +
-	"                    namespace: ' '" +
-	"                # Dependencies lists images which must be available before the test runs" +
-	"                # and the environment variables which are used to expose their pull specs." +
-	"                dependencies:" +
-	"                  - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                    env: ' '" +
-	"                    # Name is the tag or stream:tag that this dependency references" +
-	"                    name: ' '" +
-	"                # Environment lists parameters that should be set by the test." +
-	"                env:" +
-	"                  - # Default if not set, optional, makes the parameter not required if set." +
-	"                    default: \"\"" +
-	"                    # Documentation is a textual description of the parameter." +
-	"                    documentation: ' '" +
-	"                    # Name of the environment variable." +
-	"                    name: ' '" +
-	"                # From is the container image that will be used for this step." +
-	"                from: ' '" +
-	"                # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"                from_image:" +
-	"                    # As is an optional string to use as the intermediate name for this reference." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                # OptionalOnSuccess defines if this step should be skipped as long" +
-	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"                # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"                # applicable to `post` steps." +
-	"                optional_on_success: false" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    limits:" +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        \"\": \"\"" +
-	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"                termination_grace_period_seconds: 0" +
-	"        openshift_ansible:" +
-	"            cluster_profile: ' '" +
-	"        openshift_ansible_40:" +
-	"            cluster_profile: ' '" +
-	"        openshift_ansible_custom:" +
-	"            cluster_profile: ' '" +
-	"        openshift_ansible_src:" +
-	"            cluster_profile: ' '" +
-	"        openshift_ansible_upgrade:" +
-	"            cluster_profile: ' '" +
-	"            previous_rpm_deps: ' '" +
-	"            previous_version: ' '" +
-	"        openshift_installer:" +
-	"            cluster_profile: ' '" +
-	"        openshift_installer_console:" +
-	"            cluster_profile: ' '" +
-	"        openshift_installer_custom_test_image:" +
-	"            cluster_profile: ' '" +
-	"            # From defines the imagestreamtag that will be used to run the" +
-	"            # provided test command. e.g. stable:console-test" +
-	"            from: ' '" +
-	"        openshift_installer_src:" +
-	"            cluster_profile: ' '" +
-	"        openshift_installer_upi:" +
-	"            cluster_profile: ' '" +
-	"        openshift_installer_upi_src:" +
-	"            cluster_profile: ' '" +
-	"        # Secret is an optional secret object which" +
-	"        # will be mounted inside the test container." +
-	"        # You cannot set the Secret and Secrets attributes" +
-	"        # at the same time." +
-	"        secret:" +
-	"            # Secret mount path. Defaults to /usr/test-secret" +
-	"            mount_path: ' '" +
-	"            # Secret name, used inside test containers" +
-	"            name: ' '" +
-	"        # Secrets is an optional array of secret objects" +
-	"        # which will be mounted inside the test container." +
-	"        # You cannot set the Secret and Secrets attributes" +
-	"        # at the same time." +
-	"        secrets:" +
-	"          - # Secret mount path. Defaults to /usr/test-secret" +
-	"            mount_path: ' '" +
-	"            # Secret name, used inside test containers" +
-	"            name: ' '" +
-	"        steps:" +
-	"            # AllowSkipOnSuccess defines if any steps can be skipped when" +
-	"            # all previous `pre` and `test` steps were successful. The given step must explicitly" +
-	"            # ask for being skipped by setting the OptionalOnSuccess flag to true." +
-	"            allow_skip_on_success: false" +
-	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
-	"            cluster_profile: ' '" +
-	"            # Dependencies holds override values for dependency parameters." +
-	"            dependencies:" +
-	"                \"\": \"\"" +
-	"            # Environment has the values of parameters for the steps." +
-	"            env:" +
-	"                \"\": \"\"" +
-	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
-	"            # Post steps always run, even if previous steps fail. However, they have an option to skip" +
-	"            # execution if previous Pre and Test steps passed." +
-	"            post:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - active_deadline_seconds: 0" +
-	"                artifact_dir: ' '" +
-	"                as: ' '" +
-	"                # Chain is the name of a step chain reference." +
-	"                chain: \"\"" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                commands: ' '" +
-	"                credentials:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - mount_path: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                dependencies:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - env: ' '" +
-	"                    name: ' '" +
-	"                env:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - default: \"\"" +
-	"                    documentation: ' '" +
-	"                    name: ' '" +
-	"                from: ' '" +
-	"                from_image:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                optional_on_success: false" +
-	"                # Reference is the name of a step reference." +
-	"                ref: \"\"" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    limits:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                termination_grace_period_seconds: 0" +
-	"            # Pre is the array of test steps run to set up the environment for the test." +
-	"            pre:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - active_deadline_seconds: 0" +
-	"                artifact_dir: ' '" +
-	"                as: ' '" +
-	"                # Chain is the name of a step chain reference." +
-	"                chain: \"\"" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                commands: ' '" +
-	"                credentials:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - mount_path: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                dependencies:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - env: ' '" +
-	"                    name: ' '" +
-	"                env:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - default: \"\"" +
-	"                    documentation: ' '" +
-	"                    name: ' '" +
-	"                from: ' '" +
-	"                from_image:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                optional_on_success: false" +
-	"                # Reference is the name of a step reference." +
-	"                ref: \"\"" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    limits:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                termination_grace_period_seconds: 0" +
-	"            # Test is the array of test steps that define the actual test." +
-	"            test:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - active_deadline_seconds: 0" +
-	"                artifact_dir: ' '" +
-	"                as: ' '" +
-	"                # Chain is the name of a step chain reference." +
-	"                chain: \"\"" +
-	"                # Cli is the (optional) name of the release from which the `oc` binary" +
-	"                # will be injected into this step." +
-	"                cli: ' '" +
-	"                commands: ' '" +
-	"                credentials:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - mount_path: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                dependencies:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - env: ' '" +
-	"                    name: ' '" +
-	"                env:" +
-	"                  # LiteralTestStep is a full test step definition." +
-	"                  - default: \"\"" +
-	"                    documentation: ' '" +
-	"                    name: ' '" +
-	"                from: ' '" +
-	"                from_image:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    as: ' '" +
-	"                    name: ' '" +
-	"                    namespace: ' '" +
-	"                    tag: ' '" +
-	"                optional_on_success: false" +
-	"                # Reference is the name of a step reference." +
-	"                ref: \"\"" +
-	"                # Resources defines the resource requirements for the step." +
-	"                resources:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    limits:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                    requests:" +
-	"                        # LiteralTestStep is a full test step definition." +
-	"                        \"\": \"\"" +
-	"                termination_grace_period_seconds: 0" +
-	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both" +
-	"            # the config and the workflow, the fields from the config will override what is set in Workflow." +
-	"            workflow: \"\"" +
-	"# Releases maps semantic release payload identifiers" +
-	"# to the names that they will be exposed under. For" +
-	"# instance, an 'initial' name will be exposed as" +
-	"# $RELEASE_IMAGE_INITIAL. The 'latest' key is special" +
-	"# and cannot co-exist with 'tag_specification', as" +
-	"# they result in the same output." +
-	"releases:" +
-	"    \"\":" +
-	"        # Candidate describes a candidate release payload" +
-	"        candidate:" +
-	"            # Architecture is the architecture for the product." +
-	"            # Defaults to amd64." +
-	"            architecture: ' '" +
-	"            # Product is the name of the product being released" +
-	"            product: ' '" +
-	"            # ReleaseStream is the stream from which we pick the latest candidate" +
-	"            stream: ' '" +
-	"            # Version is the minor version to search for" +
-	"            version: ' '" +
-	"        # Prerelease describes a yet-to-be released payload" +
-	"        prerelease:" +
-	"            # Architecture is the architecture for the product." +
-	"            # Defaults to amd64." +
-	"            architecture: ' '" +
-	"            # Product is the name of the product being released" +
-	"            product: ' '" +
-	"            # VersionBounds describe the allowable version bounds to search in" +
-	"            version_bounds:" +
-	"                lower: ' '" +
-	"                upper: ' '" +
-	"        # Release describes a released payload" +
-	"        release:" +
-	"            # Architecture is the architecture for the release." +
-	"            # Defaults to amd64." +
-	"            architecture: ' '" +
-	"            # Channel is the release channel to search in" +
-	"            channel: ' '" +
-	"            # Version is the minor version to search for" +
-	"            version: ' '" +
-	"# Resources is a set of resource requests or limits over the" +
-	"# input types. The special name '*' may be used to set default" +
-	"# requests and limits." +
-	"resources:" +
-	"    \"\":" +
-	"        limits:" +
-	"            \"\": \"\"" +
-	"        requests:" +
-	"            \"\": \"\"" +
-	"# RpmBuildCommands will create an \"rpms\" image from \"bin\" (or \"src\", if no" +
-	"# binary build commands were specified) that contains the output of this" +
-	"# command. The created RPMs will then be served via HTTP to the \"base\" image" +
-	"# via an injected rpm.repo in the standard location at /etc/yum.repos.d." +
-	"rpm_build_commands: ' '" +
-	"# RpmBuildLocation is where RPms are deposited after being built. If" +
-	"# unset, this will default under the repository root to" +
-	"# _output/local/releases/rpms/." +
-	"rpm_build_location: ' '" +
-	"# ReleaseTagConfiguration determines how the" +
-	"# full release is assembled." +
-	"tag_specification:" +
-	"    # Name is the image stream name to use that contains all" +
-	"    # component tags." +
-	"    name: ' '" +
-	"    # NamePrefix is prepended to the final output image name" +
-	"    # if specified." +
-	"    name_prefix: ' '" +
-	"    # Namespace identifies the namespace from which" +
-	"    # all release artifacts not built in the current" +
-	"    # job are tagged from." +
-	"    namespace: ' '" +
-	"# TestBinaryBuildCommands will create a \"test-bin\" image based on \"src\" that" +
-	"# contains the output of this command. This allows reuse of binary artifacts" +
-	"# across other steps. If empty, no \"test-bin\" image will be created." +
-	"test_binary_build_commands: ' '" +
-	"# Tests describes the tests to run inside of built images." +
-	"# The images launched as pods but have no explicit access to" +
-	"# the cluster they are running on." +
-	"tests:" +
-	"  - # ArtifactDir is an optional directory that contains the" +
-	"    # artifacts to upload. If unset, this will default to" +
-	"    # \"/tmp/artifacts\"." +
-	"    artifact_dir: ' '" +
-	"    # As is the name of the test." +
-	"    as: ' '" +
-	"    # Commands are the shell commands to run in" +
-	"    # the repository root to execute tests." +
-	"    commands: ' '" +
-	"    # Only one of the following can be not-null." +
-	"    container:" +
-	"        # From is the image stream tag in the pipeline to run this" +
-	"        # command in." +
-	"        from: ' '" +
-	"        # MemoryBackedVolume mounts a volume of the specified size into" +
-	"        # the container at /tmp/volume." +
-	"        memory_backed_volume:" +
-	"            # Size is the requested size of the volume as a Kubernetes" +
-	"            # quantity, i.e. \"1Gi\" or \"500M\"" +
-	"            size: ' '" +
-	"    # Cron is how often the test is expected to run outside" +
-	"    # of pull request workflows. Setting this field will" +
-	"    # create a periodic job instead of a presubmit" +
-	"    cron: \"\"" +
-	"    literal_steps:" +
-	"        # AllowSkipOnSuccess defines if any steps can be skipped when" +
-	"        # all previous `pre` and `test` steps were successful. The given step must explicitly" +
-	"        # ask for being skipped by setting the OptionalOnSuccess flag to true." +
-	"        allow_skip_on_success: false" +
-	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
-	"        cluster_profile: ' '" +
-	"        # Dependencies holds override values for dependency parameters." +
-	"        dependencies:" +
-	"            \"\": \"\"" +
-	"        # Environment has the values of parameters for the steps." +
-	"        env:" +
-	"            \"\": \"\"" +
-	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
-	"        # Post steps always run, even if previous steps fail." +
-	"        post:" +
-	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"            active_deadline_seconds: 0" +
-	"            # ArtifactDir is the directory from which artifacts will be extracted" +
-	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"            artifact_dir: ' '" +
-	"            # As is the name of the LiteralTestStep." +
-	"            as: ' '" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            # Commands is the command(s) that will be run inside the image." +
-	"            commands: ' '" +
-	"            # Credentials defines the credentials we'll mount into this step." +
-	"            credentials:" +
-	"              - # MountPath is where the secret should be mounted." +
-	"                mount_path: ' '" +
-	"                # Names is which source secret to mount." +
-	"                name: ' '" +
-	"                # Namespace is where the source secret exists." +
-	"                namespace: ' '" +
-	"            # Dependencies lists images which must be available before the test runs" +
-	"            # and the environment variables which are used to expose their pull specs." +
-	"            dependencies:" +
-	"              - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                env: ' '" +
-	"                # Name is the tag or stream:tag that this dependency references" +
-	"                name: ' '" +
-	"            # Environment lists parameters that should be set by the test." +
-	"            env:" +
-	"              - # Default if not set, optional, makes the parameter not required if set." +
-	"                default: \"\"" +
-	"                # Documentation is a textual description of the parameter." +
-	"                documentation: ' '" +
-	"                # Name of the environment variable." +
-	"                name: ' '" +
-	"            # From is the container image that will be used for this step." +
-	"            from: ' '" +
-	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"            from_image:" +
-	"                # As is an optional string to use as the intermediate name for this reference." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            # OptionalOnSuccess defines if this step should be skipped as long" +
-	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"            # applicable to `post` steps." +
-	"            optional_on_success: false" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                limits:" +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    \"\": \"\"" +
-	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"            termination_grace_period_seconds: 0" +
-	"        # Pre is the array of test steps run to set up the environment for the test." +
-	"        pre:" +
-	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"            active_deadline_seconds: 0" +
-	"            # ArtifactDir is the directory from which artifacts will be extracted" +
-	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"            artifact_dir: ' '" +
-	"            # As is the name of the LiteralTestStep." +
-	"            as: ' '" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            # Commands is the command(s) that will be run inside the image." +
-	"            commands: ' '" +
-	"            # Credentials defines the credentials we'll mount into this step." +
-	"            credentials:" +
-	"              - # MountPath is where the secret should be mounted." +
-	"                mount_path: ' '" +
-	"                # Names is which source secret to mount." +
-	"                name: ' '" +
-	"                # Namespace is where the source secret exists." +
-	"                namespace: ' '" +
-	"            # Dependencies lists images which must be available before the test runs" +
-	"            # and the environment variables which are used to expose their pull specs." +
-	"            dependencies:" +
-	"              - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                env: ' '" +
-	"                # Name is the tag or stream:tag that this dependency references" +
-	"                name: ' '" +
-	"            # Environment lists parameters that should be set by the test." +
-	"            env:" +
-	"              - # Default if not set, optional, makes the parameter not required if set." +
-	"                default: \"\"" +
-	"                # Documentation is a textual description of the parameter." +
-	"                documentation: ' '" +
-	"                # Name of the environment variable." +
-	"                name: ' '" +
-	"            # From is the container image that will be used for this step." +
-	"            from: ' '" +
-	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"            from_image:" +
-	"                # As is an optional string to use as the intermediate name for this reference." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            # OptionalOnSuccess defines if this step should be skipped as long" +
-	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"            # applicable to `post` steps." +
-	"            optional_on_success: false" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                limits:" +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    \"\": \"\"" +
-	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"            termination_grace_period_seconds: 0" +
-	"        # Test is the array of test steps that define the actual test." +
-	"        test:" +
-	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod." +
-	"            active_deadline_seconds: 0" +
-	"            # ArtifactDir is the directory from which artifacts will be extracted" +
-	"            # when the command finishes. Defaults to \"/tmp/artifacts\"" +
-	"            artifact_dir: ' '" +
-	"            # As is the name of the LiteralTestStep." +
-	"            as: ' '" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            # Commands is the command(s) that will be run inside the image." +
-	"            commands: ' '" +
-	"            # Credentials defines the credentials we'll mount into this step." +
-	"            credentials:" +
-	"              - # MountPath is where the secret should be mounted." +
-	"                mount_path: ' '" +
-	"                # Names is which source secret to mount." +
-	"                name: ' '" +
-	"                # Namespace is where the source secret exists." +
-	"                namespace: ' '" +
-	"            # Dependencies lists images which must be available before the test runs" +
-	"            # and the environment variables which are used to expose their pull specs." +
-	"            dependencies:" +
-	"              - # Env is the environment variable that the image's pull spec is exposed with" +
-	"                env: ' '" +
-	"                # Name is the tag or stream:tag that this dependency references" +
-	"                name: ' '" +
-	"            # Environment lists parameters that should be set by the test." +
-	"            env:" +
-	"              - # Default if not set, optional, makes the parameter not required if set." +
-	"                default: \"\"" +
-	"                # Documentation is a textual description of the parameter." +
-	"                documentation: ' '" +
-	"                # Name of the environment variable." +
-	"                name: ' '" +
-	"            # From is the container image that will be used for this step." +
-	"            from: ' '" +
-	"            # FromImage is a literal ImageStreamTag reference to use for this step." +
-	"            from_image:" +
-	"                # As is an optional string to use as the intermediate name for this reference." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            # OptionalOnSuccess defines if this step should be skipped as long" +
-	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess" +
-	"            # flag is set to true in MultiStageTestConfiguration. This option is" +
-	"            # applicable to `post` steps." +
-	"            optional_on_success: false" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                limits:" +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    \"\": \"\"" +
-	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod." +
-	"            termination_grace_period_seconds: 0" +
-	"    openshift_ansible:" +
-	"        cluster_profile: ' '" +
-	"    openshift_ansible_40:" +
-	"        cluster_profile: ' '" +
-	"    openshift_ansible_custom:" +
-	"        cluster_profile: ' '" +
-	"    openshift_ansible_src:" +
-	"        cluster_profile: ' '" +
-	"    openshift_ansible_upgrade:" +
-	"        cluster_profile: ' '" +
-	"        previous_rpm_deps: ' '" +
-	"        previous_version: ' '" +
-	"    openshift_installer:" +
-	"        cluster_profile: ' '" +
-	"    openshift_installer_console:" +
-	"        cluster_profile: ' '" +
-	"    openshift_installer_custom_test_image:" +
-	"        cluster_profile: ' '" +
-	"        # From defines the imagestreamtag that will be used to run the" +
-	"        # provided test command. e.g. stable:console-test" +
-	"        from: ' '" +
-	"    openshift_installer_src:" +
-	"        cluster_profile: ' '" +
-	"    openshift_installer_upi:" +
-	"        cluster_profile: ' '" +
-	"    openshift_installer_upi_src:" +
-	"        cluster_profile: ' '" +
-	"    # Secret is an optional secret object which" +
-	"    # will be mounted inside the test container." +
-	"    # You cannot set the Secret and Secrets attributes" +
-	"    # at the same time." +
-	"    secret:" +
-	"        # Secret mount path. Defaults to /usr/test-secret" +
-	"        mount_path: ' '" +
-	"        # Secret name, used inside test containers" +
-	"        name: ' '" +
-	"    # Secrets is an optional array of secret objects" +
-	"    # which will be mounted inside the test container." +
-	"    # You cannot set the Secret and Secrets attributes" +
-	"    # at the same time." +
-	"    secrets:" +
-	"      - # Secret mount path. Defaults to /usr/test-secret" +
-	"        mount_path: ' '" +
-	"        # Secret name, used inside test containers" +
-	"        name: ' '" +
-	"    steps:" +
-	"        # AllowSkipOnSuccess defines if any steps can be skipped when" +
-	"        # all previous `pre` and `test` steps were successful. The given step must explicitly" +
-	"        # ask for being skipped by setting the OptionalOnSuccess flag to true." +
-	"        allow_skip_on_success: false" +
-	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps." +
-	"        cluster_profile: ' '" +
-	"        # Dependencies holds override values for dependency parameters." +
-	"        dependencies:" +
-	"            \"\": \"\"" +
-	"        # Environment has the values of parameters for the steps." +
-	"        env:" +
-	"            \"\": \"\"" +
-	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources." +
-	"        # Post steps always run, even if previous steps fail. However, they have an option to skip" +
-	"        # execution if previous Pre and Test steps passed." +
-	"        post:" +
-	"          # LiteralTestStep is a full test step definition." +
-	"          - active_deadline_seconds: 0" +
-	"            artifact_dir: ' '" +
-	"            as: ' '" +
-	"            # Chain is the name of a step chain reference." +
-	"            chain: \"\"" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            commands: ' '" +
-	"            credentials:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - mount_path: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"            dependencies:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - env: ' '" +
-	"                name: ' '" +
-	"            env:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - default: \"\"" +
-	"                documentation: ' '" +
-	"                name: ' '" +
-	"            from: ' '" +
-	"            from_image:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            optional_on_success: false" +
-	"            # Reference is the name of a step reference." +
-	"            ref: \"\"" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                limits:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"            termination_grace_period_seconds: 0" +
-	"        # Pre is the array of test steps run to set up the environment for the test." +
-	"        pre:" +
-	"          # LiteralTestStep is a full test step definition." +
-	"          - active_deadline_seconds: 0" +
-	"            artifact_dir: ' '" +
-	"            as: ' '" +
-	"            # Chain is the name of a step chain reference." +
-	"            chain: \"\"" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            commands: ' '" +
-	"            credentials:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - mount_path: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"            dependencies:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - env: ' '" +
-	"                name: ' '" +
-	"            env:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - default: \"\"" +
-	"                documentation: ' '" +
-	"                name: ' '" +
-	"            from: ' '" +
-	"            from_image:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            optional_on_success: false" +
-	"            # Reference is the name of a step reference." +
-	"            ref: \"\"" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                limits:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"            termination_grace_period_seconds: 0" +
-	"        # Test is the array of test steps that define the actual test." +
-	"        test:" +
-	"          # LiteralTestStep is a full test step definition." +
-	"          - active_deadline_seconds: 0" +
-	"            artifact_dir: ' '" +
-	"            as: ' '" +
-	"            # Chain is the name of a step chain reference." +
-	"            chain: \"\"" +
-	"            # Cli is the (optional) name of the release from which the `oc` binary" +
-	"            # will be injected into this step." +
-	"            cli: ' '" +
-	"            commands: ' '" +
-	"            credentials:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - mount_path: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"            dependencies:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - env: ' '" +
-	"                name: ' '" +
-	"            env:" +
-	"              # LiteralTestStep is a full test step definition." +
-	"              - default: \"\"" +
-	"                documentation: ' '" +
-	"                name: ' '" +
-	"            from: ' '" +
-	"            from_image:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                as: ' '" +
-	"                name: ' '" +
-	"                namespace: ' '" +
-	"                tag: ' '" +
-	"            optional_on_success: false" +
-	"            # Reference is the name of a step reference." +
-	"            ref: \"\"" +
-	"            # Resources defines the resource requirements for the step." +
-	"            resources:" +
-	"                # LiteralTestStep is a full test step definition." +
-	"                limits:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"                requests:" +
-	"                    # LiteralTestStep is a full test step definition." +
-	"                    \"\": \"\"" +
-	"            termination_grace_period_seconds: 0" +
-	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both" +
-	"        # the config and the workflow, the fields from the config will override what is set in Workflow." +
-	"        workflow: \"\"" +
-	"zz_generated_metadata:" +
-	"    branch: ' '" +
-	"    org: ' '" +
-	"    repo: ' '" +
-	"    variant: ' '" +
+const ciOperatorReferenceYaml = "# The list of base images describe\n" +
+	"# which images are going to be necessary outside\n" +
+	"# of the pipeline. The key will be the alias that other\n" +
+	"# steps use to refer to this image.\n" +
+	"base_images:\n" +
+	"    \"\":\n" +
+	"        # As is an optional string to use as the intermediate name for this reference.\n" +
+	"        as: ' '\n" +
+	"        name: ' '\n" +
+	"        namespace: ' '\n" +
+	"        tag: ' '\n" +
+	"# BaseRPMImages is a list of the images and their aliases that will\n" +
+	"# have RPM repositories injected into them for downstream\n" +
+	"# image builds that require built project RPMs.\n" +
+	"base_rpm_images:\n" +
+	"    \"\":\n" +
+	"        # As is an optional string to use as the intermediate name for this reference.\n" +
+	"        as: ' '\n" +
+	"        name: ' '\n" +
+	"        namespace: ' '\n" +
+	"        tag: ' '\n" +
+	"# BinaryBuildCommands will create a \"bin\" image based on \"src\" that\n" +
+	"# contains the output of this command. This allows reuse of binary artifacts\n" +
+	"# across other steps. If empty, no \"bin\" image will be created.\n" +
+	"binary_build_commands: ' '\n" +
+	"# BuildRootImage supports two ways to get the image that\n" +
+	"# the pipeline will caches on. The one way is to take the reference\n" +
+	"# from an image stream, and the other from a dockerfile.\n" +
+	"build_root:\n" +
+	"    image_stream_tag:\n" +
+	"        # As is an optional string to use as the intermediate name for this reference.\n" +
+	"        as: ' '\n" +
+	"        name: ' '\n" +
+	"        namespace: ' '\n" +
+	"        tag: ' '\n" +
+	"    project_image:\n" +
+	"        # ContextDir is the directory in the project\n" +
+	"        # from which this build should be run.\n" +
+	"        context_dir: ' '\n" +
+	"        # DockerfilePath is the path to a Dockerfile in the\n" +
+	"        # project to run relative to the context_dir.\n" +
+	"        dockerfile_path: ' '\n" +
+	"        # Inputs is a map of tag reference name to image input changes\n" +
+	"        # that will populate the build context for the Dockerfile or\n" +
+	"        # alter the input image for a multi-stage build.\n" +
+	"        inputs:\n" +
+	"            \"\":\n" +
+	"                # As is a list of multi-stage step names or image names that will\n" +
+	"                # be replaced by the image reference from this step. For instance,\n" +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying\n" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that\n" +
+	"                # image with the pipeline input.\n" +
+	"                as:\n" +
+	"                  - \"\"\n" +
+	"                # Paths is a list of paths to copy out of this image and into the\n" +
+	"                # context directory.\n" +
+	"                paths:\n" +
+	"                  - # DestinationDir is the directory in the destination image to copy\n" +
+	"                    # to.\n" +
+	"                    destination_dir: ' '\n" +
+	"                    # SourcePath is a file or directory in the source image to copy from.\n" +
+	"                    source_path: ' '\n" +
+	"# CanonicalGoRepository is a directory path that represents\n" +
+	"# the desired location of the contents of this repository in\n" +
+	"# Go. If specified the location of the repository we are\n" +
+	"# cloning from is ignored.\n" +
+	"canonical_go_repository: \"\"\n" +
+	"# Images describes the images that are built\n" +
+	"# baseImage the project as part of the release\n" +
+	"# process. The name of each image is its \"to\" value\n" +
+	"# and can be used to build only a specific image.\n" +
+	"images:\n" +
+	"  - # ContextDir is the directory in the project\n" +
+	"    # from which this build should be run.\n" +
+	"    context_dir: ' '\n" +
+	"    # DockerfilePath is the path to a Dockerfile in the\n" +
+	"    # project to run relative to the context_dir.\n" +
+	"    dockerfile_path: ' '\n" +
+	"    from: ' '\n" +
+	"    # Inputs is a map of tag reference name to image input changes\n" +
+	"    # that will populate the build context for the Dockerfile or\n" +
+	"    # alter the input image for a multi-stage build.\n" +
+	"    inputs:\n" +
+	"        \"\":\n" +
+	"            # As is a list of multi-stage step names or image names that will\n" +
+	"            # be replaced by the image reference from this step. For instance,\n" +
+	"            # if the Dockerfile defines FROM nginx:latest AS base, specifying\n" +
+	"            # either \"nginx:latest\" or \"base\" in this array will replace that\n" +
+	"            # image with the pipeline input.\n" +
+	"            as:\n" +
+	"              - \"\"\n" +
+	"            # Paths is a list of paths to copy out of this image and into the\n" +
+	"            # context directory.\n" +
+	"            paths:\n" +
+	"              - # DestinationDir is the directory in the destination image to copy\n" +
+	"                # to.\n" +
+	"                destination_dir: ' '\n" +
+	"                # SourcePath is a file or directory in the source image to copy from.\n" +
+	"                source_path: ' '\n" +
+	"    to: ' '\n" +
+	"# Operator describes the operator bundle(s) that is built by the project\n" +
+	"operator:\n" +
+	"    # Bundles define a dockerfile and build context to build a bundle\n" +
+	"    bundles:\n" +
+	"      - context_dir: ' '\n" +
+	"        dockerfile_path: ' '\n" +
+	"    # Substitutions describes the pullspecs in the operator manifests that must be subsituted\n" +
+	"    # with the pull specs of the images in the CI registry\n" +
+	"    substitutions:\n" +
+	"      - # PullSpec is the pullspec that needs to be replaced\n" +
+	"        pullspec: ' '\n" +
+	"        # With is the string that the PullSpec is being replaced by\n" +
+	"        with: ' '\n" +
+	"# PromotionConfiguration determines how images are promoted\n" +
+	"# by this command. It is ignored unless promotion has specifically\n" +
+	"# been requested. Promotion is performed after all other steps\n" +
+	"# have been completed so that tests can be run prior to promotion.\n" +
+	"# If no promotion is defined, it is defaulted from the ReleaseTagConfiguration.\n" +
+	"promotion:\n" +
+	"    # AdditionalImages is a mapping of images to promote. The\n" +
+	"    # images will be taken from the pipeline image stream. The\n" +
+	"    # key is the name to promote as and the value is the source\n" +
+	"    # name. If you specify a tag that does not exist as the source\n" +
+	"    # the destination tag will not be created.\n" +
+	"    additional_images:\n" +
+	"        \"\": \"\"\n" +
+	"    # ExcludedImages are image names that will not be promoted.\n" +
+	"    # Exclusions are made before additional_images are included.\n" +
+	"    # Use exclusions when you want to build images for testing\n" +
+	"    # but not promote them afterwards.\n" +
+	"    excluded_images:\n" +
+	"      - \"\"\n" +
+	"    # Name is an optional image stream name to use that\n" +
+	"    # contains all component tags. If specified, tag is\n" +
+	"    # ignored.\n" +
+	"    name: ' '\n" +
+	"    # NamePrefix is prepended to the final output image name\n" +
+	"    # if specified.\n" +
+	"    name_prefix: ' '\n" +
+	"    # Namespace identifies the namespace to which the built\n" +
+	"    # artifacts will be published to.\n" +
+	"    namespace: ' '\n" +
+	"    # Tag is the ImageStreamTag tagged in for each\n" +
+	"    # build image's ImageStream.\n" +
+	"    tag: ' '\n" +
+	"# RawSteps are literal Steps that should be\n" +
+	"# included in the final pipeline.\n" +
+	"raw_steps:\n" +
+	"  - bundle_source_step:\n" +
+	"        # Substitutions contains pullspecs that need to be replaced by images\n" +
+	"        # in the CI cluster for operator bundle images\n" +
+	"        substitutions:\n" +
+	"          - # PullSpec is the pullspec that needs to be replaced\n" +
+	"            pullspec: ' '\n" +
+	"            # With is the string that the PullSpec is being replaced by\n" +
+	"            with: ' '\n" +
+	"    index_generator_step:\n" +
+	"        # OperatorIndex is a list of the names of the bundle images that the\n" +
+	"        # index will contain in its database.\n" +
+	"        operator_index:\n" +
+	"          - \"\"\n" +
+	"        to: ' '\n" +
+	"    input_image_tag_step:\n" +
+	"        base_image:\n" +
+	"            # As is an optional string to use as the intermediate name for this reference.\n" +
+	"            as: ' '\n" +
+	"            name: ' '\n" +
+	"            namespace: ' '\n" +
+	"            tag: ' '\n" +
+	"        to: ' '\n" +
+	"    output_image_tag_step:\n" +
+	"        from: ' '\n" +
+	"        # Optional means the output step is not built, published, or\n" +
+	"        # promoted unless explicitly targeted. Use for builds which\n" +
+	"        # are invoked only when testing certain parts of the repo.\n" +
+	"        optional: false\n" +
+	"        to:\n" +
+	"            # As is an optional string to use as the intermediate name for this reference.\n" +
+	"            as: ' '\n" +
+	"            name: ' '\n" +
+	"            namespace: ' '\n" +
+	"            tag: ' '\n" +
+	"    pipeline_image_cache_step:\n" +
+	"        # Commands are the shell commands to run in\n" +
+	"        # the repository root to create the cached\n" +
+	"        # content.\n" +
+	"        commands: ' '\n" +
+	"        from: ' '\n" +
+	"        to: ' '\n" +
+	"    project_directory_image_build_inputs:\n" +
+	"        # ContextDir is the directory in the project\n" +
+	"        # from which this build should be run.\n" +
+	"        context_dir: ' '\n" +
+	"        # DockerfilePath is the path to a Dockerfile in the\n" +
+	"        # project to run relative to the context_dir.\n" +
+	"        dockerfile_path: ' '\n" +
+	"        # Inputs is a map of tag reference name to image input changes\n" +
+	"        # that will populate the build context for the Dockerfile or\n" +
+	"        # alter the input image for a multi-stage build.\n" +
+	"        inputs:\n" +
+	"            \"\":\n" +
+	"                # As is a list of multi-stage step names or image names that will\n" +
+	"                # be replaced by the image reference from this step. For instance,\n" +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying\n" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that\n" +
+	"                # image with the pipeline input.\n" +
+	"                as:\n" +
+	"                  - \"\"\n" +
+	"                # Paths is a list of paths to copy out of this image and into the\n" +
+	"                # context directory.\n" +
+	"                paths:\n" +
+	"                  - # DestinationDir is the directory in the destination image to copy\n" +
+	"                    # to.\n" +
+	"                    destination_dir: ' '\n" +
+	"                    # SourcePath is a file or directory in the source image to copy from.\n" +
+	"                    source_path: ' '\n" +
+	"    project_directory_image_build_step:\n" +
+	"        # ContextDir is the directory in the project\n" +
+	"        # from which this build should be run.\n" +
+	"        context_dir: ' '\n" +
+	"        # DockerfilePath is the path to a Dockerfile in the\n" +
+	"        # project to run relative to the context_dir.\n" +
+	"        dockerfile_path: ' '\n" +
+	"        from: ' '\n" +
+	"        # Inputs is a map of tag reference name to image input changes\n" +
+	"        # that will populate the build context for the Dockerfile or\n" +
+	"        # alter the input image for a multi-stage build.\n" +
+	"        inputs:\n" +
+	"            \"\":\n" +
+	"                # As is a list of multi-stage step names or image names that will\n" +
+	"                # be replaced by the image reference from this step. For instance,\n" +
+	"                # if the Dockerfile defines FROM nginx:latest AS base, specifying\n" +
+	"                # either \"nginx:latest\" or \"base\" in this array will replace that\n" +
+	"                # image with the pipeline input.\n" +
+	"                as:\n" +
+	"                  - \"\"\n" +
+	"                # Paths is a list of paths to copy out of this image and into the\n" +
+	"                # context directory.\n" +
+	"                paths:\n" +
+	"                  - # DestinationDir is the directory in the destination image to copy\n" +
+	"                    # to.\n" +
+	"                    destination_dir: ' '\n" +
+	"                    # SourcePath is a file or directory in the source image to copy from.\n" +
+	"                    source_path: ' '\n" +
+	"        to: ' '\n" +
+	"    release_images_tag_step:\n" +
+	"        # Name is the image stream name to use that contains all\n" +
+	"        # component tags.\n" +
+	"        name: ' '\n" +
+	"        # NamePrefix is prepended to the final output image name\n" +
+	"        # if specified.\n" +
+	"        name_prefix: ' '\n" +
+	"        # Namespace identifies the namespace from which\n" +
+	"        # all release artifacts not built in the current\n" +
+	"        # job are tagged from.\n" +
+	"        namespace: ' '\n" +
+	"    resolved_release_images_step:\n" +
+	"        candidate:\n" +
+	"            architecture: ' '\n" +
+	"            product: ' '\n" +
+	"            stream: ' '\n" +
+	"            version: ' '\n" +
+	"        name: ' '\n" +
+	"        prerelease:\n" +
+	"            architecture: ' '\n" +
+	"            product: ' '\n" +
+	"            version_bounds:\n" +
+	"                lower: ' '\n" +
+	"                upper: ' '\n" +
+	"        release:\n" +
+	"            architecture: ' '\n" +
+	"            channel: ' '\n" +
+	"            version: ' '\n" +
+	"    rpm_image_injection_step:\n" +
+	"        from: ' '\n" +
+	"        to: ' '\n" +
+	"    rpm_serve_step:\n" +
+	"        from: ' '\n" +
+	"    source_step:\n" +
+	"        # ClonerefsImage is the image where we get the clonerefs tool\n" +
+	"        clonerefs_image:\n" +
+	"            # As is an optional string to use as the intermediate name for this reference.\n" +
+	"            as: ' '\n" +
+	"            name: ' '\n" +
+	"            namespace: ' '\n" +
+	"            tag: ' '\n" +
+	"        # ClonerefsPath is the path in the above image where the\n" +
+	"        # clonerefs tool is placed\n" +
+	"        clonerefs_path: ' '\n" +
+	"        from: ' '\n" +
+	"        to: ' '\n" +
+	"    test_step:\n" +
+	"        # ArtifactDir is an optional directory that contains the\n" +
+	"        # artifacts to upload. If unset, this will default to\n" +
+	"        # \"/tmp/artifacts\".\n" +
+	"        artifact_dir: ' '\n" +
+	"        # As is the name of the test.\n" +
+	"        as: ' '\n" +
+	"        # Commands are the shell commands to run in\n" +
+	"        # the repository root to execute tests.\n" +
+	"        commands: ' '\n" +
+	"        # Only one of the following can be not-null.\n" +
+	"        container:\n" +
+	"            # From is the image stream tag in the pipeline to run this\n" +
+	"            # command in.\n" +
+	"            from: ' '\n" +
+	"            # MemoryBackedVolume mounts a volume of the specified size into\n" +
+	"            # the container at /tmp/volume.\n" +
+	"            memory_backed_volume:\n" +
+	"                # Size is the requested size of the volume as a Kubernetes\n" +
+	"                # quantity, i.e. \"1Gi\" or \"500M\"\n" +
+	"                size: ' '\n" +
+	"        # Cron is how often the test is expected to run outside\n" +
+	"        # of pull request workflows. Setting this field will\n" +
+	"        # create a periodic job instead of a presubmit\n" +
+	"        cron: \"\"\n" +
+	"        literal_steps:\n" +
+	"            # AllowSkipOnSuccess defines if any steps can be skipped when\n" +
+	"            # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
+	"            # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
+	"            allow_skip_on_success: false\n" +
+	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps.\n" +
+	"            cluster_profile: ' '\n" +
+	"            # Dependencies holds override values for dependency parameters.\n" +
+	"            dependencies:\n" +
+	"                \"\": \"\"\n" +
+	"            # Environment has the values of parameters for the steps.\n" +
+	"            env:\n" +
+	"                \"\": \"\"\n" +
+	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
+	"            # Post steps always run, even if previous steps fail.\n" +
+	"            post:\n" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                active_deadline_seconds: 0\n" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"                artifact_dir: ' '\n" +
+	"                # As is the name of the LiteralTestStep.\n" +
+	"                as: ' '\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                # Commands is the command(s) that will be run inside the image.\n" +
+	"                commands: ' '\n" +
+	"                # Credentials defines the credentials we'll mount into this step.\n" +
+	"                credentials:\n" +
+	"                  - # MountPath is where the secret should be mounted.\n" +
+	"                    mount_path: ' '\n" +
+	"                    # Names is which source secret to mount.\n" +
+	"                    name: ' '\n" +
+	"                    # Namespace is where the source secret exists.\n" +
+	"                    namespace: ' '\n" +
+	"                # Dependencies lists images which must be available before the test runs\n" +
+	"                # and the environment variables which are used to expose their pull specs.\n" +
+	"                dependencies:\n" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                    env: ' '\n" +
+	"                    # Name is the tag or stream:tag that this dependency references\n" +
+	"                    name: ' '\n" +
+	"                # Environment lists parameters that should be set by the test.\n" +
+	"                env:\n" +
+	"                  - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                    default: \"\"\n" +
+	"                    # Documentation is a textual description of the parameter.\n" +
+	"                    documentation: ' '\n" +
+	"                    # Name of the environment variable.\n" +
+	"                    name: ' '\n" +
+	"                # From is the container image that will be used for this step.\n" +
+	"                from: ' '\n" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"                from_image:\n" +
+	"                    # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"                # applicable to `post` steps.\n" +
+	"                optional_on_success: false\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    limits:\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        \"\": \"\"\n" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
+	"            pre:\n" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                active_deadline_seconds: 0\n" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"                artifact_dir: ' '\n" +
+	"                # As is the name of the LiteralTestStep.\n" +
+	"                as: ' '\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                # Commands is the command(s) that will be run inside the image.\n" +
+	"                commands: ' '\n" +
+	"                # Credentials defines the credentials we'll mount into this step.\n" +
+	"                credentials:\n" +
+	"                  - # MountPath is where the secret should be mounted.\n" +
+	"                    mount_path: ' '\n" +
+	"                    # Names is which source secret to mount.\n" +
+	"                    name: ' '\n" +
+	"                    # Namespace is where the source secret exists.\n" +
+	"                    namespace: ' '\n" +
+	"                # Dependencies lists images which must be available before the test runs\n" +
+	"                # and the environment variables which are used to expose their pull specs.\n" +
+	"                dependencies:\n" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                    env: ' '\n" +
+	"                    # Name is the tag or stream:tag that this dependency references\n" +
+	"                    name: ' '\n" +
+	"                # Environment lists parameters that should be set by the test.\n" +
+	"                env:\n" +
+	"                  - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                    default: \"\"\n" +
+	"                    # Documentation is a textual description of the parameter.\n" +
+	"                    documentation: ' '\n" +
+	"                    # Name of the environment variable.\n" +
+	"                    name: ' '\n" +
+	"                # From is the container image that will be used for this step.\n" +
+	"                from: ' '\n" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"                from_image:\n" +
+	"                    # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"                # applicable to `post` steps.\n" +
+	"                optional_on_success: false\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    limits:\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        \"\": \"\"\n" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"            # Test is the array of test steps that define the actual test.\n" +
+	"            test:\n" +
+	"              - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                active_deadline_seconds: 0\n" +
+	"                # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"                artifact_dir: ' '\n" +
+	"                # As is the name of the LiteralTestStep.\n" +
+	"                as: ' '\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                # Commands is the command(s) that will be run inside the image.\n" +
+	"                commands: ' '\n" +
+	"                # Credentials defines the credentials we'll mount into this step.\n" +
+	"                credentials:\n" +
+	"                  - # MountPath is where the secret should be mounted.\n" +
+	"                    mount_path: ' '\n" +
+	"                    # Names is which source secret to mount.\n" +
+	"                    name: ' '\n" +
+	"                    # Namespace is where the source secret exists.\n" +
+	"                    namespace: ' '\n" +
+	"                # Dependencies lists images which must be available before the test runs\n" +
+	"                # and the environment variables which are used to expose their pull specs.\n" +
+	"                dependencies:\n" +
+	"                  - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                    env: ' '\n" +
+	"                    # Name is the tag or stream:tag that this dependency references\n" +
+	"                    name: ' '\n" +
+	"                # Environment lists parameters that should be set by the test.\n" +
+	"                env:\n" +
+	"                  - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                    default: \"\"\n" +
+	"                    # Documentation is a textual description of the parameter.\n" +
+	"                    documentation: ' '\n" +
+	"                    # Name of the environment variable.\n" +
+	"                    name: ' '\n" +
+	"                # From is the container image that will be used for this step.\n" +
+	"                from: ' '\n" +
+	"                # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"                from_image:\n" +
+	"                    # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"                # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"                # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"                # applicable to `post` steps.\n" +
+	"                optional_on_success: false\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    limits:\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        \"\": \"\"\n" +
+	"                # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"        openshift_ansible:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_ansible_40:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_ansible_custom:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_ansible_src:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_ansible_upgrade:\n" +
+	"            cluster_profile: ' '\n" +
+	"            previous_rpm_deps: ' '\n" +
+	"            previous_version: ' '\n" +
+	"        openshift_installer:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_installer_console:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_installer_custom_test_image:\n" +
+	"            cluster_profile: ' '\n" +
+	"            # From defines the imagestreamtag that will be used to run the\n" +
+	"            # provided test command. e.g. stable:console-test\n" +
+	"            from: ' '\n" +
+	"        openshift_installer_src:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_installer_upi:\n" +
+	"            cluster_profile: ' '\n" +
+	"        openshift_installer_upi_src:\n" +
+	"            cluster_profile: ' '\n" +
+	"        # Secret is an optional secret object which\n" +
+	"        # will be mounted inside the test container.\n" +
+	"        # You cannot set the Secret and Secrets attributes\n" +
+	"        # at the same time.\n" +
+	"        secret:\n" +
+	"            # Secret mount path. Defaults to /usr/test-secret\n" +
+	"            mount_path: ' '\n" +
+	"            # Secret name, used inside test containers\n" +
+	"            name: ' '\n" +
+	"        # Secrets is an optional array of secret objects\n" +
+	"        # which will be mounted inside the test container.\n" +
+	"        # You cannot set the Secret and Secrets attributes\n" +
+	"        # at the same time.\n" +
+	"        secrets:\n" +
+	"          - # Secret mount path. Defaults to /usr/test-secret\n" +
+	"            mount_path: ' '\n" +
+	"            # Secret name, used inside test containers\n" +
+	"            name: ' '\n" +
+	"        steps:\n" +
+	"            # AllowSkipOnSuccess defines if any steps can be skipped when\n" +
+	"            # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
+	"            # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
+	"            allow_skip_on_success: false\n" +
+	"            # ClusterProfile defines the profile/cloud provider for end-to-end test steps.\n" +
+	"            cluster_profile: ' '\n" +
+	"            # Dependencies holds override values for dependency parameters.\n" +
+	"            dependencies:\n" +
+	"                \"\": \"\"\n" +
+	"            # Environment has the values of parameters for the steps.\n" +
+	"            env:\n" +
+	"                \"\": \"\"\n" +
+	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
+	"            # Post steps always run, even if previous steps fail. However, they have an option to skip\n" +
+	"            # execution if previous Pre and Test steps passed.\n" +
+	"            post:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - active_deadline_seconds: 0\n" +
+	"                artifact_dir: ' '\n" +
+	"                as: ' '\n" +
+	"                # Chain is the name of a step chain reference.\n" +
+	"                chain: \"\"\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                commands: ' '\n" +
+	"                credentials:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - mount_path: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                dependencies:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - env: ' '\n" +
+	"                    name: ' '\n" +
+	"                env:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - default: \"\"\n" +
+	"                    documentation: ' '\n" +
+	"                    name: ' '\n" +
+	"                from: ' '\n" +
+	"                from_image:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                optional_on_success: false\n" +
+	"                # Reference is the name of a step reference.\n" +
+	"                ref: \"\"\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    limits:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
+	"            pre:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - active_deadline_seconds: 0\n" +
+	"                artifact_dir: ' '\n" +
+	"                as: ' '\n" +
+	"                # Chain is the name of a step chain reference.\n" +
+	"                chain: \"\"\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                commands: ' '\n" +
+	"                credentials:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - mount_path: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                dependencies:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - env: ' '\n" +
+	"                    name: ' '\n" +
+	"                env:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - default: \"\"\n" +
+	"                    documentation: ' '\n" +
+	"                    name: ' '\n" +
+	"                from: ' '\n" +
+	"                from_image:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                optional_on_success: false\n" +
+	"                # Reference is the name of a step reference.\n" +
+	"                ref: \"\"\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    limits:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"            # Test is the array of test steps that define the actual test.\n" +
+	"            test:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - active_deadline_seconds: 0\n" +
+	"                artifact_dir: ' '\n" +
+	"                as: ' '\n" +
+	"                # Chain is the name of a step chain reference.\n" +
+	"                chain: \"\"\n" +
+	"                # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"                # will be injected into this step.\n" +
+	"                cli: ' '\n" +
+	"                commands: ' '\n" +
+	"                credentials:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - mount_path: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                dependencies:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - env: ' '\n" +
+	"                    name: ' '\n" +
+	"                env:\n" +
+	"                  # LiteralTestStep is a full test step definition.\n" +
+	"                  - default: \"\"\n" +
+	"                    documentation: ' '\n" +
+	"                    name: ' '\n" +
+	"                from: ' '\n" +
+	"                from_image:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    as: ' '\n" +
+	"                    name: ' '\n" +
+	"                    namespace: ' '\n" +
+	"                    tag: ' '\n" +
+	"                optional_on_success: false\n" +
+	"                # Reference is the name of a step reference.\n" +
+	"                ref: \"\"\n" +
+	"                # Resources defines the resource requirements for the step.\n" +
+	"                resources:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    limits:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                    requests:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        \"\": \"\"\n" +
+	"                termination_grace_period_seconds: 0\n" +
+	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
+	"            # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
+	"            workflow: \"\"\n" +
+	"# Releases maps semantic release payload identifiers\n" +
+	"# to the names that they will be exposed under. For\n" +
+	"# instance, an 'initial' name will be exposed as\n" +
+	"# $RELEASE_IMAGE_INITIAL. The 'latest' key is special\n" +
+	"# and cannot co-exist with 'tag_specification', as\n" +
+	"# they result in the same output.\n" +
+	"releases:\n" +
+	"    \"\":\n" +
+	"        # Candidate describes a candidate release payload\n" +
+	"        candidate:\n" +
+	"            # Architecture is the architecture for the product.\n" +
+	"            # Defaults to amd64.\n" +
+	"            architecture: ' '\n" +
+	"            # Product is the name of the product being released\n" +
+	"            product: ' '\n" +
+	"            # ReleaseStream is the stream from which we pick the latest candidate\n" +
+	"            stream: ' '\n" +
+	"            # Version is the minor version to search for\n" +
+	"            version: ' '\n" +
+	"        # Prerelease describes a yet-to-be released payload\n" +
+	"        prerelease:\n" +
+	"            # Architecture is the architecture for the product.\n" +
+	"            # Defaults to amd64.\n" +
+	"            architecture: ' '\n" +
+	"            # Product is the name of the product being released\n" +
+	"            product: ' '\n" +
+	"            # VersionBounds describe the allowable version bounds to search in\n" +
+	"            version_bounds:\n" +
+	"                lower: ' '\n" +
+	"                upper: ' '\n" +
+	"        # Release describes a released payload\n" +
+	"        release:\n" +
+	"            # Architecture is the architecture for the release.\n" +
+	"            # Defaults to amd64.\n" +
+	"            architecture: ' '\n" +
+	"            # Channel is the release channel to search in\n" +
+	"            channel: ' '\n" +
+	"            # Version is the minor version to search for\n" +
+	"            version: ' '\n" +
+	"# Resources is a set of resource requests or limits over the\n" +
+	"# input types. The special name '*' may be used to set default\n" +
+	"# requests and limits.\n" +
+	"resources:\n" +
+	"    \"\":\n" +
+	"        limits:\n" +
+	"            \"\": \"\"\n" +
+	"        requests:\n" +
+	"            \"\": \"\"\n" +
+	"# RpmBuildCommands will create an \"rpms\" image from \"bin\" (or \"src\", if no\n" +
+	"# binary build commands were specified) that contains the output of this\n" +
+	"# command. The created RPMs will then be served via HTTP to the \"base\" image\n" +
+	"# via an injected rpm.repo in the standard location at /etc/yum.repos.d.\n" +
+	"rpm_build_commands: ' '\n" +
+	"# RpmBuildLocation is where RPms are deposited after being built. If\n" +
+	"# unset, this will default under the repository root to\n" +
+	"# _output/local/releases/rpms/.\n" +
+	"rpm_build_location: ' '\n" +
+	"# ReleaseTagConfiguration determines how the\n" +
+	"# full release is assembled.\n" +
+	"tag_specification:\n" +
+	"    # Name is the image stream name to use that contains all\n" +
+	"    # component tags.\n" +
+	"    name: ' '\n" +
+	"    # NamePrefix is prepended to the final output image name\n" +
+	"    # if specified.\n" +
+	"    name_prefix: ' '\n" +
+	"    # Namespace identifies the namespace from which\n" +
+	"    # all release artifacts not built in the current\n" +
+	"    # job are tagged from.\n" +
+	"    namespace: ' '\n" +
+	"# TestBinaryBuildCommands will create a \"test-bin\" image based on \"src\" that\n" +
+	"# contains the output of this command. This allows reuse of binary artifacts\n" +
+	"# across other steps. If empty, no \"test-bin\" image will be created.\n" +
+	"test_binary_build_commands: ' '\n" +
+	"# Tests describes the tests to run inside of built images.\n" +
+	"# The images launched as pods but have no explicit access to\n" +
+	"# the cluster they are running on.\n" +
+	"tests:\n" +
+	"  - # ArtifactDir is an optional directory that contains the\n" +
+	"    # artifacts to upload. If unset, this will default to\n" +
+	"    # \"/tmp/artifacts\".\n" +
+	"    artifact_dir: ' '\n" +
+	"    # As is the name of the test.\n" +
+	"    as: ' '\n" +
+	"    # Commands are the shell commands to run in\n" +
+	"    # the repository root to execute tests.\n" +
+	"    commands: ' '\n" +
+	"    # Only one of the following can be not-null.\n" +
+	"    container:\n" +
+	"        # From is the image stream tag in the pipeline to run this\n" +
+	"        # command in.\n" +
+	"        from: ' '\n" +
+	"        # MemoryBackedVolume mounts a volume of the specified size into\n" +
+	"        # the container at /tmp/volume.\n" +
+	"        memory_backed_volume:\n" +
+	"            # Size is the requested size of the volume as a Kubernetes\n" +
+	"            # quantity, i.e. \"1Gi\" or \"500M\"\n" +
+	"            size: ' '\n" +
+	"    # Cron is how often the test is expected to run outside\n" +
+	"    # of pull request workflows. Setting this field will\n" +
+	"    # create a periodic job instead of a presubmit\n" +
+	"    cron: \"\"\n" +
+	"    literal_steps:\n" +
+	"        # AllowSkipOnSuccess defines if any steps can be skipped when\n" +
+	"        # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
+	"        # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
+	"        allow_skip_on_success: false\n" +
+	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps.\n" +
+	"        cluster_profile: ' '\n" +
+	"        # Dependencies holds override values for dependency parameters.\n" +
+	"        dependencies:\n" +
+	"            \"\": \"\"\n" +
+	"        # Environment has the values of parameters for the steps.\n" +
+	"        env:\n" +
+	"            \"\": \"\"\n" +
+	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
+	"        # Post steps always run, even if previous steps fail.\n" +
+	"        post:\n" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"            active_deadline_seconds: 0\n" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"            artifact_dir: ' '\n" +
+	"            # As is the name of the LiteralTestStep.\n" +
+	"            as: ' '\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            # Commands is the command(s) that will be run inside the image.\n" +
+	"            commands: ' '\n" +
+	"            # Credentials defines the credentials we'll mount into this step.\n" +
+	"            credentials:\n" +
+	"              - # MountPath is where the secret should be mounted.\n" +
+	"                mount_path: ' '\n" +
+	"                # Names is which source secret to mount.\n" +
+	"                name: ' '\n" +
+	"                # Namespace is where the source secret exists.\n" +
+	"                namespace: ' '\n" +
+	"            # Dependencies lists images which must be available before the test runs\n" +
+	"            # and the environment variables which are used to expose their pull specs.\n" +
+	"            dependencies:\n" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                env: ' '\n" +
+	"                # Name is the tag or stream:tag that this dependency references\n" +
+	"                name: ' '\n" +
+	"            # Environment lists parameters that should be set by the test.\n" +
+	"            env:\n" +
+	"              - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                default: \"\"\n" +
+	"                # Documentation is a textual description of the parameter.\n" +
+	"                documentation: ' '\n" +
+	"                # Name of the environment variable.\n" +
+	"                name: ' '\n" +
+	"            # From is the container image that will be used for this step.\n" +
+	"            from: ' '\n" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"            from_image:\n" +
+	"                # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"            # applicable to `post` steps.\n" +
+	"            optional_on_success: false\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                limits:\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    \"\": \"\"\n" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
+	"        pre:\n" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"            active_deadline_seconds: 0\n" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"            artifact_dir: ' '\n" +
+	"            # As is the name of the LiteralTestStep.\n" +
+	"            as: ' '\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            # Commands is the command(s) that will be run inside the image.\n" +
+	"            commands: ' '\n" +
+	"            # Credentials defines the credentials we'll mount into this step.\n" +
+	"            credentials:\n" +
+	"              - # MountPath is where the secret should be mounted.\n" +
+	"                mount_path: ' '\n" +
+	"                # Names is which source secret to mount.\n" +
+	"                name: ' '\n" +
+	"                # Namespace is where the source secret exists.\n" +
+	"                namespace: ' '\n" +
+	"            # Dependencies lists images which must be available before the test runs\n" +
+	"            # and the environment variables which are used to expose their pull specs.\n" +
+	"            dependencies:\n" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                env: ' '\n" +
+	"                # Name is the tag or stream:tag that this dependency references\n" +
+	"                name: ' '\n" +
+	"            # Environment lists parameters that should be set by the test.\n" +
+	"            env:\n" +
+	"              - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                default: \"\"\n" +
+	"                # Documentation is a textual description of the parameter.\n" +
+	"                documentation: ' '\n" +
+	"                # Name of the environment variable.\n" +
+	"                name: ' '\n" +
+	"            # From is the container image that will be used for this step.\n" +
+	"            from: ' '\n" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"            from_image:\n" +
+	"                # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"            # applicable to `post` steps.\n" +
+	"            optional_on_success: false\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                limits:\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    \"\": \"\"\n" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"        # Test is the array of test steps that define the actual test.\n" +
+	"        test:\n" +
+	"          - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"            active_deadline_seconds: 0\n" +
+	"            # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
+	"            artifact_dir: ' '\n" +
+	"            # As is the name of the LiteralTestStep.\n" +
+	"            as: ' '\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            # Commands is the command(s) that will be run inside the image.\n" +
+	"            commands: ' '\n" +
+	"            # Credentials defines the credentials we'll mount into this step.\n" +
+	"            credentials:\n" +
+	"              - # MountPath is where the secret should be mounted.\n" +
+	"                mount_path: ' '\n" +
+	"                # Names is which source secret to mount.\n" +
+	"                name: ' '\n" +
+	"                # Namespace is where the source secret exists.\n" +
+	"                namespace: ' '\n" +
+	"            # Dependencies lists images which must be available before the test runs\n" +
+	"            # and the environment variables which are used to expose their pull specs.\n" +
+	"            dependencies:\n" +
+	"              - # Env is the environment variable that the image's pull spec is exposed with\n" +
+	"                env: ' '\n" +
+	"                # Name is the tag or stream:tag that this dependency references\n" +
+	"                name: ' '\n" +
+	"            # Environment lists parameters that should be set by the test.\n" +
+	"            env:\n" +
+	"              - # Default if not set, optional, makes the parameter not required if set.\n" +
+	"                default: \"\"\n" +
+	"                # Documentation is a textual description of the parameter.\n" +
+	"                documentation: ' '\n" +
+	"                # Name of the environment variable.\n" +
+	"                name: ' '\n" +
+	"            # From is the container image that will be used for this step.\n" +
+	"            from: ' '\n" +
+	"            # FromImage is a literal ImageStreamTag reference to use for this step.\n" +
+	"            from_image:\n" +
+	"                # As is an optional string to use as the intermediate name for this reference.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            # OptionalOnSuccess defines if this step should be skipped as long\n" +
+	"            # as all `pre` and `test` steps were successful and AllowSkipOnSuccess\n" +
+	"            # flag is set to true in MultiStageTestConfiguration. This option is\n" +
+	"            # applicable to `post` steps.\n" +
+	"            optional_on_success: false\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                limits:\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    \"\": \"\"\n" +
+	"            # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"    openshift_ansible:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_ansible_40:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_ansible_custom:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_ansible_src:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_ansible_upgrade:\n" +
+	"        cluster_profile: ' '\n" +
+	"        previous_rpm_deps: ' '\n" +
+	"        previous_version: ' '\n" +
+	"    openshift_installer:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_installer_console:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_installer_custom_test_image:\n" +
+	"        cluster_profile: ' '\n" +
+	"        # From defines the imagestreamtag that will be used to run the\n" +
+	"        # provided test command. e.g. stable:console-test\n" +
+	"        from: ' '\n" +
+	"    openshift_installer_src:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_installer_upi:\n" +
+	"        cluster_profile: ' '\n" +
+	"    openshift_installer_upi_src:\n" +
+	"        cluster_profile: ' '\n" +
+	"    # Secret is an optional secret object which\n" +
+	"    # will be mounted inside the test container.\n" +
+	"    # You cannot set the Secret and Secrets attributes\n" +
+	"    # at the same time.\n" +
+	"    secret:\n" +
+	"        # Secret mount path. Defaults to /usr/test-secret\n" +
+	"        mount_path: ' '\n" +
+	"        # Secret name, used inside test containers\n" +
+	"        name: ' '\n" +
+	"    # Secrets is an optional array of secret objects\n" +
+	"    # which will be mounted inside the test container.\n" +
+	"    # You cannot set the Secret and Secrets attributes\n" +
+	"    # at the same time.\n" +
+	"    secrets:\n" +
+	"      - # Secret mount path. Defaults to /usr/test-secret\n" +
+	"        mount_path: ' '\n" +
+	"        # Secret name, used inside test containers\n" +
+	"        name: ' '\n" +
+	"    steps:\n" +
+	"        # AllowSkipOnSuccess defines if any steps can be skipped when\n" +
+	"        # all previous `pre` and `test` steps were successful. The given step must explicitly\n" +
+	"        # ask for being skipped by setting the OptionalOnSuccess flag to true.\n" +
+	"        allow_skip_on_success: false\n" +
+	"        # ClusterProfile defines the profile/cloud provider for end-to-end test steps.\n" +
+	"        cluster_profile: ' '\n" +
+	"        # Dependencies holds override values for dependency parameters.\n" +
+	"        dependencies:\n" +
+	"            \"\": \"\"\n" +
+	"        # Environment has the values of parameters for the steps.\n" +
+	"        env:\n" +
+	"            \"\": \"\"\n" +
+	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
+	"        # Post steps always run, even if previous steps fail. However, they have an option to skip\n" +
+	"        # execution if previous Pre and Test steps passed.\n" +
+	"        post:\n" +
+	"          # LiteralTestStep is a full test step definition.\n" +
+	"          - active_deadline_seconds: 0\n" +
+	"            artifact_dir: ' '\n" +
+	"            as: ' '\n" +
+	"            # Chain is the name of a step chain reference.\n" +
+	"            chain: \"\"\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            commands: ' '\n" +
+	"            credentials:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - mount_path: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"            dependencies:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - env: ' '\n" +
+	"                name: ' '\n" +
+	"            env:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - default: \"\"\n" +
+	"                documentation: ' '\n" +
+	"                name: ' '\n" +
+	"            from: ' '\n" +
+	"            from_image:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            optional_on_success: false\n" +
+	"            # Reference is the name of a step reference.\n" +
+	"            ref: \"\"\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                limits:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
+	"        pre:\n" +
+	"          # LiteralTestStep is a full test step definition.\n" +
+	"          - active_deadline_seconds: 0\n" +
+	"            artifact_dir: ' '\n" +
+	"            as: ' '\n" +
+	"            # Chain is the name of a step chain reference.\n" +
+	"            chain: \"\"\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            commands: ' '\n" +
+	"            credentials:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - mount_path: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"            dependencies:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - env: ' '\n" +
+	"                name: ' '\n" +
+	"            env:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - default: \"\"\n" +
+	"                documentation: ' '\n" +
+	"                name: ' '\n" +
+	"            from: ' '\n" +
+	"            from_image:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            optional_on_success: false\n" +
+	"            # Reference is the name of a step reference.\n" +
+	"            ref: \"\"\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                limits:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"        # Test is the array of test steps that define the actual test.\n" +
+	"        test:\n" +
+	"          # LiteralTestStep is a full test step definition.\n" +
+	"          - active_deadline_seconds: 0\n" +
+	"            artifact_dir: ' '\n" +
+	"            as: ' '\n" +
+	"            # Chain is the name of a step chain reference.\n" +
+	"            chain: \"\"\n" +
+	"            # Cli is the (optional) name of the release from which the `oc` binary\n" +
+	"            # will be injected into this step.\n" +
+	"            cli: ' '\n" +
+	"            commands: ' '\n" +
+	"            credentials:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - mount_path: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"            dependencies:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - env: ' '\n" +
+	"                name: ' '\n" +
+	"            env:\n" +
+	"              # LiteralTestStep is a full test step definition.\n" +
+	"              - default: \"\"\n" +
+	"                documentation: ' '\n" +
+	"                name: ' '\n" +
+	"            from: ' '\n" +
+	"            from_image:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                as: ' '\n" +
+	"                name: ' '\n" +
+	"                namespace: ' '\n" +
+	"                tag: ' '\n" +
+	"            optional_on_success: false\n" +
+	"            # Reference is the name of a step reference.\n" +
+	"            ref: \"\"\n" +
+	"            # Resources defines the resource requirements for the step.\n" +
+	"            resources:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                limits:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"                requests:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    \"\": \"\"\n" +
+	"            termination_grace_period_seconds: 0\n" +
+	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
+	"        # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
+	"        workflow: \"\"\n" +
+	"zz_generated_metadata:\n" +
+	"    branch: ' '\n" +
+	"    org: ' '\n" +
+	"    repo: ' '\n" +
+	"    variant: ' '\n" +
 	""

--- a/vendor/k8s.io/test-infra/pkg/genyaml/BUILD.bazel
+++ b/vendor/k8s.io/test-infra/pkg/genyaml/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["genyaml.go"],
+    srcs = [
+        "genyaml.go",
+        "populate_struct.go",
+    ],
     data = ["//prow/plugins:config-src"],
     importpath = "k8s.io/test-infra/pkg/genyaml",
     visibility = ["//visibility:public"],
@@ -15,7 +18,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["genyaml_test.go"],
+    srcs = [
+        "genyaml_test.go",
+        "populate_struct_test.go",
+    ],
     data = [":test-data"],
     embed = [":go_default_library"],
     deps = [

--- a/vendor/k8s.io/test-infra/pkg/genyaml/README.md
+++ b/vendor/k8s.io/test-infra/pkg/genyaml/README.md
@@ -1,7 +1,7 @@
 # Genyaml
 
 ## Description
-`genyaml` is a simple documentation tool used to marshal YAML from Golang structs. It extracts *doc comments* from `.go` sources files and adds them as *comment nodes* in the YAML output. 
+`genyaml` is a simple documentation tool used to marshal YAML from Golang structs. It extracts *doc comments* from `.go` sources files and adds them as *comment nodes* in the YAML output.
 
 ## Usage
 
@@ -75,8 +75,8 @@ All subsequent lines and blocks after a `---` will be ignored.
 ```go
 type Person struct {
 	// Name of person
-	// --- 
-	// The name of the person is both the first and last name separated 
+	// ---
+	// The name of the person is both the first and last name separated
 	// by a space character
 	Name string
 }
@@ -133,7 +133,7 @@ type Plugin struct {
 //...
 ```
 
-Next, in a separate `example.go` file, initialize a `Configuration` struct and marshal it to *commented* YAML. 
+Next, in a separate `example.go` file, initialize a `Configuration` struct and marshal it to *commented* YAML.
 
 ```go
 // example.go
@@ -157,7 +157,7 @@ config := &example.Configuration{
 }
 
 // Initialize a CommentMap instance from the `config.go` source file:
-cm := genyaml.NewCommentMap("config.go")
+cm, err := genyaml.NewCommentMap("config.go")
 
 // Generate a commented YAML snippet:
 yamlSnippet, err := cm.GenYaml(config)
@@ -177,10 +177,10 @@ plugin:
 
     # IntegerField comment
     integer: 1
-    
+
     # StringField comment
     string: string
-    
+
 ```
 
 ## Limitations / Going Forward

--- a/vendor/k8s.io/test-infra/pkg/genyaml/genyaml.go
+++ b/vendor/k8s.io/test-infra/pkg/genyaml/genyaml.go
@@ -19,8 +19,8 @@ limitations under the License.
 // from the AST of a given file.
 //
 // Example:
-//	cm := NewCommentMap("example_config.go")
-
+//	cm, err := NewCommentMap("example_config.go")
+//
 //	yamlSnippet, err := cm.GenYaml(&plugins.Configuration{
 //		Approve: []plugins.Approve{
 //			{
@@ -35,6 +35,11 @@ limitations under the License.
 //			},
 //		},
 //	})
+//
+// Alternatively, you can also use `PopulateStruct` to recursively fill all pointer fields, slices and maps of a struct via reflection:
+//
+// yamlSnippet, err := cm.GenYaml(PopulateStruct(&plugins.Configuration{}))
+//
 //
 // 	yamlSnippet will be assigned a string containing the following YAML:
 //
@@ -67,6 +72,7 @@ import (
 	"go/doc"
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -90,16 +96,24 @@ type CommentMap struct {
 }
 
 // NewCommentMap is the constructor for CommentMap accepting a variadic number of paths.
-func NewCommentMap(paths ...string) *CommentMap {
+func NewCommentMap(paths ...string) (*CommentMap, error) {
 	cm := &CommentMap{
 		comments: make(map[string]map[string]Comment),
 	}
 
+	packageFiles := map[string][]string{}
 	for _, path := range paths {
-		cm.AddPath(path)
+		dir := filepath.Dir(path)
+		packageFiles[dir] = append(packageFiles[dir], path)
 	}
 
-	return cm
+	for pkg, files := range packageFiles {
+		if err := cm.addPackage(files); err != nil {
+			return nil, fmt.Errorf("failed to add files in %s: %w", pkg, err)
+		}
+	}
+
+	return cm, nil
 }
 
 // Comment is an abstract structure for storing parsed AST comments decorated with contextual information.
@@ -146,24 +160,38 @@ func jsonToYaml(j []byte) ([]byte, error) {
 }
 
 // astFrom takes a path to a Go file and returns the abstract syntax tree (AST) for that file.
-func astFrom(path string) (*doc.Package, error) {
+func astFrom(paths []string) (*doc.Package, error) {
 	fset := token.NewFileSet()
 	m := make(map[string]*ast.File)
 
-	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse file to AST from path: %s", path)
+	for _, file := range paths {
+		f, err := parser.ParseFile(fset, file, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse file to AST from path %s: %w", file, err)
+		}
+		m[file] = f
 	}
 
-	m[path] = f
-	apkg, _ := ast.NewPackage(fset, m, nil, nil)
+	// Copied from the go doc command: https://github.com/golang/go/blob/fc116b69e2004c159d0f2563c6e91ac75a79f872/src/go/doc/doc.go#L203
+	apkg, _ := ast.NewPackage(fset, m, simpleImporter, nil)
 
 	astDoc := doc.New(apkg, "", 0)
 	if astDoc == nil {
-		return nil, fmt.Errorf("unable to parse AST documentation from path: %s", path)
+		return nil, fmt.Errorf("unable to parse AST documentation from paths %v: got no doc", paths)
 	}
 
 	return astDoc, nil
+}
+
+func simpleImporter(imports map[string]*ast.Object, path string) (*ast.Object, error) {
+	pkg := imports[path]
+	if pkg == nil {
+		// note that strings.LastIndex returns -1 if there is no "/"
+		pkg = ast.NewObj(ast.Pkg, path[strings.LastIndex(path, "/")+1:])
+		pkg.Data = ast.NewScope(nil) // required by ast.NewPackage for dot-import
+		imports[path] = pkg
+	}
+	return pkg, nil
 }
 
 // fmtRawDoc formats/sanitizes a Go doc string removing TODOs, newlines, whitespace, and various other characters from the resultant string.
@@ -259,10 +287,10 @@ func getType(typ interface{}) string {
 }
 
 // genDocMap extracts the name of the field as it should appear in YAML format and returns the resultant string.
-func (cm *CommentMap) genDocMap(path string) error {
-	pkg, err := astFrom(path)
+func (cm *CommentMap) genDocMap(packageFiles []string) error {
+	pkg, err := astFrom(packageFiles)
 	if err != nil {
-		return errors.New("unable to generate AST documentation map")
+		return fmt.Errorf("unable to generate AST documentation map: %w", err)
 	}
 
 	inlineFields := map[string][]string{}
@@ -383,33 +411,17 @@ func (cm *CommentMap) PrintComments() {
 	}
 }
 
-// AddPath allow for adding to the CommentMap via path specification to a `.go` file, returning a boolean indicating success.
-func (cm *CommentMap) AddPath(path string) bool {
+// addPackage allow for adding to the CommentMap via a list of paths to go files in the same package
+func (cm *CommentMap) addPackage(paths []string) error {
 	cm.Lock()
 	defer cm.Unlock()
 
-	err := cm.genDocMap(path)
+	err := cm.genDocMap(paths)
 	if err != nil {
-		return false
+		return err
 	}
 
-	return true
-}
-
-// SetPath allow for setting of the CommentMap via path specification to a `.go` file, returning a boolean indicating success.
-func (cm *CommentMap) SetPath(path string) bool {
-	cm.Lock()
-	defer cm.Unlock()
-
-	// Empty map.
-	cm.comments = make(map[string]map[string]Comment)
-
-	err := cm.genDocMap(path)
-	if err != nil {
-		return false
-	}
-
-	return true
+	return nil
 }
 
 // GenYaml generates a fully commented YAML snippet for a given plugin configuration.
@@ -437,7 +449,7 @@ func (cm *CommentMap) EncodeYaml(config interface{}, encoder *yaml3.Encoder) err
 	// Convert Config object to an abstract YAML node.
 	y1, err := marshal(&config)
 	if err != nil {
-		return errors.New("failed to marshal config to yaml")
+		return fmt.Errorf("failed to marshal config to yaml: %w", err)
 	}
 
 	node := yaml3.Node{}

--- a/vendor/k8s.io/test-infra/pkg/genyaml/populate_struct.go
+++ b/vendor/k8s.io/test-infra/pkg/genyaml/populate_struct.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genyaml
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// PopulateStruct will recursively populate a struct via reflection for consumption by genyaml by:
+// * Filling all pointer fields
+// * Filling all slices with a one-element slice and filling that one element
+// * Filling all maps with a one-element map and filling that one element
+// NOTE: PopulateStruct will panic if not fed a pointer. Generally if you care about
+// the stability of the app that runs this code, it is strongly recommended to recover panics:
+// defer func(){if r := recover(); r != nil { fmt.Printf("Recovered panic: %v", r } }(
+func PopulateStruct(in interface{}) interface{} {
+	typeOf := reflect.TypeOf(in)
+	if typeOf.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("got nonpointer type %T", in))
+	}
+	if typeOf.Elem().Kind() != reflect.Struct {
+		return in
+	}
+	valueOf := reflect.ValueOf(in)
+	for i := 0; i < typeOf.Elem().NumField(); i++ {
+		// Unexported
+		if !valueOf.Elem().Field(i).CanSet() {
+			continue
+		}
+		switch k := typeOf.Elem().Field(i).Type.Kind(); k {
+		// We must populate strings, because genyaml uses a custom json lib
+		// that omits structs that have empty values only and we have some
+		// structs that only have string fields
+		// TODO: Is that genyaml behavior intentional?
+		case reflect.String:
+			// ArrayOrString comes from Tekton and has a custom marshaller
+			// that errors when only setting the String field
+			if typeOf.Elem().Name() == "ArrayOrString" {
+				valueOf.Elem().FieldByName("Type").SetString("string")
+			}
+			valueOf.Elem().Field(i).SetString(" ")
+		// Needed because of the String field handling
+		case reflect.Struct:
+			PopulateStruct(valueOf.Elem().Field(i).Addr().Interface())
+		case reflect.Ptr:
+			ptr := createNonNilPtr(valueOf.Elem().Field(i).Type())
+			// Populate our ptr
+			if ptr.Elem().Kind() == reflect.Struct {
+				PopulateStruct(ptr.Interface())
+			}
+			// Set it on the parent struct
+			valueOf.Elem().Field(i).Set(ptr)
+		case reflect.Slice:
+			if typeOf.Elem().Field(i).Type == typeOfBytes || typeOf.Elem().Field(i).Type == typeOfJSONRawMessage {
+				continue
+			}
+			// Create a one element slice
+			slice := reflect.MakeSlice(typeOf.Elem().Field(i).Type, 1, 1)
+			// Get a pointer to the value
+			var sliceElementPtr interface{}
+			if slice.Index(0).Type().Kind() == reflect.Ptr {
+				// Slice of pointers, make it a non-nil pointer, then pass on its address
+				slice.Index(0).Set(createNonNilPtr(slice.Index(0).Type()))
+				sliceElementPtr = slice.Index(0).Interface()
+			} else {
+				// Slice of literals
+				sliceElementPtr = slice.Index(0).Addr().Interface()
+			}
+			PopulateStruct(sliceElementPtr)
+			// Set it on the parent struct
+			valueOf.Elem().Field(i).Set(slice)
+		case reflect.Map:
+			keyType := typeOf.Elem().Field(i).Type.Key()
+			valueType := typeOf.Elem().Field(i).Type.Elem()
+
+			key := reflect.New(keyType).Elem()
+			value := reflect.New(valueType).Elem()
+
+			var keyPtr, valPtr interface{}
+			if key.Kind() == reflect.Ptr {
+				key.Set(createNonNilPtr(key.Type()))
+				keyPtr = key.Interface()
+			} else {
+				keyPtr = key.Addr().Interface()
+			}
+			if value.Kind() == reflect.Ptr {
+				value.Set(createNonNilPtr(value.Type()))
+				valPtr = value.Interface()
+			} else {
+				valPtr = value.Addr().Interface()
+			}
+			PopulateStruct(keyPtr)
+			PopulateStruct(valPtr)
+
+			mapType := reflect.MapOf(typeOf.Elem().Field(i).Type.Key(), typeOf.Elem().Field(i).Type.Elem())
+			concreteMap := reflect.MakeMapWithSize(mapType, 0)
+			concreteMap.SetMapIndex(key, value)
+
+			valueOf.Elem().Field(i).Set(concreteMap)
+		}
+
+	}
+	return in
+}
+
+func createNonNilPtr(in reflect.Type) reflect.Value {
+	// construct a new **type and call Elem() to get the *type
+	ptr := reflect.New(in).Elem()
+	// Give it a value
+	ptr.Set(reflect.New(ptr.Type().Elem()))
+
+	return ptr
+}
+
+var typeOfBytes = reflect.TypeOf([]byte(nil))
+var typeOfJSONRawMessage = reflect.TypeOf(json.RawMessage{})

--- a/vendor/k8s.io/test-infra/prow/bugzilla/types.go
+++ b/vendor/k8s.io/test-infra/prow/bugzilla/types.go
@@ -284,7 +284,11 @@ type AddExternalBugParameters struct {
 type ExternalBugIdentifier struct {
 	// Type is the URL prefix that identifies the external bug tracker type.
 	// For GitHub, this is commonly https://github.com/
-	Type string `json:"ext_type_url"`
+	Type string `json:"ext_type_url,omitempty"`
+	// TrackerID is the internal identifier for the external bug tracker type.
+	// This should be passed instead of the ext_type_url when there is more
+	// than one external tracker for https://github.com/
+	TrackerID int `json:"ext_type_id,omitempty"`
 	// ID is the identifier of the external bug within the bug tracker type.
 	// For GitHub issues and pull requests, this ID is commonly the path
 	// like `org/repo/pull/number` or `org/repo/issue/number`.

--- a/vendor/k8s.io/test-infra/prow/config/BUILD.bazel
+++ b/vendor/k8s.io/test-infra/prow/config/BUILD.bazel
@@ -16,11 +16,14 @@ go_test(
         "tide_test.go",
     ],
     data = [
+        ":fixtures",
+        ":package-srcs",
         "//config:prowjobs",
         "//config/prow:configs",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/genyaml:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/gerrit/client:go_default_library",
@@ -94,4 +97,10 @@ filegroup(
         "//prow/config/secret:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+filegroup(
+    name = "fixtures",
+    srcs = glob(["*.yaml"]),
+    visibility = ["//visibility:private"],
 )

--- a/vendor/k8s.io/test-infra/prow/config/README.md
+++ b/vendor/k8s.io/test-infra/prow/config/README.md
@@ -2,3 +2,5 @@
 
 Core Prow component configuration is managed by the `config` package and stored in the [`Config` struct](https://godoc.org/k8s.io/test-infra/prow/config#Config). If a configuration guide is available for a component it can be found in the [`/prow/cmd`](/prow/cmd) directory. See [`jobs.md`](/prow/jobs.md) for a guide to configuring ProwJobs.
 Configuration for plugins is handled and stored separately. See the [`plugins`](/prow/plugins) package for details.
+
+You can find a sample config with all possible options and a documentation of them [here.](/prow/config/prow-config-documented.yaml)

--- a/vendor/k8s.io/test-infra/prow/config/prow-config-documented.yaml
+++ b/vendor/k8s.io/test-infra/prow/config/prow-config-documented.yaml
@@ -1,0 +1,636 @@
+branch-protection:
+    allow_deletions: false
+    allow_force_pushes: false
+    enforce_admins: false
+    exclude:
+      - ""
+
+    # Orgs holds branch protection options for orgs by name
+    orgs:
+        "":
+            allow_deletions: false
+            allow_force_pushes: false
+            enforce_admins: false
+            exclude:
+              - ""
+            protect: false
+            repos:
+                "":
+                    allow_deletions: false
+                    allow_force_pushes: false
+                    branches:
+                        "":
+                            allow_deletions: false
+                            allow_force_pushes: false
+                            enforce_admins: false
+                            exclude:
+                              - ""
+                            protect: false
+                            required_linear_history: false
+                            required_pull_request_reviews:
+                                dismiss_stale_reviews: false
+                                dismissal_restrictions:
+                                    teams:
+                                      - ""
+                                    users:
+                                      - ""
+                                require_code_owner_reviews: false
+                                required_approving_review_count: 0
+                            required_status_checks:
+                                contexts:
+                                  - ""
+                                strict: false
+                            restrictions:
+                                teams:
+                                  - ""
+                                users:
+                                  - ""
+                    enforce_admins: false
+                    exclude:
+                      - ""
+                    protect: false
+                    required_linear_history: false
+                    required_pull_request_reviews:
+                        dismiss_stale_reviews: false
+                        dismissal_restrictions:
+                            teams:
+                              - ""
+                            users:
+                              - ""
+                        require_code_owner_reviews: false
+                        required_approving_review_count: 0
+                    required_status_checks:
+                        contexts:
+                          - ""
+                        strict: false
+                    restrictions:
+                        teams:
+                          - ""
+                        users:
+                          - ""
+            required_linear_history: false
+            required_pull_request_reviews:
+                dismiss_stale_reviews: false
+                dismissal_restrictions:
+                    teams:
+                      - ""
+                    users:
+                      - ""
+                require_code_owner_reviews: false
+                required_approving_review_count: 0
+            required_status_checks:
+                contexts:
+                  - ""
+                strict: false
+            restrictions:
+                teams:
+                  - ""
+                users:
+                  - ""
+    protect: false
+    required_linear_history: false
+    required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        dismissal_restrictions:
+            teams:
+              - ""
+            users:
+              - ""
+        require_code_owner_reviews: false
+        required_approving_review_count: 0
+    required_status_checks:
+        contexts:
+          - ""
+        strict: false
+    restrictions:
+        teams:
+          - ""
+        users:
+          - ""
+deck:
+    # AdditionalAllowedBuckets is a list of storage buckets to allow in artifact requests
+    # (in addition to those listed in the GCSConfiguration).
+    # Setting this field requires "SkipStoragePathValidation" also be set to `false`.
+    additional_allowed_buckets:
+      - ""
+
+    # Branding of the frontend
+    branding:
+        # BackgroundColor is the color of the background.
+        background_color: ' '
+
+        # Favicon is the location of the favicon that will be loaded in deck.
+        favicon: ' '
+
+        # HeaderColor is the color of the header.
+        header_color: ' '
+
+        # Logo is the location of the logo that will be loaded in deck.
+        logo: ' '
+
+    # ExternalAgentLogs ensures external agents can expose
+    # their logs in prow.
+    external_agent_logs:
+      - # Agent is an external prow agent that supports exposing
+        # logs via deck.
+        agent: ' '
+
+        # SelectorString compiles into Selector at load time.
+        selector: ' '
+
+        # URLTemplateString compiles into URLTemplate at load time.
+        url_template: ' '
+
+    # GoogleAnalytics, if specified, include a Google Analytics tracking code on each page.
+    google_analytics: ' '
+
+    # HiddenRepos is a list of orgs and/or repos that should not be displayed by Deck.
+    hidden_repos:
+      - ""
+
+    # Deprecated: RerunAuthConfig specifies who is able to trigger job reruns if that feature is enabled.
+    # The permissions here apply to all jobs.
+    # This option will be removed in favor of RerunAuthConfigs in July 2020.
+    rerun_auth_config:
+        github_orgs:
+          - ""
+        github_team_ids:
+          - 0
+        github_team_slugs:
+          - org: ' '
+            slug: ' '
+        github_users:
+          - ""
+
+    # RerunAuthConfigs is a map of configs that specify who is able to trigger job reruns. The field
+    # accepts a key of: `org/repo`, `org` or `*` (wildcard) to define what GitHub org (or repo) a particular
+    # config applies to and a value of: `RerunAuthConfig` struct to define the users/groups authorized to rerun jobs.
+    rerun_auth_configs:
+        "":
+            github_orgs:
+              - ""
+            github_team_ids:
+              - 0
+            github_team_slugs:
+              - org: ' '
+                slug: ' '
+            github_users:
+              - ""
+
+    # SkipStoragePathValidation skips validation that restricts artifact requests to specific buckets.
+    # By default, buckets listed in the GCSConfiguration are automatically allowed.
+    # Additional locations can be allowed via `AdditionalAllowedBuckets` fields.
+    # When unspecified (nil), it defaults to true (until ~Jan 2021).
+    skip_storage_path_validation: false
+
+    # Spyglass specifies which viewers will be used for which artifacts when viewing a job in Deck
+    spyglass:
+        # If set, Announcement is used as a Go HTML template string to be displayed at the top of
+        # each spyglass page. Using HTML in the template is acceptable.
+        # Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
+        announcement: ' '
+
+        # GCSBrowserPrefix is used to generate a link to a human-usable GCS browser.
+        # If left empty, the link will be not be shown. Otherwise, a GCS path (with no
+        # prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.
+        gcs_browser_prefix: ' '
+
+        # GCSBrowserPrefixes are used to generate a link to a human-usable GCS browser.
+        # They are mapped by org, org/repo or '*' which is the default value.
+        gcs_browser_prefixes:
+            "": ""
+
+        # Lenses is a list of lens configurations.
+        lenses:
+          - # Lens is the lens to use, alongside any lens-specific configuration.
+            lens:
+                # Name is the name of the lens.
+                name: ' '
+
+            # OptionalFiles is a list of regexes of file paths that will be provided to the lens if they are
+            # present, but will not preclude the lens being rendered by their absence.
+            # The list entries are ORed together, so if only one of them is present it will be provided to
+            # the lens even if the others are not.
+            optional_files:
+              - ""
+
+            # RemoteConfig specifies how to access remote lenses
+            remote_config:
+                # The endpoint for the lense
+                endpoint: ' '
+
+                # HideTitle defines if we will keep showing the title after lens loads
+                hide_title: false
+
+                # Priority for lens ordering, lowest priority first
+                priority: 0
+
+                # The endpoint for static resources
+                static_root: ' '
+
+                # The human-readable title for the lens
+                title: ' '
+
+            # RequiredFiles is a list of regexes of file paths that must all be present for a lens to appear.
+            # The list entries are ANDed together, i.e. all of them are required. You can achieve an OR
+            # by using a pipe in a regex.
+            required_files:
+              - ""
+
+        # TestGridConfig is the path to the TestGrid config proto. If the path begins with
+        # "gs://" it is assumed to be a GCS reference, otherwise it is read from the local filesystem.
+        # If left blank, TestGrid links will not appear.
+        testgrid_config: ' '
+
+        # TestGridRoot is the root URL to the TestGrid frontend, e.g. "https://testgrid.k8s.io/".
+        # If left blank, TestGrid links will not appear.
+        testgrid_root: ' '
+
+        # Viewers is deprecated, prefer Lenses instead.
+        # Viewers was a map of Regexp strings to viewer names that defines which sets
+        # of artifacts need to be consumed by which viewers. It is copied in to Lenses at load time.
+        viewers:
+            "": null
+
+    # TideUpdatePeriod specifies how often Deck will fetch status from Tide. Defaults to 10s.
+    tide_update_period: 0s
+
+
+# DefaultJobTimeout this is default deadline for prow jobs. This value is used when
+# no timeout is configured at the job level. This value is set to 24 hours.
+default_job_timeout: 0s
+gerrit:
+    # TickInterval is how often we do a sync with binded gerrit instance
+    tick_interval: 0s
+
+
+# GitHubOptions allows users to control how prow applications display GitHub website links.
+github:
+    # LinkURLFromConfig is the string representation of the link_url config parameter.
+    # This config parameter allows users to override the default GitHub link url for all plugins.
+    # If this option is not set, we assume "https://github.com".
+    link_url: ' '
+github_reporter:
+    # JobTypesToReport is used to determine which type of prowjob
+    # should be reported to github
+
+    # defaults to both presubmit and postsubmit jobs.
+    job_types_to_report:
+      - ""
+in_repo_config:
+    # AllowedClusters is a list of allowed clusternames that can be used for jobs on
+    # a given repo. All clusters that are allowed for the specific repo, its org or
+    # globally can be used.
+    allowed_clusters:
+        "": null
+
+    # Enabled describes whether InRepoConfig is enabled for a given repository. This can
+    # be set globally, per org or per repo using '*', 'org' or 'org/repo' as key. The
+    # narrowest match always takes precedence.
+    enabled:
+        "": false
+jenkins_operators:
+  - # JobURLTemplateString compiles into JobURLTemplate at load time.
+    job_url_template: ' '
+
+    # LabelSelectorString compiles into LabelSelector at load time.
+    # If set, this option needs to match --label-selector used by
+    # the desired jenkins-operator. This option is considered
+    # invalid when provided with a single jenkins-operator config.
+
+    # For label selector syntax, see below:
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+    label_selector: ' '
+
+    # ReportTemplateString compiles into ReportTemplate at load time.
+    report_template: ' '
+
+    # ReportTemplateStrings is a mapping of template comments.
+    # Use `org/repo`, `org` or `*` as a key.
+    report_templates:
+        "": ""
+
+
+# LogLevel enables dynamically updating the log level of the
+# standard logger that is used by all prow components.
+
+# Valid values:
+
+# "debug", "info", "warn", "warning", "error", "fatal", "panic"
+
+# Defaults to "info".
+log_level: ' '
+
+
+# ManagedWebhooks contains information about all github repositories and organizations which are using
+# non-global Hmac token.
+managed_webhooks:
+    org_repo_config:
+        "":
+            token_created_after: "0001-01-01T00:00:00Z"
+    respect_legacy_global_token: false
+
+
+# OwnersDirBlacklist is used to configure regular expressions matching directories
+# to ignore when searching for OWNERS{,_ALIAS} files in a repo.
+owners_dir_blacklist:
+    # Default configures a default blacklist for all repos (or orgs).
+    # Some directories like ".git", "_output" and "vendor/.*/OWNERS"
+    # are already preconfigured to be blacklisted, and need not be included here.
+    default:
+      - ""
+
+    # Repos configures a directory blacklist per repo (or org)
+    repos:
+        "": null
+plank:
+    # DefaultDecorationConfigs holds the default decoration config for specific values.
+    # This config will be used on each Presubmit and Postsubmit's corresponding org/repo, and on Periodics
+    # if extraRefs[0] exists.
+    # Use `org/repo`, `org` or `*` as a key.
+    default_decoration_configs:
+        "":
+            cookiefile_secret: ' '
+            gcs_configuration:
+                bucket: ' '
+                default_org: ' '
+                default_repo: ' '
+                local_output_dir: ' '
+                mediaTypes:
+                    "": ""
+                path_prefix: ' '
+                path_strategy: ' '
+            gcs_credentials_secret: ' '
+            grace_period: 0s
+            oauth_token_secret:
+                key: ' '
+                name: ' '
+            resources:
+                clonerefs:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                initupload:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                place_entrypoint:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                sidecar:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+            s3_credentials_secret: ' '
+            skip_cloning: false
+            ssh_host_fingerprints:
+              - ""
+            ssh_key_secrets:
+              - ""
+            timeout: 0s
+            utility_images:
+                clonerefs: ' '
+                entrypoint: ' '
+                initupload: ' '
+                sidecar: ' '
+
+    # JobURLPrefixConfig is the host and path prefix under which job details
+    # will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
+    job_url_prefix_config:
+        "": ""
+
+    # JobURLTemplateString compiles into JobURLTemplate at load time.
+    job_url_template: ' '
+
+    # PodPendingTimeout is after how long the controller will perform a garbage
+    # collection on pending pods. Defaults to one day.
+    pod_pending_timeout: 0s
+
+    # PodRunningTimeout is after how long the controller will abort a prowjob pod
+    # stuck in running state. Defaults to two days.
+    pod_running_timeout: 0s
+
+    # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+    # stuck in an unscheduled state. Defaults to one day.
+    pod_unscheduled_timeout: 0s
+
+    # ReportTemplateString compiles into ReportTemplate at load time.
+    report_template: ' '
+
+    # ReportTemplateStrings is a mapping of template comments.
+    # Use `org/repo`, `org` or `*` as a key.
+    report_templates:
+        "": ""
+
+
+# PodNamespace is the namespace in the cluster that prow
+# components will use for looking up Pods owned by ProwJobs.
+# The namespace needs to exist and will not be created by prow.
+# Defaults to "default".
+pod_namespace: ' '
+
+
+# ProwJobNamespace is the namespace in the cluster that prow
+# components will use for looking up ProwJobs. The namespace
+# needs to exist and will not be created by prow.
+# Defaults to "default".
+prowjob_namespace: ' '
+
+
+# Pub/Sub Subscriptions that we want to listen to
+pubsub_subscriptions:
+    "": null
+
+
+# PushGateway is a prometheus push gateway.
+push_gateway:
+    # Endpoint is the location of the prometheus pushgateway
+    # where prow will push metrics to.
+    endpoint: ' '
+
+    # Interval specifies how often prow will push metrics
+    # to the pushgateway. Defaults to 1m.
+    interval: 0s
+
+    # ServeMetrics tells if or not the components serve metrics
+    serve_metrics: false
+sinker:
+    # MaxPodAge is how old a Pod can be before it is garbage-collected.
+    # Defaults to one day.
+    max_pod_age: 0s
+
+    # MaxProwJobAge is how old a ProwJob can be before it is garbage-collected.
+    # Defaults to one week.
+    max_prowjob_age: 0s
+
+    # ResyncPeriod is how often the controller will perform a garbage
+    # collection. Defaults to one hour.
+    resync_period: 0s
+
+    # TerminatedPodTTL is how long a Pod can live after termination before it is
+    # garbage collected.
+    # Defaults to matching MaxPodAge.
+    terminated_pod_ttl: 0s
+
+
+# Deprecated: this option will be removed in May 2020.
+slack_reporter:
+    channel: ' '
+    job_states_to_report:
+      - ""
+    job_types_to_report:
+      - ""
+    report_template: ' '
+slack_reporter_configs:
+    "":
+        channel: ' '
+        job_states_to_report:
+          - ""
+        job_types_to_report:
+          - ""
+        report_template: ' '
+
+
+# StatusErrorLink is the url that will be used for jenkins prowJobs that can't be
+# found, or have another generic issue. The default that will be used if this is not set
+# is: https://github.com/kubernetes/test-infra/issues
+status_error_link: ' '
+tide:
+    # BatchSizeLimitMap is a key/value pair of an org or org/repo as the key and
+    # integer batch size limit as the value. The empty string key can be used as
+    # a global default.
+    # Special values:
+    # 0 => unlimited batch size
+    # -1 => batch merging disabled :(
+    batch_size_limit:
+        "": 0
+
+    # BlockerLabel is an optional label that is used to identify merge blocking
+    # GitHub issues.
+    # Leave this blank to disable this feature and save 1 API token per sync loop.
+    blocker_label: ' '
+
+    # TideContextPolicyOptions defines merge options for context. If not set it will infer
+    # the required and optional contexts from the prow jobs configured and use the github
+    # combined status; otherwise it may apply the branch protection setting or let user
+    # define their own options in case branch protection is not used.
+    context_options:
+        from-branch-protection: false
+        optional-contexts:
+          - ""
+
+        # GitHub Orgs
+        orgs:
+            "":
+                from-branch-protection: false
+                optional-contexts:
+                  - ""
+                repos:
+                    "":
+                        branches:
+                            "":
+                                # Infer required and optional jobs from Branch Protection configuration
+                                from-branch-protection: false
+                                optional-contexts:
+                                  - ""
+                                required-contexts:
+                                  - ""
+                                required-if-present-contexts:
+                                  - ""
+
+                                # whether to consider unknown contexts optional (skip) or required.
+                                skip-unknown-contexts: false
+                        from-branch-protection: false
+                        optional-contexts:
+                          - ""
+                        required-contexts:
+                          - ""
+                        required-if-present-contexts:
+                          - ""
+                        skip-unknown-contexts: false
+                required-contexts:
+                  - ""
+                required-if-present-contexts:
+                  - ""
+                skip-unknown-contexts: false
+        required-contexts:
+          - ""
+        required-if-present-contexts:
+          - ""
+        skip-unknown-contexts: false
+
+    # A key/value pair of an org/repo as the key and Go template to override
+    # the default merge commit title and/or message. Template is passed the
+    # PullRequest struct (prow/github/types.go#PullRequest)
+    merge_commit_template:
+        "":
+            body: ' '
+            title: ' '
+
+    # MergeLabel is an optional label that is used to identify PRs that should
+    # always be merged with all individual commits from the PR.
+    # Leave this blank to disable this feature.
+    merge_label: ' '
+
+    # A key/value pair of an org/repo as the key and merge method to override
+    # the default method of merge. Valid options are squash, rebase, and merge.
+    merge_method:
+        "": ""
+
+    # PRStatusBaseURL is the base URL for the PR status page.
+    # This is used to link to a merge requirements overview
+    # in the tide status context.
+    # Will be deprecated on June 2020.
+    pr_status_base_url: ' '
+
+    # PRStatusBaseURLs is the base URL for the PR status page
+    # mapped by org or org/repo level.
+    pr_status_base_urls:
+        "": ""
+
+    # Queries represents a list of GitHub search queries that collectively
+    # specify the set of PRs that meet merge requirements.
+    queries:
+      - author: ' '
+        excludedBranches:
+          - ""
+        excludedRepos:
+          - ""
+        includedBranches:
+          - ""
+        labels:
+          - ""
+        milestone: ' '
+        missingLabels:
+          - ""
+        orgs:
+          - ""
+        repos:
+          - ""
+
+    # RebaseLabel is an optional label that is used to identify PRs that should
+    # always be rebased and merged.
+    # Leave this blank to disable this feature.
+    rebase_label: ' '
+
+    # SquashLabel is an optional label that is used to identify PRs that should
+    # always be squash merged.
+    # Leave this blank to disable this feature.
+    squash_label: ' '
+
+    # StatusUpdatePeriod specifies how often Tide will update GitHub status contexts.
+    # Defaults to the value of SyncPeriod.
+    status_update_period: 0s
+
+    # SyncPeriod specifies how often Tide will sync jobs with GitHub. Defaults to 1m.
+    sync_period: 0s
+
+    # URL for tide status contexts.
+    # We can consider allowing this to be set separately for separate repos, or
+    # allowing it to be a template.
+    target_url: ' '

--- a/vendor/k8s.io/test-infra/prow/flagutil/bugzilla.go
+++ b/vendor/k8s.io/test-infra/prow/flagutil/bugzilla.go
@@ -29,13 +29,15 @@ import (
 
 // BugzillaOptions holds options for interacting with Bugzilla.
 type BugzillaOptions struct {
-	endpoint   string
-	ApiKeyPath string
+	endpoint                string
+	githubExternalTrackerId uint
+	ApiKeyPath              string
 }
 
 // AddFlags injects Bugzilla options into the given FlagSet.
 func (o *BugzillaOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.endpoint, "bugzilla-endpoint", "", "Bugzilla's API endpoint.")
+	fs.UintVar(&o.githubExternalTrackerId, "bugzilla-github-external-tracker-id", 0, "The ext_type_id for GitHub external bugs, optional.")
 	fs.StringVar(&o.ApiKeyPath, "bugzilla-api-key-path", "", "Path to the file containing the Bugzilla API key.")
 }
 
@@ -77,5 +79,5 @@ func (o *BugzillaOptions) BugzillaClient(secretAgent *secret.Agent) (bugzilla.Cl
 		generator = &generatorFunc
 	}
 
-	return bugzilla.NewClient(*generator, o.endpoint), nil
+	return bugzilla.NewClient(*generator, o.endpoint, o.githubExternalTrackerId), nil
 }

--- a/vendor/k8s.io/test-infra/prow/plugins/approve/approve.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/approve/approve.go
@@ -452,7 +452,7 @@ func handle(log *logrus.Entry, ghc githubClient, repo approvers.Repo, githubConf
 	})
 	approveComments := filterComments(comments, approvalMatcher(botName, opts.LgtmActsAsApprove, opts.ConsiderReviewState()))
 	addApprovers(&approversHandler, approveComments, pr.author, opts.ConsiderReviewState())
-	log.WithField("duration", time.Since(start).String()).Debug("Completed filering approval comments in handle")
+	log.WithField("duration", time.Since(start).String()).Debug("Completed filtering approval comments in handle")
 
 	for _, user := range pr.assignees {
 		approversHandler.AddAssignees(user.Login)

--- a/vendor/k8s.io/test-infra/prow/plugins/config.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/config.go
@@ -60,34 +60,32 @@ type Configuration struct {
 
 	// Built-in plugins specific configuration.
 
-	Approve                    []Approve                    `json:"approve,omitempty"`
-	UseDeprecatedSelfApprove   bool                         `json:"use_deprecated_2018_implicit_self_approve_default_migrate_before_july_2019,omitempty"`
-	UseDeprecatedReviewApprove bool                         `json:"use_deprecated_2018_review_acts_as_approve_default_migrate_before_july_2019,omitempty"`
-	Blockades                  []Blockade                   `json:"blockades,omitempty"`
-	Blunderbuss                Blunderbuss                  `json:"blunderbuss,omitempty"`
-	Bugzilla                   Bugzilla                     `json:"bugzilla,omitempty"`
-	Cat                        Cat                          `json:"cat,omitempty"`
-	CherryPickUnapproved       CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
-	ConfigUpdater              ConfigUpdater                `json:"config_updater,omitempty"`
-	Dco                        map[string]*Dco              `json:"dco,omitempty"`
-	Golint                     Golint                       `json:"golint,omitempty"`
-	Goose                      Goose                        `json:"goose,omitempty"`
-	Heart                      Heart                        `json:"heart,omitempty"`
-	Label                      Label                        `json:"label,omitempty"`
-	Lgtm                       []Lgtm                       `json:"lgtm,omitempty"`
-	MilestoneApplier           map[string]BranchToMilestone `json:"milestone_applier,omitempty"`
-	RepoMilestone              map[string]Milestone         `json:"repo_milestone,omitempty"`
-	Project                    ProjectConfig                `json:"project_config,omitempty"`
-	ProjectManager             ProjectManager               `json:"project_manager,omitempty"`
-	RequireMatchingLabel       []RequireMatchingLabel       `json:"require_matching_label,omitempty"`
-	RequireSIG                 RequireSIG                   `json:"requiresig,omitempty"`
-	Retitle                    Retitle                      `json:"retitle,omitempty"`
-	Slack                      Slack                        `json:"slack,omitempty"`
-	SigMention                 SigMention                   `json:"sigmention,omitempty"`
-	Size                       Size                         `json:"size,omitempty"`
-	Triggers                   []Trigger                    `json:"triggers,omitempty"`
-	Welcome                    []Welcome                    `json:"welcome,omitempty"`
-	Override                   Override                     `json:"override,omitempty"`
+	Approve              []Approve                    `json:"approve,omitempty"`
+	Blockades            []Blockade                   `json:"blockades,omitempty"`
+	Blunderbuss          Blunderbuss                  `json:"blunderbuss,omitempty"`
+	Bugzilla             Bugzilla                     `json:"bugzilla,omitempty"`
+	Cat                  Cat                          `json:"cat,omitempty"`
+	CherryPickUnapproved CherryPickUnapproved         `json:"cherry_pick_unapproved,omitempty"`
+	ConfigUpdater        ConfigUpdater                `json:"config_updater,omitempty"`
+	Dco                  map[string]*Dco              `json:"dco,omitempty"`
+	Golint               Golint                       `json:"golint,omitempty"`
+	Goose                Goose                        `json:"goose,omitempty"`
+	Heart                Heart                        `json:"heart,omitempty"`
+	Label                Label                        `json:"label,omitempty"`
+	Lgtm                 []Lgtm                       `json:"lgtm,omitempty"`
+	MilestoneApplier     map[string]BranchToMilestone `json:"milestone_applier,omitempty"`
+	RepoMilestone        map[string]Milestone         `json:"repo_milestone,omitempty"`
+	Project              ProjectConfig                `json:"project_config,omitempty"`
+	ProjectManager       ProjectManager               `json:"project_manager,omitempty"`
+	RequireMatchingLabel []RequireMatchingLabel       `json:"require_matching_label,omitempty"`
+	RequireSIG           RequireSIG                   `json:"requiresig,omitempty"`
+	Retitle              Retitle                      `json:"retitle,omitempty"`
+	Slack                Slack                        `json:"slack,omitempty"`
+	SigMention           SigMention                   `json:"sigmention,omitempty"`
+	Size                 Size                         `json:"size,omitempty"`
+	Triggers             []Trigger                    `json:"triggers,omitempty"`
+	Welcome              []Welcome                    `json:"welcome,omitempty"`
+	Override             Override                     `json:"override,omitempty"`
 }
 
 // Golint holds configuration for the golint plugin
@@ -252,25 +250,20 @@ type Approve struct {
 	// IssueRequired indicates if an associated issue is required for approval in
 	// the specified repos.
 	IssueRequired bool `json:"issue_required,omitempty"`
-
 	// RequireSelfApproval requires PR authors to explicitly approve their PRs.
 	// Otherwise the plugin assumes the author of the PR approves the changes in the PR.
 	RequireSelfApproval *bool `json:"require_self_approval,omitempty"`
-
 	// LgtmActsAsApprove indicates that the lgtm command should be used to
 	// indicate approval
 	LgtmActsAsApprove bool `json:"lgtm_acts_as_approve,omitempty"`
-
 	// IgnoreReviewState causes the approve plugin to ignore the GitHub review state. Otherwise:
 	// * an APPROVE github review is equivalent to leaving an "/approve" message.
 	// * A REQUEST_CHANGES github review is equivalent to leaving an /approve cancel" message.
 	IgnoreReviewState *bool `json:"ignore_review_state,omitempty"`
-
 	// CommandHelpLink is the link to the help page which shows the available commands for each repo.
 	// The default value is "https://go.k8s.io/bot-commands". The command help page is served by Deck
 	// and available under https://<deck-url>/command-help, e.g. "https://prow.k8s.io/command-help"
 	CommandHelpLink string `json:"commandHelpLink"`
-
 	// PrProcessLink is the link to the help page which explains the code review process.
 	// The default value is "https://git.k8s.io/community/contributors/guide/owners.md#the-code-review-process".
 	PrProcessLink string `json:"pr_process_link,omitempty"`
@@ -846,9 +839,9 @@ func (c *Configuration) EnabledReposForExternalPlugin(plugin string) (orgs, repo
 }
 
 // SetDefaults sets default options for config updating
-func (c *ConfigUpdater) SetDefaults() {
-	if len(c.Maps) == 0 {
-		c.Maps = map[string]ConfigMapSpec{
+func (cu *ConfigUpdater) SetDefaults() {
+	if len(cu.Maps) == 0 {
+		cu.Maps = map[string]ConfigMapSpec{
 			"config/prow/config.yaml": {
 				Name: "config",
 			},
@@ -858,7 +851,7 @@ func (c *ConfigUpdater) SetDefaults() {
 		}
 	}
 
-	for name, spec := range c.Maps {
+	for name, spec := range cu.Maps {
 		if spec.Namespace != "" || len(spec.AdditionalNamespaces) > 0 {
 			logrus.Warn("'namespace' and 'additional_namespaces' are deprecated for config-updater plugin and will be removed in October, 2020, use 'clusters' instead")
 		}
@@ -868,7 +861,7 @@ func (c *ConfigUpdater) SetDefaults() {
 		if len(spec.Clusters) == 0 {
 			spec.Clusters = map[string][]string{kube.DefaultClusterAlias: spec.Namespaces}
 		}
-		c.Maps[name] = spec
+		cu.Maps[name] = spec
 	}
 }
 

--- a/vendor/k8s.io/test-infra/prow/plugins/plugins.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/plugins.go
@@ -53,7 +53,7 @@ var (
 	reviewEventHandlers        = map[string]ReviewEventHandler{}
 	reviewCommentEventHandlers = map[string]ReviewCommentEventHandler{}
 	statusEventHandlers        = map[string]StatusEventHandler{}
-	CommentMap                 = genyaml.NewCommentMap("prow/plugins/config.go")
+	CommentMap, _              = genyaml.NewCommentMap("prow/plugins/config.go")
 )
 
 // HelpProvider defines the function type that construct a pluginhelp.PluginHelp for enabled

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -978,7 +978,7 @@ k8s.io/klog/v2
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/kubernetes v1.14.7
 k8s.io/kubernetes/pkg/apis/core
-# k8s.io/test-infra v0.0.0-20201026133301-f7d653694b18
+# k8s.io/test-infra v0.0.0-20201029180605-20aad120bf8a
 ## explicit
 k8s.io/test-infra/experiment/autobumper/bumper
 k8s.io/test-infra/experiment/image-bumper/bumper


### PR DESCRIPTION
The content for the handler is pre-generated because the generation needs the source code which we do not have anymore in the final image.