### PR TITLE
ci-operator: don't cancel notifiers on interrupt

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -401,7 +401,7 @@ type ArtifactWorker struct {
 	hasArtifacts sets.String
 }
 
-func NewArtifactWorker(ctx context.Context, podClient PodClient, artifactDir, namespace string) *ArtifactWorker {
+func NewArtifactWorker(podClient PodClient, artifactDir, namespace string) *ArtifactWorker {
 	// stream artifacts in the background
 	w := &ArtifactWorker{
 		podClient: podClient,
@@ -414,10 +414,6 @@ func NewArtifactWorker(ctx context.Context, podClient PodClient, artifactDir, na
 
 		podsToDownload: make(chan string, 4),
 	}
-	go func() {
-		<-ctx.Done()
-		w.cancel()
-	}()
 	go w.run()
 	return w
 }
@@ -518,21 +514,6 @@ func (w *ArtifactWorker) Complete(podName string) {
 	}
 	if len(w.remaining) == 0 {
 		close(w.podsToDownload)
-	}
-}
-
-func (w *ArtifactWorker) cancel() {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-	for podName := range w.remaining {
-		if !w.hasArtifacts.Has(podName) {
-			continue
-		}
-		go func(podName string) {
-			if err := removeFile(w.podClient, w.namespace, podName, "artifacts", []string{"/tmp/done"}); err != nil {
-				logrus.WithError(err).Error("failed to remove file")
-			}
-		}(podName)
 	}
 }
 

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -1,7 +1,6 @@
 package steps
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -562,7 +561,7 @@ func TestArtifactWorker(t *testing.T) {
 		namespace: "namespace",
 		name:      pod,
 	}
-	w := NewArtifactWorker(context.Background(), podClient, tmp, "namespace")
+	w := NewArtifactWorker(podClient, tmp, "namespace")
 	w.CollectFromPod(pod, []string{"container"}, nil)
 	w.Complete(pod)
 	select {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -590,7 +590,7 @@ func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, sh
 			if c.Name == "artifacts" {
 				container := pod.Spec.Containers[0].Name
 				dir := filepath.Join(s.artifactDir, strings.TrimPrefix(pod.Name, namePrefix))
-				artifacts := NewArtifactWorker(ctx, s.client, dir, s.jobSpec.Namespace())
+				artifacts := NewArtifactWorker(s.client, dir, s.jobSpec.Namespace())
 				artifacts.CollectFromPod(pod.Name, []string{container}, nil)
 				notifier = artifacts
 				break

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -87,7 +87,7 @@ func (s *podStep) run(ctx context.Context) error {
 	// when the test container terminates and artifact directory has been set, grab everything under the directory
 	var notifier ContainerNotifier = NopNotifier
 	if s.gatherArtifacts() {
-		artifacts := NewArtifactWorker(ctx, s.client, filepath.Join(s.artifactDir, s.config.As), s.jobSpec.Namespace())
+		artifacts := NewArtifactWorker(s.client, filepath.Join(s.artifactDir, s.config.As), s.jobSpec.Namespace())
 		artifacts.CollectFromPod(pod.Name, []string{s.name}, nil)
 		notifier = artifacts
 	}

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -135,7 +135,7 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 
 	// now that the pods have been resolved by the template, add them to the artifact map
 	if len(s.artifactDir) > 0 {
-		artifacts := NewArtifactWorker(ctx, s.podClient, filepath.Join(s.artifactDir, s.template.Name), s.jobSpec.Namespace())
+		artifacts := NewArtifactWorker(s.podClient, filepath.Join(s.artifactDir, s.template.Name), s.jobSpec.Namespace())
 		for _, ref := range instance.Status.Objects {
 			switch {
 			case ref.Ref.Kind == "Pod" && ref.Ref.APIVersion == "v1":


### PR DESCRIPTION
Today, we cancel the notifier in order to stop a very specific style of
deadlock:

When we run a test workload that hangs forever upon receipt of SIGINT,
the artifacts will not be collected for that Pod as we wait for all
containers to finish before starting the artifact retrieval. If the
`ci-operator` process cannot wait for all artifacts to be retrieved,
nothing is uploaded to GCS.

If a test process is well-formed and exits early before the grace period
is up but after an interrupt is sent, however, the artifact retrieval
process should complete correctly and no explicit cancellation will be
necessary.

However, the side effect of cancelling the notifier explicitly as soon
as an interrupt is received is that we will never retrieve artifacts for
a Pod even if it is well formed and exits before the grace period.

By not cancelling the notifier, we make a trade-off: for poorly-formed
test processes, no artifacts whatsoever will be present in the output of
the job as `ci-operator` will hang, waiting on the artifacts container
(which is waiting on the test process). However, in cases where the
process *is* well-formed, we will get artifacts on an interrupt or
timeout. This latter case is by far the most common case in our jobs
today and the one we should be optimizing for.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 