### PR TITLE
ci-operator-prowgen: stop special-casing ci-tools

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -255,9 +255,6 @@ func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secre
 		"--report-username=ci",
 		"--report-password-file=/etc/report/password.txt",
 	}, additionalArgs...)
-	if info.Repo == "ci-tools" {
-		ret.Containers[0].Args = append(ret.Containers[0].Args, "--upload-via-pod-utils")
-	}
 	if customArtifactDir {
 		ret.Containers[0].Args = append(ret.Containers[0].Args, "--upload-via-pod-utils=false")
 	}

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -22,7 +22,6 @@ postsubmits:
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
-        - --upload-via-pod-utils
         command:
         - ci-operator
         image: ci-operator:latest

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -22,7 +22,6 @@ presubmits:
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=[images]
-        - --upload-via-pod-utils
         command:
         - ci-operator
         image: ci-operator:latest
@@ -72,7 +71,6 @@ presubmits:
         - --report-password-file=/etc/report/password.txt
         - --report-username=ci
         - --target=unit
-        - --upload-via-pod-utils
         command:
         - ci-operator
         image: ci-operator:latest


### PR DESCRIPTION
Using pod-utils for artifacts is now the default.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 
part of [DPTP-1819](https://issues.redhat.com/browse/DPTP-1819)
release counterpart:  https://github.com/openshift/release/pull/15378