### PR TITLE
testgrid-config-generator: disallow ignored allow-list entries

### DIFF
--- a/test/integration/testgrid-config-generator.sh
+++ b/test/integration/testgrid-config-generator.sh
@@ -18,4 +18,6 @@ os::test::junit::declare_suite_start "integration/testgrid-config-generator"
 os::cmd::expect_success "testgrid-config-generator --release-config ${suite_dir}/config/release --testgrid-config ${workdir} --prow-jobs-dir ${suite_dir}/config/jobs --allow-list ${suite_dir}/config/_allow-list.yaml"
 os::integration::compare "${workdir}" "${suite_dir}/expected"
 
+os::cmd::expect_failure_and_text "testgrid-config-generator --release-config ${suite_dir}/config/release --allow-list ${suite_dir}/config/_allow-list-broken.yaml --validate" "The following jobs are blocking by virtue of being in the release-controller configuration, but are also in the allow-list. Their entries in the allow-list are disallowed and should be removed: release-openshift-ocp-installer-e2e-aws-4.2"
+
 os::test::junit::declare_suite_end

--- a/test/integration/testgrid-config-generator/config/_allow-list-broken.yaml
+++ b/test/integration/testgrid-config-generator/config/_allow-list-broken.yaml
@@ -1,0 +1,5 @@
+release-openshift-origin-job-from-allow-list: informing
+release-openshift-origin-job: informing
+release-openshift-origin-job-without-release-label-broken: broken
+release-openshift-ocp-job: informing
+release-openshift-ocp-installer-e2e-aws-4.2: informing


### PR DESCRIPTION
When a job is listed as required in the `release-controller`
configuration, it will be added to a blocking dashboard and it is not
possible to overwrite that behavior with an entry in the allow-list. It
is not therefore useful to allow users to put any such jobs into the
allow-list in the first place.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>