### PR TITLE
ci-operator: release: use a configmap for data transfer

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -87,6 +87,11 @@ func setupReleaseImageStream(ctx context.Context, namespace string, client ctrlr
 				Resources: []string{"imagestreams", "imagestreamtags"},
 				Verbs:     []string{"create", "get", "list", "update", "watch"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"configmaps"},
+				Verbs:     []string{"create", "get", "list", "update", "watch"},
+			},
 		},
 	}
 

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -223,7 +222,8 @@ if [[ -d /pull ]]; then
 fi
 oc registry login
 oc adm release extract --from=%q --file=image-references > ${ARTIFACT_DIR}/%s
-`, pullSpec, target)
+oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
+`, pullSpec, target, target, target, target)
 
 	// run adm release extract and grab the raw image-references from the payload
 	podConfig := steps.PodStepConfiguration{
@@ -255,13 +255,18 @@ oc adm release extract --from=%q --file=image-references > ${ARTIFACT_DIR}/%s
 		return err
 	}
 
-	// read the contents from the artifacts directory
-	isContents, err := ioutil.ReadFile(filepath.Join(artifactDir, podConfig.As, target))
-	if err != nil {
-		return fmt.Errorf("unable to read release image stream: %w", err)
+	// read the contents from the configmap we created
+	var configMap coreapi.ConfigMap
+	if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: fmt.Sprintf("release-%s", target)}, &configMap); err != nil {
+		return fmt.Errorf("could not fetch extracted release %s: %w", target, err)
+	}
+
+	isContents, ok := configMap.Data[fmt.Sprintf("%s.yaml", target)]
+	if !ok {
+		return fmt.Errorf("no imagestream data found in release configMap for %s: %w", target, err)
 	}
 	var releaseIS imagev1.ImageStream
-	if err := json.Unmarshal(isContents, &releaseIS); err != nil {
+	if err := json.Unmarshal([]byte(isContents), &releaseIS); err != nil {
 		return fmt.Errorf("unable to decode release image stream: %w", err)
 	}
 	if releaseIS.Kind != "ImageStream" || releaseIS.APIVersion != "image.openshift.io/v1" {


### PR DESCRIPTION
In order to not rely on the artifact gathering code, we can take
advantage of the fact that we are running as the `ci-operator` service
account in the release `Pod` and we have access to the `oc` CLI by putting
the data we need into a `ConfigMap` and reading it out of that.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part of [DPTP-1819](https://issues.redhat.com/browse/DPTP-1819)
Depends on https://github.com/openshift/ci-tools/pull/1620