### PR TITLE
Use the same label for CRs created by ci-tools

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/logrusutil"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/api/secretbootstrap"
 	"github.com/openshift/ci-tools/pkg/bitwarden"
 	"github.com/openshift/ci-tools/pkg/kubernetes/pkg/credentialprovider"
@@ -388,7 +389,7 @@ func constructSecrets(ctx context.Context, config secretbootstrap.Config, bwClie
 					ObjectMeta: meta.ObjectMeta{
 						Name:      secretContext.Name,
 						Namespace: secretContext.Namespace,
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{api.DPTPRequesterLabel: "ci-secret-bootstrap"},
 					},
 					Type: secretContext.Type,
 				}

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1161,7 +1161,7 @@ func TestConstructSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-1",
 							Namespace: "namespace-1",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1179,7 +1179,7 @@ func TestConstructSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "ci-pull-credentials",
 							Namespace: "ci",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							".dockerconfigjson": []byte("123"),
@@ -1193,7 +1193,7 @@ func TestConstructSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-2",
 							Namespace: "namespace-2",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1422,7 +1422,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-1",
 							Namespace: "namespace-1",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1440,7 +1440,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-2",
 							Namespace: "namespace-2",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1460,7 +1460,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1478,7 +1478,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-2",
 						Namespace: "namespace-2",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1512,7 +1512,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-1",
 							Namespace: "namespace-1",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1530,7 +1530,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-2",
 							Namespace: "namespace-2",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1550,7 +1550,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1569,7 +1569,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-2",
 						Namespace: "namespace-2",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1590,7 +1590,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("abc"),
@@ -1603,7 +1603,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-1",
 							Namespace: "namespace-1",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("value1"),
@@ -1617,7 +1617,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("abc"),
@@ -1632,7 +1632,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:              "prod-secret-1",
 						Namespace:         "namespace-1",
-						Labels:            map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:            map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						CreationTimestamp: metav1.NewTime(time.Now()),
 					},
 					Data: map[string][]byte{
@@ -1646,7 +1646,7 @@ func TestUpdateSecrets(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "prod-secret-1",
 							Namespace: "namespace-1",
-							Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 						},
 						Data: map[string][]byte{
 							"key-name-1": []byte("abc"),
@@ -1659,7 +1659,7 @@ func TestUpdateSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("abc"),
@@ -1832,7 +1832,7 @@ func TestWriteSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-1",
 						Namespace: "namespace-1",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1848,7 +1848,7 @@ func TestWriteSecrets(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "prod-secret-2",
 						Namespace: "namespace-2",
-						Labels:    map[string]string{"ci.openshift.org/auto-managed": "true"},
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("value1"),
@@ -1873,7 +1873,7 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    ci.openshift.org/auto-managed: "true"
+    dptp.openshift.io/requester: ci-secret-bootstrap
   name: prod-secret-1
   namespace: namespace-1
 ---
@@ -1889,7 +1889,7 @@ kind: Secret
 metadata:
   creationTimestamp: null
   labels:
-    ci.openshift.org/auto-managed: "true"
+    dptp.openshift.io/requester: ci-secret-bootstrap
   name: prod-secret-2
   namespace: namespace-2
 ---

--- a/pkg/controller/secretsyncer/secretsyncer.go
+++ b/pkg/controller/secretsyncer/secretsyncer.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/api/secretbootstrap"
 	"github.com/openshift/ci-tools/pkg/controller/secretsyncer/config"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
@@ -235,7 +236,7 @@ func secret(nn types.NamespacedName, data map[string][]byte, tp corev1.SecretTyp
 		if s.Labels == nil {
 			s.Labels = map[string]string{}
 		}
-		s.Labels["ci.openshift.org/secret-syncer-controller-managed"] = "true"
+		s.Labels[api.DPTPRequesterLabel] = ControllerName
 		if s.Data == nil {
 			s.Data = map[string][]byte{}
 		}


### PR DESCRIPTION
Follow up https://github.com/openshift/ci-tools/pull/1601#discussion_r557520722

/cc @openshift/openshift-team-developer-productivity-test-platform 