### PR TITLE
Reintroduce Build Cache

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -80,7 +80,7 @@ func validateTags(seen tagSet) []error {
 			}
 			formatted = append(formatted, identifier)
 		}
-		dupes = append(dupes, fmt.Errorf("output tag %s/%s:%s is promoted from more than one place: %v", tag.Namespace, tag.Name, tag.Tag, strings.Join(formatted, ", ")))
+		dupes = append(dupes, fmt.Errorf("output tag %s is promoted from more than one place: %v", tag.ISTagName(), strings.Join(formatted, ", ")))
 	}
 	return dupes
 }

--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -647,7 +647,7 @@ func updateDockerfilesToMatchOCPBuildData(
 		if !ok {
 			continue
 		}
-		stringifiedPromotionTarget := fmt.Sprintf("registry.ci.openshift.org/%s/%s:%s", promotionTarget.Namespace, promotionTarget.Name, image.To)
+		stringifiedPromotionTarget := fmt.Sprintf("registry.ci.openshift.org/%s", promotionTarget.ISTagName())
 		dockerfilePath, ok := promotionTargetToDockerfileMapping[stringifiedPromotionTarget]
 		if !ok {
 			logrus.WithField("promotiontarget", stringifiedPromotionTarget).Info("Ignoring promotion target for which we have no ocp-build-data config")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -343,6 +343,10 @@ type ImageStreamTagReference struct {
 	As string `json:"as,omitempty"`
 }
 
+func (i *ImageStreamTagReference) ISTagName() string {
+	return fmt.Sprintf("%s/%s:%s", i.Namespace, i.Name, i.Tag)
+}
+
 // ReleaseTagConfiguration describes how a release is
 // assembled from release artifacts. A release image stream is a
 // single stream with multiple tags (openshift/origin-v3.9:control-plane),

--- a/pkg/controller/promotionreconciler/reconciler.go
+++ b/pkg/controller/promotionreconciler/reconciler.go
@@ -231,7 +231,7 @@ const configIndexName = "release-build-config-by-image-stream-tag"
 func configIndexFn(in cioperatorapi.ReleaseBuildConfiguration) []string {
 	var result []string
 	for _, istRef := range release.PromotedTags(&in) {
-		result = append(result, fmt.Sprintf("%s/%s:%s", istRef.Namespace, istRef.Name, istRef.Tag))
+		result = append(result, istRef.ISTagName())
 	}
 	return result
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -272,11 +272,10 @@ func fromConfig(
 		if pushSecret == nil {
 			return nil, nil, errors.New("--image-mirror-push-secret is required for promoting images")
 		}
-		cfg, err := promotionDefaults(config)
-		if err != nil {
-			return nil, nil, fmt.Errorf("could not determine promotion defaults: %w", err)
+		if config.PromotionConfiguration == nil {
+			return nil, nil, fmt.Errorf("cannot promote images, no promotion configuration defined")
 		}
-		postSteps = append(postSteps, releasesteps.PromotionStep(*cfg, config.Images, requiredNames, jobSpec, podClient, pushSecret))
+		postSteps = append(postSteps, releasesteps.PromotionStep(config, requiredNames, jobSpec, podClient, pushSecret))
 	}
 
 	return append(overridableSteps, buildSteps...), postSteps, nil
@@ -378,14 +377,6 @@ func checkForFullyQualifiedStep(step api.Step, params *api.DeferredParameters) (
 		params.Add(name, fn)
 	}
 	return step, false
-}
-
-func promotionDefaults(configSpec *api.ReleaseBuildConfiguration) (*api.PromotionConfiguration, error) {
-	config := configSpec.PromotionConfiguration
-	if config == nil {
-		return nil, fmt.Errorf("cannot promote images, no promotion or release tag configuration defined")
-	}
-	return config, nil
 }
 
 // leasesForTest aggregates all the lease configurations in a test.

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -48,7 +48,7 @@ func (s *inputImageTagStep) Inputs() (api.InputDefinition, error) {
 		return nil, fmt.Errorf("could not resolve base image: %w", err)
 	}
 
-	log.Printf("Resolved %s/%s:%s to %s", s.config.BaseImage.Namespace, s.config.BaseImage.Name, s.config.BaseImage.Tag, from.Image.Name)
+	log.Printf("Resolved %s to %s", s.config.BaseImage.ISTagName(), from.Image.Name)
 	s.imageName = from.Image.Name
 	return api.InputDefinition{from.Image.Name}, nil
 }
@@ -60,7 +60,7 @@ func (s *inputImageTagStep) Run(ctx context.Context) error {
 }
 
 func (s *inputImageTagStep) run(ctx context.Context) error {
-	log.Printf("Tagging %s/%s:%s into %s:%s", s.config.BaseImage.Namespace, s.config.BaseImage.Name, s.config.BaseImage.Tag, api.PipelineImageStream, s.config.To)
+	log.Printf("Tagging %s into %s:%s", s.config.BaseImage.ISTagName(), api.PipelineImageStream, s.config.To)
 
 	if _, err := s.Inputs(); err != nil {
 		return fmt.Errorf("could not resolve inputs for image tag step: %w", err)

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -43,7 +43,7 @@ func (s *outputImageTagStep) run(ctx context.Context) error {
 	if string(s.config.From) == s.config.To.Tag && toNamespace == s.jobSpec.Namespace() && s.config.To.Name == api.StableImageStream {
 		log.Printf("Tagging %s into %s", s.config.From, s.config.To.Name)
 	} else {
-		log.Printf("Tagging %s into %s/%s:%s", s.config.From, toNamespace, s.config.To.Name, s.config.To.Tag)
+		log.Printf("Tagging %s into %s", s.config.From, s.config.To.ISTagName())
 	}
 	from := &imagev1.ImageStreamTag{}
 	if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -264,13 +264,21 @@ func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration
 	}
 	// always promote the binary build if one exists
 	if configuration.BinaryBuildCommands != "" {
-		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = api.ImageStreamTagReference{
-			Namespace: "build-cache",
-			Name:      fmt.Sprintf("%s-%s", configuration.Metadata.Org, configuration.Metadata.Repo),
-			Tag:       configuration.Metadata.Branch,
-		}
+		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = BuildCacheFor(configuration.Metadata)
 	}
 	return promotedTags, names
+}
+
+func BuildCacheFor(metadata api.Metadata) api.ImageStreamTagReference {
+	tag := metadata.Branch
+	if metadata.Variant != "" {
+		tag = fmt.Sprintf("%s-%s", tag, metadata.Variant)
+	}
+	return api.ImageStreamTagReference{
+		Namespace: "build-cache",
+		Name:      fmt.Sprintf("%s-%s", metadata.Org, metadata.Repo),
+		Tag:       tag,
+	}
 }
 
 func (s *promotionStep) Requires() []api.StepLink {

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -240,7 +240,7 @@ func PromotedTags(configuration *api.ReleaseBuildConfiguration) []api.ImageStrea
 // PromotedTagsWithRequiredImages returns the tags that are being promoted for the given ReleaseBuildConfiguration
 // accounting for the list of required images
 func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration, requiredImages sets.String) (map[string]api.ImageStreamTagReference, sets.String) {
-	if configuration == nil || configuration.PromotionConfiguration == nil {
+	if configuration == nil || configuration.PromotionConfiguration == nil || configuration.PromotionConfiguration.Disabled {
 		return nil, nil
 	}
 	tags, names := toPromote(*configuration.PromotionConfiguration, configuration.Images, requiredImages)

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -245,7 +245,7 @@ func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration
 	}
 	tags, names := toPromote(*configuration.PromotionConfiguration, configuration.Images, requiredImages)
 	promotedTags := map[string]api.ImageStreamTagReference{}
-	for src, dst := range tags {
+	for dst, src := range tags {
 		var tag api.ImageStreamTagReference
 		if configuration.PromotionConfiguration.Name != "" {
 			tag = api.ImageStreamTagReference{

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -86,7 +86,7 @@ func getImageMirrorTarget(tags map[string]api.ImageStreamTagReference, pipeline 
 			continue
 		}
 		dockerImageReference = getPublicImageReference(dockerImageReference, pipeline.Status.PublicDockerImageRepository)
-		imageMirror[dockerImageReference] = fmt.Sprintf("%s/%s/%s:%s", api.DomainForService(api.ServiceRegistry), dst.Namespace, dst.Name, dst.Tag)
+		imageMirror[dockerImageReference] = fmt.Sprintf("%s/%s", api.DomainForService(api.ServiceRegistry), dst.ISTagName())
 	}
 	if len(imageMirror) == 0 {
 		return nil

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -234,11 +234,15 @@ func PromotedTags(configuration *api.ReleaseBuildConfiguration) []api.ImageStrea
 	for _, dest := range mapping {
 		tags = append(tags, dest)
 	}
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i].ISTagName() < tags[j].ISTagName()
+	})
 	return tags
 }
 
 // PromotedTagsWithRequiredImages returns the tags that are being promoted for the given ReleaseBuildConfiguration
-// accounting for the list of required images
+// accounting for the list of required images. Promoted tags are mapped by the source tag in the pipeline ImageStream
+// we will promote to the output.
 func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration, requiredImages sets.String) (map[string]api.ImageStreamTagReference, sets.String) {
 	if configuration == nil || configuration.PromotionConfiguration == nil || configuration.PromotionConfiguration.Disabled {
 		return nil, nil

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -170,6 +170,20 @@ func TestPromotedTags(t *testing.T) {
 			}},
 		},
 		{
+			name: "promoted image but disabled promotion means no output tags",
+			input: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+					{To: api.PipelineImageStreamTagReference("foo")},
+				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "roger",
+					Name:      "fred",
+					Disabled:  true,
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "promoted image by tag means output tags",
 			input: &api.ReleaseBuildConfiguration{
 				Images: []api.ProjectDirectoryImageBuildStepConfiguration{

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -201,6 +201,44 @@ func TestPromotedTags(t *testing.T) {
 			}},
 		},
 		{
+			name: "promoted additional image with rename",
+			input: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+					{To: api.PipelineImageStreamTagReference("foo")},
+				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "roger",
+					Tag:       "fred",
+					AdditionalImages: map[string]string{
+						"output": "src",
+					},
+				},
+			},
+			expected: []api.ImageStreamTagReference{{
+				Namespace: "roger",
+				Name:      "foo",
+				Tag:       "fred",
+			}, {
+				Namespace: "roger",
+				Name:      "output",
+				Tag:       "fred",
+			}},
+		},
+		{
+			name: "disabled image",
+			input: &api.ReleaseBuildConfiguration{
+				Images: []api.ProjectDirectoryImageBuildStepConfiguration{
+					{To: api.PipelineImageStreamTagReference("foo")},
+				},
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace:      "roger",
+					Tag:            "fred",
+					ExcludedImages: []string{"foo"},
+				},
+			},
+			expected: nil,
+		},
+		{
 			name: "promotion set and binaries built, means binaries promoted",
 			input: &api.ReleaseBuildConfiguration{
 				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	coreapi "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/diff"
@@ -267,6 +268,44 @@ func TestPromotedTags(t *testing.T) {
 				t.Errorf("%s: got incorrect promoted tags: %v", testCase.name, diff.ObjectDiff(actual, expected))
 			}
 		})
+	}
+}
+
+func TestBuildCacheFor(t *testing.T) {
+	var testCases = []struct {
+		input  api.Metadata
+		output api.ImageStreamTagReference
+	}{
+		{
+			input: api.Metadata{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			output: api.ImageStreamTagReference{
+				Namespace: "build-cache",
+				Name:      "org-repo",
+				Tag:       "branch",
+			},
+		},
+		{
+			input: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			output: api.ImageStreamTagReference{
+				Namespace: "build-cache",
+				Name:      "org-repo",
+				Tag:       "branch-variant",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		if diff := cmp.Diff(testCase.output, BuildCacheFor(testCase.input)); diff != "" {
+			t.Errorf("got incorrect ist for build cache: %v", diff)
+		}
 	}
 }
 

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1171,7 +1171,7 @@ func syntaxBash(source string) (string, error) {
 
 func fromImage(name string, reference *api.ImageStreamTagReference) string {
 	if reference != nil {
-		return fmt.Sprintf("%s/%s:%s", reference.Namespace, reference.Name, reference.Tag)
+		return reference.ISTagName()
 	}
 	return name
 }


### PR DESCRIPTION
This re-introduces the previous PRs and adds fixes + unit tests for all the cases that failed in the past. `ci-operator-checkconfig` is now happy. 