### PR TITLE
applyconfig: handle nonexisting namespaces in server-side dry-run

### DIFF
--- a/pkg/api/nsttl/const.go
+++ b/pkg/api/nsttl/const.go
@@ -1,0 +1,14 @@
+package nsttl
+
+// This package contains constants for tools that create namespaces
+// to be reaped by https://github.com/openshift/ci-ns-ttl-controller/
+
+const (
+	// AnnotationIdleCleanupDurationTTL is the annotation for requesting namespace cleanup after all pods complete
+	AnnotationIdleCleanupDurationTTL = "ci.openshift.io/ttl.soft"
+	// AnnotationCleanupDurationTTL is the annotation for requesting namespace cleanup after the namespace has been active
+	AnnotationCleanupDurationTTL = "ci.openshift.io/ttl.hard"
+	// AnnotationNamespaceLastActive contains time.RFC3339 timestamp at which the namespace was last in active use. We
+	// update this every ten minutes.
+	AnnotationNamespaceLastActive = "ci.openshift.io/active"
+)


### PR DESCRIPTION
This is an unpolished shot to make `applyconfig` handle nonexistent namespaces in dry-runs better. Currently, server-side dry-runs (default on non-api.ci clusters) fails on PRs that add manifests for both the namespace and the resources in it. Server-side dry-run will fail for the resources, because they are applied into a namespace that does not exist on the cluster yet, but the actual non-dry run would succeed because the namespace manifest would be applied previously.

The solution space has several kinks:
- We could ask people to add namespaces in separate PRs, to be merged first (works but terrible UX)
- We could ignore these errors, but then we lose all validation for newly added manifests (can cause triage alerts)
- We could proactively create the missing namespaces and retry. This gets us validation but would create even mismatching (really nonexistent namespaces) namespaces, and we would need to figure out how to clean up.

This PR implements the third option - if a manifest fails to apply because of a missing namespace, it creates the namespace and retries, until no more missing namespace messages occur or the apply passes. During the run, it bookkeeps which namespaces would be created if the run was not dry. If a manifest needed to create a missing namespace to be able to pass dry-run, `applyconfig` compares it with a set of namespaces that would be created if the run was not dry, and emits a failure if the assumed namespace would not be created.

This change makes applyconfig analyses the output of oc apply and
searches for messages that indicate that the apply failed because a
namespace was missing.  Then it tries to recover by creating these
missing namespaces and retrying the failed oc apply.  These namespaces
are created annotated for ci-ns-ttl-controller to reap it so unmerged
PRs do not clutter the cluster. If a manifest with the namespace is
actually applied (post-merge), the annotations are cleaned up.

/cc @stevekuznetsov @alvaroaleman 
/cc @openshift/openshift-team-developer-productivity-test-platform 