### PR TITLE
Revert "Revert "Promote images to app.ci""

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -42,8 +42,7 @@ func DomainForService(service Service) string {
 	switch service {
 	case ServiceBoskos, ServiceGCSWeb:
 		serviceDomain = ServiceDomainAPPCI
-	case ServiceRPMs, ServiceRegistry:
-		// TODO (hongkliu): registry migration
+	case ServiceRPMs:
 		serviceDomain = ServiceDomainAPICI
 	default:
 		serviceDomain = ServiceDomainCI

--- a/pkg/api/domain_test.go
+++ b/pkg/api/domain_test.go
@@ -25,7 +25,7 @@ func TestDomainForService(t *testing.T) {
 		},
 		{
 			service:  ServiceRegistry,
-			expected: "registry.svc.ci.openshift.org",
+			expected: "registry.ci.openshift.org",
 		},
 		{
 			service:  ServiceProw,

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -237,7 +237,7 @@ func TestGetPromotionPod(t *testing.T) {
 						{
 							Name: "promotion",
 							// TODO use local image image-registry.openshift-image-registry.svc:5000/ocp/4.6:cli after migrating promotion jobs to OCP4 clusters
-							Image:   "registry.svc.ci.openshift.org/ocp/4.6:cli",
+							Image:   "registry.ci.openshift.org/ocp/4.6:cli",
 							Command: []string{"/bin/sh", "-c"},
 							Args:    []string{"oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62 registy.ci.openshift.org/ci/applyconfig:latest && oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb registy.ci.openshift.org/ci/bin:latest"},
 							VolumeMounts: []coreapi.VolumeMount{
@@ -319,7 +319,7 @@ func TestGetImageMirror(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.svc.ci.openshift.org/ci/a:latest", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.svc.ci.openshift.org/ci/c:latest"},
+			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/a:latest", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/c:latest"},
 		},
 		{
 			name: "basic case: config.Name",
@@ -355,7 +355,7 @@ func TestGetImageMirror(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.svc.ci.openshift.org/ci/name:a", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.svc.ci.openshift.org/ci/name:c"},
+			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/name:a", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/name:c"},
 		},
 	}
 

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -94,7 +94,7 @@
       - /tmp/secret-wrapper/secret-wrapper
       command:
       - cp
-      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      image: registry.ci.openshift.org/ci/secret-wrapper:latest
       name: cp-secret-wrapper
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
@@ -225,7 +225,7 @@
       - /tmp/secret-wrapper/secret-wrapper
       command:
       - cp
-      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      image: registry.ci.openshift.org/ci/secret-wrapper:latest
       name: cp-secret-wrapper
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
@@ -344,7 +344,7 @@
       - /tmp/secret-wrapper/secret-wrapper
       command:
       - cp
-      image: registry.svc.ci.openshift.org/ci/secret-wrapper:latest
+      image: registry.ci.openshift.org/ci/secret-wrapper:latest
       name: cp-secret-wrapper
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
This reverts commit ecb704fdd1d890c40d2fe692ce0732336ba21e73.

I was not patient enough to wait for the first successful promote because promotions were failing because of https://github.com/openshift/release/pull/14268

Will try with the presubmit image this time.

/hold

