### PR TITLE
ci-operator: be more performant on promotion

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -228,9 +228,11 @@ func getPromotionPod(imageMirrorTarget map[string]string, namespace string) *cor
 	}
 	sort.Strings(keys)
 
+	var images []string
 	for _, k := range keys {
-		ocCommands = append(ocCommands, fmt.Sprintf("retry oc image mirror --registry-config=%s %s %s", filepath.Join(api.RegistryPushCredentialsCICentralSecretMountPath, coreapi.DockerConfigJsonKey), k, imageMirrorTarget[k]))
+		images = append(images, fmt.Sprintf("%s=%s", k, imageMirrorTarget[k]))
 	}
+	ocCommands = append(ocCommands, fmt.Sprintf("retry oc image mirror --registry-config=%s --continue-on-error=true --max-per-registry=20 %s", filepath.Join(api.RegistryPushCredentialsCICentralSecretMountPath, coreapi.DockerConfigJsonKey), strings.Join(images, " ")))
 	command := []string{"/bin/sh", "-c"}
 	args := []string{"set -e\n" + bashRetryFn + "\n" + strings.Join(ocCommands, "\n")}
 	return &coreapi.Pod{

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -26,8 +26,7 @@ spec:
         done
         return 0
       }
-      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62 registy.ci.openshift.org/ci/applyconfig:latest
-      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb registy.ci.openshift.org/ci/bin:latest
+      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true --max-per-registry=20 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registy.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registy.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
Instead of running each promotion serially, allow one mirror command to
push up to 20 images at once. Ensure that it continues on error, and
retry the total push if anything fails.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>