### PR TITLE
ci-operator: always promote the build cache

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -272,11 +272,10 @@ func fromConfig(
 		if pushSecret == nil {
 			return nil, nil, errors.New("--image-mirror-push-secret is required for promoting images")
 		}
-		cfg, err := promotionDefaults(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not determine promotion defaults: %w", err)
+		if config.PromotionConfiguration == nil {
+			return nil, nil, fmt.Errorf("cannot promote images, no promotion configuration defined")
 		}
-		postSteps = append(postSteps, releasesteps.PromotionStep(*cfg, config.Images, requiredNames, jobSpec, podClient, pushSecret))
+		postSteps = append(postSteps, releasesteps.PromotionStep(config, requiredNames, jobSpec, podClient, pushSecret))
 	}
 
 	return append(overridableSteps, buildSteps...), postSteps, nil
@@ -378,14 +377,6 @@ func checkForFullyQualifiedStep(step api.Step, params *api.DeferredParameters) (
 		params.Add(name, fn)
 	}
 	return step, false
-}
-
-func promotionDefaults(configSpec *api.ReleaseBuildConfiguration) (*api.PromotionConfiguration, error) {
-	config := configSpec.PromotionConfiguration
-	if config == nil {
-		return nil, fmt.Errorf("cannot promote images, no promotion or release tag configuration defined")
-	}
-	return config, nil
 }
 
 // leasesForTest aggregates all the lease configurations in a test.

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -24,7 +24,6 @@ import (
 // of images out to the configured namespace.
 type promotionStep struct {
 	configuration  *api.ReleaseBuildConfiguration
-	images         []api.ProjectDirectoryImageBuildStepConfiguration
 	requiredImages sets.String
 	jobSpec        *api.JobSpec
 	client         steps.PodClient
@@ -262,6 +261,14 @@ func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration
 			}
 		}
 		promotedTags[src] = tag
+	}
+	// always promote the binary build if one exists
+	if configuration.BinaryBuildCommands != "" {
+		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = api.ImageStreamTagReference{
+			Namespace: "build-cache",
+			Name:      fmt.Sprintf("%s-%s", configuration.Metadata.Org, configuration.Metadata.Repo),
+			Tag:       configuration.Metadata.Branch,
+		}
 	}
 	return promotedTags, names
 }

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -224,8 +224,7 @@ func TestGetPromotionPod(t *testing.T) {
 func TestGetImageMirror(t *testing.T) {
 	var testCases = []struct {
 		name     string
-		config   api.PromotionConfiguration
-		tags     map[string]string
+		tags     map[string]api.ImageStreamTagReference
 		pipeline *imageapi.ImageStream
 		expected map[string]string
 	}{
@@ -237,15 +236,18 @@ func TestGetImageMirror(t *testing.T) {
 			pipeline: &imageapi.ImageStream{},
 		},
 		{
-			name: "basic case: empty config.Name",
-			config: api.PromotionConfiguration{
-				Namespace: "ci",
-				Tag:       "latest",
-			},
-			tags: map[string]string{
-				"a": "b",
-				"c": "d",
-				"x": "y",
+			name: "basic case",
+			tags: map[string]api.ImageStreamTagReference{
+				"b": {
+					Namespace: "ci",
+					Name:      "a",
+					Tag:       "latest",
+				},
+				"d": {
+					Namespace: "ci",
+					Name:      "c",
+					Tag:       "latest",
+				},
 			},
 			pipeline: &imageapi.ImageStream{
 				Status: imageapi.ImageStreamStatus{
@@ -269,49 +271,16 @@ func TestGetImageMirror(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/a:latest", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/c:latest"},
-		},
-		{
-			name: "basic case: config.Name",
-			config: api.PromotionConfiguration{
-				Namespace: "ci",
-				Name:      "name",
-				Tag:       "latest",
+			expected: map[string]string{
+				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/a:latest",
+				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/c:latest",
 			},
-			tags: map[string]string{
-				"a": "b",
-				"c": "d",
-				"x": "y",
-			},
-			pipeline: &imageapi.ImageStream{
-				Status: imageapi.ImageStreamStatus{
-					Tags: []imageapi.NamedTagEventList{
-						{
-							Tag: "b",
-							Items: []imageapi.TagEvent{
-								{
-									DockerImageReference: "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
-								},
-							},
-						},
-						{
-							Tag: "d",
-							Items: []imageapi.TagEvent{
-								{
-									DockerImageReference: "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd",
-								},
-							},
-						},
-					},
-				},
-			},
-			expected: map[string]string{"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/name:a", "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/name:c"},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := getImageMirrorTarget(testCase.config, testCase.tags, testCase.pipeline), testCase.expected; !reflect.DeepEqual(actual, expected) {
+			if actual, expected := getImageMirrorTarget(testCase.tags, testCase.pipeline), testCase.expected; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect ImageMirror mapping: %v", testCase.name, diff.ObjectDiff(actual, expected))
 			}
 		})

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -186,6 +186,27 @@ func TestPromotedTags(t *testing.T) {
 				Tag:       "fred",
 			}},
 		},
+		{
+			name: "promotion set and binaries built, means binaries promoted",
+			input: &api.ReleaseBuildConfiguration{
+				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},
+				BinaryBuildCommands: "something",
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "roger",
+					Tag:       "fred",
+				},
+				Metadata: api.Metadata{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+			expected: []api.ImageStreamTagReference{{
+				Namespace: "build-cache",
+				Name:      "org-repo",
+				Tag:       "branch",
+			}},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Lots of valuable work is done when binaries are built from the source
code in a test. We can promote the resulting image to a build cache
repository and use it as the `build_root` for subsequent jobs (if the
underlying `build_root` that we originate from has not changed) and
thereby save enormous amounts of time in both incremental cloning and
incremental compilation.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Depends on #1774 
Part of [DPTP-2051](https://issues.redhat.com/browse/DPTP-2051)

/assign @openshift/openshift-team-developer-productivity-test-platform 