### PR TITLE
Makefile: only setup E2E environment outside of CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,11 +159,18 @@ TMPDIR ?= /tmp
 # Example:
 #   make e2e
 #   make e2e SUITE=multi-stage
-e2e: $(TMPDIR)/pull-secret/.dockerconfigjson $(TMPDIR)/import-secret/.dockerconfigjson $(TMPDIR)/boskos
+e2e: $(if $(CI),,e2e-local)
 	$(eval export PULL_SECRET_DIR=$(TMPDIR)/pull-secret)
 	$(eval export PATH=$$(shell echo -n "${PATH}:$(TMPDIR)"))
 	hack/test-e2e.sh $(SUITE)
 .PHONY: e2e
+
+# Dependencies required to execute the E2E tests outside of the CI environment.
+e2e-local: \
+	$(TMPDIR)/pull-secret/.dockerconfigjson \
+	$(TMPDIR)/import-secret/.dockerconfigjson \
+	$(TMPDIR)/boskos
+.PHONY: e2e-local
 
 # Update golden output files for integration tests.
 #


### PR DESCRIPTION
Corrects:

```
bash: oc: command not found
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/1509/pull-ci-openshift-ci-tools-master-e2e/1336962442692923392

```
$ CI=1 make --dry-run e2e
hack/test-e2e.sh
$ make --dry-run e2e
mkdir -p /tmp/pull-secret
oc --context api.ci --as system:admin --namespace ci get secret registry-pull-credentials -o 'jsonpath={.data.\.dockerconfigjson}' | base64 --decode | jq > /tmp/pull-secret/.dockerconfigjson
mkdir -p /tmp/import-secret
oc --context api.ci --as system:admin --namespace ci get secret ci-pull-credentials -o 'jsonpath={.data.\.dockerconfigjson}' | base64 --decode | jq > /tmp/import-secret/.dockerconfigjson
mkdir -p /tmp/image
oc image extract registry.ci.openshift.org/ci/boskos:latest --path /:/tmp/image
mv /tmp/image/app /tmp/boskos
chmod +x /tmp/boskos
rm -rf /tmp/image
hack/test-e2e.sh
```