### PR TITLE
Test Images Distributor: Use ResolveConfig instead of re-implementing it

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -30,7 +30,6 @@ import (
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/load/agents"
-	"github.com/openshift/ci-tools/pkg/registry"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
 )
@@ -42,7 +41,7 @@ func AddToManager(mgr manager.Manager,
 	buildClusterManagers map[string]manager.Manager,
 	configAgent agents.ConfigAgent,
 	pullSecretGetter func() []byte,
-	resolver registry.Resolver,
+	resolver agents.RegistryAgent,
 	additionalImageStreamTags sets.String,
 	additionalImageStreams sets.String,
 	additionalImageStreamNamespaces sets.String,
@@ -436,7 +435,11 @@ func (r *reconciler) pullSecret(namespace string) (*corev1.Secret, crcontrolleru
 	}
 }
 
-func testInputImageStreamTagFilterFactory(l *logrus.Entry, ca agents.ConfigAgent, client ctrlruntimeclient.Client, resolver registry.Resolver, additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces sets.String) (objectFilter, error) {
+type registryResolver interface {
+	ResolveConfig(config api.ReleaseBuildConfiguration) (api.ReleaseBuildConfiguration, error)
+}
+
+func testInputImageStreamTagFilterFactory(l *logrus.Entry, ca agents.ConfigAgent, client ctrlruntimeclient.Client, resolver registryResolver, additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces sets.String) (objectFilter, error) {
 	const indexName = "config-by-test-input-imagestreamtag"
 	if err := ca.AddIndex(indexName, indexConfigsByTestInputImageStramTag(resolver)); err != nil {
 		return nil, fmt.Errorf("failed to add %s index to configAgent: %w", indexName, err)
@@ -505,32 +508,14 @@ func imageStreamNameFromImageStreamTagName(nn types.NamespacedName) (types.Names
 	return types.NamespacedName{Namespace: nn.Namespace, Name: colonSplit[0]}, nil
 }
 
-func indexConfigsByTestInputImageStramTag(resolver registry.Resolver) agents.IndexFn {
+func indexConfigsByTestInputImageStramTag(resolver registryResolver) agents.IndexFn {
 	return func(cfg api.ReleaseBuildConfiguration) []string {
 
 		log := logrus.WithFields(logrus.Fields{"org": cfg.Metadata.Org, "repo": cfg.Metadata.Repo, "branch": cfg.Metadata.Branch})
-		for idx, testStep := range cfg.Tests {
-			if testStep.MultiStageTestConfiguration != nil {
-				resolved, err := resolver.Resolve(testStep.As, *testStep.MultiStageTestConfiguration)
-				if err != nil {
-					log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
-				}
-				cfg.Tests[idx].MultiStageTestConfigurationLiteral = &resolved
-				// We always need to set to nil or we will get another error later.
-				cfg.Tests[idx].MultiStageTestConfiguration = nil
-			}
-		}
-		for idx, rawStep := range cfg.RawSteps {
-			if rawStep.TestStepConfiguration != nil && rawStep.TestStepConfiguration.MultiStageTestConfiguration != nil {
-				resolved, err := resolver.Resolve(rawStep.TestStepConfiguration.As, *rawStep.TestStepConfiguration.MultiStageTestConfiguration)
-				if err != nil {
-					log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
-				}
-				// We always need to set to nil or we will get another error later.
-				cfg.RawSteps[idx].TestStepConfiguration.MultiStageTestConfigurationLiteral = &resolved
-				cfg.RawSteps[idx].TestStepConfiguration.MultiStageTestConfiguration = nil
-			}
-
+		cfg, err := resolver.ResolveConfig(cfg)
+		if err != nil {
+			log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
+			return nil
 		}
 		m, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(cfg)
 		if err != nil {

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -758,8 +758,10 @@ func TestTestInputImageStreamTagFilterFactory(t *testing.T) {
 	}
 }
 
+var _ registryResolver = noOpRegistryResolver{}
+
 type noOpRegistryResolver struct{}
 
-func (noOpRegistryResolver) Resolve(_ string, _ api.MultiStageTestConfiguration) (api.MultiStageTestConfigurationLiteral, error) {
-	return api.MultiStageTestConfigurationLiteral{}, nil
+func (noOpRegistryResolver) ResolveConfig(cfg api.ReleaseBuildConfiguration) (api.ReleaseBuildConfiguration, error) {
+	return cfg, nil
 }


### PR DESCRIPTION
What is confusing though:  Why does the registry not resolve `RawSteps` but only `Tests`? https://github.com/openshift/ci-tools/blob/7b99e122c7ec94a8f7b0d9f5b6b33da4570a4574/pkg/registry/resolver.go#L327