### PR TITLE
pkg/release: return version for official release

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -120,7 +120,7 @@ func FromConfig(
 				case resolveConfig.Candidate != nil:
 					value, err = candidate.ResolvePullSpec(*resolveConfig.Candidate)
 				case resolveConfig.Release != nil:
-					value, err = official.ResolvePullSpec(*resolveConfig.Release)
+					value, _, err = official.ResolvePullSpecAndVersion(*resolveConfig.Release)
 				case resolveConfig.Prerelease != nil:
 					value, err = prerelease.ResolvePullSpec(*resolveConfig.Prerelease)
 				}

--- a/pkg/release/official/client_test.go
+++ b/pkg/release/official/client_test.go
@@ -54,11 +54,12 @@ func TestDefaultFields(t *testing.T) {
 
 func TestResolvePullSpec(t *testing.T) {
 	var testCases = []struct {
-		name        string
-		release     api.Release
-		raw         []byte
-		expected    string
-		expectedErr bool
+		name             string
+		release          api.Release
+		raw              []byte
+		expectedPullspec string
+		expectedVersion  string
+		expectedErr      bool
 	}{
 		{
 			name: "normal request",
@@ -67,9 +68,10 @@ func TestResolvePullSpec(t *testing.T) {
 				Channel:      api.ReleaseChannelStable,
 				Version:      "4.4",
 			},
-			raw:         []byte(`{"nodes":[{"version":"4.2.19","payload":"quay.io/openshift-release-dev/ocp-release@sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":"4\\.1\\..*","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035","url":"https://access.redhat.com/errata/RHBA-2020:0460"}},{"version":"4.3.21","payload":"quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0","metadata":{"description":"","io.openshift.upgrades.graph.release.channels":"candidate-4.3,fast-4.3,stable-4.3,candidate-4.4,fast-4.4,stable-4.4","io.openshift.upgrades.graph.release.manifestref":"sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0","url":"https://access.redhat.com/errata/RHBA-2020:2129"}},{"version":"4.2.20","payload":"quay.io/openshift-release-dev/ocp-release@sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":"4\\.1\\..*","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787","url":"https://access.redhat.com/errata/RHBA-2020:0523"}},{"version":"4.2.33","payload":"quay.io/openshift-release-dev/ocp-release@sha256:52e780ccc7e3af73b11dcb4afe275e2e743b59ccea6f228089ac93337de244d7","metadata":{"description":"","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:52e780ccc7e3af73b11dcb4afe275e2e743b59ccea6f228089ac93337de244d7","url":"https://access.redhat.com/errata/RHBA-2020:2023"}},{"version":"4.3.3","payload":"quay.io/openshift-release-dev/ocp-release@sha256:9b8708b67dd9b7720cb7ab3ed6d12c394f689cc8927df0e727c76809ab383f44","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":".*","io.openshift.upgrades.graph.release.channels":"candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:9b8708b67dd9b7720cb7ab3ed6d12c394f689cc8927df0e727c76809ab383f44","url":"https://access.redhat.com/errata/RHBA-2020:0528"}}]}`),
-			expected:    "quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0",
-			expectedErr: false,
+			raw:              []byte(`{"nodes":[{"version":"4.2.19","payload":"quay.io/openshift-release-dev/ocp-release@sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":"4\\.1\\..*","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035","url":"https://access.redhat.com/errata/RHBA-2020:0460"}},{"version":"4.3.21","payload":"quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0","metadata":{"description":"","io.openshift.upgrades.graph.release.channels":"candidate-4.3,fast-4.3,stable-4.3,candidate-4.4,fast-4.4,stable-4.4","io.openshift.upgrades.graph.release.manifestref":"sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0","url":"https://access.redhat.com/errata/RHBA-2020:2129"}},{"version":"4.2.20","payload":"quay.io/openshift-release-dev/ocp-release@sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":"4\\.1\\..*","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787","url":"https://access.redhat.com/errata/RHBA-2020:0523"}},{"version":"4.2.33","payload":"quay.io/openshift-release-dev/ocp-release@sha256:52e780ccc7e3af73b11dcb4afe275e2e743b59ccea6f228089ac93337de244d7","metadata":{"description":"","io.openshift.upgrades.graph.release.channels":"candidate-4.2,fast-4.2,stable-4.2,candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:52e780ccc7e3af73b11dcb4afe275e2e743b59ccea6f228089ac93337de244d7","url":"https://access.redhat.com/errata/RHBA-2020:2023"}},{"version":"4.3.3","payload":"quay.io/openshift-release-dev/ocp-release@sha256:9b8708b67dd9b7720cb7ab3ed6d12c394f689cc8927df0e727c76809ab383f44","metadata":{"description":"","io.openshift.upgrades.graph.previous.remove_regex":".*","io.openshift.upgrades.graph.release.channels":"candidate-4.3,fast-4.3,stable-4.3","io.openshift.upgrades.graph.release.manifestref":"sha256:9b8708b67dd9b7720cb7ab3ed6d12c394f689cc8927df0e727c76809ab383f44","url":"https://access.redhat.com/errata/RHBA-2020:0528"}}]}`),
+			expectedPullspec: "quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0",
+			expectedVersion:  "4.3.21",
+			expectedErr:      false,
 		},
 		{
 			name: "malformed response errors",
@@ -78,9 +80,10 @@ func TestResolvePullSpec(t *testing.T) {
 				Channel:      api.ReleaseChannelStable,
 				Version:      "4.4",
 			},
-			raw:         []byte(`{"na1":}`),
-			expected:    "",
-			expectedErr: true,
+			raw:              []byte(`{"na1":}`),
+			expectedPullspec: "",
+			expectedVersion:  "",
+			expectedErr:      true,
 		},
 		{
 			name: "handle empty response",
@@ -89,9 +92,10 @@ func TestResolvePullSpec(t *testing.T) {
 				Channel:      api.ReleaseChannelStable,
 				Version:      "4.4",
 			},
-			raw:         []byte(`{"nodes":[]}`),
-			expected:    "",
-			expectedErr: true,
+			raw:              []byte(`{"nodes":[]}`),
+			expectedPullspec: "",
+			expectedVersion:  "",
+			expectedErr:      true,
 		},
 	}
 	for _, testCase := range testCases {
@@ -122,26 +126,33 @@ func TestResolvePullSpec(t *testing.T) {
 				}
 			}))
 			defer testServer.Close()
-			actual, err := resolvePullSpec(testServer.URL, testCase.release)
+			pullspec, version, err := resolvePullSpec(testServer.URL, testCase.release)
 			if err != nil && !testCase.expectedErr {
 				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 			}
 			if err == nil && testCase.expectedErr {
 				t.Errorf("%s: expected an error but got none", testCase.name)
 			}
-			if actual != testCase.expected {
-				t.Errorf("%s: got incorrect pullspec: %v", testCase.name, cmp.Diff(actual, testCase.expected))
+			if pullspec != testCase.expectedPullspec {
+				t.Errorf("%s: got incorrect pullspec: %v", testCase.name, cmp.Diff(pullspec, testCase.expectedPullspec))
+			}
+			if version != testCase.expectedVersion {
+				t.Errorf("%s: got incorrect version: %v", testCase.name, cmp.Diff(version, testCase.expectedVersion))
 			}
 		})
 	}
 }
 
 func TestLatestPullSpec(t *testing.T) {
-	if actual := latestPullSpec([]Release{
+	pullspec, version := latestPullSpecAndVersion([]Release{
 		{Version: "4.2.19", Payload: "quay.io/openshift-release-dev/ocp-release@sha256:b51a0c316bb0c11686e6b038ec7c9f7ff96763f47a53c3443ac82e8c054bc035"},
 		{Version: "4.3.21", Payload: "quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0"},
 		{Version: "4.2.20", Payload: "quay.io/openshift-release-dev/ocp-release@sha256:bd8aa8e0ce08002d4f8e73d6a2f9de5ae535a6a961ff6b8fdf2c52e4a14cc787"},
-	}); actual != "quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0" {
-		t.Errorf("got incorrect latest pull-spec: %v", actual)
+	})
+	if pullspec != "quay.io/openshift-release-dev/ocp-release@sha256:79a48030fc5e04fad0fd52f0cdd838ce94c7c1dfa7e7918fd7614d7bcab316f0" {
+		t.Errorf("got incorrect latest pull-spec: %v", pullspec)
+	}
+	if version != "4.3.21" {
+		t.Errorf("got incorrect latest version: %v", version)
 	}
 }


### PR DESCRIPTION
This PR changes the `ResolvePullSpec` function for official release to
`ResolvePullSpecAndVersion`. The `release-controller` will be importing
this package to use this function when determining releases for upgrades
and needs a tag name for the release to use as an annotation for the
upgrade job. `version` will be used as the tag name.