### PR TITLE
Cleanup code handling obsolete templates

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -514,11 +514,6 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		needsReleaseRpms = true
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
 	}
-	if testConfig := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; testConfig != nil {
-		typeCount++
-		needsReleaseRpms = true
-		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
-	}
 	if testConfig := test.OpenshiftInstallerClusterTestConfiguration; testConfig != nil {
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -530,10 +530,6 @@ func validateTestConfigurationType(fieldRoot string, test TestStepConfiguration,
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
 	}
-	if testConfig := test.OpenshiftInstallerConsoleClusterTestConfiguration; testConfig != nil {
-		typeCount++
-		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)
-	}
 	if testConfig := test.OpenshiftInstallerCustomTestImageClusterTestConfiguration; testConfig != nil {
 		typeCount++
 		validationErrors = append(validationErrors, validateClusterProfile(fieldRoot, testConfig.ClusterProfile)...)

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -498,7 +498,6 @@ type TestStepConfiguration struct {
 	OpenshiftAnsibleSrcClusterTestConfiguration               *OpenshiftAnsibleSrcClusterTestConfiguration               `json:"openshift_ansible_src,omitempty"`
 	OpenshiftAnsibleCustomClusterTestConfiguration            *OpenshiftAnsibleCustomClusterTestConfiguration            `json:"openshift_ansible_custom,omitempty"`
 	OpenshiftAnsible40ClusterTestConfiguration                *OpenshiftAnsible40ClusterTestConfiguration                `json:"openshift_ansible_40,omitempty"`
-	OpenshiftAnsibleUpgradeClusterTestConfiguration           *OpenshiftAnsibleUpgradeClusterTestConfiguration           `json:"openshift_ansible_upgrade,omitempty"`
 	OpenshiftInstallerClusterTestConfiguration                *OpenshiftInstallerClusterTestConfiguration                `json:"openshift_installer,omitempty"`
 	OpenshiftInstallerSrcClusterTestConfiguration             *OpenshiftInstallerSrcClusterTestConfiguration             `json:"openshift_installer_src,omitempty"`
 	OpenshiftInstallerUPIClusterTestConfiguration             *OpenshiftInstallerUPIClusterTestConfiguration             `json:"openshift_installer_upi,omitempty"`
@@ -985,15 +984,6 @@ type OpenshiftAnsibleCustomClusterTestConfiguration struct {
 // test that provisions a cluster using new installer and openshift-ansible
 type OpenshiftAnsible40ClusterTestConfiguration struct {
 	ClusterTestConfiguration `json:",inline"`
-}
-
-// OpenshiftAnsibleUpgradeClusterTestConfiguration describes a
-// test that provisions a cluster using openshift-ansible,
-// upgrades it to the next version and runs conformance tests.
-type OpenshiftAnsibleUpgradeClusterTestConfiguration struct {
-	ClusterTestConfiguration `json:",inline"`
-	PreviousVersion          string `json:"previous_version"`
-	PreviousRPMDeps          string `json:"previous_rpm_deps"`
 }
 
 // OpenshiftInstallerClusterTestConfiguration describes a test

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -502,7 +502,6 @@ type TestStepConfiguration struct {
 	OpenshiftInstallerSrcClusterTestConfiguration             *OpenshiftInstallerSrcClusterTestConfiguration             `json:"openshift_installer_src,omitempty"`
 	OpenshiftInstallerUPIClusterTestConfiguration             *OpenshiftInstallerUPIClusterTestConfiguration             `json:"openshift_installer_upi,omitempty"`
 	OpenshiftInstallerUPISrcClusterTestConfiguration          *OpenshiftInstallerUPISrcClusterTestConfiguration          `json:"openshift_installer_upi_src,omitempty"`
-	OpenshiftInstallerConsoleClusterTestConfiguration         *OpenshiftInstallerConsoleClusterTestConfiguration         `json:"openshift_installer_console,omitempty"`
 	OpenshiftInstallerCustomTestImageClusterTestConfiguration *OpenshiftInstallerCustomTestImageClusterTestConfiguration `json:"openshift_installer_custom_test_image,omitempty"`
 }
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -323,9 +323,6 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 		template = "cluster-launch-installer-upi-src"
 		needsLeaseServer = true
 		clusterProfile = conf.ClusterProfile
-	} else if conf := test.OpenshiftInstallerConsoleClusterTestConfiguration; conf != nil {
-		template = "cluster-launch-installer-console"
-		clusterProfile = conf.ClusterProfile
 	} else if conf := test.OpenshiftInstallerCustomTestImageClusterTestConfiguration; conf != nil {
 		template = "cluster-launch-installer-custom-test-image"
 		needsLeaseServer = true

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -300,10 +300,6 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 		template = "cluster-launch-e2e-openshift-ansible"
 		clusterProfile = conf.ClusterProfile
 		needsReleaseRpms = true
-	} else if conf := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; conf != nil {
-		template = "cluster-launch-e2e-upgrade"
-		clusterProfile = conf.ClusterProfile
-		needsReleaseRpms = true
 	} else if conf := test.OpenshiftAnsible40ClusterTestConfiguration; conf != nil {
 		template = "cluster-scaleup-e2e-40"
 		clusterProfile = conf.ClusterProfile
@@ -384,18 +380,6 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 				Name:  "RPM_REPO_CRIO_DIR",
 				Value: fmt.Sprintf("%s-rhel-7", release)},
 		)
-	}
-	if conf := test.OpenshiftAnsibleUpgradeClusterTestConfiguration; conf != nil {
-		container.Env = append(
-			container.Env,
-			corev1.EnvVar{Name: "PREVIOUS_ANSIBLE_VERSION",
-				Value: conf.PreviousVersion},
-			corev1.EnvVar{Name: "PREVIOUS_IMAGE_ANSIBLE",
-				Value: fmt.Sprintf("docker.io/openshift/origin-ansible:v%s", conf.PreviousVersion)},
-			corev1.EnvVar{Name: "PREVIOUS_RPM_DEPENDENCIES_REPO",
-				Value: conf.PreviousRPMDeps},
-			corev1.EnvVar{Name: "PREVIOUS_RPM_REPO",
-				Value: fmt.Sprintf("%s/openshift-origin-v%s/", cioperatorapi.URLForService(cioperatorapi.ServiceRPMs), conf.PreviousVersion)})
 	}
 	return podSpec
 }
@@ -531,7 +515,7 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 	labels := map[string]string{prowJobLabelGenerated: string(newlyGenerated)}
 
 	if rehearsable {
-		labels[jc.CanBeRehearsedLabel] = string(jc.CanBeRehearsedValue)
+		labels[jc.CanBeRehearsedLabel] = jc.CanBeRehearsedValue
 	}
 
 	jobName := info.JobName(prefix, name)

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -555,13 +555,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            cluster_profile: ' '\n" +
 	"        openshift_ansible_src:\n" +
 	"            cluster_profile: ' '\n" +
-	"        openshift_ansible_upgrade:\n" +
-	"            cluster_profile: ' '\n" +
-	"            previous_rpm_deps: ' '\n" +
-	"            previous_version: ' '\n" +
 	"        openshift_installer:\n" +
-	"            cluster_profile: ' '\n" +
-	"        openshift_installer_console:\n" +
 	"            cluster_profile: ' '\n" +
 	"        openshift_installer_custom_test_image:\n" +
 	"            cluster_profile: ' '\n" +
@@ -1090,13 +1084,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        cluster_profile: ' '\n" +
 	"    openshift_ansible_src:\n" +
 	"        cluster_profile: ' '\n" +
-	"    openshift_ansible_upgrade:\n" +
-	"        cluster_profile: ' '\n" +
-	"        previous_rpm_deps: ' '\n" +
-	"        previous_version: ' '\n" +
 	"    openshift_installer:\n" +
-	"        cluster_profile: ' '\n" +
-	"    openshift_installer_console:\n" +
 	"        cluster_profile: ' '\n" +
 	"    openshift_installer_custom_test_image:\n" +
 	"        cluster_profile: ' '\n" +


### PR DESCRIPTION
`openshift_ansible_upgrade`:

This template is not used in any generated job (and so in no ci-operator
config), so all code that handles the tempalte can be removed:

```console
$ git grep openshift_ansible_upgrade

$ git grep prow-job-cluster-launch-e2e-upgrade ci-operator/jobs/
ci-operator/jobs/openshift/openshift-ansible/openshift-openshift-ansible-release-3.11-presubmits.yaml:          name: prow-job-cluster-launch-e2e-upgrade
```

`openshift_installer_console`

It is only used by online ci-op configs (which should be changed to
match what the jobs actually use).

/hold 
Needs https://github.com/openshift/release/pull/13529

