### PR TITLE
testgrid-config-generator: Store more historical results

### DIFF
--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-blocking.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-blocking.yaml
@@ -56,7 +56,9 @@ dashboards:
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
   name: redhat-openshift-ocp-release-4.1-blocking
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
   name: release-openshift-origin-installer-e2e-aws-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
   name: release-openshift-origin-installer-e2e-aws-serial-4.1

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-informing.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.1-informing.yaml
@@ -29,5 +29,6 @@ dashboards:
     test_group_name: release-openshift-origin-installer-e2e-aws-optional-4.1
   name: redhat-openshift-ocp-release-4.1-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.1
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.1
   name: release-openshift-origin-installer-e2e-aws-optional-4.1

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-blocking.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-blocking.yaml
@@ -110,11 +110,15 @@ dashboards:
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
   name: redhat-openshift-ocp-release-4.2-blocking
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
   name: release-openshift-ocp-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
+- days_of_results: 8
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
   name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
   name: release-openshift-origin-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
+- days_of_results: 8
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
   name: release-openshift-origin-installer-e2e-aws-serial-4.2

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -137,12 +137,14 @@ dashboards:
     test_group_name: release-openshift-origin-job-from-allow-list
   name: redhat-openshift-ocp-release-4.2-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-optional-4.2
   name: release-openshift-ocp-installer-e2e-aws-optional-4.2
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-job
   name: release-openshift-ocp-job
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-optional-4.2
   name: release-openshift-origin-installer-e2e-aws-optional-4.2
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-job


### PR DESCRIPTION
The move to allow list was suppressing defaulting that we still wish
to do (we try to get 100 results on any testgrid page, and 24h interval
tests were only showing 7 which impacts our ability to track trends).