### PR TITLE
e2e: idk what i am doing

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -87,7 +87,7 @@ func LocalPullSecretFlag(t *T) string {
 	if !set {
 		t.Fatal("required environment LOCAL_REGISTRY_SECRET_DIR is not set")
 	}
-	return flag("secret-dir", value)
+	return flag("image-import-pull-secret", filepath.Join(value, ".dockerconfigjson"))
 }
 
 // RemotePullSecretFlag formats a flag to provide access to remote registries for
@@ -97,7 +97,7 @@ func RemotePullSecretFlag(t *T) string {
 	if !set {
 		t.Fatal("required environment REMOTE_REGISTRY_SECRET_DIR is not set")
 	}
-	return flag("image-import-pull-secret", filepath.Join(value, ".dockerconfigjson"))
+	return flag("secret-dir", value)
 }
 
 // KubernetesClientEnv returns a list of formatted environment variables for


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```
$ KUBECONFIG=~/.kube/config make install local-e2e
go install ./cmd/...
oc config use-context "build01"
Switched to context "build01".
make[1]: Entering directory '/home/stevekuznetsov/code/openshift/ci-tools/src/github.com/openshift/ci-tools'
PACKAGES="./test/e2e/..." TESTFLAGS=" -tags e2e -timeout 40m -parallel 100" hack/test-go.sh
+ gotestsum -- ./test/e2e/... -race -tags e2e -timeout 40m -parallel 100
∅  test/e2e/framework
✓  test/e2e/multi-stage (4m21.69s)
✓  test/e2e/simple (20m54.12s)

DONE 26 tests in 1254.995s
```