### PR TITLE
Fixes Azure Arc quota slice

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -955,7 +955,7 @@ func (p ClusterProfile) LeaseType() string {
 	case ClusterProfileAzure4:
 		return "azure4-quota-slice"
 	case ClusterProfileAzureArc:
-		return "azure-arc"
+		return "azure-arc-quota-slice"
 	case
 		ClusterProfileGCP,
 		ClusterProfileGCP40,


### PR DESCRIPTION
Minor fix, quota slices have the `-quota-slice` suffix.