### PR TITLE
publicize: use default censoring

### DIFF
--- a/cmd/publicize/server.go
+++ b/cmd/publicize/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	prowconfig "k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -49,8 +48,6 @@ type server struct {
 
 	ghc githubClient
 	gc  git.ClientFactory
-
-	secretAgent *secret.Agent
 
 	dry bool
 }
@@ -194,8 +191,7 @@ func (s *server) mergeAndPushToRemote(sourceOrg, sourceRepo, destOrg, destRepo s
 }
 
 func (s *server) createComment(ic github.IssueCommentEvent, message string, logger *logrus.Entry) {
-	censored := s.secretAgent.Censor([]byte(message))
-	if err := s.ghc.CreateComment(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, fmt.Sprintf("@%s: %s", ic.Comment.User.Login, censored)); err != nil {
+	if err := s.ghc.CreateComment(ic.Repo.Owner.Login, ic.Repo.Name, ic.Issue.Number, fmt.Sprintf("@%s: %s", ic.Comment.User.Login, message)); err != nil {
 		logger.WithError(err).Warn("coulnd't create comment")
 	}
 }

--- a/cmd/publicize/server_test.go
+++ b/cmd/publicize/server_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -160,8 +159,7 @@ func TestCheckPrerequisites(t *testing.T) {
 					c.Repositories = tc.repositories
 					return c
 				},
-				secretAgent: &secret.Agent{},
-				dry:         true,
+				dry: true,
 			}
 
 			actualErr := serv.checkPrerequisites(logrus.WithField("id", tc.id), fc.PullRequests[1111], ice)


### PR DESCRIPTION
Prow will, by default, run a censor for all data in the secret agent on
all log lines from logrus as well as all output bytes sent to GitHub.
There's no need to do any of this manually.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @droslean @alvaroaleman 