### PR TITLE
pkg/steps/clusterinstall/template: GCP region from the cluster

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -311,7 +311,9 @@ objects:
           export KUBE_SSH_USER=core
           mkdir -p ~/.ssh
           cp /tmp/cluster/ssh-privatekey ~/.ssh/google_compute_engine || true
-          export TEST_PROVIDER='{"type":"gce","region":"us-east1","multizone": true,"multimaster":true,"projectid":"openshift-gce-devel-ci"}'
+          # TODO: make openshift-tests auto-discover this from cluster config
+          REGION="$(oc get -o jsonpath='{.status.platformStatus.gcp.region}' infrastructure cluster)"
+          export TEST_PROVIDER="{\"type\":\"gce\",\"region\":\"${REGION}\",\"multizone\": true,\"multimaster\":true,\"projectid\":\"openshift-gce-devel-ci\"}"
         elif [[ "${CLUSTER_TYPE}" == "aws" ]]; then
           mkdir -p ~/.ssh
           cp /tmp/cluster/ssh-privatekey ~/.ssh/kube_aws_rsa || true


### PR DESCRIPTION
I still wish the end-to-end suite pulled the region out of the cluster itself, but until it does, lean on [the Infrastructure status][1] like we've been doing for AWS since openshift/release@bf0a271f5c (openshift/release#2507).  The hard-coding I'm replacing here was fine until the GCP region became dynamic in 00ebab17e1 (#1527).

[1]: https://github.com/openshift/api/blob/164a2fb63b5f12918c439a5a0a768aa911bcad99/config/v1/types_infrastructure.go#L327-L328