### PR TITLE
Retry oc image mirror when promoting

### DIFF
--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -1,0 +1,24 @@
+metadata:
+  creationTimestamp: null
+  name: promotion
+  namespace: ci-op-zyvwvffx
+spec:
+  containers:
+  - args:
+    - oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62 registy.ci.openshift.org/ci/applyconfig:latest && oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb registy.ci.openshift.org/ci/bin:latest
+    command:
+    - /bin/sh
+    - -c
+    image: registry.ci.openshift.org/ocp/4.6:cli
+    name: promotion
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/push-secret
+      name: push-secret
+      readOnly: true
+  restartPolicy: Never
+  volumes:
+  - name: push-secret
+    secret:
+      secretName: registry-push-credentials-ci-central
+status: {}

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -5,7 +5,29 @@ metadata:
 spec:
   containers:
   - args:
-    - oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62 registy.ci.openshift.org/ci/applyconfig:latest && oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb registy.ci.openshift.org/ci/bin:latest
+    - |-
+      set -e
+      retry() {
+        retries=3 ; shift
+
+        count=0
+        delay=1
+        until "$@"; do
+          rc=$?
+          count=$(( count + 1 ))
+          if [ $count -lt "$retries" ]; then
+            echo "Retry $count/$retries exited $rc, retrying in $delay seconds..." >/dev/stderr
+            sleep $delay
+          else
+            echo "Retry $count/$retries exited $rc, no more retries left." >/dev/stderr
+            return $rc
+          fi
+          delay=$(( delay * 3 ))
+        done
+        return 0
+      }
+      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62 registy.ci.openshift.org/ci/applyconfig:latest
+      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb registy.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
The `oc image mirror` ~occasionally~ regularly fails for random reasons, like e.G. here: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-images/1341157780760825856

Looking at https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-images this seems to be happening very frequently (~50%-66% of runs) and its always due to errors when running `oc image mirror`

This PR adds some nice bash-based retrying to it.