### PR TITLE
ci-operator: remove boskos username and password-file flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,8 @@ TMPDIR ?= /tmp
 #   make e2e
 #   make e2e SUITE=multi-stage
 e2e:
-	PACKAGES="./test/e2e/..." TESTFLAGS="$(TESTFLAGS) -tags e2e -timeout 70m -parallel 100" hack/test-go.sh
+	echo -n "u:p" > $(TMPDIR)/boskos-credentials
+	BOSKOS_CREDENTIALS_FILE="$(TMPDIR)/boskos-credentials" PACKAGES="./test/e2e/..." TESTFLAGS="$(TESTFLAGS) -tags e2e -timeout 70m -parallel 100" hack/test-go.sh
 .PHONY: e2e
 
 CLUSTER ?= build01

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -154,8 +154,6 @@ map.
 `
 
 const (
-	// leaseServerUsername is the default lease server username in api.ci
-	leaseServerUsername = "ci"
 	leaseAcquireTimeout = 120 * time.Minute
 
 	// where Prow wants us to put artifacts
@@ -278,8 +276,6 @@ type options struct {
 	clusterConfig              *rest.Config
 	consoleHost                string
 	leaseServer                string
-	leaseServerUsername        string
-	leaseServerPasswordFile    string
 	leaseServerCredentialsFile string
 	leaseAcquireTimeout        time.Duration
 	leaseClient                lease.Client
@@ -325,9 +321,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 
 	// what we will run
 	flag.StringVar(&opt.leaseServer, "lease-server", leaseServerAddress, "Address of the server that manages leases. Required if any test is configured to acquire a lease.")
-	flag.StringVar(&opt.leaseServerUsername, "lease-server-username", leaseServerUsername, "Username used to access the lease server")
-	flag.StringVar(&opt.leaseServerPasswordFile, "lease-server-password-file", "", "The path to password file used to access the lease server")
-	flag.StringVar(&opt.leaseServerCredentialsFile, "lease-server-credentials-file", "", "The path to credentials file used to access the lease server. The content is of the form <username>:<password>. If set, it overrides --lease-server-username and lease-server-password-file")
+	flag.StringVar(&opt.leaseServerCredentialsFile, "lease-server-credentials-file", "", "The path to credentials file used to access the lease server. The content is of the form <username>:<password>.")
 	flag.DurationVar(&opt.leaseAcquireTimeout, "lease-acquire-timeout", leaseAcquireTimeout, "Maximum amount of time to wait for lease acquisition")
 	flag.StringVar(&opt.registryPath, "registry", "", "Path to the step registry directory")
 	flag.StringVar(&opt.configSpecPath, "config", "", "The configuration file. If not specified the CONFIG_SPEC environment variable or the configresolver will be used.")
@@ -571,7 +565,7 @@ func (o *options) Run() []error {
 		log.Printf("Ran for %s", time.Since(start).Truncate(time.Second))
 	}()
 	var leaseClient *lease.Client
-	if o.leaseServer != "" && ((o.leaseServerUsername != "" && o.leaseServerPasswordFile != "") || o.leaseServerCredentialsFile != "") {
+	if o.leaseServer != "" && o.leaseServerCredentialsFile != "" {
 		leaseClient = &o.leaseClient
 	}
 	// load the graph from the configuration
@@ -1380,32 +1374,26 @@ func (o *options) saveNamespaceArtifacts() {
 	}
 }
 
-func loadLeaseCredentials(leaseServerUsername, leaseServerPasswordFile, leaseServerCredentialsFile string) (string, func() []byte, error) {
+func loadLeaseCredentials(leaseServerCredentialsFile string) (string, func() []byte, error) {
 	sa := &secret.Agent{}
-	if leaseServerCredentialsFile != "" {
-		if err := sa.Start([]string{leaseServerCredentialsFile}); err != nil {
-			return "", nil, fmt.Errorf("failed to start secret agent on file %s: %s", leaseServerCredentialsFile, string(sa.Censor([]byte(err.Error()))))
-		}
-		splits := strings.Split(string(sa.GetSecret(leaseServerCredentialsFile)), ":")
-		if len(splits) != 2 {
-			return "", nil, fmt.Errorf("got invalid content of lease server credentials file which must be of the form '<username>:<passwrod>'")
-		}
-		username := splits[0]
-		passwordGetter := func() []byte {
-			return []byte(splits[1])
-		}
-		return username, passwordGetter, nil
+	if err := sa.Start([]string{leaseServerCredentialsFile}); err != nil {
+		return "", nil, fmt.Errorf("failed to start secret agent on file %s: %s", leaseServerCredentialsFile, string(sa.Censor([]byte(err.Error()))))
 	}
-	if err := sa.Start([]string{leaseServerPasswordFile}); err != nil {
-		return "", nil, fmt.Errorf("failed to start secret agent on file %s: %s", leaseServerPasswordFile, string(sa.Censor([]byte(err.Error()))))
+	splits := strings.Split(string(sa.GetSecret(leaseServerCredentialsFile)), ":")
+	if len(splits) != 2 {
+		return "", nil, fmt.Errorf("got invalid content of lease server credentials file which must be of the form '<username>:<passwrod>'")
 	}
-	return leaseServerUsername, sa.GetTokenGenerator(leaseServerPasswordFile), nil
+	username := splits[0]
+	passwordGetter := func() []byte {
+		return []byte(splits[1])
+	}
+	return username, passwordGetter, nil
 }
 
 func (o *options) initializeLeaseClient() error {
 	var err error
 	owner := o.namespace + "-" + o.jobSpec.JobNameHash()
-	username, passwordGetter, err := loadLeaseCredentials(o.leaseServerUsername, o.leaseServerPasswordFile, o.leaseServerCredentialsFile)
+	username, passwordGetter, err := loadLeaseCredentials(o.leaseServerCredentialsFile)
 	if err != nil {
 		return fmt.Errorf("failed to load lease credentials: %w", err)
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -446,11 +446,6 @@ func TestLoadLeaseCredentials(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	leaseServerPasswordFile := filepath.Join(dir, "leaseServerPasswordFile")
-	if err := ioutil.WriteFile(leaseServerPasswordFile, []byte("secret"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
 	leaseServerCredentialsFile := filepath.Join(dir, "leaseServerCredentialsFile")
 	if err := ioutil.WriteFile(leaseServerCredentialsFile, []byte("ci-new:secret-new"), 0644); err != nil {
 		t.Fatal(err)
@@ -463,42 +458,13 @@ func TestLoadLeaseCredentials(t *testing.T) {
 
 	testCases := []struct {
 		name                       string
-		leaseServerUsername        string
-		leaseServerPasswordFile    string
 		leaseServerCredentialsFile string
 		expectedUsername           string
 		passwordGetterVerify       func(func() []byte) error
 		expectedErr                error
 	}{
 		{
-			name:                    "username and password file",
-			leaseServerUsername:     "ci",
-			leaseServerPasswordFile: leaseServerPasswordFile,
-			expectedUsername:        "ci",
-			passwordGetterVerify: func(passwordGetter func() []byte) error {
-				p := string(passwordGetter())
-				if diff := cmp.Diff("secret", p); diff != "" {
-					return fmt.Errorf("actual does not match expected, diff: %s", diff)
-				}
-				return nil
-			},
-		},
-		{
-			name:                       "username and password file and credential file",
-			leaseServerUsername:        "ci",
-			leaseServerPasswordFile:    leaseServerPasswordFile,
-			leaseServerCredentialsFile: leaseServerCredentialsFile,
-			expectedUsername:           "ci-new",
-			passwordGetterVerify: func(passwordGetter func() []byte) error {
-				p := string(passwordGetter())
-				if diff := cmp.Diff("secret-new", p); diff != "" {
-					return fmt.Errorf("actual does not match expected, diff: %s", diff)
-				}
-				return nil
-			},
-		},
-		{
-			name:                       "only credential file",
+			name:                       "valid credential file",
 			leaseServerCredentialsFile: leaseServerCredentialsFile,
 			expectedUsername:           "ci-new",
 			passwordGetterVerify: func(passwordGetter func() []byte) error {
@@ -519,7 +485,7 @@ func TestLoadLeaseCredentials(t *testing.T) {
 	for _, tc := range testCases {
 
 		t.Run(tc.name, func(t *testing.T) {
-			username, passwordGetter, err := loadLeaseCredentials(tc.leaseServerUsername, tc.leaseServerPasswordFile, tc.leaseServerCredentialsFile)
+			username, passwordGetter, err := loadLeaseCredentials(tc.leaseServerCredentialsFile)
 			if diff := cmp.Diff(tc.expectedUsername, username); diff != "" {
 				t.Errorf("actual does not match expected, diff: %s", diff)
 			}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -215,6 +215,10 @@ type BoskosOptions struct {
 // Boskos begins the boskos server and makes sure it is ready to serve
 // before returning the port it is serving on.
 func Boskos(opt BoskosOptions) *Accessory {
+	credentialsFile := os.Getenv("BOSKOS_CREDENTIALS_FILE")
+	if credentialsFile == "" {
+		credentialsFile = "/dev/null"
+	}
 	return &Accessory{
 		command: "boskos",
 		args: flags(map[string]string{
@@ -224,9 +228,9 @@ func Boskos(opt BoskosOptions) *Accessory {
 		}),
 		flags: func(port string) []string {
 			return flags(map[string]string{
-				"lease-server":               "http://127.0.0.1:" + port,
-				"lease-server-password-file": "/dev/null",
-				"lease-acquire-timeout":      "2s",
+				"lease-server":                  "http://127.0.0.1:" + port,
+				"lease-server-credentials-file": credentialsFile,
+				"lease-acquire-timeout":         "2s",
 			})
 		},
 	}


### PR DESCRIPTION
The removed flags are replaced with `--boskos-credentials-file`.

https://issues.redhat.com/browse/DPTP-1913

/hold

require https://github.com/openshift/release/pull/15825

/cc @openshift/openshift-team-developer-productivity-test-platform 