### PR TITLE
Add vault support to secret bootstrapper

### DIFF
--- a/cmd/ci-secret-bootstrap/vault.go
+++ b/cmd/ci-secret-bootstrap/vault.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/ci-tools/pkg/vaultclient"
+)
+
+var _ secretStoreClient = &vaultSecretStoreWrapper{}
+
+type vaultClient interface {
+	GetKV(path string) (*vaultclient.KVData, error)
+	ListKVRecursively(path string) ([]string, error)
+}
+
+type vaultSecretStoreWrapper struct {
+	upstream vaultClient
+	prefix   string
+}
+
+func (w *vaultSecretStoreWrapper) pathFor(item string) string {
+	return w.prefix + "/" + item
+}
+
+func (w *vaultSecretStoreWrapper) getKeyAtPath(path, key string) ([]byte, error) {
+	path = w.pathFor(path)
+	response, err := w.upstream.GetKV(path)
+	if err != nil {
+		return nil, err
+	}
+	val, ok := response.Data[key]
+	if !ok {
+		return nil, fmt.Errorf("item at path %q has no key %q", path, key)
+	}
+
+	return []byte(val), nil
+}
+
+func (w *vaultSecretStoreWrapper) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
+	return w.getKeyAtPath(itemName, fieldName)
+}
+
+func (w *vaultSecretStoreWrapper) GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error) {
+	return w.getKeyAtPath(itemName, attachmentName)
+}
+
+func (w *vaultSecretStoreWrapper) GetPassword(itemName string) ([]byte, error) {
+	return w.getKeyAtPath(itemName, "password")
+}
+
+func (w *vaultSecretStoreWrapper) GetInUseInformationForAllItems() (map[string]secretUsageComparer, error) {
+	allKeys, err := w.upstream.ListKVRecursively(w.prefix)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]secretUsageComparer, len(allKeys))
+	for _, key := range allKeys {
+		kvData, err := w.upstream.GetKV(key)
+		if err != nil {
+			return nil, err
+		}
+		comparer := vaultSecretUsageComparer{item: *kvData, allFields: sets.String{}, inUseFields: sets.String{}}
+		for key := range kvData.Data {
+			comparer.allFields.Insert(key)
+		}
+		result[strings.TrimPrefix(key, w.prefix)] = &comparer
+	}
+
+	return result, nil
+}
+
+type vaultSecretUsageComparer struct {
+	item        vaultclient.KVData
+	allFields   sets.String
+	inUseFields sets.String
+}
+
+func (v *vaultSecretUsageComparer) LastChanged() time.Time {
+	return v.item.Metadata.CreatedTime
+}
+
+func (v *vaultSecretUsageComparer) markInUse(fields sets.String) (absent sets.String) {
+	v.inUseFields.Insert(fields.List()...)
+	return fields.Difference(v.allFields)
+}
+
+func (v *vaultSecretUsageComparer) UnusedFields(inUse sets.String) (Difference sets.String) {
+	return v.markInUse(inUse)
+}
+
+func (v *vaultSecretUsageComparer) UnusedAttachments(inUse sets.String) (Difference sets.String) {
+	return v.markInUse(inUse)
+}
+
+func (v *vaultSecretUsageComparer) HasPassword() bool {
+	if v.allFields.Has("password") {
+		v.inUseFields.Insert("password")
+		return true
+	}
+	return false
+}
+
+func (v *vaultSecretUsageComparer) SuperfluousFields() sets.String {
+	return v.allFields.Difference(v.inUseFields)
+}

--- a/pkg/vaultclient/vaultclient.go
+++ b/pkg/vaultclient/vaultclient.go
@@ -87,7 +87,10 @@ func (v *VaultClient) DestroyKVIrreversibly(path string) error {
 
 func (v *VaultClient) GetKV(path string) (*KVData, error) {
 	var response KVData
-	return &response, v.readInto(InsertDataIntoPath(path), &response)
+	if err := v.readInto(InsertDataIntoPath(path), &response); err != nil {
+		return nil, fmt.Errorf("failed to get item at path %q: %w", path, err)
+	}
+	return &response, nil
 }
 
 func (v *VaultClient) UpsertKV(path string, data map[string]string) error {


### PR DESCRIPTION
This is very straightforward except for the getUnusedBWItems check. That
check verifies that all of fields, attachments and password are used, if
present. As Vault just has a k-v map and doesn't know to what bitwarden
type a field maps we do the following:
* We store all keys vault has
* For all of field/attachment/password in the config file, we ask the
  secret provider if it has them
* This will make the vault provider mark those fields as in-use
* At the end, we add another check, "superfluous fields". The Vault
  implementation will use that to report all fields it didn't get asked
  about

This allows us to re-use all tests and thus be confident that it works
for Vault as well. The error message however is slightly different for
Vault.

It is recommended to review this PR with whitespace disabled.

/cc @openshift/openshift-team-developer-productivity-test-platform 

Ref https://issues.redhat.com/browse/DPTP-1975