### PR TITLE
cmd/testgrid-config-generator: All release periodics should appear in testgrid

### DIFF
--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-informing.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-informing.yaml
@@ -27,7 +27,67 @@ dashboards:
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-job-without-informing
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-job-without-informing
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-job-without-release-label
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-job-without-release-label
   name: redhat-openshift-informing
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade
   name: release-openshift-origin-installer-e2e-aws-upgrade
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-job-without-informing
+  name: release-openshift-origin-job-without-informing
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-job-without-release-label
+  name: release-openshift-origin-job-without-release-label


### PR DESCRIPTION
Release periodics are all informing, and testgrid visibility is a key part of TRT automation. Jobs that match the standard pattern should appear in testgrid unless there is a reason. We would never allow a release periodic in the standard set that do not benefit our ability to understand what is in the release. Whether a job is old or new is irrelevant, it's input to our decision processes.

This commit allows the allow list to simply become an override of which dashboard a small set of jobs should appear in. After this change the allow list should be a very, very small set.