### PR TITLE
prowgen: explicitly opt out of pod-utils with artifact dir

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -39,13 +39,13 @@ func (config *ReleaseBuildConfiguration) Default() {
 			}
 		}
 	}
-	for _, step := range config.RawSteps {
-		if test := step.TestStepConfiguration; test != nil {
+	for i := range config.RawSteps {
+		if test := config.RawSteps[i].TestStepConfiguration; test != nil {
 			defTest(test)
 		}
 	}
-	for _, test := range config.Tests {
-		defTest(&test)
+	for i := range config.Tests {
+		defTest(&config.Tests[i])
 	}
 }
 

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -36,16 +36,16 @@ func readCiOperatorConfig(configFilePath string, info Info) (*cioperatorapi.Rele
 		return nil, fmt.Errorf("failed to read ci-operator config (%w)", err)
 	}
 
-	var configSpec *cioperatorapi.ReleaseBuildConfiguration
+	var configSpec cioperatorapi.ReleaseBuildConfiguration
 	if err := yaml.Unmarshal(data, &configSpec); err != nil {
 		return nil, fmt.Errorf("failed to load ci-operator config (%w)", err)
 	}
 
-	if err := validation.IsValidConfiguration(configSpec, info.Org, info.Repo); err != nil {
+	if err := validation.IsValidConfiguration(&configSpec, info.Org, info.Repo); err != nil {
 		return nil, fmt.Errorf("invalid ci-operator config: %w", err)
 	}
 
-	return configSpec, nil
+	return &configSpec, nil
 }
 
 // Info describes the metadata for a CI Operator configuration file

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -152,7 +152,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 			element.Secrets = append(element.Secrets, element.Secret)
 		}
 		if element.ContainerTestConfiguration != nil {
-			podSpec = generateCiOperatorPodSpec(info, element.Secrets, []string{element.As})
+			podSpec = generateCiOperatorPodSpec(info, element.Secrets, []string{element.As}, element.ArtifactDir != cioperatorapi.DefaultArtifacts)
 		} else if element.MultiStageTestConfiguration != nil {
 			podSpec = generatePodSpecMultiStage(info, &element, configSpec.Releases != nil)
 		} else {
@@ -199,12 +199,12 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 		if promotion.PromotesOfficialImages(configSpec) {
 			presubmitTargets = append(presubmitTargets, "[release:latest]")
 		}
-		podSpec := generateCiOperatorPodSpec(info, nil, presubmitTargets)
+		podSpec := generateCiOperatorPodSpec(info, nil, presubmitTargets, false)
 		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest("images", info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
 
 		if configSpec.PromotionConfiguration != nil {
 
-			podSpec := generateCiOperatorPodSpec(info, nil, imageTargets.List(), []string{"--promote"}...)
+			podSpec := generateCiOperatorPodSpec(info, nil, imageTargets.List(), false, []string{"--promote"}...)
 			podSpec.Containers[0].Args = append(podSpec.Containers[0].Args,
 				fmt.Sprintf("--image-mirror-push-secret=%s", filepath.Join(cioperatorapi.RegistryPushCredentialsCICentralSecretMountPath, corev1.DockerConfigJsonKey)))
 			podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
@@ -229,7 +229,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	}
 
 	if configSpec.Operator != nil {
-		podSpec := generateCiOperatorPodSpec(info, nil, []string{"ci-index"})
+		podSpec := generateCiOperatorPodSpec(info, nil, []string{"ci-index"}, false)
 		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest("ci-index", info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
 	}
 
@@ -240,7 +240,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	}
 }
 
-func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secret, targets []string, additionalArgs ...string) *corev1.PodSpec {
+func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secret, targets []string, customArtifactDir bool, additionalArgs ...string) *corev1.PodSpec {
 	for _, arg := range additionalArgs {
 		if !strings.HasPrefix(arg, "--") {
 			panic(fmt.Sprintf("all args to ci-operator must be in the form --flag=value, not %s", arg))
@@ -257,6 +257,9 @@ func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secre
 	}, additionalArgs...)
 	if info.Repo == "ci-tools" {
 		ret.Containers[0].Args = append(ret.Containers[0].Args, "--upload-via-pod-utils")
+	}
+	if customArtifactDir {
+		ret.Containers[0].Args = append(ret.Containers[0].Args, "--upload-via-pod-utils=false")
 	}
 	for _, target := range targets {
 		ret.Containers[0].Args = append(ret.Containers[0].Args, fmt.Sprintf("--target=%s", target))
@@ -288,7 +291,7 @@ func generatePodSpecMultiStage(info *ProwgenInfo, test *cioperatorapi.TestStepCo
 			Name: "ci-pull-credentials",
 		})
 	}
-	podSpec := generateCiOperatorPodSpec(info, secrets, []string{test.As})
+	podSpec := generateCiOperatorPodSpec(info, secrets, []string{test.As}, test.ArtifactDir != cioperatorapi.DefaultArtifacts)
 	if profile == "" {
 		return podSpec
 	}
@@ -349,7 +352,7 @@ func generatePodSpecTemplate(info *ProwgenInfo, release string, test *cioperator
 	clusterType := clusterProfile.ClusterType()
 	clusterProfilePath := fmt.Sprintf("/usr/local/%s-cluster-profile", test.As)
 	templatePath := fmt.Sprintf("/usr/local/%s", test.As)
-	podSpec := generateCiOperatorPodSpec(info, test.Secrets, []string{test.As})
+	podSpec := generateCiOperatorPodSpec(info, test.Secrets, []string{test.As}, test.ArtifactDir != cioperatorapi.DefaultArtifacts)
 	clusterProfileVolume := generateClusterProfileVolume(clusterProfile, clusterType)
 	if len(template) > 0 {
 		podSpec.Volumes = append(podSpec.Volumes, generateConfigMapVolume("job-definition", []string{fmt.Sprintf("prow-job-%s", template)}))

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -60,7 +60,7 @@ func TestGeneratePodSpec(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, tc.additionalArgs...))
+			testhelper.CompareWithFixture(t, generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, false, tc.additionalArgs...))
 		})
 	}
 }
@@ -108,8 +108,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftAnsibleClusterTestConfiguration: &ciop.OpenshiftAnsibleClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 				},
@@ -119,8 +120,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftInstallerClusterTestConfiguration: &ciop.OpenshiftInstallerClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "aws"},
 				},
@@ -130,8 +132,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -142,8 +145,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -154,8 +158,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -166,8 +171,9 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:       "test",
-				Commands: "commands",
+				As:          "test",
+				Commands:    "commands",
+				ArtifactDir: "/tmp/artifacts",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
@@ -4,6 +4,7 @@ containers:
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
+  - --upload-via-pod-utils=false
   - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
@@ -4,6 +4,7 @@ containers:
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-username=ci
   - --report-password-file=/etc/report/password.txt
+  - --upload-via-pod-utils=false
   - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
@@ -29,7 +29,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
@@ -25,7 +25,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -26,7 +26,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -25,7 +25,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
@@ -29,7 +29,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -25,7 +25,8 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
@@ -27,7 +27,8 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
@@ -27,7 +27,8 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
@@ -28,7 +28,8 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
@@ -27,7 +27,8 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
@@ -27,7 +27,8 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
@@ -28,7 +28,8 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
@@ -28,7 +28,8 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
@@ -27,7 +27,8 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -1662,7 +1662,8 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - as: multistage
+            - artifact_dir: /tmp/artifacts
+              as: multistage
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1827,7 +1828,8 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - as: multistage5
+            - artifact_dir: /tmp/artifacts
+              as: multistage5
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -1954,7 +1956,8 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - as: unit
+            - artifact_dir: /tmp/artifacts
+              as: unit
               commands: make unit CHANGED
               container:
                 from: src

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__ocp-4.7.yaml
@@ -25,7 +25,8 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e-metal-ipi
+- artifact_dir: /tmp/artifacts
+  as: e2e-metal-ipi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: packet
@@ -34,7 +35,8 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OpenShiftSDN
     workflow: baremetalds-e2e
-- as: e2e-aws-proxy
+- artifact_dir: /tmp/artifacts
+  as: e2e-aws-proxy
   cron: 0 0 */2 * *
   steps:
     cluster_profile: aws

--- a/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -18,7 +18,8 @@ tag_specification:
   name: "4.3"
   namespace: ocp
 tests:
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -24,23 +24,28 @@ tag_specification:
   namespace: ocp
 test_binary_build_commands: make test-install
 tests:
-- as: e2e-aws
+- artifact_dir: /tmp/artifacts
+  as: e2e-aws
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws
-- as: unit
+- artifact_dir: /tmp/artifacts
+  as: unit
   commands: unit
   container:
     from: src
-- as: cmd
+- artifact_dir: /tmp/artifacts
+  as: cmd
   commands: make test-cmd
   container:
     from: bin
-- as: race
+- artifact_dir: /tmp/artifacts
+  as: race
   commands: race
   container:
     from: test-bin
-- as: e2e
+- artifact_dir: /tmp/artifacts
+  as: e2e
   steps:
     cluster_profile: aws
     test:

--- a/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
@@ -19,7 +19,8 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- as: e2e
+- artifact_dir: /tmp/artifacts
+  as: e2e
   steps:
     cluster_profile: aws
     test:


### PR DESCRIPTION
There's one major difference between the current artifact gathering code
and using the Prow pod utilities: the former allows for users to
configure their artifact directory, whereas the latter expects to be
declarative itself and for the user to simply consume the directory as
an environment variable. As we work to make the latter approach default,
we first need to opt-out if we notice a user is setting their directory
to something non-standard.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 