### PR TITLE
pkg/defaults: deduplicate input images

### DIFF
--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -945,6 +945,34 @@ func TestFromConfig(t *testing.T) {
 		promote:       true,
 		expectedSteps: []string{"[output-images]", "[images]"},
 		expectedPost:  []string{"[promotion]"},
+	}, {
+		name: "duplicate input images",
+		config: api.ReleaseBuildConfiguration{
+			Tests: []api.TestStepConfiguration{{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Test: []api.LiteralTestStep{{
+						FromImage: &api.ImageStreamTagReference{
+							Namespace: ns,
+							Name:      "base_image",
+							Tag:       "tag",
+						},
+					}, {
+						FromImage: &api.ImageStreamTagReference{
+							Namespace: ns,
+							Name:      "base_image",
+							Tag:       "tag",
+						},
+					}},
+				},
+			}},
+		},
+		expectedSteps: []string{
+			"test",
+			"[input:ns-base_image-tag]",
+			"[output-images]",
+			"[images]",
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			jobSpec := api.JobSpec{


### PR DESCRIPTION
Multi-stage tests can add the same input image to the graph several
times, resulting in duplicate work:

```
$ ci-operator --config openshift/origin/openshift-origin-master.yaml --registry ci-operator/step-registry --target e2e-aws --print-graph > /dev/null
2020/12/18 17:26:52 unset version 0
2020/12/18 17:26:52 Resolved source https://github.com/openshift/origin to master@4f87b290, merging: #25762 615c1e80 @bbguimaraes
2020/12/18 17:26:53 Resolved openshift/release:golang-1.14 to sha256:b208e61f91c728fb0f4c7a17b7a5cc9176444daed9c8092d4e5ed6ef397214cf
2020/12/18 17:26:54 Resolved ocp/4.7:base to sha256:561f60ffd5df5b6cfd153f4c4389c997f569faae64a9489bd8c9e8fb516d9bd9
2020/12/18 17:26:54 Resolved ocp/builder:golang-1.13 to sha256:5203eafca990af755122d5274149eb5557fc6873a7b50c3152f31a2603ef00d0
2020/12/18 17:26:54 Resolved ocp/builder:golang-1.14 to sha256:0d98907c267a581695a69a00452307ac183cd378906552e9d4ff7e6c683d88d1
2020/12/18 17:26:54 Resolved ocp/builder:rhel-8-golang-1.15-openshift-4.6 to sha256:701f9c7cc2d3a04a81956f89b7b4f506792bf2aea3197e896fbf4fc13671d503
2020/12/18 17:26:54 Resolved ocp/builder:rhel-8-golang-1.15-openshift-4.7 to sha256:791fa247bd6aeff45bf4090f10bf13330a6c041127cad75caddcdd0e14d2e526
2020/12/18 17:26:55 Resolved ocp/builder:rhel-8-golang-openshift-4.6 to sha256:341936a6d82e3cc127a624028e94794d0a44882477958a8093369a6707537322
2020/12/18 17:26:55 Resolved ocp/4.7:tools to sha256:7dfbc751a9eecba5c681ade2efa10c4638ff0ef0f0f67ba422b107fd798e84c5
2020/12/18 17:26:55 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:55 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:56 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:56 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:56 Resolved ocp/cli-jq:latest to sha256:03e6a8145c85cb86739017a9b2c1b244e81eeddc77ffe102c21ef3982aec162f
2020/12/18 17:26:56 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:56 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:56 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:57 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:57 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:57 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:57 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:58 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:58 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:58 Resolved ocp/4.5:upi-installer to sha256:bf6e65c1283d51dcd8a4d343ef715fcb60b5fbad767b1e2b1c9c701db5ad4846
2020/12/18 17:26:58 Resolved ocp/4.5:upi-installer to sha256:bf6e65c1283d51dcd8a4d343ef715fcb60b5fbad767b1e2b1c9c701db5ad4846
2020/12/18 17:26:58 Resolved ocp/4.5:upi-installer to sha256:bf6e65c1283d51dcd8a4d343ef715fcb60b5fbad767b1e2b1c9c701db5ad4846
2020/12/18 17:26:59 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:59 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:59 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:59 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:26:59 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:00 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:00 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:00 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:00 Resolved ocp/cli-jq:latest to sha256:03e6a8145c85cb86739017a9b2c1b244e81eeddc77ffe102c21ef3982aec162f
2020/12/18 17:27:00 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:01 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:01 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:01 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:01 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:01 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:02 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:27:02 Using namespace https://console.svc.ci.openshift.org/k8s/cluster/projects/bbguimaraes
2020/12/18 17:27:02 Ran for 9s
```

With this change, duplicate input images are removed when the original
list of steps is generated, saving work both during graph creation and
run time:

```
$ ci-operator --config openshift/origin/openshift-origin-master.yaml --registry ci-operator/step-registry --target e2e-aws --print-graph > /dev/null
2020/12/18 17:37:50 unset version 0
2020/12/18 17:37:50 Resolved source https://github.com/openshift/origin to master@4f87b290, merging: #25762 615c1e80 @bbguimaraes
2020/12/18 17:37:51 Resolved openshift/release:golang-1.14 to sha256:b208e61f91c728fb0f4c7a17b7a5cc9176444daed9c8092d4e5ed6ef397214cf
2020/12/18 17:37:51 Resolved ocp/builder:golang-1.13 to sha256:5203eafca990af755122d5274149eb5557fc6873a7b50c3152f31a2603ef00d0
2020/12/18 17:37:52 Resolved ocp/builder:golang-1.14 to sha256:0d98907c267a581695a69a00452307ac183cd378906552e9d4ff7e6c683d88d1
2020/12/18 17:37:52 Resolved ocp/builder:rhel-8-golang-1.15-openshift-4.6 to sha256:701f9c7cc2d3a04a81956f89b7b4f506792bf2aea3197e896fbf4fc13671d503
2020/12/18 17:37:52 Resolved ocp/builder:rhel-8-golang-1.15-openshift-4.7 to sha256:791fa247bd6aeff45bf4090f10bf13330a6c041127cad75caddcdd0e14d2e526
2020/12/18 17:37:52 Resolved ocp/builder:rhel-8-golang-openshift-4.6 to sha256:341936a6d82e3cc127a624028e94794d0a44882477958a8093369a6707537322
2020/12/18 17:37:52 Resolved ocp/4.7:tools to sha256:7dfbc751a9eecba5c681ade2efa10c4638ff0ef0f0f67ba422b107fd798e84c5
2020/12/18 17:37:52 Resolved ocp/4.7:base to sha256:561f60ffd5df5b6cfd153f4c4389c997f569faae64a9489bd8c9e8fb516d9bd9
2020/12/18 17:37:53 Resolved origin/centos:8 to sha256:dbbacecc49b088458781c16f3775f2a2ec7521079034a7ba499c8b0bb7f86875
2020/12/18 17:37:53 Resolved ocp/cli-jq:latest to sha256:03e6a8145c85cb86739017a9b2c1b244e81eeddc77ffe102c21ef3982aec162f
2020/12/18 17:37:53 Resolved ocp/4.5:upi-installer to sha256:bf6e65c1283d51dcd8a4d343ef715fcb60b5fbad767b1e2b1c9c701db5ad4846
2020/12/18 17:37:54 Using namespace https://console.svc.ci.openshift.org/k8s/cluster/projects/bbguimaraes
2020/12/18 17:37:54 Ran for 3s
```