### PR TITLE
ci-operator: allow overriding registry for promotions

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -40,6 +41,9 @@ func main() {
 		}
 		for _, tag := range release.PromotedTags(configuration) {
 			seen[tag] = append(seen[tag], repoInfo)
+		}
+		if configuration.PromotionConfiguration != nil && configuration.PromotionConfiguration.RegistryOverride != "" {
+			return errors.New("setting promotion.registry_override is not allowed")
 		}
 		return nil
 	}); err != nil {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -407,6 +407,12 @@ type PromotionConfiguration struct {
 	// never concurrently, and you want to have promotion config
 	// in the ci-operator configuration files all the time.
 	Disabled bool `json:"disabled,omitempty"`
+
+	// RegistryOverride is an override for the registry domain to
+	// which we will mirror images. This is an advanced option and
+	// should *not* be used in common test workflows. The CI chat
+	// bot uses this option to facilitate image sharing.
+	RegistryOverride string `json:"registry_override,omitempty"`
 }
 
 // StepConfiguration holds one step configuration.

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -560,8 +560,34 @@ func TestGetImageMirror(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := getImageMirrorTarget(testCase.tags, testCase.pipeline), testCase.expected; !reflect.DeepEqual(actual, expected) {
+			if actual, expected := getImageMirrorTarget(testCase.tags, testCase.pipeline, "registry.ci.openshift.org"), testCase.expected; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect ImageMirror mapping: %v", testCase.name, diff.ObjectDiff(actual, expected))
+			}
+		})
+	}
+}
+
+func TestRegistryDomain(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		config   *api.PromotionConfiguration
+		expected string
+	}{
+		{
+			name:     "default",
+			config:   &api.PromotionConfiguration{},
+			expected: "registry.ci.openshift.org",
+		},
+		{
+			name:     "override",
+			config:   &api.PromotionConfiguration{RegistryOverride: "whoa.com.biz"},
+			expected: "whoa.com.biz",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if diff := cmp.Diff(testCase.expected, registryDomain(testCase.config)); diff != "" {
+				t.Errorf("%s: got incorrect registry domain: %v", testCase.name, diff)
 			}
 		})
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -145,6 +145,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    # Namespace identifies the namespace to which the built\n" +
 	"    # artifacts will be published to.\n" +
 	"    namespace: ' '\n" +
+	"    # RegistryOverride is an override for the registry domain to\n" +
+	"    # which we will mirror images. This is an advanced option and\n" +
+	"    # should *not* be used in common test workflows. The CI chat\n" +
+	"    # bot uses this option to facilitate image sharing.\n" +
+	"    registry_override: ' '\n" +
 	"    # Tag is the ImageStreamTag tagged in for each\n" +
 	"    # build image's ImageStream.\n" +
 	"    tag: ' '\n" +


### PR DESCRIPTION
This is a useful feature for the ci-chat-bot when working with multiple
PRs. It is not, however, actually useful to normal test flows, so we
document it as such and validate that checked-in configuration does not
set it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Depends on #1775 
/assign @smarterclayton 