### PR TITLE
ci-operator: remove support for legacy promotion

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1,6 +1,7 @@
 package defaults
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -268,6 +269,9 @@ func fromConfig(
 	addProvidesForStep(step, params)
 
 	if promote {
+		if pushSecret == nil {
+			return nil, nil, errors.New("--image-mirror-push-secret is required for promoting images")
+		}
 		cfg, err := promotionDefaults(config)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not determine promotion defaults: %w", err)

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -649,7 +649,7 @@ func TestFromConfig(t *testing.T) {
 	var leaseClient *lease.Client
 	var requiredTargets []string
 	var cloneAuthConfig *steps.CloneAuthConfig
-	var pullSecret, pushSecret *coreapi.Secret
+	pullSecret, pushSecret := &coreapi.Secret{}, &coreapi.Secret{}
 	for _, tc := range []struct {
 		name           string
 		config         api.ReleaseBuildConfiguration


### PR DESCRIPTION
Nobody uses this path any longer, we do not need to support it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>