### PR TITLE
e2e: verify that the boskos server started

### DIFF
--- a/test/e2e/lease.sh
+++ b/test/e2e/lease.sh
@@ -25,7 +25,7 @@ fi
 os::test::junit::declare_suite_start "e2e/lease"
 
 export JOB_SPEC='{"type":"presubmit","job":"pull-ci-test-test-master-success","buildid":"0","prowjobid":"uuid","refs":{"org":"test","repo":"test","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[{"number":1234,"author":"droslean","sha":"538680dfd2f6cff3b3506c80ca182dcb0dd22a58"}]}}'
-os::integration::boskos::start "${suite_dir}/boskos.yaml"
+os::integration::boskos::start "${suite_dir}/boskos.yaml" aws-quota-slice
 os::cmd::expect_failure "ci-operator ${namespace} --registry ${suite_dir}/step-registry --config ${suite_dir}/config.yaml --target success"
 os::cmd::expect_success "ci-operator ${namespace} --registry ${suite_dir}/step-registry --config ${suite_dir}/config.yaml --lease-server http://localhost:8080 --lease-server-password-file /dev/null --lease-acquire-timeout 2s --target success --secret-dir ${cluster_profiles}/success-cluster-profile"
 os::cmd::expect_failure "ci-operator ${namespace} --registry ${suite_dir}/step-registry --config ${suite_dir}/config.yaml --lease-server http://localhost:8080 --lease-server-password-file /dev/null --lease-acquire-timeout 2s --target invalid-lease --secret-dir ${cluster_profiles}/invalid-lease-cluster-profile"


### PR DESCRIPTION
There is no status API endpoint, so the name of a valid resource which
will be acquired and released is required.

Output with the current E2E failure:

```
[INFO] Waiting for boskos to be ready...
FAILURE after 0.456s: hack/lib/integration.sh:136: executing 'curl --request POST --silent --show-error --fail 'http://localhost:8080/acquire?type=aws-quota-slice&state=free&dest=leased&owner=test'' expecting success; re-trying every 0.2s until completion or 0.030s: the command timed out
Standard output from the command:
Standard error from the command:
curl: (7) Failed to connect to localhost port 8080: Connection refused
... repeated 2 times
[INFO] Stopping boskos...
/home/bbguimaraes/src/ci-tools/hack/lib/integration.sh: line 153: kill: (298912) - No such process
[ERROR] boskos exited early, logs:
{"component":"unset","error":"failed to construct rest config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","file":"/home/bbguimaraes/src/boskos/cmd/boskos/boskos.go:113","func":"main.main","level":"fatal","msg":"Failed to get kubeconfig","severity":"fatal","time":"2020-12-09T14:43:15Z"}
[ERROR] PID 298896: hack/lib/integration.sh:137: `return 1` exited with status 1.
[INFO]          Stack Trace:
[INFO]            1: hack/lib/integration.sh:137: `return 1`
[INFO]            2: test/e2e/lease.sh:28: os::integration::boskos::start
[INFO]   Exiting with code 1.
[INFO] [CLEANUP] Killing child processes
```