### PR TITLE
make: update location of kubeconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,12 +168,12 @@ CLUSTER ?= build01
 
 # Dependencies required to execute the E2E tests outside of the CI environment.
 local-e2e: \
-	$(TMPDIR)/.kubeconfig \
+	$(TMPDIR)/.ci-operator-kubeconfig \
 	$(TMPDIR)/local-secret/.dockerconfigjson \
 	$(TMPDIR)/remote-secret/.dockerconfigjson \
 	$(TMPDIR)/gcs/service-account.json \
 	$(TMPDIR)/boskos
-	$(eval export KUBECONFIG=$(TMPDIR)/.kubeconfig)
+	$(eval export KUBECONFIG=$(TMPDIR)/.ci-operator-kubeconfig)
 	$(eval export LOCAL_REGISTRY_SECRET_DIR=$(TMPDIR)/local-secret)
 	$(eval export REMOTE_REGISTRY_SECRET_DIR=$(TMPDIR)/remote-secret)
 	$(eval export GCS_CREDENTIALS_FILE=$(TMPDIR)/gcs/service-account.json)
@@ -236,8 +236,8 @@ validate-registry-metadata:
 	test -z "$$(git status -s ./test/multistage-registry/registry | grep registry)"
 .PHONY: validate-registry-metadata
 
-$(TMPDIR)/.kubeconfig:
-	oc --context $(CLUSTER) --as system:admin --namespace ci serviceaccounts create-kubeconfig ci-operator > $(TMPDIR)/.kubeconfig
+$(TMPDIR)/.ci-operator-kubeconfig:
+	oc --context $(CLUSTER) --as system:admin --namespace ci serviceaccounts create-kubeconfig ci-operator > $(TMPDIR)/.ci-operator-kubeconfig
 
 $(TMPDIR)/local-secret/.dockerconfigjson:
 	mkdir -p $(TMPDIR)/local-secret


### PR DESCRIPTION
Some integration test or something clobbers the data in
`/tmp/.kubeconfig` which is irritating.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>