### PR TITLE
Import utilerrors as utilerrors and not kerrors

### DIFF
--- a/cmd/private-org-peribolos-sync/main.go
+++ b/cmd/private-org-peribolos-sync/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/config/secret"
@@ -74,7 +74,7 @@ func validateOptions(o *options) error {
 	if err := o.Validate(); err != nil {
 		validationErrors = append(validationErrors, err)
 	}
-	return kerrors.NewAggregate(validationErrors)
+	return utilerrors.NewAggregate(validationErrors)
 }
 
 func main() {

--- a/cmd/publicize/main.go
+++ b/cmd/publicize/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
@@ -42,7 +42,7 @@ func (c *Config) validate() error {
 		}
 	}
 
-	return kerrors.NewAggregate(errs)
+	return utilerrors.NewAggregate(errs)
 }
 
 type options struct {

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -39,7 +39,7 @@ func Validate(stepsByName ReferenceByName, chainsByName ChainByName, workflowsBy
 		}
 		ret = append(ret, stack.records[0].checkUnused(&stack)...)
 	}
-	return errors.NewAggregate(ret)
+	return utilerrors.NewAggregate(ret)
 }
 
 // registry will hold all the registry information needed to convert between the
@@ -134,7 +134,7 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 	}
 	expandedFlow.Observers = observers
 	if resolveErrors != nil {
-		return api.MultiStageTestConfigurationLiteral{}, errors.NewAggregate(resolveErrors)
+		return api.MultiStageTestConfigurationLiteral{}, utilerrors.NewAggregate(resolveErrors)
 	}
 	return expandedFlow, nil
 }

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -16,7 +16,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -937,7 +936,7 @@ func (e *Executor) submitRehearsals() ([]*pjapi.ProwJob, error) {
 		pjs = append(pjs, created)
 	}
 
-	return pjs, kerrors.NewAggregate(errors)
+	return pjs, utilerrors.NewAggregate(errors)
 }
 
 func (e *Executor) submitPresubmit(job *prowconfig.Presubmit) (*pjapi.ProwJob, error) {

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -20,7 +20,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -700,7 +700,7 @@ func gatherContainerLogsOutput(podClient PodClient, artifactDir, namespace, podN
 			w.Close()
 		}
 	}
-	return kerrors.NewAggregate(validationErrors)
+	return utilerrors.NewAggregate(validationErrors)
 }
 
 // for gathering successful build logs to the artifacts, there is no way to augment the pod spec


### PR DESCRIPTION
Importing it as kerrors is extremely confusing as kerrors is 99% of the
time the "k8s.io/apimachinery/pkg/api/errors" package.