### PR TITLE
Add osd-ephemeral to cluster_profile list

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -270,7 +270,8 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfilePacket,
 		api.ClusterProfileVSphere,
 		api.ClusterProfileKubevirt,
-		api.ClusterProfileAWSCPaaS:
+		api.ClusterProfileAWSCPaaS,
+		api.ClusterProfileOSDEphemeral:
 		return nil
 	}
 	return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}


### PR DESCRIPTION
Allow osd-ephemeral (https://github.com/openshift/ci-tools/pull/1615) to participate in step registry cluster_profiles.