### PR TITLE
 registrySyncer: remove locks on imagestream at reconcile

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -52,19 +51,17 @@ func AddToManager(mgr manager.Manager,
 		imageStreamPrefixes:   imageStreamPrefixes,
 		imageStreamNamespaces: imageStreamNamespaces,
 		deniedImageStreams:    deniedImageStreams,
-		imageStreamLocks: &shardedLock{
-			mapLock: &sync.Mutex{},
-			locks:   map[simpleImageStream]*sync.Mutex{},
-			log:     log,
-		},
 	}
-	r.imageStreamLocks.runCleanup()
 	for clusterName, m := range managers {
 		r.registryClients[clusterName] = imagestreamtagwrapper.MustNew(m.GetClient(), m.GetCache())
 	}
 	c, err := controller.New(ControllerName, mgr, controller.Options{
-		Reconciler:              r,
-		MaxConcurrentReconciles: 100,
+		Reconciler: r,
+		// We conflict on ImageStream level which means multiple request for imagestreamtags
+		// of the same imagestream will conflict so stay at one worker in order to reduce the
+		// number of errors we see. If we hit performance issues, we will probably need cluster
+		// and/or imagestream level locking.
+		MaxConcurrentReconciles: 1,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to construct controller: %w", err)
@@ -81,57 +78,6 @@ func AddToManager(mgr manager.Manager,
 
 	r.log.Info("Successfully added reconciler to manager")
 	return nil
-}
-
-type simpleImageStream struct {
-	//Exclude cluster here intentionally: code is easier with litter performance impact
-	types.NamespacedName
-}
-
-type shardedLock struct {
-	mapLock *sync.Mutex
-	locks   map[simpleImageStream]*sync.Mutex
-	log     *logrus.Entry
-}
-
-func (s *shardedLock) getLock(key simpleImageStream) *sync.Mutex {
-	s.mapLock.Lock()
-	defer s.mapLock.Unlock()
-	if _, exists := s.locks[key]; !exists {
-		s.locks[key] = &sync.Mutex{}
-	}
-	return s.locks[key]
-}
-
-// cleanup deletes all locks by acquiring first
-// the mapLock and then each individual lock before
-// deleting it. The individual lock must be acquired
-// because otherwise it may be held, we delete it from
-// the map, it gets recreated and acquired and two
-// routines report in parallel for the same job.
-// Note that while this function is running, no new
-// reconcile can happen, as we hold the mapLock.
-func (s *shardedLock) cleanup() {
-	s.mapLock.Lock()
-	defer s.mapLock.Unlock()
-
-	for key, lock := range s.locks {
-		lock.Lock()
-		delete(s.locks, key)
-		lock.Unlock()
-	}
-}
-
-// runCleanup asynchronously runs the cleanup once per hour.
-func (s *shardedLock) runCleanup() {
-	go func() {
-		for range time.Tick(time.Hour) {
-			s.log.Debug("Starting to clean up imagestream locks")
-			startTime := time.Now()
-			s.cleanup()
-			s.log.WithField("duration", time.Since(startTime).String()).Debug("Finished cleaning up imagestream locks")
-		}
-	}()
 }
 
 type objectFilter func(types.NamespacedName) bool
@@ -160,7 +106,6 @@ type reconciler struct {
 	imageStreamPrefixes   sets.String
 	imageStreamNamespaces sets.String
 	deniedImageStreams    sets.String
-	imageStreamLocks      *shardedLock
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -181,16 +126,6 @@ const (
 )
 
 func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *logrus.Entry) error {
-	imageStreamNameAndTag := strings.Split(req.Name, ":")
-	if n := len(imageStreamNameAndTag); n != 2 {
-		return fmt.Errorf("when splitting imagestreamtagname %s by : expected two results, got %d", req.Name, n)
-	}
-	imageStreamName, imageTag := imageStreamNameAndTag[0], imageStreamNameAndTag[1]
-	key := simpleImageStream{NamespacedName: types.NamespacedName{Namespace: req.Namespace, Name: imageStreamName}}
-	lock := r.imageStreamLocks.getLock(key)
-	lock.Lock()
-	defer lock.Unlock()
-
 	isTags := map[string]*imagev1.ImageStreamTag{}
 	for clusterName, client := range r.registryClients {
 		*log = *log.WithField("clusterName", clusterName)
@@ -213,6 +148,11 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 	}
 	sourceImageStreamTag := isTags[srcClusterName]
 
+	imageStreamNameAndTag := strings.Split(req.Name, ":")
+	if n := len(imageStreamNameAndTag); n != 2 {
+		return fmt.Errorf("when splitting imagestreamtagname %s by : expected two results, got %d", req.Name, n)
+	}
+	imageStreamName, imageTag := imageStreamNameAndTag[0], imageStreamNameAndTag[1]
 	isName := types.NamespacedName{Namespace: req.Namespace, Name: imageStreamName}
 	sourceImageStream := &imagev1.ImageStream{}
 	if err := r.registryClients[srcClusterName].Get(ctx, isName, sourceImageStream); err != nil {
@@ -254,6 +194,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 				return fmt.Errorf("failed to create namespace %s on cluster %s: %w", req.Namespace, clusterName, err)
 			}
 		}
+
 		if err := r.ensureImageStream(ctx, sourceImageStream, client, log); err != nil {
 			return fmt.Errorf("failed to ensure imagestream on cluster %s: %w", clusterName, err)
 		}

--- a/pkg/controller/registrysyncer/registrysyncer_test.go
+++ b/pkg/controller/registrysyncer/registrysyncer_test.go
@@ -3,7 +3,6 @@ package registrysyncer
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -178,7 +177,6 @@ func init() {
 }
 
 func TestReconcile(t *testing.T) {
-	t.Parallel()
 	pullSecretGetter := func() []byte {
 		return []byte("some-secret")
 	}
@@ -527,7 +525,6 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			r := &reconciler{
 				log: logrus.NewEntry(logrus.New()),
@@ -536,12 +533,8 @@ func TestReconcile(t *testing.T) {
 					appCI: tc.appCIClient,
 				},
 				pullSecretGetter: pullSecretGetter,
-				imageStreamLocks: &shardedLock{
-					mapLock: &sync.Mutex{},
-					locks:   map[simpleImageStream]*sync.Mutex{},
-				},
 			}
-			r.imageStreamLocks.runCleanup()
+
 			request := reconcile.Request{NamespacedName: tc.request}
 			actual := r.reconcile(context.Background(), request, r.log)
 

--- a/pkg/controller/registrysyncer/registrysyncer_test.go
+++ b/pkg/controller/registrysyncer/registrysyncer_test.go
@@ -177,6 +177,7 @@ func init() {
 }
 
 func TestReconcile(t *testing.T) {
+	t.Parallel()
 	pullSecretGetter := func() []byte {
 		return []byte("some-secret")
 	}
@@ -525,6 +526,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			r := &reconciler{
 				log: logrus.NewEntry(logrus.New()),


### PR DESCRIPTION
The lock prevents the concurrent reconcile because the events for the same IS are grouping together (they are converted from the events on IS).

The reason that we lock in the first place is that we do not want to see loggings on `isConflict` errors.
Here we reconcile on those errors, but ignore the logging.

/cc @alvaroaleman 