### PR TITLE
pkg/steps/clusterinstall/template: Add LEASED_RESOURCE parameter

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -31,6 +31,7 @@ parameters:
   required: false
 - name: CLUSTER_VARIANT
 - name: USE_LEASE_CLIENT
+- name: LEASED_RESOURCE
 
 objects:
 


### PR DESCRIPTION
I'd attempted to consume this as an environment variable in 00ebab17e1 (#1527), but it's failing in CI [with][1]:

```
2020/12/15 18:04:36 Running pod e2e-aws-upgrade
Installing from initial release registry.svc.ci.openshift.org/ocp/release:4.5.23
/bin/bash: line 59: LEASED_RESOURCE: unbound variable
```

With this commit, I'm making it a template parameter, so it will be filled in by Go template expansion (and never be an environment variable within the test pod).

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5-to-4.6/1338903713728696320#1:build-log.txt%3A29