### PR TITLE
use a watch to wait for pods instead of a tight poll

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -10,7 +10,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -69,12 +69,12 @@ func FromConfig(
 	}
 	templateClient := steps.NewTemplateClient(client, templateGetter.RESTClient())
 
-	coreGetter, err := coreclientset.NewForConfig(clusterConfig)
+	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get core client for cluster config: %w", err)
 	}
 
-	podClient := steps.NewPodClient(client, clusterConfig, coreGetter.RESTClient())
+	podClient := steps.NewPodClient(client, clusterConfig, kubeClient.CoreV1().RESTClient(), kubeClient)
 	return fromConfig(config, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, &http.Client{}, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil))
 }
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -14,6 +14,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
@@ -645,7 +646,7 @@ func TestFromConfig(t *testing.T) {
 	}
 	buildClient := steps.NewBuildClient(client, nil)
 	var templateClient steps.TemplateClient
-	podClient := steps.NewPodClient(client, nil, nil)
+	podClient := steps.NewPodClient(client, nil, nil, fake.NewSimpleClientset())
 	var leaseClient *lease.Client
 	var requiredTargets []string
 	var cloneAuthConfig *steps.CloneAuthConfig

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -270,6 +270,15 @@ func waitForContainer(podClient PodClient, ns, name, containerName string) error
 
 	waitTimeout, _ := watchwait.ContextWithOptionalTimeout(ctx, 300*5*time.Second /*weird, but this is what it was*/)
 	_, err := watchwait.UntilWithSync(waitTimeout, lw, &corev1.Pod{}, podExistsPrecondition, waitForContainerStatus)
+
+	// TODO this looks like an attempt to have an informer.  Even with a punch through, this client would then miss external
+	//  modifications, so it's notion of current state is flawed.
+	// there is a side-effect based client, which appears to cache state based on a GET request and is apparently used
+	// as a side-cache by other parts of this system. While there are no tests catching this today, removing such side-effects
+	// to create an externally verifiable system is outside the scope of this PR.  I might recommend using an existing
+	// informer to drive such decisions, but this will place the current state into the client
+	_ = podClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, &corev1.Pod{})
+
 	return err
 }
 

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -18,13 +18,20 @@ import (
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/remotecommand"
+	watchwait "k8s.io/client-go/tools/watch"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -169,16 +176,23 @@ type PodClient interface {
 	WithNewLoggingClient() PodClient
 	Exec(namespace, pod string, opts *coreapi.PodExecOptions) (remotecommand.Executor, error)
 	GetLogs(namespace, name string, opts *coreapi.PodLogOptions) *rest.Request
+	RealClient() kubernetes.Interface
 }
 
 func NewPodClient(ctrlclient loggingclient.LoggingClient, config *rest.Config, client rest.Interface) PodClient {
-	return &podClient{LoggingClient: ctrlclient, config: config, client: client}
+	return &podClient{
+		LoggingClient: ctrlclient,
+		config:        config,
+		client:        client,
+		realClient:    kubernetes.NewForConfigOrDie(config),
+	}
 }
 
 type podClient struct {
 	loggingclient.LoggingClient
-	config *rest.Config
-	client rest.Interface
+	config     *rest.Config
+	client     rest.Interface
+	realClient kubernetes.Interface
 }
 
 func (c podClient) Exec(namespace, pod string, opts *coreapi.PodExecOptions) (remotecommand.Executor, error) {
@@ -194,17 +208,17 @@ func (c podClient) GetLogs(namespace, name string, opts *coreapi.PodLogOptions) 
 	return c.client.Get().Namespace(namespace).Name(name).Resource("pods").SubResource("log").VersionedParams(opts, scheme.ParameterCodec)
 }
 
+func (c podClient) RealClient() kubernetes.Interface {
+	return c.realClient
+}
 func (c podClient) WithNewLoggingClient() PodClient {
 	return podClient{
 		LoggingClient: c.New(),
 		config:        c.config,
 		client:        c.client,
+		realClient:    c.realClient,
 	}
 }
-
-// Allow tests to accelerate time
-var intervalLock = &sync.RWMutex{}
-var interval = 10 * time.Second
 
 func waitForContainer(podClient PodClient, ns, name, containerName string) error {
 	logrus.WithFields(logrus.Fields{
@@ -213,27 +227,50 @@ func waitForContainer(podClient PodClient, ns, name, containerName string) error
 		"container": containerName,
 	}).Trace("Waiting for container to be running.")
 
-	intervalLock.RLock()
-	i := interval
-	intervalLock.RUnlock()
-	return wait.PollImmediate(i, 300*i, func() (bool, error) {
-		pod := &coreapi.Pod{}
-		if err := podClient.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, pod); err != nil {
-			logrus.WithError(err).Errorf("Waiting for container %s in pod %s in namespace %s", containerName, name, ns)
+	ctx := context.TODO()
+
+	kubeClient := podClient.RealClient()
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (object runtime.Object, e error) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", name).String()
+			return kubeClient.CoreV1().Pods(ns).List(ctx, options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (i watch.Interface, e error) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", name).String()
+			return kubeClient.CoreV1().Pods(ns).Watch(ctx, options)
+		},
+	}
+
+	// pods in this call here are always expected to exist in advance
+	var podExistsPrecondition watchwait.PreconditionFunc
+
+	waitForContainerStatus := func(event watch.Event) (bool, error) {
+		if event.Type == watch.Deleted {
+			return false, fmt.Errorf("pod/%v ns/%v was deleted", name, ns)
+		}
+		// the outer library will handle errors, we have no pod data to review in this case
+		if event.Type != watch.Added && event.Type != watch.Modified {
 			return false, nil
 		}
-
-		for _, container := range pod.Status.ContainerStatuses {
-			if container.Name == containerName {
-				if container.State.Running != nil || container.State.Terminated != nil {
-					return true, nil
+		switch pod := event.Object.(type) {
+		case *corev1.Pod:
+			for _, container := range pod.Status.ContainerStatuses {
+				if container.Name == containerName {
+					if container.State.Running != nil || container.State.Terminated != nil {
+						return true, nil
+					}
+					break
 				}
-				break
 			}
+		default:
+			return false, fmt.Errorf("pod/%v ns/%v got an event that did not contain a pod: %v", name, ns, event.Object)
 		}
-
 		return false, nil
-	})
+	}
+
+	waitTimeout, _ := watchwait.ContextWithOptionalTimeout(ctx, 300*5*time.Second /*weird, but this is what it was*/)
+	_, err := watchwait.UntilWithSync(waitTimeout, lw, &corev1.Pod{}, podExistsPrecondition, waitForContainerStatus)
+	return err
 }
 
 func copyArtifacts(podClient PodClient, into, ns, name, containerName string, paths []string) error {

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -179,12 +179,12 @@ type PodClient interface {
 	RealClient() kubernetes.Interface
 }
 
-func NewPodClient(ctrlclient loggingclient.LoggingClient, config *rest.Config, client rest.Interface) PodClient {
+func NewPodClient(ctrlclient loggingclient.LoggingClient, config *rest.Config, client rest.Interface, kubeClient kubernetes.Interface) PodClient {
 	return &podClient{
 		LoggingClient: ctrlclient,
 		config:        config,
 		client:        client,
-		realClient:    kubernetes.NewForConfigOrDie(config),
+		realClient:    kubeClient,
 	}
 }
 

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 	}
 	jobSpec.SetNamespace(namespace)
 
-	client := &podClient{loggingclient.New(fakectrlruntimeclient.NewFakeClient()), nil, nil}
+	client := &podClient{loggingclient.New(fakectrlruntimeclient.NewFakeClient()), nil, nil, fake.NewSimpleClientset()}
 	ps := PodStep(stepName, config, resources, client, jobSpec)
 
 	specification := stepExpectation{

--- a/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+func newEventProcessor(out chan<- watch.Event) *eventProcessor {
+	return &eventProcessor{
+		out:  out,
+		cond: sync.NewCond(&sync.Mutex{}),
+		done: make(chan struct{}),
+	}
+}
+
+// eventProcessor buffers events and writes them to an out chan when a reader
+// is waiting. Because of the requirement to buffer events, it synchronizes
+// input with a condition, and synchronizes output with a channels. It needs to
+// be able to yield while both waiting on an input condition and while blocked
+// on writing to the output channel.
+type eventProcessor struct {
+	out chan<- watch.Event
+
+	cond *sync.Cond
+	buff []watch.Event
+
+	done chan struct{}
+}
+
+func (e *eventProcessor) run() {
+	for {
+		batch := e.takeBatch()
+		e.writeBatch(batch)
+		if e.stopped() {
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) takeBatch() []watch.Event {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+
+	for len(e.buff) == 0 && !e.stopped() {
+		e.cond.Wait()
+	}
+
+	batch := e.buff
+	e.buff = nil
+	return batch
+}
+
+func (e *eventProcessor) writeBatch(events []watch.Event) {
+	for _, event := range events {
+		select {
+		case e.out <- event:
+		case <-e.done:
+			return
+		}
+	}
+}
+
+func (e *eventProcessor) push(event watch.Event) {
+	e.cond.L.Lock()
+	defer e.cond.L.Unlock()
+	defer e.cond.Signal()
+	e.buff = append(e.buff, event)
+}
+
+func (e *eventProcessor) stopped() bool {
+	select {
+	case <-e.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (e *eventProcessor) stop() {
+	close(e.done)
+	e.cond.Signal()
+}
+
+// NewIndexerInformerWatcher will create an IndexerInformer and wrap it into watch.Interface
+// so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
+// it also returns a channel you can use to wait for the informers to fully shutdown.
+func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
+	ch := make(chan watch.Event)
+	w := watch.NewProxyWatcher(ch)
+	e := newEventProcessor(ch)
+
+	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Added,
+				Object: obj.(runtime.Object),
+			})
+		},
+		UpdateFunc: func(old, new interface{}) {
+			e.push(watch.Event{
+				Type:   watch.Modified,
+				Object: new.(runtime.Object),
+			})
+		},
+		DeleteFunc: func(obj interface{}) {
+			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+			if stale {
+				// We have no means of passing the additional information down using
+				// watch API based on watch.Event but the caller can filter such
+				// objects by checking if metadata.deletionTimestamp is set
+				obj = staleObj
+			}
+
+			e.push(watch.Event{
+				Type:   watch.Deleted,
+				Object: obj.(runtime.Object),
+			})
+		},
+	}, cache.Indexers{})
+
+	go e.run()
+
+	doneCh := make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		defer e.stop()
+		informer.Run(w.StopChan())
+	}()
+
+	return indexer, informer, w, doneCh
+}

--- a/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
+++ b/vendor/k8s.io/client-go/tools/watch/retrywatcher.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// resourceVersionGetter is an interface used to get resource version from events.
+// We can't reuse an interface from meta otherwise it would be a cyclic dependency and we need just this one method
+type resourceVersionGetter interface {
+	GetResourceVersion() string
+}
+
+// RetryWatcher will make sure that in case the underlying watcher is closed (e.g. due to API timeout or etcd timeout)
+// it will get restarted from the last point without the consumer even knowing about it.
+// RetryWatcher does that by inspecting events and keeping track of resourceVersion.
+// Especially useful when using watch.UntilWithoutRetry where premature termination is causing issues and flakes.
+// Please note that this is not resilient to etcd cache not having the resource version anymore - you would need to
+// use Informers for that.
+type RetryWatcher struct {
+	lastResourceVersion string
+	watcherClient       cache.Watcher
+	resultChan          chan watch.Event
+	stopChan            chan struct{}
+	doneChan            chan struct{}
+	minRestartDelay     time.Duration
+}
+
+// NewRetryWatcher creates a new RetryWatcher.
+// It will make sure that watches gets restarted in case of recoverable errors.
+// The initialResourceVersion will be given to watch method when first called.
+func NewRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher) (*RetryWatcher, error) {
+	return newRetryWatcher(initialResourceVersion, watcherClient, 1*time.Second)
+}
+
+func newRetryWatcher(initialResourceVersion string, watcherClient cache.Watcher, minRestartDelay time.Duration) (*RetryWatcher, error) {
+	switch initialResourceVersion {
+	case "", "0":
+		// TODO: revisit this if we ever get WATCH v2 where it means start "now"
+		//       without doing the synthetic list of objects at the beginning (see #74022)
+		return nil, fmt.Errorf("initial RV %q is not supported due to issues with underlying WATCH", initialResourceVersion)
+	default:
+		break
+	}
+
+	rw := &RetryWatcher{
+		lastResourceVersion: initialResourceVersion,
+		watcherClient:       watcherClient,
+		stopChan:            make(chan struct{}),
+		doneChan:            make(chan struct{}),
+		resultChan:          make(chan watch.Event, 0),
+		minRestartDelay:     minRestartDelay,
+	}
+
+	go rw.receive()
+	return rw, nil
+}
+
+func (rw *RetryWatcher) send(event watch.Event) bool {
+	// Writing to an unbuffered channel is blocking operation
+	// and we need to check if stop wasn't requested while doing so.
+	select {
+	case rw.resultChan <- event:
+		return true
+	case <-rw.stopChan:
+		return false
+	}
+}
+
+// doReceive returns true when it is done, false otherwise.
+// If it is not done the second return value holds the time to wait before calling it again.
+func (rw *RetryWatcher) doReceive() (bool, time.Duration) {
+	watcher, err := rw.watcherClient.Watch(metav1.ListOptions{
+		ResourceVersion:     rw.lastResourceVersion,
+		AllowWatchBookmarks: true,
+	})
+	// We are very unlikely to hit EOF here since we are just establishing the call,
+	// but it may happen that the apiserver is just shutting down (e.g. being restarted)
+	// This is consistent with how it is handled for informers
+	switch err {
+	case nil:
+		break
+
+	case io.EOF:
+		// watch closed normally
+		return false, 0
+
+	case io.ErrUnexpectedEOF:
+		klog.V(1).Infof("Watch closed with unexpected EOF: %v", err)
+		return false, 0
+
+	default:
+		msg := "Watch failed: %v"
+		if net.IsProbableEOF(err) || net.IsTimeout(err) {
+			klog.V(5).Infof(msg, err)
+			// Retry
+			return false, 0
+		}
+
+		klog.Errorf(msg, err)
+		// Retry
+		return false, 0
+	}
+
+	if watcher == nil {
+		klog.Error("Watch returned nil watcher")
+		// Retry
+		return false, 0
+	}
+
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+
+	for {
+		select {
+		case <-rw.stopChan:
+			klog.V(4).Info("Stopping RetryWatcher.")
+			return true, 0
+		case event, ok := <-ch:
+			if !ok {
+				klog.V(4).Infof("Failed to get event! Re-creating the watcher. Last RV: %s", rw.lastResourceVersion)
+				return false, 0
+			}
+
+			// We need to inspect the event and get ResourceVersion out of it
+			switch event.Type {
+			case watch.Added, watch.Modified, watch.Deleted, watch.Bookmark:
+				metaObject, ok := event.Object.(resourceVersionGetter)
+				if !ok {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(errors.New("retryWatcher: doesn't support resourceVersion")).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				resourceVersion := metaObject.GetResourceVersion()
+				if resourceVersion == "" {
+					_ = rw.send(watch.Event{
+						Type:   watch.Error,
+						Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher: object %#v doesn't support resourceVersion", event.Object)).ErrStatus,
+					})
+					// We have to abort here because this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+					return true, 0
+				}
+
+				// All is fine; send the non-bookmark events and update resource version.
+				if event.Type != watch.Bookmark {
+					ok = rw.send(event)
+					if !ok {
+						return true, 0
+					}
+				}
+				rw.lastResourceVersion = resourceVersion
+
+				continue
+
+			case watch.Error:
+				// This round trip allows us to handle unstructured status
+				errObject := apierrors.FromObject(event.Object)
+				statusErr, ok := errObject.(*apierrors.StatusError)
+				if !ok {
+					klog.Error(spew.Sprintf("Received an error which is not *metav1.Status but %#+v", event.Object))
+					// Retry unknown errors
+					return false, 0
+				}
+
+				status := statusErr.ErrStatus
+
+				statusDelay := time.Duration(0)
+				if status.Details != nil {
+					statusDelay = time.Duration(status.Details.RetryAfterSeconds) * time.Second
+				}
+
+				switch status.Code {
+				case http.StatusGone:
+					// Never retry RV too old errors
+					_ = rw.send(event)
+					return true, 0
+
+				case http.StatusGatewayTimeout, http.StatusInternalServerError:
+					// Retry
+					return false, statusDelay
+
+				default:
+					// We retry by default. RetryWatcher is meant to proceed unless it is certain
+					// that it can't. If we are not certain, we proceed with retry and leave it
+					// up to the user to timeout if needed.
+
+					// Log here so we have a record of hitting the unexpected error
+					// and we can whitelist some error codes if we missed any that are expected.
+					klog.V(5).Info(spew.Sprintf("Retrying after unexpected error: %#+v", event.Object))
+
+					// Retry
+					return false, statusDelay
+				}
+
+			default:
+				klog.Errorf("Failed to recognize Event type %q", event.Type)
+				_ = rw.send(watch.Event{
+					Type:   watch.Error,
+					Object: &apierrors.NewInternalError(fmt.Errorf("retryWatcher failed to recognize Event type %q", event.Type)).ErrStatus,
+				})
+				// We are unable to restart the watch and have to stop the loop or this might cause lastResourceVersion inconsistency by skipping a potential RV with valid data!
+				return true, 0
+			}
+		}
+	}
+}
+
+// receive reads the result from a watcher, restarting it if necessary.
+func (rw *RetryWatcher) receive() {
+	defer close(rw.doneChan)
+	defer close(rw.resultChan)
+
+	klog.V(4).Info("Starting RetryWatcher.")
+	defer klog.V(4).Info("Stopping RetryWatcher.")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-rw.stopChan:
+			cancel()
+			return
+		case <-ctx.Done():
+			return
+		}
+	}()
+
+	// We use non sliding until so we don't introduce delays on happy path when WATCH call
+	// timeouts or gets closed and we need to reestablish it while also avoiding hot loops.
+	wait.NonSlidingUntilWithContext(ctx, func(ctx context.Context) {
+		done, retryAfter := rw.doReceive()
+		if done {
+			cancel()
+			return
+		}
+
+		time.Sleep(retryAfter)
+
+		klog.V(4).Infof("Restarting RetryWatcher at RV=%q", rw.lastResourceVersion)
+	}, rw.minRestartDelay)
+}
+
+// ResultChan implements Interface.
+func (rw *RetryWatcher) ResultChan() <-chan watch.Event {
+	return rw.resultChan
+}
+
+// Stop implements Interface.
+func (rw *RetryWatcher) Stop() {
+	close(rw.stopChan)
+}
+
+// Done allows the caller to be notified when Retry watcher stops.
+func (rw *RetryWatcher) Done() <-chan struct{} {
+	return rw.doneChan
+}

--- a/vendor/k8s.io/client-go/tools/watch/until.go
+++ b/vendor/k8s.io/client-go/tools/watch/until.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+// PreconditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition failed or detected an error state.
+type PreconditionFunc func(store cache.Store) (bool, error)
+
+// ConditionFunc returns true if the condition has been reached, false if it has not been reached yet,
+// or an error if the condition cannot be checked and should terminate. In general, it is better to define
+// level driven conditions over edge driven conditions (pod has ready=true, vs pod modified and ready changed
+// from false to true).
+type ConditionFunc func(event watch.Event) (bool, error)
+
+// ErrWatchClosed is returned when the watch channel is closed before timeout in UntilWithoutRetry.
+var ErrWatchClosed = errors.New("watch closed before UntilWithoutRetry timeout")
+
+// UntilWithoutRetry reads items from the watch until each provided condition succeeds, and then returns the last watch
+// encountered. The first condition that returns an error terminates the watch (and the event is also returned).
+// If no event has been received, the returned event will be nil.
+// Conditions are satisfied sequentially so as to provide a useful primitive for higher level composition.
+// Waits until context deadline or until context is canceled.
+//
+// Warning: Unless you have a very specific use case (probably a special Watcher) don't use this function!!!
+// Warning: This will fail e.g. on API timeouts and/or 'too old resource version' error.
+// Warning: You are most probably looking for a function *Until* or *UntilWithSync* below,
+// Warning: solving such issues.
+// TODO: Consider making this function private to prevent misuse when the other occurrences in our codebase are gone.
+func UntilWithoutRetry(ctx context.Context, watcher watch.Interface, conditions ...ConditionFunc) (*watch.Event, error) {
+	ch := watcher.ResultChan()
+	defer watcher.Stop()
+	var lastEvent *watch.Event
+	for _, condition := range conditions {
+		// check the next condition against the previous event and short circuit waiting for the next watch
+		if lastEvent != nil {
+			done, err := condition(*lastEvent)
+			if err != nil {
+				return lastEvent, err
+			}
+			if done {
+				continue
+			}
+		}
+	ConditionSucceeded:
+		for {
+			select {
+			case event, ok := <-ch:
+				if !ok {
+					return lastEvent, ErrWatchClosed
+				}
+				lastEvent = &event
+
+				done, err := condition(event)
+				if err != nil {
+					return lastEvent, err
+				}
+				if done {
+					break ConditionSucceeded
+				}
+
+			case <-ctx.Done():
+				return lastEvent, wait.ErrWaitTimeout
+			}
+		}
+	}
+	return lastEvent, nil
+}
+
+// Until wraps the watcherClient's watch function with RetryWatcher making sure that watcher gets restarted in case of errors.
+// The initialResourceVersion will be given to watch method when first called. It shall not be "" or "0"
+// given the underlying WATCH call issues (#74022). If you want the initial list ("", "0") done for you use ListWatchUntil instead.
+// Remaining behaviour is identical to function UntilWithoutRetry. (See above.)
+// Until can deal with API timeouts and lost connections.
+// It guarantees you to see all events and in the order they happened.
+// Due to this guarantee there is no way it can deal with 'Resource version too old error'. It will fail in this case.
+// (See `UntilWithSync` if you'd prefer to recover from all the errors including RV too old by re-listing
+//  those items. In normal code you should care about being level driven so you'd not care about not seeing all the edges.)
+// The most frequent usage for Until would be a test where you want to verify exact order of events ("edges").
+func Until(ctx context.Context, initialResourceVersion string, watcherClient cache.Watcher, conditions ...ConditionFunc) (*watch.Event, error) {
+	w, err := NewRetryWatcher(initialResourceVersion, watcherClient)
+	if err != nil {
+		return nil, err
+	}
+
+	return UntilWithoutRetry(ctx, w, conditions...)
+}
+
+// UntilWithSync creates an informer from lw, optionally checks precondition when the store is synced,
+// and watches the output until each provided condition succeeds, in a way that is identical
+// to function UntilWithoutRetry. (See above.)
+// UntilWithSync can deal with all errors like API timeout, lost connections and 'Resource version too old'.
+// It is the only function that can recover from 'Resource version too old', Until and UntilWithoutRetry will
+// just fail in that case. On the other hand it can't provide you with guarantees as strong as using simple
+// Watch method with Until. It can skip some intermediate events in case of watch function failing but it will
+// re-list to recover and you always get an event, if there has been a change, after recovery.
+// Also with the current implementation based on DeltaFIFO, order of the events you receive is guaranteed only for
+// particular object, not between more of them even it's the same resource.
+// The most frequent usage would be a command that needs to watch the "state of the world" and should't fail, like:
+// waiting for object reaching a state, "small" controllers, ...
+func UntilWithSync(ctx context.Context, lw cache.ListerWatcher, objType runtime.Object, precondition PreconditionFunc, conditions ...ConditionFunc) (*watch.Event, error) {
+	indexer, informer, watcher, done := NewIndexerInformerWatcher(lw, objType)
+	// We need to wait for the internal informers to fully stop so it's easier to reason about
+	// and it works with non-thread safe clients.
+	defer func() { <-done }()
+	// Proxy watcher can be stopped multiple times so it's fine to use defer here to cover alternative branches and
+	// let UntilWithoutRetry to stop it
+	defer watcher.Stop()
+
+	if precondition != nil {
+		if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+			return nil, fmt.Errorf("UntilWithSync: unable to sync caches: %v", ctx.Err())
+		}
+
+		done, err := precondition(indexer)
+		if err != nil {
+			return nil, err
+		}
+
+		if done {
+			return nil, nil
+		}
+	}
+
+	return UntilWithoutRetry(ctx, watcher, conditions...)
+}
+
+// ContextWithOptionalTimeout wraps context.WithTimeout and handles infinite timeouts expressed as 0 duration.
+func ContextWithOptionalTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout < 0 {
+		// This should be handled in validation
+		klog.Errorf("Timeout for context shall not be negative!")
+		timeout = 0
+	}
+
+	if timeout == 0 {
+		return context.WithCancel(parent)
+	}
+
+	return context.WithTimeout(parent, timeout)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1069,6 +1069,7 @@ k8s.io/client-go/tools/record
 k8s.io/client-go/tools/record/util
 k8s.io/client-go/tools/reference
 k8s.io/client-go/tools/remotecommand
+k8s.io/client-go/tools/watch
 k8s.io/client-go/transport
 k8s.io/client-go/transport/spdy
 k8s.io/client-go/util/cert


### PR DESCRIPTION
Updates the ci-operator to use standard kuberentes principle established in the upstream client (not controller-runtime) which have successfully scalable systems like
1. kube-apiserver RBAC
2. every apps controller
3. every controller in kube-controller-manager
4. all openshift-controllers
5. kubelet
6. scheduler
7. network plugins
8. csi drivers
9. more than a third of all operators

The backing library itself is well tested (see references above), so we should consider using the standard client library that is prove scalable and not a shim which has not been.