### PR TITLE
PJ rehearse: Treat 403 like 404 when determining if to import

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -538,7 +538,7 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 				istLog.Info("ImageStreamTag already exists in the build cluster")
 				return nil
 			}
-			if !apierrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) && !apierrors.IsForbidden(err) {
 				return fmt.Errorf("failed to check if imagestreamtag %s exists: %w", requiredImageStreamTag, err)
 			}
 			istImport := &testimagestreamtagimportv1.TestImageStreamTagImport{


### PR DESCRIPTION
We get a 403 if the namespace doesn't exist, which also means we need to
create an import.