### PR TITLE
[DPTP-1969] Implement a more sophisticated way to chooses a subset of jobs when there is a rehearsal limit

### DIFF
--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -4,20 +4,58 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 )
 
+var (
+	SourceTypeLabel string = "pj-rehearse.openshift.io/source-type"
+
+	ChangedPresubmit              SourceType = "changedPresubmit"
+	ChangedPeriodic               SourceType = "changedPeriodic"
+	ChangedCiopConfigs            SourceType = "changedCiopConfigs"
+	ChangedClusterProfiles        SourceType = "changedClusterProfiles"
+	RandomJobsForChangedTemplates SourceType = "randomJobsForChangedTemplates"
+	RandomJobsForChangedRegistry  SourceType = "randomJobsForChangedRegistry"
+	Unknown                       SourceType = "unknownSource"
+)
+
+type SourceType string
+
+func GetSourceType(labels map[string]string) SourceType {
+	sourceType, ok := labels[SourceTypeLabel]
+	if !ok {
+		return Unknown
+	}
+
+	switch sourceType {
+	case "changedPresubmit":
+		return ChangedPresubmit
+	case "changedPeriodic":
+		return ChangedPeriodic
+	case "changedCiopConfigs":
+		return ChangedCiopConfigs
+	case "changedClusterProfiles":
+		return ChangedClusterProfiles
+	case "randomJobsForChangedTemplates":
+		return RandomJobsForChangedTemplates
+	case "randomJobsForChangedRegistry":
+		return RandomJobsForChangedRegistry
+	default:
+		return Unknown
+	}
+}
+
 type Presubmits map[string][]prowconfig.Presubmit
 
 // AddAll adds all jobs from a different instance.
 // The method assumes two jobs with a matching name for the same repository
 // are identical, so if a presubmit with a given name already exists, it
 // is kept as is.
-func (p Presubmits) AddAll(jobs Presubmits) {
+func (p Presubmits) AddAll(jobs Presubmits, sourceType SourceType) {
 	for repo := range jobs {
 		if _, ok := p[repo]; !ok {
 			p[repo] = []prowconfig.Presubmit{}
 		}
 
 		for _, sourceJob := range jobs[repo] {
-			p.Add(repo, sourceJob)
+			p.Add(repo, sourceJob, sourceType)
 		}
 	}
 }
@@ -25,13 +63,20 @@ func (p Presubmits) AddAll(jobs Presubmits) {
 // Add a presubmit for a given repo.
 // The method assumes two jobs with a matching name are identical, so if
 // a presubmit with a given name already exists, it is kept as is.
-func (p Presubmits) Add(repo string, job prowconfig.Presubmit) {
+func (p Presubmits) Add(repo string, job prowconfig.Presubmit, sourceType SourceType) {
 	for _, destJob := range p[repo] {
 		if destJob.Name == job.Name {
 			return
 		}
 	}
 
+	if len(job.Labels) == 0 {
+		job.Labels = make(map[string]string)
+	}
+
+	if _, ok := job.Labels[SourceTypeLabel]; !ok {
+		job.Labels[SourceTypeLabel] = string(sourceType)
+	}
 	p[repo] = append(p[repo], job)
 }
 
@@ -51,6 +96,12 @@ func (p Periodics) AddAll(jobs Periodics) {
 // The method assumes two jobs with a matching name are identical,
 // so if a periodic with a given name already exists, it
 // is overridden.
-func (p Periodics) Add(job prowconfig.Periodic) {
+func (p Periodics) Add(job prowconfig.Periodic, sourceType SourceType) {
+	if len(job.Labels) == 0 {
+		job.Labels = make(map[string]string)
+	}
+	if _, ok := job.Labels[SourceTypeLabel]; !ok {
+		job.Labels[SourceTypeLabel] = string(sourceType)
+	}
 	p[job.Name] = job
 }

--- a/pkg/config/jobs_test.go
+++ b/pkg/config/jobs_test.go
@@ -1,14 +1,16 @@
 package config
 
 import (
-	"reflect"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/util/diff"
+	"github.com/google/go-cmp/cmp"
+
 	prowconfig "k8s.io/test-infra/prow/config"
 )
 
 func TestPresubmitsAddAll(t *testing.T) {
+	allowUnexported := cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Presubmit{})
+
 	testCases := []struct {
 		description string
 		source      Presubmits
@@ -32,7 +34,7 @@ func TestPresubmitsAddAll(t *testing.T) {
 		}},
 		destination: Presubmits{},
 		expected: Presubmits{"org/repo": {
-			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo", Labels: map[string]string{"pj-rehearse.openshift.io/source-type": "changedPresubmit"}}},
 		}},
 	}, {
 		description: "merge different jobs for a single repo, result should have both",
@@ -43,7 +45,7 @@ func TestPresubmitsAddAll(t *testing.T) {
 			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}}}},
 		expected: Presubmits{"org/repo": {
 			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-repo"}},
-			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo"}},
+			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-repo", Labels: map[string]string{"pj-rehearse.openshift.io/source-type": "changedPresubmit"}}},
 		}},
 	}, {
 		description: "merge jobs for different repos, result should have both",
@@ -53,7 +55,7 @@ func TestPresubmitsAddAll(t *testing.T) {
 		destination: Presubmits{"org/destination-repo": {
 			prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-destination-repo"}}}},
 		expected: Presubmits{
-			"org/source-repo":      {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-source-repo"}}},
+			"org/source-repo":      {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "source-job-for-org-source-repo", Labels: map[string]string{"pj-rehearse.openshift.io/source-type": "changedPresubmit"}}}},
 			"org/destination-repo": {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "destination-job-for-org-destination-repo"}}},
 		},
 	}, {
@@ -80,16 +82,18 @@ func TestPresubmitsAddAll(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			tc.destination.AddAll(tc.source)
+			tc.destination.AddAll(tc.source, ChangedPresubmit)
 
-			if !reflect.DeepEqual(tc.destination, tc.expected) {
-				t.Errorf("Presubmits differ from expected after AddAll:\n%s", diff.ObjectDiff(tc.expected, tc.destination))
+			if diff := cmp.Diff(tc.destination, tc.expected, allowUnexported); diff != "" {
+				t.Errorf("Presubmits differ from expected after AddAll:\n%s", diff)
 			}
 		})
 	}
 }
 
 func TestPresubmitsAdd(t *testing.T) {
+	allowUnexported := cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Presubmit{})
+
 	testCases := []struct {
 		description string
 		presubmits  Presubmits
@@ -101,18 +105,64 @@ func TestPresubmitsAdd(t *testing.T) {
 		presubmits:  Presubmits{},
 		repo:        "org/repo",
 		job:         prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "job-for-org-repo"}},
-		expected:    Presubmits{"org/repo": {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "job-for-org-repo"}}}},
+		expected:    Presubmits{"org/repo": {prowconfig.Presubmit{JobBase: prowconfig.JobBase{Name: "job-for-org-repo", Labels: map[string]string{"pj-rehearse.openshift.io/source-type": "changedPresubmit"}}}}},
 	},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			tc.presubmits.Add(tc.repo, tc.job)
+			tc.presubmits.Add(tc.repo, tc.job, ChangedPresubmit)
 
-			if !reflect.DeepEqual(tc.expected, tc.presubmits) {
-				t.Errorf("Presubmits differ from expected after Add:\n%s", diff.ObjectDiff(tc.expected, tc.presubmits))
+			if diff := cmp.Diff(tc.expected, tc.presubmits, allowUnexported); diff != "" {
+				t.Errorf("Presubmits differ from expected after Add:\n%s", diff)
 			}
 		})
 	}
 
+}
+
+func TestGetSourceType(t *testing.T) {
+	testCases := []struct {
+		id       string
+		labels   map[string]string
+		expected SourceType
+	}{
+		{
+			id:       "happy",
+			labels:   map[string]string{SourceTypeLabel: "changedPresubmit"},
+			expected: ChangedPresubmit,
+		},
+		{
+			id: "happy multiple",
+			labels: map[string]string{
+				"another-label":  "another-value",
+				"another-label2": "another-value2",
+				SourceTypeLabel:  "changedPresubmit"},
+			expected: ChangedPresubmit,
+		},
+		{
+			id:       "sad",
+			labels:   map[string]string{},
+			expected: Unknown,
+		},
+		{
+			id: "sad multiple",
+			labels: map[string]string{
+				"another-label":  "another-value",
+				"another-label2": "another-value2",
+			},
+			expected: Unknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+
+			actual := GetSourceType(tc.labels)
+
+			if diff := cmp.Diff(actual, tc.expected); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
 }

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -103,7 +103,7 @@ func GetChangedPresubmits(prowMasterConfig, prowPRConfig *prowconfig.Config, log
 			if len(reasons) > 0 {
 				selectionFields := logrus.Fields{LogRepo: repo, LogJobName: job.Name, LogReasons: strings.Join(reasons, ",")}
 				logger.WithFields(selectionFields).Info(ChosenJob)
-				ret.Add(repo, job)
+				ret.Add(repo, job, config.ChangedPresubmit)
 			}
 		}
 	}
@@ -183,7 +183,7 @@ func GetPresubmitsForCiopConfigs(prowConfig *prowconfig.Config, ciopConfigs conf
 
 			selectionFields := logrus.Fields{LogRepo: orgRepo, LogJobName: job.Name, LogReasons: "ci-operator config changed"}
 			logger.WithFields(selectionFields).Info(ChosenJob)
-			ret.Add(orgRepo, job)
+			ret.Add(orgRepo, job, config.ChangedCiopConfigs)
 		}
 	}
 
@@ -223,7 +223,7 @@ func GetPresubmitsForClusterProfiles(prowConfig *prowconfig.Config, profiles set
 			if matches(&job) {
 				selectionFields := logrus.Fields{LogRepo: repo, LogJobName: job.Name, LogReasons: "cluster profile changed"}
 				logger.WithFields(selectionFields).Info(ChosenJob)
-				ret.Add(repo, job)
+				ret.Add(repo, job, config.ChangedClusterProfiles)
 			}
 		}
 	}
@@ -263,7 +263,7 @@ func GetChangedPeriodics(prowMasterConfig, prowPRConfig *prowconfig.Config, logg
 		if len(reasons) > 0 {
 			selectionFields := logrus.Fields{LogJobName: name, LogReasons: reasons}
 			logger.WithFields(selectionFields).Info(ChosenJob)
-			changed.Add(job)
+			changed.Add(job, config.ChangedPeriodic)
 		}
 	}
 

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -188,6 +188,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 				Agent:   "kubernetes",
 				Cluster: "api.ci",
 				Name:    "test-base-presubmit",
+				Labels:  map[string]string{"pj-rehearse.openshift.io/source-type": "changedPresubmit"},
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{{
 						Command: []string{"ci-operator"},
@@ -417,8 +418,9 @@ func TestGetPresubmitsForCiopConfigs(t *testing.T) {
 			Branches: []string{baseCiopConfig.Branch},
 		},
 		JobBase: prowconfig.JobBase{
-			Name:  baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "test"),
-			Agent: string(pjapi.KubernetesAgent),
+			Name:   baseCiopConfig.JobName(jobconfig.PresubmitPrefix, "test"),
+			Labels: map[string]string{"pj-rehearse.openshift.io/source-type": "changedCiopConfigs"},
+			Agent:  string(pjapi.KubernetesAgent),
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Env: []v1.EnvVar{{
@@ -813,6 +815,7 @@ func TestGetChangedPeriodics(t *testing.T) {
 			JobBase: prowconfig.JobBase{
 				Agent:   "kubernetes",
 				Cluster: "api.ci",
+				Labels:  map[string]string{"pj-rehearse.openshift.io/source-type": "changedPeriodic"},
 				Name:    "test-base-periodic",
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{{

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -179,7 +179,7 @@ func filterPresubmits(changedPresubmits map[string][]prowconfig.Presubmit, logge
 				continue
 			}
 
-			presubmits.Add(repo, job)
+			presubmits.Add(repo, job, config.GetSourceType(job.Labels))
 		}
 	}
 	return presubmits

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -153,6 +153,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-e2e
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -283,6 +284,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-no-ciop
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -355,6 +357,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-periodic-with-unresolved
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -492,6 +495,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-periodic-with-unresolved
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -676,6 +680,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedCiopConfigs
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-custom
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -788,6 +793,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedCiopConfigs
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -893,6 +899,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedClusterProfiles
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-cluster-profile-test-profile
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1021,6 +1028,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-cmd
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1126,6 +1134,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-e2e-aws
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1254,6 +1263,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-integration
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1359,6 +1369,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-cmd
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1464,6 +1475,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-e2e-aws
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1593,6 +1605,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: randomJobsForChangedRegistry
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1758,6 +1771,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPresubmit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage5
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"
@@ -1886,6 +1900,7 @@
       ci.openshift.org/rehearse: "1234"
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedCiopConfigs
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-unit
       prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "1234"


### PR DESCRIPTION
Currently, the design of the tool is really fragile when picking all the presubmits to rehearse. In the effort of avoiding bad refactoring, this PR introduces a new label `pj-rehearse.openshift.io/source-type` that is injected in all rehearsals, and based on its value the tool will sophisticated choose a subset of the jobs to be rehearsed when the jobs are more than the rehearsal limit. 

Pros: We can use this label to gather Prometheus metrics from the rehearsals and create grafana dashboard to have a clear picture of which changes are triggering rehearsals. 

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>