### PR TITLE
Vault secret manager: Add frontend for deletions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ install:
 .PHONY: install
 
 cmd/vault-secret-collection-manager/index.js: cmd/vault-secret-collection-manager/index.ts
-	tsc cmd/vault-secret-collection-manager/index.ts
+	tsc --lib ES2015,dom cmd/vault-secret-collection-manager/index.ts
 
 # Install Go binaries to $GOPATH/bin.
 # Set version and name variables.

--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ pr-deploy-vault-secret-manager:
 	$(eval USER=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.user.login))
 	$(eval BRANCH=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.ref))
 	oc --context app.ci --as system:admin process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy-vault-secret-manager.yaml | oc  --context app.ci --as system:admin apply -f -
+	kubectl patch  -n vault rolebinding registry-viewer --type=json --patch='[{"op":"replace", "path":"/subjects/1/namespace", "value":"ci-tools-$(PULL_REQUEST)"}]'
 	echo "server is at https://$$( oc  --context app.ci --as system:admin get route vault-secret-collection-manager -n ci-tools-$(PULL_REQUEST) -o jsonpath={.spec.host} )"
 .PHONY: pr-deploy-backporter
 

--- a/cmd/vault-secret-collection-manager/index.template.html
+++ b/cmd/vault-secret-collection-manager/index.template.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head><title>Secret Collection Management</title></head>
   <body>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style.css">
     <script type="application/json" id="secretcollections">
       {{ . }}
@@ -12,19 +13,22 @@
           <th>Name</th>
           <th>Path</th>
           <th>Members</th>
+          <th></th>
         </thead>
         <tbody id="secretCollectionTableBody"></tbody>
       </tr>
     </table>
-    <button type="button" class="right-aligned" id="newCollectionButton">New Collection</button>
-    <div id="createCollection" class="create-dialog hidden">
-      <div id="createCollectionError" class="create-dialog-content error hidden"></div>
-      <div id="createCollectionContent" class="create-dialog-content">
-        <div id="createCollectionInput">
+    <button type="button" class="new-collection-button  right-aligned" id="newCollectionButton">New Collection</button>
+    <div id="modalContainer" class="create-dialog hidden">
+      <div id="modalError" class="create-dialog-content error hidden"></div>
+      <div id="modalContent" class="create-dialog-content">
+        <div id="createCollectionInput" class="hidden">
           <label for="name">Name:</label>
           <input type="text" id="name" name="name"><br><br>
-          <input type="submit" id="abortCreateCollectionButton" value="Cancel">
-          <input type="submit" id="createCollectionButton" value="Submit">
+          <button type="button" id="abortCreateCollectionButton" class="grey-button">Cancel</button>
+          <button type="button" id="createCollectionButton" class="green-button">Submit</button>
+        </div>
+        <div id="deleteConfirmation" class="hidden">
         </div>
       </div>
     </div>

--- a/cmd/vault-secret-collection-manager/index.template.html
+++ b/cmd/vault-secret-collection-manager/index.template.html
@@ -1,37 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head><title>Secret Collection Management</title></head>
-  <body>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="style.css">
-    <script type="application/json" id="secretcollections">
+
+<head>
+  <title>Secret Collection Management</title>
+</head>
+
+<body>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="style.css">
+  <script type="application/json" id="secretcollections">
       {{ . }}
     </script>
-    <table style="width:100%" id="secretcollectionTable">
-      <tr>
-        <thead>
-          <th>Name</th>
-          <th>Path</th>
-          <th>Members</th>
-          <th></th>
-        </thead>
-        <tbody id="secretCollectionTableBody"></tbody>
-      </tr>
-    </table>
-    <button type="button" class="new-collection-button  right-aligned" id="newCollectionButton">New Collection</button>
-    <div id="modalContainer" class="create-dialog hidden">
-      <div id="modalError" class="create-dialog-content error hidden"></div>
-      <div id="modalContent" class="create-dialog-content">
-        <div id="createCollectionInput" class="hidden">
-          <label for="name">Name:</label>
-          <input type="text" id="name" name="name"><br><br>
-          <button type="button" id="abortCreateCollectionButton" class="grey-button">Cancel</button>
-          <button type="button" id="createCollectionButton" class="green-button">Submit</button>
-        </div>
-        <div id="deleteConfirmation" class="hidden">
-        </div>
+  <table style="width:100%" id="secretcollectionTable">
+    <tr>
+      <thead>
+        <th>Name</th>
+        <th>Path</th>
+        <th>Members</th>
+        <th></th>
+      </thead>
+      <tbody id="secretCollectionTableBody"></tbody>
+    </tr>
+  </table>
+  <button type="button" class="new-collection-button  right-aligned" id="newCollectionButton">New Collection</button>
+  <div id="modalContainer" class="create-dialog hidden">
+    <div id="modalError" class="create-dialog-content error hidden"></div>
+    <div id="modalContent" class="create-dialog-content">
+      <div id="createCollectionInput" class="hidden">
+        <label for="name">Name:</label>
+        <input type="text" id="newSecretCollectionName" name="name"><br><br>
+        <button type="button" id="abortCreateCollectionButton" class="grey-button">Cancel</button>
+        <button type="button" id="createCollectionButton" class="green-button">Submit</button>
+      </div>
+      <div id="deleteConfirmation" class="hidden">
       </div>
     </div>
-    <script src="index.js"></script>
-  </body>
+  </div>
+  <script src="index.js"></script>
+</body>
+
 </html>

--- a/cmd/vault-secret-collection-manager/index.ts
+++ b/cmd/vault-secret-collection-manager/index.ts
@@ -106,7 +106,7 @@ function fetchAndRenderSecretCollections() {
 }
 
 function createSecretCollection() {
-  const input = document.getElementById('name') as HTMLInputElement;
+  const input = document.getElementById('newSecretCollectionName') as HTMLInputElement;
   const name = input.value;
   input.value = '';
   fetch(`${window.location.protocol}//${window.location.host}/secretcollection/${name}`, { method: 'PUT' })
@@ -124,8 +124,9 @@ function createSecretCollection() {
 }
 
 document.getElementById('newCollectionButton')?.addEventListener('click', () => {
-  document.getElementById('createCollectionInput').classList.remove('hidden');
+  document.getElementById('createCollectionInput')?.classList.remove('hidden');
   showModal();
+  document.getElementById('newSecretCollectionName')?.focus();
 });
 
 document.getElementById('abortCreateCollectionButton')?.addEventListener('click', () => hideModal());

--- a/cmd/vault-secret-collection-manager/index.ts
+++ b/cmd/vault-secret-collection-manager/index.ts
@@ -1,86 +1,146 @@
 interface secretCollection {
-  name:    string;
-  path:    string;
+  name: string;
+  path: string;
   members: string[];
 }
 
-const secretCollections: secretCollection[] = JSON.parse(document.getElementById('secretcollections').innerHTML);
+function displayCreateSecretCollectionError(attemptedAction: string, msg: string) {
+  const div = document.getElementById('modalError') as HTMLDivElement;
+  div.innerHTML = `Failed to ${attemptedAction}: ${msg}`;
+  div.classList.remove('hidden');
+}
+
+function clearCreateSecretCollectionError() {
+  const div = document.getElementById('modalError') as HTMLDivElement;
+  div.innerHTML = '';
+  div.classList.add('hidden');
+}
+
+function hideModal() {
+  document.getElementById('modalContainer')?.classList.add('hidden');
+  clearCreateSecretCollectionError();
+  const modalContent = document.getElementById('modalContent') as HTMLDivElement;
+  for (const child of Array.from(modalContent.children)) {
+    child.classList.add('hidden');
+  }
+}
+
+function showModal() {
+  document.getElementById('modalContainer')?.classList.remove('hidden');
+}
+
+function deleteColectionEventHandler(collectionName: string) {
+  return function () {
+    const deleteConfirmation = document.getElementById('deleteConfirmation') as HTMLDivElement;
+    deleteConfirmation.innerHTML = `Are you sure you want to irreversibly delete the secret collection ${collectionName} and all its content?<br><br>`;
+
+    const cancelButton = document.createElement('button') as HTMLButtonElement;
+    cancelButton.type = 'button';
+    cancelButton.innerHTML = 'cancel';
+    cancelButton.classList.add('grey-button');
+    cancelButton.addEventListener('click', () => hideModal());
+    deleteConfirmation.appendChild(cancelButton);
+
+    const confirmButton = document.createElement('button') as HTMLButtonElement;
+    confirmButton.type = 'button';
+    confirmButton.innerHTML = '<i class="fa fa-trash"></i> Delete';
+    confirmButton.classList.add('red-button');
+    confirmButton.addEventListener('click', () => {
+      fetch(`${window.location.protocol}//${window.location.host}/secretcollection/${collectionName}`, { method: 'DELETE' })
+        .then(async (response) => {
+          if (!response.ok) {
+            const msg = await response.text();
+            throw msg;
+          }
+          fetchAndRenderSecretCollections();
+          hideModal();
+        })
+        .catch((error) => {
+          displayCreateSecretCollectionError('delete secret collection', error);
+        });
+    });
+    deleteConfirmation.append('          ');
+    deleteConfirmation.appendChild(confirmButton);
+
+    clearCreateSecretCollectionError();
+    document.getElementById('deleteConfirmation')?.classList.remove('hidden');
+    showModal();
+  };
+}
 
 function renderCollectionTable(data: secretCollection[]) {
   if (data === null) {
-    return;
+    // The generated javascript loop will do a NPD if this is null because it accesses the .length property
+    data = new Array<secretCollection>();
   }
-  const newTableBody = document.createElement("tbody") as HTMLTableSectionElement;
-  newTableBody.id = "secretCollectionTableBody";
-  for (let secretCollection of data){
+  const newTableBody = document.createElement('tbody') as HTMLTableSectionElement;
+  newTableBody.id = 'secretCollectionTableBody';
+  for (const secretCollection of data) {
     const row = newTableBody.insertRow();
     row.insertCell().innerHTML = secretCollection.name;
     row.insertCell().innerHTML = secretCollection.path;
     row.insertCell().innerHTML = secretCollection.members.toString();
+    const deleteCell = row.insertCell();
+    deleteCell.innerHTML = '<button class="red-button"><i class="fa fa-trash"></i> Delete</button>';
+    const deleteHandler = deleteColectionEventHandler(secretCollection.name);
+    deleteCell.addEventListener('click', () => deleteHandler());
   }
 
-  const oldTableBody = document.getElementById("secretCollectionTableBody") as HTMLTableSectionElement;
+  const oldTableBody = document.getElementById('secretCollectionTableBody') as HTMLTableSectionElement;
   oldTableBody.parentNode?.replaceChild(newTableBody, oldTableBody);
 }
-renderCollectionTable(secretCollections);
-
-function createSecretCollection(){
-  let input = document.getElementById("name") as HTMLInputElement;
-  let name = input.value;
-  input.value = "";
-  fetch(window.location.protocol + "//" + window.location.host + "/secretcollection/" + name, {method: "PUT"})
-  .then(function (response) {
-    if (response.ok) {
-      fetchAndRenderSecretCollections();
-      (document.getElementById("createCollection") as HTMLDivElement).classList.add("hidden");
-    } else {
-      return response.text();
-    };
-  })
-  .then(function (errMsg: string){
-    displayCreateSecretCollectionError(errMsg)  ;
-  })
-  .catch(function (error) {
-    displayCreateSecretCollectionError(error);
-  });
-};
 
 function fetchAndRenderSecretCollections() {
-  fetch(window.location.protocol + "//" + window.location.host + "/secretcollection/")
-  .then(function(response) {
-    if (response.ok) {
-      return response.text();
-    }
-  })
-  .then(function(data: string) {
-    renderCollectionTable(JSON.parse(data) as secretCollection[]);
-  });
+  fetch(`${window.location.protocol}//${window.location.host}/secretcollection`)
+    .then(async (response) => {
+      const msg = await response.text();
+      if (!response.ok) {
+        throw msg;
+      }
+      let secretCollections = [] as secretCollection[];
+      if (msg !== '') {
+        secretCollections = JSON.parse(msg) as secretCollection[];
+      }
+      renderCollectionTable(secretCollections);
+    });
 }
 
-function displayCreateSecretCollectionError(msg: string) {
-  let div = document.getElementById("createCollectionError") as HTMLDivElement;
-  div.innerHTML = `Failed to create secret colltion: ${msg}`;
-  div.classList.remove("hidden");
+function createSecretCollection() {
+  const input = document.getElementById('name') as HTMLInputElement;
+  const name = input.value;
+  input.value = '';
+  fetch(`${window.location.protocol}//${window.location.host}/secretcollection/${name}`, { method: 'PUT' })
+    .then(async (response) => {
+      if (!response.ok) {
+        const responseText = await response.text();
+        throw responseText;
+      }
+      fetchAndRenderSecretCollections();
+      hideModal();
+    })
+    .catch((error) => {
+      displayCreateSecretCollectionError('create secret collection', error);
+    });
 }
 
-function clearCreateSecretCollectionError(){
-  let div = document.getElementById("createCollectionError") as HTMLDivElement;
-  div.innerHTML = ""
-  div.classList.add("hidden");
-}
+document.getElementById('newCollectionButton')?.addEventListener('click', () => {
+  document.getElementById('createCollectionInput').classList.remove('hidden');
+  showModal();
+});
 
-document.getElementById("newCollectionButton")?.addEventListener("click", (e: Event) => {
-  clearCreateSecretCollectionError();
-  document.getElementById("createCollection")?.classList.remove("hidden");
-})
-document.getElementById("abortCreateCollectionButton")?.addEventListener("click", (e: Event) => {
-  document.getElementById("createCollection")?.classList.add("hidden");
-})
-document.addEventListener("keydown", event => {
-  // esc
-  if (event.keyCode == 27) {
-    (document.getElementById("createCollection") as HTMLDivElement).classList.add("hidden");
-  };
-})
+document.getElementById('abortCreateCollectionButton')?.addEventListener('click', () => hideModal());
 
-document.getElementById("createCollectionButton").addEventListener("click", (e: Event) => createSecretCollection());
+document.addEventListener('keydown', (event) => {
+  const escKeyCode = 27;
+  const enterKeyCode = 13;
+  if (event.keyCode === escKeyCode) {
+    hideModal();
+  } else if (event.keyCode === enterKeyCode && !document.getElementById('createCollectionInput')?.classList.contains('hidden')) {
+    createSecretCollection();
+  }
+});
+
+document.getElementById('createCollectionButton').addEventListener('click', () => createSecretCollection());
+
+const secretCollections: secretCollection[] = JSON.parse(document.getElementById('secretcollections').innerHTML);
+renderCollectionTable(secretCollections);

--- a/cmd/vault-secret-collection-manager/style.css
+++ b/cmd/vault-secret-collection-manager/style.css
@@ -24,19 +24,34 @@ th {
     color: #333;
 }
 
+.new-collection-button {
+  background-color: #009688;
+}
+
+.grey-button {
+  background: #616161;
+}
+
+.red-button {
+  background: #F44336;
+}
+
+.green-button {
+  background: #4CAF50;
+}
+
 button {
   border: none;
-  display: inline-block;
-  padding: 8px 16px;
-  vertical-align: middle;
   overflow: hidden;
   text-decoration: none;
   text-align: center;
-  color: #fff;
-  cursor: pointer;
   white-space: nowrap;
   font-size: 14px;
-  background-color: #009688;
+  padding: 8px 16px;
+  cursor: pointer;
+  color: #fff;
+  display: inline-block;
+  vertical-align: middle;
 }
 
 button:hover {

--- a/cmd/vault-secret-collection-manager/tsconfig.json
+++ b/cmd/vault-secret-collection-manager/tsconfig.json
@@ -1,12 +1,14 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
-
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "es2015",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "target": "es2015", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "es2015", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": [
+      "dom",
+      "es2015"
+    ], /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -23,9 +25,8 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -33,13 +34,11 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
@@ -48,22 +47,19 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
-    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "skipLibCheck": true, /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   }
 }


### PR DESCRIPTION
This change adds the frontend part to allow secret collection deletion, ref: https://issues.redhat.com/browse/DPTP-1891
Also includes a couple of refactoring:
* Rename the modal, its main content div and the error div to clarify that it's not only used to create a secret collection but
* Move hiding of the modal into a func that will hide the modal, the error and content sub-div and all children of the latter, so that funcs that put something into there do not first need to do that (and know about everything else that could put content in there)
* Fix the http requests to not always create a modal error when there is any body and to use exception handling for both "request fails entirely" and "request didn't get a 2XX status", rather than only for the first
* Fix `fetchAndRenderSecretCollections` to be able to cope with no secret collections being there, rather than simply doing nothing in that case which would keep deleted collections on the screen
* Consistently use candy crush theming for buttons rather than combining it with some Windows 98 styles
* Handle enter key press and use it to confirm secret collection creation
* Move code around so things only get used after they were defined

/cc @openshift/openshift-team-developer-productivity-test-platform 

Preview is here: https://vault-secret-collection-manager-ci-tools-1756.apps.ci.l2s4.p1.openshiftapps.com