### PR TITLE
ci-operator: label digest of image we built on top of

### DIFF
--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -45,8 +45,13 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	fromTag := api.PipelineImageStreamTagReferenceSource
+	fromDigest, err := resolvePipelineImageStreamTagReference(ctx, s.client, fromTag, s.jobSpec)
+	if err != nil {
+		return err
+	}
 	build := buildFromSource(
-		s.jobSpec, api.PipelineImageStreamTagReferenceSource, api.PipelineImageStreamTagReferenceBundleSource,
+		s.jobSpec, fromTag, api.PipelineImageStreamTagReferenceBundleSource,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
@@ -63,6 +68,7 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 				},
 			},
 		},
+		fromDigest,
 		"",
 		s.resources,
 		s.pullSecret,

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -51,7 +51,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 				URI: cloneURI,
 				Ref: refs.BaseRef,
 			},
-		}, s.config.DockerfilePath, s.resources, s.pullSecret))
+		}, "", s.config.DockerfilePath, s.resources, s.pullSecret))
 	}
 
 	return fmt.Errorf("nothing to build source image from, no refs")

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -47,8 +47,13 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	fromTag := api.PipelineImageStreamTagReferenceSource
+	fromDigest, err := resolvePipelineImageStreamTagReference(ctx, s.client, fromTag, s.jobSpec)
+	if err != nil {
+		return err
+	}
 	build := buildFromSource(
-		s.jobSpec, api.PipelineImageStreamTagReferenceSource, s.config.To,
+		s.jobSpec, fromTag, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
@@ -68,6 +73,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 				Secret: coreapi.LocalObjectReference{Name: s.pullSecret.Name},
 			}},
 		},
+		fromDigest,
 		"",
 		s.resources,
 		s.pullSecret,

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -40,12 +40,17 @@ func (s *pipelineImageCacheStep) Run(ctx context.Context) error {
 
 func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 	dockerfile := rawCommandDockerfile(s.config.From, s.config.Commands)
+	fromDigest, err := resolvePipelineImageStreamTagReference(ctx, s.client, s.config.From, s.jobSpec)
+	if err != nil {
+		return err
+	}
 	return handleBuild(ctx, s.client, buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		fromDigest,
 		"",
 		s.resources,
 		s.pullSecret,

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -44,12 +44,17 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 	}
 
 	dockerfile := rpmInjectionDockerfile(s.config.From, route.Spec.Host)
+	fromDigest, err := resolvePipelineImageStreamTagReference(ctx, s.client, s.config.From, s.jobSpec)
+	if err != nil {
+		return err
+	}
 	return handleBuild(ctx, s.client, buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,
 			Dockerfile: &dockerfile,
 		},
+		fromDigest,
 		"",
 		s.resources,
 		s.pullSecret,

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -288,7 +288,7 @@ func TestCreateBuild(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.jobSpec.SetNamespace("namespace")
-			actual := createBuild(testCase.config, testCase.jobSpec, testCase.clonerefsRef, testCase.resources, testCase.cloneAuthConfig, testCase.pullSecret)
+			actual := createBuild(testCase.config, testCase.jobSpec, testCase.clonerefsRef, testCase.resources, testCase.cloneAuthConfig, testCase.pullSecret, "imagedigest")
 			testhelper.CompareWithFixture(t, actual)
 		})
 	}

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -27,6 +27,8 @@ spec:
     - name: io.openshift.build.namespace
     - name: io.openshift.build.source-context-dir
     - name: io.openshift.build.source-location
+    - name: io.openshift.ci.from.root
+      value: imagedigest
     - name: vcs-ref
     - name: vcs-type
     - name: vcs-url

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -264,7 +264,7 @@ func TestOptionalOperators(t *testing.T) {
 		indexName:  "ci-index",
 		bundleName: "ci-bundle1",
 	}, {
-		name:       "named bunlde",
+		name:       "named bundle",
 		indexName:  "ci-index-named-bundle",
 		bundleName: "named-bundle",
 	}}


### PR DESCRIPTION
In the future, `ci-operator` will optionally re-use a `bin` image to get
access to the clone and build cache that is stored there after the image
is built. In order to be able to tell that a cached image is
out-of-date, we need to label the version of the root it's built on top
of and check that against the version of the root we resolved at
runtime.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

part of [DPTP-2051](https://issues.redhat.com/browse/DPTP-2051)