### PR TITLE
Revert "Merge pull request #1774 from stevekuznetsov/skuznets/unify-promotion-lists"

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -49,7 +49,7 @@ func (s *promotionStep) Run(ctx context.Context) error {
 }
 
 func (s *promotionStep) run(ctx context.Context) error {
-	tags, names := PromotedTagsWithRequiredImages(s.config, s.images, s.requiredImages)
+	tags, names := toPromote(s.config, s.images, s.requiredImages)
 	if len(names) == 0 {
 		log.Println("Nothing to promote, skipping...")
 		return nil
@@ -64,7 +64,7 @@ func (s *promotionStep) run(ctx context.Context) error {
 		return fmt.Errorf("could not resolve pipeline imagestream: %w", err)
 	}
 
-	imageMirrorTarget := getImageMirrorTarget(tags, pipeline)
+	imageMirrorTarget := getImageMirrorTarget(s.config, tags, pipeline)
 	if len(imageMirrorTarget) == 0 {
 		log.Println("Nothing to promote, skipping...")
 		return nil
@@ -76,18 +76,29 @@ func (s *promotionStep) run(ctx context.Context) error {
 	return nil
 }
 
-func getImageMirrorTarget(tags map[string]api.ImageStreamTagReference, pipeline *imagev1.ImageStream) map[string]string {
+func getImageMirrorTarget(config api.PromotionConfiguration, tags map[string]string, pipeline *imagev1.ImageStream) map[string]string {
 	if pipeline == nil {
 		return nil
 	}
 	imageMirror := map[string]string{}
-	for src, dst := range tags {
-		dockerImageReference := findDockerImageReference(pipeline, src)
-		if dockerImageReference == "" {
-			continue
+	if len(config.Name) > 0 {
+		for dst, src := range tags {
+			dockerImageReference := findDockerImageReference(pipeline, src)
+			if dockerImageReference == "" {
+				continue
+			}
+			dockerImageReference = getPublicImageReference(dockerImageReference, pipeline.Status.PublicDockerImageRepository)
+			imageMirror[dockerImageReference] = fmt.Sprintf("%s/%s/%s:%s", api.DomainForService(api.ServiceRegistry), config.Namespace, config.Name, dst)
 		}
-		dockerImageReference = getPublicImageReference(dockerImageReference, pipeline.Status.PublicDockerImageRepository)
-		imageMirror[dockerImageReference] = fmt.Sprintf("%s/%s/%s:%s", api.DomainForService(api.ServiceRegistry), dst.Namespace, dst.Name, dst.Tag)
+	} else {
+		for dst, src := range tags {
+			dockerImageReference := findDockerImageReference(pipeline, src)
+			if dockerImageReference == "" {
+				continue
+			}
+			dockerImageReference = getPublicImageReference(dockerImageReference, pipeline.Status.PublicDockerImageRepository)
+			imageMirror[dockerImageReference] = fmt.Sprintf("%s/%s/%s:%s", api.DomainForService(api.ServiceRegistry), config.Namespace, dst, config.Tag)
+		}
 	}
 	if len(imageMirror) == 0 {
 		return nil
@@ -230,40 +241,29 @@ func toPromote(config api.PromotionConfiguration, images []api.ProjectDirectoryI
 
 // PromotedTags returns the tags that are being promoted for the given ReleaseBuildConfiguration
 func PromotedTags(configuration *api.ReleaseBuildConfiguration) []api.ImageStreamTagReference {
-	if configuration == nil || configuration.PromotionConfiguration == nil {
+	if configuration.PromotionConfiguration == nil {
 		return nil
 	}
-	var tags []api.ImageStreamTagReference
-	mapping, _ := PromotedTagsWithRequiredImages(*configuration.PromotionConfiguration, configuration.Images, sets.NewString())
-	for _, dest := range mapping {
-		tags = append(tags, dest)
-	}
-	return tags
-}
-
-// PromotedTagsWithRequiredImages returns the tags that are being promoted for the given ReleaseBuildConfiguration
-// accounting for the list of required images
-func PromotedTagsWithRequiredImages(configuration api.PromotionConfiguration, images []api.ProjectDirectoryImageBuildStepConfiguration, requiredImages sets.String) (map[string]api.ImageStreamTagReference, sets.String) {
-	tags, names := toPromote(configuration, images, requiredImages)
-	promotedTags := map[string]api.ImageStreamTagReference{}
-	for src, dst := range tags {
+	tags, _ := toPromote(*configuration.PromotionConfiguration, configuration.Images, sets.NewString())
+	var promotedTags []api.ImageStreamTagReference
+	for dst := range tags {
 		var tag api.ImageStreamTagReference
-		if configuration.Name != "" {
+		if configuration.PromotionConfiguration.Name != "" {
 			tag = api.ImageStreamTagReference{
-				Namespace: configuration.Namespace,
-				Name:      configuration.Name,
+				Namespace: configuration.PromotionConfiguration.Namespace,
+				Name:      configuration.PromotionConfiguration.Name,
 				Tag:       dst,
 			}
 		} else { // promotion.Tag must be set
 			tag = api.ImageStreamTagReference{
-				Namespace: configuration.Namespace,
+				Namespace: configuration.PromotionConfiguration.Namespace,
 				Name:      dst,
-				Tag:       configuration.Tag,
+				Tag:       configuration.PromotionConfiguration.Tag,
 			}
 		}
-		promotedTags[src] = tag
+		promotedTags = append(promotedTags, tag)
 	}
-	return promotedTags, names
+	return promotedTags
 }
 
 func (s *promotionStep) Requires() []api.StepLink {


### PR DESCRIPTION
This reverts commit 9ba1c998b7b6bc924f3f26fe56476c0a8e5649b4, reversing
changes made to 190702e34c11619b0d763a35490e6dfd61ab3c2d.

`ci-operator-checkconfig` started rejecting `openshift/release@master`
after the merge:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-images/1370330368489558016
https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-release-master-ci-operator-config

```
$ git checkout -q 9ba1c998b^
$ go run ./cmd/ci-operator-checkconfig --config-dir $release/ci-operator/config --registry $release/ci-operator/step-registry
$ git checkout -q 9ba1c998b
$ go run ./cmd/ci-operator-checkconfig --config-dir $release/ci-operator/config --registry $release/ci-operator/step-registry
non-unique image publication found:
…
```

@stevekuznetsov: FYI.