### PR TITLE
backport-verifier: only use the first line of a commit

### DIFF
--- a/cmd/backport-verifier/server.go
+++ b/cmd/backport-verifier/server.go
@@ -110,7 +110,7 @@ func (s *server) handle(l *logrus.Entry, org, repo, user string, num int, reques
 	errorsByCommit := map[string]string{}
 	messagesByCommit := map[string]string{}
 	for _, commit := range commits {
-		messagesByCommit[commit.SHA] = commit.Commit.Message
+		messagesByCommit[commit.SHA] = strings.Split(commit.Commit.Message, "\n")[0]
 		parts := upstreamPullRe.FindStringSubmatch(commit.Commit.Message)
 		if len(parts) != 2 {
 			invalidCommits[commit.SHA] = "does not specify an upstream backport in the commit message"

--- a/cmd/backport-verifier/server_test.go
+++ b/cmd/backport-verifier/server_test.go
@@ -132,7 +132,7 @@ The following commits are valid:
 				{SHA: "456789abc", Commit: github.GitCommit{Message: "UPSTREAM: 2: whoa"}},
 				{SHA: "789abcdef", Commit: github.GitCommit{Message: "UPSTREAM: 3: whoa"}},
 				{SHA: "abcdefghi", Commit: github.GitCommit{Message: "UPSTREAM: <carry>: whoa"}},
-				{SHA: "defghijkl", Commit: github.GitCommit{Message: "UPSTREAM: 4: whoa"}},
+				{SHA: "defghijkl", Commit: github.GitCommit{Message: "UPSTREAM: 4: whoa\nmore\ndata\nto\nbe\nskipped"}},
 			},
 			prs: map[orgrepopr]*github.PullRequest{
 				{org: "upstream", repo: "repo", pr: 1}: {Merged: true},


### PR DESCRIPTION
Turns out the GitHub Git API does not make a distinction between a
commit's title and the full message, so we need to selectively show only
the first line.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @sttts 