### PR TITLE
webreg: collect and expose workflow/chain dependencies in UI

### DIFF
--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alecthomas/chroma/styles"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/repoowners"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -209,6 +210,8 @@ const workflowJobPage = `
 {{ template "stepTable" .Workflow.Steps.Test }}
 <h3 id="post" title="Steps run by this {{ toLower $type }} to clean up and teardown test resources, in runtime order"><a href="#post">Post Steps</a></h3>
 {{ template "stepTable" .Workflow.Steps.Post }}
+<h3 id="dependencies" title="Dependencies of this {{ toLower $type }}"><a href="#dependencies">Dependencies</a></h3>
+{{ template "workflowDependencies" .Workflow.As }}
 <h3 id="graph" title="Visual representation of steps run by this {{ toLower $type }}"><a href="#graph">Step Graph</a></h3>
 {{ workflowGraph .Workflow.As .Workflow.Type }}
 {{ if eq $type "Workflow" }}
@@ -308,7 +311,40 @@ const templateDefinitions = `
   {{ end }}
   </tbody>
   </table>
+{{ end  }}
 
+{{ define "workflowDependencies" }}
+  {{ $data := workflowDependencies . }}
+  <table class="table">
+  <thead>
+    <tr>
+     <th title="Image on which this workflow depends">Image</th>
+     <th title="Environmental variable exposing the pullspec to steps">Exposed As</th>
+     <th title="Whether the value is an override in the workflow">Override<sup>[<a href="https://docs.ci.openshift.org/docs/architecture/ci-operator/#dependency-overrides">?</a>]</sup></th>
+     <th title="Which steps consume the image exposed by this variable">Required By Steps</th>
+    <tr>
+  </thead>
+  <tbody>
+  {{ range $dep, $vars := $data }}
+    {{ $first := true }}
+    {{ range $var, $line := $vars }}
+    <tr>
+      {{ if eq $first true }}
+      <td rowspan={{ len $vars }} style="font-family:monospace">{{ $dep }}</td>
+      {{ end }}
+      <td><span style="font-family:monospace">{{ $var }}</span></td>
+      <td>{{ if $line.Override }}yes{{ else }}no{{ end }}</td>
+      <td>
+      {{ range $i, $step := $line.Steps }}
+        <a href="/reference/{{ $step }}">{{ $step }}</a>
+      {{ end }}
+     </td>
+    </tr>
+    {{ $first = false }}
+    {{ end }}
+  {{ end }}
+  </tbody>
+  </table>
 {{ end }}
 
 {{ define "stepEnvironment" }}
@@ -642,9 +678,10 @@ func getBaseTemplate() (*template.Template, error) {
 		template.FuncMap{
 			// These three are placeholders to be overwritten by the handlers
 			// that actually care about this data (see set{Docs,ChainGraph,WorkflowGraph) functions
-			"docsForName":   func(string) string { return "" },
-			"workflowGraph": func(_, _ string) string { return "" },
-			"chainGraph":    func(string) string { return "" },
+			"docsForName":          func(string) string { return "" },
+			"workflowGraph":        func(_, _ string) string { return "" },
+			"chainGraph":           func(string) string { return "" },
+			"workflowDependencies": func(string) map[string]map[string][]string { return nil },
 
 			"testStepNameAndType": getTestStepNameAndType,
 			"noescape": func(str string) template.HTML {
@@ -780,6 +817,84 @@ func setWorkflowGraph(t *template.Template, chains registry.ChainByName, workflo
 					return template.HTML(err.Error())
 				}
 				return template.HTML(svg)
+			},
+		})
+}
+
+type workflowDependencyLine struct {
+	Steps    []string
+	Override bool
+}
+type workflowDependencyVars map[string]workflowDependencyLine
+
+// release:latest --> ENV_VAR_1 -> { override=false steps=step1,step2 }
+//                \-> ENV_VAR_2 -> { override=true steps=step3 }
+type workflowDependencyData map[string]workflowDependencyVars
+
+func workflowDeps(as string, refs registry.ReferenceByName, chains registry.ChainByName, workflows registry.WorkflowByName) workflowDependencyData {
+	workflow := workflows[as]
+
+	data := workflowDependencyData{}
+	add := func(image, variable, step string) {
+		override, isOverride := workflow.Dependencies[variable]
+		if isOverride {
+			image = override
+		}
+
+		if _, ok := data[image]; !ok {
+			data[image] = workflowDependencyVars{}
+		}
+		if _, ok := data[image][variable]; !ok {
+			data[image][variable] = workflowDependencyLine{Override: isOverride}
+		}
+		line := data[image][variable]
+		line.Steps = append(line.Steps, step)
+		data[image][variable] = line
+	}
+
+	chainWorklist := sets.NewString()
+	seenChains := sets.NewString()
+	dispatch := func(step api.TestStep) {
+		switch {
+		case step.Reference != nil:
+			ref := refs[*step.Reference]
+			for _, dep := range ref.Dependencies {
+				add(dep.Name, dep.Env, ref.As)
+			}
+		case step.Chain != nil:
+			if !seenChains.Has(*step.Chain) {
+				chainWorklist.Insert(*step.Chain)
+			}
+		case step.LiteralTestStep != nil:
+			for _, dep := range step.Dependencies {
+				add(dep.Name, dep.Env, step.As)
+			}
+		}
+	}
+
+	for _, list := range [][]api.TestStep{workflow.Pre, workflow.Test, workflow.Post} {
+		for _, step := range list {
+			dispatch(step)
+		}
+	}
+
+	for len(chainWorklist) > 0 {
+		name, _ := chainWorklist.PopAny()
+		seenChains.Insert(name)
+		chain := chains[name]
+		for _, item := range chain.Steps {
+			dispatch(item)
+		}
+	}
+
+	return data
+}
+
+func setWorkflowDependencies(t *template.Template, refs registry.ReferenceByName, chains registry.ChainByName, workflows registry.WorkflowByName) *template.Template {
+	return t.Funcs(
+		template.FuncMap{
+			"workflowDependencies": func(as string) workflowDependencyData {
+				return workflowDeps(as, refs, chains, workflows)
 			},
 		})
 }
@@ -1136,7 +1251,7 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 	w.Header().Set("Content-Type", "text/html;charset=UTF-8")
 	name := path.Base(req.URL.Path)
 
-	_, chains, workflows, docs, metadata := agent.GetRegistryComponents()
+	refs, chains, workflows, docs, metadata := agent.GetRegistryComponents()
 	page, err := baseTemplate.Clone()
 	if err != nil {
 		writeErrorPage(w, fmt.Errorf("Failed to render page: %w", err), http.StatusInternalServerError)
@@ -1146,6 +1261,7 @@ func workflowHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *htt
 	page = setDocs(page, docs)
 	page = setWorkflowGraph(page, chains, workflows)
 	page = setChainGraph(page, chains)
+	page = setWorkflowDependencies(page, refs, chains, workflows)
 
 	if page, err = page.Parse(workflowJobPage); err != nil {
 		writeErrorPage(w, fmt.Errorf("Failed to render page: %w", err), http.StatusInternalServerError)

--- a/pkg/webreg/webreg_test.go
+++ b/pkg/webreg/webreg_test.go
@@ -1,0 +1,167 @@
+package webreg
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/registry"
+)
+
+func TestGetDependencyDataItems(t *testing.T) {
+	stepWithoutDep := api.TestStep{
+		LiteralTestStep: &api.LiteralTestStep{
+			As: "step-without-dependency",
+		},
+	}
+
+	registrySteps := registry.ReferenceByName{
+		stepWithoutDep.As: *stepWithoutDep.LiteralTestStep,
+	}
+	for _, step := range []string{"step-1", "step-2"} {
+		for _, image := range []string{"image-1", "image-2"} {
+			for _, variable := range []string{"var", "anothervar"} {
+				name := fmt.Sprintf("%s-depends-on-%s-under-%s", step, image, variable)
+				registrySteps[name] = api.LiteralTestStep{
+					As:           name,
+					Dependencies: []api.StepDependency{{Name: image, Env: variable}},
+				}
+			}
+		}
+	}
+
+	stepPtr := func(name string) *api.LiteralTestStep {
+		if step, ok := registrySteps[name]; !ok {
+			t.Fatalf("TEST BUG: step '%s' not in test registry", name)
+			return nil
+		} else {
+			return &step
+		}
+	}
+
+	registryChains := registry.ChainByName{
+		"chain-with-step-1-depends-on-image-1-under-var": api.RegistryChain{
+			As:    "chain-with-step-1-depends-on-image-1-under-var",
+			Steps: []api.TestStep{{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")}},
+		},
+	}
+
+	testCases := []struct {
+		description string
+		inputSteps  []api.TestStep
+		overrides   api.TestDependencies
+
+		expected map[string]dependencyVars
+	}{
+		{
+			description: "no input, no data",
+		},
+		{
+			description: "step without dependencies, no data",
+			inputSteps:  []api.TestStep{stepWithoutDep},
+		},
+		{
+			description: "literal step with dependency",
+			inputSteps:  []api.TestStep{{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")}},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var": dependencyLine{
+						Steps: []string{"step-1-depends-on-image-1-under-var"},
+					},
+				},
+			},
+		},
+		{
+			description: "reference to a step with dependency",
+			inputSteps:  []api.TestStep{{Reference: pointer.StringPtr("step-1-depends-on-image-1-under-var")}},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var": dependencyLine{
+						Steps: []string{"step-1-depends-on-image-1-under-var"},
+					},
+				},
+			},
+		},
+		{
+			description: "reference to a chain that contains a step with dependency",
+			inputSteps:  []api.TestStep{{Chain: pointer.StringPtr("chain-with-step-1-depends-on-image-1-under-var")}},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var": dependencyLine{
+						Steps: []string{"step-1-depends-on-image-1-under-var"},
+					},
+				},
+			},
+		},
+		{
+			description: "two steps depending on same image under same name",
+			inputSteps: []api.TestStep{
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")},
+				{LiteralTestStep: stepPtr("step-2-depends-on-image-1-under-var")},
+			},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var": dependencyLine{Steps: []string{"step-1-depends-on-image-1-under-var", "step-2-depends-on-image-1-under-var"}},
+				},
+			},
+		},
+		{
+			description: "two steps depending on same image under different names",
+			inputSteps: []api.TestStep{
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")},
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-anothervar")},
+			},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var":        dependencyLine{Steps: []string{"step-1-depends-on-image-1-under-var"}},
+					"anothervar": dependencyLine{Steps: []string{"step-1-depends-on-image-1-under-anothervar"}},
+				},
+			},
+		},
+		{
+			description: "two steps depending on different image under same name",
+			inputSteps: []api.TestStep{
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")},
+				{LiteralTestStep: stepPtr("step-2-depends-on-image-2-under-var")},
+			},
+			expected: map[string]dependencyVars{
+				"image-1": {"var": dependencyLine{Steps: []string{"step-1-depends-on-image-1-under-var"}}},
+				"image-2": {"var": dependencyLine{Steps: []string{"step-2-depends-on-image-2-under-var"}}},
+			},
+		},
+		{
+			description: "two steps depending on same image under different names, one is overridden",
+			inputSteps: []api.TestStep{
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-var")},
+				{LiteralTestStep: stepPtr("step-1-depends-on-image-1-under-anothervar")},
+			},
+			overrides: map[string]string{"anothervar": "workflow-overrode-this"},
+			expected: map[string]dependencyVars{
+				"image-1": {
+					"var": dependencyLine{Steps: []string{"step-1-depends-on-image-1-under-var"}},
+				},
+				"workflow-overrode-this": {
+					"anothervar": dependencyLine{
+						Steps:    []string{"step-1-depends-on-image-1-under-anothervar"},
+						Override: true,
+					},
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+
+	for i := range testCases {
+		t.Run(testCases[i].description, func(t *testing.T) {
+			data := getDependencyDataItems(testCases[i].inputSteps, registrySteps, registryChains, testCases[i].overrides)
+			if diff := cmp.Diff(testCases[i].expected, data); diff != "" {
+				t.Errorf("%s: data differs from expected:\n%s", testCases[i].description, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves: [DPTP-1652](https://issues.redhat.com/browse/DPTP-1652)


Expose dependencies of the steps involved in the workflows and chains together with the envvars that expose them to tests. The workflow view also shows whether the value is set by the workflow or the step. The data structure for the presentation is a bit complicated because the same dependency can be exposed under different names in multiple steps.

Examples:
- Workflow: https://server-ci-tools-1600.apps.ci.l2s4.p1.openshiftapps.com/workflow/openshift-upgrade-gcp#dependencies
- Chain: https://server-ci-tools-1600.apps.ci.l2s4.p1.openshiftapps.com/chain/ipi-install-stableinitial#dependencies

The code needs a bit more polishing to be mergeable but I am interested in the feedback for how the data is presented before I do that.
/hold
