### PR TITLE
Ignore ocp/builder constraint in unpromoted configs

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -532,6 +532,21 @@ func pruneOCPBuilderReplacements(config *api.ReleaseBuildConfiguration) error {
 		if orgRepoTag.org != "ocp" || orgRepoTag.repo != "builder" {
 			return true, nil
 		}
+
+		// If a config does not promote to ocp, it is not a configuration we want to hold
+		// accountable to this rule. It could be a variant defined solely for testing something
+		// exotic.
+		promotesToOCP := false
+		for _, promotedTag := range release.PromotedTags(config) {
+			if promotedTag.Namespace == "ocp" {
+				promotesToOCP = true
+				break
+			}
+		}
+		if !promotesToOCP {
+			return true, nil
+		}
+
 		imagestreamTagReference, imageStreamTagReferenceExists := config.BaseImages[imageKey]
 		if !imageStreamTagReferenceExists {
 			return false, nil

--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -160,9 +160,50 @@ func TestReplacer(t *testing.T) {
 						},
 					},
 				}},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "ocp",
+					Tag:       "4.8",
+				},
 			},
 			pruneOCPBuilderReplacementsEnabled: true,
 			expectWrite:                        true,
+		},
+		{
+			name: "OCP builder pruning skips when ocp promotion is disabled",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "ocp",
+					Tag:       "4.8",
+					Disabled:  true,
+				},
+			},
+			pruneOCPBuilderReplacementsEnabled: true,
+			expectWrite:                        false,
+		},
+		{
+			name: "OCP builder pruning skips config which does not promote to ocp",
+			config: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						Inputs: map[string]api.ImageBuildInputs{
+							"root": {As: []string{"ocp/builder:something"}},
+						},
+					},
+				}},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "notocp",
+					Tag:       "4.8",
+				},
+			},
+			pruneOCPBuilderReplacementsEnabled: true,
+			expectWrite:                        false,
 		},
 		{
 			name: "Dockerfile gets fixed up",
@@ -635,8 +676,17 @@ func TestPruneOCPBuilderReplacements(t *testing.T) {
 						},
 					}},
 				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "ocp",
+					Tag:       "4.8",
+				},
 			},
-			expected: &api.ReleaseBuildConfiguration{},
+			expected: &api.ReleaseBuildConfiguration{
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "ocp",
+					Tag:       "4.8",
+				},
+			},
 		},
 		{
 			name: "OCP builder that directly references api.ci is left",

--- a/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_OCP_builder_pruning_happens.yaml
+++ b/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_OCP_builder_pruning_happens.yaml
@@ -1,3 +1,6 @@
+promotion:
+  namespace: ocp
+  tag: "4.8"
 zz_generated_metadata:
   branch: ""
   org: ""


### PR DESCRIPTION
Full context: https://coreos.slack.com/archives/CBN38N3MW/p1614952333017200