### PR TITLE
Test image distributor: Name pull secret after original

### DIFF
--- a/pkg/controller/registrysyncer/registrysyncer.go
+++ b/pkg/controller/registrysyncer/registrysyncer.go
@@ -26,6 +26,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	testimagedistrutorapi "github.com/openshift/ci-tools/pkg/controller/test-images-distributor/api"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
@@ -377,8 +378,6 @@ func findNewest(isTags map[string]*imagev1.ImageStreamTag) string {
 	return result
 }
 
-const pullSecretName = "registry-cluster-pull-secret"
-
 func (r *reconciler) ensureImagePullSecret(ctx context.Context, namespace string, client ctrlruntimeclient.Client, log *logrus.Entry) error {
 	secret, mutateFn := r.pullSecret(namespace)
 	return upsertObject(ctx, client, secret, mutateFn, log)
@@ -420,7 +419,7 @@ func (r *reconciler) pullSecret(namespace string) (*corev1.Secret, crcontrolleru
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      pullSecretName,
+			Name:      testimagedistrutorapi.PullSecretName,
 		},
 	}
 	return s, func() error {

--- a/pkg/controller/test-images-distributor/api/api.go
+++ b/pkg/controller/test-images-distributor/api/api.go
@@ -1,0 +1,4 @@
+package api
+
+// PullSecretName is the name of the pull secret created by the test image distributor so it can import images
+const PullSecretName = "registry-pull-credentials"

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	apihelper "github.com/openshift/ci-tools/pkg/api/helper"
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
+	testimagedistrutorapi "github.com/openshift/ci-tools/pkg/controller/test-images-distributor/api"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
@@ -318,8 +319,6 @@ func (r *reconciler) isImageStreamTagCurrent(
 	return imageStreamTag.Image.Name == reference.Image.Name, nil
 }
 
-const pullSecretName = "registry-cluster-pull-secret"
-
 func (r *reconciler) ensureImagePullSecret(ctx context.Context, namespace string, client ctrlruntimeclient.Client, log *logrus.Entry) error {
 	secret, mutateFn := r.pullSecret(namespace)
 	return upsertObject(ctx, client, secret, mutateFn, log)
@@ -415,7 +414,7 @@ func (r *reconciler) pullSecret(namespace string) (*corev1.Secret, crcontrolleru
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      pullSecretName,
+			Name:      testimagedistrutorapi.PullSecretName,
 		},
 	}
 	return s, func() error {

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -196,7 +196,7 @@ func TestReconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: referenceImageStreamTag.Namespace,
 			// Do not use the const here, we want this to fail if someone changes its value
-			Name: "registry-cluster-pull-secret",
+			Name: "registry-pull-credentials",
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
 		Data: map[string][]byte{


### PR DESCRIPTION
This PR changes the test-image-distributor to use the same pull secret name when creating the secret as it has at the source: https://github.com/openshift/release/blob/5ee2cd373314273f0be04dec82fa842c2c36c178/clusters/app.ci/assets/dptp-controller-manager.yaml#L256

This avoids confusion, especially in app.ci where we end up having the secret twice under different names.

We can not rename the source secret, because it is referenced at various places throughout our jobs.

I will manually delete the old secret everywhere after this was deployed, to avoid issues the next time we rotate