### PR TITLE
[DPTP-2014] Refactor blocking-issue-creator to use the prow github client

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -1,19 +1,16 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
-	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config/secret"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
@@ -22,19 +19,17 @@ import (
 
 type options struct {
 	promotion.FutureOptions
-	username  string
-	tokenPath string
+	github prowflagutil.GitHubOptions
+
+	dryRun bool
 }
 
 func (o *options) Validate() error {
 	if err := o.FutureOptions.Validate(); err != nil {
 		return err
 	}
-	if o.username == "" {
-		return errors.New("--username is required")
-	}
-	if o.tokenPath == "" {
-		return errors.New("--token-path is required")
+	if err := o.github.Validate(o.dryRun); err != nil {
+		return err
 	}
 	return nil
 }
@@ -42,9 +37,12 @@ func (o *options) Validate() error {
 func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.username, "username", "", "Username to use when communicating with GitHub.")
-	fs.StringVar(&o.tokenPath, "token-path", "", "Path to token to use when communicating with GitHub.")
-	o.Bind(fs)
+
+	fs.BoolVar(&o.dryRun, "dry-run", false, "Dry run for testing. Uses API tokens but does not mutate.")
+
+	o.github.AddFlags(fs)
+	o.FutureOptions.Bind(fs)
+
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("could not parse input")
 	}
@@ -57,13 +55,24 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
-	rawToken, err := ioutil.ReadFile(o.tokenPath)
-	if err != nil {
-		logrus.WithError(err).Fatal("Could not read token.")
+	secretAgent := &secret.Agent{}
+	if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
+		logrus.WithError(err).Fatal("Error starting secrets agent.")
 	}
-	client := githubql.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(&oauth2.Token{AccessToken: strings.TrimSpace(string(rawToken))})))
+
+	client, err := o.github.GitHubClient(secretAgent, o.dryRun)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error creating github client.")
+	}
+
+	botUser, err := client.BotUser()
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting bot's user.")
+	}
 
 	failed := false
+	client.Throttle(300, 300)
+
 	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := config.LoggerForInfo(*repoInfo)
 
@@ -96,178 +105,62 @@ func main() {
 		body += "\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information."
 		title := fmt.Sprintf("Future Release Branches Frozen For Merging | %s", strings.Join(branchTokens, " "))
 
-		// check to see if there's a blocker issue we already created so we can just edit it
-		var blockerQuery struct {
-			Search struct {
-				Nodes []struct {
-					Issue Issue `graphql:"... on Issue"`
-				}
-			} `graphql:"search(type: ISSUE, first: 10, query: $query)"`
-		}
-		vars := map[string]interface{}{
-			"query": githubql.String(fmt.Sprintf("is:issue state:open label:\"tide/merge-blocker\" repo:%s/%s author:%s", repoInfo.Org, repoInfo.Repo, o.username)),
-		}
-		logger.WithField("query", vars["query"]).Debug("Issuing query.")
-		if err := client.Query(context.Background(), &blockerQuery, vars); err != nil {
+		query := fmt.Sprintf("is:issue state:open label:\"tide/merge-blocker\" repo:%s/%s author:%s", repoInfo.Org, repoInfo.Repo, botUser)
+		sort := "updated"
+		// We will make sure that the first issue in the list will be with the most recent update.
+		ascending := false
+		issues, err := client.FindIssues(query, sort, ascending)
+		if err != nil {
 			logger.WithError(err).Error("Failed to search for open issues.")
 			failed = true
 		}
-		var issues []Issue
-		var numbers []int
-		for _, node := range blockerQuery.Search.Nodes {
-			issues = append(issues, node.Issue)
-			numbers = append(numbers, int(node.Issue.Number))
-		}
-		if len(numbers) > 1 {
-			logger.Warnf("Found more than one merge blocking issue by the bot: %v", numbers)
+
+		if len(issues) > 1 {
+			logger.Warnf("Found more than one merge blocking issue by the bot: %v", len(issues))
 			for _, issue := range issues[1:] {
-				// we need to close this extra issue
-				var closeIssue struct {
-					CloseIssue struct {
-						Issue struct {
-							Number githubql.Int
-						}
-					} `graphql:"closeIssue(input: $input)"`
-				}
-				// this needs to be a named type for the library
-				type CloseIssueInput struct {
-					IssueID githubql.ID `json:"issueId"`
-				}
-				input := CloseIssueInput{
-					IssueID: issue.ID,
-				}
-				if !o.Confirm {
-					logger.Infof("Would close issue %d.", issue.Number)
-					return nil
-				}
-				if err := client.Mutate(context.Background(), &closeIssue, input, nil); err != nil {
+				if err := client.CloseIssue(repoInfo.Org, repoInfo.Repo, issue.Number); err != nil {
 					logger.WithError(err).Error("Failed to close issue.")
 					failed = true
 					return nil
 				}
-				logger.Infof("Closed extra issue %d.", issue.Number)
+				logger.WithField("number", issue.Number).Info("Closed extra issue.")
 			}
 		}
 
 		// we have an existing issue that needs to be up to date
-		if len(issues) != 0 && issues[0].ID != nil {
-			logger = logger.WithField("merge-blocker", numbers[0])
+		if len(issues) != 0 {
+			logger = logger.WithField("merge-blocker", issues[0])
 			existing := issues[0]
-			needsUpdate := string(existing.Title) != title || string(existing.Body) != body
 
+			needsUpdate := existing.Title != title || existing.Body != body
 			if !needsUpdate {
 				logger.Info("Current merge-blocker issue is up to date, no update necessary.")
 				return nil
 			}
 
-			// we need to update the issue
-			var updateIssue struct {
-				UpdateIssue struct {
-					Issue struct {
-						Number githubql.Int
-					}
-				} `graphql:"updateIssue(input: $input)"`
-			}
-			// this needs to be a named type for the library
-			type UpdateIssueInput struct {
-				ID    githubql.ID     `json:"id"`
-				Title githubql.String `json:"title"`
-				Body  githubql.String `json:"body"`
-			}
-			input := UpdateIssueInput{
-				ID:    issues[0].ID,
-				Title: githubql.String(title),
-				Body:  githubql.String(body),
-			}
-			if !o.Confirm {
-				logger.Info("Would update issue.")
-				return nil
-			}
-			if err := client.Mutate(context.Background(), &updateIssue, input, nil); err != nil {
+			toBeUpdated := existing
+			toBeUpdated.Title = title
+			toBeUpdated.Body = body
+
+			if _, err := client.EditIssue(repoInfo.Org, repoInfo.Repo, existing.Number, &toBeUpdated); err != nil {
 				logger.WithError(err).Error("Failed to update issue.")
 				failed = true
 				return nil
 			}
-
-			logger.Infof("Updated issue %d", updateIssue.UpdateIssue.Issue.Number)
+			logger.WithField("number", toBeUpdated.Number).Info("Updated issue")
 		} else {
 			// we need to create a new issue
-
-			// what is the ID of the blocker label?
-			var labelQuery struct {
-				Repository struct {
-					ID    githubql.ID
-					Label struct {
-						ID githubql.ID
-					} `graphql:"label(name:\"tide/merge-blocker\")"`
-				} `graphql:"repository(owner: $owner, name: $name)"`
-			}
-			vars = map[string]interface{}{
-				"owner": githubql.String(repoInfo.Org),
-				"name":  githubql.String(repoInfo.Repo),
-			}
-			if err := client.Query(context.Background(), &labelQuery, vars); err != nil {
-				logger.WithError(err).Error("Failed to search for merge blocker labels.")
-				failed = true
-				return nil
-			}
-			if labelQuery.Repository.Label.ID == nil {
-				logger.Error("Failed to find a merge blocker label.")
-				failed = true
-				return nil
-			}
-
-			var createIssue struct {
-				CreateIssue struct {
-					Issue struct {
-						Number githubql.Int
-					}
-				} `graphql:"createIssue(input: $input)"`
-			}
-			// this needs to be a named type for the library
-			type CreateIssueInput struct {
-				RepositoryID githubql.ID     `json:"repositoryId"`
-				Title        githubql.String `json:"title"`
-				Body         githubql.String `json:"body"`
-				LabelIDs     []githubql.ID   `json:"labelIds"`
-			}
-			input := CreateIssueInput{
-				RepositoryID: labelQuery.Repository.ID,
-				Title:        githubql.String(title),
-				Body:         githubql.String(body),
-				LabelIDs:     []githubql.ID{labelQuery.Repository.Label.ID},
-			}
-
-			if !o.Confirm {
-				logger.Info("Would create issue.")
-				return nil
-			}
-
-			if err := client.Mutate(context.Background(), &createIssue, input, nil); err != nil {
+			issueNumber, err := client.CreateIssue(repoInfo.Org, repoInfo.Repo, title, body, 0, []string{"tide/merge-blocker"}, []string{})
+			if err != nil {
 				logger.WithError(err).Error("Failed to create merge blocker issue.")
 				failed = true
 				return nil
 			}
-
-			logger.Infof("Created issue %d", createIssue.CreateIssue.Issue.Number)
+			logger.WithField("number", issueNumber).Info("Created issue")
 		}
 
 		return nil
 	}); err != nil || failed {
 		logrus.WithError(err).Fatal("Could not publish merge blocking issues.")
-	}
-}
-
-// Issue holds graphql response data about issues
-type Issue struct {
-	ID         githubql.ID
-	Number     githubql.Int
-	Title      githubql.String
-	Body       githubql.String
-	Repository struct {
-		Name  githubql.String
-		Owner struct {
-			Login githubql.String
-		}
 	}
 }

--- a/cmd/blocking-issue-creator/main_test.go
+++ b/cmd/blocking-issue-creator/main_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+)
+
+type fakeGithubClient struct {
+	*fakegithub.FakeClient
+}
+
+func (f fakeGithubClient) FindIssues(query, sortVerb string, asc bool) ([]github.Issue, error) {
+	var issues []github.Issue
+	for _, issue := range f.FakeClient.Issues {
+		issues = append(issues, *issue)
+	}
+	sort.Slice(issues, func(i, j int) bool { return issues[i].ID < issues[j].ID })
+	return issues, nil
+}
+
+func TestManageIssues(t *testing.T) {
+	testCases := []struct {
+		id             string
+		branches       sets.String
+		issues         map[int]*github.Issue
+		repoInfo       *config.Info
+		expectedIssues []github.Issue
+	}{
+		{
+			id:       "all up to date case",
+			branches: sets.NewString([]string{"release-4.9"}...),
+			repoInfo: &config.Info{
+				Metadata: cioperatorapi.Metadata{
+					Org:    "testOrg",
+					Repo:   "testRepo",
+					Branch: "testBranch",
+				},
+			},
+			issues: map[int]*github.Issue{
+				1: {
+					ID:     1,
+					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+			expectedIssues: []github.Issue{
+				{
+					ID:     1,
+					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+		},
+		{
+			id:       "create case",
+			branches: sets.NewString([]string{"release-4.9"}...),
+			repoInfo: &config.Info{
+				Metadata: cioperatorapi.Metadata{
+					Org:    "testOrg",
+					Repo:   "testRepo",
+					Branch: "testBranch",
+				},
+			},
+			issues: map[int]*github.Issue{},
+			expectedIssues: []github.Issue{
+				{
+					ID:     1,
+					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+		},
+		{
+			id:       "update case",
+			branches: sets.NewString([]string{"release-4.9"}...),
+			repoInfo: &config.Info{Metadata: cioperatorapi.Metadata{
+				Org:    "testOrg",
+				Repo:   "testRepo",
+				Branch: "testBranch",
+			},
+			},
+			issues: map[int]*github.Issue{
+				1: {
+					Number: 1,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+			expectedIssues: []github.Issue{
+				{
+					Number: 1,
+					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+		},
+		{
+			id:       "close multiple case",
+			branches: sets.NewString([]string{"release-4.9"}...),
+			repoInfo: &config.Info{Metadata: cioperatorapi.Metadata{
+				Org:    "testOrg",
+				Repo:   "testRepo",
+				Branch: "testBranch",
+			},
+			},
+			issues: map[int]*github.Issue{
+				1: {
+					ID:     1,
+					Number: 1,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+				2: {
+					ID:     2,
+					Number: 2,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+				3: {
+					ID:     3,
+					Number: 3,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+			},
+			expectedIssues: []github.Issue{
+				{
+					ID:     1,
+					Number: 1,
+					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+				},
+				{
+					ID:     2,
+					Number: 2,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+					State:  "closed",
+				},
+				{
+					ID:     3,
+					Number: 3,
+					Title:  "Old Title",
+					Body:   "Old Body",
+					Labels: []github.Label{{Name: "tide/merge-blocker"}},
+					State:  "closed",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			fgh := fakeGithubClient{
+				FakeClient: fakegithub.NewFakeClient(),
+			}
+			fgh.FakeClient.Issues = tc.issues
+
+			if err := manageIssues(fgh, "", tc.repoInfo, tc.branches, logrus.WithField("id", tc.id)); err != nil {
+				t.Fatal(err)
+			}
+
+			openedIssues, _ := fgh.ListOpenIssues(tc.repoInfo.Org, tc.repoInfo.Repo)
+			sort.Slice(openedIssues, func(i, j int) bool { return openedIssues[i].ID < openedIssues[j].ID })
+
+			if diff := cmp.Diff(openedIssues, tc.expectedIssues); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -51,11 +51,9 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.10.0
 	github.com/satori/go.uuid v1.2.0
-	github.com/shurcooL/githubv4 v0.0.0-20191102174205-af46314aec7b
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slack-go/slack v0.7.3
 	github.com/spf13/afero v1.4.1
-	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	google.golang.org/api v0.32.0
 	gopkg.in/fsnotify.v1 v1.4.7

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,7 +461,6 @@ github.com/ryanuber/go-glob
 ## explicit
 github.com/satori/go.uuid
 # github.com/shurcooL/githubv4 v0.0.0-20191102174205-af46314aec7b
-## explicit
 github.com/shurcooL/githubv4
 # github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 github.com/shurcooL/graphql
@@ -564,7 +563,6 @@ golang.org/x/net/idna
 golang.org/x/net/internal/timeseries
 golang.org/x/net/trace
 # golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
-## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal


### PR DESCRIPTION
The old implementation creates flakes like [job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-openshift-release-merge-blockers/1364198484130926592)

This PR refactors the `blocking-issue-creator` tool to use the Prow's GitHub client

follow-up https://github.com/openshift/release/pull/16280


/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>