### PR TITLE
release-job-migrator: support interval

### DIFF
--- a/cmd/release-job-migrator/main.go
+++ b/cmd/release-job-migrator/main.go
@@ -488,9 +488,16 @@ func run(o options) error {
 					return err
 				}
 			}
-			cron := periodic.Cron
-			if cron == "" {
-				cron = fmt.Sprintf("@every %s", periodic.Interval)
+			var cron, interval *string
+			if periodic.Cron != "" {
+				// yaml.Marshal doesn't properly see &periodic.Cron, but does see &cronCopy...
+				cronCopy := periodic.Cron
+				cron = &cronCopy
+			}
+			if periodic.Interval != "" {
+				// yaml.Marshal doesn't properly see &periodic.Interval, but does see &intervalCopy...
+				intervalCopy := periodic.Interval
+				interval = &intervalCopy
 			}
 			// check that test does not already exist in config
 			combinedTests := append(replacements[filename].tests, ciopConfigs[filename].Configuration.Tests...)
@@ -503,7 +510,8 @@ func run(o options) error {
 			testsAndImages.tests = append(testsAndImages.tests, api.TestStepConfiguration{
 				As:                          info.As,
 				MultiStageTestConfiguration: conf.Steps,
-				Cron:                        &cron,
+				Cron:                        cron,
+				Interval:                    interval,
 			})
 			replacements[filename] = testsAndImages
 			replacedJobs[periodic.Name] = metadataFromJobInfo(info).JobName(jobconfig.PeriodicPrefix, info.As)

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
@@ -40,7 +40,7 @@ tests:
     cluster_profile: aws
     workflow: openshift-e2e-aws-proxy
 - as: e2e-aws
-  cron: '@every 48h'
+  interval: 48h
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__okd-4.7.yaml
@@ -11,7 +11,7 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws
-  cron: '@every 48h'
+  interval: 48h
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.6.yaml
@@ -17,7 +17,7 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws
-  cron: '@every 48h'
+  interval: 48h
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__origin-4.7.yaml
@@ -17,7 +17,7 @@ resources:
       memory: 200Mi
 tests:
 - as: e2e-aws
-  cron: '@every 48h'
+  interval: 48h
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws


### PR DESCRIPTION
This PR updates the release-job-migrator to use the recently added
interval field for ci-operator defined tests instead of converting job
intervals to `@every interval` crons.