### PR TITLE
registrySyncer: Use patch to add finalizer

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -307,8 +307,9 @@ func ensureFinalizer(ctx context.Context, stream *imagev1.ImageStream, client ct
 	if sets.NewString(stream.Finalizers...).Has(finalizerName) {
 		return nil
 	}
+	originalStream := stream.DeepCopy()
 	stream.Finalizers = append(stream.Finalizers, finalizerName)
-	return client.Update(ctx, stream)
+	return client.Patch(ctx, stream, ctrlruntimeclient.MergeFrom(originalStream))
 }
 
 func dockerImageImportedFromTargetingCluster(cluster string, tag *imagev1.ImageStreamTag) bool {


### PR DESCRIPTION
95 hits in the last 3 hours.

```
failed to ensure finalizer to ocp-ppc64le/4.5.14 from cluster app.ci: Operation cannot be fulfilled on imagestreams.image.openshift.io "4.5.14": the object has been modified; please apply your changes to the latest version and try again
```

/cc @alvaroaleman 
