### PR TITLE
release-job-migrator: fix release-controller jobName replacement

### DIFF
--- a/cmd/release-job-migrator/main.go
+++ b/cmd/release-job-migrator/main.go
@@ -554,7 +554,9 @@ func run(o options) error {
 			return fmt.Errorf("failed to read file %s: %w", info.Name(), err)
 		}
 		for oldName, newName := range replacedJobs {
-			raw = bytes.ReplaceAll(raw, []byte(oldName), []byte(newName))
+			oldJob := fmt.Sprintf("\"name\":\"%s\"", oldName)
+			newJob := fmt.Sprintf("\"name\":\"%s\"", newName)
+			raw = bytes.ReplaceAll(raw, []byte(oldJob), []byte(newJob))
 		}
 		if err := ioutil.WriteFile(path, raw, 0644); err != nil {
 			return fmt.Errorf("failed to write updated release-controller config file %s: %w", filepath.Base(path), err)

--- a/test/integration/release-job-migrator/expected.txt
+++ b/test/integration/release-job-migrator/expected.txt
@@ -6,9 +6,10 @@ release-openshift-origin-installer-e2e-aws-4.7 -> periodic-ci-openshift-release-
 release-openshift-origin-installer-e2e-aws-upgrade-4.4-nightly-to-4.4-nightly -> periodic-ci-openshift-release-master-origin-4.4-nightly-to-4.4-nightly-e2e-aws-upgrade
 release-openshift-origin-installer-e2e-aws-upgrade-4.5-stable-to-4.6-ci -> periodic-ci-openshift-release-master-origin-4.5-stable-to-4.6-ci-e2e-aws-upgrade
 release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.6-to-4.7 -> periodic-ci-openshift-release-master-origin-4.6-to-4.7-e2e-aws-upgrade-rollback
+release-openshift-origin-installer-e2e-gcp-upgrade-4.6 -> periodic-ci-openshift-release-master-origin-4.6-e2e-gcp-upgrade
 release-openshift-origin-installer-e2e-gcp-upgrade-4.7 -> periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade
 
 The following tests do not have entries in the generator config:
-[e2e-aws-compact e2e-gcp]
+[e2e-aws-compact e2e-gcp e2e-gcp-upgrade]
 
 Please run `make update` to regenerate job configs using the updated ci-operator configs.

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
@@ -26,6 +26,11 @@ tests:
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws
+- as: e2e-gcp-upgrade
+  cron: '@yearly'
+  steps:
+    cluster_profile: gcp
+    workflow: openshift-upgrade-gcp-loki
 zz_generated_metadata:
   branch: master
   org: openshift

--- a/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.7-periodics.yaml
+++ b/test/integration/release-job-migrator/expected/jobs/openshift-release-release-4.7-periodics.yaml
@@ -230,3 +230,105 @@ periodics:
     - name: release-pull-secret
       secret:
         secretName: ci-pull-credentials
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  labels:
+    job-env: gcp
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-upgrade-4.6-stable-to-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/pull-secret
+      - --secret-dir=/usr/local/e2e-$(CLUSTER_TYPE)-upgrade-cluster-profile
+      - --target=e2e-$(CLUSTER_TYPE)-upgrade
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_INITIAL
+      - name: RELEASE_IMAGE_LATEST
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: BRANCH
+        value: "4.7"
+      - name: CONFIG_SPEC
+        value: |
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-upgrade-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+      - mountPath: /etc/appci
+        name: appci-release-bot-credentials
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+    - name: appci-release-bot-credentials
+      secret:
+        items:
+        - key: sa.release-bot.app.ci.config
+          path: sa.release-bot.app.ci.config
+        secretName: build-farm-credentials

--- a/test/integration/release-job-migrator/expected/releases/release-origin-4.7.json
+++ b/test/integration/release-job-migrator/expected/releases/release-origin-4.7.json
@@ -22,6 +22,12 @@
         "interval":"6h",
         "upgrade":true,
         "prowJob":{"name":"periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade"}
+      },
+      "upgrade-gcp-minor":{
+        "interval":"6h",
+        "upgrade":true,
+        "upgradeType": "PreviousMinor",
+        "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade-4.6-stable-to-4.7"}
       }
     }
   }

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.6-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.6-periodics.yaml
@@ -337,3 +337,104 @@ periodics:
         - key: sa.release-bot.app.ci.config
           path: sa.release-bot.app.ci.config
         secretName: build-farm-credentials
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  labels:
+    job-env: gcp
+    job-release: "4.6"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-upgrade-4.6
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/pull-secret
+      - --secret-dir=/usr/local/e2e-$(CLUSTER_TYPE)-upgrade-cluster-profile
+      - --target=e2e-$(CLUSTER_TYPE)-upgrade
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_INITIAL
+      - name: RELEASE_IMAGE_LATEST
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: BRANCH
+        value: "4.6"
+      - name: UNRESOLVED_CONFIG
+        value: |
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            steps:
+              cluster_profile: $(CLUSTER_TYPE)
+              workflow: openshift-upgrade-$(CLUSTER_TYPE)-loki
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-upgrade-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+      - mountPath: /etc/appci
+        name: appci-release-bot-credentials
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+    - name: appci-release-bot-credentials
+      secret:
+        items:
+        - key: sa.release-bot.app.ci.config
+          path: sa.release-bot.app.ci.config
+        secretName: build-farm-credentials

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
@@ -691,6 +691,108 @@ periodics:
   cron: '@yearly'
   decorate: true
   labels:
+    job-env: gcp
+    job-release: "4.7"
+    job-test: e2e
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: release-openshift-origin-installer-e2e-gcp-upgrade-4.6-stable-to-4.7
+  spec:
+    containers:
+    - args:
+      - --artifact-dir=$(ARTIFACTS)
+      - --kubeconfig=/etc/apici/kubeconfig
+      - --lease-server-password-file=/etc/boskos/password
+      - --lease-server-username=ci
+      - --secret-dir=/usr/local/pull-secret
+      - --secret-dir=/usr/local/e2e-$(CLUSTER_TYPE)-upgrade-cluster-profile
+      - --target=e2e-$(CLUSTER_TYPE)-upgrade
+      - --input-hash=$(BUILD_ID)
+      - --input-hash=$(JOB_NAME)
+      command:
+      - ci-operator
+      env:
+      - name: RELEASE_IMAGE_INITIAL
+      - name: RELEASE_IMAGE_LATEST
+      - name: CLUSTER_TYPE
+        value: gcp
+      - name: BRANCH
+        value: "4.7"
+      - name: CONFIG_SPEC
+        value: |
+          tag_specification:
+            name: "$(BRANCH)"
+            namespace: ocp
+          resources:
+            '*':
+              limits:
+                memory: 4Gi
+              requests:
+                cpu: 100m
+                memory: 200Mi
+          tests:
+          - as: e2e-$(CLUSTER_TYPE)-upgrade
+            commands: TEST_SUITE=all run-upgrade-tests
+            openshift_installer:
+              cluster_profile: "$(CLUSTER_TYPE)"
+              upgrade: true
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /etc/apici
+        name: apici-ci-operator-credentials
+        readOnly: true
+      - mountPath: /etc/boskos
+        name: boskos
+        readOnly: true
+      - mountPath: /usr/local/e2e-gcp-upgrade-cluster-profile
+        name: cluster-profile
+      - mountPath: /usr/local/pull-secret
+        name: release-pull-secret
+      - mountPath: /etc/appci
+        name: appci-release-bot-credentials
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: apici-ci-operator-credentials
+      secret:
+        items:
+        - key: sa.ci-operator.apici.config
+          path: kubeconfig
+        secretName: apici-ci-operator-credentials
+    - name: boskos
+      secret:
+        items:
+        - key: password
+          path: password
+        secretName: boskos-credentials
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-gcp
+        - configMap:
+            name: cluster-profile-gcp
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: release-pull-secret
+      secret:
+        secretName: ci-pull-credentials
+    - name: appci-release-bot-credentials
+      secret:
+        items:
+        - key: sa.release-bot.app.ci.config
+          path: sa.release-bot.app.ci.config
+        secretName: build-farm-credentials
+- agent: kubernetes
+  cluster: api.ci
+  cron: '@yearly'
+  decorate: true
+  labels:
     job-env: aws
     job-release: "4.7"
     job-test: e2e

--- a/test/integration/release-job-migrator/input/releases/release-origin-4.7.json
+++ b/test/integration/release-job-migrator/input/releases/release-origin-4.7.json
@@ -22,6 +22,12 @@
         "interval":"6h",
         "upgrade":true,
         "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade-4.7"}
+      },
+      "upgrade-gcp-minor":{
+        "interval":"6h",
+        "upgrade":true,
+        "upgradeType": "PreviousMinor",
+        "prowJob":{"name":"release-openshift-origin-installer-e2e-gcp-upgrade-4.6-stable-to-4.7"}
       }
     }
   }


### PR DESCRIPTION
Due to very simple find replace for updating release-controller job
names, some upgrades would get renamed improperly. For example, in the
updated integration test, the code would've changed
`release-openshift-origin-installer-e2e-gcp-upgrade-4.6-stable-to-4.7`
to
`periodic-ci-openshift-release-master-origin-4.6-e2e-gcp-upgrade-stable-to-4.7`
due to `release-openshift-origin-installer-e2e-gcp-upgrade-4.6` being
migrated and the 4.6-to-4.7 job containing the entire 4.6 job's name in
it. The replacement now does a larger replacement that avoids this
issue.