### PR TITLE
ci-secret-bootstrap: process allowed unused records soon enough

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -644,41 +644,39 @@ func getUnusedBWItems(config secretbootstrap.Config, bwClient bitwarden.Client, 
 
 		diffFields := item.fields.Difference(cfgComparableItemsByName[bwName].fields)
 		if diffFields.Len() > 0 {
-			if _, ok := unused[bwName]; !ok {
-				unused[bwName] = &comparable{}
-			}
-
 			if bwAllowUnused.Has(bwName) {
 				l.WithField("fields", strings.Join(diffFields.List(), ",")).Info("Unused fields from item are allowed by arguments")
 				continue
+			}
+
+			if _, ok := unused[bwName]; !ok {
+				unused[bwName] = &comparable{}
 			}
 			unused[bwName].fields = diffFields
 		}
 
 		diffAttachments := item.attachments.Difference(cfgComparableItemsByName[bwName].attachments)
 		if diffAttachments.Len() > 0 {
-			if _, ok := unused[bwName]; !ok {
-				unused[bwName] = &comparable{}
-			}
-
 			if bwAllowUnused.Has(bwName) {
 				l.WithField("attachments", strings.Join(diffAttachments.List(), ",")).Info("Unused attachments from item are allowed by arguments")
 				continue
 			}
 
+			if _, ok := unused[bwName]; !ok {
+				unused[bwName] = &comparable{}
+			}
 			unused[bwName].attachments = diffAttachments
 		}
 
 		if item.hasPassword && !cfgComparableItemsByName[bwName].hasPassword {
-			if _, ok := unused[bwName]; !ok {
-				unused[bwName] = &comparable{}
-			}
-
 			if bwAllowUnused.Has(bwName) {
 				l.Info("Unused password fields from item is allowed by arguments")
 				continue
 			}
 
+			if _, ok := unused[bwName]; !ok {
+				unused[bwName] = &comparable{}
+			}
 			unused[bwName].hasPassword = true
 		}
 	}


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/1677 fixed logging for unused
secrets' individual fields and attachments, but added the "is allowed"
checks too late, after the empty "wrongly unused secrets" (=`comparable`
instances) were already created in the `unused` map, resulting in
spurious errors like these:

```
Unused bw item: 'AWS ci-longlivedcluster-bot' with , Unused bw item: 'build_farm_02_cluster' with ,
...
```

(see
https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-private/logs/periodic-ci-secret-bootstrap/1361269747353653248#1:build-log.txt%3A28
for occurrences)

The diff looks more complicated than the change actually is, the operatios are just reordered, nothing else.

/cc @droslean 