### PR TITLE
multi_stage: update PATH for cli using entrypoint-wrapper

### DIFF
--- a/cmd/entrypoint-wrapper/main.go
+++ b/cmd/entrypoint-wrapper/main.go
@@ -28,6 +28,7 @@ import (
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 
+	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
@@ -180,6 +181,7 @@ func execCmd(argv []string) error {
 		proc.Env = os.Environ()
 	}
 	manageHome(proc)
+	manageCLI(proc)
 	if err := manageKubeconfig(proc); err != nil {
 		return err
 	}
@@ -201,6 +203,14 @@ func execCmd(argv []string) error {
 		}
 	}()
 	return proc.Run()
+}
+
+// manageCLI configures the PATH to include a CLI_DIR if one was provided
+func manageCLI(proc *exec.Cmd) {
+	cliDir, set := os.LookupEnv(steps.CliEnv)
+	if set {
+		proc.Env = append(proc.Env, fmt.Sprintf("PATH=%s:%s", os.Getenv("PATH"), cliDir))
+	}
 }
 
 // manageHome provides a writeable home so kubectl discovery can be cached

--- a/test/entrypoint-wrapper-integration.sh
+++ b/test/entrypoint-wrapper-integration.sh
@@ -5,6 +5,7 @@ dir=$(mktemp -d)
 trap 'rm -r "${dir}"' EXIT
 export SHARED_DIR=${dir}/shared
 export TMPDIR=${dir}/tmp
+export CLI_DIR="/cli-dir"
 export NAMESPACE=test
 export JOB_NAME_SAFE=test
 ERR=${dir}/err.log
@@ -44,6 +45,16 @@ test_shared_dir() {
         fail '[ERROR] entrypoint-wrapper failed'
     fi
     diff <(echo "$v") <(echo "${TMPDIR}"/secret)
+}
+
+test_cli_dir() {
+    echo '[INFO] Verifying PATH is set correctly when CLI_DIR is set'
+    if ! v=$(entrypoint-wrapper --dry-run bash -c 'echo >&3 "${PATH}"' \
+        3>&1 > /dev/null 2> "${ERR}")
+    then
+        fail '[ERROR] entrypoint-wrapper failed'
+    fi
+    diff <(echo "$v") <(echo "${PATH}:${CLI_DIR}")
 }
 
 test_home_dir() {
@@ -159,6 +170,7 @@ test_signal() {
 mkdir "${SHARED_DIR}"
 test_mkdir
 test_shared_dir
+test_cli_dir
 test_copy_dir
 test_home_dir
 test_copy_kubeconfig


### PR DESCRIPTION
Instead of modifying the script that a multistage step runs in order to
update the `PATH` to point to the copied CLI, `entrypoint-wrapper`
checks for the `CLI_DIR` env var and, if it exists, appends that to the
`PATH` for the wrapped entrypoint.