### PR TITLE
registrySyncer: fix finalizer name

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer_test.go
+++ b/pkg/controller/registrysyncer/registrysyncer_test.go
@@ -245,7 +245,7 @@ func TestReconcile(t *testing.T) {
 				"release.openshift.io-something": "copied",
 				"something":                      "not-copied",
 			},
-			Finalizers:        []string{"registry_syncer"},
+			Finalizers:        []string{"dptp.openshift.io/registry-syncer"},
 			DeletionTimestamp: &now,
 		},
 	}
@@ -338,7 +338,7 @@ func TestReconcile(t *testing.T) {
 							"release.openshift.io-something": "copied",
 							"something":                      "not-copied",
 						},
-						Finalizers: []string{"registry_syncer"},
+						Finalizers: []string{"dptp.openshift.io/registry-syncer"},
 					},
 				}
 				if diff := cmp.Diff(expectedImageStream, actualImageStream); diff != "" {
@@ -845,7 +845,7 @@ func TestEnsureRemoveFinalizer(t *testing.T) {
 				"release.openshift.io-something": "copied",
 				"something":                      "not-copied",
 			},
-			Finalizers:      []string{"registry_syncer", "some"},
+			Finalizers:      []string{"dptp.openshift.io/registry-syncer", "some"},
 			ResourceVersion: "1",
 		},
 	}


### PR DESCRIPTION
hit:

```
failed to ensure finalizer to ocp-priv/4.6-art-latest-priv-2020-11-18-154142 from cluster app.ci: ImageStream.image.openshift.io "4.6-art-latest-priv-2020-11-18-154142" is invalid: metadata.finalizers[0]: Invalid value: "registry_syncer": name is neither a standard finalizer name nor is it fully qualified
```

/cc @alvaroaleman 