### PR TITLE
ci-operator: always delete template instance

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -117,7 +117,8 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 	go func() {
 		<-ctx.Done()
 		log.Printf("cleanup: Deleting template %s", s.template.Name)
-		if err := s.client.Delete(ctx, &templateapi.TemplateInstance{ObjectMeta: meta.ObjectMeta{Namespace: s.jobSpec.Namespace(), Name: s.template.Name}}, ctrlruntimeclient.PropagationPolicy(meta.DeletePropagationForeground)); err != nil && !kerrors.IsNotFound(err) {
+		// we need the deletion to run regardless of what the test context
+		if err := s.client.Delete(context.Background(), &templateapi.TemplateInstance{ObjectMeta: meta.ObjectMeta{Namespace: s.jobSpec.Namespace(), Name: s.template.Name}}, ctrlruntimeclient.PropagationPolicy(meta.DeletePropagationForeground)); err != nil && !kerrors.IsNotFound(err) {
 			log.Printf("error: Could not delete template instance: %v", err)
 		}
 	}()


### PR DESCRIPTION
The previous use of the test context for this client call meant that by
definition we would fail to make the call in every case, since a
precondition for the call was that the context was done.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

addresses part of https://issues.redhat.com/browse/DPTP-1683