### PR TITLE
Add Azure Arc cluster profile validation

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -251,6 +251,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileAWSCentos40,
 		api.ClusterProfileAWSGluster,
 		api.ClusterProfileAzure4,
+		api.ClusterProfileAzureArc,
 		api.ClusterProfileGCP,
 		api.ClusterProfileGCP40,
 		api.ClusterProfileGCPHA,


### PR DESCRIPTION
Add Azure Arc cluster profile validation. This was missing in https://github.com/openshift/ci-tools/pull/1611.