### PR TITLE
ci-operator: add support for interval field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	google.golang.org/api v0.32.0
 	gopkg.in/fsnotify.v1 v1.4.7
+	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
 	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -487,6 +487,11 @@ type TestStepConfiguration struct {
 	// create a periodic job instead of a presubmit
 	Cron *string `json:"cron,omitempty"`
 
+	// Interval is how frequently the test should be run based
+	// on the last time the test ran. Setting this field will
+	// create a periodic job instead of a presubmit
+	Interval *string `json:"interval,omitempty"`
+
 	// Postsubmit configures prowgen to generate the job as a postsubmit rather than a presubmit
 	Postsubmit bool `json:"postsubmit,omitempty"`
 

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -231,21 +231,34 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		repoInfo   *ProwgenInfo
 		jobRelease string
 		clone      bool
-	}{{
-		description: "periodic for standard test",
-		test:        "testname",
-		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-	},
+		cron       string
+		interval   string
+	}{
+		{
+			description: "periodic for standard test",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			cron:        "@yearly",
+		},
 		{
 			description: "periodic for a test in a variant config",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
+			cron:        "@yearly",
 		},
 		{
 			description: "periodic for specific release",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			jobRelease:  "4.6",
+			cron:        "@yearly",
+		},
+		{
+			description: "periodic for specific release using interval",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			jobRelease:  "4.6",
+			interval:    "6h",
 		},
 		{
 			description: "periodic for specific release and clone: true",
@@ -253,12 +266,13 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			jobRelease:  "4.6",
 			clone:       true,
+			cron:        "@yearly",
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			// podSpec tested in generatePodSpec
-			testhelper.CompareWithFixture(t, generatePeriodicForTest(tc.test, tc.repoInfo, nil, true, "@yearly", nil, tc.jobRelease, !tc.clone))
+			testhelper.CompareWithFixture(t, generatePeriodicForTest(tc.test, tc.repoInfo, nil, true, tc.cron, tc.interval, nil, tc.jobRelease, !tc.clone))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_using_interval.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_specific_release_using_interval.yaml
@@ -1,0 +1,14 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+interval: 6h
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -15,6 +15,9 @@ import (
 
 func TestValidateTests(t *testing.T) {
 	cronString := "0 0 * * 1"
+	invalidCronString := "r 0 * * 1"
+	intervalString := "6h"
+	invalidIntervalString := "6t"
 	for _, tc := range []struct {
 		id            string
 		release       *api.ReleaseTagConfiguration
@@ -388,6 +391,67 @@ func TestValidateTests(t *testing.T) {
 					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
 					Cron:                       &cronString,
 					Postsubmit:                 true,
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "valid cron",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Cron:                       &cronString,
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			id: "valid interval",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Interval:                   &intervalString,
+				},
+			},
+			expectedValid: true,
+		},
+		{
+			id: "cron and interval together are invalid",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Cron:                       &cronString,
+					Interval:                   &intervalString,
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "invalid cron",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Cron:                       &invalidCronString,
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "invalid interval",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Interval:                   &invalidIntervalString,
 				},
 			},
 			expectedValid: false,

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -326,6 +326,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # of pull request workflows. Setting this field will\n" +
 	"        # create a periodic job instead of a presubmit\n" +
 	"        cron: \"\"\n" +
+	"        # Interval is how frequently the test should be run based\n" +
+	"        # on the last time the test ran. Setting this field will\n" +
+	"        # create a periodic job instead of a presubmit\n" +
+	"        interval: \"\"\n" +
 	"        literal_steps:\n" +
 	"            # AllowBestEffortPostSteps defines if any `post` steps can be ignored when\n" +
 	"            # they fail. The given step must explicitly ask for being ignored by setting\n" +
@@ -932,6 +936,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # of pull request workflows. Setting this field will\n" +
 	"      # create a periodic job instead of a presubmit\n" +
 	"      cron: \"\"\n" +
+	"      # Interval is how frequently the test should be run based\n" +
+	"      # on the last time the test ran. Setting this field will\n" +
+	"      # create a periodic job instead of a presubmit\n" +
+	"      interval: \"\"\n" +
 	"      literal_steps:\n" +
 	"        # AllowBestEffortPostSteps defines if any `post` steps can be ignored when\n" +
 	"        # they fail. The given step must explicitly ask for being ignored by setting\n" +

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -60,6 +60,11 @@ tests:
   cron: '@yearly'
   openshift_ansible:
     cluster_profile: aws
+- as: e2e-aws-nightly-interval
+  commands: make e2e
+  interval: '24h'
+  openshift_ansible:
+    cluster_profile: aws
 - as: steps
   steps:
     test:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -71,6 +71,77 @@ periodics:
       secret:
         secretName: result-aggregator
 - agent: kubernetes
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  interval: 24h
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-duper-master-e2e-aws-nightly-interval
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-password-file=/etc/report/password.txt
+      - --report-username=ci
+      - --secret-dir=/usr/local/e2e-aws-nightly-interval-cluster-profile
+      - --target=e2e-aws-nightly-interval
+      - --template=/usr/local/e2e-aws-nightly-interval
+      command:
+      - ci-operator
+      env:
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: JOB_NAME_SAFE
+        value: e2e-aws-nightly-interval
+      - name: RPM_REPO_OPENSHIFT_ORIGIN
+        value: https://rpms.svc.ci.openshift.org/openshift-origin-v4.0/
+      - name: TEST_COMMAND
+        value: make e2e
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /usr/local/e2e-aws-nightly-interval-cluster-profile
+        name: cluster-profile
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /usr/local/e2e-aws-nightly-interval
+        name: job-definition
+        subPath: cluster-launch-e2e.yaml
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: cluster-profile
+      projected:
+        sources:
+        - secret:
+            name: cluster-secrets-aws
+    - configMap:
+        name: prow-job-cluster-launch-e2e
+      name: job-definition
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
   cron: '@yearly'
   decorate: true
   decoration_config:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -683,6 +683,7 @@ gopkg.in/inf.v0
 # gopkg.in/ini.v1 v1.62.0
 gopkg.in/ini.v1
 # gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
+## explicit
 gopkg.in/robfig/cron.v2
 # gopkg.in/yaml.v2 v2.3.0
 gopkg.in/yaml.v2


### PR DESCRIPTION
This PR adds support for using the `interval` field for periodics
instead of `cron`. This allows users to set intervals for running jobs
more easily than `cron` without having to use `@every duration` in,
which would result in the job getting triggered every time horologium
restarts.