### PR TITLE
e2e: make timeout 120s instead of 10s

### DIFF
--- a/test/e2e/multi-stage.sh
+++ b/test/e2e/multi-stage.sh
@@ -27,7 +27,7 @@ os::cmd::expect_success "ci-operator ${namespace} --secret-dir ${PULL_SECRET_DIR
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target without-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references --unresolved-config ${suite_dir}/config.yaml"
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target skip-on-success --unresolved-config ${suite_dir}/config.yaml"
-os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 '"timeout" pod "timeout-timeout" exceeded the configured timeout activeDeadlineSeconds=10: the pod [^ ]* failed after 1[0-5]s \(failed containers: \): DeadlineExceeded Pod was active on the node longer than the specified deadline'
+os::cmd::expect_code_and_text "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target timeout --unresolved-config ${suite_dir}/config.yaml" 1 '"timeout" pod "timeout-timeout" exceeded the configured timeout activeDeadlineSeconds=120: the pod [^ ]* failed after .* \(failed containers: \): DeadlineExceeded Pod was active on the node longer than the specified deadline'
 UNRESOLVED_CONFIG="$( cat "${suite_dir}/config.yaml" )"
 export UNRESOLVED_CONFIG
 os::cmd::expect_success "ci-operator ${namespace} --artifact-dir ${BASETMPDIR} --resolver-address http://127.0.0.1:8080 --target with-references"

--- a/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
+++ b/test/e2e/multi-stage/registry/timeout/timeout-commands.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec sleep 60
+exec sleep 360

--- a/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
+++ b/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
@@ -2,7 +2,7 @@ ref:
   as: timeout
   from: os
   commands: timeout-commands.sh
-  active_deadline_seconds: 10
+  active_deadline_seconds: 120
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
While we try to determine the particular deadlock/hang that occurs when
a Pod starts after it's ActiveDeadlineSeconds are exhausted, make the
test timeout in a longer period of time to make it less likely that we
hit this issue and cause 4h timeouts in e2e presubmits.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Addresses [DPTP-1698](https://issues.redhat.com/browse/DPTP-1698)