### PR TITLE
ci-operator: remove deprecated flags

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -306,8 +306,6 @@ type options struct {
 }
 
 func bindOptions(flag *flag.FlagSet) *options {
-	// for backwards compatibility
-	var dry, determinize bool
 	opt := &options{
 		idleCleanupDuration: 1 * time.Hour,
 		cleanupDuration:     12 * time.Hour,
@@ -327,7 +325,6 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.configSpecPath, "config", "", "The configuration file. If not specified the CONFIG_SPEC environment variable or the configresolver will be used.")
 	flag.StringVar(&opt.unresolvedConfigPath, "unresolved-config", "", "The configuration file, before resolution. If not specified the UNRESOLVED_CONFIG environment variable will be used, if set.")
 	flag.Var(&opt.targets, "target", "One or more targets in the configuration to build. Only steps that are required for this target will be run.")
-	flag.BoolVar(&dry, "dry-run", dry, "DEPRECATED: DO NOT USE")
 	flag.BoolVar(&opt.print, "print-graph", opt.print, "Print a directed graph of the build steps and exit. Intended for use with the golang digraph utility.")
 
 	// add to the graph of things we run or create
@@ -354,7 +351,6 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.gitRef, "git-ref", "", "Populate the job spec from this local Git reference. If JOB_SPEC is set, the refs field will be overwritten.")
 	flag.BoolVar(&opt.givePrAuthorAccessToNamespace, "give-pr-author-access-to-namespace", true, "Give view access to the temporarily created namespace to the PR author.")
 	flag.StringVar(&opt.impersonateUser, "as", "", "Username to impersonate")
-	flag.BoolVar(&determinize, "determinize-output", false, "DEPRECATED: DO NOT USE")
 
 	// flags needed for the configresolver
 	flag.StringVar(&opt.resolverAddress, "resolver-address", configResolverAddress, "Address of configresolver")

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -55,7 +55,6 @@ var envForProfile = []string{
 }
 
 type multiStageTestStep struct {
-	dry     bool
 	name    string
 	profile api.ClusterProfile
 	config  *api.ReleaseBuildConfiguration
@@ -345,10 +344,8 @@ func (s *multiStageTestStep) runSteps(
 	select {
 	case <-ctx.Done():
 		log.Printf("cleanup: Deleting pods with label %s=%s", MultiStageTestLabel, s.name)
-		if !s.dry {
-			if err := deletePods(s.podClient.Pods(s.jobSpec.Namespace()), s.name); err != nil {
-				errs = append(errs, fmt.Errorf("failed to delete pods with label %s=%s: %w", MultiStageTestLabel, s.name, err))
-			}
+		if err := deletePods(s.podClient.Pods(s.jobSpec.Namespace()), s.name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete pods with label %s=%s: %w", MultiStageTestLabel, s.name, err))
 		}
 		errs = append(errs, fmt.Errorf("cancelled"))
 	default:


### PR DESCRIPTION
These have been deprecated for months and are not used anywhere.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>