### PR TITLE
autotestgridgenerator: report command error

### DIFF
--- a/cmd/autotestgridgenerator/main.go
+++ b/cmd/autotestgridgenerator/main.go
@@ -88,6 +88,7 @@ func main() {
 		Info("running command")
 
 	c := exec.Command(command, arguments...)
+	c.Stderr = os.Stderr
 	err := c.Run()
 	if err != nil {
 		logrus.WithError(err).Fatalf("failed to run %s", fullCommand)


### PR DESCRIPTION
To avoid inscrutable messages such as:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-testgrid-generator/1329213114704465920

```
time="2020-11-19T00:01:52Z" level=fatal msg="failed to run /usr/bin/testgrid-config-generator -testgrid-config ./config/testgrids/openshift -release-config ../../openshift/release/core-services/release-controller/_releases -prow-jobs-dir ../../openshift/release/ci-operator/jobs -allow-list ../../openshift/release/core-services/testgrid-config-generator/_allow-list.yaml" error="exit status 1"
```