### PR TITLE
template-deprecator: add enforcing checks

### DIFF
--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kataras/tablewriter"
 	"github.com/sirupsen/logrus"
+
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	prowplugins "k8s.io/test-infra/prow/plugins"

--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/kataras/tablewriter"
 	"github.com/sirupsen/logrus"
-
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	prowplugins "k8s.io/test-infra/prow/plugins"
@@ -25,6 +24,7 @@ type options struct {
 	printStats           bool
 	hideTotals           bool
 	blockNewJobs         flagutil.Strings
+	checks               bool
 
 	help bool
 }
@@ -40,6 +40,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.BoolVar(&opt.prune, "prune", false, "If set, remove from allowlist all jobs that either no longer exist or no longer use a template")
 	fs.BoolVar(&opt.printStats, "stats", false, "If true, print template usage stats")
 	fs.BoolVar(&opt.hideTotals, "hide-totals", false, "If true, hide totals in template usage stats")
+	fs.BoolVar(&opt.checks, "checks", true, "If true (default), validate allowlist for correctness after update")
 
 	return opt
 }
@@ -115,6 +116,17 @@ func main() {
 		table.SetFooter(footer)
 		table.AppendBulk(data)
 		table.Render()
+	}
+
+	if opt.checks {
+		if errs := enforcer.Validate(); len(errs) > 0 {
+			fmt.Printf("ERROR: Template deprecation allowlist has errors:\n")
+			for idx, err := range errs {
+				fmt.Printf("\nERROR: %d)\n", idx+1)
+				fmt.Printf(err.Error())
+			}
+			logrus.Fatalf("Template deprecation allowlist failed validation")
+		}
 	}
 
 	if err := enforcer.SaveAllowlist(opt.allowlistPath); err != nil {

--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -119,12 +119,13 @@ func main() {
 	}
 
 	if opt.checks {
-		if errs := enforcer.Validate(); len(errs) > 0 {
+		if violations := enforcer.Validate(); len(violations) > 0 {
 			fmt.Printf("ERROR: Template deprecation allowlist has errors:\n")
-			for idx, err := range errs {
+			for idx, violation := range violations {
 				fmt.Printf("\nERROR: %d)\n", idx+1)
-				fmt.Printf("%s\n", err.Error())
+				fmt.Printf("%s\n", violation)
 			}
+			fmt.Println()
 			logrus.Fatalf("Template deprecation allowlist failed validation")
 		}
 	}

--- a/cmd/template-deprecator/main.go
+++ b/cmd/template-deprecator/main.go
@@ -123,7 +123,7 @@ func main() {
 			fmt.Printf("ERROR: Template deprecation allowlist has errors:\n")
 			for idx, err := range errs {
 				fmt.Printf("\nERROR: %d)\n", idx+1)
-				fmt.Printf(err.Error())
+				fmt.Printf("%s\n", err.Error())
 			}
 			logrus.Fatalf("Template deprecation allowlist failed validation")
 		}

--- a/pkg/deprecatetemplates/allowlist.go
+++ b/pkg/deprecatetemplates/allowlist.go
@@ -77,6 +77,10 @@ func (b blockedJobs) Union(other blockedJobs) blockedJobs {
 }
 
 type deprecatedTemplateBlocker struct {
+	// unexported field so it is never serialized and it is `false` by default on
+	// read. we set this to true when we create new blockers to recognize them
+	newlyAdded bool
+
 	Description string      `json:"description"`
 	Jobs        blockedJobs `json:"jobs,omitempty"`
 }
@@ -118,8 +122,12 @@ func (d *deprecatedTemplate) insert(job config.JobBase, defaultBlockers JiraHint
 	}
 
 	if d.UnknownBlocker == nil {
-		d.UnknownBlocker = &deprecatedTemplateBlocker{Jobs: blockedJobs{}}
+		d.UnknownBlocker = &deprecatedTemplateBlocker{
+			newlyAdded: true,
+			Jobs:       blockedJobs{},
+		}
 	} else if d.UnknownBlocker.Jobs == nil {
+		d.UnknownBlocker.newlyAdded = true
 		d.UnknownBlocker.Jobs = blockedJobs{}
 	}
 	d.UnknownBlocker.Jobs.Insert(job)

--- a/pkg/deprecatetemplates/enforcer.go
+++ b/pkg/deprecatetemplates/enforcer.go
@@ -207,15 +207,13 @@ type enforcingFunc func() []error
 
 func (e *Enforcer) noNewUnknownBlockers() []error {
 	makeError := func(template string, blockers map[string]deprecatedTemplateBlocker) error {
-		lines := []string{fmt.Sprintf(`ERROR: Jobs using the '%s' template were added with an
-ERROR: unknown blocker. Add them under one of existing blockers by running one of the following:
-`, template)}
+		lines := []string{fmt.Sprintf(`Jobs using the '%s' template were added with an
+unknown blocker. Add them under one of existing blockers by running one of the following:`, template)}
 		for id, blocker := range blockers {
-			lines = append(lines, fmt.Sprintf("ERROR: $ make template-allowlist BLOCKER=%s # %s", id, blocker.Description))
+			lines = append(lines, fmt.Sprintf("$ make template-allowlist BLOCKER=%s # %s", id, blocker.Description))
 		}
-		lines = append(lines, "", `ERROR: Alternatively, create a new JIRA and start tracking it in the allowlist:
-
-ERROR: $ make template-allowlist BLOCKER="JIRAID:short description"`)
+		lines = append(lines, "", `Alternatively, create a new JIRA and start tracking it in the allowlist:
+$ make template-allowlist BLOCKER="JIRAID:short description"`)
 
 		return errors.New(strings.Join(lines, "\n"))
 	}
@@ -246,12 +244,12 @@ func (e *Enforcer) noUnusedTemplates() []error {
 	if len(unused) == 0 {
 		return nil
 	}
-	lines := []string{`ERROR: The following templates are not used by any job. Please remove their
-ERROR: config-updater config from core-services/prow/02_config/_plugins.yaml)
-ERROR: and code from ci-operator/templates. If you are trying to add a new template,
-ERROR: you should add multi-stage steps instead.`}
+	lines := []string{`The following templates are not used by any job. Please remove their
+config-updater config from core-services/prow/02_config/_plugins.yaml)
+and code from ci-operator/templates. If you are trying to add a new template,
+you should add multi-stage steps instead.`}
 	for _, line := range unused {
-		lines = append(lines, fmt.Sprintf("ERROR: - %s", line))
+		lines = append(lines, fmt.Sprintf("- %s", line))
 	}
 
 	return []error{errors.New(strings.Join(lines, "\n"))}

--- a/pkg/deprecatetemplates/enforcer.go
+++ b/pkg/deprecatetemplates/enforcer.go
@@ -201,3 +201,8 @@ func (e *Enforcer) Stats(hideTotals bool) (header, footer []string, lines [][]st
 	}
 	return header, footer, lines
 }
+
+func (e *Enforcer) Validate() []error {
+	var errs []error
+	return errs
+}

--- a/pkg/deprecatetemplates/enforcer_test.go
+++ b/pkg/deprecatetemplates/enforcer_test.go
@@ -244,11 +244,11 @@ func TestEnforcer_Validate(t *testing.T) {
 			description:        "unused template",
 			templates:          sets.NewString("unused", "used"),
 			allowlistTemplates: map[string]*deprecatedTemplate{"used": {Name: "used"}},
-			expected: []string{`ERROR: The following templates are not used by any job. Please remove their
-ERROR: config-updater config from core-services/prow/02_config/_plugins.yaml)
-ERROR: and code from ci-operator/templates. If you are trying to add a new template,
-ERROR: you should add multi-stage steps instead.
-ERROR: - unused`,
+			expected: []string{`The following templates are not used by any job. Please remove their
+config-updater config from core-services/prow/02_config/_plugins.yaml)
+and code from ci-operator/templates. If you are trying to add a new template,
+you should add multi-stage steps instead.
+- unused`,
 			},
 		},
 		{
@@ -265,14 +265,12 @@ ERROR: - unused`,
 					},
 				},
 			},
-			expected: []string{`ERROR: Jobs using the 'template' template were added with an
-ERROR: unknown blocker. Add them under one of existing blockers by running one of the following:
+			expected: []string{`Jobs using the 'template' template were added with an
+unknown blocker. Add them under one of existing blockers by running one of the following:
+$ make template-allowlist BLOCKER=BLOCKER-1 # known blocker
 
-ERROR: $ make template-allowlist BLOCKER=BLOCKER-1 # known blocker
-
-ERROR: Alternatively, create a new JIRA and start tracking it in the allowlist:
-
-ERROR: $ make template-allowlist BLOCKER="JIRAID:short description"`,
+Alternatively, create a new JIRA and start tracking it in the allowlist:
+$ make template-allowlist BLOCKER="JIRAID:short description"`,
 			},
 		},
 	}


### PR DESCRIPTION
Adds two checks over the allowlist:

- Force removal of unused templates
- Prevent people from adding jobs to an "unknown blokcker" section that was previously empty

Example output:

```console
$ template-deprecator --prow-jobs-dir ci-operator/jobs --prow-config-path core-services/prow/02_config/_config.yaml --prow-plugin-config-path core-services/prow/02_config/_plugins.yaml --allowlist-path core-services/template-deprecation/_allowlist.yam
ERROR: Template deprecation allowlist has errors:

ERROR: 1)
The following templates are not used by any job. Please remove their
config-updater config from core-services/prow/02_config/_plugins.yaml)
and code from ci-operator/templates. If you are trying to add a new template,
you should add multi-stage steps instead.
- prow-job-cluster-launch-installer-nested-virt-tests
- prow-job-cluster-launch-installer-gcp-nested-virt-custom-test-image
- prow-job-rbac-azure
- prow-job-cluster-launch-installer-openstack-e2e-ppc64le

ERROR: 2)
Jobs using the 'prow-job-cluster-launch-installer-remote-libvirt-e2e' template were added with an
unknown blocker. Add them under one of existing blockers by running one of the following:
$ make template-allowlist BLOCKER=[DPTP-1735](https://issues.redhat.com/browse/DPTP-1735) # multi-stage workflows need a hostAliases equivalent

Alternatively, create a new JIRA and start tracking it in the allowlist:
$ make template-allowlist BLOCKER="JIRAID:short description"

FATA[0005] Template deprecation allowlist failed validation
```