### PR TITLE
Fix finishedAt in step graph

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -117,6 +117,7 @@ func runStep(ctx context.Context, node *api.StepNode, out chan<- message) {
 	}
 	duration := time.Since(start)
 	failed := err != nil
+	finishedAt := start.Add(duration)
 
 	out <- message{
 		node:            node,
@@ -127,7 +128,7 @@ func runStep(ctx context.Context, node *api.StepNode, out chan<- message) {
 			StepName:    node.Step.Name(),
 			Description: node.Step.Description(),
 			StartedAt:   &start,
-			FinishedAt:  func() *time.Time { start.Add(duration); return &start }(),
+			FinishedAt:  &finishedAt,
 			Duration:    &duration,
 			Manifests:   node.Step.Objects(),
 			Failed:      &failed,


### PR DESCRIPTION
Right now it always contains the start time, as we add to the start time, ignore the result of that operation and then use the start time