### PR TITLE
registrySyncer: add more flags for debugging

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -96,6 +96,8 @@ type registrySyncerOptions struct {
 	imageStreamNamespaces    sets.String
 	deniedImageStreamsRaw    flagutil.Strings
 	deniedImageStreams       sets.String
+	maxConcurrentReconciles  int
+	readOnly                 bool
 }
 
 type secretSyncerConfigOptions struct {
@@ -133,6 +135,8 @@ func newOpts() (*options, error) {
 	flag.Var(&opts.registrySyncerOptions.imageStreamPrefixesRaw, "registrySyncerOptions.image-stream-prefix", "An imagestream prefix that will be synced. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
 	flag.Var(&opts.registrySyncerOptions.imageStreamNamespacesRaw, "registrySyncerOptions.image-stream-namespace", "A namespace in which imagestreams will be synced (e.G `ci`). Can be passed multiple times.")
 	flag.Var(&opts.registrySyncerOptions.deniedImageStreamsRaw, "registrySyncerOptions.denied-image-stream", "An imagestream that will NOT be synced. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
+	flag.IntVar(&opts.registrySyncerOptions.maxConcurrentReconciles, "registrySyncerOptions.max-concurrent-reconciles", 1, "the maximum number of concurrent Reconciles which can be run. Defaults to 1.")
+	flag.BoolVar(&opts.registrySyncerOptions.readOnly, "registrySyncerOptions.read-only", false, "Whether to run the registrySyncer in read-only mode")
 	flag.Var(&opts.testImagesDistributorOptions.forbiddenRegistriesRaw, "testImagesDistributorOptions.forbidden-registry", "The hostname of an image registry from which there is no synchronization of its images. Can be passed multiple times.")
 	flag.StringVar(&opts.registrySyncerOptions.imagePullSecretPath, "registrySyncerOptions.imagePullSecretPath", "", "A file to use for reading an ImagePullSecret that will be bound to all `default` ServiceAccounts in all namespaces that have a test ImageStream on all build clusters")
 	flag.StringVar(&opts.secretSyncerConfigOptions.configFile, "secretSyncerConfigOptions.config", "", "The config file for the secret syncer controller")
@@ -476,6 +480,8 @@ func main() {
 			opts.registrySyncerOptions.imageStreamPrefixes,
 			opts.registrySyncerOptions.imageStreamNamespaces,
 			opts.registrySyncerOptions.deniedImageStreams,
+			opts.registrySyncerOptions.maxConcurrentReconciles,
+			opts.registrySyncerOptions.readOnly,
 		); err != nil {
 			logrus.WithError(err).Fatal("failed to add registrysyncer")
 		}


### PR DESCRIPTION
I want to know if it improves at all if we do not create and check the import.

/cc @alvaroaleman 