### PR TITLE
template-deprecator: allow adding new jobs under a blocker

### DIFF
--- a/pkg/deprecatetemplates/enforcer.go
+++ b/pkg/deprecatetemplates/enforcer.go
@@ -24,11 +24,13 @@ type Enforcer struct {
 // NewEnforcer initializes a new enforcer instance. The enforcer will be
 // initialized with an allowlist from the given location. If the allowlist
 // does not exist, the enforcer will have an empty allowlist.
-func NewEnforcer(allowlistPath string) (*Enforcer, error) {
+func NewEnforcer(allowlistPath string, newJobBlockers JiraHints) (*Enforcer, error) {
 	allowlist, err := loadAllowlist(allowlistPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load template deprecating allowlist from %q: %w", allowlistPath, err)
 	}
+	allowlist.SetNewJobBlockers(newJobBlockers)
+
 	return &Enforcer{
 		allowlist:         allowlist,
 		existingTemplates: sets.NewString(),

--- a/pkg/deprecatetemplates/enforcer_test.go
+++ b/pkg/deprecatetemplates/enforcer_test.go
@@ -68,6 +68,10 @@ func (m *mockAllowlist) Prune() {
 	panic("this should never be called")
 }
 
+func (m *mockAllowlist) SetNewJobBlockers(_ JiraHints) {
+	panic("this should never be called")
+}
+
 func (m *mockAllowlist) GetTemplates() map[string]*deprecatedTemplate {
 	return m.getTemplates
 }


### PR DESCRIPTION
Newly added jobs are by default added to the "unknown" blocker, allow to
override this behavior.  This is a UX prerequisite for stricter
validations, I wanted to have an easy way to suggest to the users.

Allow the following things:

```console
$ template-deprecator --block-new-jobs JIRA-1234
$ template-deprecator --block-new-jobs JIRA-1234 --block-new-jobs JIRA-4568
$ template-deprecator --block-new-jobs "JIRA-1234:templates are great can we have moar templates"
```

/cc @stevekuznetsov 