### PR TITLE
blocking-issue-creator: allow using GH proxy

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -22,8 +22,9 @@ import (
 
 type options struct {
 	promotion.FutureOptions
-	username  string
-	tokenPath string
+	username          string
+	tokenPath         string
+	ghGraphqlEndpoint string
 }
 
 func (o *options) Validate() error {
@@ -44,6 +45,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	fs.StringVar(&o.username, "username", "", "Username to use when communicating with GitHub.")
 	fs.StringVar(&o.tokenPath, "token-path", "", "Path to token to use when communicating with GitHub.")
+	fs.StringVar(&o.ghGraphqlEndpoint, "github-graphql-endpoint", "https://api.github.com/graphql", "GH GraphQL endpoint URL")
 	o.Bind(fs)
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("could not parse input")
@@ -61,7 +63,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not read token.")
 	}
-	client := githubql.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(rawToken))})))
+	client := githubql.NewEnterpriseClient(o.ghGraphqlEndpoint, oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(rawToken))})))
 
 	failed := false
 	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {


### PR DESCRIPTION
The tool is recently hitting API abuse limits (https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-openshift-release-merge-blockers/1362446851738963968#1:build-log.txt%3A93), going through the proxy should help.

Unfortunately the client does not seem to have any client throttling nor does it expose the rate limit error in any reasonable way for us to act on.