### PR TITLE
release: use app.ci URLs for release-controllers

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -12,7 +12,6 @@ const (
 	// ServiceDomain is the domain under which services are
 	// routed for the current service cluster.
 	ServiceDomainCI    = "ci.openshift.org"
-	ServiceDomainAPICI = "svc.ci.openshift.org"
 	ServiceDomainAPPCI = "apps.ci.l2s4.p1.openshiftapps.com"
 
 	ServiceDomainAPICIRegistry = "registry.svc.ci.openshift.org"
@@ -22,13 +21,12 @@ const (
 type Service string
 
 const (
-	ServiceBoskos          Service = "boskos-ci"
-	ServiceRegistry        Service = "registry"
-	ServiceRPMs            Service = "artifacts-rpms-openshift-origin-ci-rpms"
-	ServiceProw            Service = "prow"
-	ServiceConfig          Service = "config"
-	ServiceGCSWeb          Service = "gcsweb-ci"
-	ServiceSecretMirroring Service = "secret-mirroring"
+	ServiceBoskos   Service = "boskos-ci"
+	ServiceRegistry Service = "registry"
+	ServiceRPMs     Service = "artifacts-rpms-openshift-origin-ci-rpms"
+	ServiceProw     Service = "prow"
+	ServiceConfig   Service = "config"
+	ServiceGCSWeb   Service = "gcsweb-ci"
 )
 
 // URLForService returns the URL for the service including scheme

--- a/pkg/release/candidate/client.go
+++ b/pkg/release/candidate/client.go
@@ -13,17 +13,16 @@ import (
 	"github.com/openshift/ci-tools/pkg/release"
 )
 
-func ServiceHost(product api.ReleaseProduct, arch api.ReleaseArchitecture) string {
-	var prefix string
-	switch product {
+func ServiceHost(releaseProduct api.ReleaseProduct, arch api.ReleaseArchitecture) string {
+	var product string
+	switch releaseProduct {
 	case api.ReleaseProductOCP:
-		prefix = "openshift-"
+		product = "ocp"
 	case api.ReleaseProductOKD:
-		prefix = "origin-"
+		product = "origin"
 	}
 
-	postfix := architecture(arch)
-	return fmt.Sprintf("https://%srelease%s.%s/api/v1/releasestream", prefix, postfix, api.ServiceDomainAPICI)
+	return fmt.Sprintf("https://%s.%s.releases.%s/api/v1/releasestream", arch, product, api.ServiceDomainCI)
 }
 
 func architecture(architecture api.ReleaseArchitecture) string {

--- a/pkg/release/candidate/client_test.go
+++ b/pkg/release/candidate/client_test.go
@@ -20,31 +20,24 @@ func TestServiceHost(t *testing.T) {
 		{
 			product:      api.ReleaseProductOKD,
 			architecture: api.ReleaseArchitectureAMD64,
-			output:       "https://origin-release.svc.ci.openshift.org/api/v1/releasestream",
+			output:       "https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream",
 		},
 		{
 
 			product:      api.ReleaseProductOCP,
 			architecture: api.ReleaseArchitectureAMD64,
-			output:       "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream",
+			output:       "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream",
 		},
 		{
-
-			product:      api.ReleaseProductOCP,
-			architecture: api.ReleaseArchitectureAMD64,
-			output:       "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream",
-		},
-		{
-
 			product:      api.ReleaseProductOCP,
 			architecture: api.ReleaseArchitecturePPC64le,
-			output:       "https://openshift-release-ppc64le.svc.ci.openshift.org/api/v1/releasestream",
+			output:       "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream",
 		},
 		{
 
 			product:      api.ReleaseProductOCP,
 			architecture: api.ReleaseArchitectureS390x,
-			output:       "https://openshift-release-s390x.svc.ci.openshift.org/api/v1/releasestream",
+			output:       "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream",
 		},
 	}
 
@@ -67,7 +60,7 @@ func TestEndpoint(t *testing.T) {
 				Stream:       api.ReleaseStreamOKD,
 				Version:      "4.4",
 			},
-			output: "https://origin-release.svc.ci.openshift.org/api/v1/releasestream/4.4.0-0.okd/latest",
+			output: "https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4.4.0-0.okd/latest",
 		},
 		{
 			input: api.Candidate{
@@ -76,7 +69,7 @@ func TestEndpoint(t *testing.T) {
 				Stream:       api.ReleaseStreamCI,
 				Version:      "4.5",
 			},
-			output: "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.5.0-0.ci/latest",
+			output: "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.5.0-0.ci/latest",
 		},
 		{
 			input: api.Candidate{
@@ -85,7 +78,7 @@ func TestEndpoint(t *testing.T) {
 				Stream:       api.ReleaseStreamNightly,
 				Version:      "4.6",
 			},
-			output: "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4.6.0-0.nightly/latest",
+			output: "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.6.0-0.nightly/latest",
 		},
 		{
 			input: api.Candidate{
@@ -94,7 +87,7 @@ func TestEndpoint(t *testing.T) {
 				Stream:       api.ReleaseStreamCI,
 				Version:      "4.7",
 			},
-			output: "https://openshift-release-ppc64le.svc.ci.openshift.org/api/v1/releasestream/4.7.0-0.ci-ppc64le/latest",
+			output: "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream/4.7.0-0.ci-ppc64le/latest",
 		},
 		{
 			input: api.Candidate{
@@ -103,7 +96,7 @@ func TestEndpoint(t *testing.T) {
 				Stream:       api.ReleaseStreamNightly,
 				Version:      "4.8",
 			},
-			output: "https://openshift-release-s390x.svc.ci.openshift.org/api/v1/releasestream/4.8.0-0.nightly-s390x/latest",
+			output: "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4.8.0-0.nightly-s390x/latest",
 		},
 	}
 

--- a/pkg/release/prerelease/client_test.go
+++ b/pkg/release/prerelease/client_test.go
@@ -20,35 +20,28 @@ func TestEndpoint(t *testing.T) {
 				Product:      api.ReleaseProductOKD,
 				Architecture: api.ReleaseArchitectureAMD64,
 			},
-			output: "https://origin-release.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
 		},
 		{
 			input: api.Prerelease{
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitectureAMD64,
 			},
-			output: "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest",
-		},
-		{
-			input: api.Prerelease{
-				Product:      api.ReleaseProductOCP,
-				Architecture: api.ReleaseArchitectureAMD64,
-			},
-			output: "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
 		},
 		{
 			input: api.Prerelease{
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitecturePPC64le,
 			},
-			output: "https://openshift-release-ppc64le.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
 		},
 		{
 			input: api.Prerelease{
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitectureS390x,
 			},
-			output: "https://openshift-release-s390x.svc.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
 		},
 	}
 


### PR DESCRIPTION
This was also a last usage of `svc.ci.openshift.org` except for registry URLs.