### PR TITLE
Multiple secrets: causes spec.volumes[].name duplication

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -795,7 +795,8 @@ type TestDependencies map[string]string
 type Secret struct {
 	// Secret name, used inside test containers
 	Name string `json:"name"`
-	// Secret mount path. Defaults to /usr/test-secret
+	// Secret mount path. Defaults to /usr/test-secrets for first
+	// secret. /usr/test-secrets-2 for second, and so on.
 	MountPath string `json:"mount_path"`
 }
 

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -136,7 +136,7 @@ func TestGetPodObjectMounts(t *testing.T) {
 		{
 			name: "with secret name results in secret mounted with default path",
 			podStep: func(expectedPodStepTemplate *podStep) {
-				expectedPodStepTemplate.config.Secrets = []*api.Secret{{Name: testSecretName}}
+				expectedPodStepTemplate.config.Secrets = []*api.Secret{{Name: "some-secret"}}
 			},
 		},
 		{
@@ -144,7 +144,7 @@ func TestGetPodObjectMounts(t *testing.T) {
 			podStep: func(expectedPodStepTemplate *podStep) {
 				expectedPodStepTemplate.config.Secrets = []*api.Secret{
 					{
-						Name:      testSecretName,
+						Name:      "some-secret",
 						MountPath: "/usr/local/secrets",
 					},
 				}
@@ -155,8 +155,40 @@ func TestGetPodObjectMounts(t *testing.T) {
 			podStep: func(expectedPodStepTemplate *podStep) {
 				expectedPodStepTemplate.config.Secrets = []*api.Secret{
 					{
-						Name:      testSecretName,
+						Name:      "some-secret",
 						MountPath: "/usr/local/secrets",
+					},
+				}
+				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"
+				expectedPodStepTemplate.config.ArtifactDir = "/tmp/artifacts"
+			},
+		},
+		{
+			name: "with artifacts, multiple secrets and path results in multiple mounts",
+			podStep: func(expectedPodStepTemplate *podStep) {
+				expectedPodStepTemplate.config.Secrets = []*api.Secret{
+					{
+						Name:      "some-secret",
+						MountPath: "/usr/local/secrets",
+					},
+					{
+						Name:      "another-secret",
+						MountPath: "/usr/local/secrets2",
+					},
+				}
+				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"
+				expectedPodStepTemplate.config.ArtifactDir = "/tmp/artifacts"
+			},
+		},
+		{
+			name: "with artifacts, multiple secrets and path results with unspecified mounts",
+			podStep: func(expectedPodStepTemplate *podStep) {
+				expectedPodStepTemplate.config.Secrets = []*api.Secret{
+					{
+						Name: "some-secret",
+					},
+					{
+						Name: "another-secret",
 					},
 				}
 				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
@@ -1,0 +1,8 @@
+- mountPath: /tmp/artifacts
+  name: artifacts
+- mountPath: /usr/local/secrets
+  name: test-secret
+  readOnly: true
+- mountPath: /usr/local/secrets2
+  name: test-secret-2
+  readOnly: true

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
@@ -1,0 +1,8 @@
+- mountPath: /tmp/artifacts
+  name: artifacts
+- mountPath: /usr/test-secrets
+  name: test-secret
+  readOnly: true
+- mountPath: /usr/test-secrets-2
+  name: test-secret-2
+  readOnly: true

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
@@ -3,3 +3,6 @@
 - name: test-secret
   secret:
     secretName: some-secret
+- name: test-secret-2
+  secret:
+    secretName: another-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
@@ -3,3 +3,6 @@
 - name: test-secret
   secret:
     secretName: some-secret
+- name: test-secret-2
+  secret:
+    secretName: another-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
@@ -1,3 +1,3 @@
 - name: test-secret
   secret:
-    secretName: test-secret
+    secretName: some-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
@@ -1,3 +1,3 @@
 - name: test-secret
   secret:
-    secretName: test-secret
+    secretName: some-secret

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -626,7 +626,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secret:\n" +
-	"            # Secret mount path. Defaults to /usr/test-secret\n" +
+	"            # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"            # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"            mount_path: ' '\n" +
 	"            # Secret name, used inside test containers\n" +
 	"            name: ' '\n" +
@@ -635,7 +636,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
 	"        # at the same time.\n" +
 	"        secrets:\n" +
-	"            - # Secret mount path. Defaults to /usr/test-secret\n" +
+	"            - # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"              # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"              mount_path: ' '\n" +
 	"              # Secret name, used inside test containers\n" +
 	"              name: ' '\n" +
@@ -1236,7 +1238,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secret:\n" +
-	"        # Secret mount path. Defaults to /usr/test-secret\n" +
+	"        # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"        # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"        mount_path: ' '\n" +
 	"        # Secret name, used inside test containers\n" +
 	"        name: ' '\n" +
@@ -1245,7 +1248,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
 	"      # at the same time.\n" +
 	"      secrets:\n" +
-	"        - # Secret mount path. Defaults to /usr/test-secret\n" +
+	"        - # Secret mount path. Defaults to /usr/test-secrets for first\n" +
+	"          # secret. /usr/test-secrets-2 for second, and so on.\n" +
 	"          mount_path: ' '\n" +
 	"          # Secret name, used inside test containers\n" +
 	"          name: ' '\n" +


### PR DESCRIPTION
Example:
could not run steps: step launch failed: failed to create or restart test pod: unable to create pod: Pod "launch" is invalid: spec.volumes[1].name: Duplicate value: "test-secret"