### PR TITLE
pj-rehearse: no longer detect references to ci-op config CMs

### DIFF
--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -68,12 +68,6 @@ periodics:
       - --CHANGED
       command:
       - no-ci-op
-      env:
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-ciop-cfg-change.yaml
-            name: ci-operator-misc-configs
       image: ci-operator:latest
       imagePullPolicy: Always
       name: ""

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -323,37 +323,6 @@
         - --CHANGED
         command:
         - no-ci-op
-        env:
-        - name: CONFIG_SPEC
-          value: |
-            base_images:
-              base:
-                name: origin-v4.0
-                namespace: openshift
-                tag: base
-            build_root:
-              image_stream_tag:
-                name: release
-                namespace: openshift
-                tag: golang-1.10
-            images:
-            - from: base
-              to: test-image
-            - from: base
-              to: change-should-cause-rehearsal-of-all-jobs-that-use-this-cfg
-            resources:
-              '*':
-                limits:
-                  cpu: 500Mi
-                requests:
-                  cpu: 10Mi
-            tag_specification:
-              name: origin-v4.0
-              namespace: openshift
-            zz_generated_metadata:
-              branch: ciop-cfg-change
-              org: super
-              repo: duper
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-periodics.yaml
@@ -59,11 +59,6 @@ periodics:
       command:
       - no-ci-op
       env:
-      - name: CONFIG_SPEC
-        valueFrom:
-          configMapKeyRef:
-            key: super-duper-ciop-cfg-change.yaml
-            name: ci-operator-misc-configs
       image: ci-operator:latest
       imagePullPolicy: Always
       name: ""


### PR DESCRIPTION
Previously, pj-rehearse had code that detected when Prow jobs mounted
ci-operator config CMs (`ci-operator-*-configs`) directly, and handled
resolving and inlining this case. OpenShift CI Prowjobs are no longer
supposed to mount ci-op configs like this (and no longer do so [1]), so
all this code is no longer necessary.

[1]
```console
$ git grep 'ci-operator-.*-configs' ci-operator/jobs/
$
```

This code cleanup is part of [DPTP-1685](https://issues.redhat.com/browse/DPTP-1685)