### PR TITLE
[DPTP-1731] add the ability to create rbacs and wait until the image pull secret has been created

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -70,7 +70,7 @@ func (s *importReleaseStep) Run(ctx context.Context) error {
 }
 
 func (s *importReleaseStep) run(ctx context.Context) error {
-	_, err := setupReleaseImageStream(s.jobSpec.Namespace(), s.client)
+	_, err := setupReleaseImageStream(ctx, s.jobSpec.Namespace(), s.client)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/rbacs.go
+++ b/pkg/util/rbacs.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	coreapi "k8s.io/api/core/v1"
+	rbacapi "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/ci-tools/pkg/results"
+)
+
+// CreateRBACs creates the given service account, role, and role binding. In addition, it waits until the service account will be updated with an image pull secret.
+// Because the DockerCfgController controller needs some time to create the corresponding secrets we need to wait until this happens, otherwise, the pod that
+// will use this service account will fail to start since there are no credentials to pull any images.
+func CreateRBACs(ctx context.Context, sa *coreapi.ServiceAccount, role *rbacapi.Role, roleBinding *rbacapi.RoleBinding, client ctrlruntimeclient.Client, retryDuration, timeout time.Duration) error {
+	skipPoll := false
+
+	err := client.Create(ctx, sa)
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return results.ForReason("creating_service_account").WithError(err).Errorf("could not create service account '%s'", sa.Name)
+	}
+
+	if kerrors.IsAlreadyExists(err) {
+		skipPoll = true
+	}
+
+	if err := client.Create(ctx, role); err != nil && !kerrors.IsAlreadyExists(err) {
+		return results.ForReason("creating_roles").WithError(err).Errorf("could not create role '%s'", role.Name)
+	}
+	if err := client.Create(ctx, roleBinding); err != nil && !kerrors.IsAlreadyExists(err) {
+		return results.ForReason("binding_roles").WithError(err).Errorf("could not create role binding '%s'", roleBinding.Name)
+	}
+
+	if skipPoll {
+		return nil
+	}
+
+	if err := wait.Poll(retryDuration, timeout, func() (bool, error) {
+		actualSA := &coreapi.ServiceAccount{}
+		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{
+			Namespace: sa.Namespace,
+			Name:      sa.Name,
+		}, actualSA); err != nil {
+			return false, fmt.Errorf("couldn't get service account %s: %w", sa.Name, err)
+		}
+
+		if len(actualSA.ImagePullSecrets) == 0 {
+			return false, nil
+		}
+
+		return true, nil
+	},
+	); err != nil {
+		return results.ForReason("create_dockercfg_secrets").WithError(err).Errorf("timeout while waiting for dockercfg secret creation for service account '%s'", sa.Name)
+	}
+
+	return nil
+}

--- a/pkg/util/rbacs_test.go
+++ b/pkg/util/rbacs_test.go
@@ -1,0 +1,102 @@
+package util
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	coreapi "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacapi "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCreateRBACs(t *testing.T) {
+	testCases := []struct {
+		id            string
+		sa            *coreapi.ServiceAccount
+		role          *rbacapi.Role
+		roleBinding   *rbacapi.RoleBinding
+		expectedError string
+	}{
+		{
+			id: "happy",
+			sa: &coreapi.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "ci-operator", Namespace: "test-namespace"}},
+			role: &rbacapi.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: "ci-operator-image", Namespace: "test-namespace"},
+				Rules: []rbacapi.PolicyRule{
+					{
+						APIGroups: []string{"", "image.openshift.io"},
+						Resources: []string{"imagestreams/layers"},
+						Verbs:     []string{"get", "update"},
+					},
+				},
+			},
+			roleBinding: &rbacapi.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-operator-image",
+					Namespace: "test-namespace",
+				},
+				Subjects: []rbacapi.Subject{{Kind: "ServiceAccount", Name: "ci-operator", Namespace: "test-namespace"}},
+				RoleRef: rbacapi.RoleRef{
+					Kind: "Role",
+					Name: "ci-operator-image",
+				},
+			},
+		},
+		{
+			id: "sad",
+			sa: &coreapi.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "ci-operator", Namespace: "test-namespace"}},
+			role: &rbacapi.Role{
+				ObjectMeta: metav1.ObjectMeta{Name: "ci-operator-image", Namespace: "test-namespace"},
+				Rules: []rbacapi.PolicyRule{
+					{
+						APIGroups: []string{"", "image.openshift.io"},
+						Resources: []string{"imagestreams/layers"},
+						Verbs:     []string{"get", "update"},
+					},
+				},
+			},
+			roleBinding: &rbacapi.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-operator-image",
+					Namespace: "test-namespace",
+				},
+				Subjects: []rbacapi.Subject{{Kind: "ServiceAccount", Name: "ci-operator", Namespace: "test-namespace"}},
+				RoleRef: rbacapi.RoleRef{
+					Kind: "Role",
+					Name: "ci-operator-image",
+				},
+			},
+			expectedError: "timeout while waiting for dockercfg secret creation for service account 'ci-operator'",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			client := fake.NewFakeClient()
+
+			if tc.expectedError == "" {
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					newSA := &coreapi.ServiceAccount{}
+					_ = client.Get(context.Background(), ctrlruntimeclient.ObjectKey{
+						Namespace: "test-namespace",
+						Name:      "ci-operator",
+					}, newSA)
+					newSA.ImagePullSecrets = append(newSA.ImagePullSecrets, v1.LocalObjectReference{Name: "ci-operator-dockercfg-12345"})
+					_ = client.Update(context.Background(), newSA)
+				}()
+			}
+
+			if err := CreateRBACs(context.TODO(), tc.sa, tc.role, tc.roleBinding, client, 1*time.Millisecond, 100*time.Millisecond); err != nil {
+				if !reflect.DeepEqual(err.Error(), tc.expectedError) {
+					t.Fatalf("Expected: %v\nGot: %v", tc.expectedError, err.Error())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
When a service account is being created, the [DockercfgController](https://github.com/openshift/openshift-controller-manager/blob/master/pkg/serviceaccounts/controllers/create_dockercfg_secrets.go#L315) creates the pull secret and then update the service account. Therefore if the service account will be used before the creation of that secret, the running pod will pull images as anonymous instead. 

This PR fixes this race condition by creating a new function that will be responsible for the RBAC creation and waits until the dockercfg controller will create the secret and sync the service account.

Jobs with the related error: [ci-search - Container .* is not ready with reason ImagePullBackOff](https://search.ci.openshift.org/?search=Container+.*+is+not+ready+with+reason+ImagePullBackOff&maxAge=24h&context=0&type=build-log&name=.*&maxMatches=1&maxBytes=&groupBy=job)


/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>