### PR TITLE
ipi-deprovisioner: tighen timeout to 10m per cluster

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -54,7 +54,7 @@ done
 
 failed=""
 for workdir in $( find /tmp/deprovision -mindepth 1 -type d | shuf ); do
-  if ! timeout --signal=SIGQUIT 30m openshift-install --dir "${workdir}" --log-level debug destroy cluster; then
+  if ! timeout --signal=SIGQUIT 10m openshift-install --dir "${workdir}" --log-level debug destroy cluster; then
     failed+=",$( basename "${workdir}" )"
   fi
 done


### PR DESCRIPTION
The job is currently timing out b/c of problems with cleaning up AWS
clusters ([DPTP-1770](https://issues.redhat.com/browse/DPTP-1770)), which creates a backlog and prevents analysing
which clusters are stuck - and some clusters are stuck for days, so the
long timeout does not help.

I checked the logs for the duration of successful cleanups, and in 99%
cases, we either manage to cleanup under 10m, or we hit the 30m timeout.
From the ~370 successful cleanups, just 7 were over 10 minutes, which I
think is acceptable for now when we need to get that job under the
timeout so that we can continue to analyze which clusters are stuck
long-term.