### PR TITLE
Specify registry-config for oc adm release new command

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -200,7 +200,7 @@ func fromConfig(
 					log.Printf("Resolved release %s to %s", name, pullSpec)
 					releaseStep = releasesteps.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, artifactDir, jobSpec, pullSecret)
 				} else {
-					releaseStep = releasesteps.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, artifactDir, jobSpec)
+					releaseStep = releasesteps.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, artifactDir, jobSpec, pullSecret)
 				}
 				overridableSteps = append(overridableSteps, releaseStep)
 				addProvidesForStep(releaseStep, params)


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/CB95J6R4N/p1608041576301800?thread_ts=1608025161.293000&cid=CB95J6R4N
and
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.7/1338794407553404928#1:build-log.txt%3A71

I think the best is to move the job to app.ci.

Otherwise, our source images are on app.ci now. We need to be able to pull from it.
https://github.com/openshift/ci-tools/pull/1102/files

We had a similar case: https://github.com/openshift/ci-tools/pull/1102/files
We cannot use directly in commands because we need to push to the local registry (ci-op-XXXX namespace) as well.
It needs to record the login token to the dockerconfig file.
So we copy it to the temp folder first.

/cc @jupierce @stevekuznetsov 