### PR TITLE
ci-operator: stop explicitly updating submodules

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -94,7 +94,6 @@ func sourceDockerfile(fromTag api.PipelineImageStreamTagReference, workingDir st
 	dockerCommands = append(dockerCommands, fmt.Sprintf("RUN umask 0002 && /clonerefs && find %s/src -type d -not -perm -0775 | xargs -r chmod g+xw", gopath))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s/", workingDir))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("ENV GOPATH=%s", gopath))
-	dockerCommands = append(dockerCommands, "RUN git submodule update --init")
 
 	// After the clonerefs command, we don't need the secret anymore.
 	// We don't want to let the key keep existing in the image's layer.

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -46,7 +46,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/github.com/org/repo/
       ENV GOPATH=/go
-      RUN git submodule update --init
     images:
     - from:
         kind: ImageStreamTag

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -47,7 +47,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/github.com/org/repo/
       ENV GOPATH=/go
-      RUN git submodule update --init
       RUN rm -f /oauth-token
     images:
     - from:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -46,7 +46,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/somewhere/else/
       ENV GOPATH=/go
-      RUN git submodule update --init
     images:
     - from:
         kind: ImageStreamTag

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -46,7 +46,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/github.com/org/repo/
       ENV GOPATH=/go
-      RUN git submodule update --init
     images:
     - from:
         kind: ImageStreamTag

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -46,7 +46,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/github.com/org/repo/
       ENV GOPATH=/go
-      RUN git submodule update --init
     images:
     - from:
         kind: ImageStreamTag

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -46,7 +46,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/this/is/nuts/
       ENV GOPATH=/go
-      RUN git submodule update --init
     images:
     - from:
         kind: ImageStreamTag

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -48,7 +48,6 @@ spec:
       RUN umask 0002 && /clonerefs && find /go/src -type d -not -perm -0775 | xargs -r chmod g+xw
       WORKDIR /go/src/github.com/org/repo/
       ENV GOPATH=/go
-      RUN git submodule update --init
       RUN rm -f /sshprivatekey
     images:
     - from:


### PR DESCRIPTION
It is not clear why this change ever landed into our build manifest for
the source image. The `clonerefs` utility gained this behavior six
months after the change here landed, and obsoleted it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Our hack: https://github.com/openshift/ci-tools/commit/9ee986993c1c5c3f92078ba664710a892587255f
Upstream: https://github.com/kubernetes/test-infra/commit/7f9f4fc812769639ea72924fa2b7c99ca0bf25c1