### PR TITLE
ci-operator: stop munging bash

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -42,12 +42,7 @@ const (
 	// CliEnv if the env we use to expose the path to the cli
 	CliEnv = "CLI_DIR"
 	// CommandPrefix is the prefix we add to a user's commands
-	CommandPrefix = "#!/bin/bash\n" +
-		"set -eu\n" +
-		// provide a writeable kubeconfig so ppl can for example set a namespace, but do not pass it on to subsequent steps to limit the amount of possible footshooting
-		"if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi\n" +
-		// provide a writeable home so kubectl discovery can be cached
-		"if ! [[ -w ${HOME:-} ]]; then export HOME=/alabama; fi\n"
+	CommandPrefix = "#!/bin/bash\nset -eu\n"
 )
 
 var envForProfile = []string{

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePodReadonly.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePodReadonly.yaml
@@ -23,8 +23,6 @@
       - |-
         #!/bin/bash
         set -eu
-        if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi
-        if ! [[ -w ${HOME:-} ]]; then export HOME=/alabama; fi
         command0
       env:
       - name: BUILD_ID

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -23,8 +23,6 @@
       - |-
         #!/bin/bash
         set -eu
-        if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi
-        if ! [[ -w ${HOME:-} ]]; then export HOME=/alabama; fi
         command0
       command:
       - /tmp/secret-wrapper/secret-wrapper
@@ -140,8 +138,6 @@
       - |-
         #!/bin/bash
         set -eu
-        if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi
-        if ! [[ -w ${HOME:-} ]]; then export HOME=/alabama; fi
         command1
       command:
       - /tmp/secret-wrapper/secret-wrapper
@@ -273,8 +269,6 @@
       - |-
         #!/bin/bash
         set -eu
-        if [[ -e ${KUBECONFIG:-} ]]; then WRITEABLE_KUBECONFIG_LOCATION=$(mktemp) && cp $KUBECONFIG $WRITEABLE_KUBECONFIG_LOCATION && export KUBECONFIG=$WRITEABLE_KUBECONFIG_LOCATION && unset WRITEABLE_KUBECONFIG_LOCATION; fi
-        if ! [[ -w ${HOME:-} ]]; then export HOME=/alabama; fi
         command2
       command:
       - /tmp/secret-wrapper/secret-wrapper


### PR DESCRIPTION
The functions that this bash did for us are now done in the
secret-wrapper utility, so there's no need for this mess.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @alvaroaleman 