### PR TITLE
ci-operator multi-stage: add lease env once

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -49,7 +49,6 @@ const (
 
 var envForProfile = []string{
 	utils.ReleaseImageEnv(api.LatestReleaseName),
-	DefaultLeaseEnv,
 	utils.ImageFormatEnv,
 }
 


### PR DESCRIPTION
Made redundant by https://github.com/openshift/ci-tools/pull/1312.  A
synthetic lease configuration is always added if the test declares a
cluster profile:

https://github.com/openshift/ci-tools/blob/7cb311dcb781a92b5ab12e9cb382e5c8b57246e6/pkg/defaults/defaults.go#L378-L384

This results in a (harmless) duplicated environment variable in the pod,
e.g.:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2289/pull-ci-openshift-machine-config-operator-release-4.6-e2e-vsphere/1337056306510434304

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_machine-config-operator/2289/pull-ci-openshift-machine-config-operator-release-4.6-e2e-vsphere/1337056306510434304/artifacts/build-resources/pods.json

```json
{
    "name": "LEASED_RESOURCE",
    "value": "ci-segment-4"
},
{
    "name": "RELEASE_IMAGE_LATEST",
    "value": "registry.apps.build01-us-west-2.vmc.ci.openshift.org/ci-op-4h9kplyk/release@sha256:60718a60c16b3543937c09141e8f1f8346c3d69e0625d11905c33ebb511004bf"
},
{
    "name": "LEASED_RESOURCE",
    "value": "ci-segment-4"
},
```