### PR TITLE
template-deprecator: do not choke on nil maps

### DIFF
--- a/pkg/deprecatetemplates/allowlist_test.go
+++ b/pkg/deprecatetemplates/allowlist_test.go
@@ -160,6 +160,15 @@ func TestDeprecatedTemplateInsert(t *testing.T) {
 				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown", current: true}}},
 			},
 		},
+		{
+			description: "do not choke on nil map",
+			existingDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: nil},
+			},
+			expectedDT: deprecatedTemplate{
+				UnknownBlocker: deprecatedTemplateBlocker{Jobs: blockedJobs{job: blockedJob{Generated: false, Kind: "unknown", current: true}}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -179,12 +188,12 @@ func TestAllowlistInsert(t *testing.T) {
 
 	testCases := []struct {
 		description   string
-		before        map[string]deprecatedTemplate
-		expectedAfter map[string]deprecatedTemplate
+		before        map[string]*deprecatedTemplate
+		expectedAfter map[string]*deprecatedTemplate
 	}{
 		{
 			description: "add job to new template record",
-			expectedAfter: map[string]deprecatedTemplate{
+			expectedAfter: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					UnknownBlocker: deprecatedTemplateBlocker{
@@ -196,7 +205,7 @@ func TestAllowlistInsert(t *testing.T) {
 		},
 		{
 			description: "add job to existing template record",
-			before: map[string]deprecatedTemplate{
+			before: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					UnknownBlocker: deprecatedTemplateBlocker{
@@ -204,7 +213,7 @@ func TestAllowlistInsert(t *testing.T) {
 					},
 				},
 			},
-			expectedAfter: map[string]deprecatedTemplate{
+			expectedAfter: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					UnknownBlocker: deprecatedTemplateBlocker{
@@ -216,7 +225,7 @@ func TestAllowlistInsert(t *testing.T) {
 		},
 		{
 			description: "add job to existing template record, already known blocker",
-			before: map[string]deprecatedTemplate{
+			before: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					Blockers: map[string]deprecatedTemplateBlocker{
@@ -226,7 +235,7 @@ func TestAllowlistInsert(t *testing.T) {
 					},
 				},
 			},
-			expectedAfter: map[string]deprecatedTemplate{
+			expectedAfter: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					Blockers: map[string]deprecatedTemplateBlocker{
@@ -239,7 +248,7 @@ func TestAllowlistInsert(t *testing.T) {
 		},
 		{
 			description: "add job to existing template record, already unknown blocker",
-			before: map[string]deprecatedTemplate{
+			before: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					UnknownBlocker: deprecatedTemplateBlocker{
@@ -250,7 +259,7 @@ func TestAllowlistInsert(t *testing.T) {
 					},
 				},
 			},
-			expectedAfter: map[string]deprecatedTemplate{
+			expectedAfter: map[string]*deprecatedTemplate{
 				template: {
 					Name: template,
 					UnknownBlocker: deprecatedTemplateBlocker{

--- a/pkg/deprecatetemplates/enforcer_test.go
+++ b/pkg/deprecatetemplates/enforcer_test.go
@@ -50,7 +50,7 @@ func TestLoadTemplates(t *testing.T) {
 
 type mockAllowlist struct {
 	jobs         map[string]sets.String
-	getTemplates map[string]deprecatedTemplate
+	getTemplates map[string]*deprecatedTemplate
 }
 
 func (m *mockAllowlist) Insert(job config.JobBase, template string) {
@@ -68,7 +68,7 @@ func (m *mockAllowlist) Prune() {
 	panic("this should never be called")
 }
 
-func (m *mockAllowlist) GetTemplates() map[string]deprecatedTemplate {
+func (m *mockAllowlist) GetTemplates() map[string]*deprecatedTemplate {
 	return m.getTemplates
 }
 
@@ -169,7 +169,7 @@ func TestProcessJobs(t *testing.T) {
 
 func TestEnforcerStats(t *testing.T) {
 	mock := &mockAllowlist{
-		getTemplates: map[string]deprecatedTemplate{
+		getTemplates: map[string]*deprecatedTemplate{
 			"template-1": {
 				Name: "template-1",
 				UnknownBlocker: deprecatedTemplateBlocker{


### PR DESCRIPTION
Some maps are nil after unmarshaling, so we need to test before
assigning into them.

Unfortunately I needed to change few internal types to be pointers so the change is larger than would be necessary if I did the initial programming job right :)