### PR TITLE
release-job-migrator: support updating testgrid allowlist

### DIFF
--- a/test/integration/release-job-migrator.sh
+++ b/test/integration/release-job-migrator.sh
@@ -15,7 +15,7 @@ inputs="${workdir}/input"
 output="${workdir}/output.yaml"
 
 os::test::junit::declare_suite_start "integration/release-job-migrator"
-os::cmd::expect_success "release-job-migrator --config ${inputs}/config.yaml --jobs ${inputs}/jobs --ci-op-configs ${inputs}/ci-operator/openshift/release --rc-configs ${inputs}/releases > ${output}"
+os::cmd::expect_success "release-job-migrator --config ${inputs}/config.yaml --jobs ${inputs}/jobs --ci-op-configs ${inputs}/ci-operator/openshift/release --rc-configs ${inputs}/releases -testgrid-allowlist ${inputs}/_allow-list.yaml > ${output}"
 os::integration::compare "${inputs}" "${suite_dir}/expected"
 os::integration::compare "${output}" "${suite_dir}/expected.txt"
 os::test::junit::declare_suite_end

--- a/test/integration/release-job-migrator/expected/_allow-list.yaml
+++ b/test/integration/release-job-migrator/expected/_allow-list.yaml
@@ -1,0 +1,4 @@
+periodic-ci-openshift-release-master-origin-4.6-e2e-aws: blocking
+release-openshift-origin-installer-e2e-gcp-4.7: blocking
+periodic-ci-openshift-release-master-origin-4.7-e2e-gcp-upgrade: informing
+release-openshift-origin-installer-e2e-aws-compact-4.7: informing

--- a/test/integration/release-job-migrator/input/_allow-list.yaml
+++ b/test/integration/release-job-migrator/input/_allow-list.yaml
@@ -1,0 +1,4 @@
+release-openshift-origin-installer-e2e-aws-4.6: blocking
+release-openshift-origin-installer-e2e-gcp-4.7: blocking
+release-openshift-origin-installer-e2e-gcp-upgrade-4.7: informing
+release-openshift-origin-installer-e2e-aws-compact-4.7: informing


### PR DESCRIPTION
This PR adds support for updating the testgrid allowlist for migrated
jobs, which is necessary to allow the jobs to continue appearing on
testgrid with their new names.