### PR TITLE
repo-init: copycat CVO merge criteria instead of origin

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -395,7 +395,7 @@ No additional "tide" queries will be added.
 	var copyCatQueries prowconfig.TideQueries
 	switch {
 	case config.Promotes && config.PromotesWithOpenShift:
-		copyCatQueries = queries.ForRepo(prowconfig.OrgRepo{Org: "openshift", Repo: "origin"})
+		copyCatQueries = queries.ForRepo(prowconfig.OrgRepo{Org: "openshift", Repo: "cluster-version-operator"})
 	case !config.PromotesWithOpenShift:
 		copyCatQueries = queries.ForRepo(prowconfig.OrgRepo{Org: "openshift", Repo: "ci-tools"})
 	}

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -83,7 +83,7 @@ func TestEditProwConfig(t *testing.T) {
 				ProwConfig: prowconfig.ProwConfig{
 					Tide: prowconfig.Tide{
 						Queries: prowconfig.TideQueries{{
-							Repos: []string{"openshift/origin"},
+							Repos: []string{"openshift/cluster-version-operator"},
 						}},
 					},
 				},
@@ -92,7 +92,7 @@ func TestEditProwConfig(t *testing.T) {
 				ProwConfig: prowconfig.ProwConfig{
 					Tide: prowconfig.Tide{
 						Queries: prowconfig.TideQueries{{
-							Repos: []string{"openshift/origin", "org/repo"},
+							Repos: []string{"openshift/cluster-version-operator", "org/repo"},
 						}},
 					},
 				},
@@ -207,10 +207,10 @@ func TestEditPluginConfig(t *testing.T) {
 			},
 			pluginConfig: &plugins.Configuration{
 				Plugins: map[string][]string{
-					"openshift":        {"foo"},
-					"openshift/origin": {"bar"},
-					"org":              {"other"},
-					"org/repo":         {"something"},
+					"openshift":                          {"foo"},
+					"openshift/cluster-version-operator": {"bar"},
+					"org":                                {"other"},
+					"org/repo":                           {"something"},
 				},
 				ExternalPlugins: map[string][]plugins.ExternalPlugin{
 					"openshift": {{Endpoint: "oops"}},
@@ -220,10 +220,10 @@ func TestEditPluginConfig(t *testing.T) {
 			},
 			expected: &plugins.Configuration{
 				Plugins: map[string][]string{
-					"openshift":        {"foo"},
-					"openshift/origin": {"bar"},
-					"org":              {"other"},
-					"org/repo":         {"something"},
+					"openshift":                          {"foo"},
+					"openshift/cluster-version-operator": {"bar"},
+					"org":                                {"other"},
+					"org/repo":                           {"something"},
 				},
 				ExternalPlugins: map[string][]plugins.ExternalPlugin{
 					"openshift": {{Endpoint: "oops"}},

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
@@ -64,7 +64,7 @@ tide:
     - do-not-merge/invalid-owners-file
     - bugzilla/invalid-bug
     repos:
-    - openshift/origin
+    - openshift/cluster-version-operator
     - org/repo
   - excludedBranches:
     - release-4.0
@@ -85,7 +85,7 @@ tide:
     - bugzilla/invalid-bug
     repos:
     - openshift/ci-tools
-    - openshift/origin
+    - openshift/cluster-version-operator
     - org/repo
     - org/other
     - org/third

--- a/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
@@ -1,7 +1,7 @@
 tide:
   queries:
   - repos:
-    - openshift/origin
+    - openshift/cluster-version-operator
     includedBranches:
     - release-4.0
     - release-4.1
@@ -23,7 +23,7 @@ tide:
     - bugzilla/invalid-bug
   - repos:
     - openshift/ci-tools
-    - openshift/origin
+    - openshift/cluster-version-operator
     excludedBranches:
     - release-4.0
     - release-4.1


### PR DESCRIPTION
o/origin is now a snowflake (its newer branches do not participate in
the OCP process) so we should no longer use it as an anchor for adding
new repos.