### PR TITLE
Add DockerfileLiteral option to images

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1215,6 +1215,10 @@ type ProjectDirectoryImageBuildInputs struct {
 	// project to run relative to the context_dir.
 	DockerfilePath string `json:"dockerfile_path,omitempty"`
 
+	// DockerfileLiteral can be used to  provide an inline Dockerfile.
+	// Mutually exclusive with DockerfilePath.
+	DockerfileLiteral *string `json:"dockerfile_literal,omitempty"`
+
 	// Inputs is a map of tag reference name to image input changes
 	// that will populate the build context for the Dockerfile or
 	// alter the input image for a multi-stage build.

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -45,6 +45,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 
 		return handleBuild(ctx, s.buildClient, buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
 			Type:         buildapi.BuildSourceGit,
+			Dockerfile:   s.config.DockerfileLiteral,
 			ContextDir:   s.config.ContextDir,
 			SourceSecret: getSourceSecretFromName(secretName),
 			Git: &buildapi.GitBuildSource{

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -92,8 +92,9 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 	build := buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
-			Type:   buildapi.BuildSourceImage,
-			Images: images,
+			Type:       buildapi.BuildSourceImage,
+			Dockerfile: s.config.DockerfileLiteral,
+			Images:     images,
 		},
 		s.config.DockerfilePath,
 		s.resources,

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -144,6 +144,9 @@ func validateImages(fieldRoot string, input []api.ProjectDirectoryImageBuildStep
 		if image.To == api.PipelineImageStreamTagReferenceIndexImage {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImage))
 		}
+		if image.DockerfileLiteral != nil && (image.ContextDir != "" || image.DockerfilePath != "") {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: dockerfile_literal is mutually exclusive with context_dir and dockerfile_path", fieldRootN))
+		}
 	}
 	return validationErrors
 }

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"k8s.io/utils/diff"
+	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/openshift/ci-tools/pkg/api"
 )
@@ -365,6 +366,32 @@ func TestValidateImages(t *testing.T) {
 			},
 			output: []error{
 				errors.New("images[1]: duplicate image name 'same-thing' (previously seen in images[0])"),
+			},
+		},
+		{
+			name: "Dockerfile literal is mutually exclusive with context_dir",
+			input: []api.ProjectDirectoryImageBuildStepConfiguration{{
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfileLiteral: utilpointer.StringPtr("FROM foo"),
+					ContextDir:        "foo",
+				},
+				To: "amsterdam",
+			}},
+			output: []error{
+				errors.New("images[0]: dockerfile_literal is mutually exclusive with context_dir and dockerfile_path"),
+			},
+		},
+		{
+			name: "Dockerfile literal is mutually exclusive with dockerfile_path",
+			input: []api.ProjectDirectoryImageBuildStepConfiguration{{
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfileLiteral: utilpointer.StringPtr("FROM foo"),
+					DockerfilePath:    "foo",
+				},
+				To: "amsterdam",
+			}},
+			output: []error{
+				errors.New("images[0]: dockerfile_literal is mutually exclusive with context_dir and dockerfile_path"),
 			},
 		},
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -39,6 +39,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # ContextDir is the directory in the project\n" +
 	"        # from which this build should be run.\n" +
 	"        context_dir: ' '\n" +
+	"        # DockerfileLiteral can be used to provide an inline Dockerfile.\n" +
+	"        # Mutually exclusive with DockerfilePath.\n" +
+	"        dockerfile_literal: \"\"\n" +
 	"        # DockerfilePath is the path to a Dockerfile in the\n" +
 	"        # project to run relative to the context_dir.\n" +
 	"        dockerfile_path: ' '\n" +
@@ -75,6 +78,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    - # ContextDir is the directory in the project\n" +
 	"      # from which this build should be run.\n" +
 	"      context_dir: ' '\n" +
+	"      # DockerfileLiteral can be used to provide an inline Dockerfile.\n" +
+	"      # Mutually exclusive with DockerfilePath.\n" +
+	"      dockerfile_literal: \"\"\n" +
 	"      # DockerfilePath is the path to a Dockerfile in the\n" +
 	"      # project to run relative to the context_dir.\n" +
 	"      dockerfile_path: ' '\n" +
@@ -190,6 +196,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # ContextDir is the directory in the project\n" +
 	"        # from which this build should be run.\n" +
 	"        context_dir: ' '\n" +
+	"        # DockerfileLiteral can be used to provide an inline Dockerfile.\n" +
+	"        # Mutually exclusive with DockerfilePath.\n" +
+	"        dockerfile_literal: \"\"\n" +
 	"        # DockerfilePath is the path to a Dockerfile in the\n" +
 	"        # project to run relative to the context_dir.\n" +
 	"        dockerfile_path: ' '\n" +
@@ -217,6 +226,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # ContextDir is the directory in the project\n" +
 	"        # from which this build should be run.\n" +
 	"        context_dir: ' '\n" +
+	"        # DockerfileLiteral can be used to provide an inline Dockerfile.\n" +
+	"        # Mutually exclusive with DockerfilePath.\n" +
+	"        dockerfile_literal: \"\"\n" +
 	"        # DockerfilePath is the path to a Dockerfile in the\n" +
 	"        # project to run relative to the context_dir.\n" +
 	"        dockerfile_path: ' '\n" +


### PR DESCRIPTION
This is very useful for trivial dockerfiles like "copy one thing from a
different image" or "install one package"

/cc @openshift/openshift-team-developer-productivity-test-platform 