### PR TITLE
pkg/defaults: only process `Provides` once

### DIFF
--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"sync"
 )
@@ -79,9 +80,11 @@ func (p *DeferredParameters) Set(name, value string) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	if _, ok := p.fns[name]; ok {
+		log.Printf("warning: ignoring parameter %q, already set", name)
 		return
 	}
 	if _, ok := p.values[name]; ok {
+		log.Printf("warning: ignoring parameter %q, already set", name)
 		return
 	}
 	p.values[name] = value
@@ -90,6 +93,9 @@ func (p *DeferredParameters) Set(name, value string) {
 func (p *DeferredParameters) Add(name string, fn func() (string, error)) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+	if _, ok := p.fns[name]; ok {
+		log.Printf("warning: overriding parameter %q", name)
+	}
 	p.fns[name] = fn
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -61,31 +61,29 @@ func FromConfig(
 	var podClient steps.PodClient
 	var client ctrlruntimeclient.Client
 
-	if clusterConfig != nil {
-		var err error
-		client, err = ctrlruntimeclient.New(clusterConfig, ctrlruntimeclient.Options{})
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to construct client: %w", err)
-		}
-		buildGetter, err := buildclientset.NewForConfig(clusterConfig)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not get build client for cluster config: %w", err)
-		}
-		buildClient = steps.NewBuildClient(client, buildGetter.RESTClient())
-
-		templateGetter, err := templateclientset.NewForConfig(clusterConfig)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not get template client for cluster config: %w", err)
-		}
-		templateClient = steps.NewTemplateClient(client, templateGetter.RESTClient())
-
-		coreGetter, err := coreclientset.NewForConfig(clusterConfig)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not get core client for cluster config: %w", err)
-		}
-
-		podClient = steps.NewPodClient(coreGetter, clusterConfig, coreGetter.RESTClient())
+	var err error
+	client, err = ctrlruntimeclient.New(clusterConfig, ctrlruntimeclient.Options{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to construct client: %w", err)
 	}
+	buildGetter, err := buildclientset.NewForConfig(clusterConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get build client for cluster config: %w", err)
+	}
+	buildClient = steps.NewBuildClient(client, buildGetter.RESTClient())
+
+	templateGetter, err := templateclientset.NewForConfig(clusterConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get template client for cluster config: %w", err)
+	}
+	templateClient = steps.NewTemplateClient(client, templateGetter.RESTClient())
+
+	coreGetter, err := coreclientset.NewForConfig(clusterConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not get core client for cluster config: %w", err)
+	}
+
+	podClient = steps.NewPodClient(coreGetter, clusterConfig, coreGetter.RESTClient())
 
 	params := api.NewDeferredParameters()
 	params.Add("JOB_NAME", func() (string, error) { return jobSpec.Job, nil })


### PR DESCRIPTION
Part of https://github.com/openshift/ci-tools/pull/1362 (which in turn is part
of https://github.com/openshift/ci-tools/pull/1312).  Opened separately to limit
the number of changes in a single PR.

See https://github.com/openshift/ci-tools/pull/1362#issuecomment-723284065 for
more details.  Due to refactorings in `pkg/defaults`, we eventually started
processing `Provides` more than once for some types of build steps.  This does
not appear to have a negative effect, but is certainly wrong and misleading.