### PR TITLE
Artifacts: Remove stack printing

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -440,9 +439,6 @@ func (w *ArtifactWorker) run() {
 		w.lock.Lock()
 		if val, ok := w.remaining[podName]; ok && val.done != nil {
 			close(w.remaining[podName].done)
-		} else {
-			fmt.Printf("Pod %s found in map: %t, channel nil: %t\n", podName, ok, val.done == nil)
-			debug.PrintStack()
 		}
 		delete(w.remaining, podName)
 		w.lock.Unlock()


### PR DESCRIPTION
It seems getting called multiple times is expected and not an issue, so
don't confuse users. We will hopefully get rid of this soon and use
decoration utils instead.