### PR TITLE
multi_stage: stop setting path in multi_stage.go

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/test-infra/prow/entrypoint"
 	utilpointer "k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
@@ -478,7 +477,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 			}...)
 		}
 		if step.Cli != "" {
-			errs = append(errs, addCliInjector(step.Cli, pod))
+			addCliInjector(step.Cli, pod)
 		}
 		addSharedDirSecret(s.name, pod)
 		addCredentials(step.Credentials, pod)
@@ -632,19 +631,7 @@ func addProfile(name string, profile api.ClusterProfile, pod *coreapi.Pod) {
 	}}...)
 }
 
-func injectPath(initial []string) []string {
-	var args []string
-	for _, arg := range initial {
-		if strings.HasPrefix(arg, CommandPrefix) {
-			args = append(args, fmt.Sprintf("%s%s\n%s", CommandPrefix, `export PATH="${PATH}:${CLI_DIR}"`, strings.TrimPrefix(arg, CommandPrefix)))
-		} else {
-			args = append(args, arg)
-		}
-	}
-	return args
-}
-
-func addCliInjector(release string, pod *coreapi.Pod) error {
+func addCliInjector(release string, pod *coreapi.Pod) {
 	volumeName := "cli"
 	pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
 		Name: volumeName,
@@ -663,23 +650,6 @@ func addCliInjector(release string, pod *coreapi.Pod) error {
 		}},
 	})
 	container := &pod.Spec.Containers[0]
-
-	for i, env := range container.Env {
-		if env.Name != entrypoint.JSONConfigEnvVar {
-			continue
-		}
-		var options entrypoint.Options
-		if err := yaml.Unmarshal([]byte(env.Value), &options); err != nil {
-			return err
-		}
-		options.Args = injectPath(options.Args)
-		encoded, err := entrypoint.Encode(options)
-		if err != nil {
-			return err
-		}
-		container.Env[i].Value = encoded
-		break
-	}
 	container.VolumeMounts = append(container.VolumeMounts, coreapi.VolumeMount{
 		Name:      volumeName,
 		MountPath: CliMountPath,
@@ -688,7 +658,6 @@ func addCliInjector(release string, pod *coreapi.Pod) error {
 		Name:  CliEnv,
 		Value: CliMountPath,
 	})
-	return nil
 }
 
 func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, shortCircuit bool, isBestEffort func(string) bool) error {


### PR DESCRIPTION
Now that `entrypoint-wrapper` sets the updated `PATH` including the cli,
stop setting it in the multistage step.

/cc @stevekuznetsov 