### PR TITLE
Ensure ImageStreamSpec while sync images

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -279,9 +279,6 @@ func imagestream(imageStream *imagev1.ImageStream) (*imagev1.ImageStream, crcont
 			}
 		}
 		stream.Spec.LookupPolicy.Local = imageStream.Spec.LookupPolicy.Local
-		for i := range stream.Spec.Tags {
-			stream.Spec.Tags[i].ReferencePolicy.Type = imageStream.Spec.Tags[i].ReferencePolicy.Type
-		}
 		return nil
 	}
 }


### PR DESCRIPTION
```
   dockerImageRepository	<string>
     dockerImageRepository is optional, if specified this stream is backed by a
     container repository on this server Deprecated: This field is deprecated as
     of v3.7 and will be removed in a future release. Specify the source for the
     tags to be imported in each tag via the spec.tags.from reference instead.

   lookupPolicy	<Object>
     lookupPolicy controls how other resources reference images within this
     namespace.

   tags	<[]Object>
     tags map arbitrary string values to specific image locators
```

We copied `lookupPolicy` already and `dockerImageRepository` is deprecated.
Maybe keep the whole `tags` as the sourceImageStream which (has the latest isTag)?

