### PR TITLE
release-job-migrator: don't add `base` to `base_images`

### DIFF
--- a/cmd/release-job-migrator/main.go
+++ b/cmd/release-job-migrator/main.go
@@ -217,10 +217,8 @@ func newDataWithInfoFromFilename(filename string) configlib.DataWithInfo {
 	}
 	var product api.ReleaseProduct
 	var stream api.ReleaseStream
-	var namespace string
 	// toStream overrides the identifier
 	if toStream != "" {
-		namespace = "ocp"
 		product = api.ReleaseProductOCP
 		if toStream == "nightly" {
 			stream = api.ReleaseStreamNightly
@@ -232,15 +230,12 @@ func newDataWithInfoFromFilename(filename string) configlib.DataWithInfo {
 		case "ocp":
 			product = api.ReleaseProductOCP
 			stream = api.ReleaseStreamNightly
-			namespace = "ocp"
 		case "origin":
 			product = api.ReleaseProductOCP
 			stream = api.ReleaseStreamCI
-			namespace = "ocp"
 		case "okd":
 			product = api.ReleaseProductOKD
 			stream = api.ReleaseStreamOKD
-			namespace = "origin"
 		}
 	}
 	data := configlib.DataWithInfo{
@@ -254,13 +249,7 @@ func newDataWithInfoFromFilename(filename string) configlib.DataWithInfo {
 		},
 		Configuration: api.ReleaseBuildConfiguration{
 			InputConfiguration: api.InputConfiguration{
-				BaseImages: map[string]api.ImageStreamTagReference{
-					"base": {
-						Name:      version,
-						Namespace: namespace,
-						Tag:       "base",
-					},
-				},
+				BaseImages: map[string]api.ImageStreamTagReference{},
 				Releases: map[string]api.UnresolvedRelease{
 					"latest": {
 						Candidate: &api.Candidate{

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.7"
-    namespace: origin
-    tag: base
 releases:
   latest:
     candidate:

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.4-nightly-to-4.4-nightly.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.4-nightly-to-4.4-nightly.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.4"
-    namespace: ocp
-    tag: base
 releases:
   initial:
     candidate:

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.5-stable-to-4.6-ci.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.5-stable-to-4.6-ci.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.6"
-    namespace: ocp
-    tag: base
 releases:
   initial:
     prerelease:

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6-to-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6-to-4.7.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.7"
-    namespace: ocp
-    tag: base
 releases:
   initial:
     prerelease:

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.6"
-    namespace: ocp
-    tag: base
 releases:
   initial:
     candidate:

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
@@ -1,8 +1,3 @@
-base_images:
-  base:
-    name: "4.7"
-    namespace: ocp
-    tag: base
 releases:
   initial:
     candidate:


### PR DESCRIPTION
The `base` image shouldn't really be necessary for tests, so it
shouldn't be added by default.