### PR TITLE
ci-operator: remove old timing fields

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -618,17 +618,11 @@ type LiteralTestStep struct {
 	FromImage *ImageStreamTagReference `json:"from_image,omitempty"`
 	// Commands is the command(s) that will be run inside the image.
 	Commands string `json:"commands,omitempty"`
-	// ActiveDeadlineSeconds is passed directly through to the step's Pod.
-	// DEPRECATED: set Timeout instead.
-	ActiveDeadlineSeconds *int64 `json:"active_deadline_seconds,omitempty"`
 	// ArtifactDir is the directory from which artifacts will be extracted
 	// when the command finishes. Defaults to "/tmp/artifacts"
 	ArtifactDir string `json:"artifact_dir,omitempty"`
 	// Resources defines the resource requirements for the step.
 	Resources ResourceRequirements `json:"resources"`
-	// TerminationGracePeriodSeconds is passed directly through to the step's Pod.
-	// DEPRECATED: set GracePeriod instead.
-	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty"`
 	// Timeout is how long the we will wait before aborting a job with SIGINT.
 	Timeout *prowv1.Duration `json:"timeout,omitempty"`
 	// GracePeriod is how long the we will wait after sending SIGINT to send

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -12,13 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"sigs.k8s.io/yaml"
 
@@ -393,12 +391,6 @@ func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, str
 	err := yaml.UnmarshalStrict(bytes, &step)
 	if err != nil {
 		return "", "", api.LiteralTestStep{}, err
-	}
-	if step.Reference.LiteralTestStep.Timeout == nil && step.Reference.LiteralTestStep.ActiveDeadlineSeconds != nil {
-		step.Reference.LiteralTestStep.Timeout = &prowv1.Duration{Duration: time.Duration(*step.Reference.LiteralTestStep.ActiveDeadlineSeconds) * time.Second}
-	}
-	if step.Reference.LiteralTestStep.GracePeriod == nil && step.Reference.LiteralTestStep.TerminationGracePeriodSeconds != nil {
-		step.Reference.LiteralTestStep.GracePeriod = &prowv1.Duration{Duration: time.Duration(*step.Reference.LiteralTestStep.TerminationGracePeriodSeconds) * time.Second}
 	}
 	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
 		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -255,17 +255,17 @@ const templateDefinitions = `
   </tr>
   </thead>
   <tbody>
-  {{ if .ActiveDeadlineSeconds }}
+  {{ if .Timeout }}
     <tr>
-      <td>Step timeout<sup>[<a href="https://docs.ci.openshift.org/docs/architecture/timeouts/#step-timeout">?</a>]</sup></td>
-      <td>{{ .ActiveDeadlineSeconds }} seconds</td>
+      <td>Step timeout<sup>[<a href="https://docs.ci.openshift.org/docs/architecture/timeouts/#step-registry-test-process-timeouts">?</a>]</sup></td>
+      <td>{{ .Timeout.String }}</td>
       <td>Limits the execution time of the step.</td>
     </tr>
   {{ end }}
-  {{ if .TerminationGracePeriodSeconds }}
+  {{ if .GracePeriod }}
     <tr>
-      <td>Termination grace period<sup>[<a href="https://docs.ci.openshift.org/docs/architecture/timeouts/#step-timeout">?</a>]</sup></td>
-      <td>{{ .TerminationGracePeriodSeconds }} seconds</td>
+      <td>Termination grace period<sup>[<a href="https://docs.ci.openshift.org/docs/architecture/timeouts/#step-registry-test-process-timeouts">?</a>]</sup></td>
+      <td>{{ .GracePeriod.String }}</td>
       <td>Period of time until SIGKILL signal is sent to the test pod (after SIGTERM signal is sent).</td>
     </tr>
   {{ end }}
@@ -1242,20 +1242,20 @@ func referenceHandler(agent agents.RegistryAgent, w http.ResponseWriter, req *ht
 	}{
 		Reference: api.RegistryReference{
 			LiteralTestStep: api.LiteralTestStep{
-				As:                            name,
-				Commands:                      refs[name].Commands,
-				From:                          refs[name].From,
-				FromImage:                     refs[name].FromImage,
-				Dependencies:                  refs[name].Dependencies,
-				Environment:                   refs[name].Environment,
-				Leases:                        refs[name].Leases,
-				ActiveDeadlineSeconds:         refs[name].ActiveDeadlineSeconds,
-				TerminationGracePeriodSeconds: refs[name].TerminationGracePeriodSeconds,
-				Resources:                     refs[name].Resources,
-				OptionalOnSuccess:             refs[name].OptionalOnSuccess,
-				BestEffort:                    refs[name].BestEffort,
-				ReadonlySharedDir:             refs[name].ReadonlySharedDir,
-				Cli:                           refs[name].Cli,
+				As:                name,
+				Commands:          refs[name].Commands,
+				From:              refs[name].From,
+				FromImage:         refs[name].FromImage,
+				Dependencies:      refs[name].Dependencies,
+				Environment:       refs[name].Environment,
+				Leases:            refs[name].Leases,
+				Timeout:           refs[name].Timeout,
+				GracePeriod:       refs[name].GracePeriod,
+				Resources:         refs[name].Resources,
+				OptionalOnSuccess: refs[name].OptionalOnSuccess,
+				BestEffort:        refs[name].BestEffort,
+				ReadonlySharedDir: refs[name].ReadonlySharedDir,
+				Cli:               refs[name].Cli,
 			},
 			Documentation: docs[name],
 		},

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -383,10 +383,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
 	"            # Post steps always run, even if previous steps fail.\n" +
 	"            post:\n" +
-	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set Timeout instead.\n" +
-	"                  active_deadline_seconds: 0\n" +
-	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"                  artifact_dir: ' '\n" +
 	"                  # As is the name of the LiteralTestStep.\n" +
@@ -460,17 +457,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
-	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set GracePeriod instead.\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"            pre:\n" +
-	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set Timeout instead.\n" +
-	"                  active_deadline_seconds: 0\n" +
-	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"                  artifact_dir: ' '\n" +
 	"                  # As is the name of the LiteralTestStep.\n" +
@@ -544,17 +535,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
-	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set GracePeriod instead.\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
 	"            test:\n" +
-	"                - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set Timeout instead.\n" +
-	"                  active_deadline_seconds: 0\n" +
-	"                  # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"                - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"                  # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"                  artifact_dir: ' '\n" +
 	"                  # As is the name of the LiteralTestStep.\n" +
@@ -628,9 +613,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
-	"                  # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"                  # DEPRECATED: set GracePeriod instead.\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"        openshift_ansible:\n" +
@@ -706,8 +688,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # execution if previous Pre and Test steps passed.\n" +
 	"            post:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
-	"                - active_deadline_seconds: 0\n" +
-	"                  artifact_dir: ' '\n" +
+	"                - artifact_dir: ' '\n" +
 	"                  as: ' '\n" +
 	"                  best_effort: false\n" +
 	"                  # Chain is the name of a step chain reference.\n" +
@@ -757,13 +738,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"            pre:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
-	"                - active_deadline_seconds: 0\n" +
-	"                  artifact_dir: ' '\n" +
+	"                - artifact_dir: ' '\n" +
 	"                  as: ' '\n" +
 	"                  best_effort: false\n" +
 	"                  # Chain is the name of a step chain reference.\n" +
@@ -813,13 +792,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
 	"            test:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
-	"                - active_deadline_seconds: 0\n" +
-	"                  artifact_dir: ' '\n" +
+	"                - artifact_dir: ' '\n" +
 	"                  as: ' '\n" +
 	"                  best_effort: false\n" +
 	"                  # Chain is the name of a step chain reference.\n" +
@@ -869,7 +846,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
-	"                  termination_grace_period_seconds: 0\n" +
 	"                  timeout: 0s\n" +
 	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"            # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
@@ -1018,10 +994,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # Post is the array of test steps run after the tests finish and teardown/deprovision resources.\n" +
 	"        # Post steps always run, even if previous steps fail.\n" +
 	"        post:\n" +
-	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set Timeout instead.\n" +
-	"              active_deadline_seconds: 0\n" +
-	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"              artifact_dir: ' '\n" +
 	"              # As is the name of the LiteralTestStep.\n" +
@@ -1095,17 +1068,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
-	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set GracePeriod instead.\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"        pre:\n" +
-	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set Timeout instead.\n" +
-	"              active_deadline_seconds: 0\n" +
-	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"              artifact_dir: ' '\n" +
 	"              # As is the name of the LiteralTestStep.\n" +
@@ -1179,17 +1146,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
-	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set GracePeriod instead.\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
 	"        test:\n" +
-	"            - # ActiveDeadlineSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set Timeout instead.\n" +
-	"              active_deadline_seconds: 0\n" +
-	"              # ArtifactDir is the directory from which artifacts will be extracted\n" +
+	"            - # ArtifactDir is the directory from which artifacts will be extracted\n" +
 	"              # when the command finishes. Defaults to \"/tmp/artifacts\"\n" +
 	"              artifact_dir: ' '\n" +
 	"              # As is the name of the LiteralTestStep.\n" +
@@ -1263,9 +1224,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
-	"              # TerminationGracePeriodSeconds is passed directly through to the step's Pod.\n" +
-	"              # DEPRECATED: set GracePeriod instead.\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"      openshift_ansible:\n" +
@@ -1341,8 +1299,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # execution if previous Pre and Test steps passed.\n" +
 	"        post:\n" +
 	"            # LiteralTestStep is a full test step definition.\n" +
-	"            - active_deadline_seconds: 0\n" +
-	"              artifact_dir: ' '\n" +
+	"            - artifact_dir: ' '\n" +
 	"              as: ' '\n" +
 	"              best_effort: false\n" +
 	"              # Chain is the name of a step chain reference.\n" +
@@ -1392,13 +1349,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"        pre:\n" +
 	"            # LiteralTestStep is a full test step definition.\n" +
-	"            - active_deadline_seconds: 0\n" +
-	"              artifact_dir: ' '\n" +
+	"            - artifact_dir: ' '\n" +
 	"              as: ' '\n" +
 	"              best_effort: false\n" +
 	"              # Chain is the name of a step chain reference.\n" +
@@ -1448,13 +1403,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
 	"        test:\n" +
 	"            # LiteralTestStep is a full test step definition.\n" +
-	"            - active_deadline_seconds: 0\n" +
-	"              artifact_dir: ' '\n" +
+	"            - artifact_dir: ' '\n" +
 	"              as: ' '\n" +
 	"              best_effort: false\n" +
 	"              # Chain is the name of a step chain reference.\n" +
@@ -1504,7 +1457,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
-	"              termination_grace_period_seconds: 0\n" +
 	"              timeout: 0s\n" +
 	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"        # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +


### PR DESCRIPTION
These are now unused, all users were migrated.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Follows up on https://github.com/openshift/ci-tools/pull/1715
Part of [DPTP-1668](https://issues.redhat.com/browse/DPTP-1668)