### PR TITLE
ci-operator: show that new timeout fields work

### DIFF
--- a/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
+++ b/test/e2e/multi-stage/registry/timeout/timeout-ref.yaml
@@ -2,8 +2,8 @@ ref:
   as: timeout
   from: os
   commands: timeout-commands.sh
-  active_deadline_seconds: 120
-  termination_grace_period_seconds: 10
+  timeout: 120s
+  grace_period: 10s
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follows up on https://github.com/openshift/ci-tools/pull/1715
 Part of [DPTP-1668](https://issues.redhat.com/browse/DPTP-1668)