### PR TITLE
[DPTP-1789] Ignore context cancelled errors from steps when the job is interrupted

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -56,7 +56,9 @@ func Run(ctx context.Context, graph []*api.StepNode) (*junit.TestSuites, []api.C
 			stepDetails = append(stepDetails, out.stepDetails)
 			if out.err != nil {
 				testCase.FailureOutput = &junit.FailureOutput{Output: out.err.Error()}
-				executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
+				if out.err != context.Canceled {
+					executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
+				}
 			} else {
 				seen = append(seen, out.node.Step.Creates()...)
 				if !interrupted {

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -3,12 +3,18 @@ package steps
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
+	"sort"
 	"sync"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/results"
 )
 
 type fakeStep struct {
@@ -40,135 +46,290 @@ func (*fakeStep) Objects() []ctrlruntimeclient.Object { return nil }
 
 func (f *fakeStep) Provides() api.ParameterMap { return nil }
 
-func TestRunNormalCase(t *testing.T) {
-	root := &fakeStep{
-		name:      "root",
-		shouldRun: true,
-		requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
-	}
-	other := &fakeStep{
-		name:      "other",
-		shouldRun: true,
-		requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
-		creates:   []api.StepLink{api.InternalImageLink("other")},
-	}
-	src := &fakeStep{
-		name:      "src",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-	}
-	bin := &fakeStep{
-		name:      "bin",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
-	}
-	testBin := &fakeStep{
-		name:      "testBin",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
-	}
-	rpm := &fakeStep{
-		name:      "rpm",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
-	}
-	unrelated := &fakeStep{
-		name:      "unrelated",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
-		creates:   []api.StepLink{api.InternalImageLink("unrelated")},
-	}
-	final := &fakeStep{
-		name:      "final",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink("unrelated")},
-		creates:   []api.StepLink{api.InternalImageLink("final")},
+func TestStepsRun(t *testing.T) {
+	testCases := []struct {
+		id          string
+		steps       []*fakeStep
+		errExpected []error
+		cancelled   bool
+	}{
+		{
+			id: "happy case, no errors",
+			steps: []*fakeStep{
+				{
+					name:      "root",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+				}, {
+					name:      "other",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
+					creates:   []api.StepLink{api.InternalImageLink("other")},
+				}, {
+					name:      "src",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+				}, {
+					name:      "bin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+				}, {
+					name:      "testBin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
+				}, {
+					name:      "rpm",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+				}, {
+					name:      "unrelated",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+					creates:   []api.StepLink{api.InternalImageLink("unrelated")},
+				}, {
+					name:      "final",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink("unrelated")},
+					creates:   []api.StepLink{api.InternalImageLink("final")},
+				},
+			},
+		},
+		{
+			id: "sad case with one error",
+			steps: []*fakeStep{
+				{
+					name:      "root",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+				},
+				{
+					name:      "other",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
+					creates:   []api.StepLink{api.InternalImageLink("other")},
+				},
+				{
+					name:      "src",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+				},
+				{
+					name:      "bin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+				},
+				{
+					name:      "testBin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
+				},
+				{
+					name:      "rpm",
+					runErr:    errors.New("oopsie"),
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+				},
+				{
+					name:      "unrelated",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+					creates:   []api.StepLink{api.InternalImageLink("unrelated")},
+				}, {
+					name:      "final",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("unrelated")},
+					creates:   []api.StepLink{api.InternalImageLink("final")},
+				},
+			},
+			errExpected: []error{
+				results.ForReason("step_failed").WithError(errors.New("oopsie")).Errorf("step rpm failed: oopsie"),
+			},
+		},
+		{
+			id: "execution cancelled, expect one error",
+			steps: []*fakeStep{
+				{
+					name:      "root",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+				},
+				{
+					name:      "other",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
+					creates:   []api.StepLink{api.InternalImageLink("other")},
+				},
+				{
+					name:      "src",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+				},
+				{
+					name:      "bin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+				},
+				{
+					name:      "testBin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
+				},
+				{
+					name:      "rpm",
+					runErr:    context.Canceled,
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+				},
+				{
+					name:      "unrelated",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+					creates:   []api.StepLink{api.InternalImageLink("unrelated")},
+				}, {
+					name:      "final",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("unrelated")},
+					creates:   []api.StepLink{api.InternalImageLink("final")},
+				},
+			},
+			errExpected: []error{
+				results.ForReason("interrupted").ForError(errors.New("execution cancelled")),
+			},
+			cancelled: true,
+		},
+		{
+			id: "execution cancelled but a step failed as well, expect multiple errors",
+			steps: []*fakeStep{
+				{
+					name:      "root",
+					runErr:    errors.New("oopsie"),
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+				},
+				{
+					name:      "other",
+					shouldRun: true,
+					requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
+					creates:   []api.StepLink{api.InternalImageLink("other")},
+				},
+				{
+					name:      "src",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+				},
+				{
+					name:     "bin",
+					requires: []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+				},
+				{
+					name:      "testBin",
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
+				},
+				{
+					name:      "rpm",
+					runErr:    context.Canceled,
+					shouldRun: true,
+					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
+					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+				},
+				{
+					name:      "unrelated",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
+					creates:   []api.StepLink{api.InternalImageLink("unrelated")},
+				}, {
+					name:      "final",
+					shouldRun: false,
+					requires:  []api.StepLink{api.InternalImageLink("unrelated")},
+					creates:   []api.StepLink{api.InternalImageLink("final")},
+				},
+			},
+			errExpected: []error{
+				results.ForReason("interrupted").ForError(errors.New("execution cancelled")),
+				results.ForReason("step_failed").WithError(errors.New("oopsie")).Errorf("step root failed: oopsie"),
+			},
+			cancelled: true,
+		},
 	}
 
-	if _, _, err := Run(context.Background(), api.BuildGraph([]api.Step{root, other, src, bin, testBin, rpm, unrelated, final})); err != nil {
-		t.Errorf("got an error but expected none: %v", err)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			shouldFail := 0
+			shouldRun := 0
 
-	for _, step := range []*fakeStep{root, other, src, bin, testBin, rpm, unrelated, final} {
-		if step.shouldRun && step.numRuns != 1 {
-			t.Errorf("step %s did not run just once, but %d times", step.name, step.numRuns)
-		}
-		if !step.shouldRun && step.numRuns != 0 {
-			t.Errorf("step %s expected to never run, but ran %d times", step.name, step.numRuns)
-		}
-	}
-}
+			var steps []api.Step
+			for _, step := range tc.steps {
+				if step.runErr != nil {
+					shouldFail++
+				}
+				if step.shouldRun {
+					shouldRun++
+				}
+				steps = append(steps, step)
+			}
 
-func TestRunFailureCase(t *testing.T) {
-	root := &fakeStep{
-		name:      "root",
-		shouldRun: true,
-		requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "latest"})},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
-	}
-	other := &fakeStep{
-		name:      "other",
-		shouldRun: true,
-		requires:  []api.StepLink{api.ExternalImageLink(api.ImageStreamTagReference{Namespace: "ns", Name: "base", Tag: "other"})},
-		creates:   []api.StepLink{api.InternalImageLink("other")},
-	}
-	src := &fakeStep{
-		name:      "src",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRoot)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-	}
-	bin := &fakeStep{
-		name:      "bin",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
-	}
-	testBin := &fakeStep{
-		name:      "testBin",
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceSource)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceTestBinaries)},
-	}
-	rpm := &fakeStep{
-		name:      "rpm",
-		runErr:    errors.New("oopsie"),
-		shouldRun: true,
-		requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
-		creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
-	}
-	unrelated := &fakeStep{
-		name:      "unrelated",
-		shouldRun: false,
-		requires:  []api.StepLink{api.InternalImageLink("other"), api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
-		creates:   []api.StepLink{api.InternalImageLink("unrelated")},
-	}
-	final := &fakeStep{
-		name:      "final",
-		shouldRun: false,
-		requires:  []api.StepLink{api.InternalImageLink("unrelated")},
-		creates:   []api.StepLink{api.InternalImageLink("final")},
-	}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancelled {
+				cancel()
+			}
+			suites, _, errs := Run(ctx, api.BuildGraph(steps))
+			if errs == nil && len(tc.errExpected) > 0 {
+				t.Error("got no error but expected one")
+			}
 
-	suites, _, err := Run(context.Background(), api.BuildGraph([]api.Step{root, other, src, bin, testBin, rpm, unrelated, final}))
-	if err == nil {
-		t.Error("got no error but expected one")
-	}
-	if suites.Suites != nil && len(suites.Suites) != 1 || len(suites.Suites[0].TestCases) != 6 || suites.Suites[0].NumTests != 6 || suites.Suites[0].NumFailed != 1 {
-		t.Errorf("unexpected junit output: %#v", suites.Suites[0])
-	}
+			var expectedErrorsString []string
+			for _, e := range tc.errExpected {
+				expectedErrorsString = append(expectedErrorsString, fmt.Sprintf("%s: %s", e.(*results.Error).FullReason(), e.Error()))
+			}
+			var actualErrorsString []string
+			for _, e := range errs {
+				actualErrorsString = append(actualErrorsString, fmt.Sprintf("%s: %s", e.(*results.Error).FullReason(), e.Error()))
+			}
+			sort.Strings(expectedErrorsString)
+			sort.Strings(actualErrorsString)
 
-	for _, step := range []*fakeStep{root, other, src, bin, testBin, rpm, unrelated, final} {
-		if step.shouldRun && step.numRuns != 1 {
-			t.Errorf("step %s did not run just once, but %d times", step.name, step.numRuns)
-		}
-		if !step.shouldRun && step.numRuns != 0 {
-			t.Errorf("step %s expected to never run, but ran %d times", step.name, step.numRuns)
-		}
+			if !reflect.DeepEqual(expectedErrorsString, actualErrorsString) {
+				t.Fatalf(cmp.Diff(expectedErrorsString, actualErrorsString))
+			}
+
+			if !tc.cancelled {
+				if suites.Suites != nil && len(suites.Suites) != 1 ||
+					len(suites.Suites[0].TestCases) != shouldRun ||
+					int(suites.Suites[0].NumTests) != shouldRun ||
+					int(suites.Suites[0].NumFailed) != shouldFail {
+					t.Errorf("unexpected junit output: %#v", suites.Suites[0])
+				}
+
+				for _, step := range tc.steps {
+					if step.shouldRun && step.numRuns != 1 {
+						t.Errorf("step %s did not run just once, but %d times", step.name, step.numRuns)
+					}
+					if !step.shouldRun && step.numRuns != 0 {
+						t.Errorf("step %s expected to never run, but ran %d times", step.name, step.numRuns)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
In this example [job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/eclipse_che-operator/553/pull-ci-eclipse-che-operator-master-v4-che-operator-update/1332264893667086336#1:build-log.txt%3A34) the ci-operator reports the cancelled context error from all of the interrupted steps. 

This PR changes this logic and allows only the `interrupted` error to be reported in the results server.

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>