### PR TITLE
secret-wrapper: do not log cancellations

### DIFF
--- a/cmd/secret-wrapper/main.go
+++ b/cmd/secret-wrapper/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -230,7 +231,7 @@ func uploadKubeconfig(ctx context.Context, client coreclientset.SecretInterface,
 		// kubeconfig exists, we can upload it
 		uploadErr = createSecret(client, name, dir, dry)
 		return uploadErr == nil, nil // retry errors
-	}, ctx.Done()); err != nil {
+	}, ctx.Done()); !errors.Is(err, wait.ErrWaitTimeout) {
 		log.Printf("Failed to upload $KUBECONFIG: %v: %v\n", err, uploadErr)
 	}
 }


### PR DESCRIPTION
The unconditional log message in the go routine that uploads the
`kubeconfig` misleads readers into thinking there is some infrastructure
problem when a test fails, e.g.:

```
level=fatal msg=failed to initialize the cluster: Working towards 4.7.0-0.ci.test-2020-12-17-035943-ci-op-lqd3b7rr: 88% complete
2020/12/17 05:29:25 Failed to upload $KUBECONFIG: timed out waiting for the condition: stat /tmp/secret/kubeconfig: no such file or directory
error: failed to execute wrapped command: exit status 1
2020/12/17 05:29:30 Container test in pod kubevirt-plugin-ipi-install-install failed, exit code 1, reason Error
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console/6739/pull-ci-openshift-console-master-kubevirt-plugin/1339417605932322816