### PR TITLE
Promotion retrying: Remove wrong shift

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -268,7 +268,7 @@ func getPromotionPod(imageMirrorTarget map[string]string, namespace string) *cor
 }
 
 const bashRetryFn = `retry() {
-  retries=3 ; shift
+  retries=3
 
   count=0
   delay=1

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -8,7 +8,7 @@ spec:
     - |-
       set -e
       retry() {
-        retries=3 ; shift
+        retries=3
 
         count=0
         delay=1


### PR DESCRIPTION
Or we will fail like this: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-images/1341456330409381888#1:build-log.txt%3A159