### PR TITLE
Secret bootstrapper: Allow finding config entry for faulty dockercfg

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -326,7 +326,8 @@ func constructSecrets(ctx context.Context, config secretbootstrap.Config, bwClie
 	errChan := make(chan error, potentialErrors)
 
 	secretConfigWG := &sync.WaitGroup{}
-	for _, cfg := range config.Secrets {
+	for idx, cfg := range config.Secrets {
+		idx := idx
 		secretConfigWG.Add(1)
 
 		go func(secretConfig secretbootstrap.SecretConfig) {
@@ -368,7 +369,7 @@ func constructSecrets(ctx context.Context, config secretbootstrap.Config, bwClie
 						}
 					}
 					if err != nil {
-						errChan <- fmt.Errorf("[%s] %w", key, err)
+						errChan <- fmt.Errorf("config.%d.\"%s\": %w", idx, key, err)
 						return
 					}
 					dataLock.Lock()

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1288,7 +1288,7 @@ func TestConstructSecrets(t *testing.T) {
 					"a-id-3-2": "attachment-name-3-2-value",
 				},
 			),
-			expectedError: fmt.Errorf("[[.dockerconfigjson] failed to find field Pull Credentials in item quay.io, [key-name-1] failed to find field field-name-1 in item item-name-1]"),
+			expectedError: errors.New(`[config.0."key-name-1": failed to find field field-name-1 in item item-name-1, config.1.".dockerconfigjson": failed to find field Pull Credentials in item quay.io]`),
 		},
 		{
 			name:   "error: no such an attachment",
@@ -1366,7 +1366,7 @@ func TestConstructSecrets(t *testing.T) {
 					"a-id-3-2": "attachment-name-3-2-value",
 				},
 			),
-			expectedError: fmt.Errorf("[[.dockerconfigjson] failed to find field Pull Credentials in item quay.io, [key-name-5] failed to find attachment attachment-name-1 in item item-name-2, [key-name-7] failed to find password in item item-name-3]"),
+			expectedError: errors.New(`[config.0."key-name-5": failed to find attachment attachment-name-1 in item item-name-2, config.0."key-name-7": failed to find password in item item-name-3, config.1.".dockerconfigjson": failed to find field Pull Credentials in item quay.io]`),
 		},
 	}
 


### PR DESCRIPTION
The current error is pretty much useless for finding the offending item

/cc @openshift/openshift-team-developer-productivity-test-platform 