### PR TITLE
ci-operator: disallow opting out of pod-utils

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -366,7 +366,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.StringVar(&opt.pullSecretPath, "image-import-pull-secret", "", "A set of dockercfg credentials used to import images for the tag_specification.")
 	flag.StringVar(&opt.pushSecretPath, "image-mirror-push-secret", "", "A set of dockercfg credentials used to mirror images for the promotion.")
 	flag.StringVar(&opt.uploadSecretPath, "gcs-upload-secret", "", "GCS credentials used to upload logs and artifacts.")
-	flag.BoolVar(&opt.uploadViaPodUtils, "upload-via-pod-utils", true, "Use the Prow pod utilities to upload logs and artifacts.")
+	flag.BoolVar(&opt.uploadViaPodUtils, "upload-via-pod-utils", true, "DEPRECATED")
 
 	opt.resultsOptions.Bind(flag)
 	return opt
@@ -565,7 +565,7 @@ func (o *options) Run() []error {
 		leaseClient = &o.leaseClient
 	}
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.uploadViaPodUtils)
+	buildSteps, postSteps, err := defaults.FromConfig(o.configSpec, o.jobSpec, o.templates, o.writeParams, o.artifactDir, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -986,7 +986,7 @@ func TestFromConfig(t *testing.T) {
 			for k, v := range tc.params {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
-			steps, post, err := fromConfig(&tc.config, &jobSpec, tc.templates, tc.paramFiles, "", tc.promote, client, buildClient, templateClient, podClient, leaseClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, false)
+			steps, post, err := fromConfig(&tc.config, &jobSpec, tc.templates, tc.paramFiles, "", tc.promote, client, buildClient, templateClient, podClient, leaseClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -60,7 +60,7 @@ func TestGeneratePodSpec(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, false, tc.additionalArgs...))
+			testhelper.CompareWithFixture(t, generateCiOperatorPodSpec(tc.info, tc.secrets, tc.targets, tc.additionalArgs...))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
@@ -3,7 +3,6 @@ containers:
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-credentials-file=/etc/report/credentials
-  - --upload-via-pod-utils=false
   - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
@@ -3,7 +3,6 @@ containers:
   - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-credentials-file=/etc/report/credentials
-  - --upload-via-pod-utils=false
   - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -366,27 +366,6 @@ func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.
 	return nil
 }
 
-func addArtifacts(pod *coreapi.Pod, artifactDir string) {
-	for i := range pod.Spec.Containers {
-		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, coreapi.VolumeMount{
-			Name:      "artifacts",
-			MountPath: artifactDir,
-		})
-		pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, coreapi.EnvVar{Name: artifactEnv, Value: artifactDir})
-	}
-	addArtifactsContainer(pod)
-}
-
-func addArtifactsContainer(pod *coreapi.Pod) {
-	pod.Spec.Containers = append(pod.Spec.Containers, artifactsContainer())
-	pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
-		Name: "artifacts",
-		VolumeSource: coreapi.VolumeSource{
-			EmptyDir: &coreapi.EmptyDirVolumeSource{},
-		},
-	})
-}
-
 func artifactsContainer() coreapi.Container {
 	return coreapi.Container{
 		Name:  "artifacts",

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -48,6 +49,14 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 				Pulls:   []prowapi.Pull{{Number: 123, SHA: "72532003f9e01e89f455187dd92c275204bc9781"}},
 				BaseRef: "base-ref",
 				BaseSHA: "base-sha",
+			},
+			DecorationConfig: &prowapi.DecorationConfig{
+				Timeout:     &prowapi.Duration{Duration: time.Minute},
+				GracePeriod: &prowapi.Duration{Duration: time.Second},
+				UtilityImages: &prowapi.UtilityImages{
+					Sidecar:    "sidecar",
+					Entrypoint: "entrypoint",
+				},
 			},
 		},
 	}
@@ -228,6 +237,14 @@ func expectedPodStepTemplate() *podStep {
 				BuildID:   "podStep.jobSpec.BuildId",
 				ProwJobID: "podStep.jobSpec.ProwJobID",
 				Type:      "periodic",
+				DecorationConfig: &prowapi.DecorationConfig{
+					Timeout:     &prowapi.Duration{Duration: time.Minute},
+					GracePeriod: &prowapi.Duration{Duration: time.Second},
+					UtilityImages: &prowapi.UtilityImages{
+						Sidecar:    "sidecar",
+						Entrypoint: "entrypoint",
+					},
+				},
 			},
 		},
 		name: "podStep.name",

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -45,13 +45,12 @@ import (
 // inject the images from a known historic release for the purposes of building
 // branches of those releases.
 type assembleReleaseStep struct {
-	config               *api.ReleaseTagConfiguration
-	name                 string
-	resources            api.ResourceConfiguration
-	client               steps.PodClient
-	artifactDir          string
-	jobSpec              *api.JobSpec
-	artifactsViaPodUtils bool
+	config      *api.ReleaseTagConfiguration
+	name        string
+	resources   api.ResourceConfiguration
+	client      steps.PodClient
+	artifactDir string
+	jobSpec     *api.JobSpec
 }
 
 func (s *assembleReleaseStep) Inputs() (api.InputDefinition, error) {
@@ -209,7 +208,6 @@ oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q --name %q
 oc adm release extract --from=%q --to=${ARTIFACT_DIR}/release-payload-%s
 `, s.jobSpec.Namespace(), streamName, cvo, destination, version, destination, s.name),
-		ArtifactsViaPodUtils: s.artifactsViaPodUtils,
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary
@@ -262,14 +260,13 @@ func (s *assembleReleaseStep) Objects() []ctrlruntimeclient.Object {
 // and the operators defined in the release configuration.
 func AssembleReleaseStep(name string, config *api.ReleaseTagConfiguration, resources api.ResourceConfiguration,
 	client steps.PodClient,
-	artifactDir string, jobSpec *api.JobSpec, artifactsViaPodUtils bool) api.Step {
+	artifactDir string, jobSpec *api.JobSpec) api.Step {
 	return &assembleReleaseStep{
-		config:               config,
-		name:                 name,
-		resources:            resources,
-		client:               client,
-		artifactDir:          artifactDir,
-		jobSpec:              jobSpec,
-		artifactsViaPodUtils: artifactsViaPodUtils,
+		config:      config,
+		name:        name,
+		resources:   resources,
+		client:      client,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
 	}
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -50,13 +50,12 @@ type importReleaseStep struct {
 	// pullSpec is the fully-resolved pull spec of the release payload image we are importing
 	pullSpec string
 	// append determines if we wait for other processes to create images first
-	append               bool
-	resources            api.ResourceConfiguration
-	client               steps.PodClient
-	artifactDir          string
-	jobSpec              *api.JobSpec
-	pullSecret           *coreapi.Secret
-	artifactsViaPodUtils bool
+	append      bool
+	resources   api.ResourceConfiguration
+	client      steps.PodClient
+	artifactDir string
+	jobSpec     *api.JobSpec
+	pullSecret  *coreapi.Secret
 }
 
 func (s *importReleaseStep) Inputs() (api.InputDefinition, error) {
@@ -243,11 +242,10 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 			Name: streamName,
 			Tag:  "cli",
 		},
-		ServiceAccountName:   "ci-operator",
-		ArtifactDir:          "/tmp/artifacts",
-		Secrets:              secrets,
-		Commands:             commands,
-		ArtifactsViaPodUtils: s.artifactsViaPodUtils,
+		ServiceAccountName: "ci-operator",
+		ArtifactDir:        "/tmp/artifacts",
+		Secrets:            secrets,
+		Commands:           commands,
 	}
 
 	// set an explicit default for release-latest resources, but allow customization if necessary
@@ -442,16 +440,15 @@ func (s *importReleaseStep) Objects() []ctrlruntimeclient.Object {
 // ImportReleaseStep imports an existing update payload image
 func ImportReleaseStep(name, pullSpec string, append bool, resources api.ResourceConfiguration,
 	client steps.PodClient,
-	artifactDir string, jobSpec *api.JobSpec, pullSecret *coreapi.Secret, artifactsViaPodUtils bool) api.Step {
+	artifactDir string, jobSpec *api.JobSpec, pullSecret *coreapi.Secret) api.Step {
 	return &importReleaseStep{
-		name:                 name,
-		pullSpec:             pullSpec,
-		append:               append,
-		resources:            resources,
-		client:               client,
-		artifactDir:          artifactDir,
-		jobSpec:              jobSpec,
-		pullSecret:           pullSecret,
-		artifactsViaPodUtils: artifactsViaPodUtils,
+		name:        name,
+		pullSpec:    pullSpec,
+		append:      append,
+		resources:   resources,
+		client:      client,
+		artifactDir: artifactDir,
+		jobSpec:     jobSpec,
+		pullSecret:  pullSecret,
 	}
 }

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -18,12 +18,7 @@
   spec:
     containers:
     - args:
-      - /bin/bash
-      - -c
-      - |-
-        #!/bin/bash
-        set -eu
-        command0
+      - /tools/entrypoint
       command:
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
       env:
@@ -34,7 +29,7 @@
       - name: JOB_NAME
         value: job
       - name: JOB_SPEC
-        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"},"decoration_config":{"utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -51,6 +46,10 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
       - name: NAMESPACE
         value: namespace
       - name: JOB_NAME_SAFE
@@ -78,6 +77,10 @@
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
       - mountPath: /alabama
         name: home
       - mountPath: /tmp/entrypoint-wrapper
@@ -86,7 +89,30 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
     initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
     - args:
       - /bin/entrypoint-wrapper
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
@@ -101,7 +127,12 @@
         name: entrypoint-wrapper
     restartPolicy: Never
     serviceAccountName: test
+    terminationGracePeriodSeconds: 18
     volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
     - emptyDir: {}
       name: home
     - emptyDir: {}
@@ -133,12 +164,7 @@
   spec:
     containers:
     - args:
-      - /bin/bash
-      - -c
-      - |-
-        #!/bin/bash
-        set -eu
-        command1
+      - /tools/entrypoint
       command:
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
       env:
@@ -149,7 +175,7 @@
       - name: JOB_NAME
         value: job
       - name: JOB_SPEC
-        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"},"decoration_config":{"utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -166,8 +192,10 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
-        value: /artifact/dir
+        value: /logs/artifacts
       - name: NAMESPACE
         value: namespace
       - name: JOB_NAME_SAFE
@@ -195,8 +223,10 @@
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
-      - mountPath: /artifact/dir
-        name: artifacts
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
       - mountPath: /alabama
         name: home
       - mountPath: /tmp/entrypoint-wrapper
@@ -206,16 +236,29 @@
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
     - command:
-      - /bin/sh
-      - -c
-      - "#!/bin/sh\nset -euo pipefail\ntrap 'kill $(jobs -p); exit 0' TERM\n\ntouch /tmp/done\necho \"Waiting for artifacts to be extracted\"\nwhile true; do\n\tif [[ ! -f /tmp/done ]]; then\n\t\techo \"Artifacts extracted, will terminate after 30s\"\n\t\tsleep 30\n\t\techo \"Exiting\"\n\t\texit 0\n\tfi\n\tsleep 5 & wait\ndone\n"
-      image: quay.io/prometheus/busybox:latest
-      name: artifacts
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      image: sidecar
+      name: sidecar
       resources: {}
       volumeMounts:
-      - mountPath: /tmp/artifacts
-        name: artifacts
+      - mountPath: /logs
+        name: logs
     initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
     - args:
       - /bin/entrypoint-wrapper
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
@@ -230,9 +273,12 @@
         name: entrypoint-wrapper
     restartPolicy: Never
     serviceAccountName: test
+    terminationGracePeriodSeconds: 18
     volumes:
     - emptyDir: {}
-      name: artifacts
+      name: logs
+    - emptyDir: {}
+      name: tools
     - emptyDir: {}
       name: home
     - emptyDir: {}
@@ -264,12 +310,7 @@
   spec:
     containers:
     - args:
-      - /bin/bash
-      - -c
-      - |-
-        #!/bin/bash
-        set -eu
-        command2
+      - /tools/entrypoint
       command:
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
       env:
@@ -280,7 +321,7 @@
       - name: JOB_NAME
         value: job
       - name: JOB_SPEC
-        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"}}'
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base sha"},"decoration_config":{"utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -297,6 +338,10 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
       - name: NAMESPACE
         value: namespace
       - name: JOB_NAME_SAFE
@@ -324,6 +369,10 @@
       resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
       - mountPath: /alabama
         name: home
       - mountPath: /tmp/entrypoint-wrapper
@@ -332,7 +381,30 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
     initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
     - args:
       - /bin/entrypoint-wrapper
       - /tmp/entrypoint-wrapper/entrypoint-wrapper
@@ -347,7 +419,12 @@
         name: entrypoint-wrapper
     restartPolicy: Never
     serviceAccountName: test
+    terminationGracePeriodSeconds: 18
     volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
     - emptyDir: {}
       name: home
     - emptyDir: {}

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -20,12 +20,7 @@ metadata:
 spec:
   containers:
   - command:
-    - /bin/bash
-    - -c
-    - |-
-      #!/bin/bash
-      set -eu
-      launch-tests
+    - /tools/entrypoint
     env:
     - name: BUILD_ID
       value: test-build-id
@@ -34,7 +29,7 @@ spec:
     - name: JOB_NAME
       value: very-cool-prow-job
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]}}'
+      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
     - name: JOB_TYPE
       value: presubmit
     - name: OPENSHIFT_CI
@@ -55,10 +50,48 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
+    - name: ENTRYPOINT_OPTIONS
+      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+    - name: ARTIFACT_DIR
+      value: /logs/artifacts
     image: somename:sometag
     name: StepName
     resources: {}
     terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /logs
+      name: logs
+    - mountPath: /tools
+      name: tools
+  - command:
+    - /sidecar
+    env:
+    - name: JOB_SPEC
+    - name: SIDECAR_OPTIONS
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+    image: sidecar
+    name: sidecar
+    resources: {}
+    volumeMounts:
+    - mountPath: /logs
+      name: logs
+  initContainers:
+  - args:
+    - /entrypoint
+    - /tools/entrypoint
+    command:
+    - /bin/cp
+    image: entrypoint
+    name: place-entrypoint
+    resources: {}
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
   restartPolicy: Never
+  volumes:
+  - emptyDir: {}
+    name: logs
+  - emptyDir: {}
+    name: tools
 status:
   phase: Failed

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -20,12 +20,7 @@ metadata:
 spec:
   containers:
   - command:
-    - /bin/bash
-    - -c
-    - |-
-      #!/bin/bash
-      set -eu
-      launch-tests
+    - /tools/entrypoint
     env:
     - name: BUILD_ID
       value: test-build-id
@@ -34,7 +29,7 @@ spec:
     - name: JOB_NAME
       value: very-cool-prow-job
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]}}'
+      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
     - name: JOB_TYPE
       value: presubmit
     - name: OPENSHIFT_CI
@@ -55,10 +50,48 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
+    - name: ENTRYPOINT_OPTIONS
+      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+    - name: ARTIFACT_DIR
+      value: /logs/artifacts
     image: somename:sometag
     name: StepName
     resources: {}
     terminationMessagePolicy: FallbackToLogsOnError
+    volumeMounts:
+    - mountPath: /logs
+      name: logs
+    - mountPath: /tools
+      name: tools
+  - command:
+    - /sidecar
+    env:
+    - name: JOB_SPEC
+    - name: SIDECAR_OPTIONS
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+    image: sidecar
+    name: sidecar
+    resources: {}
+    volumeMounts:
+    - mountPath: /logs
+      name: logs
+  initContainers:
+  - args:
+    - /entrypoint
+    - /tools/entrypoint
+    command:
+    - /bin/cp
+    image: entrypoint
+    name: place-entrypoint
+    resources: {}
+    volumeMounts:
+    - mountPath: /tools
+      name: tools
   restartPolicy: Never
+  volumes:
+  - emptyDir: {}
+    name: logs
+  - emptyDir: {}
+    name: tools
 status:
   phase: Succeeded

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_no_secret_results_in_no_mounted_secrets.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_no_secret_results_in_no_mounted_secrets.yaml
@@ -1,1 +1,4 @@
-null
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
@@ -1,5 +1,7 @@
-- mountPath: /tmp/artifacts
-  name: artifacts
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /usr/local/secrets
   name: test-secret
   readOnly: true

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
@@ -1,5 +1,7 @@
-- mountPath: /tmp/artifacts
-  name: artifacts
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /usr/test-secrets
   name: test-secret
   readOnly: true

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__secret_name_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_artifacts__secret_name_and_path_results_in_multiple_mounts.yaml
@@ -1,5 +1,7 @@
-- mountPath: /tmp/artifacts
-  name: artifacts
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /usr/local/secrets
   name: test-secret
   readOnly: true

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_memory_backed_volume_gets_a_volume.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_memory_backed_volume_gets_a_volume.yaml
@@ -1,2 +1,6 @@
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /tmp/volume
   name: memory-backed

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
@@ -1,3 +1,7 @@
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /usr/local/secrets
   name: test-secret
   readOnly: true

--- a/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_mountsTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
@@ -1,3 +1,7 @@
+- mountPath: /logs
+  name: logs
+- mountPath: /tools
+  name: tools
 - mountPath: /usr/test-secrets
   name: test-secret
   readOnly: true

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_no_secret_results_in_no_mounted_secrets.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_no_secret_results_in_no_mounted_secrets.yaml
@@ -1,1 +1,4 @@
-null
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_in_multiple_mounts.yaml
@@ -1,5 +1,7 @@
 - emptyDir: {}
-  name: artifacts
+  name: logs
+- emptyDir: {}
+  name: tools
 - name: test-secret
   secret:
     secretName: some-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__multiple_secrets_and_path_results_with_unspecified_mounts.yaml
@@ -1,5 +1,7 @@
 - emptyDir: {}
-  name: artifacts
+  name: logs
+- emptyDir: {}
+  name: tools
 - name: test-secret
   secret:
     secretName: some-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__secret_name_and_path_results_in_multiple_mounts.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_artifacts__secret_name_and_path_results_in_multiple_mounts.yaml
@@ -1,5 +1,7 @@
 - emptyDir: {}
-  name: artifacts
+  name: logs
+- emptyDir: {}
+  name: tools
 - name: test-secret
   secret:
     secretName: some-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_memory_backed_volume_gets_a_volume.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_memory_backed_volume_gets_a_volume.yaml
@@ -1,3 +1,7 @@
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools
 - emptyDir:
     medium: Memory
     sizeLimit: 1Gi

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_and_path_results_in_mounted_secret_with_custom_path.yaml
@@ -1,3 +1,7 @@
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools
 - name: test-secret
   secret:
     secretName: some-secret

--- a/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
+++ b/pkg/steps/testdata/zz_fixture_volumesTestGetPodObjectMounts_with_secret_name_results_in_secret_mounted_with_default_path.yaml
@@ -1,3 +1,7 @@
+- emptyDir: {}
+  name: logs
+- emptyDir: {}
+  name: tools
 - name: test-secret
   secret:
     secretName: some-secret


### PR DESCRIPTION
We already opt everyone in by default and as of yesterday nobody opts
back out, so this should be a no-op.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part 1 of superseding https://github.com/openshift/ci-tools/pull/1731
Part of DPTP-1668
/assign @alvaroaleman @petr-muller @bbguimaraes 