### PR TITLE
registerSyncer: Allow images pushed back to the original cluster

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -184,7 +184,6 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 		}
 		if dockerImageImportedFromTargetingCluster(clusterName, sourceImageStreamTag) {
 			log.Debug("dockerImage imported from targeting cluster")
-			continue
 		}
 		if err := client.Get(ctx, types.NamespacedName{Name: req.Namespace}, &corev1.Namespace{}); err != nil {
 			if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
`.tag.from.name` does NOT reflect the current status of the image.
After promoting to `app.ci`, this became an overkill: we ignore some images that we should sync.

I keep the log there because I want to see how many of them are happening.

/cc @alvaroaleman @stevekuznetsov 