### PR TITLE
isTag handler: reconcile when DeletionTimestamp is defined

### DIFF
--- a/pkg/util/imagestreamtagmapper/imagestreamtagmapper.go
+++ b/pkg/util/imagestreamtagmapper/imagestreamtagmapper.go
@@ -42,8 +42,9 @@ func (m *imagestreamtagmapper) Update(e event.UpdateEvent, q workqueue.RateLimit
 		return
 	}
 
+	isDeleted := newStream.DeletionTimestamp != nil
 	for _, newTag := range newStream.Status.Tags {
-		if namedTagEventListHasElement(oldStream.Status.Tags, newTag) {
+		if !isDeleted && namedTagEventListHasElement(oldStream.Status.Tags, newTag) {
 			continue
 		}
 		for _, request := range m.upstream(reconcile.Request{


### PR DESCRIPTION
Changes on `DeletionTimestamp` generate UpdateEvent.
The DeleteEvent occurs only when the the object is deleted.

When we handles the annotations of isTag, I believe we need to modify this function too.

/cc @stevekuznetsov @alvaroaleman 