### PR TITLE
steps: run scripts with /bin/sh

### DIFF
--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -47,7 +47,7 @@
       - name: REPO_OWNER
         value: org
       - name: ENTRYPOINT_OPTIONS
-        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/sh","-c","echo Y29tbWFuZDA= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
         value: /logs/artifacts
       - name: NAMESPACE
@@ -94,7 +94,7 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/sh","-c","echo Y29tbWFuZDA= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
       image: sidecar
       name: sidecar
       resources: {}
@@ -193,7 +193,7 @@
       - name: REPO_OWNER
         value: org
       - name: ENTRYPOINT_OPTIONS
-        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/sh","-c","echo Y29tbWFuZDE= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
         value: /logs/artifacts
       - name: NAMESPACE
@@ -240,7 +240,7 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/sh","-c","echo Y29tbWFuZDE= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
       image: sidecar
       name: sidecar
       resources: {}
@@ -339,7 +339,7 @@
       - name: REPO_OWNER
         value: org
       - name: ENTRYPOINT_OPTIONS
-        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+        value: '{"timeout":0,"grace_period":0,"artifact_dir":"/logs/artifacts","args":["/bin/sh","-c","echo Y29tbWFuZDI= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
         value: /logs/artifacts
       - name: NAMESPACE
@@ -386,7 +386,7 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/sh","-c","echo Y29tbWFuZDI= | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
       image: sidecar
       name: sidecar
       resources: {}

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -51,7 +51,7 @@ spec:
     - name: REPO_OWNER
       value: org
     - name: ENTRYPOINT_OPTIONS
-      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/sh","-c","echo bGF1bmNoLXRlc3Rz | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
     - name: ARTIFACT_DIR
       value: /logs/artifacts
     image: somename:sometag
@@ -68,7 +68,7 @@ spec:
     env:
     - name: JOB_SPEC
     - name: SIDECAR_OPTIONS
-      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/sh","-c","echo bGF1bmNoLXRlc3Rz | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
     image: sidecar
     name: sidecar
     resources: {}

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -51,7 +51,7 @@ spec:
     - name: REPO_OWNER
       value: org
     - name: ENTRYPOINT_OPTIONS
-      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/sh","-c","echo bGF1bmNoLXRlc3Rz | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
     - name: ARTIFACT_DIR
       value: /logs/artifacts
     image: somename:sometag
@@ -68,7 +68,7 @@ spec:
     env:
     - name: JOB_SPEC
     - name: SIDECAR_OPTIONS
-      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/StepName","dry_run":false},"entries":[{"args":["/bin/sh","-c","echo bGF1bmNoLXRlc3Rz | base64 -d \u003e ci-operator-script.sh; chmod +x ci-operator-script.sh; ./ci-operator-script.sh"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
     image: sidecar
     name: sidecar
     resources: {}


### PR DESCRIPTION
The current method of running commands in either container or multistage
tests is essentially by running `/bin/bash -c ""#!/bin/bash\nset
-eu\nCommandProvidedByUser"`, where `CommandProvidedByUser` is command
that the user specified in their container or multistage test step's
command field. This has 2 problems:
- Requires `bash`. I am not sure if this has been complained about
  before, but ci-tools has. Specifically, ci-tools has not been able to
  test whether the index images generated for operators are generated
  correctly. Since the opm image used to serve the index is an alpine
  based image, there is no bash, only busybox (available at `/bin/sh`).
  This means the only testing our e2e can currently do is check whether
  the build step for the index succeeded or failed. Allowing a test to run
  in the generated index wouls allow us to check the contents of the index
  as well.
- It does not allow a user to specify their own shell. We currently have
  users set the shebang for their scripts in the step registry. However,
  this has no effect. This is because the shebang is completely ignored by
  shells when the command is provided in string form. The shebang is only
  honored when the OS executes the command and chooses the shell to use.
  This means that the `#!/bin/bash` that the ci-operator sets for all
  commands as well as any shebang that a user sets are ignored. This could
  be a problem is a user wants to execute any non-bash compatible script
  (for example, `#!/bin/python3`).

The solution to this is to execute the script directly. The simplest way
is to `echo` the user's script to disk, mark that as executable, and
then execute it. To prevent the shell from trying to execute code in the
provided command during the `echo`, we can encode the original command
as base64. This result in a command like this:
```
/bin/sh -c "echo B64== | base64 -d > test.sh; chmod +x ./test.sh; ./test.sh
```

This allows us to run in simpler container images lacking `bash` as well
as respect script shebangs.