### PR TITLE
Rename var apiCIRegistry to ciRegistry

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	apiCIRegistry = api.DomainForService(api.ServiceRegistry)
+	ciRegistry = api.DomainForService(api.ServiceRegistry)
 )
 
 // inputImageTagStep will ensure that a tag exists

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -460,7 +460,7 @@ func addSecretWrapper(pod *coreapi.Pod) {
 	})
 	mount := coreapi.VolumeMount{Name: volume, MountPath: dir}
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coreapi.Container{
-		Image:                    fmt.Sprintf("%s/ci/secret-wrapper:latest", apiCIRegistry),
+		Image:                    fmt.Sprintf("%s/ci/secret-wrapper:latest", ciRegistry),
 		Name:                     "cp-secret-wrapper",
 		Command:                  []string{"cp"},
 		Args:                     []string{"/bin/secret-wrapper", bin},


### PR DESCRIPTION
We are migrating the registry soon and decouple `api.ci` and CI registry.

