### PR TITLE
ci-operator: handle explicit imagestreams in step from

### DIFF
--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -75,6 +75,15 @@ func TestRequires(t *testing.T) {
 			api.InternalImageLink(
 				api.PipelineImageStreamTagReferenceSource),
 		},
+	}, {
+		name: "step needs pipeline image explicitly, should have InternalImageLink",
+		steps: api.MultiStageTestConfigurationLiteral{
+			Test: []api.LiteralTestStep{{From: "pipeline:src"}},
+		},
+		req: []api.StepLink{
+			api.InternalImageLink(
+				api.PipelineImageStreamTagReferenceSource),
+		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			step := MultiStageTestStep(api.TestStepConfiguration{

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -97,6 +97,13 @@ func TestMultiStage(t *testing.T) {
 			success: false,
 			output:  []string{`could not run steps: step best-effort-failure failed`},
 		},
+		{
+			name:    "step name explicitly uses an imagestream name",
+			args:    []string{"--unresolved-config=names.yaml", "--target=os"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output:  []string{`Pod os-test succeeded after`},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/test/e2e/multi-stage/names.yaml
+++ b/test/e2e/multi-stage/names.yaml
@@ -1,0 +1,27 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: '7'
+resources:
+  '*':
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 10m
+tests:
+  - as: os
+    steps:
+      test:
+        - as: test
+          commands: exit 0
+          from: pipeline:os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+
+zz_generated_metadata:
+  branch: master
+  org: test
+  repo: test


### PR DESCRIPTION
This is the same way we process user input references in other fields
like in dependencies, etc, not sure why we were not already doing this
processing for the `from` field.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 
fixes [DPTP-2002](https://issues.redhat.com/browse/DPTP-2002)