### PR TITLE
autoconfigbrancher: maintain and prune template deprecation allowlist

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -185,6 +185,16 @@ func main() {
 			command:   "/usr/bin/sanitize-prow-jobs",
 			arguments: []string{"--prow-jobs-dir", "./ci-operator/jobs", "--config-path", "./core-services/sanitize-prow-jobs/_config.yaml"},
 		},
+		{
+			command: "/usr/bin/template-deprecator",
+			arguments: []string{
+				"--prow-config-path", "./core-services/prow/02_config/_config.yaml",
+				"--prow-plugin-config-path", "./core-services/prow/02_config/_plugins.yaml",
+				"--prow-jobs-dir", "./ci-operator/jobs",
+				"--allowlist-path", "./core-services/template-deprecation/_allowlist.yaml",
+				"--prune=true",
+			},
+		},
 	}
 
 	stdout := bumper.HideSecretsWriter{Delegate: os.Stdout, Censor: sa}

--- a/images/autoconfigbrancher/Dockerfile
+++ b/images/autoconfigbrancher/Dockerfile
@@ -8,6 +8,7 @@ ADD ci-operator-config-mirror /usr/bin/ci-operator-config-mirror
 ADD private-prow-configs-mirror /usr/bin/private-prow-configs-mirror
 ADD sanitize-prow-jobs /usr/bin/sanitize-prow-jobs
 ADD determinize-prow-config /usr/bin/determinize-prow-config
+ADD template-deprecator /usr/bin/template-deprecator
 
 RUN dnf install -y git && \
     dnf clean all && \


### PR DESCRIPTION
The tool can add copies of existing jobs, so it needs to be able to add
them to the the allowlist, too. Also, remove non-existent/irrelevant
jobs from the allowlist.

/hold
Needs https://github.com/openshift/ci-tools/pull/1399 first