### PR TITLE
ci-operator: correctly extract branch names from regex

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -84,8 +84,13 @@ func NewCMClient(clusterConfig *rest.Config, namespace string, dry bool) (corecl
 	return cmClient.ConfigMaps(namespace), nil
 }
 
+// BranchFromRegexes undoes the changes we add to a branch name to make it
+// an explicit regular expression. We can simply remove the "^$" pre/suffix
+// and we know that `\` is an invalid character in Git branch names, so any
+// that exist in the name have been placed there by regexp.QuoteMeta() and
+// can simply be removed as well.
 func BranchFromRegexes(branches []string) string {
-	return strings.TrimPrefix(strings.TrimSuffix(branches[0], "$"), "^")
+	return strings.ReplaceAll(strings.TrimPrefix(strings.TrimSuffix(branches[0], "$"), "^"), "\\", "")
 }
 
 func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber int, refs *pjapi.Refs) (*prowconfig.Presubmit, error) {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1153,6 +1153,10 @@ func TestGetTrimmedBranch(t *testing.T) {
 		input:    []string{"^master$"},
 		expected: "master",
 	}, {
+		name:     "release-3.5 with regex",
+		input:    []string{"^release-3\\.5$"},
+		expected: "release-3.5",
+	}, {
 		name:     "release-4.2 no regex",
 		input:    []string{"release-4.2"},
 		expected: "release-4.2",


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes DPTP-1772

/assign @hongkailiu @droslean 