### PR TITLE
secret generator: set default org and collections on create

### DIFF
--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -101,30 +101,30 @@ func (o *options) validateOptions() error {
 
 func (o *options) completeOptions(secrets sets.String) error {
 	if !o.validateOnly {
-		bytes, err := ioutil.ReadFile(o.bwPasswordPath)
+		pwBytes, err := ioutil.ReadFile(o.bwPasswordPath)
 		if err != nil {
 			return err
 		}
-		o.bwPassword = strings.TrimSpace(string(bytes))
+		o.bwPassword = strings.TrimSpace(string(pwBytes))
 		secrets.Insert(o.bwPassword)
 	}
 
-	bytes, err := ioutil.ReadFile(o.configPath)
+	cfgBytes, err := ioutil.ReadFile(o.configPath)
 	if err != nil {
 		return err
 	}
 
-	if err := yaml.Unmarshal(bytes, &o.config); err != nil {
+	if err := yaml.Unmarshal(cfgBytes, &o.config); err != nil {
 		return err
 	}
 
 	if o.bootstrapConfigPath != "" {
-		bytes, err = ioutil.ReadFile(o.bootstrapConfigPath)
+		cfgBytes, err = ioutil.ReadFile(o.bootstrapConfigPath)
 		if err != nil {
 			return err
 		}
 
-		if err := yaml.Unmarshal(bytes, &o.bootstrapConfig); err != nil {
+		if err := yaml.Unmarshal(cfgBytes, &o.bootstrapConfig); err != nil {
 			return err
 		}
 	}
@@ -181,9 +181,8 @@ func replaceParameter(paramName, param, template string) string {
 
 func processBwParameters(bwItems []bitWardenItem) ([]bitWardenItem, error) {
 	var errs []error
-	processedBwItems := []bitWardenItem{}
+	var processedBwItems []bitWardenItem
 	for _, bwItemWithParams := range bwItems {
-		hasErrors := false
 		bwItemsProcessingHolder := []bitWardenItem{bwItemWithParams}
 		for paramName, params := range bwItemWithParams.Params {
 			bwItemsProcessed := []bitWardenItem{}
@@ -210,7 +209,7 @@ func processBwParameters(bwItems []bitWardenItem) ([]bitWardenItem, error) {
 			}
 			bwItemsProcessingHolder = bwItemsProcessed
 		}
-		if !hasErrors {
+		if len(errs) == 0 {
 			processedBwItems = append(processedBwItems, bwItemsProcessingHolder...)
 		}
 	}

--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -36,6 +36,9 @@ type Item struct {
 	// RevisionTime is a pointer so that omitempty works. The field is set only
 	// when we get the record from BW but not e.g. when we create or update records
 	RevisionTime *time.Time `json:"revisionDate,omitempty"`
+
+	Organization string   `json:"organizationId,omitempty""`
+	Collections  []string `json:"collectionIds,omitempty"`
 }
 
 // Client is used to communicate with BitWarden
@@ -49,6 +52,8 @@ type Client interface {
 	SetAttachmentOnItem(itemName, attachmentName string, fileContents []byte) error
 	SetPassword(itemName string, password []byte) error
 	UpdateNotesOnItem(itemName string, notes string) error
+
+	OnCreate(func(*Item) error)
 }
 
 // NewClient generates a BitWarden client

--- a/pkg/bitwarden/bitwarden.go
+++ b/pkg/bitwarden/bitwarden.go
@@ -37,7 +37,7 @@ type Item struct {
 	// when we get the record from BW but not e.g. when we create or update records
 	RevisionTime *time.Time `json:"revisionDate,omitempty"`
 
-	Organization string   `json:"organizationId,omitempty""`
+	Organization string   `json:"organizationId,omitempty"`
 	Collections  []string `json:"collectionIds,omitempty"`
 }
 

--- a/pkg/bitwarden/cli.go
+++ b/pkg/bitwarden/cli.go
@@ -23,6 +23,10 @@ type cliClient struct {
 	savedItems []Item
 	run        func(args ...string) ([]byte, error)
 	addSecret  func(s string)
+
+	// onCreate is called before secrets are created by client methods, allowing
+	// user code to default/validate created items
+	onCreate func(*Item) error
 }
 
 func newCliClient(username, password string, addSecret func(s string)) (Client, error) {
@@ -191,9 +195,20 @@ func (c *cliClient) Logout() ([]byte, error) {
 	return c.run("logout")
 }
 
-func (c *cliClient) createItem(itemTemplate string, targetItem *Item) error {
+func (c *cliClient) createItem(item Item, targetItem *Item) error {
+	if c.onCreate != nil {
+		if err := c.onCreate(&item); err != nil {
+			return fmt.Errorf("OnCreate() failed on item: %w", err)
+		}
+	}
+
+	itemBytes, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("failed to serialize item: %w", err)
+	}
+
 	// the bitwarden cli expects the item to be base64 encoded
-	encItem := base64.StdEncoding.EncodeToString([]byte(itemTemplate))
+	encItem := base64.StdEncoding.EncodeToString(itemBytes)
 	out, err := c.runWithSession("create", "item", encItem)
 	if err != nil {
 		return err
@@ -235,11 +250,7 @@ func (c *cliClient) createEmptyItem(itemName string, targetItem *Item) error {
 		Name:  itemName,
 		Login: &Login{},
 	}
-	itemBytes, err := json.Marshal(item)
-	if err != nil {
-		return fmt.Errorf("failed to serialize item: %w", err)
-	}
-	return c.createItem(string(itemBytes), targetItem)
+	return c.createItem(item, targetItem)
 }
 
 func (c *cliClient) createItemWithPassword(itemName string, password []byte, targetItem *Item) error {
@@ -248,11 +259,7 @@ func (c *cliClient) createItemWithPassword(itemName string, password []byte, tar
 		Name:  itemName,
 		Login: &Login{string(password)},
 	}
-	itemBytes, err := json.Marshal(item)
-	if err != nil {
-		return fmt.Errorf("failed to serialize item: %w", err)
-	}
-	return c.createItem(string(itemBytes), targetItem)
+	return c.createItem(item, targetItem)
 }
 
 func (c *cliClient) createItemWithNotes(itemName, notes string, targetItem *Item) error {
@@ -262,11 +269,7 @@ func (c *cliClient) createItemWithNotes(itemName, notes string, targetItem *Item
 		Notes: notes,
 		Login: &Login{},
 	}
-	itemBytes, err := json.Marshal(item)
-	if err != nil {
-		return fmt.Errorf("failed to serialize item: %w", err)
-	}
-	return c.createItem(string(itemBytes), targetItem)
+	return c.createItem(item, targetItem)
 }
 
 func (c *cliClient) editItem(targetItem Item) error {
@@ -439,6 +442,10 @@ func (c *cliClient) SetPassword(itemName string, password []byte) error {
 	return nil
 }
 
+func (c *cliClient) OnCreate(callback func(*Item) error) {
+	c.onCreate = callback
+}
+
 type dryRunCliClient struct {
 	file *os.File
 }
@@ -477,6 +484,8 @@ func (d *dryRunCliClient) UpdateNotesOnItem(itemName, notes string) error {
 	fmt.Fprintf(d.file, "ItemName: %s\n\tNotes: %s\n", itemName, notes)
 	return nil
 }
+func (d *dryRunCliClient) OnCreate(func(*Item) error) {}
+
 func newDryRunClient(file *os.File) (Client, error) {
 	return &dryRunCliClient{
 		file: file,

--- a/pkg/bitwarden/cli.go
+++ b/pkg/bitwarden/cli.go
@@ -235,9 +235,6 @@ func (c *cliClient) createAttachment(fileContents []byte, fileName string, itemI
 	if err != nil {
 		return fmt.Errorf("bw create failed: %w", err)
 	}
-	if err != nil {
-		return fmt.Errorf("failed to delete file %s: %w", filePath, err)
-	}
 	if err = json.Unmarshal(out, newAttachment); err != nil {
 		return fmt.Errorf("failed to parse bw output %s: %w", out, err)
 	}
@@ -450,7 +447,7 @@ type dryRunCliClient struct {
 	file *os.File
 }
 
-func (d *dryRunCliClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
+func (d *dryRunCliClient) GetFieldOnItem(_, _ string) ([]byte, error) {
 	return nil, nil
 }
 
@@ -458,14 +455,14 @@ func (d *dryRunCliClient) GetAllItems() []Item {
 	return nil
 }
 
-func (d *dryRunCliClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
+func (d *dryRunCliClient) GetAttachmentOnItem(_, _ string) ([]byte, error) {
 	return nil, nil
 }
-func (d *dryRunCliClient) GetPassword(itemName string) ([]byte, error) {
+func (d *dryRunCliClient) GetPassword(_ string) ([]byte, error) {
 	return nil, nil
 }
 func (d *dryRunCliClient) Logout() ([]byte, error) {
-	d.file.Close()
+	_ = d.file.Close()
 	return nil, nil
 }
 func (d *dryRunCliClient) SetFieldOnItem(itemName, fieldName string, fieldValue []byte) error {

--- a/pkg/bitwarden/cli_test.go
+++ b/pkg/bitwarden/cli_test.go
@@ -114,6 +114,7 @@ func TestLoginAndListItems(t *testing.T) {
 				{
 					ID:           "id1",
 					Name:         "unsplash.com",
+					Organization: "org1",
 					Type:         2,
 					RevisionTime: &revDate,
 					Fields: []Field{
@@ -122,10 +123,12 @@ func TestLoginAndListItems(t *testing.T) {
 							Value: "value1",
 						},
 					},
+					Collections: []string{"id1"},
 				},
 				{
 					ID:           "id2",
 					Name:         "my-credentials",
+					Organization: "org1",
 					Type:         2,
 					Login:        &Login{Password: "yyy"},
 					RevisionTime: &revDate,
@@ -135,7 +138,8 @@ func TestLoginAndListItems(t *testing.T) {
 							FileName: "secret.auto.vars",
 						},
 					},
-					Notes: "important notes",
+					Notes:       "important notes",
+					Collections: []string{"id2"},
 				},
 			},
 		},

--- a/pkg/bitwarden/fake.go
+++ b/pkg/bitwarden/fake.go
@@ -156,6 +156,8 @@ func (c fakeClient) UpdateNotesOnItem(itemName, notes string) error {
 	return nil
 }
 
+func (c fakeClient) OnCreate(func(*Item) error) {}
+
 // NewFakeClient generates a fake BitWarden client which is supposed to used only for testing
 func NewFakeClient(items []Item, attachments map[string]string) Client {
 	return fakeClient{items: items, attachments: attachments}

--- a/pkg/bitwarden/fake.go
+++ b/pkg/bitwarden/fake.go
@@ -10,8 +10,8 @@ type fakeClient struct {
 	attachments map[string]string
 }
 
-func (c fakeClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
-	for _, item := range c.items {
+func (f fakeClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
+	for _, item := range f.items {
 		if itemName == item.Name {
 			for _, field := range item.Fields {
 				if field.Name == fieldName {
@@ -26,12 +26,12 @@ func (c fakeClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
 func (f fakeClient) GetAllItems() []Item {
 	return f.items
 }
-func (c fakeClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
-	for _, item := range c.items {
+func (f fakeClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
+	for _, item := range f.items {
 		if itemName == item.Name {
 			for _, attachment := range item.Attachments {
 				if attachment.FileName == attachmentName {
-					if value, ok := c.attachments[attachment.ID]; ok {
+					if value, ok := f.attachments[attachment.ID]; ok {
 						return []byte(value), nil
 					}
 				}
@@ -41,12 +41,12 @@ func (c fakeClient) GetAttachmentOnItem(itemName, attachmentName string) ([]byte
 	return nil, fmt.Errorf("failed to find attachment %s in item %s", attachmentName, itemName)
 }
 
-func (c fakeClient) Logout() ([]byte, error) {
+func (f fakeClient) Logout() ([]byte, error) {
 	return []byte("logged out"), nil
 }
 
-func (c fakeClient) GetPassword(itemName string) ([]byte, error) {
-	for _, item := range c.items {
+func (f fakeClient) GetPassword(itemName string) ([]byte, error) {
+	for _, item := range f.items {
 		if itemName == item.Name {
 			if item.Login != nil {
 				return []byte(item.Login.Password), nil
@@ -61,17 +61,17 @@ func getNewUUID() string {
 	return fmt.Sprintf("%d", nanoTime)
 }
 
-func (c fakeClient) SetFieldOnItem(itemName, fieldName string, fieldValue []byte) error {
+func (f fakeClient) SetFieldOnItem(itemName, fieldName string, fieldValue []byte) error {
 	var targetItem *Item
 	var targetField *Field
-	for index, item := range c.items {
+	for index, item := range f.items {
 		if itemName != item.Name {
 			continue
 		}
-		targetItem = &c.items[index]
+		targetItem = &f.items[index]
 		for fieldIndex, field := range item.Fields {
 			if field.Name == fieldName {
-				targetField = &c.items[index].Fields[fieldIndex]
+				targetField = &f.items[index].Fields[fieldIndex]
 				break
 			}
 		}
@@ -80,8 +80,8 @@ func (c fakeClient) SetFieldOnItem(itemName, fieldName string, fieldValue []byte
 	}
 	if targetItem == nil {
 		newItemID := getNewUUID()
-		c.items = append(c.items, Item{ID: newItemID, Name: itemName, Type: 1})
-		targetItem = &c.items[len(c.items)-1]
+		f.items = append(f.items, Item{ID: newItemID, Name: itemName, Type: 1})
+		targetItem = &f.items[len(f.items)-1]
 	}
 	if targetField == nil {
 		targetItem.Fields = append(targetItem.Fields, Field{fieldName, string(fieldValue)})
@@ -91,17 +91,17 @@ func (c fakeClient) SetFieldOnItem(itemName, fieldName string, fieldValue []byte
 	return nil
 }
 
-func (c fakeClient) SetAttachmentOnItem(itemName, attachmentName string, fileContents []byte) error {
+func (f fakeClient) SetAttachmentOnItem(itemName, attachmentName string, fileContents []byte) error {
 	var targetItem *Item
 	var targetAttachment *Attachment
-	for index, item := range c.items {
+	for index, item := range f.items {
 		if itemName != item.Name {
 			continue
 		}
-		targetItem = &c.items[index]
+		targetItem = &f.items[index]
 		for attachmentIndex, attachment := range item.Attachments {
 			if attachment.FileName == attachmentName {
-				targetAttachment = &c.items[index].Attachments[attachmentIndex]
+				targetAttachment = &f.items[index].Attachments[attachmentIndex]
 				break
 			}
 		}
@@ -109,54 +109,54 @@ func (c fakeClient) SetAttachmentOnItem(itemName, attachmentName string, fileCon
 	}
 	if targetItem == nil {
 		newItemID := getNewUUID()
-		c.items = append(c.items, Item{ID: newItemID, Name: itemName, Type: 1})
-		targetItem = &c.items[len(c.items)-1]
+		f.items = append(f.items, Item{ID: newItemID, Name: itemName, Type: 1})
+		targetItem = &f.items[len(f.items)-1]
 	}
 	if targetAttachment == nil {
 		newAttachmentID := getNewUUID()
-		c.attachments[newAttachmentID] = string(fileContents)
+		f.attachments[newAttachmentID] = string(fileContents)
 		targetAttachment = &Attachment{newAttachmentID, attachmentName}
 		targetItem.Attachments = append(targetItem.Attachments, *targetAttachment)
 	}
-	c.attachments[targetAttachment.ID] = string(fileContents)
+	f.attachments[targetAttachment.ID] = string(fileContents)
 	return nil
 }
 
-func (c fakeClient) SetPassword(itemName string, password []byte) error {
+func (f fakeClient) SetPassword(itemName string, password []byte) error {
 	var targetItem *Item
-	for index, item := range c.items {
+	for index, item := range f.items {
 		if itemName == item.Name {
-			targetItem = &c.items[index]
+			targetItem = &f.items[index]
 			break
 		}
 	}
 	if targetItem == nil {
 		newItemID := getNewUUID()
-		c.items = append(c.items, Item{ID: newItemID, Name: itemName, Type: 1, Login: &Login{Password: string(password)}})
-		targetItem = &c.items[len(c.items)-1]
+		f.items = append(f.items, Item{ID: newItemID, Name: itemName, Type: 1, Login: &Login{Password: string(password)}})
+		targetItem = &f.items[len(f.items)-1]
 	}
 	targetItem.Login.Password = string(password)
 	return nil
 }
 
-func (c fakeClient) UpdateNotesOnItem(itemName, notes string) error {
+func (f fakeClient) UpdateNotesOnItem(itemName, notes string) error {
 	var targetItem *Item
-	for index, item := range c.items {
+	for index, item := range f.items {
 		if itemName == item.Name {
-			targetItem = &c.items[index]
+			targetItem = &f.items[index]
 			break
 		}
 	}
 	if targetItem == nil {
 		newItemID := getNewUUID()
-		c.items = append(c.items, Item{ID: newItemID, Name: itemName, Type: 1, Notes: notes})
-		targetItem = &c.items[len(c.items)-1]
+		f.items = append(f.items, Item{ID: newItemID, Name: itemName, Type: 1, Notes: notes})
+		targetItem = &f.items[len(f.items)-1]
 	}
 	targetItem.Notes = notes
 	return nil
 }
 
-func (c fakeClient) OnCreate(func(*Item) error) {}
+func (f fakeClient) OnCreate(func(*Item) error) {}
 
 // NewFakeClient generates a fake BitWarden client which is supposed to used only for testing
 func NewFakeClient(items []Item, attachments map[string]string) Client {


### PR DESCRIPTION
Previously, when `ci-secret-generator` created a brand new BW record (entire record, not just an item), it did not set the record's organization and it set no collections. I understand that it was basically creating its personal secrets :)

Creating BW records is an internal detail of the BW client (it creates secrets when it is supposed to update an item or attachment on a record that does not exist  yet). I did not want to hardcode these values into the client nor did I want to refactor the client for the creation logic to not be an internal detail, so I decided to implement an `OnCreate` callback that the callsites can use to provide a defaulting logic. I'm not convinced it's the best solution of them all but it is reasoably simple, IMO.

I included a separate commits with some IDE-driven cleanups. If needed, I can remove it.