### PR TITLE
ci-operator: resolve imported release image pullspec better

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -106,7 +106,17 @@ func setupReleaseImageStream(ctx context.Context, namespace string, client ctrlr
 	}
 
 	// ensure the image stream exists
-	release := &imagev1.ImageStream{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "release"}}
+	release := &imagev1.ImageStream{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "release",
+		},
+		Spec: imagev1.ImageStreamSpec{
+			LookupPolicy: imagev1.ImageLookupPolicy{
+				Local: true,
+			},
+		},
+	}
 	if err := client.Create(ctx, release); err != nil {
 		if !kerrors.IsAlreadyExists(err) {
 			return "", err

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -94,8 +94,6 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 	if err != nil && !kerrors.IsAlreadyExists(err) {
 		return fmt.Errorf("could not create stable imagestreamtag: %w", err)
 	}
-	// tag the release image in and let it import
-	var pullSpec string
 
 	// retry importing the image a few times because we might race against establishing credentials/roles
 	// and be unable to import images on the same cluster
@@ -135,10 +133,15 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 		if image.Image == nil {
 			return false, nil
 		}
-		pullSpec = streamImport.Status.Images[0].Image.DockerImageReference
 		return true, nil
 	}); err != nil {
 		return fmt.Errorf("unable to import %s release image: %w", s.name, err)
+	}
+
+	// read the pullSpec of the CLI image we need to use
+	pullSpec, err := utils.ImageDigestFor(s.client, s.jobSpec.Namespace, "release", s.name)()
+	if err != nil {
+		return fmt.Errorf("could not resolve release image after import: %w", err)
 	}
 
 	// override anything in stable with the contents of the release image

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -87,7 +87,7 @@ func LocalPullSecretFlag(t *T) string {
 	if !set {
 		t.Fatal("required environment LOCAL_REGISTRY_SECRET_DIR is not set")
 	}
-	return flag("image-import-pull-secret", filepath.Join(value, ".dockerconfigjson"))
+	return flag("secret-dir", value)
 }
 
 // RemotePullSecretFlag formats a flag to provide access to remote registries for
@@ -97,7 +97,7 @@ func RemotePullSecretFlag(t *T) string {
 	if !set {
 		t.Fatal("required environment REMOTE_REGISTRY_SECRET_DIR is not set")
 	}
-	return flag("secret-dir", value)
+	return flag("image-import-pull-secret", filepath.Join(value, ".dockerconfigjson"))
 }
 
 // KubernetesClientEnv returns a list of formatted environment variables for

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -128,6 +128,7 @@ func TestDynamicReleases(t *testing.T) {
 			cmd.AddArgs(
 				"--config=dynamic-releases.yaml",
 				framework.LocalPullSecretFlag(t),
+				framework.RemotePullSecretFlag(t),
 				"--target=[release:"+testCase.release+"]",
 			)
 			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]}}`)
@@ -213,6 +214,7 @@ func TestOptionalOperators(t *testing.T) {
 		cmd.AddArgs(
 			"--config=optional-operators.yaml",
 			framework.LocalPullSecretFlag(t),
+			framework.RemotePullSecretFlag(t),
 			"--target=[images]",
 			"--target=ci-index",
 		)


### PR DESCRIPTION
The image reference field in the image import API is documented as being
the correct place from which to pull the imported image, but from
experience we see that it's just the image reference in the stream,
pointing to the image that was imported. As the mechanisms for
authenticating the import are different from the mechanisms used for
using the image directly, it's possible (and likely) that a client that
may import the image may not be able to use it directly. Furthermore,
there's no utility to using the image reference, without a direct pull,
as that is the entire point in doing the import in the first place. By
using out image reference resolution code we can make sure that the
fully resolved pull-spec that we end up using is a local reference and
the kubelet will be able to pull it correctly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 