### PR TITLE
test-images-distributor: ingore logging IsConflict errors

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -172,7 +172,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	log := r.log.WithField("request", req.String())
 	log.Info("Starting reconciliation")
 	err := r.reconcile(ctx, req, log)
-	if err != nil {
+	if err != nil && !apierrors.IsConflict(err) {
 		log.WithError(err).Error("Reconciliation failed")
 	} else {
 		log.Info("Finished reconciliation")
@@ -531,7 +531,7 @@ func upsertObject(ctx context.Context, c ctrlruntimeclient.Client, obj ctrlrunti
 	log = log.WithFields(logrus.Fields{"namespace": obj.GetNamespace(), "name": obj.GetName(), "type": fmt.Sprintf("%T", obj)})
 	result, err := crcontrollerutil.CreateOrUpdate(ctx, c, obj, mutateFn)
 	log = log.WithField("operation", result)
-	if err != nil {
+	if err != nil && !apierrors.IsConflict(err) {
 		log.WithError(err).Error("Upsert failed")
 	} else if result != crcontrollerutil.OperationResultNone {
 		log.Info("Upsert succeeded")


### PR DESCRIPTION
In the last 12 hours: 99 hits in total where 2 of them are in upsert function.

/cc @openshift/openshift-team-developer-productivity-test-platform