### PR TITLE
DPTP-2006 check in the step execution error if the context is cancelled properly 

### DIFF
--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -56,7 +56,7 @@ func Run(ctx context.Context, graph []*api.StepNode) (*junit.TestSuites, []api.C
 			stepDetails = append(stepDetails, out.stepDetails)
 			if out.err != nil {
 				testCase.FailureOutput = &junit.FailureOutput{Output: out.err.Error()}
-				if out.err != context.Canceled {
+				if !errors.Is(out.err, context.Canceled) {
 					executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
 				}
 			} else {


### PR DESCRIPTION
@openshift/openshift-team-developer-productivity-test-platform @petr-muller 

`out.err` is a [results.Error](https://github.com/openshift/ci-tools/blob/master/pkg/results/error.go#L14) wrapped in an original golang error while [context.Canceled](https://go.googlesource.com/go/+/go1.16/src/context/context.go#157) is not. This makes the comparison fail. since the `out.err` contains also other elements. 

The current code was ignoring passing that check when the context was canceled. The change in this PR, just makes sure that we compare only the error message.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>