### PR TITLE
registry-replacer: use app.ci'registry in ci-op's configs

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -416,7 +416,7 @@ func upsertPR(gc pgithub.Client, dir, githubUsername string, token []byte, selfA
 	}
 
 	prBody := `This PR:
-* Adds a replacement of all FROM registry.svc.ci.openshift.org/anything directives found in any Dockerfile
+* Adds a replacement of all FROM registry.ci.openshift.org/anything directives found in any Dockerfile
   to make sure all images are pulled from the build cluster registry`
 
 	if pruneUnusedReplacements {
@@ -622,7 +622,7 @@ func updateDockerfilesToMatchOCPBuildData(
 		if !ok {
 			continue
 		}
-		stringifiedPromotionTarget := fmt.Sprintf("registry.svc.ci.openshift.org/%s/%s:%s", promotionTarget.Namespace, promotionTarget.Name, image.To)
+		stringifiedPromotionTarget := fmt.Sprintf("registry.ci.openshift.org/%s/%s:%s", promotionTarget.Namespace, promotionTarget.Name, image.To)
 		dockerfilePath, ok := promotionTargetToDockerfileMapping[stringifiedPromotionTarget]
 		if !ok {
 			logrus.WithField("promotiontarget", stringifiedPromotionTarget).Info("Ignoring promotion target for which we have no ocp-build-data config")

--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -179,7 +179,7 @@ func TestReplacer(t *testing.T) {
 				Metadata:               api.Metadata{Branch: "master"},
 			},
 			ensureCorrectPromotionDockerfile:   true,
-			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {dockerfile: "Dockerfile.rhel"}},
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {dockerfile: "Dockerfile.rhel"}},
 			expectWrite:                        true,
 		},
 		{
@@ -233,7 +233,7 @@ func TestReplacer(t *testing.T) {
 				Metadata:               api.Metadata{Branch: "master"},
 			},
 			ensureCorrectPromotionDockerfile:   true,
-			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {contextDir: "other_dir", dockerfile: "Dockerfile.rhel"}},
+			promotionTargetToDockerfileMapping: map[string]dockerfileLocation{fmt.Sprintf("registry.ci.openshift.org/ocp/%s:promotionTarget", majorMinor.String()): {contextDir: "other_dir", dockerfile: "Dockerfile.rhel"}},
 			expectWrite:                        true,
 		},
 		{


### PR DESCRIPTION
To achieve https://github.com/openshift/release/pull/14724

/hold

Should go together with openshift/ocp-build-data#796

/cc @openshift/openshift-team-developer-productivity-test-platform 