### PR TITLE
Allow unmarshaling ci-operator step graph

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -420,12 +420,12 @@ func HasAllLinks(needles, haystack []StepLink) bool {
 	return true
 }
 
-type CIOperatorStepGraph []CIOperatorStepWithDependencies
+type CIOperatorStepGraph []CIOperatorStepDetails
 
 // MergeFrom merges two CIOperatorStepGraphs together using StepNames as merge keys.
 // The merging logic will never ovewrwrite data and only set unset fields.
 // Steps that do not exist in the first graph get appended.
-func (graph *CIOperatorStepGraph) MergeFrom(from ...CIOperatorStepWithDependencies) {
+func (graph *CIOperatorStepGraph) MergeFrom(from ...CIOperatorStepDetails) {
 	for _, step := range from {
 		var found bool
 		for idx, existing := range *graph {
@@ -442,7 +442,7 @@ func (graph *CIOperatorStepGraph) MergeFrom(from ...CIOperatorStepWithDependenci
 
 }
 
-func mergeSteps(into, from CIOperatorStepWithDependencies) CIOperatorStepWithDependencies {
+func mergeSteps(into, from CIOperatorStepDetails) CIOperatorStepDetails {
 	if into.Description == "" {
 		into.Description = from.Description
 	}
@@ -470,11 +470,19 @@ func mergeSteps(into, from CIOperatorStepWithDependencies) CIOperatorStepWithDep
 	if into.Failed == nil {
 		into.Failed = from.Failed
 	}
+	if into.Substeps == nil {
+		into.Substeps = from.Substeps
+	}
 
 	return into
 }
 
-type CIOperatorStepWithDependencies struct {
+type CIOperatorStepDetails struct {
+	CIOperatorStepDetailInfo `json:",inline"`
+	Substeps                 []CIOperatorStepDetailInfo `json:"substeps,omitempty"`
+}
+
+type CIOperatorStepDetailInfo struct {
 	StepName     string                     `json:"name"`
 	Description  string                     `json:"description"`
 	Dependencies []string                   `json:"dependencies"`

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -429,7 +429,7 @@ func TestCIOperatorStepGraphMergeFromKeepsAllData(t *testing.T) {
 			for i := 0; i < 100; i++ {
 				t.Run(strconv.Itoa(i), func(t *testing.T) {
 					existinGraphCopy := append(CIOperatorStepGraph{}, tc.existinGraph...)
-					step := CIOperatorStepWithDependencies{}
+					step := CIOperatorStepDetails{}
 					fuzz.New().Funcs(func(r *ctrlruntimeclient.Object, _ fuzz.Continue) { *r = &corev1.Pod{} }).Fuzz(&step)
 					if len(existinGraphCopy) == 1 {
 						existinGraphCopy[0].StepName = step.StepName

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strconv"
@@ -442,6 +443,46 @@ func TestCIOperatorStepGraphMergeFromKeepsAllData(t *testing.T) {
 						t.Errorf("original element differs from merged element: %s", diff)
 					}
 				})
+			}
+		})
+	}
+}
+
+func TestCIOperatorStepWithDependenciesSerializationRoundTrips(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			step := &CIOperatorStepDetailInfo{}
+			fuzz.New().Funcs(func(r *ctrlruntimeclient.Object, _ fuzz.Continue) {
+				p := &corev1.Pod{}
+				p.APIVersion = "v1"
+				p.Kind = "Pod"
+				*r = p
+			}).Fuzz(&step)
+
+			serializedFirstPasss, err := json.Marshal(step)
+			if err != nil {
+				t.Fatalf("first serializiation failed: %v", err)
+			}
+			var stepRoundTripped CIOperatorStepDetailInfo
+			if err := json.Unmarshal(serializedFirstPasss, &stepRoundTripped); err != nil {
+				t.Fatalf("failed to unserialize: %v", err)
+			}
+			serializationSecondPass, err := json.Marshal(stepRoundTripped)
+			if err != nil {
+				t.Fatalf("second serialization failed: %v", err)
+			}
+
+			// Have to serialize them yet again, because the field order is not deterministic
+			var o1 interface{}
+			var o2 interface{}
+			if err = json.Unmarshal(serializationSecondPass, &o1); err != nil {
+				t.Fatalf("failed to re-marshal first serialization: %v", err)
+			}
+			if err = json.Unmarshal(serializationSecondPass, &o2); err != nil {
+				t.Fatalf("failed to re-marshal first serialization: %v", err)
+			}
+			if diff := cmp.Diff(o1, o2); diff != "" {
+				t.Errorf("Serializations differ: %s", diff)
 			}
 		})
 	}

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -507,6 +507,10 @@ func (*fakePodClient) GetLogs(string, string, *coreapi.PodLogOptions) *rest.Requ
 	return rest.NewRequestWithClient(nil, "", rest.ClientContentConfig{}, nil)
 }
 
+func (f *fakePodClient) WithNewLoggingClient() PodClient {
+	return f
+}
+
 type testExecutor struct {
 	command []string
 }

--- a/pkg/steps/loggingclient/loggingclient.go
+++ b/pkg/steps/loggingclient/loggingclient.go
@@ -15,6 +15,9 @@ type LoggingClient interface {
 	// Object contains the latest revision of each object the client has
 	// seen. Calling this will reset the cache.
 	Objects() []ctrlruntimeclient.Object
+	// New returns a new instance of a LoggingClient whose objects will
+	// not be logged in the parent.
+	New() LoggingClient
 }
 
 func New(upstream ctrlruntimeclient.Client) LoggingClient {
@@ -113,6 +116,10 @@ func (lc *loggingClient) Objects() []ctrlruntimeclient.Object {
 
 	lc.logTo = map[string]map[string]ctrlruntimeclient.Object{}
 	return result
+}
+
+func (lc *loggingClient) New() LoggingClient {
+	return New(lc.upstream)
 }
 
 func (lc *loggingClient) Status() ctrlruntimeclient.StatusWriter {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
+// the multiStageTestStep implements the subStepReporter interface
+var _ SubStepReporter = &multiStageTestStep{}
+
 func TestRequires(t *testing.T) {
 	for _, tc := range []struct {
 		name   string


### PR DESCRIPTION
Includes https://github.com/openshift/ci-tools/pull/1458 to avoid needing another rebase

The json unmarshaler refuses to unmarshal into a non-empty interface as it can't know the underlying type. So this adds a custom unmarshaler, that unmarshals the manifests into `*unstructured.Unstructured`. This in turn requires TypeMeta which is not set by default, so the second commit adds that.