### PR TITLE
[DPTP-1721] make repo-init tool to generate multi-stage jobs instead of templates

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -826,6 +826,7 @@ const (
 	ClusterProfileAWSCentos          ClusterProfile = "aws-centos"
 	ClusterProfileAWSCentos40        ClusterProfile = "aws-centos-40"
 	ClusterProfileAWSGluster         ClusterProfile = "aws-gluster"
+	ClusterProfileAzure              ClusterProfile = "azure"
 	ClusterProfileAzure4             ClusterProfile = "azure4"
 	ClusterProfileGCP                ClusterProfile = "gcp"
 	ClusterProfileGCP40              ClusterProfile = "gcp-40"

--- a/test/integration/repo-init.sh
+++ b/test/integration/repo-init.sh
@@ -50,6 +50,7 @@ inputs=(
               "e2e" # What is the name of this test (e.g. "e2e-operator")?  e2e
                  "" # Which specific cloud provider does the test require, if any?  [default: aws]
               "e2e" # What commands in the repository run the test (e.g. "make test-e2e")?  make test-e2e
+              "yes" # Does your test require the OpenShift client (oc)?
                "no" # Are there any more end-to-end test scripts to configure?  [default: no] no
 )
 export inputs
@@ -92,6 +93,7 @@ inputs=(
               "e2e" # What is the name of this test (e.g. "e2e-operator")?  e2e
                  "" # Which specific cloud provider does the test require, if any?  [default: aws]
               "e2e" # What commands in the repository run the test (e.g. "make test-e2e")?  make test-e2e
+               "no" # Does your test require the OpenShift client (oc)? no
                "no" # Are there any more end-to-end test scripts to configure?  [default: no] no
           "nightly" # What type of OpenShift release do the end-to-end tests run on top of? [nightly, published]
               "4.4" # Which OpenShift version is being tested? [default: 4.6]

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -25,9 +25,9 @@ tag_specification:
 test_binary_build_commands: make test-install
 tests:
 - as: e2e-aws
-  commands: TEST_SUITE=openshift/conformance/parallel run-tests
-  openshift_installer:
+  steps:
     cluster_profile: aws
+    workflow: openshift-e2e-aws
 - as: unit
   commands: unit
   container:
@@ -41,9 +41,17 @@ tests:
   container:
     from: test-bin
 - as: e2e
-  commands: e2e
-  openshift_installer_src:
+  steps:
     cluster_profile: aws
+    test:
+    - as: e2e
+      cli: latest
+      commands: e2e
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
 zz_generated_metadata:
   branch: master
   org: org

--- a/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
@@ -20,9 +20,16 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e
-  commands: e2e
-  openshift_installer_src:
+  steps:
     cluster_profile: aws
+    test:
+    - as: e2e
+      commands: e2e
+      from: src
+      resources:
+        requests:
+          cpu: 100m
+    workflow: ipi-aws
 zz_generated_metadata:
   branch: nonstandard
   org: org

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -73,16 +73,8 @@ presubmits:
         - --report-username=ci
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --target=e2e
-        - --template=/usr/local/e2e
         command:
         - ci-operator
-        env:
-        - name: CLUSTER_TYPE
-          value: aws
-        - name: JOB_NAME_SAFE
-          value: e2e
-        - name: TEST_COMMAND
-          value: e2e
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -98,9 +90,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /usr/local/e2e
-          name: job-definition
-          subPath: cluster-launch-installer-src.yaml
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -120,9 +109,6 @@ presubmits:
           sources:
           - secret:
               name: cluster-secrets-aws
-      - configMap:
-          name: prow-job-cluster-launch-installer-src
-        name: job-definition
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -154,16 +140,8 @@ presubmits:
         - --report-username=ci
         - --secret-dir=/usr/local/e2e-aws-cluster-profile
         - --target=e2e-aws
-        - --template=/usr/local/e2e-aws
         command:
         - ci-operator
-        env:
-        - name: CLUSTER_TYPE
-          value: aws
-        - name: JOB_NAME_SAFE
-          value: e2e-aws
-        - name: TEST_COMMAND
-          value: TEST_SUITE=openshift/conformance/parallel run-tests
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -179,9 +157,6 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /usr/local/e2e-aws
-          name: job-definition
-          subPath: cluster-launch-installer-e2e.yaml
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -201,9 +176,6 @@ presubmits:
           sources:
           - secret:
               name: cluster-secrets-aws
-      - configMap:
-          name: prow-job-cluster-launch-installer-e2e
-        name: job-definition
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -24,18 +24,11 @@ presubmits:
         - --lease-server-password-file=/etc/boskos/password
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
+        - --secret-dir=/secrets/ci-pull-credentials
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --target=e2e
-        - --template=/usr/local/e2e
         command:
         - ci-operator
-        env:
-        - name: CLUSTER_TYPE
-          value: aws
-        - name: JOB_NAME_SAFE
-          value: e2e
-        - name: TEST_COMMAND
-          value: e2e
         image: ci-operator:latest
         imagePullPolicy: Always
         name: ""
@@ -46,14 +39,14 @@ presubmits:
         - mountPath: /etc/boskos
           name: boskos
           readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
         - mountPath: /usr/local/e2e-cluster-profile
           name: cluster-profile
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
-        - mountPath: /usr/local/e2e
-          name: job-definition
-          subPath: cluster-launch-installer-src.yaml
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -68,14 +61,14 @@ presubmits:
           - key: password
             path: password
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: cluster-profile
         projected:
           sources:
           - secret:
               name: cluster-secrets-aws
-      - configMap:
-          name: prow-job-cluster-launch-installer-src
-        name: job-definition
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials


### PR DESCRIPTION
This PR makes the `repo-init` tool to generate multi-stage jobs instead of template ones. 
It is currently allows to create a job using only `gcp` `aws` and `azure4` cluster profiles.

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>