### PR TITLE
ci-secret-bootstrap: tolerate unused secrets for 7 days after modification

### DIFF
--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -2,6 +2,7 @@ package bitwarden
 
 import (
 	"os"
+	"time"
 )
 
 // Field represents a field in BitWarden
@@ -28,10 +29,13 @@ type Item struct {
 	Name  string `json:"name"`
 	Type  int    `json:"type"`
 	Notes string `json:"notes,omitempty"`
-	//Login does NOT exist on some BitWarden entries, e.g, secure notes.
+	// Login does NOT exist on some BitWarden entries, e.g, secure notes.
 	Login       *Login       `json:"login,omitempty"`
 	Fields      []Field      `json:"fields"`
 	Attachments []Attachment `json:"attachments"`
+	// RevisionTime is a pointer so that omitempty works. The field is set only
+	// when we get the record from BW but not e.g. when we create or update records
+	RevisionTime *time.Time `json:"revisionDate,omitempty"`
 }
 
 // Client is used to communicate with BitWarden

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -9,11 +9,16 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestLoginAndListItems(t *testing.T) {
+	revDate, err := time.Parse(time.RFC3339, "2019-10-11T23:33:21.970Z")
+	if err != nil {
+		t.Fatal("Failed to parse a date")
+	}
 	testCases := []struct {
 		name               string
 		username           string
@@ -95,7 +100,7 @@ func TestLoginAndListItems(t *testing.T) {
         "url": "https://cdn.bitwarden.net/attachments/111/222"
       }
     ],
-    "revisionDate": "2019-04-04T03:43:19.503Z"
+    "revisionDate": "2019-10-11T23:33:21.970Z"
   }
 ]`),
 				},
@@ -107,9 +112,10 @@ func TestLoginAndListItems(t *testing.T) {
 			expectedSession: "not-going-to-tell-you==",
 			expectedSavedItems: []Item{
 				{
-					ID:   "id1",
-					Name: "unsplash.com",
-					Type: 2,
+					ID:           "id1",
+					Name:         "unsplash.com",
+					Type:         2,
+					RevisionTime: &revDate,
 					Fields: []Field{
 						{
 							Name:  "API Key",
@@ -118,10 +124,11 @@ func TestLoginAndListItems(t *testing.T) {
 					},
 				},
 				{
-					ID:    "id2",
-					Name:  "my-credentials",
-					Type:  2,
-					Login: &Login{Password: "yyy"},
+					ID:           "id2",
+					Name:         "my-credentials",
+					Type:         2,
+					Login:        &Login{Password: "yyy"},
+					RevisionTime: &revDate,
 					Attachments: []Attachment{
 						{
 							ID:       "a-id1",


### PR DESCRIPTION
Avoid tripping dptp-triage alert about unused secrets when working with
secrets. Allows setting up BW items with bootsrap config followups.