### PR TITLE
Add / to regex generated by dispatcher

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -278,7 +278,7 @@ func dispatchJobs(ctx context.Context, prowJobConfigDir string, maxConcurrency i
 			switch o := o.(type) {
 			case configResult:
 				if !config.MatchingPathRegEx(o.path) {
-					results[o.cluster] = append(results[o.cluster], fmt.Sprintf(".*%s$", o.filename))
+					results[o.cluster] = append(results[o.cluster], fmt.Sprintf(".*/%s$", o.filename))
 				}
 			case error:
 				errs = append(errs, o)

--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -158,8 +158,8 @@ func TestDispatchJobs(t *testing.T) {
 				"pull-ci-openshift-cluster-etcd-operator-master-unit": 6,
 			},
 			expectedBuildFarm: map[dispatcher.CloudProvider]dispatcher.JobGroups{
-				"aws": {"build01": {Paths: []string{".*ci-tools-presubmits.yaml$"}}},
-				"gcp": {"build02": {Paths: []string{".*cluster-api-provider-gcp-presubmits.yaml$", ".*cluster-etcd-operator-master-presubmits.yaml$", ".*wildfly-operator-presubmits.yaml$"}}},
+				"aws": {"build01": {Paths: []string{".*/ci-tools-presubmits.yaml$"}}},
+				"gcp": {"build02": {Paths: []string{".*/cluster-api-provider-gcp-presubmits.yaml$", ".*/cluster-etcd-operator-master-presubmits.yaml$", ".*/wildfly-operator-presubmits.yaml$"}}},
 			},
 		},
 	}


### PR DESCRIPTION
```
FATA[0020] Failed to check if the config can determinize jobs  error="path ci-operator/jobs/kubevirt/kubevirt-ssp-operator/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml matches more than 1 regex: [.*kubevirt-kubevirt-ssp-operator-master-presubmits.yaml$ .*kubevirt-ssp-operator-master-presubmits.yaml$]"
```

org kubevirt there are 2 repos: `ssp-operator` and `kubevirt-ssp-operator`
https://github.com/openshift/release/tree/master/ci-operator/jobs/kubevirt

Preaction of https://issues.redhat.com/browse/DPTP-1984

/cc @openshift/openshift-team-developer-productivity-test-platform 