### PR TITLE
registrySyncer: handle deleted ImageStreams

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -159,6 +159,18 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 		return fmt.Errorf("failed to get imageStream %s from cluster %s: %w", isName.String(), srcClusterName, err)
 	}
 
+	if sourceImageStream.DeletionTimestamp != nil {
+		if err := finalizeIfNeeded(ctx, sourceImageStream, srcClusterName, r.registryClients); err != nil {
+			return fmt.Errorf("failed to finalize %s from cluster %s: %w", isName.String(), srcClusterName, err)
+		}
+		// no sync if the srcIS is deleted
+		return nil
+	}
+
+	if err := ensureFinalizer(ctx, sourceImageStream, r.registryClients[srcClusterName]); err != nil {
+		return fmt.Errorf("failed to ensure finalizer to %s from cluster %s: %w", isName.String(), srcClusterName, err)
+	}
+
 	*log = *log.WithField("docker_image_reference", sourceImageStreamTag.Image.DockerImageReference)
 
 	for clusterName, client := range r.registryClients {
@@ -245,6 +257,57 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 		log.Debug("Imported successfully")
 	}
 	return nil
+}
+
+func finalizeIfNeeded(ctx context.Context, stream *imagev1.ImageStream, srcClusterName string, clients map[string]ctrlruntimeclient.Client) error {
+	finalizerSet := sets.NewString(stream.Finalizers...)
+	if !finalizerSet.Has(ControllerName) {
+		return nil
+	}
+	for clusterName, client := range clients {
+		if clusterName == srcClusterName {
+			continue
+		}
+
+		isToDelete := &imagev1.ImageStream{}
+		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: stream.Name, Namespace: stream.Namespace}, isToDelete); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+
+		if err := ensureRemoveFinalizer(ctx, isToDelete, client); err != nil {
+			return err
+		}
+
+		// populate deleting to all clusters except srcClusterName
+		if err := client.Delete(ctx, isToDelete); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	// remove our finalizer from the list and update it.
+	return ensureRemoveFinalizer(ctx, stream, clients[srcClusterName])
+}
+
+func ensureRemoveFinalizer(ctx context.Context, stream *imagev1.ImageStream, client ctrlruntimeclient.Client) error {
+	finalizerSet := sets.NewString(stream.Finalizers...)
+	if !finalizerSet.Has(ControllerName) {
+		return nil
+	}
+	originalStream := stream.DeepCopy()
+	stream.Finalizers = finalizerSet.Delete(ControllerName).List()
+	// Use Patch instead of Update to avoid conflicting
+	return client.Patch(ctx, stream, ctrlruntimeclient.MergeFrom(originalStream))
+}
+
+func ensureFinalizer(ctx context.Context, stream *imagev1.ImageStream, client ctrlruntimeclient.Client) error {
+	if sets.NewString(stream.Finalizers...).Has(ControllerName) {
+		return nil
+	}
+	stream.Finalizers = append(stream.Finalizers, ControllerName)
+	return client.Update(ctx, stream)
 }
 
 func dockerImageImportedFromTargetingCluster(cluster string, tag *imagev1.ImageStreamTag) bool {


### PR DESCRIPTION
When a src IS is deleted, it will be deleted on other clusters.

We still need to clean up the current mess after merge: delete each IS on app.ci as src IS (or equivalently, has our own finalizer). Then our queue should be back to normal.

/cc @alvaroaleman @stevekuznetsov 