### PR TITLE
[DPTP-1836] ci-secret-bootstrap: allow recreating secrets on `--force` when an immutable field changes

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1705,11 +1705,11 @@ func TestUpdateSecrets(t *testing.T) {
   }
 }`),
 						},
+						Type: coreapi.SecretTypeOpaque,
 					},
 				},
 			},
-			force:    true,
-			expected: fmt.Errorf("cannot change secret type from \"kubernetes.io/dockerconfigjson\" to \"\" (immutable field): default:namespace-2/prod-secret-2"),
+			force: true,
 			expectedSecretsOnDefault: []coreapi.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -1726,7 +1726,7 @@ func TestUpdateSecrets(t *testing.T) {
   }
 }`),
 					},
-					Type: coreapi.SecretTypeDockerConfigJson,
+					Type: coreapi.SecretTypeOpaque,
 				},
 			},
 		},


### PR DESCRIPTION
When `--force` is used and an immutable field needs to be changed, we allow recreating the secret

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>