### PR TITLE
cmd/ipi-deprovision: Parallel cluster teardown

### DIFF
--- a/cmd/ipi-deprovision/ipi-deprovision.sh
+++ b/cmd/ipi-deprovision/ipi-deprovision.sh
@@ -4,13 +4,30 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
+
+function queue() {
+  local LIVE="$(jobs | wc -l)"
+  while [[ "${LIVE}" -ge 10 ]]; do
+    sleep 1
+    LIVE="$(jobs | wc -l)"
+  done
+  echo "${@}"
+  "${@}" &
+}
+
+function deprovision() {
+  WORKDIR="${1}"
+  timeout --signal=SIGQUIT 30m openshift-install --dir "${WORKDIR}" --log-level error destroy cluster && touch "${WORDIR}/success" || touch "${WORKDIR}/failure"
+}
+
 aws_cluster_age_cutoff="$(TZ=":Africa/Abidjan" date --date="${CLUSTER_TTL}" '+%Y-%m-%dT%H:%M+0000')"
 echo "deprovisioning clusters with an expirationDate before ${aws_cluster_age_cutoff} in AWS ..."
 # we need to pass --region for ... some reason?
 for region in $( aws ec2 describe-regions --region us-east-1 --query "Regions[].{Name:RegionName}" --output text ); do
   echo "deprovisioning in AWS region ${region} ..."
   for cluster in $( aws ec2 describe-vpcs --output json --region "${region}" | jq --arg date "${aws_cluster_age_cutoff}" -r -S '.Vpcs[] | select (.Tags[]? | (.Key == "expirationDate" and .Value < $date)) | .Tags[] | select (.Value == "owned") | .Key' ); do
-    workdir="/tmp/deprovision/${cluster:22:14}"
+    workdir="${ARTIFACT_DIR}/deprovision/${cluster:22:14}"
     mkdir -p "${workdir}"
     cat <<EOF >"${workdir}/metadata.json"
 {
@@ -38,7 +55,7 @@ for network in $( gcloud --project=openshift-gce-devel-ci compute networks list 
   if [[ -z "${region:-}" ]]; then
     region=us-east1
   fi
-  workdir="/tmp/deprovision/${infraID}"
+  workdir="${ARTIFACT_DIR}/deprovision/${infraID}"
   mkdir -p "${workdir}"
   cat <<EOF >"${workdir}/metadata.json"
 {
@@ -52,12 +69,11 @@ EOF
   echo "will deprovision GCE cluster ${infraID} in region ${region}"
 done
 
-failed=""
-for workdir in $( find /tmp/deprovision -mindepth 1 -type d | shuf ); do
-  if ! timeout --signal=SIGQUIT 30m openshift-install --dir "${workdir}" --log-level debug destroy cluster; then
-    failed+=",$( basename "${workdir}" )"
-  fi
+for workdir in $( find "${ARTIFACT_DIR}/deprovision" -mindepth 1 -type d | shuf ); do
+  queue deprovision "${workdir}"
 done
+
+wait
 
 gcs_bucket_age_cutoff="$(TZ="GMT" date --date="${CLUSTER_TTL}-4 hours" '+%a, %d %b %Y %H:%M:%S GMT')"
 gcs_bucket_age_cutoff_seconds="$(date --date="${gcs_bucket_age_cutoff}" '+%s')"
@@ -73,8 +89,10 @@ if [[ "${#buckets[@]}" -gt 0 ]]; then
   timeout 30m gsutil -m rm -r "${buckets[@]}"
 fi
 
-if [[ -n "${failed}" ]]; then
-  echo "Deprovision failed on the following clusters: ${failed:1}"
+FAILED="$(ls "${ARTIFACT_DIR}"/deprovision/*/failure)"
+if [[ -n "${FAILED}" ]]; then
+  echo "Deprovision failed on the following clusters:"
+  echo "${FAILED}"
   exit 1
 else
   echo "Deprovision finished successfully"


### PR DESCRIPTION
Cluster teardown is not particularly CPU-intensive, and there is a lot of waiting around for cloud-provider queries to come back or cloud-provider state to become eventually consistent.  Tearing down clusters in parallel will allow us to grind through a backlog of leaked clusters more quickly, and will also give us some ability to continue reaping in the face of small numbers of stuck-in-teardown clusters (which currently gum up the works for their full 30m quota before being SIGQUITed).

The `queue` function is lifted from `pkg/steps/clusterinstall/template.go` with minor changes (no need to redirect stdout, since the installer is mostly writing to stderr).  I've dropped the parallel-job to 10, which will still be 10x faster than the outgoing, serial logic, and seems like plenty until we have more experience with this approach.

I'm moving the working directory under `ARTIFACT_DIR` so we have the installer's `.openshift_install.log` (with timestamps!) streaming into a capture location, even if the overall container times out and is killed.  That means I can tune down --log-level (which only affects stderr) to error, because we don't need a lot of noise there, especially now that all the standard streams are getting interleaved.

With the backgrounded teardown, counting failed deletions is a bit more awkward.  We could track in-flight PIDs, and `wait "${PID}"` each of them to collect exit codes, but I'm taking the easy way out and just touching `success`/`failure` files in the artifact directory from the backgrounded process.