### PR TITLE
GitHub: Include URL on errors

### DIFF
--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -57,10 +57,10 @@ func FileGetterFactory(org, repo, branch string, opts ...Opt) FileGetter {
 		}
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read response body: %w", err)
+			return nil, fmt.Errorf("failed to read response body when getting %s: %w", url, err)
 		}
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("got unexpected http status code %d, response body: %s", resp.StatusCode, string(body))
+			return nil, fmt.Errorf("got unexpected http status code %d when getting %s, response body: %s", resp.StatusCode, url, string(body))
 		}
 		return body, nil
 	}


### PR DESCRIPTION
Makes debugging of errors like this one possible: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-registry-replacer/1323369491274403840#1:build-log.txt%3A81