### PR TITLE
Revert "Revert "test-images-distributor: no distribution to api.ci""

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -68,6 +68,10 @@ func AddToManager(mgr manager.Manager,
 
 	buildClusters := sets.String{}
 	for buildClusterName, buildClusterManager := range buildClusterManagers {
+		if buildClusterName == "api.ci" {
+			log.Debug("distribution to api.ci is disabled")
+			continue
+		}
 		buildClusters.Insert(buildClusterName)
 		r.buildClusterClients[buildClusterName] = imagestreamtagwrapper.MustNew(buildClusterManager.GetClient(), buildClusterManager.GetCache())
 	}


### PR DESCRIPTION
This reverts commit 77c9006a9707a091617db652b859a93c587d8db4.

https://issues.redhat.com/browse/DPTP-1981

/cc @openshift/openshift-team-developer-productivity-test-platform 