### PR TITLE
ServiceAccountRefresher: Allow excluding ServiceAccounts

### DIFF
--- a/cmd/dptp-controller-manager/main_test.go
+++ b/cmd/dptp-controller-manager/main_test.go
@@ -83,7 +83,7 @@ func TestCompleteImageStream(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, actualErrors := completeImageStream(tc.flagName, tc.raw)
+			actual, actualErrors := completeNamespaceNameFlag(tc.flagName, tc.raw)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
 				t.Errorf("actual does not match expected, diff: %s", diff)
 			}

--- a/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher.go
+++ b/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher.go
@@ -23,10 +23,12 @@ import (
 
 const ControllerName = "serviceaccount_secret_refresher"
 
-func AddToManager(clusterName string, mgr manager.Manager, enabledNamespaces sets.String, removeOldSecrets bool) error {
+func AddToManager(clusterName string, mgr manager.Manager, enabledNamespaces sets.String, excludedServiceAccounts sets.String, removeOldSecrets bool) error {
 	r := &reconciler{
-		client:           mgr.GetClient(),
-		filter:           func(r reconcile.Request) bool { return enabledNamespaces.Has(r.Namespace) },
+		client: mgr.GetClient(),
+		filter: func(r reconcile.Request) bool {
+			return enabledNamespaces.Has(r.Namespace) && !excludedServiceAccounts.Has(r.String())
+		},
 		log:              logrus.WithField("controller", ControllerName).WithField("cluster", clusterName),
 		second:           time.Second,
 		removeOldSecrets: removeOldSecrets,


### PR DESCRIPTION
We can not just rotate all secrets in a namespace, some need to be
excluded.