### PR TITLE
pkg/testhelper: mark as helper, include filename

### DIFF
--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -69,6 +69,7 @@ func golden(t *testing.T, opts *Options) (string, error) {
 // If output is not a []byte or string, it will get serialized as yaml prior to the comparison.
 // The fixtures are stored in $PWD/testdata/prefix${testName}.yaml
 func CompareWithFixture(t *testing.T, output interface{}, opts ...Option) {
+	t.Helper()
 	options := &Options{}
 	for _, opt := range opts {
 		opt(options)
@@ -108,7 +109,7 @@ func CompareWithFixture(t *testing.T, output interface{}, opts ...Option) {
 	diff := difflib.UnifiedDiff{
 		A:        difflib.SplitLines(string(expected)),
 		B:        difflib.SplitLines(string(serializedOutput)),
-		FromFile: "Fixture",
+		FromFile: golden,
 		ToFile:   "Current",
 		Context:  3,
 	}


### PR DESCRIPTION
- mark `CompareWithFixture` as a test helper so failure messages display
  the true origin
- include the fixture file name in the diff to make it a real patch