### PR TITLE
ci-operator: allow opting out of build cache promotion

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -414,6 +414,12 @@ type PromotionConfiguration struct {
 	// should *not* be used in common test workflows. The CI chat
 	// bot uses this option to facilitate image sharing.
 	RegistryOverride string `json:"registry_override,omitempty"`
+
+	// DisableBuildCache stops us from uploading the build cache.
+	// This is useful (only) for CI chat bot invocations where
+	// promotion does not imply output artifacts are being created
+	// for posterity.
+	DisableBuildCache bool `json:"disable_build_cache,omitempty"`
 }
 
 // StepConfiguration holds one step configuration.

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -275,8 +275,8 @@ func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration
 		}
 		promotedTags[src] = tag
 	}
-	// always promote the binary build if one exists
-	if configuration.BinaryBuildCommands != "" {
+	// promote the binary build if one exists and this isn't disabled
+	if configuration.BinaryBuildCommands != "" && !configuration.PromotionConfiguration.DisableBuildCache {
 		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = BuildCacheFor(configuration.Metadata)
 	}
 	return promotedTags, names

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -427,6 +427,24 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 				Tag:       "branch",
 			}},
 		},
+		{
+			name: "promotion set and binaries built, build cache disabled means no binaries promoted",
+			input: &api.ReleaseBuildConfiguration{
+				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},
+				BinaryBuildCommands: "something",
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace:         "roger",
+					Tag:               "fred",
+					DisableBuildCache: true,
+				},
+				Metadata: api.Metadata{
+					Org:    "org",
+					Repo:   "repo",
+					Branch: "branch",
+				},
+			},
+			expected: map[string]api.ImageStreamTagReference{},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
In general it is true that if a `ci-operator` instance is running with
promotion, it is running after a merge happened and in an isntance where
publishing the build cache is valuable. The CI chat bot breaks this
assumption and needs an opt-out.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @smarterclayton 