### PR TITLE
ci-operator: let artifacts worker cancel itself

### DIFF
--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -553,7 +554,7 @@ func TestArtifactWorker(t *testing.T) {
 		namespace: "namespace",
 		name:      pod,
 	}
-	w := NewArtifactWorker(podClient, tmp, podClient.namespace)
+	w := NewArtifactWorker(podClient, tmp, podClient.namespace, context.Background())
 	w.CollectFromPod(pod, []string{"container"}, nil)
 	w.Complete(pod)
 	select {

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -89,7 +89,7 @@ func (s *podStep) run(ctx context.Context) error {
 	// when the test container terminates and artifact directory has been set, grab everything under the directory
 	var notifier ContainerNotifier = NopNotifier
 	if s.gatherArtifacts() {
-		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.config.As), s.jobSpec.Namespace())
+		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.config.As), s.jobSpec.Namespace(), ctx)
 		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
 		notifier = artifacts
 	}
@@ -101,7 +101,6 @@ func (s *podStep) run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		notifier.Cancel()
 		log.Printf("cleanup: Deleting %s pod %s", s.name, s.config.As)
 		if err := s.podClient.Pods(s.jobSpec.Namespace()).Delete(context.TODO(), s.config.As, meta.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 			log.Printf("error: Could not delete %s pod: %v", s.name, err)

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -117,7 +117,6 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		notifier.Cancel()
 		log.Printf("cleanup: Deleting template %s", s.template.Name)
 		policy := meta.DeletePropagationForeground
 		opt := meta.DeleteOptions{
@@ -142,7 +141,7 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 
 	// now that the pods have been resolved by the template, add them to the artifact map
 	if len(s.artifactDir) > 0 {
-		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.template.Name), s.jobSpec.Namespace())
+		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.template.Name), s.jobSpec.Namespace(), ctx)
 		for _, ref := range instance.Status.Objects {
 			switch {
 			case ref.Ref.Kind == "Pod" && ref.Ref.APIVersion == "v1":


### PR DESCRIPTION
In all cases that the worker had it's work cancelled, this was done as a
result of a context being done. In every case, it is improper to not
cancel the worker if the test context is cancelled, so there is no use
in forcing callers that construct an artifact worker remember that they
need to cancel it appropriately. We can instead just require the context
to be passed to the constructor and always do the right thing.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>