### PR TITLE
ci-operator: improve user experience for timeouts

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/repoowners"
 )
 
@@ -618,6 +619,7 @@ type LiteralTestStep struct {
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
 	// ActiveDeadlineSeconds is passed directly through to the step's Pod.
+	// DEPRECATED: set Timeout instead.
 	ActiveDeadlineSeconds *int64 `json:"active_deadline_seconds,omitempty"`
 	// ArtifactDir is the directory from which artifacts will be extracted
 	// when the command finishes. Defaults to "/tmp/artifacts"
@@ -625,7 +627,13 @@ type LiteralTestStep struct {
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources"`
 	// TerminationGracePeriodSeconds is passed directly through to the step's Pod.
+	// DEPRECATED: set GracePeriod instead.
 	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty"`
+	// Timeout is how long the we will wait before aborting a job with SIGINT.
+	Timeout *prowv1.Duration `json:"timeout,omitempty"`
+	// GracePeriod is how long the we will wait after sending SIGINT to send
+	// SIGKILL when aborting a Step.
+	GracePeriod *prowv1.Duration `json:"grace_period,omitempty"`
 	// Credentials defines the credentials we'll mount into this step.
 	Credentials []CredentialReference `json:"credentials,omitempty"`
 	// Environment lists parameters that should be set by the test.

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -12,11 +12,13 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"sigs.k8s.io/yaml"
 
@@ -391,6 +393,12 @@ func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, str
 	err := yaml.UnmarshalStrict(bytes, &step)
 	if err != nil {
 		return "", "", api.LiteralTestStep{}, err
+	}
+	if step.Reference.LiteralTestStep.Timeout == nil && step.Reference.LiteralTestStep.ActiveDeadlineSeconds != nil {
+		step.Reference.LiteralTestStep.Timeout = &prowv1.Duration{Duration: time.Duration(*step.Reference.LiteralTestStep.ActiveDeadlineSeconds) * time.Second}
+	}
+	if step.Reference.LiteralTestStep.GracePeriod == nil && step.Reference.LiteralTestStep.TerminationGracePeriodSeconds != nil {
+		step.Reference.LiteralTestStep.GracePeriod = &prowv1.Duration{Duration: time.Duration(*step.Reference.LiteralTestStep.TerminationGracePeriodSeconds) * time.Second}
 	}
 	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
 		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -384,6 +384,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # Post steps always run, even if previous steps fail.\n" +
 	"            post:\n" +
 	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set Timeout instead.\n" +
 	"                  active_deadline_seconds: 0\n" +
 	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -432,6 +433,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"                  # SIGKILL when aborting a Step.\n" +
+	"                  grace_period: 0s\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -457,10 +461,14 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set GracePeriod instead.\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"            pre:\n" +
 	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set Timeout instead.\n" +
 	"                  active_deadline_seconds: 0\n" +
 	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -509,6 +517,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"                  # SIGKILL when aborting a Step.\n" +
+	"                  grace_period: 0s\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -534,10 +545,14 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set GracePeriod instead.\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
 	"            test:\n" +
 	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set Timeout instead.\n" +
 	"                  active_deadline_seconds: 0\n" +
 	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -586,6 +601,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"                  # SIGKILL when aborting a Step.\n" +
+	"                  grace_period: 0s\n" +
 	"                  # Leases lists resources that should be acquired for the test.\n" +
 	"                  leases:\n" +
 	"                    - # Env is the environment variable that will contain the resource name.\n" +
@@ -611,7 +629,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
 	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"                  # DEPRECATED: set GracePeriod instead.\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"                  timeout: 0s\n" +
 	"        openshift_ansible:\n" +
 	"            cluster_profile: ' '\n" +
 	"        openshift_ansible_custom:\n" +
@@ -716,6 +737,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  grace_period: 0s\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -736,6 +758,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"            pre:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -770,6 +793,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  grace_period: 0s\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -790,6 +814,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
 	"            test:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -824,6 +849,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    name: ' '\n" +
 	"                    namespace: ' '\n" +
 	"                    tag: ' '\n" +
+	"                  grace_period: 0s\n" +
 	"                  leases:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    - env: ' '\n" +
@@ -844,6 +870,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
 	"                  termination_grace_period_seconds: 0\n" +
+	"                  timeout: 0s\n" +
 	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"            # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
 	"            workflow: \"\"\n" +
@@ -992,6 +1019,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # Post steps always run, even if previous steps fail.\n" +
 	"        post:\n" +
 	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set Timeout instead.\n" +
 	"              active_deadline_seconds: 0\n" +
 	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -1040,6 +1068,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"              # SIGKILL when aborting a Step.\n" +
+	"              grace_period: 0s\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1065,10 +1096,14 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set GracePeriod instead.\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"        pre:\n" +
 	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set Timeout instead.\n" +
 	"              active_deadline_seconds: 0\n" +
 	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -1117,6 +1152,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"              # SIGKILL when aborting a Step.\n" +
+	"              grace_period: 0s\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1142,10 +1180,14 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set GracePeriod instead.\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
 	"        test:\n" +
 	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set Timeout instead.\n" +
 	"              active_deadline_seconds: 0\n" +
 	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
@@ -1194,6 +1236,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              # GracePeriod is how long the we will wait after sending SIGINT to send\n" +
+	"              # SIGKILL when aborting a Step.\n" +
+	"              grace_period: 0s\n" +
 	"              # Leases lists resources that should be acquired for the test.\n" +
 	"              leases:\n" +
 	"                - # Env is the environment variable that will contain the resource name.\n" +
@@ -1219,7 +1264,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
 	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
+	"              # DEPRECATED: set GracePeriod instead.\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
+	"              timeout: 0s\n" +
 	"      openshift_ansible:\n" +
 	"        cluster_profile: ' '\n" +
 	"      openshift_ansible_custom:\n" +
@@ -1324,6 +1372,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              grace_period: 0s\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
@@ -1344,6 +1393,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"        pre:\n" +
 	"            # LiteralTestStep is a full test step definition.\n" +
@@ -1378,6 +1428,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              grace_period: 0s\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
@@ -1398,6 +1449,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
 	"        test:\n" +
 	"            # LiteralTestStep is a full test step definition.\n" +
@@ -1432,6 +1484,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                name: ' '\n" +
 	"                namespace: ' '\n" +
 	"                tag: ' '\n" +
+	"              grace_period: 0s\n" +
 	"              leases:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
 	"                - env: ' '\n" +
@@ -1452,6 +1505,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
 	"              termination_grace_period_seconds: 0\n" +
+	"              timeout: 0s\n" +
 	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"        # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
 	"        workflow: \"\"\n" +

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -67,7 +67,11 @@ func TestMultiStage(t *testing.T) {
 			args:    []string{"--unresolved-config=config.yaml", "--target=timeout"},
 			env:     []string{defaultJobSpec},
 			success: false,
-			output:  []string{`"timeout" pod "timeout-timeout" exceeded the configured timeout activeDeadlineSeconds=120`},
+			output: []string{
+				`Process did not finish before 2m0s timeout`,
+				`Process gracefully exited before 10s grace period`,
+				`Container test in pod timeout-timeout failed`,
+			},
 		},
 		{
 			name:    "step with dependencies",

--- a/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
+++ b/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
@@ -3,6 +3,7 @@ ref:
   from: os
   commands: timeout-commands.sh
   active_deadline_seconds: 120
+  termination_grace_period_seconds: 10
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
Today, timeouts and grace periods are in theory possible for test steps
in a multi-stage workflow. However, there are two major drawbacks with
the implementation:

 - pod.spec.activeDeadlineSeconds constrains the "active time" of a Pod
   on a node, which *includes* the time to mount volumes, pull images,
   set up the sandbox, etc. The implication is therefore that a user's
   setting for "timeout" may expire without the process they wish to
   constrain ever even starting. As we allow a 15 minute image pull
   timeout, no setting of active deadline shorter than that is
   guaranteed to be applied sensibly.
 - pod.spec.terminationGracePeriodSeconds constrains the full window
   between the Pod being asked to delete (and getting SIGTERM) and the
   time at which the kubelet sends SIGKILL. Test steps often execute two
   distinct phases during this time: in-process cleanup and post-process
   log and artifact upload. The user is *only* in control of the former,
   but this grace period must be set long enough for both to succeed.
   Users will nto get this right.

Now that we inject the Prow pod-utils into each test step (modulo some
that are actively being removed as we deprecate running without them),
we can use the entrypoint utility to control the timeout and grace
period for steps in a multi-stage workflow. This fixes both of the above
issues.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @wking 