### PR TITLE
ci-operator: handle empty response by cincinnati

### DIFF
--- a/pkg/release/official/client.go
+++ b/pkg/release/official/client.go
@@ -57,6 +57,9 @@ func resolvePullSpec(endpoint string, release api.Release) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to unmarshal response: %w", err)
 	}
+	if len(response.Nodes) == 0 {
+		return "", errors.New("failed to request latest release: server returned empty list of releases (despite status code 200)")
+	}
 	return latestPullSpec(response.Nodes), nil
 }
 

--- a/pkg/release/official/client_test.go
+++ b/pkg/release/official/client_test.go
@@ -82,6 +82,17 @@ func TestResolvePullSpec(t *testing.T) {
 			expected:    "",
 			expectedErr: true,
 		},
+		{
+			name: "handle empty response",
+			release: api.Release{
+				Architecture: api.ReleaseArchitectureAMD64,
+				Channel:      api.ReleaseChannelStable,
+				Version:      "4.4",
+			},
+			raw:         []byte(`{"nodes":[]}`),
+			expected:    "",
+			expectedErr: true,
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Reproduced by:

```yaml
releases:
  latest:
    release:
      channel: stable
      version: "4.7"
```

Should this be a bug in cincinatti? This should IMO return a 404 or maybe a 204.