### PR TITLE
Don't automount ServiceAccount token in pods

### DIFF
--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -16,6 +16,7 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
@@ -208,7 +209,8 @@ func generateBasePod(
 			},
 		},
 		Spec: coreapi.PodSpec{
-			RestartPolicy: coreapi.RestartPolicyNever,
+			RestartPolicy:                coreapi.RestartPolicyNever,
+			AutomountServiceAccountToken: utilpointer.BoolPtr(false),
 			Containers: []coreapi.Container{
 				{
 					Image:                    image,

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -15,6 +15,7 @@
       job: job
     name: test-step0
   spec:
+    automountServiceAccountToken: false
     containers:
     - args:
       - /bin/bash
@@ -131,6 +132,7 @@
       job: job
     name: test-step1
   spec:
+    automountServiceAccountToken: false
     containers:
     - args:
       - /bin/bash
@@ -263,6 +265,7 @@
       job: job
     name: test-step2
   spec:
+    automountServiceAccountToken: false
     containers:
     - args:
       - /bin/bash

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -15,6 +15,7 @@ metadata:
   name: TestName
   namespace: TestNamespace
 spec:
+  automountServiceAccountToken: false
   containers:
   - command:
     - /bin/bash

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -15,6 +15,7 @@ metadata:
   name: TestName
   namespace: TestNamespace
 spec:
+  automountServiceAccountToken: false
   containers:
   - command:
     - /bin/bash


### PR DESCRIPTION
This is not only not needed, it may create issues when it interacts with
the OC command by for example setting a namespace that doesn't exist in
the target cluster.