### PR TITLE
checkconfig: resolve configurations

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -17,7 +17,7 @@ func main() {
 	flag.Parse()
 
 	if configDir == "" {
-		fmt.Println("The --config-dir flag is required but was not provided")
+		fmt.Fprintln(os.Stderr, "The --config-dir flag is required but was not provided")
 		os.Exit(1)
 	}
 
@@ -30,7 +30,7 @@ func main() {
 		}
 		return nil
 	}); err != nil {
-		fmt.Printf("error validating configuration files: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error validating configuration files: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -49,9 +49,9 @@ func main() {
 		}
 	}
 	if len(dupes) > 0 {
-		fmt.Println("non-unique image publication found: ")
+		fmt.Fprintln(os.Stderr, "non-unique image publication found: ")
 		for _, dupe := range dupes {
-			fmt.Printf("ERROR: %v\n", dupe)
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", dupe)
 		}
 		os.Exit(1)
 	}

--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -35,7 +35,16 @@ func main() {
 		fmt.Fprintf(os.Stderr, "error validating configuration files: %v\n", err)
 		os.Exit(1)
 	}
+	if dupes := validateTags(seen); len(dupes) > 0 {
+		fmt.Fprintln(os.Stderr, "non-unique image publication found: ")
+		for _, dupe := range dupes {
+			fmt.Fprintf(os.Stderr, "ERROR: %v\n", dupe)
+		}
+		os.Exit(1)
+	}
+}
 
+func validateTags(seen tagSet) []error {
 	var dupes []error
 	for tag, infos := range seen {
 		if len(infos) <= 1 {
@@ -51,11 +60,5 @@ func main() {
 		}
 		dupes = append(dupes, fmt.Errorf("output tag %s/%s:%s is promoted from more than one place: %v", tag.Namespace, tag.Name, tag.Tag, strings.Join(formatted, ", ")))
 	}
-	if len(dupes) > 0 {
-		fmt.Fprintln(os.Stderr, "non-unique image publication found: ")
-		for _, dupe := range dupes {
-			fmt.Fprintf(os.Stderr, "ERROR: %v\n", dupe)
-		}
-		os.Exit(1)
-	}
+	return dupes
 }

--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -8,25 +8,36 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/load"
+	"github.com/openshift/ci-tools/pkg/registry"
 	"github.com/openshift/ci-tools/pkg/steps/release"
 )
 
 type tagSet map[api.ImageStreamTagReference][]*config.Info
 
 func main() {
-	var configDir string
+	var configDir, registryDir string
 	flag.StringVar(&configDir, "config-dir", "", "The directory containing configuration files.")
+	flag.StringVar(&registryDir, "registry", "", "Path to the step registry directory")
 	flag.Parse()
 
 	if configDir == "" {
 		fmt.Fprintln(os.Stderr, "The --config-dir flag is required but was not provided")
 		os.Exit(1)
 	}
-
+	resolver, err := loadResolver(registryDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to load registry: %v\n", err)
+		os.Exit(1)
+	}
 	seen := tagSet{}
 	if err := config.OperateOnCIOperatorConfigDir(configDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
-		// validation is implicit, so we don't need to do anything
-		// but record the images we saw for future validation
+		// basic validation of the configuration is implicit in the iteration
+		if resolver != nil {
+			if _, err := registry.ResolveConfig(resolver, *configuration); err != nil {
+				return err
+			}
+		}
 		for _, tag := range release.PromotedTags(configuration) {
 			seen[tag] = append(seen[tag], repoInfo)
 		}
@@ -42,6 +53,17 @@ func main() {
 		}
 		os.Exit(1)
 	}
+}
+
+func loadResolver(path string) (registry.Resolver, error) {
+	if path == "" {
+		return nil, nil
+	}
+	refs, chains, workflows, _, _, observers, err := load.Registry(path, false)
+	if err != nil {
+		return nil, err
+	}
+	return registry.NewResolver(refs, chains, workflows, observers), nil
 }
 
 func validateTags(seen tagSet) []error {


### PR DESCRIPTION
```
$ git rev-parse --short HEAD
734de06838
$ time ci-operator-checkconfig --config-dir config/ --registry step-registry/

real    0m1.396s
user    0m1.984s
sys     0m0.136s
$ sed -i '/steps/a\    env: {"INVALID": "invalid"}' config/openshift/ci-tools/openshift-ci-tools-master.yaml
$ ci-operator-checkconfig --config-dir config/ --registry step-registry/
ERRO[0000] Failed to execute callback                    error="Failed resolve MultiStageTestConfiguration: e2e: no step declares parameter \"INVALID\"" source-file=/home/bbguimaraes/src/release/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
error validating configuration files: Failed resolve MultiStageTestConfiguration: e2e: no step declares parameter "INVALID"
```