### PR TITLE
autoconfigbrancher: determinize prow config

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -178,6 +178,10 @@ func main() {
 			}(),
 		},
 		{
+			command:   "/usr/bin/determinize-prow-config",
+			arguments: []string{"--prow-config-dir", "./core-services/prow/02_config/"},
+		},
+		{
 			command:   "/usr/bin/sanitize-prow-jobs",
 			arguments: []string{"--prow-jobs-dir", "./ci-operator/jobs", "--config-path", "./core-services/sanitize-prow-jobs/_config.yaml"},
 		},
@@ -210,7 +214,7 @@ func main() {
 
 	var labelsToAdd []string
 	if o.selfApprove {
-		logrus.Infof("Self-aproving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
+		logrus.Infof("Self-approving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)
 	}
 	if err := bumper.UpdatePullRequestWithLabels(gc, githubOrg, githubRepo, title, fmt.Sprintf("/cc @%s", o.assign),

--- a/images/autoconfigbrancher/Dockerfile
+++ b/images/autoconfigbrancher/Dockerfile
@@ -7,6 +7,7 @@ ADD autoconfigbrancher /usr/bin/autoconfigbrancher
 ADD ci-operator-config-mirror /usr/bin/ci-operator-config-mirror
 ADD private-prow-configs-mirror /usr/bin/private-prow-configs-mirror
 ADD sanitize-prow-jobs /usr/bin/sanitize-prow-jobs
+ADD determinize-prow-config /usr/bin/determinize-prow-config
 
 RUN dnf install -y git && \
     dnf clean all && \


### PR DESCRIPTION
Changing Prow config in `private-prow-configs-mirror` may cause
reshuffling of Tide queries. 

The binaries are provided as inputs to the build already in https://github.com/openshift/release/pull/13422