### PR TITLE
ci-operator: gather artifacts only when needed

### DIFF
--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -133,7 +133,7 @@ func (s *podStep) SubTests() []*junit.TestCase {
 }
 
 func (s *podStep) gatherArtifacts() bool {
-	return len(s.config.ArtifactDir) > 0 && len(s.artifactDir) > 0
+	return len(s.config.ArtifactDir) > 0 && len(s.artifactDir) > 0 && !s.config.ArtifactsViaPodUtils
 }
 
 func (s *podStep) Requires() []api.StepLink {


### PR DESCRIPTION
When the pod utils are being used to push artifacts up, we should not
bother grabbing them manually, especially since we do not know from
where to do so.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @bbguimaraes 