### PR TITLE
[DPTP-2057] multi_stage: write commands.sh to configmap

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -662,6 +662,9 @@ type LiteralTestStep struct {
 	Cli string `json:"cli,omitempty"`
 	// Observers are the observers that should be running
 	Observers []string `json:"observers,omitempty"`
+	// RunAsScript defines if this step should be executed as a script mounted
+	// in the test container instead of being executed directly via bash
+	RunAsScript *bool `json:"run_as_script,omitempty"`
 }
 
 // StepParameter is a variable set by the test, with an optional default.

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -105,6 +105,7 @@ func TestRequires(t *testing.T) {
 }
 
 func TestGeneratePods(t *testing.T) {
+	yes := true
 	config := api.ReleaseBuildConfiguration{
 		Tests: []api.TestStepConfiguration{{
 			As: "test",
@@ -117,7 +118,7 @@ func TestGeneratePods(t *testing.T) {
 					From:     "image1",
 					Commands: "command1",
 				}, {
-					As: "step2", From: "stable-initial:installer", Commands: "command2",
+					As: "step2", From: "stable-initial:installer", Commands: "command2", RunAsScript: &yes,
 				}},
 			},
 		}},

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -349,7 +349,7 @@
       - name: REPO_OWNER
         value: org
       - name: ENTRYPOINT_OPTIONS
-        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/var/run/configmaps/ci.openshift.io/multi-stage/step2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
         value: /logs/artifacts
       - name: NAMESPACE
@@ -391,12 +391,14 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /var/run/configmaps/ci.openshift.io/multi-stage
+        name: commands-script
     - command:
       - /sidecar
       env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
-        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset -eu\ncommand2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/var/run/configmaps/ci.openshift.io/multi-stage/step2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"secret_directories":["/secret"]}'
       image: sidecar
       name: sidecar
       resources: {}
@@ -450,4 +452,8 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        defaultMode: 511
+        name: test-commands
+      name: commands-script
   status: {}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -468,6 +468,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
+	"                  # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"                  # in the test container instead of being executed directly via bash\n" +
+	"                  run_as_script: false\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
@@ -543,6 +546,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
+	"                  # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"                  # in the test container instead of being executed directly via bash\n" +
+	"                  run_as_script: false\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
@@ -618,6 +624,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    # These are directly used in creating the Pods that execute the Job.\n" +
 	"                    requests:\n" +
 	"                        \"\": \"\"\n" +
+	"                  # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"                  # in the test container instead of being executed directly via bash\n" +
+	"                  run_as_script: false\n" +
 	"                  # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"                  timeout: 0s\n" +
 	"        openshift_ansible:\n" +
@@ -742,6 +751,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
+	"                  run_as_script: false\n" +
 	"                  timeout: 0s\n" +
 	"            # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"            pre:\n" +
@@ -795,6 +805,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
+	"                  run_as_script: false\n" +
 	"                  timeout: 0s\n" +
 	"            # Test is the array of test steps that define the actual test.\n" +
 	"            test:\n" +
@@ -848,6 +859,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                    requests:\n" +
 	"                        # LiteralTestStep is a full test step definition.\n" +
 	"                        \"\": \"\"\n" +
+	"                  run_as_script: false\n" +
 	"                  timeout: 0s\n" +
 	"            # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"            # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +
@@ -1063,6 +1075,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
+	"              # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"              # in the test container instead of being executed directly via bash\n" +
+	"              run_as_script: false\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
@@ -1138,6 +1153,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
+	"              # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"              # in the test container instead of being executed directly via bash\n" +
+	"              run_as_script: false\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
@@ -1213,6 +1231,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                # These are directly used in creating the Pods that execute the Job.\n" +
 	"                requests:\n" +
 	"                    \"\": \"\"\n" +
+	"              # RunAsScript defines if this step should be executed as a script mounted\n" +
+	"              # in the test container instead of being executed directly via bash\n" +
+	"              run_as_script: false\n" +
 	"              # Timeout is how long the we will wait before aborting a job with SIGINT.\n" +
 	"              timeout: 0s\n" +
 	"      openshift_ansible:\n" +
@@ -1337,6 +1358,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
+	"              run_as_script: false\n" +
 	"              timeout: 0s\n" +
 	"        # Pre is the array of test steps run to set up the environment for the test.\n" +
 	"        pre:\n" +
@@ -1390,6 +1412,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
+	"              run_as_script: false\n" +
 	"              timeout: 0s\n" +
 	"        # Test is the array of test steps that define the actual test.\n" +
 	"        test:\n" +
@@ -1443,6 +1466,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                requests:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
 	"                    \"\": \"\"\n" +
+	"              run_as_script: false\n" +
 	"              timeout: 0s\n" +
 	"        # Workflow is the name of the workflow to be used for this configuration. For fields defined in both\n" +
 	"        # the config and the workflow, the fields from the config will override what is set in Workflow.\n" +

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -3,6 +3,10 @@ base_images:
     name: centos
     namespace: openshift
     tag: '7'
+  alpine:
+    name: alpine
+    namespace: ci
+    tag: '3.10'
 resources:
   '*':
     limits:
@@ -10,6 +14,19 @@ resources:
     requests:
       cpu: 10m
 tests:
+  - as: run-as-script
+    steps:
+      test:
+        - as: success
+          commands: |
+            #!/bin/sh
+            echo "success"
+          from: alpine
+          run_as_script: true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
   - as: without-references
     steps:
       test:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -108,6 +108,13 @@ func TestMultiStage(t *testing.T) {
 			success: true,
 			output:  []string{`Pod os-test succeeded after`},
 		},
+		{
+			name:    "step with run_as_script in alpine image",
+			args:    []string{"--unresolved-config=config.yaml", "--target=run-as-script"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output:  []string{`run-as-script-success succeeded`},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Instead of running commands directly with `bash` when running multistage
tests, `ci-operator` should instead execute the script directly so that
the shebang specifying what shell to use is followed (it is ignored when
run directly by the shell) and to remove the multistage test steps'
dependance on `bash`, which does not exist in certain images, usually
alpine based.

This PR now runs commands by creating a configmap and mounting it to a
known location in the pod. Then, the script is executed by doing
`/bin/sh -c /path/to/script.sh`. At a bare minimum, all images should
have a `/bin/sh`, and in order to continue supporting injecting the cli
binary into images, the ci-operator needs to execute commands via
`/bin/sh` so the `$PATH` env var can be updated to include the path to
the cli before running the user's script.