### PR TITLE
controllers: add retries for failed images jobs

### DIFF
--- a/pkg/controller/promotionreconciler/prowjobretrigger/reconciler.go
+++ b/pkg/controller/promotionreconciler/prowjobretrigger/reconciler.go
@@ -1,0 +1,181 @@
+package prowjobretrigger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
+	prowjobsv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler/prowjobreconciler"
+	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
+	"github.com/openshift/ci-tools/pkg/load/agents"
+	"github.com/openshift/ci-tools/pkg/rehearse"
+)
+
+type Options struct {
+	CIOperatorConfigAgent agents.ConfigAgent
+	GitHubClient          github.Client
+	Enqueuer              prowjobreconciler.Enqueuer
+}
+
+const (
+	ControllerName = "promotion_job_retrigger"
+)
+
+func AddToManager(mgr controllerruntime.Manager, opts Options) error {
+	log := logrus.WithField("controller", ControllerName)
+	r := &reconciler{
+		ctx:          context.Background(),
+		log:          log,
+		client:       mgr.GetClient(),
+		gitHubClient: opts.GitHubClient,
+		enqueueJob:   opts.Enqueuer,
+	}
+
+	c, err := controller.New(ControllerName, mgr, controller.Options{
+		Reconciler:              r,
+		MaxConcurrentReconciles: 10,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+	if err := c.Watch(
+		&source.Kind{Type: &prowjobsv1.ProwJob{}},
+		handler.Funcs{
+			UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+				q.Add(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: e.MetaNew.GetNamespace(),
+						Name:      e.MetaNew.GetName(),
+					},
+				})
+			},
+		},
+		predicate.NewPredicateFuncs(func(meta metav1.Object, object runtime.Object) bool {
+			prowJob, ok := object.(*prowjobsv1.ProwJob)
+			if !ok {
+				return false
+			}
+			if prowJob.Spec.Type != prowjobsv1.PostsubmitJob {
+				return false
+			}
+			if !strings.HasSuffix(prowJob.Spec.Job, "-images") {
+				return false
+			}
+			return prowJob.Status.State == prowjobsv1.FailureState || prowJob.Status.State == prowjobsv1.ErrorState
+		}),
+	); err != nil {
+		return fmt.Errorf("failed to create watch for ProwJobs: %w", err)
+	}
+	r.log.Info("Successfully added reconciler to manager")
+
+	return nil
+}
+
+type RefGetter interface {
+	GetRef(org, repo, ref string) (string, error)
+}
+
+type reconciler struct {
+	ctx          context.Context
+	log          *logrus.Entry
+	client       ctrlruntimeclient.Client
+	gitHubClient RefGetter
+	enqueueJob   prowjobreconciler.Enqueuer
+}
+
+func (r *reconciler) Reconcile(req controllerruntime.Request) (controllerruntime.Result, error) {
+	log := r.log.WithField("name", req.Name).WithField("namespace", req.Namespace)
+	log.Trace("Starting reconciliation")
+	startTime := time.Now()
+	defer func() { log.WithField("duration", time.Since(startTime)).Trace("Finished reconciliation") }()
+
+	err := r.reconcile(req, log)
+	if err != nil {
+		log.WithError(err).Error("Reconciliation failed")
+	}
+
+	return controllerruntime.Result{}, controllerutil.SwallowIfTerminal(err)
+}
+
+func (r *reconciler) reconcile(req controllerruntime.Request, log *logrus.Entry) error {
+	prowJob := &prowjobsv1.ProwJob{}
+	if err := r.client.Get(r.ctx, req.NamespacedName, prowJob); err != nil {
+		// Object got deleted while it was in the workqueue
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get object: %w", err)
+	}
+
+	if prowJob.Spec.Refs == nil {
+		return controllerutil.TerminalError(fmt.Errorf("promotion prowJob has no refs: %v", req.NamespacedName))
+	}
+
+	metadata := cioperatorapi.Metadata{
+		Org:     prowJob.Spec.Refs.Org,
+		Repo:    prowJob.Spec.Refs.Repo,
+		Branch:  prowJob.Spec.Refs.BaseRef,
+		Variant: rehearse.VariantFromLabels(prowJob.Labels),
+	}
+	log = log.WithField("org", metadata.Org).WithField("repo", metadata.Repo).WithField("branch", metadata.Branch)
+
+	currentHEAD, found, err := CurrentHEADForBranch(r.gitHubClient, metadata, log)
+	if err != nil {
+		return fmt.Errorf("failed to get current git head: %w", err)
+	}
+	if !found {
+		return controllerutil.TerminalError(fmt.Errorf("got 404 for %s/%s/%s from github, this likely means the repo or branch got deleted or we are not allowed to access it", metadata.Org, metadata.Repo, metadata.Branch))
+	}
+	if currentHEAD != prowJob.Spec.Refs.BaseSHA {
+		log.Debug("Not re-triggering failed image job as it is not building images for the latest commit.")
+		return nil
+	}
+	log = log.WithField("currentHEAD", currentHEAD)
+
+	log.Info("Requesting prowjob creation")
+	r.enqueueJob(prowjobreconciler.OrgRepoBranchCommit{
+		Org:    metadata.Org,
+		Repo:   metadata.Repo,
+		Branch: metadata.Branch,
+		Commit: currentHEAD,
+	})
+	return nil
+}
+
+func CurrentHEADForBranch(client RefGetter, metadata cioperatorapi.Metadata, log *logrus.Entry) (string, bool, error) {
+	// We attempted for some time to use the gitClient for this, but we do so many reconciliations that
+	// it results in a massive performance issues that can easely kill the developers laptop.
+	ref, err := client.GetRef(metadata.Org, metadata.Repo, "heads/"+metadata.Branch)
+	if err != nil {
+		if github.IsNotFound(err) {
+			return "", false, nil
+		}
+		if errors.Is(err, github.GetRefTooManyResultsError{}) {
+			log.WithError(err).Debug("got multiple refs back")
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("failed to get sha for ref %s/%s/heads/%s from github: %w", metadata.Org, metadata.Repo, metadata.Branch, err)
+	}
+	return ref, true, nil
+}

--- a/pkg/controller/promotionreconciler/prowjobretrigger/reconciler_test.go
+++ b/pkg/controller/promotionreconciler/prowjobretrigger/reconciler_test.go
@@ -1,6 +1,7 @@
 package prowjobretrigger
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -133,7 +134,7 @@ func TestReconcile(t *testing.T) {
 				enqueueJob:   func(orbc prowjobreconciler.OrgRepoBranchCommit) { req = &orbc },
 			}
 
-			err := r.reconcile(reconcile.Request{NamespacedName: types.NamespacedName{
+			err := r.reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{
 				Namespace: "namespace",
 				Name:      "name",
 			}}, r.log)

--- a/pkg/controller/promotionreconciler/prowjobretrigger/reconciler_test.go
+++ b/pkg/controller/promotionreconciler/prowjobretrigger/reconciler_test.go
@@ -1,0 +1,146 @@
+package prowjobretrigger
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	prowjobsv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/github"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler/prowjobreconciler"
+	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
+)
+
+func init() {
+	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to register imagev1 scheme: %v", err))
+	}
+}
+
+type fakeGithubClient struct {
+	getGef func(string, string, string) (string, error)
+}
+
+func (fghc fakeGithubClient) GetRef(org, repo, ref string) (string, error) {
+	return fghc.getGef(org, repo, ref)
+}
+
+func TestReconcile(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name              string
+		githubClient      func(owner, repo, ref string) (string, error)
+		promotionDisabled bool
+		verify            func(error, *prowjobreconciler.OrgRepoBranchCommit) error
+	}{
+		{
+			name:         "404 getting commit for branch returns terminal error",
+			githubClient: func(_, _, _ string) (string, error) { return "", fmt.Errorf("wrapped: %w", github.NewNotFound()) },
+			verify: func(e error, _ *prowjobreconciler.OrgRepoBranchCommit) error {
+				if !controllerutil.IsTerminal(e) {
+					return fmt.Errorf("expected to get terminal error, got %v", e)
+				}
+				return nil
+			},
+		},
+		{
+			name: "ErrTooManyRefs getting commit for branch returns terminal error",
+			githubClient: func(_, _, _ string) (string, error) {
+				return "", fmt.Errorf("wrapped: %w", github.GetRefTooManyResultsError{})
+			},
+			verify: func(e error, _ *prowjobreconciler.OrgRepoBranchCommit) error {
+				if !controllerutil.IsTerminal(e) {
+					return fmt.Errorf("expected to get terminal error, got %v", e)
+				}
+				return nil
+			},
+		},
+		{
+			name:         "outdated job failed, nothing to do",
+			githubClient: func(_, _, _ string) (string, error) { return "other", nil },
+			verify: func(e error, req *prowjobreconciler.OrgRepoBranchCommit) error {
+				if e != nil {
+					return fmt.Errorf("expected error to be nil, was %w", e)
+				}
+				if req != nil {
+					return fmt.Errorf("expected to not get a prowjob creation request, got %v", req)
+				}
+				return nil
+			},
+		},
+		{
+			name:         "current commit job failed, prowjob created",
+			githubClient: func(_, _, _ string) (string, error) { return "commit", nil },
+			verify: func(e error, req *prowjobreconciler.OrgRepoBranchCommit) error {
+				if e != nil {
+					return fmt.Errorf("expected error to be nil, was %w", e)
+				}
+				if req == nil {
+					return errors.New("expected to get request, was nil")
+				}
+				expected := &prowjobreconciler.OrgRepoBranchCommit{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+					Commit: "commit",
+				}
+				if diff := cmp.Diff(req, expected); diff != "" {
+					return fmt.Errorf("req differs from expected: %s", diff)
+				}
+				return nil
+			},
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.TraceLevel)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			prowJob := &prowjobsv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "namespace",
+					Name:      "name",
+				},
+				Spec: prowjobsv1.ProwJobSpec{
+					Job: "branch-ci-org-repo-branch-images",
+					Refs: &prowjobsv1.Refs{
+						Org:     "org",
+						Repo:    "repo",
+						BaseRef: "branch",
+						BaseSHA: "commit",
+					},
+				},
+			}
+
+			var req *prowjobreconciler.OrgRepoBranchCommit
+
+			r := &reconciler{
+				log:          logger.WithField("test", tc.name),
+				client:       fakectrlruntimeclient.NewFakeClient(prowJob),
+				gitHubClient: fakeGithubClient{getGef: tc.githubClient},
+				enqueueJob:   func(orbc prowjobreconciler.OrgRepoBranchCommit) { req = &orbc },
+			}
+
+			err := r.reconcile(reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      "name",
+			}}, r.log)
+
+			if err := tc.verify(err, req); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/pkg/controller/promotionreconciler/reconciler.go
+++ b/pkg/controller/promotionreconciler/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +22,7 @@ import (
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler/prowjobreconciler"
+	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler/prowjobretrigger"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/promotion"
@@ -32,46 +32,31 @@ import (
 )
 
 type Options struct {
-	DryRun                bool
 	CIOperatorConfigAgent agents.ConfigAgent
-	ConfigGetter          config.Getter
 	GitHubClient          github.Client
-	// The registryManager is set up to talk to the cluster
-	// that contains our imageRegistry. This cluster is
-	// most likely not the one the normal manager talks to.
-	RegistryManager controllerruntime.Manager
+	Enqueuer              prowjobreconciler.Enqueuer
 }
 
 const ControllerName = "promotionreconciler"
 
-func AddToManager(mgr controllerruntime.Manager, opts Options) error {
-	// Pre-Allocate the Image informer rather than letting it allocate on demand, because
-	// starting the watch takes very long (~2 minutes) and having that delay added to our
-	// first (# worker) reconciles skews the workqueue duration metric bigtimes.
-	if _, err := opts.RegistryManager.GetCache().GetInformer(context.TODO(), &imagev1.Image{}); err != nil {
-		return fmt.Errorf("failed to get informer for image: %w", err)
-	}
-
+// AddToManager adds this controller to the manager, which must be the one for the cluster
+// hosting our central image registry, as we react to changes in ImageStreamTags there.
+func AddToManager(registryMgr controllerruntime.Manager, opts Options) error {
 	if err := opts.CIOperatorConfigAgent.AddIndex(configIndexName, configIndexFn); err != nil {
 		return fmt.Errorf("failed to add indexer to config-agent: %w", err)
-	}
-
-	prowJobEnqueuer, err := prowjobreconciler.AddToManager(mgr, opts.ConfigGetter, opts.DryRun)
-	if err != nil {
-		return fmt.Errorf("failed to construct prowjobreconciler: %w", err)
 	}
 
 	log := logrus.WithField("controller", ControllerName)
 	r := &reconciler{
 		log:    log,
-		client: imagestreamtagwrapper.MustNew(opts.RegistryManager.GetClient(), opts.RegistryManager.GetCache()),
+		client: imagestreamtagwrapper.MustNew(registryMgr.GetClient(), registryMgr.GetCache()),
 		releaseBuildConfigs: func(identifier string) ([]*cioperatorapi.ReleaseBuildConfiguration, error) {
 			return opts.CIOperatorConfigAgent.GetFromIndex(configIndexName, identifier)
 		},
 		gitHubClient: opts.GitHubClient,
-		enqueueJob:   prowJobEnqueuer,
+		enqueueJob:   opts.Enqueuer,
 	}
-	c, err := controller.New(ControllerName, opts.RegistryManager, controller.Options{
+	c, err := controller.New(ControllerName, registryMgr, controller.Options{
 		Reconciler: r,
 		// We currently have 50k ImageStreamTags in the OCP namespace and need to periodically reconcile all of them,
 		// so don't be stingy with the workers
@@ -210,20 +195,7 @@ func commitForIST(ist *imagev1.ImageStreamTag) (string, error) {
 }
 
 func (r *reconciler) currentHEADForBranch(metadata cioperatorapi.Metadata, log *logrus.Entry) (string, bool, error) {
-	// We attempted for some time to use the gitClient for this, but we do so many reconciliations that
-	// it results in a massive performance issues that can easely kill the developers laptop.
-	ref, err := r.gitHubClient.GetRef(metadata.Org, metadata.Repo, "heads/"+metadata.Branch)
-	if err != nil {
-		if github.IsNotFound(err) {
-			return "", false, nil
-		}
-		if errors.Is(err, github.GetRefTooManyResultsError{}) {
-			log.WithError(err).Debug("got multiple refs back")
-			return "", false, nil
-		}
-		return "", false, fmt.Errorf("failed to get sha for ref %s/%s/heads/%s from github: %w", metadata.Org, metadata.Repo, metadata.Branch, err)
-	}
-	return ref, true, nil
+	return prowjobretrigger.CurrentHEADForBranch(r.gitHubClient, metadata, log)
 }
 
 const configIndexName = "release-build-config-by-image-stream-tag"


### PR DESCRIPTION
The current image promotion reconciler ensures that we have correct
output in the form of ImageStreamTags, but misses the most common reason
that the content may be incorrect: a post-submit job building images
failed. This new controller re-triggers failed post-submit images jobs
when they are for the latest commit in the branch they're meant to
build.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 
implements [DPTP-1647](https://issues.redhat.com/browse/DPTP-1647)