### PR TITLE
repo-init: allow users basic custom release choice

### DIFF
--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -588,6 +588,109 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "custom nightly release configured",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				ReleaseType:           "nightly",
+				ReleaseVersion:        "4.5",
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					InputConfiguration: api.InputConfiguration{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+						Releases: map[string]api.UnresolvedRelease{
+							"latest": {
+								Candidate: &api.Candidate{
+									Architecture: "amd64",
+									Product:      "ocp",
+									Stream:       "nightly",
+									Version:      "4.5",
+								},
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+					Tests: []api.TestStepConfiguration{},
+				},
+				Info: ciopconfig.Info{
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
+				},
+			},
+		},
+		{
+			name: "custom published release configured",
+			config: initConfig{
+				Org:                   "org",
+				Repo:                  "repo",
+				Branch:                "branch",
+				CanonicalGoRepository: "sometimes.com",
+				GoVersion:             "1",
+				ReleaseType:           "published",
+				ReleaseVersion:        "4.5",
+			},
+			originConfig: &api.PromotionConfiguration{
+				Namespace: "promote",
+				Name:      "version",
+			},
+			expected: ciopconfig.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					InputConfiguration: api.InputConfiguration{
+						BuildRootImage: &api.BuildRootImageConfiguration{
+							ImageStreamTagReference: &api.ImageStreamTagReference{
+								Namespace: "openshift",
+								Name:      "release",
+								Tag:       "golang-1",
+							},
+						},
+						Releases: map[string]api.UnresolvedRelease{
+							"latest": {
+								Release: &api.Release{
+									Architecture: "amd64",
+									Channel:      "stable",
+									Version:      "4.5",
+								},
+							},
+						},
+					},
+					CanonicalGoRepository: strP("sometimes.com"),
+					Resources: map[string]api.ResourceRequirements{"*": {
+						Limits:   map[string]string{"memory": "4Gi"},
+						Requests: map[string]string{"memory": "200Mi", "cpu": "100m"},
+					}},
+					Tests: []api.TestStepConfiguration{},
+				},
+				Info: ciopconfig.Info{
+					Metadata: api.Metadata{
+						Org:    "org",
+						Repo:   "repo",
+						Branch: "branch",
+					},
+				},
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/test/integration/repo-init.sh
+++ b/test/integration/repo-init.sh
@@ -76,6 +76,28 @@ inputs=(
 )
 export inputs
 os::cmd::expect_success 'for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo "${actual}"'
+
+# this test case will use a custom release
+inputs=(
+              "org" # Enter the organization for the repository: org
+            "third" # Enter the repository to initialize: repo
+      "nonstandard" # Enter the development branch for the repository: [default: master]
+               "no" # Does the repository build and promote container images?  [default: no] yes
+             "1.15" # What version of Go does the repository build with? [default: 1.12]
+      "k8s.io/cool" # Enter the Go import path for the repository if it uses a vanity URL (e.g. "k8s.io/my-repo"):
+                 "" # What commands are used to build binaries in the repository? (e.g. "go install ./cmd/...") make install
+                 "" # What commands, if any, are used to build test binaries? (e.g. "go install -race ./cmd/..." or "go test -c ./test/...") make test-install
+               "no" # Are there any test scripts to configure?  [default: no] yes
+              "yes" # Are there any end-to-end test scripts to configure?  [default: no] yes
+              "e2e" # What is the name of this test (e.g. "e2e-operator")?  e2e
+                 "" # Which specific cloud provider does the test require, if any?  [default: aws]
+              "e2e" # What commands in the repository run the test (e.g. "make test-e2e")?  make test-e2e
+               "no" # Are there any more end-to-end test scripts to configure?  [default: no] no
+          "nightly" # What type of OpenShift release do the end-to-end tests run on top of? [nightly, published]
+              "4.4" # Which OpenShift version is being tested? [default: 4.6]
+)
+export inputs
+os::cmd::expect_success 'for input in "${inputs[@]}"; do echo "${input}"; done | repo-init -release-repo "${actual}"'
 os::cmd::expect_success 'ci-operator-prowgen --from-dir "${actual}/ci-operator/config" --to-dir "${actual}/ci-operator/jobs"'
 os::cmd::expect_success 'sanitize-prow-jobs --prow-jobs-dir "${actual}/ci-operator/jobs" --config-path "${actual}/core-services/sanitize-prow-jobs/_config.yaml"'
 os::cmd::expect_success 'determinize-ci-operator --config-dir "${actual}/ci-operator/config" --confirm'

--- a/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
@@ -1,0 +1,29 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.15
+canonical_go_repository: k8s.io/cool
+releases:
+  latest:
+    candidate:
+      architecture: amd64
+      product: ocp
+      stream: nightly
+      version: "4.4"
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e
+  commands: e2e
+  openshift_installer_src:
+    cluster_profile: aws
+zz_generated_metadata:
+  branch: nonstandard
+  org: org
+  repo: third

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -1,0 +1,81 @@
+presubmits:
+  org/third:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - nonstandard
+    cluster: api.ci
+    context: ci/prow/e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      job-release: "4.4"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-org-third-nonstandard-e2e
+    path_alias: k8s.io/cool
+    rerun_command: /test e2e
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-password-file=/etc/boskos/password
+        - --report-password-file=/etc/report/password.txt
+        - --report-username=ci
+        - --secret-dir=/usr/local/e2e-cluster-profile
+        - --target=e2e
+        - --template=/usr/local/e2e
+        command:
+        - ci-operator
+        env:
+        - name: CLUSTER_TYPE
+          value: aws
+        - name: JOB_NAME_SAFE
+          value: e2e
+        - name: TEST_COMMAND
+          value: e2e
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /usr/local/e2e-cluster-profile
+          name: cluster-profile
+        - mountPath: /usr/local/e2e
+          name: job-definition
+          subPath: cluster-launch-installer-src.yaml
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: password
+            path: password
+          secretName: boskos-credentials
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-aws
+      - configMap:
+          name: prow-job-cluster-launch-installer-src
+        name: job-definition
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e,?($|\s.*)

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
@@ -88,5 +88,6 @@ tide:
     - openshift/origin
     - org/repo
     - org/other
+    - org/third
   status_update_period: 1m0s
   sync_period: 1m0s

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_plugins.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_plugins.yaml
@@ -12,6 +12,10 @@ approve:
   repos:
   - org/other
   require_self_approval: false
+- commandHelpLink: ""
+  repos:
+  - org/third
+  require_self_approval: false
 blunderbuss:
   request_count: 2
 bugzilla: {}
@@ -75,6 +79,20 @@ external_plugins:
     events:
     - pull_request
     name: needs-rebase
+  org/third:
+  - endpoint: http://refresh
+    events:
+    - issue_comment
+    name: refresh
+  - endpoint: http://cherrypick
+    events:
+    - issue_comment
+    - pull_request
+    name: cherrypick
+  - endpoint: http://needs-rebase
+    events:
+    - pull_request
+    name: needs-rebase
 golint: {}
 goose: {}
 heart: {}
@@ -89,6 +107,9 @@ lgtm:
   review_acts_as_lgtm: true
 - repos:
   - org/other
+  review_acts_as_lgtm: true
+- repos:
+  - org/third
   review_acts_as_lgtm: true
 override: {}
 owners:
@@ -154,6 +175,34 @@ plugins:
   - yuks
   - approve
   org/repo:
+  - assign
+  - blunderbuss
+  - blockade
+  - bugzilla
+  - cat
+  - dog
+  - heart
+  - golint
+  - goose
+  - help
+  - hold
+  - label
+  - lgtm
+  - lifecycle
+  - override
+  - pony
+  - retitle
+  - shrug
+  - sigmention
+  - size
+  - skip
+  - trigger
+  - verify-owners
+  - owners-label
+  - wip
+  - yuks
+  - approve
+  org/third:
   - assign
   - blunderbuss
   - blockade


### PR DESCRIPTION
When a user is not promoting with the OpenShift release we don't put
them into the CI stream with `tag_specification`, so we can ask them
some basic questions about the release they want to run e2es with. We
don't expose every possible option as that's par for the course for this
simple bootstrapping tool.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes [DPTP-1722](https://issues.redhat.com/browse/DPTP-1722)