### PR TITLE
regSyncer: ingore images in ci-ln* namespaces

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -421,7 +421,7 @@ func (r *reconciler) pullSecret(namespace string) (*corev1.Secret, crcontrolleru
 }
 
 var (
-	deniedNamespacePrefixes = sets.NewString("kube", "openshift", "default", "redhat", "ci-op")
+	deniedNamespacePrefixes = sets.NewString("kube", "openshift", "default", "redhat", "ci-op", "ci-ln")
 )
 
 func testInputImageStreamTagFilterFactory(


### PR DESCRIPTION
/cc @stevekuznetsov @alvaroaleman 