### PR TITLE
load: print response body from configresolver for literal configs

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -231,7 +231,13 @@ func literalConfigFromResolver(raw []byte, address string) (*api.ReleaseBuildCon
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("response from configresolver == %d (%s)", resp.StatusCode, http.StatusText(resp.StatusCode))
+		var responseBody string
+		if data, err := ioutil.ReadAll(resp.Body); err != nil {
+			log.Printf("Failed to read response body from configresolver: %v\n", err)
+		} else {
+			responseBody = string(data)
+		}
+		return nil, fmt.Errorf("got unexpected http %d status code from configresolver: %s", resp.StatusCode, responseBody)
 	}
 	resolved, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
The `configFromResolver` function prints the response body for non-200
status responses from the resolver, but it wasn't changed for
`literalConfigFromResolver`. This PR fixes that.

/cc @alvaroaleman 