### PR TITLE
steps/import_release: Always use the correct pull configuration

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -207,10 +207,8 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 		return fmt.Errorf("unable to tag the 'cli' image into the stable stream: %w", err)
 	}
 
-	var registryConfig string
 	var secrets []*api.Secret
 	if s.pullSecret != nil {
-		registryConfig = " --registry-config=/pull/.dockerconfigjson"
 		secrets = []*api.Secret{{
 			Name:      s.pullSecret.Name,
 			MountPath: "/pull",
@@ -224,8 +222,8 @@ if [[ -d /pull ]]; then
 	cp /pull/.dockerconfigjson $HOME/.docker/config.json
 fi
 oc registry login
-oc adm release extract%s --from=%q --file=image-references > /tmp/artifacts/%s
-`, registryConfig, pullSpec, target)
+oc adm release extract --from=%q --file=image-references > /tmp/artifacts/%s
+`, pullSpec, target)
 
 	// run adm release extract and grab the raw image-references from the payload
 	podConfig := steps.PodStepConfiguration{


### PR DESCRIPTION
The default pull secret is always $HOME/.docker/config.json, there
is no need for registry config.