### PR TITLE
Check sanitize's config if it can dispatch jobs determinically

### DIFF
--- a/cmd/sanitize-prow-jobs/main_test.go
+++ b/cmd/sanitize-prow-jobs/main_test.go
@@ -22,7 +22,9 @@ func TestDefaultJobConfig(t *testing.T) {
 	}
 
 	config := &dispatcher.Config{Default: "api.ci"}
-	defaultJobConfig(jc, "", config)
+	if err := defaultJobConfig(jc, "", config); err != nil {
+		t.Errorf("failed default job config: %v", err)
+	}
 
 	for k := range jc.PresubmitsStatic {
 		for _, j := range jc.PresubmitsStatic[k] {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -2,16 +2,21 @@ package dispatcher
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/test-infra/prow/config"
 	prowconfig "k8s.io/test-infra/prow/config"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 var (
@@ -21,12 +26,10 @@ var (
 			"api.ci": {
 				Paths: []string{
 					".*-postsubmits.yaml$",
-					".*openshift/release/.*-periodics.yaml$",
 					".*-periodics.yaml$",
 				},
 				PathREs: []*regexp.Regexp{
 					regexp.MustCompile(".*-postsubmits.yaml$"),
-					regexp.MustCompile(".*openshift/release/.*-periodics.yaml$"),
 					regexp.MustCompile(".*-periodics.yaml$"),
 				},
 				Jobs: []string{
@@ -120,12 +123,10 @@ var (
 			"api.ci": {
 				Paths: []string{
 					".*-postsubmits.yaml$",
-					".*openshift/release/.*-periodics.yaml$",
 					".*-periodics.yaml$",
 				},
 				PathREs: []*regexp.Regexp{
 					regexp.MustCompile(".*-postsubmits.yaml$"),
-					regexp.MustCompile(".*openshift/release/.*-periodics.yaml$"),
 					regexp.MustCompile(".*-periodics.yaml$"),
 				},
 				Jobs: []string{
@@ -163,15 +164,15 @@ func TestLoadConfig(t *testing.T) {
 	}{
 		{
 			name:          "file not exist",
-			expectedError: fmt.Errorf("failed to read the config file \"testdata/TestLoadConfig/file_not_exist.yaml\": open testdata/TestLoadConfig/file_not_exist.yaml: no such file or directory"),
+			expectedError: fmt.Errorf("failed to read the config file \"testdata/TestLoadConfig/file_not_exist.yaml\": %w", &os.PathError{Op: "open", Path: "testdata/TestLoadConfig/file_not_exist.yaml", Err: syscall.Errno(0x02)}),
 		},
 		{
 			name:          "invalid yaml",
-			expectedError: fmt.Errorf("failed to unmarshal the config \"invalid yaml format\\n\": error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type dispatcher.Config"),
+			expectedError: fmt.Errorf("failed to unmarshal the config \"invalid yaml format\\n\": %w", fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type dispatcher.Config")),
 		},
 		{
 			name:          "invalid regex",
-			expectedError: fmt.Errorf("[failed to compile regex config.Groups[default].Paths[0] from \"[\": error parsing regexp: missing closing ]: `[`, failed to compile regex config.Groups[default].Paths[1] from \"[0-9]++\": error parsing regexp: invalid nested repetition operator: `++`]"),
+			expectedError: utilerrors.NewAggregate([]error{fmt.Errorf("[failed to compile regex config.Groups[default].Paths[0] from \"[\": error parsing regexp: missing closing ]: `[`, failed to compile regex config.Groups[default].Paths[1] from \"[0-9]++\": error parsing regexp: invalid nested repetition operator: `++`]")}),
 		},
 		{
 			name:     "good config",
@@ -190,22 +191,30 @@ func TestLoadConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := LoadConfig(filepath.Join("testdata", fmt.Sprintf("%s.yaml", t.Name())))
-			if !reflect.DeepEqual(tc.expected, actual) {
-				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expected, actual))
+			if diff := cmp.Diff(tc.expected, actual, EquateRegexp); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
-			equalError(t, tc.expectedError, err)
+			if diff := cmp.Diff(tc.expectedError, err, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
+			}
 		})
 	}
 }
 
+var (
+	EquateRegexp = cmp.Comparer(func(x, y regexp.Regexp) bool {
+		return x.String() == y.String()
+	})
+)
+
 func TestGetClusterForJob(t *testing.T) {
 	testCases := []struct {
-		name string
-
-		config   *Config
-		jobBase  prowconfig.JobBase
-		path     string
-		expected ClusterName
+		name        string
+		config      *Config
+		jobBase     prowconfig.JobBase
+		path        string
+		expected    ClusterName
+		expectedErr error
 	}{
 		{
 			name:     "some job",
@@ -233,12 +242,81 @@ func TestGetClusterForJob(t *testing.T) {
 			jobBase: config.JobBase{Agent: "jenkins", Name: "test_branch_wildfly_images"},
 			path:    "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 		},
+		{
+			//https://github.com/openshift/release/pull/15918
+			name: "error: PR 15918",
+			config: &Config{
+				Default: "api.ci",
+				BuildFarm: map[CloudProvider]JobGroups{
+					CloudAWS: {
+						ClusterBuild01: {
+							PathREs: []*regexp.Regexp{
+								regexp.MustCompile(".*infra-periodics.yaml$"),
+							},
+						},
+					},
+					CloudGCP: {
+						ClusterBuild02: {
+							PathREs: []*regexp.Regexp{
+								regexp.MustCompile(".*/openshift-openshift-azure-infra-periodics.yaml$"),
+							},
+						},
+					},
+				},
+			},
+			jobBase:     config.JobBase{Agent: "kubernetes", Name: "some-job"},
+			path:        "ci-operator/jobs/openshift/openshift-azure/openshift-openshift-azure-infra-periodics.yaml",
+			expectedErr: fmt.Errorf("path ci-operator/jobs/openshift/openshift-azure/openshift-openshift-azure-infra-periodics.yaml matches more than 1 regex: [.*/openshift-openshift-azure-infra-periodics.yaml$ .*infra-periodics.yaml$]"),
+		},
+		{
+			//https://github.com/openshift/ci-tools/pull/1722
+			name: "error: PR 1722",
+			config: &Config{
+				Default: "api.ci",
+				BuildFarm: map[CloudProvider]JobGroups{
+					CloudGCP: {
+						ClusterBuild02: {
+							PathREs: []*regexp.Regexp{
+								regexp.MustCompile(".*kubevirt-kubevirt-ssp-operator-master-presubmits.yaml$"),
+								regexp.MustCompile(".*kubevirt-ssp-operator-master-presubmits.yaml$"),
+							},
+						},
+					},
+				},
+			},
+			jobBase:     config.JobBase{Agent: "kubernetes", Name: "some-job"},
+			path:        "ci-operator/jobs/kubevirt/kubevirt-ssp-operator/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml",
+			expectedErr: fmt.Errorf("path ci-operator/jobs/kubevirt/kubevirt-ssp-operator/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml matches more than 1 regex: [.*kubevirt-kubevirt-ssp-operator-master-presubmits.yaml$ .*kubevirt-ssp-operator-master-presubmits.yaml$]"),
+		},
+		{
+			//https://github.com/openshift/ci-tools/pull/1722
+			name: "fix: PR 1722",
+			config: &Config{
+				Default: "api.ci",
+				BuildFarm: map[CloudProvider]JobGroups{
+					CloudGCP: {
+						ClusterBuild02: {
+							PathREs: []*regexp.Regexp{
+								regexp.MustCompile(".*/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml$"),
+								regexp.MustCompile(".*/kubevirt-ssp-operator-master-presubmits.yaml$"),
+							},
+						},
+					},
+				},
+			},
+			jobBase:  config.JobBase{Agent: "kubernetes", Name: "some-job"},
+			path:     "ci-operator/jobs/kubevirt/kubevirt-ssp-operator/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml",
+			expected: ClusterBuild02,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := tc.config.GetClusterForJob(tc.jobBase, tc.path)
-			if !reflect.DeepEqual(tc.expected, actual) {
-				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expected, actual))
+			actual, actualErr := tc.config.GetClusterForJob(tc.jobBase, tc.path)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
+			}
+			if diff := cmp.Diff(tc.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
 		})
 	}
@@ -246,45 +324,51 @@ func TestGetClusterForJob(t *testing.T) {
 
 func TestDetermineClusterForJob(t *testing.T) {
 	testCases := []struct {
-		name string
-
+		name                   string
 		config                 *Config
 		jobBase                prowconfig.JobBase
 		path                   string
 		expected               ClusterName
 		expectedCanBeRelocated bool
+		expectedErr            error
 	}{
 		{
 			name:     "some job",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "some-job"},
 			path:     "org/repo/some-postsubmits.yaml",
 			expected: "api.ci",
 		},
 		{
 			name:     "job must on build01",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "periodic-build01-upgrade"},
 			expected: "build01",
 		},
 		{
 			name:     "some periodic job in release repo",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "promote-release-openshift-machine-os-content-e2e-aws-4.1"},
 			path:     "ci-operator/jobs/openshift/release/openshift-release-release-4.1-periodics.yaml",
 			expected: "api.ci",
 		},
 		{
 			name:     "some jenkins job",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "jenkins", Name: "test_branch_wildfly_images"},
 			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 			expected: "",
 		},
 		{
 			name:     "some job without agent",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Name: "no-agent-job"},
 			path:     "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 			expected: "api.ci",
 		},
 		{
 			name:                   "some job in build farm",
+			config:                 &configWithBuildFarmWithJobs,
 			jobBase:                config.JobBase{Agent: "kubernetes", Name: "some-build-farm-job"},
 			path:                   "org/repo/some-build-farm-presubmits.yaml",
 			expected:               "build01",
@@ -292,11 +376,13 @@ func TestDetermineClusterForJob(t *testing.T) {
 		},
 		{
 			name:     "Vsphere job",
+			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "yalayala-vsphere"},
 			expected: "vsphere",
 		},
 		{
-			name: "applyconfig job for vsphere",
+			name:   "applyconfig job for vsphere",
+			config: &configWithBuildFarmWithJobs,
 			jobBase: config.JobBase{Agent: "kubernetes", Name: "pull-ci-openshift-release-master-vsphere-dry", Spec: &v1.PodSpec{
 				Containers: []v1.Container{
 					{Image: "registry.svc.ci.openshift.org/ci/applyconfig:latest"},
@@ -309,12 +395,15 @@ func TestDetermineClusterForJob(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, canBeRelocated := configWithBuildFarmWithJobs.DetermineClusterForJob(tc.jobBase, tc.path)
-			if !reflect.DeepEqual(tc.expected, actual) {
-				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expected, actual))
+			actual, canBeRelocated, actualErr := tc.config.DetermineClusterForJob(tc.jobBase, tc.path)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
-			if !reflect.DeepEqual(tc.expectedCanBeRelocated, canBeRelocated) {
-				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expectedCanBeRelocated, canBeRelocated))
+			if diff := cmp.Diff(tc.expectedCanBeRelocated, canBeRelocated); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
+			}
+			if diff := cmp.Diff(tc.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
 		})
 	}
@@ -411,6 +500,45 @@ func TestIsSSHBastionJob(t *testing.T) {
 			actual := isSSHBastionJob(tc.base)
 			if !reflect.DeepEqual(tc.expected, actual) {
 				t.Errorf("%s: actual differs from expected:\n%s", t.Name(), cmp.Diff(tc.expected, actual))
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *Config
+		expected error
+	}{
+		{
+			name: "basic case",
+			config: &Config{
+				Default: "api.ci",
+				BuildFarm: map[CloudProvider]JobGroups{
+					CloudAWS: {
+						ClusterBuild01: {
+							Jobs: []string{"a", "b"},
+						},
+					},
+					CloudGCP: {
+						ClusterBuild02: {
+							Jobs: []string{"c", "b"},
+						},
+					},
+				},
+				Groups: map[ClusterName]Group{ClusterAPICI: {
+					Jobs: []string{"c", "d"},
+				}},
+			},
+			expected: fmt.Errorf("there are job names occurring more than once: [b c]"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.config.Validate()
+			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
 		})
 	}

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config.yaml
@@ -3,7 +3,6 @@ groups:
   "api.ci":
     paths:
       - ".*-postsubmits.yaml$"
-      - ".*openshift/release/.*-periodics.yaml$"
       - ".*-periodics.yaml$"
     jobs:
       - pull-ci-openshift-release-master-build01-dry

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
@@ -3,7 +3,6 @@ groups:
   "api.ci":
     paths:
       - ".*-postsubmits.yaml$"
-      - ".*openshift/release/.*-periodics.yaml$"
       - ".*-periodics.yaml$"
     jobs:
       - pull-ci-openshift-release-master-build01-dry


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-1984

We have 3 places to use the config:
- `sanitize`: read the config as input (run in a presubmit)
- `dispatcher`: read the config as input, query promotheus and then output the config (run in a periodic)
- us: change the config to move jobs

We ensure
- no job name will occur more than once in the config.
- no path of the job yaml matches more than one regex in the config