### PR TITLE
ci-operator: remove name_prefix fields

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -355,10 +355,6 @@ type ReleaseTagConfiguration struct {
 	// Name is the image stream name to use that contains all
 	// component tags.
 	Name string `json:"name"`
-
-	// NamePrefix is prepended to the final output image name
-	// if specified.
-	NamePrefix string `json:"name_prefix,omitempty"`
 }
 
 // ReleaseConfiguration records a resolved release with its name.
@@ -386,10 +382,6 @@ type PromotionConfiguration struct {
 	// Tag is the ImageStreamTag tagged in for each
 	// build image's ImageStream.
 	Tag string `json:"tag,omitempty"`
-
-	// NamePrefix is prepended to the final output image name
-	// if specified.
-	NamePrefix string `json:"name_prefix,omitempty"`
 
 	// ExcludedImages are image names that will not be promoted.
 	// Exclusions are made before additional_images are included.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -504,21 +504,16 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 
 	for i := range config.Images {
 		image := &config.Images[i]
-		buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
-		var outputImageStreamName string
-		if config.ReleaseTagConfiguration != nil {
-			outputImageStreamName = fmt.Sprintf("%s%s", config.ReleaseTagConfiguration.NamePrefix, api.StableImageStream)
-		} else {
-			outputImageStreamName = api.StableImageStream
-		}
-		buildSteps = append(buildSteps, api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
-			From: image.To,
-			To: api.ImageStreamTagReference{
-				Name: outputImageStreamName,
-				Tag:  string(image.To),
-			},
-			Optional: image.Optional,
-		}})
+		buildSteps = append(buildSteps,
+			api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image},
+			api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
+				From: image.To,
+				To: api.ImageStreamTagReference{
+					Name: api.StableImageStream,
+					Tag:  string(image.To),
+				},
+				Optional: image.Optional,
+			}})
 	}
 
 	if config.Operator != nil {

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -308,19 +308,7 @@ func toPromote(config api.PromotionConfiguration, images []api.ProjectDirectoryI
 		names.Insert(dst)
 	}
 
-	if config.NamePrefix == "" {
-		return tagsByDst, names
-	}
-
-	namesByDst := map[string]string{}
-	names = sets.NewString()
-	for dst, src := range tagsByDst {
-		name := fmt.Sprintf("%s%s", config.NamePrefix, dst)
-		namesByDst[name] = src
-		names.Insert(name)
-	}
-
-	return namesByDst, names
+	return tagsByDst, names
 }
 
 // PromotedTags returns the tags that are being promoted for the given ReleaseBuildConfiguration

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -52,21 +52,6 @@ func TestToPromote(t *testing.T) {
 			expectedNames:    sets.NewString("foo", "bar", "baz"),
 		},
 		{
-			name: "enabled config with prefix returns prefixed input list",
-			config: api.PromotionConfiguration{
-				Disabled:   false,
-				NamePrefix: "some",
-			},
-			images: []api.ProjectDirectoryImageBuildStepConfiguration{
-				{To: api.PipelineImageStreamTagReference("foo")},
-				{To: api.PipelineImageStreamTagReference("bar")},
-				{To: api.PipelineImageStreamTagReference("baz")},
-			},
-			requiredImages:   sets.NewString(),
-			expectedBySource: map[string]string{"somefoo": "foo", "somebar": "bar", "somebaz": "baz"},
-			expectedNames:    sets.NewString("somefoo", "somebar", "somebaz"),
-		},
-		{
 			name: "enabled config with exclude returns filtered input list",
 			config: api.PromotionConfiguration{
 				ExcludedImages: []string{"foo"},

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -191,7 +191,7 @@ func (s *releaseImagesTagStep) imageFormat() (string, error) {
 		return "REGISTRY", err
 	}
 	registry := strings.SplitN(spec, "/", 2)[0]
-	format := fmt.Sprintf("%s/%s/%s:%s", registry, s.jobSpec.Namespace(), fmt.Sprintf("%s%s", s.config.NamePrefix, api.StableImageStream), api.ComponentFormatReplacement)
+	format := fmt.Sprintf("%s/%s/%s:%s", registry, s.jobSpec.Namespace(), api.StableImageStream, api.ComponentFormatReplacement)
 	return format, nil
 }
 

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -136,9 +136,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    # contains all component tags. If specified, tag is\n" +
 	"    # ignored.\n" +
 	"    name: ' '\n" +
-	"    # NamePrefix is prepended to the final output image name\n" +
-	"    # if specified.\n" +
-	"    name_prefix: ' '\n" +
 	"    # Namespace identifies the namespace to which the built\n" +
 	"    # artifacts will be published to.\n" +
 	"    namespace: ' '\n" +
@@ -249,9 +246,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # Name is the image stream name to use that contains all\n" +
 	"        # component tags.\n" +
 	"        name: ' '\n" +
-	"        # NamePrefix is prepended to the final output image name\n" +
-	"        # if specified.\n" +
-	"        name_prefix: ' '\n" +
 	"        # Namespace identifies the namespace from which\n" +
 	"        # all release artifacts not built in the current\n" +
 	"        # job are tagged from.\n" +
@@ -902,9 +896,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    # Name is the image stream name to use that contains all\n" +
 	"    # component tags.\n" +
 	"    name: ' '\n" +
-	"    # NamePrefix is prepended to the final output image name\n" +
-	"    # if specified.\n" +
-	"    name_prefix: ' '\n" +
 	"    # Namespace identifies the namespace from which\n" +
 	"    # all release artifacts not built in the current\n" +
 	"    # job are tagged from.\n" +


### PR DESCRIPTION
Searching git history in openshift/release shows this is not used (and never was):

```console
$ git grep name_prefix
$ git log -G '.*name_prefix:.*'
```

So why bother carrying it...

/cc @stevekuznetsov @smarterclayton  
WDYT?