### PR TITLE
template-deprecator: install diff in image

### DIFF
--- a/images/template-deprecator/Dockerfile
+++ b/images/template-deprecator/Dockerfile
@@ -1,4 +1,8 @@
 FROM centos:8
 LABEL maintainer="muller@redhat.com"
+
+RUN dnf install -y diffutils && \
+      dnf clean all
+
 ADD template-deprecator /usr/bin/template-deprecator
 ENTRYPOINT ["/usr/bin/template-deprecator"]


### PR DESCRIPTION
We need `diff` to run the presubmit that compares allowlists (https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/13427/rehearse-13427-pull-ci-openshift-release-master-deprecate-templates/1324654573951913984#1:build-log.txt%3A1)