### PR TITLE
Revert "ci-operator: add support for operator upgrade tests"

### DIFF
--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -412,7 +412,7 @@ func TestBuildPartialGraph(t *testing.T) {
 						},
 						To: api.PipelineImageStreamTagReference("oc-bin-image"),
 					},
-					&api.ReleaseBuildConfiguration{}, api.ResourceConfiguration{}, nil, nil, nil,
+					api.ResourceConfiguration{}, nil, nil, nil,
 				),
 				steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil),
 				steps.ImagesReadyStep(steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil).Creates()),

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -141,7 +141,7 @@ func (config ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
 		string(PipelineImageStreamTagReferenceIndexImage):
 		return true
 	}
-	return config.IsBundleImage(name)
+	return IsBundleImage(name)
 }
 
 // ResourceConfiguration defines resource overrides for jobs run
@@ -1136,28 +1136,10 @@ type OperatorStepConfiguration struct {
 	Substitutions []PullSpecSubstitution `json:"substitutions,omitempty"`
 }
 
-// IndexUpdate specifies the update mode for an operator being added to an index
-type IndexUpdate string
-
-const (
-	IndexUpdateSemver          = "semver"
-	IndexUpdateReplaces        = "replaces"
-	IndexUpdateSemverSkippatch = "semver-skippatch"
-)
-
-// Bundle contains the data needed to build a bundle from the bundle source image and update an index to include the new bundle
+// Bundle contains the data needed to build a bundle from the bundle source image
 type Bundle struct {
-	// As defines the name for this bundle. If not set, a name will be automatically generated for the bundle.
-	As string `json:"as,omitempty"`
-	// DockerfilePath defines where the dockerfile for build the bundle exists relative to the contextdir
 	DockerfilePath string `json:"dockerfile_path,omitempty"`
-	// ContextDir defines the source directory to build the bundle from relative to the repository root
-	ContextDir string `json:"context_dir,omitempty"`
-	// BaseIndex defines what index image to use as a base when adding the bundle to an index
-	BaseIndex string `json:"base_index,omitempty"`
-	// UpdateGraph defines the update mode to use when adding the bundle to the base index.
-	// Can be: semver (default), semver-skippatch, or replaces
-	UpdateGraph IndexUpdate `json:"update_graph,omitempty"`
+	ContextDir     string `json:"context_dir,omitempty"`
 }
 
 // IndexGeneratorStepConfiguration describes a step that creates an index database and
@@ -1169,12 +1151,6 @@ type IndexGeneratorStepConfiguration struct {
 	// OperatorIndex is a list of the names of the bundle images that the
 	// index will contain in its database.
 	OperatorIndex []string `json:"operator_index,omitempty"`
-
-	// BaseIndex is the index image to add the bundle(s) to. If unset, a new index is created
-	BaseIndex string `json:"base_index,omitempty"`
-
-	// UpdateGraph defines the mode to us when updating the index graph
-	UpdateGraph IndexUpdate `json:"update_graph,omitempty"`
 }
 
 // PipelineImageStreamTagReferenceIndexImageGenerator is the name of the index image generator built by ci-operator
@@ -1182,18 +1158,6 @@ const PipelineImageStreamTagReferenceIndexImageGenerator PipelineImageStreamTagR
 
 // PipelineImageStreamTagReferenceIndexImage is the name of the index image built by ci-operator
 const PipelineImageStreamTagReferenceIndexImage PipelineImageStreamTagReference = "ci-index"
-
-func IsIndexImage(imageName string) bool {
-	return strings.HasPrefix(imageName, string(PipelineImageStreamTagReferenceIndexImage))
-}
-
-func IndexName(bundleName string) string {
-	return fmt.Sprintf("%s-%s", PipelineImageStreamTagReferenceIndexImage, bundleName)
-}
-
-func IndexGeneratorName(indexName PipelineImageStreamTagReference) PipelineImageStreamTagReference {
-	return PipelineImageStreamTagReference(fmt.Sprintf("%s-gen", indexName))
-}
 
 // BundleSourceStepConfiguration describes a step that performs a set of
 // substitutions on all yaml files in the `src` image so that the
@@ -1208,22 +1172,11 @@ type BundleSourceStepConfiguration struct {
 // PipelineImageStreamTagReferenceBundleSourceName is the name of the bundle source image built by the CI
 const PipelineImageStreamTagReferenceBundleSource PipelineImageStreamTagReference = "src-bundle"
 
-// BundlePrefix is the prefix used by ci-operator for bundle images without an explicitly configured name
+// BundlePrefix is the prefix used by ci-operator for bundle images
 const BundlePrefix = "ci-bundle"
 
-func (config ReleaseBuildConfiguration) IsBundleImage(imageName string) bool {
-	if config.Operator == nil {
-		return false
-	}
-	if strings.HasPrefix(imageName, BundlePrefix) {
-		return true
-	}
-	for _, bundle := range config.Operator.Bundles {
-		if imageName == bundle.As {
-			return true
-		}
-	}
-	return false
+func IsBundleImage(imageName string) bool {
+	return strings.HasPrefix(imageName, BundlePrefix)
 }
 
 func BundleName(index int) string {

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -207,32 +207,16 @@ func TestBundleName(t *testing.T) {
 }
 
 func TestIsBundleImage(t *testing.T) {
-	config := ReleaseBuildConfiguration{
-		Operator: &OperatorStepConfiguration{
-			Bundles: []Bundle{{As: "my-bundle"}},
-		},
+	if !IsBundleImage("ci-bundle0") {
+		t.Errorf("Expected true, got false for `ci-bundle0`")
 	}
-	testCases := []struct {
-		name     string
-		expected bool
-	}{{
-		name:     BundleName(0),
-		expected: true,
-	}, {
-		name:     BundleName(1),
-		expected: true,
-	}, {
-		name:     "my-bundle",
-		expected: true,
-	}, {
-		name:     "not-a-bundle",
-		expected: false,
-	}}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			if config.IsBundleImage(testCase.name) != testCase.expected {
-				t.Errorf("Expected %t, got %t", testCase.expected, config.IsBundleImage(testCase.name))
-			}
-		})
+	if !IsBundleImage("ci-bundle1") {
+		t.Errorf("Expected true, got false for `ci-bundle1`")
+	}
+	if !IsBundleImage(BundleName(0)) {
+		t.Errorf("Expected true, got false for func BundleName(0)")
+	}
+	if !IsBundleImage(BundleName(1)) {
+		t.Errorf("Expected true, got false for func BundleName(1)")
 	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -173,7 +173,7 @@ func fromConfig(
 		} else if rawStep.IndexGeneratorStepConfiguration != nil {
 			step = steps.IndexGeneratorStep(*rawStep.IndexGeneratorStepConfiguration, config, config.Resources, buildClient, jobSpec, pullSecret)
 		} else if rawStep.ProjectDirectoryImageBuildStepConfiguration != nil {
-			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config, config.Resources, buildClient, jobSpec, pullSecret)
+			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config.Resources, buildClient, jobSpec, pullSecret)
 		} else if rawStep.ProjectDirectoryImageBuildInputs != nil {
 			step = steps.GitSourceStep(*rawStep.ProjectDirectoryImageBuildInputs, config.Resources, buildClient, jobSpec, cloneAuthConfig, pullSecret)
 		} else if rawStep.RPMImageInjectionStepConfiguration != nil {
@@ -539,48 +539,9 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			Substitutions: config.Operator.Substitutions,
 		}})
 		// Build bundles
-		// First build named bundles and corresponding indices
-		// store list of indices for unnamed bundles
-		var unnamedBundles []int
-		for index, bundleConfig := range config.Operator.Bundles {
-			if bundleConfig.As == "" {
-				unnamedBundles = append(unnamedBundles, index)
-				continue
-			}
-			bundle := &api.ProjectDirectoryImageBuildStepConfiguration{
-				To: api.PipelineImageStreamTagReference(bundleConfig.As),
-				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-					ContextDir:     bundleConfig.ContextDir,
-					DockerfilePath: bundleConfig.DockerfilePath,
-				},
-			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: bundle})
-			// Build index generator
-			indexName := api.PipelineImageStreamTagReference(api.IndexName(bundleConfig.As))
-			updateGraph := bundleConfig.UpdateGraph
-			if updateGraph == "" {
-				updateGraph = api.IndexUpdateSemver
-			}
-			buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
-				To:            api.IndexGeneratorName(indexName),
-				OperatorIndex: []string{bundleConfig.As},
-				BaseIndex:     bundleConfig.BaseIndex,
-				UpdateGraph:   updateGraph,
-			}})
-			// Build the index
-			index := &api.ProjectDirectoryImageBuildStepConfiguration{
-				To: indexName,
-				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-					DockerfilePath: steps.IndexDockerfileName,
-				},
-			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index})
-		}
-		// Build non-named bundles following old naming system
 		var bundles []string
-		for _, bundleIndex := range unnamedBundles {
-			bundle := config.Operator.Bundles[bundleIndex]
-			bundleName := api.BundleName(bundleIndex)
+		for index, bundle := range config.Operator.Bundles {
+			bundleName := api.BundleName(index)
 			bundles = append(bundles, bundleName)
 			image := &api.ProjectDirectoryImageBuildStepConfiguration{
 				To: api.PipelineImageStreamTagReference(bundleName),
@@ -591,22 +552,19 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			}
 			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
 		}
-		if len(bundles) > 0 {
-			// Build index generator
-			buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
-				To:            api.PipelineImageStreamTagReferenceIndexImageGenerator,
-				OperatorIndex: bundles,
-				UpdateGraph:   api.IndexUpdateSemver,
-			}})
-			// Build the index
-			image := &api.ProjectDirectoryImageBuildStepConfiguration{
-				To: api.PipelineImageStreamTagReferenceIndexImage,
-				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-					DockerfilePath: steps.IndexDockerfileName,
-				},
-			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
+		// Build index generator
+		buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
+			To:            api.PipelineImageStreamTagReferenceIndexImageGenerator,
+			OperatorIndex: bundles,
+		}})
+		// Build the index
+		image := &api.ProjectDirectoryImageBuildStepConfiguration{
+			To: api.PipelineImageStreamTagReferenceIndexImage,
+			ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+				DockerfilePath: steps.IndexDockerfileName,
+			},
 		}
+		buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
 	}
 
 	for i := range config.Tests {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -515,7 +515,6 @@ func TestStepConfigsForBuild(t *testing.T) {
 				IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
 					To:            "ci-index-gen",
 					OperatorIndex: []string{"ci-bundle0"},
-					UpdateGraph:   api.IndexUpdateSemver,
 				},
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
@@ -530,75 +529,6 @@ func TestStepConfigsForBuild(t *testing.T) {
 			}, {
 				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
 					To: "ci-bundle0",
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-						ContextDir:     "manifests/olm",
-						DockerfilePath: "bundle.Dockerfile",
-					},
-				},
-			}, {
-				SourceStepConfiguration: &api.SourceStepConfiguration{
-					From:           "root",
-					To:             "src",
-					ClonerefsImage: api.ImageStreamTagReference{Namespace: "ci", Name: "managed-clonerefs", Tag: "latest"},
-					ClonerefsPath:  "/clonerefs",
-				},
-			}},
-		},
-		{
-			name: "including an named operator bundle creates the bundle-sub and the named index-gen and index images",
-			input: &api.ReleaseBuildConfiguration{
-				InputConfiguration: api.InputConfiguration{
-					BuildRootImage: &api.BuildRootImageConfiguration{
-						ImageStreamTagReference: &api.ImageStreamTagReference{Tag: "manual"},
-					},
-				},
-				Operator: &api.OperatorStepConfiguration{
-					Bundles: []api.Bundle{{
-						As:             "my-bundle",
-						ContextDir:     "manifests/olm",
-						DockerfilePath: "bundle.Dockerfile",
-					}},
-					Substitutions: []api.PullSpecSubstitution{{
-						PullSpec: "quay.io/origin/oc",
-						With:     "pipeline:oc",
-					}},
-				},
-			},
-			jobSpec: &api.JobSpec{
-				JobSpec: downwardapi.JobSpec{
-					Refs: &prowapi.Refs{
-						Org:  "org",
-						Repo: "repo",
-					},
-				},
-				BaseNamespace: "base-1",
-			},
-			output: []api.StepConfiguration{{
-				BundleSourceStepConfiguration: &api.BundleSourceStepConfiguration{
-					Substitutions: []api.PullSpecSubstitution{{
-						PullSpec: "quay.io/origin/oc",
-						With:     "pipeline:oc",
-					}},
-				},
-			}, {
-				IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
-					To:            "ci-index-my-bundle-gen",
-					OperatorIndex: []string{"my-bundle"},
-					UpdateGraph:   api.IndexUpdateSemver,
-				},
-			}, {
-				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
-					BaseImage: api.ImageStreamTagReference{Namespace: "base-1", Name: "repo-test-base", Tag: "manual"},
-					To:        "root",
-				},
-			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
-					To:                               "ci-index-my-bundle",
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{DockerfilePath: "index.Dockerfile"},
-				},
-			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
-					To: "my-bundle",
 					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
 						ContextDir:     "manifests/olm",
 						DockerfilePath: "bundle.Dockerfile",

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -13,7 +13,6 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 	utilpointer "k8s.io/utils/pointer"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
@@ -235,20 +234,8 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	}
 
 	if configSpec.Operator != nil {
-		containsUnnamedBundle := false
-		for _, bundle := range configSpec.Operator.Bundles {
-			if bundle.As == "" {
-				containsUnnamedBundle = true
-				continue
-			}
-			indexName := api.IndexName(bundle.As)
-			podSpec := generateCiOperatorPodSpec(info, nil, []string{indexName})
-			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(indexName, info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
-		}
-		if containsUnnamedBundle {
-			podSpec := generateCiOperatorPodSpec(info, nil, []string{string(api.PipelineImageStreamTagReferenceIndexImage)})
-			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(string(api.PipelineImageStreamTagReferenceIndexImage), info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
-		}
+		podSpec := generateCiOperatorPodSpec(info, nil, []string{"ci-index"})
+		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest("ci-index", info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
 	}
 
 	return &prowconfig.JobConfig{

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -93,20 +93,7 @@ func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
 		}
 		bundles = append(bundles, fullSpec)
 	}
-	baseIndex := ""
-	if s.config.BaseIndex != "" {
-		fullSpec, err := utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, s.config.BaseIndex)()
-		if err != nil {
-			return "", fmt.Errorf("failed to get image digest for bundle `%s`: %w", s.config.BaseIndex, err)
-		}
-		baseIndex = fullSpec
-	}
-	opmCommand := fmt.Sprintf(`RUN ["opm", "index", "add", "--mode", "%s", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"`, s.config.UpdateGraph, strings.Join(bundles, ","), IndexDockerfileName)
-	if baseIndex != "" {
-		opmCommand = fmt.Sprintf(`%s, "--from-index", "%s"`, opmCommand, baseIndex)
-	}
-	opmCommand = fmt.Sprintf("%s]", opmCommand)
-	dockerCommands = append(dockerCommands, opmCommand)
+	dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"]`, strings.Join(bundles, ","), IndexDockerfileName))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))
@@ -118,10 +105,6 @@ func (s *indexGeneratorStep) Requires() []api.StepLink {
 	var links []api.StepLink
 	for _, bundle := range s.config.OperatorIndex {
 		imageStream, name, _ := s.releaseBuildConfig.DependencyParts(api.StepDependency{Name: bundle})
-		links = append(links, api.LinkForImage(imageStream, name))
-	}
-	if s.config.BaseIndex != "" {
-		imageStream, name, _ := s.releaseBuildConfig.DependencyParts(api.StepDependency{Name: s.config.BaseIndex})
 		links = append(links, api.LinkForImage(imageStream, name))
 	}
 	return links

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -33,84 +33,55 @@ func TestIndexGenDockerfile(t *testing.T) {
 					Items: []apiimagev1.TagEvent{{
 						Image: "ci-bundle1",
 					}},
-				}, {
-					Tag: "the-index",
-					Items: []apiimagev1.TagEvent{{
-						Image: "the-index",
-					}},
 				}},
 			},
 		})
-	testCases := []struct {
-		name     string
-		step     indexGeneratorStep
-		expected string
-	}{{
-		name: "single bundle",
-		step: indexGeneratorStep{
-			config: api.IndexGeneratorStepConfiguration{
-				OperatorIndex: []string{"ci-bundle0"},
-				UpdateGraph:   api.IndexUpdateSemver,
-			},
-			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
-		},
-		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
+
+	var expectedDockerfileSingleBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
-COPY --from=builder /database/ database`,
-	}, {
-		name: "multiple bundles",
-		step: indexGeneratorStep{
-			config: api.IndexGeneratorStepConfiguration{
-				OperatorIndex: []string{"ci-bundle0", "ci-bundle1"},
-				UpdateGraph:   api.IndexUpdateSemver,
-			},
-			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+COPY --from=builder /database/ database`
+	stepSingleBundle := indexGeneratorStep{
+		config: api.IndexGeneratorStepConfiguration{
+			OperatorIndex: []string{"ci-bundle0"},
 		},
-		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
+		jobSpec: &api.JobSpec{},
+		client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+	}
+	stepSingleBundle.jobSpec.SetNamespace("target-namespace")
+	generatedDockerfile, err := stepSingleBundle.indexGenDockerfile()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if expectedDockerfileSingleBundle != generatedDockerfile {
+		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileSingleBundle, generatedDockerfile))
+	}
+
+	var expectedDockerfileMultiBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
-COPY --from=builder /database/ database`,
-	}, {
-		name: "With base index",
-		step: indexGeneratorStep{
-			config: api.IndexGeneratorStepConfiguration{
-				OperatorIndex: []string{"ci-bundle0"},
-				UpdateGraph:   api.IndexUpdateSemver,
-				BaseIndex:     "the-index",
-			},
-			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+COPY --from=builder /database/ database`
+	stepMultiBundle := indexGeneratorStep{
+		config: api.IndexGeneratorStepConfiguration{
+			OperatorIndex: []string{"ci-bundle0", "ci-bundle1"},
 		},
-		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
-COPY .dockerconfigjson .
-RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
-RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate", "--from-index", "some-reg/target-namespace/pipeline@the-index"]
-FROM pipeline:src
-WORKDIR /index-data
-COPY --from=builder index.Dockerfile index.Dockerfile
-COPY --from=builder /database/ database`,
-	}}
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			testCase.step.jobSpec.SetNamespace("target-namespace")
-			generated, err := testCase.step.indexGenDockerfile()
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if testCase.expected != generated {
-				t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(testCase.expected, generated))
-			}
-		})
+		jobSpec: &api.JobSpec{},
+		client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+	}
+	stepMultiBundle.jobSpec.SetNamespace("target-namespace")
+	generatedDockerfile, err = stepMultiBundle.indexGenDockerfile()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if expectedDockerfileMultiBundle != generatedDockerfile {
+		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileMultiBundle, generatedDockerfile))
 	}
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -18,12 +18,11 @@ import (
 )
 
 type projectDirectoryImageBuildStep struct {
-	config             api.ProjectDirectoryImageBuildStepConfiguration
-	releaseBuildConfig *api.ReleaseBuildConfiguration
-	resources          api.ResourceConfiguration
-	client             BuildClient
-	jobSpec            *api.JobSpec
-	pullSecret         *coreapi.Secret
+	config     api.ProjectDirectoryImageBuildStepConfiguration
+	resources  api.ResourceConfiguration
+	client     BuildClient
+	jobSpec    *api.JobSpec
+	pullSecret *coreapi.Secret
 }
 
 func (s *projectDirectoryImageBuildStep) Inputs() (api.InputDefinition, error) {
@@ -37,9 +36,10 @@ func (s *projectDirectoryImageBuildStep) Run(ctx context.Context) error {
 }
 
 func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
+
 	images := buildInputsFromStep(s.config.Inputs)
 	// If image being built is an operator bundle, use the bundle source instead of original source
-	if s.releaseBuildConfig.IsBundleImage(string(s.config.To)) {
+	if api.IsBundleImage(string(s.config.To)) {
 		source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceBundleSource)
 		workingDir, err := getWorkingDir(s.client, source, s.jobSpec.Namespace())
 		if err != nil {
@@ -55,8 +55,8 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 				DestinationDir: ".",
 			}},
 		})
-	} else if api.IsIndexImage(string(s.config.To)) {
-		source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.IndexGeneratorName(s.config.To))
+	} else if s.config.To == api.PipelineImageStreamTagReferenceIndexImage {
+		source := fmt.Sprintf("%s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceIndexImageGenerator)
 		workingDir, err := getWorkingDir(s.client, source, s.jobSpec.Namespace())
 		if err != nil {
 			return fmt.Errorf("failed to get workingDir: %w", err)
@@ -124,11 +124,11 @@ func (s *projectDirectoryImageBuildStep) Requires() []api.StepLink {
 	if len(s.config.From) > 0 {
 		links = append(links, api.InternalImageLink(s.config.From))
 	}
-	if s.releaseBuildConfig.IsBundleImage(string(s.config.To)) {
+	if api.IsBundleImage(string(s.config.To)) {
 		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReferenceBundleSource))
 	}
-	if api.IsIndexImage(string(s.config.To)) {
-		links = append(links, api.InternalImageLink(api.IndexGeneratorName(s.config.To)))
+	if s.config.To == api.PipelineImageStreamTagReferenceIndexImage {
+		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReferenceIndexImageGenerator))
 	}
 	for name := range s.config.Inputs {
 		links = append(links, api.InternalImageLink(api.PipelineImageStreamTagReference(name), api.StepLinkWithUnsatisfiableErrorMessage(fmt.Sprintf("%q is neither an imported nor a built image", name))))
@@ -159,13 +159,12 @@ func (s *projectDirectoryImageBuildStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, releaseBuildConfig *api.ReleaseBuildConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, jobSpec *api.JobSpec, pullSecret *coreapi.Secret) api.Step {
+func ProjectDirectoryImageBuildStep(config api.ProjectDirectoryImageBuildStepConfiguration, resources api.ResourceConfiguration, buildClient BuildClient, jobSpec *api.JobSpec, pullSecret *coreapi.Secret) api.Step {
 	return &projectDirectoryImageBuildStep{
-		config:             config,
-		releaseBuildConfig: releaseBuildConfig,
-		resources:          resources,
-		client:             buildClient,
-		jobSpec:            jobSpec,
-		pullSecret:         pullSecret,
+		config:     config,
+		resources:  resources,
+		client:     buildClient,
+		jobSpec:    jobSpec,
+		pullSecret: pullSecret,
 	}
 }

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -86,50 +86,46 @@ func TestValidateBuildRoot(t *testing.T) {
 	}
 }
 
-func TestValidateImageStreamTagReferenceMap(t *testing.T) {
+func TestValidateBaseImages(t *testing.T) {
 	for _, tc := range []struct {
 		id            string
 		baseImages    map[string]api.ImageStreamTagReference
 		expectedValid bool
 	}{
 		{
-			id: "valid",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"test": {Tag: "test"}, "test2": {Tag: "test2"},
-			},
-			expectedValid: true,
-		},
-		{
-			id: "missing tag",
-			baseImages: map[string]api.ImageStreamTagReference{
-				"test": {Tag: "test"}, "test2": {},
-			},
-			expectedValid: false,
-		},
-		{
-			id: "cannot be bundle source",
-			baseImages: map[string]api.ImageStreamTagReference{
-				string(api.PipelineImageStreamTagReferenceBundleSource): {Tag: "bundle-src"},
-			},
-			expectedValid: false,
-		},
-		{
-			id: "cannot be bundle prefixed",
-			baseImages: map[string]api.ImageStreamTagReference{
-				api.BundleName(0): {Tag: "bundle"},
-			},
-			expectedValid: false,
-		},
-		{
-			id: "cannot be index prefixed",
-			baseImages: map[string]api.ImageStreamTagReference{
-				api.IndexName("test"): {Tag: "index"},
+			id: "base images",
+			baseImages: map[string]api.ImageStreamTagReference{"test": {},
+				"test2": {Tag: "test2"}, "test3": {},
 			},
 			expectedValid: false,
 		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			if errs := validateImageStreamTagReferenceMap("base_images", tc.baseImages); len(errs) > 0 && tc.expectedValid {
+				t.Errorf("expected to be valid, got: %v", errs)
+			} else if !tc.expectedValid && len(errs) == 0 {
+				t.Error("expected to be invalid, but returned valid")
+			}
+		})
+	}
+}
+
+func TestValidateBaseRpmImages(t *testing.T) {
+	for _, tc := range []struct {
+		id            string
+		baseRpmImages map[string]api.ImageStreamTagReference
+		expectedValid bool
+	}{
+		{
+			id: "base rpm images",
+			baseRpmImages: map[string]api.ImageStreamTagReference{"test": {},
+				"test2": {Tag: "test2"}, "test3": {},
+			},
+			expectedValid: false,
+		},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			if errs := validateImageStreamTagReferenceMap("base_rpm_images", tc.baseRpmImages); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")
@@ -351,7 +347,7 @@ func TestValidateImages(t *testing.T) {
 			To: "ci-index-gen",
 		}},
 		output: []error{
-			errors.New("images[0]: `to` cannot begin with ci-index"),
+			errors.New("images[0]: `to` cannot be ci-index-gen"),
 		},
 	}, {
 		name: "`to` cannot be ci-index",
@@ -359,7 +355,7 @@ func TestValidateImages(t *testing.T) {
 			To: "ci-index",
 		}},
 		output: []error{
-			errors.New("images[0]: `to` cannot begin with ci-index"),
+			errors.New("images[0]: `to` cannot be ci-index"),
 		},
 	},
 		{
@@ -413,14 +409,6 @@ func TestValidateImages(t *testing.T) {
 func TestValidateOperator(t *testing.T) {
 	var goodStepLink = api.AllStepsLink()
 	var badStepLink api.StepLink
-	var config = &api.ReleaseBuildConfiguration{
-		InputConfiguration: api.InputConfiguration{
-			BaseImages: map[string]api.ImageStreamTagReference{
-				"a-base-image": {},
-			},
-		},
-		Images: []api.ProjectDirectoryImageBuildStepConfiguration{{To: "an-image"}, {To: "my-image"}},
-	}
 	var testCases = []struct {
 		name           string
 		input          *api.OperatorStepConfiguration
@@ -430,13 +418,6 @@ func TestValidateOperator(t *testing.T) {
 		{
 			name: "everything is good",
 			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:             "my-bundle",
-					DockerfilePath: "./dockerfile",
-					ContextDir:     ".",
-					BaseIndex:      "an-index",
-					UpdateGraph:    "replaces",
-				}},
 				Substitutions: []api.PullSpecSubstitution{
 					{
 						PullSpec: "original",
@@ -465,7 +446,7 @@ func TestValidateOperator(t *testing.T) {
 			},
 		},
 		{
-			name: "bad step link",
+			name: "everything is good",
 			input: &api.OperatorStepConfiguration{
 				Substitutions: []api.PullSpecSubstitution{
 					{
@@ -479,85 +460,13 @@ func TestValidateOperator(t *testing.T) {
 				errors.New("operator.substitute[0].with: could not resolve 'substitute' to an image involved in the config"),
 			},
 		},
-		{
-			name: "bundle set without conflict",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As: "no conflict",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-		},
-		{
-			name: "bundle set with image conflict",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As: "my-image",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].as: bundle name `my-image` matches image defined in `images`"),
-			},
-		},
-		{
-			name: "bundle set with base_image conflict",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As: "a-base-image",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].as: bundle name `a-base-image` matches a base image"),
-			},
-		},
-		{
-			name: "bundle set with update_graph but not base_index set",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:          "valid bundle",
-					UpdateGraph: "replaces",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].update_graph: update_graph requires base_index to be set"),
-			},
-		},
-		{
-			name: "bundle set with base_index but not as set",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					BaseIndex: "an-index",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].base_index: base_index requires as to be set"),
-			},
-		},
-		{
-			name: "invalid update_graph",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:          "valid bundle",
-					BaseIndex:   "an-index",
-					UpdateGraph: "hello",
-				}},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].update_graph: update_graph must be semver, semver-skippatch, or replaces"),
-			},
-		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			linkFunc := func(string) api.StepLink {
 				return testCase.withResolvesTo
 			}
-			if actual, expected := validateOperator("operator", testCase.input, linkFunc, config), testCase.output; !reflect.DeepEqual(actual, expected) {
+			if actual, expected := validateOperator("operator", testCase.input, linkFunc), testCase.output; !reflect.DeepEqual(actual, expected) {
 				t.Errorf("%s: got incorrect errors: %s", testCase.name, cmp.Diff(actual, expected, cmp.Comparer(func(x, y error) bool {
 					return x.Error() == y.Error()
 				})))
@@ -607,24 +516,19 @@ func TestReleaseBuildConfiguration_validateTestStepDependencies(t *testing.T) {
 					Bundles: []api.Bundle{{
 						DockerfilePath: "bundle.Dockerfile",
 						ContextDir:     "manifests",
-					}, {
-						As:             "my-bundle",
-						DockerfilePath: "bundle.Dockerfile",
-						ContextDir:     "manifests",
 					}},
 				},
 				Tests: []api.TestStepConfiguration{
 					{MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
 						Pre: []api.TestStep{
 							{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "src"}, {Name: "bin"}, {Name: "installer"}, {Name: "pipeline:ci-index"}}}},
-							{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "pipeline:my-bundle"}}}},
 							{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "stable:installer"}, {Name: "stable-initial:installer"}}}},
 						},
 						Test: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "pipeline:bin"}}}}},
 						Post: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "image"}}}}},
 					}},
 					{MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
-						Pre:  []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "stable-custom:cli"}, {Name: "ci-index-my-bundle"}}}},
+						Pre:  []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "stable-custom:cli"}, {Name: "ci-index"}}}},
 						Test: []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "release:custom"}, {Name: "release:initial"}}}},
 						Post: []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "pipeline:image"}}}},
 					}},
@@ -647,9 +551,7 @@ func TestReleaseBuildConfiguration_validateTestStepDependencies(t *testing.T) {
 						Post: []api.TestStep{{LiteralTestStep: &api.LiteralTestStep{Dependencies: []api.StepDependency{{Name: "pipeline:image"}}}}},
 					}},
 					{MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
-						Pre: []api.LiteralTestStep{
-							{Dependencies: []api.StepDependency{{Name: "release:custom"}, {Name: "pipeline:ci-index"}}},
-							{Dependencies: []api.StepDependency{{Name: "pipeline:ci-index-my-bundle"}}}},
+						Pre:  []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "release:custom"}, {Name: "pipeline:ci-index"}}}},
 						Test: []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "pipeline:root"}}}},
 						Post: []api.LiteralTestStep{{Dependencies: []api.StepDependency{{Name: "pipeline:rpms"}}}},
 					}},
@@ -662,10 +564,9 @@ func TestReleaseBuildConfiguration_validateTestStepDependencies(t *testing.T) {
 				errors.New(`tests[0].steps.pre[1].dependencies[1]: cannot determine source for dependency "totally-invalid:cli" - ensure the correct ImageStream name was provided`),
 				errors.New(`tests[0].steps.test[0].dependencies[0]: cannot determine source for dependency "pipeline:bin" - this dependency requires built binaries, which are not configured`),
 				errors.New(`tests[0].steps.test[1].dependencies[0]: cannot determine source for dependency "pipeline:test-bin" - this dependency requires built test binaries, which are not configured`),
-				errors.New(`tests[0].steps.post[0].dependencies[0]: cannot determine source for dependency "pipeline:image" - no base image import, project image build, or bundle image build is configured to provide this dependency`),
+				errors.New(`tests[0].steps.post[0].dependencies[0]: cannot determine source for dependency "pipeline:image" - no base image import or project image build is configured to provide this dependency`),
 				errors.New(`tests[1].literal_steps.pre[0].dependencies[0]: cannot determine source for dependency "release:custom" - this dependency requires a "custom" release, which is not configured`),
 				errors.New(`tests[1].literal_steps.pre[0].dependencies[1]: cannot determine source for dependency "pipeline:ci-index" - this dependency requires an operator bundle configuration, which is not configured`),
-				errors.New(`tests[1].literal_steps.pre[1].dependencies[0]: cannot determine source for dependency "pipeline:ci-index-my-bundle" - this dependency requires an operator bundle configuration, which is not configured`),
 				errors.New(`tests[1].literal_steps.test[0].dependencies[0]: cannot determine source for dependency "pipeline:root" - this dependency requires a build root, which is not configured`),
 				errors.New(`tests[1].literal_steps.post[0].dependencies[0]: cannot determine source for dependency "pipeline:rpms" - this dependency requires built RPMs, which are not configured`),
 			},

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -59,8 +59,8 @@ func validateTestStepConfiguration(fieldRoot string, input []api.TestStepConfigu
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: is required", fieldRootN))
 		} else if test.As == "images" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'images' because it gets confused with '[images]' target", fieldRootN))
-		} else if strings.HasPrefix(test.As, string(api.PipelineImageStreamTagReferenceIndexImage)) {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should begin with 'ci-index' because it gets confused with 'ci-index' and `ci-index-...` targets", fieldRootN))
+		} else if test.As == "ci-index" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'ci-index' because it gets confused with 'ci-index' target", fieldRootN))
 		} else if len(validation.IsDNS1123Subdomain(test.As)) != 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' is not a valid Kubernetes object name", fieldRootN, test.As))
 		}
@@ -187,27 +187,9 @@ func validateTestStepDependencies(config *api.ReleaseBuildConfiguration) []error
 							errs = append(errs, validationError("this dependency requires an operator bundle configuration, which is not configured"))
 						}
 					default:
-						// this could be a named index image
-						if api.IsIndexImage(name) {
-							if config.Operator != nil {
-								foundBundle := false
-								for _, bundle := range config.Operator.Bundles {
-									if api.IndexName(bundle.As) == name {
-										foundBundle = true
-										break
-									}
-								}
-								if !foundBundle {
-									errs = append(errs, validationError(fmt.Sprintf("this dependency requires an operator bundle named %s, which is not configured", strings.TrimPrefix(name, string(api.PipelineImageStreamTagReferenceIndexImage)))))
-								}
-							} else {
-								errs = append(errs, validationError("this dependency requires an operator bundle configuration, which is not configured"))
-							}
-							break
-						}
-						// this could be a base image, a project image, or a bundle image
-						if !config.IsBaseImage(name) && !config.BuildsImage(name) && !config.IsBundleImage(name) {
-							errs = append(errs, validationError("no base image import, project image build, or bundle image build is configured to provide this dependency"))
+						// this could be a base image, or a project image
+						if !config.IsBaseImage(name) && !config.BuildsImage(name) {
+							errs = append(errs, validationError("no base image import or project image build is configured to provide this dependency"))
 						}
 					}
 				}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -60,17 +60,6 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
-			id: `ReleaseBuildConfiguration{Tests: {As: "ci-index-my-bundle"}}`,
-			tests: []api.TestStepConfiguration{
-				{
-					As:                         "ci-index-my-bundle",
-					Commands:                   "commands",
-					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
-				},
-			},
-			expectedValid: false,
-		},
-		{
 			id: "No test type",
 			tests: []api.TestStepConfiguration{
 				{

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -110,17 +110,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"operator:\n" +
 	"    # Bundles define a dockerfile and build context to build a bundle\n" +
 	"    bundles:\n" +
-	"        - # As defines the name for this bundle. If not set, a name will be automatically generated for the bundle.\n" +
-	"          as: ' '\n" +
-	"          # BaseIndex defines what index image to use as a base when adding the bundle to an index\n" +
-	"          base_index: ' '\n" +
-	"          # ContextDir defines the source directory to build the bundle from relative to the repository root\n" +
-	"          context_dir: ' '\n" +
-	"          # DockerfilePath defines where the dockerfile for build the bundle exists relative to the contextdir\n" +
+	"        - context_dir: ' '\n" +
 	"          dockerfile_path: ' '\n" +
-	"          # UpdateGraph defines the update mode to use when adding the bundle to the base index.\n" +
-	"          # Can be: semver (default), semver-skippatch, or replaces\n" +
-	"          update_graph: ' '\n" +
 	"    # Substitutions describes the pullspecs in the operator manifests that must be subsituted\n" +
 	"    # with the pull specs of the images in the CI registry\n" +
 	"    substitutions:\n" +
@@ -169,15 +160,11 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # With is the string that the PullSpec is being replaced by\n" +
 	"              with: ' '\n" +
 	"      index_generator_step:\n" +
-	"        # BaseIndex is the index image to add the bundle(s) to. If unset, a new index is created\n" +
-	"        base_index: ' '\n" +
 	"        # OperatorIndex is a list of the names of the bundle images that the\n" +
 	"        # index will contain in its database.\n" +
 	"        operator_index:\n" +
 	"            - \"\"\n" +
 	"        to: ' '\n" +
-	"        # UpdateGraph defines the mode to us when updating the index graph\n" +
-	"        update_graph: ' '\n" +
 	"      input_image_tag_step:\n" +
 	"        base_image:\n" +
 	"            # As is an optional string to use as the intermediate name for this reference.\n" +

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -5,7 +5,6 @@ package simple
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -255,44 +254,24 @@ func TestLiteralDynamicRelease(t *testing.T) {
 }
 
 func TestOptionalOperators(t *testing.T) {
-	var testCases = []struct {
-		name       string
-		indexName  string
-		bundleName string
-	}{{
-		name:       "unnamed bundle",
-		indexName:  "ci-index",
-		bundleName: "ci-bundle1",
-	}, {
-		name:       "named bunlde",
-		indexName:  "ci-index-named-bundle",
-		bundleName: "named-bundle",
-	}}
-	for _, testCase := range testCases {
-		testCase := testCase
-		framework.Run(t, fmt.Sprintf("optional operators %s", testCase.name), func(t *framework.T, cmd *framework.CiOperatorCommand) {
-			cmd.AddArgs(
-				"--config=optional-operators.yaml",
-				framework.LocalPullSecretFlag(t),
-				framework.RemotePullSecretFlag(t),
-				"--target=[images]",
-				fmt.Sprintf("--target=%s", testCase.indexName),
-			)
-			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
-			cmd.AddEnv(framework.KubernetesClientEnv(t)...)
-			output, err := cmd.Run()
-			if err != nil {
-				t.Fatalf("explicit var: didn't expect an error from ci-operator: %v; output:\n%v", err, string(output))
+	framework.Run(t, "optional operators", func(t *framework.T, cmd *framework.CiOperatorCommand) {
+		cmd.AddArgs(
+			"--config=optional-operators.yaml",
+			framework.LocalPullSecretFlag(t),
+			framework.RemotePullSecretFlag(t),
+			"--target=[images]",
+			"--target=ci-index",
+		)
+		cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
+		cmd.AddEnv(framework.KubernetesClientEnv(t)...)
+		output, err := cmd.Run()
+		if err != nil {
+			t.Fatalf("explicit var: didn't expect an error from ci-operator: %v; output:\n%v", err, string(output))
+		}
+		for _, line := range []string{"Build src-bundle succeeded after", "Build ci-bundle0 succeeded after", "Build ci-index-gen succeeded after", "Build ci-index succeeded after"} {
+			if !bytes.Contains(output, []byte(line)) {
+				t.Errorf("optional operators: could not find line %q in output; output:\n%v", line, string(output))
 			}
-			for _, line := range []string{
-				"Build src-bundle succeeded after",
-				fmt.Sprintf("Build %s succeeded after", testCase.bundleName),
-				fmt.Sprintf("Build %s-gen succeeded after", testCase.indexName),
-				fmt.Sprintf("Build %s succeeded after", testCase.indexName)} {
-				if !bytes.Contains(output, []byte(line)) {
-					t.Errorf("optional operators: could not find line %q in output; output:\n%v", line, string(output))
-				}
-			}
-		})
-	}
+		}
+	})
 }

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -3,10 +3,6 @@ base_images:
     name: centos
     namespace: openshift
     tag: '7'
-  operator-index-46:
-    name: redhat-operator-index
-    namespace: ci
-    tag: 'v4.6'
 build_root:
   image_stream_tag:
     name: release
@@ -20,18 +16,14 @@ resources:
       cpu: 10m
 operator:
   bundles:
-  - as: named-bundle
-    context_dir: "test/manifests"
-    dockerfile_path: "bundle.Dockerfile"
-    base_index: operator-index-46
   - context_dir: "test/manifests"
     dockerfile_path: "bundle.Dockerfile"
   substitutions:
-  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.6
+  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.5
     with: metering-reporting-operator # another `images:` list item
-  - pullspec: quay.io/openshift/origin-oauth-proxy:4.6
+  - pullspec: quay.io/openshift/origin-oauth-proxy:4.5
     with: oauth-proxy # OCP component
-  - pullspec: quay.io/openshift/origin-hive:4.6
+  - pullspec: quay.io/openshift/origin-hive:4.5
     with: metering-hive # operand image, must be present in `stable` imagestream
 tag_specification:
   namespace: ocp

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -15,9 +15,6 @@ operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
     context_dir: manifests
-  - as: my-bundle
-    dockerfile_path: bundle.Dockerfile
-    context_dir: manifests
 promotion:
   name: other
   namespace: ocp

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -51,53 +51,6 @@ presubmits:
     always_run: true
     branches:
     - master
-    context: ci/prow/ci-index-my-bundle
-    decorate: true
-    decoration_config:
-      skip_cloning: true
-    labels:
-      ci-operator.openshift.io/prowgen-controlled: "true"
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-super-duper-master-ci-index-my-bundle
-    rerun_command: /test ci-index-my-bundle
-    spec:
-      containers:
-      - args:
-        - --gcs-upload-secret=/secrets/gcs/service-account.json
-        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --report-credentials-file=/etc/report/credentials
-        - --target=ci-index-my-bundle
-        command:
-        - ci-operator
-        image: ci-operator:latest
-        imagePullPolicy: Always
-        name: ""
-        resources:
-          requests:
-            cpu: 10m
-        volumeMounts:
-        - mountPath: /secrets/gcs
-          name: gcs-credentials
-          readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
-        - mountPath: /etc/report
-          name: result-aggregator
-          readOnly: true
-      serviceAccountName: ci-operator
-      volumes:
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
-      - name: result-aggregator
-        secret:
-          secretName: result-aggregator
-    trigger: (?m)^/test( | .* )ci-index-my-bundle,?($|\s.*)
-  - agent: kubernetes
-    always_run: true
-    branches:
-    - master
     context: ci/prow/e2e
     decorate: true
     decoration_config:

--- a/test/manifests/bundle.Dockerfile
+++ b/test/manifests/bundle.Dockerfile
@@ -4,8 +4,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=metering-ocp
-LABEL operators.operatorframework.io.bundle.channels.v1=test-channel
-LABEL operators.operatorframework.io.bundle.channel.default.v1=test-channel
+LABEL operators.operatorframework.io.bundle.channels.v1=4.6
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6
 
 COPY 4.6/*.yaml /manifests/
 COPY metadata /metadata/

--- a/test/manifests/metadata/annotations.yaml
+++ b/test/manifests/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: "test-channel"
-  operators.operatorframework.io.bundle.channels.v1: "test-channel"
+  operators.operatorframework.io.bundle.channel.default.v1: "4.6"
+  operators.operatorframework.io.bundle.channels.v1: "4.6"
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
Reverts openshift/ci-tools#1748

Broke existing operator tests with:

```
2021/03/15 16:17:50 step <*steps.leaseStep> is missing dependencies: <&api.internalImageStreamTagLink{name:"pipeline", tag:"", unsatisfiableError:""}>
```
such as https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/kubevirt_hyperconverged-cluster-operator/1180/pull-ci-kubevirt-hyperconverged-cluster-operator-master-okd-hco-e2e-image-index-aws/1371495842573193216#1:build-log.txt%3A11

Pinpointed using job history https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-kubevirt-hyperconverged-cluster-operator-master-okd-hco-e2e-image-index-aws

Reported in https://coreos.slack.com/archives/CBN38N3MW/p1615883791001400

FYI @AlexNPavel 