### PR TITLE
[DPTP-1735] add the hostAliases field in literal multi stage step

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/test-infra/prow/repoowners"
 )
 
@@ -645,6 +646,9 @@ type LiteralTestStep struct {
 	Cli string `json:"cli,omitempty"`
 	// Observers are the observers that should be running
 	Observers []string `json:"observers,omitempty"`
+	// HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.
+	// reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 }
 
 // StepParameter is a variable set by the test, with an optional default.

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -184,6 +184,8 @@
         value: release:latest
       - name: LEASED_RESOURCE
         value: uuid
+      - name: TEST_HOSTNAME
+        value: test.hostname
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR
@@ -219,6 +221,15 @@
       volumeMounts:
       - mountPath: /tmp/artifacts
         name: artifacts
+    hostAliases:
+    - hostnames:
+      - api.test.hostname.com
+      - test2
+      ip: 10.0.0.1
+    - hostnames:
+      - api.test.hostname.com
+      - test4
+      ip: 10.0.0.2
     initContainers:
     - args:
       - /bin/secret-wrapper

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -413,6 +413,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"                  # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"                  hostAliases:\n" +
+	"                    - hostnames:\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -481,6 +487,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"                  # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"                  hostAliases:\n" +
+	"                    - hostnames:\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -549,6 +561,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"                  # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"                  hostAliases:\n" +
+	"                    - hostnames:\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -672,6 +690,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  hostAliases:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - hostnames:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -725,6 +749,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  hostAliases:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - hostnames:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -778,6 +808,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  hostAliases:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - hostnames:\n" +
+	"                        # LiteralTestStep is a full test step definition.\n" +
+	"                        - \"\"\n" +
+	"                      ip: ' '\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -984,6 +1020,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"              # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"              hostAliases:\n" +
+	"                - hostnames:\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1052,6 +1094,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"              # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"              hostAliases:\n" +
+	"                - hostnames:\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1120,6 +1168,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # HostAliases is an optional list of hosts and IPs that will be injected into the pod’s hosts file if specified.\n" +
+	"              # reference: https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases\n" +
+	"              hostAliases:\n" +
+	"                - hostnames:\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1243,6 +1297,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              hostAliases:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                - hostnames:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
@@ -1296,6 +1356,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              hostAliases:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                - hostnames:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
@@ -1349,6 +1415,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              hostAliases:\n" +
+	"                # LiteralTestStep is a full test step definition.\n" +
+	"                - hostnames:\n" +
+	"                    # LiteralTestStep is a full test step definition.\n" +
+	"                    - \"\"\n" +
+	"                  ip: ' '\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +


### PR DESCRIPTION
This change adds the ability to specify a `hostAliases` for a literal multi-stage step.

This will be injected in the generated pod's spec for the corresponding step.

example:
```yaml
chain:
  as: some-chain
  steps:
  - ref: some-step
  - chain: other-chain 
  env:
  - name: MY_VAR_IP
    default: 10.0.0.2
  - name: HOSTNAME
    default: "test.hostname"
  hostAliases:
  - ip: "${MY_VAR_IP}"
    hostnames:
    - "api.${HOSTNAME}.com"
    - "api.${NAMESPACE}-${JOB_NAME_HASH}"
```

Follow-up: Update ci-docs.

/cc @openshift/openshift-team-developer-productivity-test-platform 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>