### PR TITLE
ci-operator: use local tag reference policy

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -116,6 +116,9 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 						Kind: "DockerImage",
 						Name: s.pullSpec,
 					},
+					ReferencePolicy: imagev1.TagReferencePolicy{
+						Type: imagev1.LocalTagReferencePolicy,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
We want users to refer to images after import with their location on the
registry they just got imported to.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>