### PR TITLE
ci-operator: releases: use artifact dir env

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -201,7 +201,7 @@ set -xeuo pipefail
 export HOME=/tmp
 oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q --name %q
-oc adm release extract --from=%q --to=/tmp/artifacts/release-payload-%s
+oc adm release extract --from=%q --to=${ARTIFACT_DIR}/release-payload-%s
 `, s.jobSpec.Namespace(), streamName, cvo, destination, version, destination, s.name),
 	}
 

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -222,7 +222,7 @@ if [[ -d /pull ]]; then
 	cp /pull/.dockerconfigjson $HOME/.docker/config.json
 fi
 oc registry login
-oc adm release extract --from=%q --file=image-references > /tmp/artifacts/%s
+oc adm release extract --from=%q --file=image-references > ${ARTIFACT_DIR}/%s
 `, pullSpec, target)
 
 	// run adm release extract and grab the raw image-references from the payload


### PR DESCRIPTION
When we create artifacts in these steps, we should honor the environment
variable that tells us where to put them instead of guessing as to where
the literal artifact dir may end up being.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @smarterclayton 