### PR TITLE
Add feature to automatically migrate openshift_installer jobs

### DIFF
--- a/cmd/determinize-ci-operator/main_test.go
+++ b/cmd/determinize-ci-operator/main_test.go
@@ -378,3 +378,146 @@ func TestMigrateOpenshiftOpenshiftInstallerUPIClusterTestConfiguration(t *testin
 		})
 	}
 }
+
+func TestMigrateOpenshiftInstallerTemplates(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name                                                string
+		configuration                                       *config.DataWithInfo
+		allowedBranches, allowedOrgs, allowedCloudproviders sets.String
+		expectedConfig                                      *config.DataWithInfo
+		expectedMigrationCount                              int
+	}{
+		{
+			name: "Template gets migrated for non-upgrade test",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+					},
+				}},
+			}},
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
+						ClusterProfile: "aws",
+						Workflow:       utilpointer.StringPtr("openshift-e2e-aws"),
+					},
+				}},
+			}},
+			expectedMigrationCount: 1,
+		},
+		{
+			name: "Template gets migrated for upgrade test",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
+						ClusterProfile: "aws",
+						Workflow:       utilpointer.StringPtr("openshift-upgrade-aws-loki"),
+					},
+				}},
+			}},
+			expectedMigrationCount: 1,
+		},
+		{
+			name: "Special case for disruptive tests, nothing happens",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					Commands: "setup_ssh_bastion; TEST_SUITE=openshift/disruptive run-tests; TEST_SUITE=openshift/conformance/parallel run-tests",
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+					},
+				}},
+			}},
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					Commands: "setup_ssh_bastion; TEST_SUITE=openshift/disruptive run-tests; TEST_SUITE=openshift/conformance/parallel run-tests",
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+					},
+				}},
+			}},
+		},
+		{
+			name: "Config excluded via branches, nothing happens",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+			allowedBranches: sets.NewString("some-branch"),
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+		},
+		{
+			name: "Config excluded via orgs, nothing happens",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+			allowedOrgs: sets.NewString("some-org"),
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+		},
+		{
+			name: "Config excluded via cloudprovider, nothing happens",
+			configuration: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+			allowedCloudproviders: sets.NewString("gcp"),
+			expectedConfig: &config.DataWithInfo{Configuration: api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{
+						ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: api.ClusterProfileAWS},
+						Upgrade:                  true,
+					},
+				}},
+			}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualMigrationCount := migrateOpenShiftInstallerTemplates(tc.configuration, tc.allowedOrgs, tc.allowedBranches, tc.allowedCloudproviders)
+			if actualMigrationCount != tc.expectedMigrationCount {
+				t.Errorf("expected %d migrated tests, got %d", tc.expectedMigrationCount, actualMigrationCount)
+			}
+
+			if diff := cmp.Diff(tc.configuration, tc.expectedConfig); diff != "" {
+				t.Errorf("Configuration differs from expected configuration: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Moves forward [DPTP-1775](https://issues.redhat.com/browse/DPTP-1775)

Right now we have these two types in the repo:
1. upgrade tests (are migrated to the matching workflow)
```diff
 - as: e2e-aws-upgrade
-  commands: TEST_SUITE=all run-upgrade-tests
-  openshift_installer:
+  steps:
     cluster_profile: aws
-    upgrade: true
+    workflow: openshift-upgrade-aws-loki
```


2. disruptive tests (cannot be simply migrated right now, so they are
  kept)

I added code to migrate plain `openshift_installer` jobs too b/c it was
simple enough. Not handling that case would be suprising to an
unsuspecting reader of the code.