### PR TITLE
ci-operator: censor all secret data in sidecar

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -343,7 +343,7 @@ func removeFile(podClient PodClient, ns, name, containerName string, paths []str
 	return nil
 }
 
-func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.DecorationConfig, rawJobSpec string) error {
+func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.DecorationConfig, rawJobSpec string, secretsToCensor []coreapi.VolumeMount) error {
 	logMount, logVolume := decorate.LogMountAndVolume()
 	toolsMount, toolsVolume := decorate.ToolsMountAndVolume()
 	blobStorageVolumes, blobStorageMounts, blobStorageOptions := decorate.BlobStorageOptions(*decorationConfig, false)
@@ -356,7 +356,7 @@ func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.
 	}
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, coreapi.EnvVar{Name: artifactEnv, Value: logMount.MountPath + "/artifacts"})
 
-	sidecar, err := decorate.Sidecar(decorationConfig, blobStorageOptions, blobStorageMounts, logMount, nil, rawJobSpec, !decorate.RequirePassingEntries, decorate.IgnoreInterrupts, nil, *wrapperOptions)
+	sidecar, err := decorate.Sidecar(decorationConfig, blobStorageOptions, blobStorageMounts, logMount, nil, rawJobSpec, !decorate.RequirePassingEntries, decorate.IgnoreInterrupts, secretsToCensor, *wrapperOptions)
 	if err != nil {
 		return fmt.Errorf("could not create sidecar: %w", err)
 	}

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -707,7 +707,7 @@ func TestAddPodUtils(t *testing.T) {
 			PathStrategy: prowv1.PathStrategyExplicit,
 		},
 		GCSCredentialsSecret: func() *string { s := "gce-sa-credentials-gcs-publisher"; return &s }(),
-	}, "rawspec"); err != nil {
+	}, "rawspec", []coreapi.VolumeMount{{Name: "secret", MountPath: "/secret"}}); err != nil {
 		t.Errorf("failed to decorate: %v", err)
 	}
 	testhelper.CompareWithFixture(t, base)

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -152,7 +152,15 @@ func TestGeneratePods(t *testing.T) {
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},
 		{Name: "LEASED_RESOURCE", Value: "uuid"},
 	}
-	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, false)
+	secretVolumes := []coreapi.Volume{{
+		Name:         "secret",
+		VolumeSource: coreapi.VolumeSource{Secret: &coreapi.SecretVolumeSource{SecretName: "k8-secret"}},
+	}}
+	secretVolumeMounts := []coreapi.VolumeMount{{
+		Name:      "secret",
+		MountPath: "/secret",
+	}}
+	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, false, secretVolumes, secretVolumeMounts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +233,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Environment: tc.env,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil)
-			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, false)
+			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, false, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -293,7 +301,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil)
-	_, isBestEffort, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, false)
+	_, isBestEffort, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, false, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/steps/testdata/zz_fixture_TestAddPodUtils.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestAddPodUtils.yaml
@@ -25,7 +25,7 @@ spec:
     - name: JOB_SPEC
       value: rawspec
     - name: SIDECAR_OPTIONS
-      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"mydir","bucket":"bucket","path_strategy":"explicit","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["cmd","arg1","arg2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+      value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"mydir","bucket":"bucket","path_strategy":"explicit","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["cmd","arg1","arg2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
     image: sidecar
     name: sidecar
     resources: {}
@@ -34,6 +34,8 @@ spec:
       name: logs
     - mountPath: /secrets/gcs
       name: gcs-credentials
+    - mountPath: /secret
+      name: secret
   initContainers:
   - args:
     - /entrypoint

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -94,13 +94,15 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
       image: sidecar
       name: sidecar
       resources: {}
       volumeMounts:
       - mountPath: /logs
         name: logs
+      - mountPath: /secret
+        name: secret
     initContainers:
     - args:
       - /entrypoint
@@ -135,6 +137,9 @@
       name: tools
     - emptyDir: {}
       name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
     - emptyDir: {}
       name: entrypoint-wrapper
     - name: cluster-profile
@@ -240,13 +245,15 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
       image: sidecar
       name: sidecar
       resources: {}
       volumeMounts:
       - mountPath: /logs
         name: logs
+      - mountPath: /secret
+        name: secret
     initContainers:
     - args:
       - /entrypoint
@@ -281,6 +288,9 @@
       name: tools
     - emptyDir: {}
       name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
     - emptyDir: {}
       name: entrypoint-wrapper
     - name: cluster-profile
@@ -386,13 +396,15 @@
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
       image: sidecar
       name: sidecar
       resources: {}
       volumeMounts:
       - mountPath: /logs
         name: logs
+      - mountPath: /secret
+        name: secret
     initContainers:
     - args:
       - /entrypoint
@@ -427,6 +439,9 @@
       name: tools
     - emptyDir: {}
       name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
     - emptyDir: {}
       name: entrypoint-wrapper
     - name: cluster-profile


### PR DESCRIPTION
The Prow pod utilities can now censor secret data before uploading
anything to the cloud, both in plain-text files and in archives that the
user creates during a test run. We know that the set of sensitive data
available to test Pods for a job is limited to the set of Secrets in the
Namespace that ci-operator created for the job, so by mounting them all
into the test Pods we can effectively guard against all secret leaks in
the future.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @petr-muller @alvaroaleman @bbguimaraes 