### PR TITLE
blocking-issue-creator: sort branch tokens

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -88,7 +88,7 @@ func main() {
 		}
 
 		var branchTokens []string
-		for branch := range branches {
+		for _, branch := range branches.List() {
 			branchTokens = append(branchTokens, fmt.Sprintf("branch:%s", branch))
 		}
 		title := fmt.Sprintf("Future Release Branches Frozen For Merging | %s", strings.Join(branchTokens, " "))


### PR DESCRIPTION
Avoid this:

openshift-merge-robot changed the title ~Future Release Branches Frozen For Merging | branch:release-4.9 branch:release-4.8~ Future Release Branches Frozen For Merging | branch:release-4.8 branch:release-4.9 9 hours ago
openshift-merge-robot changed the title ~Future Release Branches Frozen For Merging | branch:release-4.8 branch:release-4.9~ Future Release Branches Frozen For Merging | branch:release-4.9 branch:release-4.8 8 hours ago 

 https://github.com/openshift/cluster-capacity/issues/26#event-4345576341