### PR TITLE
Skip a linux-only test

### DIFF
--- a/pkg/steps/bundle_source_test.go
+++ b/pkg/steps/bundle_source_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -44,6 +45,9 @@ var subs = []api.PullSpecSubstitution{
 }
 
 func TestReplaceCommand(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("skipping test on %s OS", runtime.GOOS)
+	}
 	temp, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatalf("Failed to create temporary directory for unit test: %v", err)


### PR DESCRIPTION
This test prevents me from running `make test` successfully on a non-Linux PC.

/cc @openshift/openshift-team-developer-productivity-test-platform 