### PR TITLE
configresolver: output log as JSON

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -16,6 +16,7 @@ import (
 	prowConfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/simplifypath"
@@ -202,6 +203,7 @@ func l(fragment string, children ...simplifypath.Node) simplifypath.Node {
 }
 
 func main() {
+	logrusutil.ComponentInit()
 	o, err := gatherOptions()
 	if err != nil {
 		logrus.WithError(err).Fatal("failed go gather options")


### PR DESCRIPTION
Required so that logs are collected and stored in CloudWatch:

https://github.com/openshift/release/blob/master/clusters/app.ci/assets/logging.yaml

Before:

```
INFO[0000] Configs reloaded                              duration=444.131131ms
INFO[0000] Registry reloaded                             duration=48.632878ms
^CINFO[0001] Received signal.                              signal=interrupt
INFO[0001] Server shutting down...
INFO[0001] Interrupt received.
INFO[0001] Server shutting down...
INFO[0001] Server shutting down...
INFO[0001] Server exited.                                error="http: Server closed"
INFO[0001] Server shutting down...
INFO[0001] Server exited.                                error="http: Server closed"
INFO[0001] Server exited.                                error="http: Server closed"
INFO[0001] Server exited.                                error="http: Server closed"
INFO[0001] All workers gracefully terminated, exiting.
```

After:

```
{"component":"ci-operator-configresolver","duration":372742637,"file":"/home/bbguimaraes/src/ci-tools/pkg/load/agents/configAgent.go:211","func":"github.com/openshift/ci-tools/pkg/load/agents.(*configAgent).loadFilenameToConfig","level":"info","msg":"Configs reloaded","severity":"info","time":"2021-02-17T10:31:05Z"}
{"component":"ci-operator-configresolver","duration":40035404,"file":"/home/bbguimaraes/src/ci-tools/pkg/load/agents/registryAgent.go:145","func":"github.com/openshift/ci-tools/pkg/load/agents.(*registryAgent).loadRegistry","level":"info","msg":"Registry reloaded","severity":"info","time":"2021-02-17T10:31:05Z"}
^C{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:63","func":"k8s.io/test-infra/prow/interrupts.handleInterrupt","level":"info","msg":"Received signal.","severity":"info","signal":2,"time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:197","func":"k8s.io/test-infra/prow/interrupts.shutdown.func1","level":"info","msg":"Server shutting down...","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:197","func":"k8s.io/test-infra/prow/interrupts.shutdown.func1","level":"info","msg":"Server shutting down...","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","error":"http: Server closed","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:169","func":"k8s.io/test-infra/prow/interrupts.ListenAndServe.func1","level":"info","msg":"Server exited.","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","error":"http: Server closed","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:169","func":"k8s.io/test-infra/prow/interrupts.ListenAndServe.func1","level":"info","msg":"Server exited.","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:108","func":"k8s.io/test-infra/prow/interrupts.WaitForGracefulShutdown.func1","level":"info","msg":"Interrupt received.","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:197","func":"k8s.io/test-infra/prow/interrupts.shutdown.func1","level":"info","msg":"Server shutting down...","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:197","func":"k8s.io/test-infra/prow/interrupts.shutdown.func1","level":"info","msg":"Server shutting down...","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","error":"http: Server closed","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:169","func":"k8s.io/test-infra/prow/interrupts.ListenAndServe.func1","level":"info","msg":"Server exited.","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","error":"http: Server closed","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:169","func":"k8s.io/test-infra/prow/interrupts.ListenAndServe.func1","level":"info","msg":"Server exited.","severity":"info","time":"2021-02-17T10:31:09Z"}
{"component":"ci-operator-configresolver","file":"/home/bbguimaraes/src/ci-tools/vendor/k8s.io/test-infra/prow/interrupts/interrupts.go:117","func":"k8s.io/test-infra/prow/interrupts.WaitForGracefulShutdown","level":"info","msg":"All workers gracefully terminated, exiting.","severity":"info","time":"2021-02-17T10:31:09Z"}
```