### PR TITLE
template-deprecator: --prune

### DIFF
--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -18,6 +18,7 @@ type options struct {
 	prowConfigPath       string
 	prowPluginConfigPath string
 	allowlistPath        string
+	prune                bool
 
 	help bool
 }
@@ -29,6 +30,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&opt.prowConfigPath, "prow-config-path", "", "Path to the Prow configuration file")
 	fs.StringVar(&opt.prowPluginConfigPath, "prow-plugin-config-path", "", "Path to the Prow plugin configuration file")
 	fs.StringVar(&opt.allowlistPath, "allowlist-path", "", "Path to template deprecation allowlist")
+	fs.BoolVar(&opt.prune, "prune", false, "If set, remove from allowlist all jobs that either no longer exist or no longer use a template")
 
 	return opt
 }
@@ -79,6 +81,10 @@ func main() {
 
 	enforcer.LoadTemplates(pluginCfg)
 	enforcer.ProcessJobs(prowCfg)
+
+	if opt.prune {
+		enforcer.Prune()
+	}
 
 	if err := enforcer.SaveAllowlist(opt.allowlistPath); err != nil {
 		logrus.WithError(err).Fatal("Failed to save template deprecation allowlist")

--- a/pkg/deprecatetemplates/allowlist_test.go
+++ b/pkg/deprecatetemplates/allowlist_test.go
@@ -9,6 +9,114 @@ import (
 	"k8s.io/test-infra/prow/config"
 )
 
+func TestDeprecatedTemplatePrune(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       deprecatedTemplate
+		expected    deprecatedTemplate
+	}{
+		{
+			description: "non-current job is removed from unknown blockers",
+			input: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{
+					Description: "unknown",
+					Jobs:        blockedJobs{"job": blockedJob{current: false}},
+				},
+			},
+			expected: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{
+					Description: "unknown",
+					Jobs:        blockedJobs{},
+				},
+			},
+		},
+		{
+			description: "non-current job is removed from unknown blockers, current is kept",
+			input: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{
+					Description: "unknown",
+					Jobs: blockedJobs{
+						"job":         blockedJob{current: false},
+						"current-job": blockedJob{current: true},
+					},
+				},
+			},
+			expected: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{
+					Description: "unknown",
+					Jobs: blockedJobs{
+						"current-job": blockedJob{current: true},
+					},
+				},
+			},
+		},
+		{
+			description: "non-current job is removed from all blockers, current jobs are kept",
+			input: deprecatedTemplate{
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"BLOCKER-1": {Jobs: blockedJobs{
+						"job":         blockedJob{current: false},
+						"current-job": blockedJob{current: true},
+					}},
+					"BLOCKER-2": {Jobs: blockedJobs{
+						"job":         blockedJob{current: false},
+						"current-job": blockedJob{current: true},
+					}},
+				},
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+			},
+			expected: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"BLOCKER-1": {Jobs: blockedJobs{
+						"current-job": blockedJob{current: true},
+					}},
+					"BLOCKER-2": {Jobs: blockedJobs{
+						"current-job": blockedJob{current: true},
+					}},
+				},
+			},
+		},
+		{
+			description: "blocker without jobs is removed, blocker with jobs is kept",
+			input: deprecatedTemplate{
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"BLOCKER-KEPT":    {Jobs: blockedJobs{"current-job": blockedJob{current: true}}},
+					"BLOCKER-REMOVED": {Jobs: blockedJobs{"job": blockedJob{current: false}}},
+				},
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+			},
+			expected: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"BLOCKER-KEPT": {Jobs: blockedJobs{"current-job": blockedJob{current: true}}},
+				},
+			},
+		},
+		{
+			description: "blockers are pruned entirely when all jobs are pruned",
+			input: deprecatedTemplate{
+				Blockers: map[string]deprecatedTemplateBlocker{
+					"BLOCKER-REMOVED":     {Jobs: blockedJobs{"job": blockedJob{current: false}}},
+					"BLOCKER-REMOVED-TOO": {Jobs: blockedJobs{"another-job": blockedJob{current: false}}},
+				},
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+			},
+			expected: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Description: "unknown"},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			tc.input.prune()
+			if diff := cmp.Diff(tc.input, tc.expected, cmp.AllowUnexported(blockedJob{})); diff != "" {
+				t.Errorf("%s: deprecated template record differs from expected:\n%s", tc.description, diff)
+			}
+		})
+	}
+}
+
 func TestDeprecatedTemplateInsert(t *testing.T) {
 	job := "inserted-job"
 
@@ -23,7 +131,7 @@ func TestDeprecatedTemplateInsert(t *testing.T) {
 				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{}},
 			},
 			expectedDT: deprecatedTemplate{
-				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown", current: true}}},
 			},
 		},
 		{
@@ -38,18 +146,18 @@ func TestDeprecatedTemplateInsert(t *testing.T) {
 			expectedDT: deprecatedTemplate{
 				Blockers: map[string]deprecatedTemplateBlocker{
 					"DPTP-1235": {
-						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}},
+						Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown", current: true}},
 					},
 				},
 			},
 		},
 		{
-			description: "adding job already in unknown blockers is a nop",
+			description: "adding job already in unknown blockers only sets the current field",
 			existingDT: deprecatedTemplate{
 				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
 			},
 			expectedDT: deprecatedTemplate{
-				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown"}}},
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown", current: true}}},
 			},
 		},
 	}
@@ -57,7 +165,7 @@ func TestDeprecatedTemplateInsert(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tc.existingDT.insert(config.JobBase{Name: job})
-			if diff := cmp.Diff(tc.existingDT, tc.expectedDT); diff != "" {
+			if diff := cmp.Diff(tc.existingDT, tc.expectedDT, cmp.AllowUnexported(blockedJob{})); diff != "" {
 				t.Errorf("%s: deprecated template record differs from expected:\n%s", tc.description, diff)
 			}
 		})
@@ -161,7 +269,7 @@ func TestAllowlistInsert(t *testing.T) {
 			actual := allowlist{Templates: tc.before}
 			actual.Insert(config.JobBase{Name: job}, template)
 			expected := allowlist{Templates: tc.expectedAfter}
-			if diff := cmp.Diff(&expected, &actual, cmpopts.IgnoreUnexported(allowlist{})); diff != "" {
+			if diff := cmp.Diff(&expected, &actual, cmpopts.IgnoreUnexported(allowlist{}, blockedJob{})); diff != "" {
 				t.Errorf("%s: allowlist differs from expected:\n%s", tc.description, diff)
 			}
 		})

--- a/pkg/deprecatetemplates/enforcer.go
+++ b/pkg/deprecatetemplates/enforcer.go
@@ -82,3 +82,7 @@ func (e *Enforcer) ingest(job prowconfig.JobBase) {
 func (e *Enforcer) SaveAllowlist(path string) error {
 	return e.allowlist.Save(path)
 }
+
+func (e *Enforcer) Prune() {
+	e.allowlist.Prune()
+}

--- a/pkg/deprecatetemplates/enforcer_test.go
+++ b/pkg/deprecatetemplates/enforcer_test.go
@@ -63,6 +63,10 @@ func (m *mockAllowlist) Save(_ string) error {
 	panic("this should never be called")
 }
 
+func (m *mockAllowlist) Prune() {
+	panic("this should never be called")
+}
+
 type mockJobConfig struct {
 	presubmits  []config.Presubmit
 	postsubmits []config.Postsubmit

--- a/test/integration/template-deprecator.sh
+++ b/test/integration/template-deprecator.sh
@@ -30,4 +30,9 @@ cp "${inputs}/blockered-allowlist.yaml" "${allowlist}"
 os::cmd::expect_success "template-deprecator --prow-jobs-dir ${inputs}/jobs --prow-config-path ${inputs}/config.yaml --prow-plugin-config-path ${inputs}/plugins.yaml --allowlist-path ${allowlist}"
 os::integration::compare "${allowlist}" "${suite_dir}/expected/blockered-allowlist.yaml"
 
+# this invocation should prune old jobs from the allowlist
+cp "${inputs}/to-be-pruned-allowlist.yaml" "${allowlist}"
+os::cmd::expect_success "template-deprecator --prune=true --prow-jobs-dir ${inputs}/jobs --prow-config-path ${inputs}/config.yaml --prow-plugin-config-path ${inputs}/plugins.yaml --allowlist-path ${allowlist}"
+os::integration::compare "${allowlist}" "${suite_dir}/expected/blockered-allowlist.yaml"
+
 os::test::junit::declare_suite_end

--- a/test/integration/template-deprecator/input/to-be-pruned-allowlist.yaml
+++ b/test/integration/template-deprecator/input/to-be-pruned-allowlist.yaml
@@ -1,0 +1,28 @@
+templates:
+  testing-template:
+    blockers:
+      DPTP-1234:
+        description: "serious problem"
+        jobs:
+          periodic-job-1:
+            generated: false
+            kind: periodic
+          periodic-job-2:
+            generated: false
+            kind: periodic
+          should-be-pruned:
+            generated: false
+            kind: periodic
+      SHOULD-BE-PRUNED:
+        description: "no serious problem"
+        jobs:
+          should-be-pruned-too:
+            generated: false
+            kind: periodic
+    template_name: testing-template
+    unknown_blocker:
+      description: unknown
+      jobs:
+        this-should-be-pruned-too:
+          generated: false
+          kind: periodic


### PR DESCRIPTION
To be called in autoconfigbrancher to regularly clean up the allowlist
(do not bother people who are migrating jobs with allowlist changes).