### PR TITLE
config: document resource requests and limits

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -167,12 +167,20 @@ func (c ResourceConfiguration) RequirementsForStep(name string) ResourceRequirem
 // to the individual steps in the job. They are passed directly to
 // builds or pods.
 type ResourceRequirements struct {
+	// Requests are resource requests applied to an individual step in the job.
+	// These are directly used in creating the Pods that execute the Job.
 	Requests ResourceList `json:"requests,omitempty"`
-	Limits   ResourceList `json:"limits,omitempty"`
+	// Limits are resource limits applied to an individual step in the job.
+	// These are directly used in creating the Pods that execute the Job.
+	Limits ResourceList `json:"limits,omitempty"`
 }
 
 // ResourceList is a map of string resource names and resource
-// quantities, as defined on Kubernetes objects.
+// quantities, as defined on Kubernetes objects. Common resources
+// to request or limit are `cpu` and `memory`. For `cpu`, values
+// are provided in vCPUs - for instance, `2` or `200m`. For
+// `memory`, values are provided in bytes - for instance, `20Mi`
+// or `3Gi`.
 type ResourceList map[string]string
 
 func (l ResourceList) Add(values ResourceList) {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -438,8 +438,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  optional_on_success: false\n" +
 	"                  # Resources defines the resource requirements for the step.\n" +
 	"                  resources:\n" +
+	"                    # Limits are resource limits applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    limits:\n" +
 	"                        \"\": \"\"\n" +
+	"                    # Requests are resource requests applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
@@ -511,8 +515,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  optional_on_success: false\n" +
 	"                  # Resources defines the resource requirements for the step.\n" +
 	"                  resources:\n" +
+	"                    # Limits are resource limits applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    limits:\n" +
 	"                        \"\": \"\"\n" +
+	"                    # Requests are resource requests applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
@@ -584,8 +592,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  optional_on_success: false\n" +
 	"                  # Resources defines the resource requirements for the step.\n" +
 	"                  resources:\n" +
+	"                    # Limits are resource limits applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    limits:\n" +
 	"                        \"\": \"\"\n" +
+	"                    # Requests are resource requests applied to an individual step in the job.\n" +
+	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
@@ -1035,8 +1047,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              optional_on_success: false\n" +
 	"              # Resources defines the resource requirements for the step.\n" +
 	"              resources:\n" +
+	"                # Limits are resource limits applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                limits:\n" +
 	"                    \"\": \"\"\n" +
+	"                # Requests are resource requests applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
@@ -1108,8 +1124,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              optional_on_success: false\n" +
 	"              # Resources defines the resource requirements for the step.\n" +
 	"              resources:\n" +
+	"                # Limits are resource limits applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                limits:\n" +
 	"                    \"\": \"\"\n" +
+	"                # Requests are resource requests applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
@@ -1181,8 +1201,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              optional_on_success: false\n" +
 	"              # Resources defines the resource requirements for the step.\n" +
 	"              resources:\n" +
+	"                # Limits are resource limits applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                limits:\n" +
 	"                    \"\": \"\"\n" +
+	"                # Requests are resource requests applied to an individual step in the job.\n" +
+	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 

Why is the generator missing the docstring for `ResourceList`? Is it getting lost on the type alias to `map[string]string`?
Fixes [DPTP-1744](https://issues.redhat.com/browse/DPTP-1744)