### PR TITLE
ci-operator: force clients into JSON when verbose

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -517,6 +517,11 @@ func (o *options) Complete() error {
 		clusterConfig.Impersonate = rest.ImpersonationConfig{UserName: o.impersonateUser}
 	}
 
+	if o.verbose {
+		clusterConfig.ContentType = "application/json"
+		clusterConfig.AcceptContentTypes = "application/json"
+	}
+
 	o.clusterConfig = clusterConfig
 
 	if o.pullSecretPath != "" {


### PR DESCRIPTION
There's no simple way to decode the protos that are otherwise used on
the wire, so debugging client calls is impossible.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>