### PR TITLE
Add azure-arc cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -828,6 +828,7 @@ const (
 	ClusterProfileAWSGluster         ClusterProfile = "aws-gluster"
 	ClusterProfileAzure              ClusterProfile = "azure"
 	ClusterProfileAzure4             ClusterProfile = "azure4"
+	ClusterProfileAzureArc           ClusterProfile = "azure-arc"
 	ClusterProfileGCP                ClusterProfile = "gcp"
 	ClusterProfileGCP40              ClusterProfile = "gcp-40"
 	ClusterProfileGCPHA              ClusterProfile = "gcp-ha"
@@ -858,6 +859,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSGluster,
 		ClusterProfileAzure4,
+		ClusterProfileAzureArc,
 		ClusterProfileGCP,
 		ClusterProfileGCP40,
 		ClusterProfileGCPHA,
@@ -891,7 +893,9 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSCPaaS:
 		return "aws"
-	case ClusterProfileAzure4:
+	case
+		ClusterProfileAzure4,
+		ClusterProfileAzureArc:
 		return "azure4"
 	case
 		ClusterProfileGCP,
@@ -940,6 +944,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-quota-slice"
 	case ClusterProfileAzure4:
 		return "azure4-quota-slice"
+	case ClusterProfileAzureArc:
+		return "azure-arc"
 	case
 		ClusterProfileGCP,
 		ClusterProfileGCP40,
@@ -980,7 +986,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "azure4", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas":
+	case "aws", "azure4", "azure-arc", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -471,6 +471,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 	switch profile {
 	case cioperatorapi.ClusterProfileAWS,
 		cioperatorapi.ClusterProfileAzure4,
+		cioperatorapi.ClusterProfileAzureArc,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,
 		cioperatorapi.ClusterProfileOpenStack,


### PR DESCRIPTION
Add an additional Azure profile for clusters with the Arc-enabled
Kubernetes feature.

For CI purposes, Arc-enabled clusters have absolutely no difference
when compared to other `azure4` clusters and are created the same way,
however they [must run in specific Azure regions](https://docs.microsoft.com/en-us/azure/azure-arc/kubernetes/connect-cluster#supported-regions) where that feature is
already provided.

In this PR we create a new cluster profile to allow us to have a
separate Boskos quota slice only with the supported regions, but
everything else (cluster installation, etc) must work like a regular 
`azure4` cluster.

Related to: https://github.com/openshift/release/pull/14798