### PR TITLE
determinize-ci-operator: Use TEST_TYPE instead of TEST_COMMAND

### DIFF
--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -284,12 +284,12 @@ func migrateOpenshiftOpenshiftInstallerUPIClusterTestConfiguration(
 			continue
 		}
 
-		var testCommandEnv string
+		var testTypeEnv string
 		switch commandFields[1] {
 		case "run-tests":
-			testCommandEnv = ""
+			testTypeEnv = ""
 		case "run-upgrade":
-			testCommandEnv = "run-upgrade"
+			testTypeEnv = "upgrade"
 		default:
 			log.Warnf("command %q has unrecognized command element %q, known elements: ['run-tests', 'run-upgrade'], skipping migration of openshift_installer_upi template", test.Commands, commandFields[1])
 			continue
@@ -305,9 +305,9 @@ func migrateOpenshiftOpenshiftInstallerUPIClusterTestConfiguration(
 			},
 			Workflow: utilpointer.StringPtr(fmt.Sprintf("openshift-e2e-%s-upi", providerNameForProfile(clusterProfile))),
 		}
-		if testCommandEnv != "" {
+		if testTypeEnv != "" {
 			// https://github.com/openshift/release/blob/ea3cc4842843c941e9fa1e71ce8a4dc3ce841184/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-ref.yaml#L7
-			test.MultiStageTestConfiguration.Environment["TEST_COMMAND"] = testCommandEnv
+			test.MultiStageTestConfiguration.Environment["TEST_TYPE"] = testTypeEnv
 		}
 		test.Commands = ""
 

--- a/cmd/determinize-ci-operator/main_test.go
+++ b/cmd/determinize-ci-operator/main_test.go
@@ -294,8 +294,8 @@ func TestMigrateOpenshiftOpenshiftInstallerUPIClusterTestConfiguration(t *testin
 					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
 						ClusterProfile: "aws",
 						Environment: api.TestEnvironment{
-							"TEST_SUITE":   "openshift/conformance/parallel",
-							"TEST_COMMAND": "run-upgrade",
+							"TEST_SUITE": "openshift/conformance/parallel",
+							"TEST_TYPE":  "upgrade",
 						},
 						Workflow: utilpointer.StringPtr("openshift-e2e-aws-upi"),
 					},

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6-to-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6-to-4.7.yaml
@@ -22,9 +22,8 @@ tests:
     cluster_profile: aws
     env:
       DELETE_MC: "false"
-      TEST_COMMAND: run-upgrade
       TEST_OPTIONS: abort-at=99
-      TEST_SUITE: all
+      TEST_TYPE: upgrade
     workflow: openshift-upgrade-aws
 zz_generated_metadata:
   branch: master

--- a/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
+++ b/test/integration/release-job-migrator/input/jobs/openshift-release-release-4.7-periodics.yaml
@@ -848,10 +848,9 @@ periodics:
             steps:
               cluster_profile: "$(CLUSTER_TYPE)"
               env:
-                TEST_COMMAND: "run-upgrade"
-                TEST_SUITE: "all"
-                DELETE_MC: "false"
+                TEST_TYPE: "upgrade"
                 TEST_OPTIONS: "abort-at=99"
+                DELETE_MC: "false"
               workflow: openshift-upgrade-aws
       image: ci-operator:latest
       imagePullPolicy: Always


### PR DESCRIPTION
The openshift-e2e-test step is changing to focus on test types
(upgrade, upgrade then test, multiple upgrades) and TEST_COMMAND
is no longer the appropriate mapping for an upgrade test. Update
the migrator to take that into account.