### PR TITLE
ci-operator: stop allowing users to set artifact dir for pods

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -25,7 +25,6 @@ func (config *ReleaseBuildConfiguration) Default() {
 		defLeases(s.Leases)
 	}
 	defTest := func(t *TestStepConfiguration) {
-		defArtifacts(&t.ArtifactDir)
 		if s := t.MultiStageTestConfigurationLiteral; s != nil {
 			defLeases(s.Leases)
 			for i := range s.Pre {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -466,10 +466,6 @@ type TestStepConfiguration struct {
 	// Commands are the shell commands to run in
 	// the repository root to execute tests.
 	Commands string `json:"commands,omitempty"`
-	// ArtifactDir is an optional directory that contains the
-	// artifacts to upload. If unset, this will default to
-	// "/tmp/artifacts".
-	ArtifactDir string `json:"artifact_dir,omitempty"`
 
 	// Secret is an optional secret object which
 	// will be mounted inside the test container.

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1,7 +1,6 @@
 package defaults
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -295,9 +294,6 @@ func stepForTest(
 	inputImages inputImageSet,
 	c *api.TestStepConfiguration,
 ) ([]api.Step, error) {
-	if c.ArtifactDir != "" && c.ArtifactDir != api.DefaultArtifacts {
-		return nil, errors.New("custom artifacts directories are not allowed when uploading via pod-utilities; output artifacts to $ARTIFACT_DIR")
-	}
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		leases := leasesForTest(test)
 		if len(leases) != 0 {

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -199,30 +199,26 @@ build_root:
     namespace: ci
     tag: master
 tests:
-- artifact_dir: /tmp/artifacts
-  as: cmd
+- as: cmd
   commands: TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1
     KUBERNETES_SERVICE_HOST= make test-cmd -k
   container:
     from: bin
     memory_backed_volume:
       size: 4Gi
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST=
     hack/test-go.sh
   container:
     from: src
-- artifact_dir: /tmp/artifacts
-  as: integration
+- as: integration
   commands: GOMAXPROCS=8 TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1
     KUBERNETES_SERVICE_HOST= make test-integration
   container:
     from: bin
     memory_backed_volume:
       size: 4Gi
-- artifact_dir: /tmp/artifacts
-  as: verify
+- as: verify
   commands: ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make
     verify -k
   container:
@@ -425,9 +421,8 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 		"verify":      {Limits: map[string]string{"memory": "12Gi"}, Requests: map[string]string{"cpu": "3", "memory": "8Gi"}},
 	},
 	Tests: []api.TestStepConfiguration{{
-		As:          "cmd",
-		ArtifactDir: "/tmp/artifacts",
-		Commands:    `TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-cmd -k`,
+		As:       "cmd",
+		Commands: `TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-cmd -k`,
 		ContainerTestConfiguration: &api.ContainerTestConfiguration{
 			From: "bin",
 			MemoryBackedVolume: &api.MemoryBackedVolume{
@@ -435,16 +430,14 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 			},
 		},
 	}, {
-		As:          "unit",
-		ArtifactDir: "/tmp/artifacts",
-		Commands:    `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh`,
+		As:       "unit",
+		Commands: `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh`,
 		ContainerTestConfiguration: &api.ContainerTestConfiguration{
 			From: "src",
 		},
 	}, {
-		As:          "integration",
-		ArtifactDir: "/tmp/artifacts",
-		Commands:    `GOMAXPROCS=8 TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-integration`,
+		As:       "integration",
+		Commands: `GOMAXPROCS=8 TMPDIR=/tmp/volume ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make test-integration`,
 		ContainerTestConfiguration: &api.ContainerTestConfiguration{
 			From: "bin",
 			MemoryBackedVolume: &api.MemoryBackedVolume{
@@ -452,9 +445,8 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 			},
 		},
 	}, {
-		As:          "verify",
-		ArtifactDir: "/tmp/artifacts",
-		Commands:    `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make verify -k`,
+		As:       "verify",
+		Commands: `ARTIFACT_DIR=/tmp/artifacts JUNIT_REPORT=1 KUBERNETES_SERVICE_HOST= make verify -k`,
 		ContainerTestConfiguration: &api.ContainerTestConfiguration{
 			From: "bin",
 		},

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -108,9 +108,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftAnsibleClusterTestConfiguration: &ciop.OpenshiftAnsibleClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 				},
@@ -120,9 +119,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftInstallerClusterTestConfiguration: &ciop.OpenshiftInstallerClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "aws"},
 				},
@@ -132,9 +130,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -145,9 +142,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -158,9 +154,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",
@@ -171,9 +166,8 @@ func TestGeneratePodSpecTemplate(t *testing.T) {
 			info:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "organization", Repo: "repo", Branch: "branch"}},
 			release: "origin-v4.0",
 			test: ciop.TestStepConfiguration{
-				As:          "test",
-				Commands:    "commands",
-				ArtifactDir: "/tmp/artifacts",
+				As:       "test",
+				Commands: "commands",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
 					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: "gcp"},
 					From:                     "pipeline:kubevirt-test",

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -44,7 +44,6 @@ type PodStepConfiguration struct {
 	As                 string
 	From               api.ImageStreamTagReference
 	Commands           string
-	ArtifactDir        string
 	ServiceAccountName string
 	Secrets            []*api.Secret
 	MemoryBackedVolume *api.MemoryBackedVolume
@@ -155,7 +154,6 @@ func TestStep(config api.TestStepConfiguration, resources api.ResourceConfigurat
 			As:                 config.As,
 			From:               api.ImageStreamTagReference{Name: api.PipelineImageStream, Tag: string(config.ContainerTestConfiguration.From)},
 			Commands:           config.Commands,
-			ArtifactDir:        config.ArtifactDir,
 			Secrets:            config.Secrets,
 			MemoryBackedVolume: config.ContainerTestConfiguration.MemoryBackedVolume,
 		},

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -30,7 +30,6 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 			As:   "FromName",
 		},
 		Commands:           "launch-tests",
-		ArtifactDir:        artifactDir,
 		ServiceAccountName: "",
 	}
 
@@ -169,7 +168,6 @@ func TestGetPodObjectMounts(t *testing.T) {
 					},
 				}
 				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"
-				expectedPodStepTemplate.config.ArtifactDir = "/tmp/artifacts"
 			},
 		},
 		{
@@ -186,7 +184,6 @@ func TestGetPodObjectMounts(t *testing.T) {
 					},
 				}
 				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"
-				expectedPodStepTemplate.config.ArtifactDir = "/tmp/artifacts"
 			},
 		},
 		{
@@ -201,7 +198,6 @@ func TestGetPodObjectMounts(t *testing.T) {
 					},
 				}
 				expectedPodStepTemplate.artifactDir = "/tmp/artifacts"
-				expectedPodStepTemplate.config.ArtifactDir = "/tmp/artifacts"
 			},
 		},
 		{

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -200,7 +200,6 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 			Tag:  "cli",
 		},
 		ServiceAccountName: "ci-operator",
-		ArtifactDir:        "/tmp/artifacts",
 		Commands: fmt.Sprintf(`
 set -xeuo pipefail
 export HOME=/tmp

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -243,7 +243,6 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 			Tag:  "cli",
 		},
 		ServiceAccountName: "ci-operator",
-		ArtifactDir:        "/tmp/artifacts",
 		Secrets:            secrets,
 		Commands:           commands,
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -314,10 +314,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        from: ' '\n" +
 	"        to: ' '\n" +
 	"      test_step:\n" +
-	"        # ArtifactDir is an optional directory that contains the\n" +
-	"        # artifacts to upload. If unset, this will default to\n" +
-	"        # \"/tmp/artifacts\".\n" +
-	"        artifact_dir: ' '\n" +
 	"        # As is the name of the test.\n" +
 	"        as: ' '\n" +
 	"        # Commands are the shell commands to run in\n" +
@@ -925,11 +921,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"# The images launched as pods but have no explicit access to\n" +
 	"# the cluster they are running on.\n" +
 	"tests:\n" +
-	"    - # ArtifactDir is an optional directory that contains the\n" +
-	"      # artifacts to upload. If unset, this will default to\n" +
-	"      # \"/tmp/artifacts\".\n" +
-	"      artifact_dir: ' '\n" +
-	"      # As is the name of the test.\n" +
+	"    - # As is the name of the test.\n" +
 	"      as: ' '\n" +
 	"      # Commands are the shell commands to run in\n" +
 	"      # the repository root to execute tests.\n" +

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
@@ -29,8 +29,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
@@ -25,8 +25,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -26,8 +26,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -25,8 +25,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
@@ -29,8 +29,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -25,8 +25,7 @@ tag_specification:
   name: origin-v4.0
   namespace: openshift
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
@@ -27,8 +27,7 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
@@ -27,8 +27,7 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
@@ -28,8 +28,7 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
@@ -27,8 +27,7 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
@@ -27,8 +27,7 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
@@ -28,8 +28,7 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
@@ -28,8 +28,7 @@ tag_specification:
   name: "4.5"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
@@ -27,8 +27,7 @@ tag_specification:
   name: "4.6"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -1662,8 +1662,7 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - artifact_dir: /tmp/artifacts
-              as: multistage
+            - as: multistage
               literal_steps:
                 cluster_profile: ""
                 post:
@@ -1828,8 +1827,7 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - artifact_dir: /tmp/artifacts
-              as: multistage5
+            - as: multistage5
               literal_steps:
                 cluster_profile: ""
                 test:
@@ -1956,8 +1954,7 @@
               name: origin-v4.0
               namespace: openshift
             tests:
-            - artifact_dir: /tmp/artifacts
-              as: unit
+            - as: unit
               commands: make unit CHANGED
               container:
                 from: src

--- a/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__nightly-4.7.yaml
+++ b/test/integration/release-job-migrator/expected/ci-operator/openshift/release/openshift-release-master__nightly-4.7.yaml
@@ -25,8 +25,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- artifact_dir: /tmp/artifacts
-  as: e2e-metal-ipi
+- as: e2e-metal-ipi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: packet
@@ -35,8 +34,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OpenShiftSDN
     workflow: baremetalds-e2e
-- artifact_dir: /tmp/artifacts
-  as: e2e-aws-proxy
+- as: e2e-aws-proxy
   cron: 0 0 */2 * *
   steps:
     cluster_profile: aws

--- a/test/integration/release-job-migrator/expected2/ci-operator/openshift/release/openshift-release-master__nightly-4.7.yaml
+++ b/test/integration/release-job-migrator/expected2/ci-operator/openshift/release/openshift-release-master__nightly-4.7.yaml
@@ -25,8 +25,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- artifact_dir: /tmp/artifacts
-  as: e2e-metal-ipi
+- as: e2e-metal-ipi
   cron: 0 0 1 1 *
   steps:
     cluster_profile: packet
@@ -35,8 +34,7 @@ tests:
         IP_STACK=v4
         NETWORK_TYPE=OpenShiftSDN
     workflow: baremetalds-e2e
-- artifact_dir: /tmp/artifacts
-  as: e2e-aws-proxy
+- as: e2e-aws-proxy
   cron: 0 0 */2 * *
   steps:
     cluster_profile: aws

--- a/test/integration/repo-init/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -23,8 +23,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: ARTIFACT_DIR=/tmp/artifacts make test
   container:
     from: src

--- a/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -29,8 +29,7 @@ tag_specification:
   name: "4.3"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: TMPDIR=/tmp/volume GOTEST_FLAGS='-p 8' ARTIFACT_DIR=/tmp/artifacts TIMEOUT=180s JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh
   container:
     from: src

--- a/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -18,8 +18,7 @@ tag_specification:
   name: "4.3"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: make test-unit
   container:
     from: src

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -24,28 +24,23 @@ tag_specification:
   namespace: ocp
 test_binary_build_commands: make test-install
 tests:
-- artifact_dir: /tmp/artifacts
-  as: e2e-aws
+- as: e2e-aws
   steps:
     cluster_profile: aws
     workflow: openshift-e2e-aws
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: unit
   container:
     from: src
-- artifact_dir: /tmp/artifacts
-  as: cmd
+- as: cmd
   commands: make test-cmd
   container:
     from: bin
-- artifact_dir: /tmp/artifacts
-  as: race
+- as: race
   commands: race
   container:
     from: test-bin
-- artifact_dir: /tmp/artifacts
-  as: e2e
+- as: e2e
   steps:
     cluster_profile: aws
     test:

--- a/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/third/org-third-nonstandard.yaml
@@ -19,8 +19,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- artifact_dir: /tmp/artifacts
-  as: e2e
+- as: e2e
   steps:
     cluster_profile: aws
     test:


### PR DESCRIPTION
As can be seen by the validation that was removed in this, it's already
not valid to set this to anything other than the default and the value
is unused.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part 2 of superseding #1731
Part of [DPTP-1668](https://issues.redhat.com/browse/DPTP-1668)
/assign @alvaroaleman @petr-muller @bbguimaraes

Will introduce breaking changes to prowgen since we serialize the default even when it's unset.