### PR TITLE
backport-verifier: use correct SHA field

### DIFF
--- a/cmd/backport-verifier/server.go
+++ b/cmd/backport-verifier/server.go
@@ -111,17 +111,17 @@ func (s *server) handle(l *logrus.Entry, org, repo, user string, num int, reques
 	for _, commit := range commits {
 		parts := upstreamPullRe.FindStringSubmatch(commit.Commit.Message)
 		if len(parts) != 2 {
-			invalidCommits[commit.Commit.SHA] = "does not specify an upstream backport in the commit message"
+			invalidCommits[commit.SHA] = "does not specify an upstream backport in the commit message"
 			continue
 		}
 		pr, err := strconv.Atoi(parts[1])
 		if err != nil {
 			// based on the regex this should not happen ...
 			logger.WithError(err).Warn("Failed to parse PR as integer")
-			errorsByCommit[commit.Commit.SHA] = fmt.Sprintf("failed to parse PR identifier: %s", err.Error())
+			errorsByCommit[commit.SHA] = fmt.Sprintf("failed to parse PR identifier: %s", err.Error())
 			continue
 		}
-		upstreamPullsByCommit[commit.Commit.SHA] = pr
+		upstreamPullsByCommit[commit.SHA] = pr
 	}
 
 	for commit, pull := range upstreamPullsByCommit {

--- a/cmd/backport-verifier/server_test.go
+++ b/cmd/backport-verifier/server_test.go
@@ -106,9 +106,9 @@ func TestHandle(t *testing.T) {
 			name:   "valid upstreams",
 			config: Config{Repositories: map[string]string{"org/repo": "upstream/repo"}},
 			commits: []github.RepositoryCommit{
-				{Commit: github.GitCommit{SHA: "123", Message: "UPSTREAM: 1: whoa"}},
-				{Commit: github.GitCommit{SHA: "456", Message: "UPSTREAM: 2: whoa"}},
-				{Commit: github.GitCommit{SHA: "789", Message: "UPSTREAM: 3: whoa"}},
+				{SHA: "123", Commit: github.GitCommit{Message: "UPSTREAM: 1: whoa"}},
+				{SHA: "456", Commit: github.GitCommit{Message: "UPSTREAM: 2: whoa"}},
+				{SHA: "789", Commit: github.GitCommit{Message: "UPSTREAM: 3: whoa"}},
 			},
 			prs: map[orgrepopr]*github.PullRequest{
 				{org: "upstream", repo: "repo", pr: 1}: {Merged: true},
@@ -128,11 +128,11 @@ The following commits are valid:
 			name:   "invalid upstreams",
 			config: Config{Repositories: map[string]string{"org/repo": "upstream/repo"}},
 			commits: []github.RepositoryCommit{
-				{Commit: github.GitCommit{SHA: "123", Message: "UPSTREAM: 1: whoa"}},
-				{Commit: github.GitCommit{SHA: "456", Message: "UPSTREAM: 2: whoa"}},
-				{Commit: github.GitCommit{SHA: "789", Message: "UPSTREAM: 3: whoa"}},
-				{Commit: github.GitCommit{SHA: "abc", Message: "UPSTREAM: <carry>: whoa"}},
-				{Commit: github.GitCommit{SHA: "def", Message: "UPSTREAM: 4: whoa"}},
+				{SHA: "123", Commit: github.GitCommit{Message: "UPSTREAM: 1: whoa"}},
+				{SHA: "456", Commit: github.GitCommit{Message: "UPSTREAM: 2: whoa"}},
+				{SHA: "789", Commit: github.GitCommit{Message: "UPSTREAM: 3: whoa"}},
+				{SHA: "abc", Commit: github.GitCommit{Message: "UPSTREAM: <carry>: whoa"}},
+				{SHA: "def", Commit: github.GitCommit{Message: "UPSTREAM: 4: whoa"}},
 			},
 			prs: map[orgrepopr]*github.PullRequest{
 				{org: "upstream", repo: "repo", pr: 1}: {Merged: true},


### PR DESCRIPTION
Apparently the SHA field in the GitCommit is no longer filled by GitHub
API responses, so we need to use the top-level SHA field. Cool.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part of [DPTP-1842](https://issues.redhat.com/browse/DPTP-1842)