### PR TITLE
release-job-migrator: initial commit

### DIFF
--- a/cmd/release-job-migrator/main.go
+++ b/cmd/release-job-migrator/main.go
@@ -1,0 +1,458 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+	configlib "github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
+)
+
+type GeneratorConfig struct {
+	// Configs defines the configuration needed for a specified test name
+	Configs map[string]testConfig `json:"config"`
+}
+
+type testConfig struct {
+	// Steps defines the multistage test step configuration to use for this job
+	Steps *api.MultiStageTestConfiguration `json:"steps"`
+	// BaseImages defines any images that this test relies on. Omit the "Name" and/or
+	// "Namespace" fields to have them autofilled based on the job name
+	BaseImages map[string]api.ImageStreamTagReference `json:"base_images,omitempty"`
+}
+
+type testsAndBaseImages struct {
+	tests      []api.TestStepConfiguration
+	baseImages map[string]api.ImageStreamTagReference
+}
+
+type jobInfo struct {
+	As      string
+	Product string
+	Version string
+}
+
+type options struct {
+	config        string
+	ciopConfigDir string
+	rcConfigDir   string
+	jobDir        string
+}
+
+func gatherOptions() (options, error) {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.config, "config", "", "Path to config file")
+	fs.StringVar(&o.ciopConfigDir, "ci-op-configs", "", "Path to ci-operator config files")
+	fs.StringVar(&o.rcConfigDir, "rc-configs", "", "Path to release-controller release config files")
+	fs.StringVar(&o.jobDir, "jobs", "", "Path to ci-operator jobs")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return o, fmt.Errorf("failed to parse flags: %w", err)
+	}
+	return o, nil
+}
+
+func validateOptions(o options) error {
+	if len(o.config) == 0 {
+		return errors.New("--config must be set")
+	}
+	if len(o.ciopConfigDir) == 0 {
+		return errors.New("--ci-op-configs must be set")
+	}
+	if len(o.rcConfigDir) == 0 {
+		return errors.New("--rc-configs must be set")
+	}
+	if len(o.jobDir) == 0 {
+		return errors.New("--jobs must be set")
+	}
+	return nil
+}
+
+func getJobInfo(jobName string) (jobInfo, bool) {
+	// release jobs follow the format of "release-openshift-product-installer-testname-version"
+	if !strings.HasPrefix(jobName, "release-openshift-") {
+		return jobInfo{}, false
+	}
+	splitName := strings.Split(jobName, "-")
+	if len(splitName) < 6 {
+		return jobInfo{}, false
+	}
+	version := splitName[len(splitName)-1]
+	if !regexp.MustCompile(`4.\d`).MatchString(version) {
+		return jobInfo{}, false
+	}
+	return jobInfo{
+		As:      strings.Join(splitName[4:len(splitName)-1], "-"),
+		Product: splitName[2],
+		Version: splitName[len(splitName)-1],
+	}, true
+}
+
+func metadataFromJobInfo(info jobInfo) *api.Metadata {
+	return &api.Metadata{
+		Org:     "openshift",
+		Repo:    "release",
+		Branch:  "master",
+		Variant: fmt.Sprintf("%s-%s", info.Product, info.Version),
+	}
+}
+
+func newDataWithInfoFromFilename(filename string) configlib.DataWithInfo {
+	// identify product and version from variant
+	variant := strings.Split(strings.TrimSuffix(filename, ".yaml"), "__")[1]
+	splitVariant := strings.Split(variant, "-")
+	identifier := splitVariant[0]
+	var product api.ReleaseProduct
+	var stream api.ReleaseStream
+	var namespace string
+	switch identifier {
+	case "ocp":
+		product = api.ReleaseProductOCP
+		stream = api.ReleaseStreamNightly
+		namespace = "ocp"
+	case "origin":
+		product = api.ReleaseProductOCP
+		stream = api.ReleaseStreamCI
+		namespace = "ocp"
+	case "okd":
+		product = api.ReleaseProductOKD
+		stream = api.ReleaseStreamOKD
+		namespace = "origin"
+	}
+	version := splitVariant[1]
+	return configlib.DataWithInfo{
+		Info: config.Info{
+			Metadata: api.Metadata{
+				Org:     "openshift",
+				Repo:    "release",
+				Branch:  "master",
+				Variant: variant,
+			},
+		},
+		Configuration: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				BaseImages: map[string]api.ImageStreamTagReference{
+					"base": {
+						Name:      version,
+						Namespace: namespace,
+						Tag:       "base",
+					},
+				},
+				Releases: map[string]api.UnresolvedRelease{
+					"latest": {
+						Candidate: &api.Candidate{
+							Product: product,
+							Stream:  stream,
+							Version: version,
+						},
+					},
+				},
+			},
+			Resources: api.ResourceConfiguration{
+				"*": api.ResourceRequirements{
+					Requests: api.ResourceList{
+						"cpu":    "100m",
+						"memory": "200Mi",
+					},
+				},
+			},
+			Metadata: api.Metadata{
+				Org:     "openshift",
+				Repo:    "release",
+				Branch:  "master",
+				Variant: variant,
+			},
+		},
+	}
+}
+
+func updateBaseImages(newImages, ciOpImages, replacementImages map[string]api.ImageStreamTagReference, version string) error {
+	for name, newImage := range newImages {
+		if newImage.Namespace == "" {
+			newImage.Namespace = "ocp"
+		}
+		if newImage.Name == "" {
+			newImage.Name = version
+		}
+		// check if image already exists
+		baseImage, ok := replacementImages[name]
+		if !ok {
+			baseImage, ok = ciOpImages[name]
+		}
+		if ok {
+			if baseImage.As != newImage.As || baseImage.Name != newImage.Name || baseImage.Namespace != newImage.Namespace || baseImage.Tag != newImage.Tag {
+				return fmt.Errorf("2 different images detected for base image %s: (%+v) and (%+v)", name, baseImage, newImage)
+			}
+		} else {
+			replacementImages[name] = newImage
+		}
+	}
+	return nil
+}
+
+func run(o options) error {
+	// key: filename
+	jobs := make(map[string]prowconfig.JobConfig)
+	if err := filepath.Walk(o.jobDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && info.Name() != filepath.Base(o.jobDir) {
+			return filepath.SkipDir
+		}
+		if !strings.HasSuffix(path, "-periodics.yaml") {
+			return nil
+		}
+		raw, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", info.Name(), err)
+		}
+		periodics := prowconfig.JobConfig{}
+		if err := yaml.UnmarshalStrict(raw, &periodics); err != nil {
+			return fmt.Errorf("failed to unmarshal file %s: %w", info.Name(), err)
+		}
+		jobs[info.Name()] = periodics
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to load periodic job configs: %w", err)
+	}
+
+	rawConfig, err := ioutil.ReadFile(o.config)
+	if err != nil {
+		return fmt.Errorf("failed to read config file %s: %w", o.config, err)
+	}
+	generatorConfig := GeneratorConfig{}
+	if err := yaml.UnmarshalStrict(rawConfig, &generatorConfig); err != nil {
+		return fmt.Errorf("failed to unmarshal config file %s: %w", o.config, err)
+	}
+	ciopConfigs, err := configlib.LoadDataByFilename(o.ciopConfigDir)
+	if err != nil {
+		return fmt.Errorf("failed to load ci-operator configs: %w", err)
+	}
+
+	// store replacement info for each ci-op config
+	replacements := make(map[string]testsAndBaseImages)
+	// key: old jobname, value: new (generated jobname)
+	replacedJobs := make(map[string]string)
+	// list of test names for detected release jobs with no configuration
+	configlessTests := sets.NewString()
+	for _, jobConfig := range jobs {
+		for _, periodic := range jobConfig.Periodics {
+			info, isReleaseJob := getJobInfo(periodic.Name)
+			if !isReleaseJob {
+				continue
+			}
+			// avoid jobs that do more than just run ci-operator
+			if periodic.Spec.Containers[0].Command[0] != "ci-operator" {
+				logrus.Warnf("periodic job %s has a command != \"ci-operator\", ignoring", periodic.Name)
+				continue
+			}
+			// check if an UNRESOLVED_CONFIG exists and populate an env var map to handle configs with env vars
+			envs := make(map[string]string)
+			isUnresolved := false
+			for _, env := range periodic.Spec.Containers[0].Env {
+				envs[env.Name] = env.Value
+				if env.Name == "UNRESOLVED_CONFIG" {
+					isUnresolved = true
+				}
+			}
+			filename := metadataFromJobInfo(info).Basename()
+			if _, ok := replacements[filename]; !ok {
+				replacements[filename] = testsAndBaseImages{
+					baseImages: make(map[string]api.ImageStreamTagReference),
+				}
+			}
+			var config testConfig
+			if isUnresolved {
+				target := ""
+				for _, arg := range periodic.Spec.Containers[0].Args {
+					if strings.Split(arg, "=")[0] == "--target" {
+						target = strings.Split(arg, "=")[1]
+						// args can contain env vars; make sure they're replaced
+						for name, value := range envs {
+							target = strings.ReplaceAll(target, fmt.Sprintf("$(%s)", name), value)
+						}
+					}
+				}
+				if target == "" {
+					return fmt.Errorf("found UNRESOLVED_CONFIG for job %s but could not identify target job", periodic.Name)
+				}
+				// replace all env vars in UNRESOLVED CONFIG
+				unresolvedConfig := envs["UNRESOLVED_CONFIG"]
+				for name, value := range envs {
+					unresolvedConfig = strings.ReplaceAll(unresolvedConfig, fmt.Sprintf("$(%s)", name), value)
+				}
+				unmarshaledConfig := api.ReleaseBuildConfiguration{}
+				if err := yaml.Unmarshal([]byte(unresolvedConfig), &unmarshaledConfig); err != nil {
+					return fmt.Errorf("failed to unmarshal UNRESOLVED_CONFIG for periodic %s: %w", periodic.Name, err)
+				}
+				for _, test := range unmarshaledConfig.Tests {
+					if test.As == target {
+						config.Steps = test.MultiStageTestConfiguration
+					}
+				}
+				if config.Steps == nil {
+					return fmt.Errorf("failed to identify multi-stage test configuration for job %s", periodic.Name)
+				}
+				if err := updateBaseImages(config.BaseImages, ciopConfigs[filename].Configuration.BaseImages, replacements[filename].baseImages, info.Version); err != nil {
+					return err
+				}
+			} else {
+				var ok bool
+				config, ok = generatorConfig.Configs[info.As]
+				if !ok {
+					configlessTests.Insert(info.As)
+					continue
+				}
+				if err := updateBaseImages(config.BaseImages, ciopConfigs[filename].Configuration.BaseImages, replacements[filename].baseImages, info.Version); err != nil {
+					return err
+				}
+			}
+			cron := periodic.Cron
+			if cron == "" {
+				cron = fmt.Sprintf("@every %s", periodic.Interval)
+			}
+			// check that test does not already exist in config
+			combinedTests := append(replacements[filename].tests, ciopConfigs[filename].Configuration.Tests...)
+			for _, step := range combinedTests {
+				if step.As == info.As {
+					return fmt.Errorf("error adding periodic %s: test name %s already exists", periodic.Name, step.As)
+				}
+			}
+			testsAndImages := replacements[filename]
+			testsAndImages.tests = append(testsAndImages.tests, api.TestStepConfiguration{
+				As:                          info.As,
+				MultiStageTestConfiguration: config.Steps,
+				Cron:                        &cron,
+			})
+			replacements[filename] = testsAndImages
+			replacedJobs[periodic.Name] = metadataFromJobInfo(info).JobName(jobconfig.PeriodicPrefix, info.As)
+		}
+	}
+
+	for filename, replacement := range replacements {
+		_, ok := ciopConfigs[filename]
+		if !ok {
+			ciopConfigs[filename] = newDataWithInfoFromFilename(filename)
+		}
+		updatedConfig := ciopConfigs[filename].Configuration
+		updatedConfig.Tests = append(updatedConfig.Tests, replacement.tests...)
+		for name, ist := range replacement.baseImages {
+			if _, ok := updatedConfig.BaseImages[name]; !ok {
+				updatedConfig.BaseImages[name] = ist
+			}
+		}
+		raw, err := yaml.Marshal(updatedConfig)
+		if err != nil {
+			return fmt.Errorf("failed to marshal updated config for file %s: %w", filename, err)
+		}
+		if err := ioutil.WriteFile(filepath.Join(o.ciopConfigDir, filename), raw, 0644); err != nil {
+			return fmt.Errorf("failed to write updated config file %s: %w", filename, err)
+		}
+	}
+
+	// delete old jobs
+	for filename, config := range jobs {
+		newConfig := prowconfig.JobConfig{}
+		// remake periodic jobconfig excluding replaced jobs
+		for _, job := range config.Periodics {
+			if _, ok := replacedJobs[job.Name]; !ok {
+				newConfig.Periodics = append(newConfig.Periodics, job)
+			}
+		}
+		raw, err := yaml.Marshal(newConfig)
+		if err != nil {
+			return fmt.Errorf("failed to marshal updated jobconfig for file %s: %w", filename, err)
+		}
+		if err := ioutil.WriteFile(filepath.Join(o.jobDir, filename), raw, 0644); err != nil {
+			return fmt.Errorf("failed to write updated jobconfig file %s: %w", filename, err)
+		}
+	}
+
+	// update release-controller configs
+	if err := filepath.Walk(o.rcConfigDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if info.Name() != filepath.Base(o.rcConfigDir) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		raw, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", info.Name(), err)
+		}
+		for oldName, newName := range replacedJobs {
+			raw = bytes.ReplaceAll(raw, []byte(oldName), []byte(newName))
+		}
+		if err := ioutil.WriteFile(path, raw, 0644); err != nil {
+			return fmt.Errorf("failed to write updated release-controller config file %s: %w", filepath.Base(path), err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to process release-controller files: %w", err)
+	}
+
+	// print out replacement info
+	if len(replacedJobs) == 0 && len(configlessTests) == 0 {
+		fmt.Println("No non-generated release-controller jobs detected.")
+		return nil
+	}
+
+	if len(replacedJobs) > 0 {
+		fmt.Println("These jobs from the following files have been replaced:")
+		// print in alphabetical order
+		sortedNames := []string{}
+		for oldName := range replacedJobs {
+			sortedNames = append(sortedNames, oldName)
+		}
+		sort.Strings(sortedNames)
+		for _, oldName := range sortedNames {
+			fmt.Printf("%s: %s\n", oldName, replacedJobs[oldName])
+		}
+	} else {
+		fmt.Println("No jobs detected with matching config.")
+	}
+
+	if len(configlessTests) > 0 {
+		fmt.Printf("\nThe following tests do not have entries in the generator config:\n%v\n", configlessTests.List())
+	}
+
+	// keep this message at the end to make sure it is seen by whoever is running the command
+	if len(replacedJobs) > 0 {
+		fmt.Printf("\nPlease run `make update` to regenerate job configs using the updated ci-operator configs.")
+	}
+	fmt.Println()
+	return nil
+}
+
+func main() {
+	o, err := gatherOptions()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed go gather options")
+	}
+	if err := validateOptions(o); err != nil {
+		logrus.Fatalf("invalid options: %v", err)
+	}
+	if err := run(o); err != nil {
+		logrus.Fatalf("failed to generate jobs: %v", err)
+	}
+}

--- a/cmd/release-job-migrator/main_test.go
+++ b/cmd/release-job-migrator/main_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestGetJobInfo(t *testing.T) {
+	testCases := []struct {
+		name      string
+		expected  jobInfo
+		isRelease bool
+	}{{
+		name: "release-openshift-origin-installer-e2e-gcp-upgrade-4.7",
+		expected: jobInfo{
+			As:      "e2e-gcp-upgrade",
+			Product: "origin",
+			Version: "4.7",
+		},
+		isRelease: true,
+	}, {
+		name:      "promote-release-openshift-machine-os-content-e2e-aws-4.7",
+		isRelease: false,
+	}}
+	for _, testCase := range testCases {
+		info, isRelease := getJobInfo(testCase.name)
+		if isRelease != testCase.isRelease {
+			t.Errorf("%s: wrong `isNotRelease`. Actual: %t, Expected: %t", testCase.name, isRelease, testCase.isRelease)
+		}
+		if info.As != testCase.expected.As {
+			t.Errorf("%s: wrong `as`. Actual: %s, Expected: %s", testCase.name, info.As, testCase.expected.As)
+		}
+		if info.Product != testCase.expected.Product {
+			t.Errorf("%s: wrong `product`. Actual: %s, Expected: %s", testCase.name, info.Product, testCase.expected.Product)
+		}
+		if info.Version != testCase.expected.Version {
+			t.Errorf("%s: wrong `version`. Actual: %s, Expected: %s", testCase.name, info.Version, testCase.expected.Version)
+		}
+	}
+}
+
+func TestUpdateBaseImages(t *testing.T) {
+	testCases := []struct {
+		name              string
+		newImages         map[string]api.ImageStreamTagReference
+		ciopImages        map[string]api.ImageStreamTagReference
+		replacementImages map[string]api.ImageStreamTagReference
+		expectedImages    map[string]api.ImageStreamTagReference
+		version           string
+		expectedErr       bool
+	}{{
+		name: "No conflict",
+		newImages: map[string]api.ImageStreamTagReference{
+			"new-image": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "new-image",
+			},
+		},
+		ciopImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		replacementImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		expectedImages: map[string]api.ImageStreamTagReference{
+			"new-image": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "new-image",
+			},
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		version:     "4.7",
+		expectedErr: false,
+	}, {
+		name: "ciop-conflict",
+		newImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.6",
+				Tag:       "base",
+			},
+		},
+		ciopImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		replacementImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		expectedImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		version:     "4.7",
+		expectedErr: true,
+	}, {
+		name: "replacements-conflict",
+		newImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "new-dev-scripts",
+			},
+		},
+		ciopImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		replacementImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		expectedImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		version:     "4.7",
+		expectedErr: true,
+	}, {
+		name: "non-conlict overlap",
+		newImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		ciopImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		replacementImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		expectedImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		version:     "4.7",
+		expectedErr: false,
+	}, {
+		name: "empty config gets filled in",
+		newImages: map[string]api.ImageStreamTagReference{
+			"myimage": {
+				Tag: "myimage",
+			},
+		},
+		ciopImages: map[string]api.ImageStreamTagReference{
+			"base": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "base",
+			},
+		},
+		replacementImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+		},
+		expectedImages: map[string]api.ImageStreamTagReference{
+			"dev-scripts": {
+				Namespace: "openshift-kni",
+				Name:      "test",
+				Tag:       "dev-scripts",
+			},
+			"myimage": {
+				Namespace: "ocp",
+				Name:      "4.7",
+				Tag:       "myimage",
+			},
+		},
+		version:     "4.7",
+		expectedErr: false,
+	}}
+	for _, testCase := range testCases {
+		if err := updateBaseImages(testCase.newImages, testCase.ciopImages, testCase.replacementImages, testCase.version); err != nil && !testCase.expectedErr {
+			t.Errorf("%s: Got error when one was not expected: %v", testCase.name, err)
+		} else if err == nil && testCase.expectedErr {
+			t.Errorf("%s: Did not get error when one was expected", testCase.name)
+		} else {
+			if !reflect.DeepEqual(testCase.replacementImages, testCase.expectedImages) {
+				t.Errorf("%s: expected does not match actual: %s", testCase.name, cmp.Diff(testCase.replacementImages, testCase.expectedImages))
+			}
+		}
+	}
+}

--- a/cmd/release-job-migrator/main_test.go
+++ b/cmd/release-job-migrator/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,19 +26,21 @@ func TestGetJobInfo(t *testing.T) {
 		isRelease: false,
 	}}
 	for _, testCase := range testCases {
-		info, isRelease := getJobInfo(testCase.name)
-		if isRelease != testCase.isRelease {
-			t.Errorf("%s: wrong `isNotRelease`. Actual: %t, Expected: %t", testCase.name, isRelease, testCase.isRelease)
-		}
-		if info.As != testCase.expected.As {
-			t.Errorf("%s: wrong `as`. Actual: %s, Expected: %s", testCase.name, info.As, testCase.expected.As)
-		}
-		if info.Product != testCase.expected.Product {
-			t.Errorf("%s: wrong `product`. Actual: %s, Expected: %s", testCase.name, info.Product, testCase.expected.Product)
-		}
-		if info.Version != testCase.expected.Version {
-			t.Errorf("%s: wrong `version`. Actual: %s, Expected: %s", testCase.name, info.Version, testCase.expected.Version)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			info, isRelease := getJobInfo(testCase.name)
+			if isRelease != testCase.isRelease {
+				t.Errorf("wrong `isNotRelease`. Actual: %t, Expected: %t", isRelease, testCase.isRelease)
+			}
+			if info.As != testCase.expected.As {
+				t.Errorf("wrong `as`. Actual: %s, Expected: %s", info.As, testCase.expected.As)
+			}
+			if info.Product != testCase.expected.Product {
+				t.Errorf("wrong `product`. Actual: %s, Expected: %s", info.Product, testCase.expected.Product)
+			}
+			if info.Version != testCase.expected.Version {
+				t.Errorf("wrong `version`. Actual: %s, Expected: %s", info.Version, testCase.expected.Version)
+			}
+		})
 	}
 }
 
@@ -222,14 +223,16 @@ func TestUpdateBaseImages(t *testing.T) {
 		expectedErr: false,
 	}}
 	for _, testCase := range testCases {
-		if err := updateBaseImages(testCase.newImages, testCase.ciopImages, testCase.replacementImages, testCase.version); err != nil && !testCase.expectedErr {
-			t.Errorf("%s: Got error when one was not expected: %v", testCase.name, err)
-		} else if err == nil && testCase.expectedErr {
-			t.Errorf("%s: Did not get error when one was expected", testCase.name)
-		} else {
-			if !reflect.DeepEqual(testCase.replacementImages, testCase.expectedImages) {
-				t.Errorf("%s: expected does not match actual: %s", testCase.name, cmp.Diff(testCase.replacementImages, testCase.expectedImages))
+		t.Run(testCase.name, func(t *testing.T) {
+			if err := updateBaseImages(testCase.newImages, testCase.ciopImages, testCase.replacementImages, testCase.version); err != nil && !testCase.expectedErr {
+				t.Errorf("received error when one was not expected: %v", err)
+			} else if err == nil && testCase.expectedErr {
+				t.Error("Did not get error when one was expected")
+			} else {
+				if diff := cmp.Diff(testCase.replacementImages, testCase.expectedImages); diff != "" {
+					t.Errorf("expected does not match actual: %s", diff)
+				}
 			}
-		}
+		})
 	}
 }

--- a/test/integration/release-job-migrator.sh
+++ b/test/integration/release-job-migrator.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+source "$(dirname "${BASH_SOURCE}")/../../hack/lib/init.sh"
+
+function cleanup() {
+    os::test::junit::reconcile_output
+    os::cleanup::processes
+}
+trap "cleanup" EXIT
+
+suite_dir="${OS_ROOT}/test/integration/release-job-migrator/"
+workdir="${BASETMPDIR}/release-job-migrator"
+mkdir -p "${workdir}"
+cp -a "${suite_dir}"/* "${workdir}"
+inputs="${workdir}/input"
+output="${workdir}/output.yaml"
+
+os::test::junit::declare_suite_start "integration/release-job-migrator"
+os::cmd::expect_success "release-job-migrator --config ${inputs}/config.yaml --jobs ${inputs}/jobs --ci-op-configs ${inputs}/ci-operator/openshift/release --rc-configs ${inputs}/releases > ${output}"
+os::integration::compare "${inputs}" "${suite_dir}/expected"
+os::integration::compare "${output}" "${suite_dir}/expected.txt"
+os::test::junit::declare_suite_end

--- a/test/integration/release-job-migrator/expected.txt
+++ b/test/integration/release-job-migrator/expected.txt
@@ -1,0 +1,11 @@
+These jobs from the following files have been replaced:
+release-openshift-ocp-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws
+release-openshift-okd-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-okd-4.7-e2e-aws
+release-openshift-origin-installer-e2e-aws-4.6: periodic-ci-openshift-release-master-origin-4.6-e2e-aws
+release-openshift-origin-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-origin-4.7-e2e-aws
+release-openshift-origin-installer-e2e-gcp-upgrade-4.7: periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade
+
+The following tests do not have entries in the generator config:
+[e2e-aws-compact e2e-gcp]
+
+Please run `make update` to regenerate job configs using the updated ci-operator configs.

--- a/test/integration/release-job-migrator/expected.txt
+++ b/test/integration/release-job-migrator/expected.txt
@@ -1,9 +1,9 @@
-These jobs from the following files have been replaced:
-release-openshift-ocp-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws
-release-openshift-okd-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-okd-4.7-e2e-aws
-release-openshift-origin-installer-e2e-aws-4.6: periodic-ci-openshift-release-master-origin-4.6-e2e-aws
-release-openshift-origin-installer-e2e-aws-4.7: periodic-ci-openshift-release-master-origin-4.7-e2e-aws
-release-openshift-origin-installer-e2e-gcp-upgrade-4.7: periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade
+The following jobs have been replaced:
+release-openshift-ocp-installer-e2e-aws-4.7 -> periodic-ci-openshift-release-master-ocp-4.7-e2e-aws
+release-openshift-okd-installer-e2e-aws-4.7 -> periodic-ci-openshift-release-master-okd-4.7-e2e-aws
+release-openshift-origin-installer-e2e-aws-4.6 -> periodic-ci-openshift-release-master-origin-4.6-e2e-aws
+release-openshift-origin-installer-e2e-aws-4.7 -> periodic-ci-openshift-release-master-origin-4.7-e2e-aws
+release-openshift-origin-installer-e2e-gcp-upgrade-4.7 -> periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade
 
 The following tests do not have entries in the generator config:
 [e2e-aws-compact e2e-gcp]

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
@@ -1,0 +1,44 @@
+base_images:
+  base:
+    name: "4.7"
+    namespace: ocp
+    tag: base
+  dev-scripts:
+    name: test
+    namespace: openshift-kni
+    tag: dev-scripts
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.7"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-metal-ipi
+  cron: 0 0 1 1 *
+  steps:
+    cluster_profile: packet
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OpenShiftSDN
+    workflow: baremetalds-e2e
+- as: e2e-aws-proxy
+  cron: 0 0 */2 * *
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws-proxy
+- as: e2e-aws
+  cron: '@every 48h'
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws
+zz_generated_metadata:
+  branch: ""
+  org: ""
+  repo: ""

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    name: "4.7"
+    namespace: origin
+    tag: base
+releases:
+  latest:
+    candidate:
+      product: okd
+      stream: okd
+      version: "4.7"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-aws
+  cron: '@every 48h'
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: release
+  variant: okd-4.7

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
@@ -1,0 +1,27 @@
+base_images:
+  base:
+    name: "4.6"
+    namespace: ocp
+    tag: base
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.6"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-aws
+  cron: '@every 48h'
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: release
+  variant: origin-4.6

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
@@ -1,0 +1,32 @@
+base_images:
+  base:
+    name: "4.7"
+    namespace: ocp
+    tag: base
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: ci
+      version: "4.7"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-aws
+  cron: '@every 48h'
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws
+- as: e2e-gcp-upgrade
+  cron: '@yearly'
+  steps:
+    cluster_profile: gcp
+    workflow: openshift-upgrade-gcp-loki
+zz_generated_metadata:
+  branch: master
+  org: openshift
+  repo: release
+  variant: origin-4.7

--- a/test/integration/release-job-migrator/expected/config.yaml
+++ b/test/integration/release-job-migrator/expected/config.yaml
@@ -1,0 +1,5 @@
+config:
+  e2e-aws:
+    steps:
+      cluster_profile: aws
+      workflow: openshift-e2e-aws

--- a/test/integration/release-job-migrator/expected/jobs/openshift-release-master-periodics.yaml
+++ b/test/integration/release-job-migrator/expected/jobs/openshift-release-master-periodics.yaml
@@ -1,0 +1,147 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  cron: 0 0 */2 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    ci-operator.openshift.io/variant: ocp-4.7
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-proxy
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/e2e-aws-proxy-cluster-profile
+      - --target=e2e-aws-proxy
+      - --variant=ocp-4.7
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-proxy-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: api.ci
+  cron: 0 0 1 1 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    ci-operator.openshift.io/variant: ocp-4.7
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-ocp-4.7-e2e-metal-ipi-ovn-dualstack
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/e2e-metal-ipi-ovn-dualstack-cluster-profile
+      - --target=e2e-metal-ipi-ovn-dualstack
+      - --variant=ocp-4.7
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-metal-ipi-ovn-dualstack-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-packet
+        - configMap:
+            name: cluster-profile-packet
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.6-periodics.yaml
+++ b/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.6-periodics.yaml
@@ -1,0 +1,122 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.6"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-compact-4.6
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.6-ci
+      - name: BRANCH
+        value: "4.6"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_VARIANT
+        value: compact
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials

--- a/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.7-periodics.yaml
+++ b/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.7-periodics.yaml
@@ -1,0 +1,232 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-compact-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7-ci
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_VARIANT
+        value: compact
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-gcp-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-gcp
+      - --template=/usr/local/e2e-gcp
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7-ci
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-gcp
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-gcp
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials

--- a/test/integration/release-job-migrator/expected/releases/release-ocp-4.7.json
+++ b/test/integration/release-job-migrator/expected/releases/release-ocp-4.7.json
@@ -1,0 +1,36 @@
+{
+    "name":"4.7.0-0.nightly",
+    "to": "release",
+    "message": "This release contains OSBS official image builds of all code in release-4.7 (master) branches, and is updated after those builds are synced to quay.io.",
+    "mirrorPrefix": "4.7-art-latest",
+    "expires":"168h",
+    "maxUnreadyReleases": 2,
+    "minCreationIntervalSeconds": 2400,
+    "referenceMode": "source",
+    "pullSecretName": "source",
+    "check":{
+      "OCP and Origin images should match": {
+        "consistentImages":{"parent":"4.7.0-0.ci"}
+      }
+    },
+    "publish":{
+      "tag":{"tagRef":{"name":"4.7"}},
+      "bugs":{"verifyBugs":{
+        "previousReleaseTag":{
+          "namespace":"ocp",
+          "name":"release",
+          "tag":"4.7.0-rc.0"
+        }
+      }}
+    },
+    "verify":{
+      "aws":{
+        "maxRetries": 3,
+        "prowJob":{"name":"periodic-ci-openshift-release-master-ocp-4.7-e2e-aws"}
+      },
+      "gcp":{
+        "optional":true,
+        "prowJob":{"name":"release-openshift-ocp-installer-e2e-gcp-4.7"}
+      }
+    }
+}

--- a/test/integration/release-job-migrator/expected/releases/release-origin-4.7.json
+++ b/test/integration/release-job-migrator/expected/releases/release-origin-4.7.json
@@ -1,0 +1,27 @@
+{
+    "name":"4.7.0-0.ci",
+    "to": "release",
+    "message": "This release contains CI image builds of all code in release-4.7 (master) branches, and is updated each time someone merges.",
+    "mirrorPrefix": "4.7",
+    "expires":"72h",
+    "maxUnreadyReleases": 2,
+    "minCreationIntervalSeconds": 1800,
+    "pullSecretName": "source",
+    "publish":{
+      "tag":{"tagRef":{"name":"4.7-ci"}}
+    },
+    "verify":{
+      "upgrade":{
+        "upgrade":true,
+        "optional":true,
+        "prowJob":{"name":"periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade"}
+      }
+    },
+    "periodic":{
+      "upgrade-gcp":{
+        "interval":"6h",
+        "upgrade":true,
+        "prowJob":{"name":"periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade"}
+      }
+    }
+  }

--- a/test/integration/release-job-migrator/input/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
+++ b/test/integration/release-job-migrator/input/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: "4.7"
+    namespace: ocp
+    tag: base
+  dev-scripts:
+    name: test
+    namespace: openshift-kni
+    tag: dev-scripts
+releases:
+  latest:
+    candidate:
+      product: ocp
+      stream: nightly
+      version: "4.7"
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-metal-ipi
+  cron: 0 0 1 1 *
+  steps:
+    cluster_profile: packet
+    env:
+      DEVSCRIPTS_CONFIG: |
+        IP_STACK=v4
+        NETWORK_TYPE=OpenShiftSDN
+    workflow: baremetalds-e2e
+- as: e2e-aws-proxy
+  cron: 0 0 */2 * *
+  steps:
+    cluster_profile: aws
+    workflow: openshift-e2e-aws-proxy

--- a/test/integration/release-job-migrator/input/config.yaml
+++ b/test/integration/release-job-migrator/input/config.yaml
@@ -1,0 +1,5 @@
+config:
+  e2e-aws:
+    steps:
+      cluster_profile: aws
+      workflow: openshift-e2e-aws

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-master-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-master-periodics.yaml
@@ -1,0 +1,147 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  cron: 0 0 */2 * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    ci-operator.openshift.io/variant: ocp-4.7
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-proxy
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/e2e-aws-proxy-cluster-profile
+      - --target=e2e-aws-proxy
+      - --variant=ocp-4.7
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-proxy-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cluster: api.ci
+  cron: 0 0 1 1 *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: openshift
+    repo: release
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    ci-operator.openshift.io/variant: ocp-4.7
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-openshift-release-master-ocp-4.7-e2e-metal-ipi-ovn-dualstack
+  spec:
+    containers:
+    - args:
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --lease-server-password-file=/etc/boskos/password
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/secrets/ci-pull-credentials
+      - --secret-dir=/usr/local/e2e-metal-ipi-ovn-dualstack-cluster-profile
+      - --target=e2e-metal-ipi-ovn-dualstack
+      - --variant=ocp-4.7
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /secrets/ci-pull-credentials
+        name: ci-pull-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-metal-ipi-ovn-dualstack-cluster-profile
+        name: cluster-profile
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: ci-pull-credentials
+      secret:
+        secretName: ci-pull-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-packet
+        - configMap:
+            name: cluster-profile-packet
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.6-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.6-periodics.yaml
@@ -1,0 +1,241 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.6"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-4.6
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.6-ci
+      - name: BRANCH
+        value: "4.6"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.6"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-compact-4.6
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.6-ci
+      - name: BRANCH
+        value: "4.6"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_VARIANT
+        value: compact
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
@@ -1,0 +1,688 @@
+periodics:
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-okd-installer-e2e-aws-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/origin/release:4.7
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: origin
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7-ci
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-env: aws
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-aws-compact-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7-ci
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_VARIANT
+        value: compact
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-ocp-installer-e2e-aws-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-aws-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-aws
+      - --template=/usr/local/e2e-aws
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+          - as: launch-$(CLUSTER_TYPE)
+            commands: sleep 9000 & wait
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-aws
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-aws
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  decorate: true
+  interval: 48h
+  labels:
+    job-release: "4.7"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --give-pr-author-access-to-namespace=true
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/e2e-gcp-cluster-profile
+      - --secret-dir=/usr/local/pull-secret
+      - --target=e2e-gcp
+      - --template=/usr/local/e2e-gcp
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_LATEST
+        value: registry.svc.ci.openshift.org/ocp/release:4.7-ci
+      - name: BRANCH
+        value: "4.7"
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: CONFIG_SPEC
+        value: |
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)
+            commands: TEST_SUITE=openshift/conformance/parallel run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+          - as: e2e-$(CLUSTER_TYPE)-serial
+            commands: TEST_SUITE=openshift/conformance/serial run-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+      - name: JOB_NAME_SAFE
+        value: e2e-gcp
+      - name: TEST_COMMAND
+        value: TEST_SUITE=openshift/conformance/parallel run-tests
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/e2e-gcp
+        name: job-definition
+        subPath: cluster-launch-installer-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - configMap:
+        name: prow-job-cluster-launch-installer-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  labels:
+    job-env: gcp
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-upgrade-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/pull-secret
+      - --secret-dir=/usr/local/e2e-$(CLUSTER_TYPE)-upgrade-cluster-profile
+      - --target=e2e-$(CLUSTER_TYPE)-upgrade
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_INITIAL
+      - name: RELEASE_IMAGE_LATEST
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: BRANCH
+        value: "4.7"
+      - name: UNRESOLVED_CONFIG
+        value: |
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            steps:
+              cluster_profile: $(CLUSTER_TYPE)
+              workflow: openshift-upgrade-$(CLUSTER_TYPE)-loki
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-upgrade-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+      - mountPath: /etc/appci
+        name: appci-release-bot-credentials
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+    - name: appci-release-bot-credentials
+      secret:
+        items:
+        - key: sa.release-bot.app.ci.config
+          path: sa.release-bot.app.ci.config
+        secretName: build-farm-credentials

--- a/test/integration/release-job-migrator/input/releases/release-ocp-4.7.json
+++ b/test/integration/release-job-migrator/input/releases/release-ocp-4.7.json
@@ -1,0 +1,36 @@
+{
+    "name":"4.7.0-0.nightly",
+    "to": "release",
+    "message": "This release contains OSBS official image builds of all code in release-4.7 (master) branches, and is updated after those builds are synced to quay.io.",
+    "mirrorPrefix": "4.7-art-latest",
+    "expires":"168h",
+    "maxUnreadyReleases": 2,
+    "minCreationIntervalSeconds": 2400,
+    "referenceMode": "source",
+    "pullSecretName": "source",
+    "check":{
+      "OCP and Origin images should match": {
+        "consistentImages":{"parent":"4.7.0-0.ci"}
+      }
+    },
+    "publish":{
+      "tag":{"tagRef":{"name":"4.7"}},
+      "bugs":{"verifyBugs":{
+        "previousReleaseTag":{
+          "namespace":"ocp",
+          "name":"release",
+          "tag":"4.7.0-rc.0"
+        }
+      }}
+    },
+    "verify":{
+      "aws":{
+        "maxRetries": 3,
+        "prowJob":{"name":"release-openshift-ocp-installer-e2e-aws-4.7"}
+      },
+      "gcp":{
+        "optional":true,
+        "prowJob":{"name":"release-openshift-ocp-installer-e2e-gcp-4.7"}
+      }
+    }
+}

--- a/test/integration/release-job-migrator/input/releases/release-origin-4.7.json
+++ b/test/integration/release-job-migrator/input/releases/release-origin-4.7.json
@@ -1,0 +1,27 @@
+{
+    "name":"4.7.0-0.ci",
+    "to": "release",
+    "message": "This release contains CI image builds of all code in release-4.7 (master) branches, and is updated each time someone merges.",
+    "mirrorPrefix": "4.7",
+    "expires":"72h",
+    "maxUnreadyReleases": 2,
+    "minCreationIntervalSeconds": 1800,
+    "pullSecretName": "source",
+    "publish":{
+      "tag":{"tagRef":{"name":"4.7-ci"}}
+    },
+    "verify":{
+      "upgrade":{
+        "upgrade":true,
+        "optional":true,
+        "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade-4.7"}
+      }
+    },
+    "periodic":{
+      "upgrade-gcp":{
+        "interval":"6h",
+        "upgrade":true,
+        "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade-4.7"}
+      }
+    }
+  }


### PR DESCRIPTION
This PR adds a new command to ci-tools that migrates release jobs from
hand-crafted jobs to jobs generated by a ci-operator config file. There
are 2 ways it can do this conversion:
1. If a job has an `UNRESOLVED_CONFIG` set, it can identify required base images and tests from there.
2. A config file can be used to configure jobs that use the same test name.

The config file is simply a yaml map where the key is the base test
name of a job (for example, for job `release-openshift-origin-installer-e2e-gcp-upgrade-4.7`,
the base test name is `gcp-upgrade`) and the value contains 2 things:
1. The corresponding multi-stage test configuration.
2. Any extra base images that the test may require.

This is an example of the config:
```
config:
  e2e-metal-ipi:
    steps:
      cluster_profile: packet
      env:
        DEVSCRIPTS_CONFIG: |
          IP_STACK=v4
          NETWORK_TYPE=OpenShiftSDN
      workflow: baremetalds-e2e
    base_images:
      dev-scripts:
        name: test
        namespace: openshift-kni
        tag: dev-scripts
```

The tool identifies what ci-operator config the tests and images should
be added to based on the name of the periodic job. If the ci-operator
config file does not exist yet, it creates a new one with the proper release
and base image set.

Currently the tool does not support handling of jobs that upgrade
between different release streams. That will be added in a future
PR.