### PR TITLE
Fix a typo in DPTP-CM

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -152,7 +152,7 @@ func newOpts() (*options, error) {
 		}
 	}
 	opts.testImagesDistributorOptions.additionalImageStreams = sets.String{}
-	if vals := opts.testImagesDistributorOptions.additionalImageStreamTagsRaw.Strings(); len(vals) > 0 {
+	if vals := opts.testImagesDistributorOptions.additionalImageStreamsRaw.Strings(); len(vals) > 0 {
 		for _, val := range vals {
 			slashSplit := strings.Split(val, "/")
 			if len(slashSplit) != 2 {


### PR DESCRIPTION
We have not used this flag yet.
https://github.com/openshift/release/blob/fae7f47a56abf5c3ac4ea9e9230eb2ec123b2597/clusters/app.ci/assets/dptp-controller-manager.yaml#L100-L111

/cc @alvaroaleman 

