### PR TITLE
ci-operator: add support for operator upgrade tests

### DIFF
--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -412,7 +412,7 @@ func TestBuildPartialGraph(t *testing.T) {
 						},
 						To: api.PipelineImageStreamTagReference("oc-bin-image"),
 					},
-					api.ResourceConfiguration{}, nil, nil, nil,
+					&api.ReleaseBuildConfiguration{}, api.ResourceConfiguration{}, nil, nil, nil,
 				),
 				steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil),
 				steps.ImagesReadyStep(steps.OutputImageTagStep(api.OutputImageTagStepConfiguration{From: api.PipelineImageStreamTagReference("oc-bin-image")}, nil, nil).Creates()),

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -136,9 +136,10 @@ func (config ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
 		string(PipelineImageStreamTagReferenceBinaries),
 		string(PipelineImageStreamTagReferenceTestBinaries),
 		string(PipelineImageStreamTagReferenceRPMs),
-		string(PipelineImageStreamTagReferenceBundleSource),
-		string(PipelineImageStreamTagReferenceIndexImageGenerator),
-		string(PipelineImageStreamTagReferenceIndexImage):
+		string(PipelineImageStreamTagReferenceBundleSource):
+		return true
+	}
+	if IsIndexImage(name) {
 		return true
 	}
 	return config.IsBundleImage(name)
@@ -1219,7 +1220,7 @@ func (config ReleaseBuildConfiguration) IsBundleImage(imageName string) bool {
 		return true
 	}
 	for _, bundle := range config.Operator.Bundles {
-		if imageName == bundle.As {
+		if bundle.As != "" && imageName == bundle.As {
 			return true
 		}
 	}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -207,16 +207,32 @@ func TestBundleName(t *testing.T) {
 }
 
 func TestIsBundleImage(t *testing.T) {
-	if !IsBundleImage("ci-bundle0") {
-		t.Errorf("Expected true, got false for `ci-bundle0`")
+	config := ReleaseBuildConfiguration{
+		Operator: &OperatorStepConfiguration{
+			Bundles: []Bundle{{As: "my-bundle"}},
+		},
 	}
-	if !IsBundleImage("ci-bundle1") {
-		t.Errorf("Expected true, got false for `ci-bundle1`")
-	}
-	if !IsBundleImage(BundleName(0)) {
-		t.Errorf("Expected true, got false for func BundleName(0)")
-	}
-	if !IsBundleImage(BundleName(1)) {
-		t.Errorf("Expected true, got false for func BundleName(1)")
+	testCases := []struct {
+		name     string
+		expected bool
+	}{{
+		name:     BundleName(0),
+		expected: true,
+	}, {
+		name:     BundleName(1),
+		expected: true,
+	}, {
+		name:     "my-bundle",
+		expected: true,
+	}, {
+		name:     "not-a-bundle",
+		expected: false,
+	}}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			if config.IsBundleImage(testCase.name) != testCase.expected {
+				t.Errorf("Expected %t, got %t", testCase.expected, config.IsBundleImage(testCase.name))
+			}
+		})
 	}
 }

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -209,7 +209,7 @@ func TestBundleName(t *testing.T) {
 func TestIsBundleImage(t *testing.T) {
 	config := ReleaseBuildConfiguration{
 		Operator: &OperatorStepConfiguration{
-			Bundles: []Bundle{{As: "my-bundle"}},
+			Bundles: []Bundle{{As: "my-bundle"}, {As: ""}},
 		},
 	}
 	testCases := []struct {
@@ -226,6 +226,9 @@ func TestIsBundleImage(t *testing.T) {
 		expected: true,
 	}, {
 		name:     "not-a-bundle",
+		expected: false,
+	}, {
+		name:     "",
 		expected: false,
 	}}
 	for _, testCase := range testCases {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -173,7 +173,7 @@ func fromConfig(
 		} else if rawStep.IndexGeneratorStepConfiguration != nil {
 			step = steps.IndexGeneratorStep(*rawStep.IndexGeneratorStepConfiguration, config, config.Resources, buildClient, jobSpec, pullSecret)
 		} else if rawStep.ProjectDirectoryImageBuildStepConfiguration != nil {
-			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config.Resources, buildClient, jobSpec, pullSecret)
+			step = steps.ProjectDirectoryImageBuildStep(*rawStep.ProjectDirectoryImageBuildStepConfiguration, config, config.Resources, buildClient, jobSpec, pullSecret)
 		} else if rawStep.ProjectDirectoryImageBuildInputs != nil {
 			step = steps.GitSourceStep(*rawStep.ProjectDirectoryImageBuildInputs, config.Resources, buildClient, jobSpec, cloneAuthConfig, pullSecret)
 		} else if rawStep.RPMImageInjectionStepConfiguration != nil {
@@ -539,9 +539,48 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			Substitutions: config.Operator.Substitutions,
 		}})
 		// Build bundles
+		// First build named bundles and corresponding indices
+		// store list of indices for unnamed bundles
+		var unnamedBundles []int
+		for index, bundleConfig := range config.Operator.Bundles {
+			if bundleConfig.As == "" {
+				unnamedBundles = append(unnamedBundles, index)
+				continue
+			}
+			bundle := &api.ProjectDirectoryImageBuildStepConfiguration{
+				To: api.PipelineImageStreamTagReference(bundleConfig.As),
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					ContextDir:     bundleConfig.ContextDir,
+					DockerfilePath: bundleConfig.DockerfilePath,
+				},
+			}
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: bundle})
+			// Build index generator
+			indexName := api.PipelineImageStreamTagReference(api.IndexName(bundleConfig.As))
+			updateGraph := bundleConfig.UpdateGraph
+			if updateGraph == "" {
+				updateGraph = api.IndexUpdateSemver
+			}
+			buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
+				To:            api.IndexGeneratorName(indexName),
+				OperatorIndex: []string{bundleConfig.As},
+				BaseIndex:     bundleConfig.BaseIndex,
+				UpdateGraph:   updateGraph,
+			}})
+			// Build the index
+			index := &api.ProjectDirectoryImageBuildStepConfiguration{
+				To: indexName,
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfilePath: steps.IndexDockerfileName,
+				},
+			}
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index})
+		}
+		// Build non-named bundles following old naming system
 		var bundles []string
-		for index, bundle := range config.Operator.Bundles {
-			bundleName := api.BundleName(index)
+		for _, bundleIndex := range unnamedBundles {
+			bundle := config.Operator.Bundles[bundleIndex]
+			bundleName := api.BundleName(bundleIndex)
 			bundles = append(bundles, bundleName)
 			image := &api.ProjectDirectoryImageBuildStepConfiguration{
 				To: api.PipelineImageStreamTagReference(bundleName),
@@ -552,19 +591,22 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 			}
 			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
 		}
-		// Build index generator
-		buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
-			To:            api.PipelineImageStreamTagReferenceIndexImageGenerator,
-			OperatorIndex: bundles,
-		}})
-		// Build the index
-		image := &api.ProjectDirectoryImageBuildStepConfiguration{
-			To: api.PipelineImageStreamTagReferenceIndexImage,
-			ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-				DockerfilePath: steps.IndexDockerfileName,
-			},
+		if len(bundles) > 0 {
+			// Build index generator
+			buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
+				To:            api.PipelineImageStreamTagReferenceIndexImageGenerator,
+				OperatorIndex: bundles,
+				UpdateGraph:   api.IndexUpdateSemver,
+			}})
+			// Build the index
+			image := &api.ProjectDirectoryImageBuildStepConfiguration{
+				To: api.PipelineImageStreamTagReferenceIndexImage,
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfilePath: steps.IndexDockerfileName,
+				},
+			}
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
 		}
-		buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
 	}
 
 	for i := range config.Tests {

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -13,6 +13,7 @@ import (
 	prowconfig "k8s.io/test-infra/prow/config"
 	utilpointer "k8s.io/utils/pointer"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
@@ -234,8 +235,20 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	}
 
 	if configSpec.Operator != nil {
-		podSpec := generateCiOperatorPodSpec(info, nil, []string{"ci-index"})
-		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest("ci-index", info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
+		containsUnnamedBundle := false
+		for _, bundle := range configSpec.Operator.Bundles {
+			if bundle.As == "" {
+				containsUnnamedBundle = true
+				continue
+			}
+			indexName := api.IndexName(bundle.As)
+			podSpec := generateCiOperatorPodSpec(info, nil, []string{indexName})
+			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(indexName, info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
+		}
+		if containsUnnamedBundle {
+			podSpec := generateCiOperatorPodSpec(info, nil, []string{string(api.PipelineImageStreamTagReferenceIndexImage)})
+			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(string(api.PipelineImageStreamTagReferenceIndexImage), info, podSpec, configSpec.CanonicalGoRepository, jobRelease, skipCloning))
+		}
 	}
 
 	return &prowconfig.JobConfig{

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -93,7 +93,20 @@ func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
 		}
 		bundles = append(bundles, fullSpec)
 	}
-	dockerCommands = append(dockerCommands, fmt.Sprintf(`RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"]`, strings.Join(bundles, ","), IndexDockerfileName))
+	baseIndex := ""
+	if s.config.BaseIndex != "" {
+		fullSpec, err := utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.PipelineImageStream, s.config.BaseIndex)()
+		if err != nil {
+			return "", fmt.Errorf("failed to get image digest for bundle `%s`: %w", s.config.BaseIndex, err)
+		}
+		baseIndex = fullSpec
+	}
+	opmCommand := fmt.Sprintf(`RUN ["opm", "index", "add", "--mode", "%s", "--bundles", "%s", "--out-dockerfile", "%s", "--generate"`, s.config.UpdateGraph, strings.Join(bundles, ","), IndexDockerfileName)
+	if baseIndex != "" {
+		opmCommand = fmt.Sprintf(`%s, "--from-index", "%s"`, opmCommand, baseIndex)
+	}
+	opmCommand = fmt.Sprintf("%s]", opmCommand)
+	dockerCommands = append(dockerCommands, opmCommand)
 	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))
@@ -105,6 +118,10 @@ func (s *indexGeneratorStep) Requires() []api.StepLink {
 	var links []api.StepLink
 	for _, bundle := range s.config.OperatorIndex {
 		imageStream, name, _ := s.releaseBuildConfig.DependencyParts(api.StepDependency{Name: bundle})
+		links = append(links, api.LinkForImage(imageStream, name))
+	}
+	if s.config.BaseIndex != "" {
+		imageStream, name, _ := s.releaseBuildConfig.DependencyParts(api.StepDependency{Name: s.config.BaseIndex})
 		links = append(links, api.LinkForImage(imageStream, name))
 	}
 	return links

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -33,55 +33,84 @@ func TestIndexGenDockerfile(t *testing.T) {
 					Items: []apiimagev1.TagEvent{{
 						Image: "ci-bundle1",
 					}},
+				}, {
+					Tag: "the-index",
+					Items: []apiimagev1.TagEvent{{
+						Image: "the-index",
+					}},
 				}},
 			},
 		})
-
-	var expectedDockerfileSingleBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
+	testCases := []struct {
+		name     string
+		step     indexGeneratorStep
+		expected string
+	}{{
+		name: "single bundle",
+		step: indexGeneratorStep{
+			config: api.IndexGeneratorStepConfiguration{
+				OperatorIndex: []string{"ci-bundle0"},
+				UpdateGraph:   api.IndexUpdateSemver,
+			},
+			jobSpec: &api.JobSpec{},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+		},
+		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
-COPY --from=builder /database/ database`
-	stepSingleBundle := indexGeneratorStep{
-		config: api.IndexGeneratorStepConfiguration{
-			OperatorIndex: []string{"ci-bundle0"},
+COPY --from=builder /database/ database`,
+	}, {
+		name: "multiple bundles",
+		step: indexGeneratorStep{
+			config: api.IndexGeneratorStepConfiguration{
+				OperatorIndex: []string{"ci-bundle0", "ci-bundle1"},
+				UpdateGraph:   api.IndexUpdateSemver,
+			},
+			jobSpec: &api.JobSpec{},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
 		},
-		jobSpec: &api.JobSpec{},
-		client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
-	}
-	stepSingleBundle.jobSpec.SetNamespace("target-namespace")
-	generatedDockerfile, err := stepSingleBundle.indexGenDockerfile()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if expectedDockerfileSingleBundle != generatedDockerfile {
-		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileSingleBundle, generatedDockerfile))
-	}
-
-	var expectedDockerfileMultiBundle = `FROM quay.io/operator-framework/upstream-opm-builder AS builder
+		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
-COPY --from=builder /database/ database`
-	stepMultiBundle := indexGeneratorStep{
-		config: api.IndexGeneratorStepConfiguration{
-			OperatorIndex: []string{"ci-bundle0", "ci-bundle1"},
+COPY --from=builder /database/ database`,
+	}, {
+		name: "With base index",
+		step: indexGeneratorStep{
+			config: api.IndexGeneratorStepConfiguration{
+				OperatorIndex: []string{"ci-bundle0"},
+				UpdateGraph:   api.IndexUpdateSemver,
+				BaseIndex:     "the-index",
+			},
+			jobSpec: &api.JobSpec{},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
 		},
-		jobSpec: &api.JobSpec{},
-		client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
-	}
-	stepMultiBundle.jobSpec.SetNamespace("target-namespace")
-	generatedDockerfile, err = stepMultiBundle.indexGenDockerfile()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if expectedDockerfileMultiBundle != generatedDockerfile {
-		t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(expectedDockerfileMultiBundle, generatedDockerfile))
+		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
+COPY .dockerconfigjson .
+RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
+RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate", "--from-index", "some-reg/target-namespace/pipeline@the-index"]
+FROM pipeline:src
+WORKDIR /index-data
+COPY --from=builder index.Dockerfile index.Dockerfile
+COPY --from=builder /database/ database`,
+	}}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.step.jobSpec.SetNamespace("target-namespace")
+			generated, err := testCase.step.indexGenDockerfile()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if testCase.expected != generated {
+				t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(testCase.expected, generated))
+			}
+		})
 	}
 }

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -167,14 +167,16 @@ func (s *multiStageTestStep) SubSteps() []api.CIOperatorStepDetailInfo {
 func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 	var needsReleaseImage, needsReleasePayload bool
 	for _, step := range append(append(s.pre, s.test...), s.post...) {
-		dependency := api.StepDependency{Name: step.From}
-		imageStream, name, explicit := s.config.DependencyParts(dependency)
-		if explicit {
-			ret = append(ret, api.LinkForImage(imageStream, name))
-		} else {
-			// if the user did not specify an explicit namespace for this image,
-			// it's likely coming from an imported release we need to wait for
-			needsReleaseImage = true
+		if step.From != "" {
+			dependency := api.StepDependency{Name: step.From}
+			imageStream, name, explicit := s.config.DependencyParts(dependency)
+			if explicit {
+				ret = append(ret, api.LinkForImage(imageStream, name))
+			} else {
+				// if the user did not specify an explicit namespace for this image,
+				// it's likely coming from an imported release we need to wait for
+				needsReleaseImage = true
+			}
 		}
 
 		if link, ok := step.FromImageTag(); ok {

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -167,7 +167,9 @@ func (s *multiStageTestStep) SubSteps() []api.CIOperatorStepDetailInfo {
 func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 	var needsReleaseImage, needsReleasePayload bool
 	for _, step := range append(append(s.pre, s.test...), s.post...) {
-		if step.From != "" {
+		if link, ok := step.FromImageTag(); ok {
+			ret = append(ret, api.InternalImageLink(link))
+		} else {
 			dependency := api.StepDependency{Name: step.From}
 			imageStream, name, explicit := s.config.DependencyParts(dependency)
 			if explicit {
@@ -177,10 +179,6 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 				// it's likely coming from an imported release we need to wait for
 				needsReleaseImage = true
 			}
-		}
-
-		if link, ok := step.FromImageTag(); ok {
-			ret = append(ret, api.InternalImageLink(link))
 		}
 
 		for _, dependency := range step.Dependencies {

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -56,7 +56,7 @@ func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo stri
 			imageStream, name, _ := config.DependencyParts(api.StepDependency{Name: image})
 			return api.LinkForImage(imageStream, name)
 		}
-		validationErrors = append(validationErrors, validateOperator("operator", config.Operator, linkForImage)...)
+		validationErrors = append(validationErrors, validateOperator("operator", config.Operator, linkForImage, config)...)
 	}
 
 	if config.InputConfiguration.BaseImages != nil {
@@ -135,14 +135,11 @@ func validateImages(fieldRoot string, input []api.ProjectDirectoryImageBuildStep
 		if image.To == api.PipelineImageStreamTagReferenceBundleSource {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceBundleSource))
 		}
-		if api.IsBundleImage(string(image.To)) {
+		if strings.HasPrefix(string(image.To), api.BundlePrefix) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot begin with `%s`", fieldRootN, api.BundlePrefix))
 		}
-		if image.To == api.PipelineImageStreamTagReferenceIndexImageGenerator {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImageGenerator))
-		}
-		if image.To == api.PipelineImageStreamTagReferenceIndexImage {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImage))
+		if strings.HasPrefix(string(image.To), string(api.PipelineImageStreamTagReferenceIndexImage)) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot begin with %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImage))
 		}
 		if image.DockerfileLiteral != nil && (image.ContextDir != "" || image.DockerfilePath != "") {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: dockerfile_literal is mutually exclusive with context_dir and dockerfile_path", fieldRootN))
@@ -151,8 +148,30 @@ func validateImages(fieldRoot string, input []api.ProjectDirectoryImageBuildStep
 	return validationErrors
 }
 
-func validateOperator(fieldRoot string, input *api.OperatorStepConfiguration, linkForImage func(string) api.StepLink) []error {
+func validateOperator(fieldRoot string, input *api.OperatorStepConfiguration, linkForImage func(string) api.StepLink, config *api.ReleaseBuildConfiguration) []error {
 	var validationErrors []error
+	for num, bundle := range input.Bundles {
+		fieldRootN := fmt.Sprintf("%s.bundles[%d]", fieldRoot, num)
+		if bundle.As != "" {
+			if config.IsBaseImage(bundle.As) {
+				validationErrors = append(validationErrors, fmt.Errorf("%s.as: bundle name `%s` matches a base image", fieldRootN, bundle.As))
+			}
+			if config.BuildsImage(bundle.As) {
+				validationErrors = append(validationErrors, fmt.Errorf("%s.as: bundle name `%s` matches image defined in `images`", fieldRootN, bundle.As))
+			}
+		}
+		if bundle.As == "" && bundle.BaseIndex != "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.base_index: base_index requires as to be set", fieldRootN))
+		}
+		if bundle.UpdateGraph != "" {
+			if bundle.BaseIndex == "" {
+				validationErrors = append(validationErrors, fmt.Errorf("%s.update_graph: update_graph requires base_index to be set", fieldRootN))
+			}
+			if bundle.UpdateGraph != api.IndexUpdateSemver && bundle.UpdateGraph != api.IndexUpdateSemverSkippatch && bundle.UpdateGraph != api.IndexUpdateReplaces {
+				validationErrors = append(validationErrors, fmt.Errorf("%s.update_graph: update_graph must be %s, %s, or %s", fieldRootN, api.IndexUpdateSemver, api.IndexUpdateSemverSkippatch, api.IndexUpdateReplaces))
+			}
+		}
+	}
 	for num, sub := range input.Substitutions {
 		fieldRootN := fmt.Sprintf("%s.substitute[%d]", fieldRoot, num)
 		if sub.PullSpec == "" {
@@ -184,6 +203,15 @@ func validateImageStreamTagReferenceMap(fieldRoot string, input map[string]api.I
 	for k, v := range input {
 		if k == "root" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.%s can't be named 'root'", fieldRoot, k))
+		}
+		if k == string(api.PipelineImageStreamTagReferenceBundleSource) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.%s: cannot be named %s", fieldRoot, k, api.PipelineImageStreamTagReferenceBundleSource))
+		}
+		if strings.HasPrefix(k, api.BundlePrefix) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.%s: cannot begin with `%s`", fieldRoot, k, api.BundlePrefix))
+		}
+		if strings.HasPrefix(k, string(api.PipelineImageStreamTagReferenceIndexImage)) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.%s: cannot begin with %s", fieldRoot, k, api.PipelineImageStreamTagReferenceIndexImage))
 		}
 		validationErrors = append(validationErrors, validateImageStreamTagReference(fmt.Sprintf("%s.%s", fieldRoot, k), v)...)
 	}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -60,6 +60,17 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			id: `ReleaseBuildConfiguration{Tests: {As: "ci-index-my-bundle"}}`,
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "ci-index-my-bundle",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+				},
+			},
+			expectedValid: false,
+		},
+		{
 			id: "No test type",
 			tests: []api.TestStepConfiguration{
 				{

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -110,8 +110,17 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"operator:\n" +
 	"    # Bundles define a dockerfile and build context to build a bundle\n" +
 	"    bundles:\n" +
-	"        - context_dir: ' '\n" +
+	"        - # As defines the name for this bundle. If not set, a name will be automatically generated for the bundle.\n" +
+	"          as: ' '\n" +
+	"          # BaseIndex defines what index image to use as a base when adding the bundle to an index\n" +
+	"          base_index: ' '\n" +
+	"          # ContextDir defines the source directory to build the bundle from relative to the repository root\n" +
+	"          context_dir: ' '\n" +
+	"          # DockerfilePath defines where the dockerfile for build the bundle exists relative to the contextdir\n" +
 	"          dockerfile_path: ' '\n" +
+	"          # UpdateGraph defines the update mode to use when adding the bundle to the base index.\n" +
+	"          # Can be: semver (default), semver-skippatch, or replaces\n" +
+	"          update_graph: ' '\n" +
 	"    # Substitutions describes the pullspecs in the operator manifests that must be subsituted\n" +
 	"    # with the pull specs of the images in the CI registry\n" +
 	"    substitutions:\n" +
@@ -160,11 +169,15 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # With is the string that the PullSpec is being replaced by\n" +
 	"              with: ' '\n" +
 	"      index_generator_step:\n" +
+	"        # BaseIndex is the index image to add the bundle(s) to. If unset, a new index is created\n" +
+	"        base_index: ' '\n" +
 	"        # OperatorIndex is a list of the names of the bundle images that the\n" +
 	"        # index will contain in its database.\n" +
 	"        operator_index:\n" +
 	"            - \"\"\n" +
 	"        to: ' '\n" +
+	"        # UpdateGraph defines the mode to us when updating the index graph\n" +
+	"        update_graph: ' '\n" +
 	"      input_image_tag_step:\n" +
 	"        base_image:\n" +
 	"            # As is an optional string to use as the intermediate name for this reference.\n" +

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -5,6 +5,7 @@ package simple
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -254,24 +255,44 @@ func TestLiteralDynamicRelease(t *testing.T) {
 }
 
 func TestOptionalOperators(t *testing.T) {
-	framework.Run(t, "optional operators", func(t *framework.T, cmd *framework.CiOperatorCommand) {
-		cmd.AddArgs(
-			"--config=optional-operators.yaml",
-			framework.LocalPullSecretFlag(t),
-			framework.RemotePullSecretFlag(t),
-			"--target=[images]",
-			"--target=ci-index",
-		)
-		cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
-		cmd.AddEnv(framework.KubernetesClientEnv(t)...)
-		output, err := cmd.Run()
-		if err != nil {
-			t.Fatalf("explicit var: didn't expect an error from ci-operator: %v; output:\n%v", err, string(output))
-		}
-		for _, line := range []string{"Build src-bundle succeeded after", "Build ci-bundle0 succeeded after", "Build ci-index-gen succeeded after", "Build ci-index succeeded after"} {
-			if !bytes.Contains(output, []byte(line)) {
-				t.Errorf("optional operators: could not find line %q in output; output:\n%v", line, string(output))
+	var testCases = []struct {
+		name       string
+		indexName  string
+		bundleName string
+	}{{
+		name:       "unnamed bundle",
+		indexName:  "ci-index",
+		bundleName: "ci-bundle1",
+	}, {
+		name:       "named bunlde",
+		indexName:  "ci-index-named-bundle",
+		bundleName: "named-bundle",
+	}}
+	for _, testCase := range testCases {
+		testCase := testCase
+		framework.Run(t, fmt.Sprintf("optional operators %s", testCase.name), func(t *framework.T, cmd *framework.CiOperatorCommand) {
+			cmd.AddArgs(
+				"--config=optional-operators.yaml",
+				framework.LocalPullSecretFlag(t),
+				framework.RemotePullSecretFlag(t),
+				"--target=[images]",
+				fmt.Sprintf("--target=%s", testCase.indexName),
+			)
+			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
+			cmd.AddEnv(framework.KubernetesClientEnv(t)...)
+			output, err := cmd.Run()
+			if err != nil {
+				t.Fatalf("explicit var: didn't expect an error from ci-operator: %v; output:\n%v", err, string(output))
 			}
-		}
-	})
+			for _, line := range []string{
+				"Build src-bundle succeeded after",
+				fmt.Sprintf("Build %s succeeded after", testCase.bundleName),
+				fmt.Sprintf("Build %s-gen succeeded after", testCase.indexName),
+				fmt.Sprintf("Build %s succeeded after", testCase.indexName)} {
+				if !bytes.Contains(output, []byte(line)) {
+					t.Errorf("optional operators: could not find line %q in output; output:\n%v", line, string(output))
+				}
+			}
+		})
+	}
 }

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -275,8 +275,8 @@ func TestOptionalOperators(t *testing.T) {
 				"--config=optional-operators.yaml",
 				framework.LocalPullSecretFlag(t),
 				framework.RemotePullSecretFlag(t),
-				"--target=[images]",
 				fmt.Sprintf("--target=%s", testCase.indexName),
+				"--target=success",
 			)
 			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
 			cmd.AddEnv(framework.KubernetesClientEnv(t)...)

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -3,6 +3,10 @@ base_images:
     name: centos
     namespace: openshift
     tag: '7'
+  operator-index-46:
+    name: redhat-operator-index
+    namespace: ci
+    tag: 'v4.6'
 build_root:
   image_stream_tag:
     name: release
@@ -16,14 +20,18 @@ resources:
       cpu: 10m
 operator:
   bundles:
+  - as: named-bundle
+    context_dir: "test/manifests"
+    dockerfile_path: "bundle.Dockerfile"
+    base_index: operator-index-46
   - context_dir: "test/manifests"
     dockerfile_path: "bundle.Dockerfile"
   substitutions:
-  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.5
+  - pullspec: quay.io/openshift/origin-metering-reporting-operator:4.6
     with: metering-reporting-operator # another `images:` list item
-  - pullspec: quay.io/openshift/origin-oauth-proxy:4.5
+  - pullspec: quay.io/openshift/origin-oauth-proxy:4.6
     with: oauth-proxy # OCP component
-  - pullspec: quay.io/openshift/origin-hive:4.5
+  - pullspec: quay.io/openshift/origin-hive:4.6
     with: metering-hive # operand image, must be present in `stable` imagestream
 tag_specification:
   namespace: ocp

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -36,9 +36,17 @@ operator:
 tag_specification:
   namespace: ocp
   name: "4.6"
-# need a test or image field to be valid ci-operator config
 tests:
 - as: success
-  commands: exit 0
-  container:
-    from: os
+  literal_steps:
+    test:
+      - as: success
+        commands: exit 0
+        from_image:
+          namespace: origin
+          name: centos
+          tag: '8'
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -15,6 +15,9 @@ operator:
   bundles:
   - dockerfile_path: bundle.Dockerfile
     context_dir: manifests
+  - as: my-bundle
+    dockerfile_path: bundle.Dockerfile
+    context_dir: manifests
 promotion:
   name: other
   namespace: ocp

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -51,6 +51,53 @@ presubmits:
     always_run: true
     branches:
     - master
+    context: ci/prow/ci-index-my-bundle
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-super-duper-master-ci-index-my-bundle
+    rerun_command: /test ci-index-my-bundle
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=ci-index-my-bundle
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )ci-index-my-bundle,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - master
     context: ci/prow/e2e
     decorate: true
     decoration_config:

--- a/test/manifests/bundle.Dockerfile
+++ b/test/manifests/bundle.Dockerfile
@@ -4,8 +4,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=metering-ocp
-LABEL operators.operatorframework.io.bundle.channels.v1=4.6
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6
+LABEL operators.operatorframework.io.bundle.channels.v1=test-channel
+LABEL operators.operatorframework.io.bundle.channel.default.v1=test-channel
 
 COPY 4.6/*.yaml /manifests/
 COPY metadata /metadata/

--- a/test/manifests/metadata/annotations.yaml
+++ b/test/manifests/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: "4.6"
-  operators.operatorframework.io.bundle.channels.v1: "4.6"
+  operators.operatorframework.io.bundle.channel.default.v1: "test-channel"
+  operators.operatorframework.io.bundle.channels.v1: "test-channel"
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
This re-adds the content from #1748 and fixes a bug where a dependency on `pipeline:` was being erroneously created and breaking all tests that had an `operator` section. The fix is in the second commit of this PR. This is the message from that commit:

types: empty string is not a bundle image

This commit improves checking of the `IsPipelineImage` function by
identifying all index images instead of just unnamed ones and preventing
`IsBundleImage` from returning `true` for empty image names, which was
causing broken dependencies when the PR containing the previous commit
in this PR merged. Further, this commit prevents the MultiStage step's
run function from adding a dependency for the `from` image if `from` is
empty (which is why `IsBundleImage` was given an empty `imageName`
string in the first place).

/cc @petr-muller 