### PR TITLE
ocpbuilddata api: use app.ci's registry

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -44,7 +44,7 @@ func (o OCPImageConfig) validate() error {
 }
 
 func (o OCPImageConfig) PromotesTo() string {
-	return fmt.Sprintf("registry.svc.ci.openshift.org/ocp/%s.%s:%s", o.Version.Major, o.Version.Minor, strings.TrimPrefix(o.Name, "openshift/ose-"))
+	return fmt.Sprintf("registry.ci.openshift.org/ocp/%s.%s:%s", o.Version.Major, o.Version.Minor, strings.TrimPrefix(o.Name, "openshift/ose-"))
 }
 
 type OCPImageConfigContent struct {

--- a/pkg/api/ocpbuilddata/types_test.go
+++ b/pkg/api/ocpbuilddata/types_test.go
@@ -204,7 +204,7 @@ func TestDereferenceConfig(t *testing.T) {
 			expectedConfig: OCPImageConfig{
 				From: OCPImageConfigFrom{
 					OCPImageConfigFromStream: OCPImageConfigFromStream{
-						Stream: "registry.svc.ci.openshift.org/ocp/4.6:base"},
+						Stream: "registry.ci.openshift.org/ocp/4.6:base"},
 				},
 			},
 		},
@@ -245,9 +245,9 @@ func TestDereferenceConfig(t *testing.T) {
 			},
 			expectedConfig: OCPImageConfig{
 				From: OCPImageConfigFrom{
-					Builder: []OCPImageConfigFromStream{{Stream: "registry.svc.ci.openshift.org/ocp/4.6:base"}},
+					Builder: []OCPImageConfigFromStream{{Stream: "registry.ci.openshift.org/ocp/4.6:base"}},
 					OCPImageConfigFromStream: OCPImageConfigFromStream{
-						Stream: "registry.svc.ci.openshift.org/ocp/4.6:base"},
+						Stream: "registry.ci.openshift.org/ocp/4.6:base"},
 				},
 			},
 		},


### PR DESCRIPTION
Missed in https://github.com/openshift/ci-tools/pull/1587

I just realized that https://github.com/openshift/ci-tools/pull/1587 has nothing to do with the registry hostname used in `config.images.input[key].as`.
The expecting replacement took place already before merging the PR, for example, https://github.com/openshift/release/pull/14786/files.

The impact of https://github.com/openshift/ci-tools/pull/1587 is
* the PR message 
* `config.images.ContextDir` and `config.images.DockerfilePath`: The current PR is needed for those fields to be calculated correctly.

/cc @alvaroaleman 