### PR TITLE
Allow steps to create roles

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -230,7 +230,7 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 		ObjectMeta: m,
 		Rules: []rbacapi.PolicyRule{{
 			APIGroups: []string{"rbac.authorization.k8s.io"},
-			Resources: []string{"rolebindings"},
+			Resources: []string{"rolebindings", "roles"},
 			Verbs:     []string{"create", "list"},
 		}, {
 			APIGroups:     []string{""},


### PR DESCRIPTION
Allow step serviceaccount to create roles. This will enable a step to,
for example, expose a resource within its namespace to another
serviceaccount.

The first use case is to enable a registry step which allows cluster-bot
to monitor a secrets within a launched cluster namespace and
extract the kubeconfig when a cluster is available. This kubeconfig
is shared back to the slack user who requested the cluster.