### PR TITLE
pkg/api: check `values` in `Params::has`

### DIFF
--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -133,7 +133,11 @@ func (p *DeferredParameters) Has(name string) bool {
 func (p *DeferredParameters) has(name string) bool {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	_, ok := p.fns[name]
+	_, ok := p.values[name]
+	if ok {
+		return true
+	}
+	_, ok = p.fns[name]
 	return ok
 }
 

--- a/pkg/api/parameters_test.go
+++ b/pkg/api/parameters_test.go
@@ -200,6 +200,9 @@ func TestDeferredParametersParent(t *testing.T) {
 			if ret != "expected" {
 				t.Errorf("got unexpected value %q", ret)
 			}
+			if !tc.params.Has("K") {
+				t.Errorf(`"Has" and "Get" disagree`)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I noticed while working on 5b88367b55758f6b7310bc4bcd46a4033019522d that this
discrepancy existed, but did not have time to correct it.  I do not see a reason
for it to exist.