### PR TITLE
ci-operator: detect duplicate images[*].to stanzas

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -295,11 +295,17 @@ func validateBuildRootImageConfiguration(fieldRoot string, input *BuildRootImage
 
 func validateImages(fieldRoot string, input []ProjectDirectoryImageBuildStepConfiguration) []error {
 	var validationErrors []error
+	seenNames := map[PipelineImageStreamTagReference]int{}
 	for num, image := range input {
 		fieldRootN := fmt.Sprintf("%s[%d]", fieldRoot, num)
 		if image.To == "" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` must be set", fieldRootN))
 		}
+		if idx, seen := seenNames[image.To]; seen {
+			fieldRootIdx := fmt.Sprintf("%s[%d]", fieldRoot, idx)
+			validationErrors = append(validationErrors, fmt.Errorf("%s: duplicate image name '%s' (previously seen in %s)", fieldRootN, string(image.To), fieldRootIdx))
+		}
+		seenNames[image.To] = num
 		if image.To == PipelineImageStreamTagReferenceBundleSource {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, PipelineImageStreamTagReferenceBundleSource))
 		}

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -1585,7 +1585,18 @@ func TestValidateImages(t *testing.T) {
 		output: []error{
 			errors.New("images[0]: `to` cannot be ci-index"),
 		},
-	}}
+	},
+		{
+			name: "two items cannot have identical `to`",
+			input: []ProjectDirectoryImageBuildStepConfiguration{
+				{To: "same-thing"},
+				{To: "same-thing"},
+			},
+			output: []error{
+				errors.New("images[1]: duplicate image name 'same-thing' (previously seen in images[0])"),
+			},
+		},
+	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			if actual, expected := validateImages("images", testCase.input), testCase.output; !reflect.DeepEqual(actual, expected) {


### PR DESCRIPTION
Fixes [DPTP-1727](https://issues.redhat.com/browse/DPTP-1727) (happened in https://github.com/openshift/release/pull/13394)