### PR TITLE
ci-operator: wait longer for artifacts

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -197,7 +197,7 @@ func waitForContainer(podClient PodClient, ns, name, containerName string) error
 		"container": containerName,
 	}).Trace("Waiting for container to be running.")
 
-	return wait.PollImmediate(time.Second, 30*timeSecond, func() (bool, error) {
+	return wait.PollImmediate(time.Second, 300*timeSecond, func() (bool, error) {
 		pod := &coreapi.Pod{}
 		if err := podClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, pod); err != nil {
 			logrus.WithError(err).Errorf("Waiting for container %s in pod %s in namespace %s", containerName, name, ns)


### PR DESCRIPTION
When we run into issues starting containers, it may take much longer
than thirty seconds to start the artifacts container. There's no real
reason we need to be so aggressive.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller 
Addresses [DPTP-1787](https://issues.redhat.com/browse/DPTP-1787)