### PR TITLE
Revert "test-images-distributor: no distribution to api.ci"

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -68,10 +68,6 @@ func AddToManager(mgr manager.Manager,
 
 	buildClusters := sets.String{}
 	for buildClusterName, buildClusterManager := range buildClusterManagers {
-		if buildClusterName == "api.ci" {
-			log.Debug("distribution to api.ci is disabled")
-			continue
-		}
 		buildClusters.Insert(buildClusterName)
 		r.buildClusterClients[buildClusterName] = imagestreamtagwrapper.MustNew(buildClusterManager.GetClient(), buildClusterManager.GetCache())
 	}


### PR DESCRIPTION
This reverts commit 51ad77d68d8d52b6a9f6293b1fc3822dcb2296ad.

Follow up https://github.com/openshift/release/pull/15506

/cc @openshift/openshift-team-developer-productivity-test-platform 