### PR TITLE
Revert "test: write out test JSON"

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 JUNIT_ARG=""
 if [[ -n ${ARTIFACT_DIR:-} ]]; then
-  JUNIT_ARG="--junitfile=$ARTIFACT_DIR/junit.xml --jsonfile=$ARTIFACT_DIR/tests.json"
+  JUNIT_ARG="--junitfile=$ARTIFACT_DIR/junit.xml"
 fi
 
 set -o xtrace


### PR DESCRIPTION
Reverts openshift/ci-tools#1575

It generates excessively large (~60MB) files:

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_ci-tools/1640/pull-ci-openshift-ci-tools-master-unit/1354157004817436672/artifacts/test/artifacts/