### PR TITLE
prowgen: move code to pkg/ and simplify it

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -28,7 +28,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -30,7 +30,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       ci-operator.openshift.io/variant: rhel
     max_concurrency: 1
     name: branch-ci-super-duper-branch-rhel-images

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -8,7 +8,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -9,7 +9,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
@@ -53,7 +53,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -9,7 +9,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       ci-operator.openshift.io/variant: rhel
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-rhel-images
@@ -55,7 +55,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       ci-operator.openshift.io/variant: rhel
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-rhel-unit

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
@@ -53,7 +53,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -19,19 +19,15 @@ import (
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 )
 
-type ProwgenLabel string
-
 const (
-	ProwJobLabelGenerated              = "ci-operator.openshift.io/prowgen-controlled"
-	CanBeRehearsedLabel                = "pj-rehearse.openshift.io/can-be-rehearsed"
-	SSHBastionLabel                    = "dptp.openshift.io/ssh-bastion"
-	ProwJobLabelVariant                = "ci-operator.openshift.io/variant"
-	JobReleaseKey                      = "job-release"
-	Generated             ProwgenLabel = "true"
-	New                   ProwgenLabel = "newly-generated"
-	PresubmitPrefix                    = "pull"
-	PostsubmitPrefix                   = "branch"
-	PeriodicPrefix                     = "periodic"
+	CanBeRehearsedLabel = "pj-rehearse.openshift.io/can-be-rehearsed"
+	CanBeRehearsedValue = "true"
+	SSHBastionLabel     = "dptp.openshift.io/ssh-bastion"
+	ProwJobLabelVariant = "ci-operator.openshift.io/variant"
+	JobReleaseKey       = "job-release"
+	PresubmitPrefix     = "pull"
+	PostsubmitPrefix    = "branch"
+	PeriodicPrefix      = "periodic"
 )
 
 // DataWithInfo describes the metadata for a Prow job configuration file

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_config_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_config_variant.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   ci-operator.openshift.io/variant: whatever
 name: pull-ci-org-repo-branch-whatever-test
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: pull-ci-org-repo-branch-test
 spec:
   containers:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: pull-ci-org-repo-branch-test
 spec:
   containers:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private_with_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private_with_clone__true.yaml
@@ -1,7 +1,7 @@
 agent: kubernetes
 decorate: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: pull-ci-org-repo-branch-test
 spec:
   containers:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
@@ -4,7 +4,7 @@ decoration_config:
   skip_cloning: true
 hidden: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: pull-ci-org-repo-branch-test
 spec:
   containers:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_no_special_options.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_no_special_options.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: pull-ci-org-repo-branch-test
 spec:
   containers:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_path_alias.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_path_alias.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   ci-operator.openshift.io/variant: whatever
 name: pull-ci-org-repo-branch-whatever-test
 path_alias: /some/where

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_rehearsable.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_rehearsable.yaml
@@ -3,7 +3,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-test
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
@@ -2,13 +2,13 @@ postsubmits:
   organization/repository:
   - labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -8,7 +8,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
     spec:
@@ -61,7 +61,7 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-images
     rerun_command: /test images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
@@ -2,6 +2,6 @@ presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
@@ -2,6 +2,6 @@ presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-ci-index

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_template_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_template_test.yaml
@@ -2,6 +2,6 @@ presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-oTeste

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_template_test_which_doesn_t_require_tag_specification_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_template_test_which_doesn_t_require_tag_specification_.yaml
@@ -2,6 +2,6 @@ presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-oTeste

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
@@ -2,11 +2,11 @@ presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-derTest
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-leTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
@@ -1,13 +1,13 @@
 postsubmits:
   organization/repository:
   - labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-leTest
 presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-derTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
@@ -2,23 +2,23 @@ postsubmits:
   organization/repository:
   - labels:
       ci-operator.openshift.io/is-promotion: "true"
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
   organization/repository:
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-derTest
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-leTest
   - always_run: false
     labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
@@ -8,7 +8,7 @@ extra_refs:
   org: org
   repo: repo
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   ci-operator.openshift.io/variant: also
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: periodic-ci-org-repo-branch-also-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release.yaml
@@ -8,7 +8,7 @@ extra_refs:
   org: org
   repo: repo
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   job-release: "4.6"
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_and_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_and_clone__true.yaml
@@ -6,7 +6,7 @@ extra_refs:
   org: org
   repo: repo
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   job-release: "4.6"
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
@@ -8,6 +8,6 @@ extra_refs:
   org: org
   repo: repo
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
@@ -5,5 +5,5 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: branch-ci-organization-repository-branch-Lowercase org repo and branch

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch_with_release.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch_with_release.yaml
@@ -5,6 +5,6 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   job-release: "4.6"
 name: branch-ci-organization-repository-branch-Lowercase org repo and branch with release

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
@@ -5,5 +5,5 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: branch-ci-Organization-Repository-Branch-Uppercase org, repo and branch

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch_with_clone__true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch_with_clone__true.yaml
@@ -3,5 +3,5 @@ branches:
 - ^Branch$
 decorate: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
 name: 'branch-ci-Organization-Repository-Branch-Uppercase org, repo and branch with clone: true'

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -7,7 +7,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   ci-operator.openshift.io/variant: also
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-also-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -7,7 +7,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
@@ -7,7 +7,7 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   job-release: "4.6"
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
@@ -5,7 +5,7 @@ branches:
 context: ci/prow/testname
 decorate: true
 labels:
-  ci-operator.openshift.io/prowgen-controlled: "true"
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
   job-release: "4.6"
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-testname

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1127,16 +1127,16 @@ func TestVariantFromLabels(t *testing.T) {
 		input:    map[string]string{},
 		expected: "",
 	}, {
-		name: "generated label",
+		name: "unrelated label",
 		input: map[string]string{
-			jobconfig.ProwJobLabelGenerated: "true",
+			"unrelated-label": "true",
 		},
 		expected: "",
 	}, {
 		name: "generated and variant labels",
 		input: map[string]string{
-			jobconfig.ProwJobLabelGenerated: "true",
-			jobconfig.ProwJobLabelVariant:   "v2",
+			"unrelated-label":             "true",
+			jobconfig.ProwJobLabelVariant: "v2",
 		},
 		expected: "v2",
 	}}


### PR DESCRIPTION
As a followup to DRYing `IsGenerated()` in #1274, this change moves more
logic from `cmd/ci-operator-prowgen` to `pkg/prowgen`. Some code was
made an internal implementation detail, resulting in simpler signatures. Some
prowgen-related code was also moved from `jobconfig` to `prowgen`.

The labels that prowgen uses to mark (newly) generated jobs are now
internal and no longer configurable, but that was not used anyway.
`GenerateJobs` now always generates jobs with a `newly-generated` label
value, and `Prune` then switches the label to `true`.
Unfortunately many tests for `[gG]Generate*` methods passed different
labels so a lot of fixtures needed to be changed, but the actual
behavior of `ci-operator-prowgen` does not change, witnessed by
integration tests.

/hold 
Needs https://github.com/openshift/ci-tools/pull/1274 first