### PR TITLE
Make CI Registry configurable

### DIFF
--- a/pkg/api/domain_test.go
+++ b/pkg/api/domain_test.go
@@ -1,7 +1,12 @@
 package api
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestDomainForService(t *testing.T) {
@@ -36,6 +41,60 @@ func TestDomainForService(t *testing.T) {
 		t.Run(string(tc.service), func(t *testing.T) {
 			if result := DomainForService(tc.service); result != tc.expected {
 				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestPublicDomainForImage(t *testing.T) {
+	testCases := []struct {
+		name               string
+		clusterName        string
+		potentiallyPrivate string
+		expected           string
+		expectedError      error
+	}{
+		{
+			name:               "app.ci with svc dns",
+			clusterName:        "app.ci",
+			potentiallyPrivate: "image-registry.openshift-image-registry.svc:5000/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
+			expected:           "registry.ci.openshift.org/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
+		},
+		{
+			name:               "api.ci with svc dns",
+			clusterName:        "api.ci",
+			potentiallyPrivate: "docker-registry.default.svc:5000/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
+			expected:           "registry.svc.ci.openshift.org/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
+		},
+		{
+			name:               "api.ci with public domain",
+			clusterName:        "api.ci",
+			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
+			expected:           "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
+		},
+		{
+			name:               "app.ci with public domain",
+			clusterName:        "app.ci",
+			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
+			expected:           "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
+		},
+		{
+			name:               "unknown context",
+			clusterName:        "unknown",
+			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
+			expected:           "",
+			expectedError:      fmt.Errorf("failed to get the domain for cluster unknown"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, actualError := PublicDomainForImage(tc.clusterName, tc.potentiallyPrivate)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("actual does not match expected, diff: %s", diff)
+			}
+			if diff := cmp.Diff(tc.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("actualError does not match expectedError, diff: %s", diff)
 			}
 		})
 	}

--- a/pkg/controller/registrysyncer/registrysyncer_test.go
+++ b/pkg/controller/registrysyncer/registrysyncer_test.go
@@ -25,60 +25,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-func TestPublicDomainForImage(t *testing.T) {
-	testCases := []struct {
-		name               string
-		clusterName        string
-		potentiallyPrivate string
-		expected           string
-		expectedError      error
-	}{
-		{
-			name:               "app.ci with svc dns",
-			clusterName:        "app.ci",
-			potentiallyPrivate: "image-registry.openshift-image-registry.svc:5000/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
-			expected:           "registry.ci.openshift.org/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
-		},
-		{
-			name:               "api.ci with svc dns",
-			clusterName:        "api.ci",
-			potentiallyPrivate: "docker-registry.default.svc:5000/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
-			expected:           "registry.svc.ci.openshift.org/ci/applyconfig@sha256:bf08a76268b29f056cfab7a105c8473b359d1154fbbe3091fe6052ad6d0427cd",
-		},
-		{
-			name:               "api.ci with public domain",
-			clusterName:        "api.ci",
-			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
-			expected:           "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
-		},
-		{
-			name:               "app.ci with public domain",
-			clusterName:        "app.ci",
-			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
-			expected:           "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
-		},
-		{
-			name:               "unknown context",
-			clusterName:        "unknown",
-			potentiallyPrivate: "gcr.io/k8s-prow/tide@sha256:5245b7747c44d560aab27bc07dbaaf50bbb55f71d0973f85b09c79b8d8b93c97",
-			expected:           "",
-			expectedError:      fmt.Errorf("failed to get the domain for cluster unknown"),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, actualError := publicDomainForImage(tc.clusterName, tc.potentiallyPrivate)
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("actual does not match expected, diff: %s", diff)
-			}
-			if diff := cmp.Diff(tc.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
-				t.Errorf("actualError does not match expectedError, diff: %s", diff)
-			}
-		})
-	}
-}
-
 func TestFindNewest(t *testing.T) {
 	now := metav1.Now()
 	testCases := []struct {

--- a/pkg/controller/secretsyncer/secretsyncer.go
+++ b/pkg/controller/secretsyncer/secretsyncer.go
@@ -28,14 +28,14 @@ import (
 )
 
 const (
-	ControllerName       = "secret_syncer"
-	referenceClusterName = "api.ci"
+	ControllerName = "secret_syncer"
 )
 
 // Enqueuer allows the caller to Enqueue a config change event
 type Enqueuer func(allSecretsInConfig []config.MirrorConfig)
 
 func AddToManager(mgr manager.Manager,
+	referenceClusterName string,
 	referenceCluster manager.Manager,
 	otherBuildClusters map[string]manager.Manager,
 	config config.Getter,

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -585,6 +585,7 @@ func TestReconcile(t *testing.T) {
 			logrus.SetLevel(logrus.TraceLevel)
 			r := &reconciler{
 				log:                 log,
+				registryClusterName: "api.ci",
 				registryClient:      tc.registryClient,
 				buildClusterClients: tc.buildClusterClients,
 				pullSecretGetter:    func() []byte { return pullSecretData },


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-1657

The target of this PR is that promotion and DPTP-CM are ready for CI registry migration from api.ci to app.ci:
Modify the two TODOs in this PR.
