### PR TITLE
Migrate to non-loki upgrade workflow

### DIFF
--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -111,7 +111,7 @@ func main() {
 }
 
 func upgradeWorkflowForClusterProfile(clusterProfile api.ClusterProfile) string {
-	return fmt.Sprintf("openshift-upgrade-%s-loki", clusterProfile)
+	return fmt.Sprintf("openshift-upgrade-%s", clusterProfile)
 }
 
 func e2eWorkflowForClusterProfile(clusterProfile api.ClusterProfile) string {

--- a/cmd/determinize-ci-operator/main_test.go
+++ b/cmd/determinize-ci-operator/main_test.go
@@ -421,7 +421,7 @@ func TestMigrateOpenshiftInstallerTemplates(t *testing.T) {
 				Tests: []api.TestStepConfiguration{{
 					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
 						ClusterProfile: "aws",
-						Workflow:       utilpointer.StringPtr("openshift-upgrade-aws-loki"),
+						Workflow:       utilpointer.StringPtr("openshift-upgrade-aws"),
 					},
 				}},
 			}},


### PR DESCRIPTION
@wking and @vrutkovs prefer to use the non-loki workflow for the general usage