### PR TITLE
ci-operator: optionally use build cache for the root

### DIFF
--- a/pkg/api/helper/imageextraction.go
+++ b/pkg/api/helper/imageextraction.go
@@ -35,6 +35,9 @@ func TestInputImageStreamTagsFromResolvedConfig(cfg api.ReleaseBuildConfiguratio
 	imageStreamTagReferenceMapIntoMap(cfg.BaseRPMImages, result)
 	if cfg.BuildRootImage != nil && cfg.BuildRootImage.ImageStreamTagReference != nil {
 		insert(*cfg.BuildRootImage.ImageStreamTagReference, result)
+		if cfg.InputConfiguration.BuildRootImage.UseBuildCache {
+			insert(api.BuildCacheFor(cfg.Metadata), result)
+		}
 	}
 
 	var errs []error

--- a/pkg/api/helper/imageextraction_test.go
+++ b/pkg/api/helper/imageextraction_test.go
@@ -46,6 +46,9 @@ func TestTestInputImageStreamTagsFromResolvedConfigReturnsAllImageStreamTags(t *
 					numberInsertedElements--
 				}
 			}
+			if cfg.InputConfiguration.BuildRootImage != nil && cfg.InputConfiguration.BuildRootImage.UseBuildCache {
+				numberInsertedElements++
+			}
 
 			res, err := TestInputImageStreamTagsFromResolvedConfig(cfg)
 			if err != nil {

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -108,3 +108,19 @@ func LogFieldsFor(metadata Metadata) logrus.Fields {
 		"variant": metadata.Variant,
 	}
 }
+
+func BuildCacheFor(metadata Metadata) ImageStreamTagReference {
+	tag := metadata.Branch
+	if metadata.Variant != "" {
+		tag = fmt.Sprintf("%s-%s", tag, metadata.Variant)
+	}
+	return ImageStreamTagReference{
+		Namespace: "build-cache",
+		Name:      fmt.Sprintf("%s-%s", metadata.Org, metadata.Repo),
+		Tag:       tag,
+	}
+}
+
+func ImageVersionLabel(fromTag PipelineImageStreamTagReference) string {
+	return fmt.Sprintf("io.openshift.ci.from.%s", fromTag)
+}

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -277,21 +277,9 @@ func PromotedTagsWithRequiredImages(configuration *api.ReleaseBuildConfiguration
 	}
 	// promote the binary build if one exists and this isn't disabled
 	if configuration.BinaryBuildCommands != "" && !configuration.PromotionConfiguration.DisableBuildCache {
-		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = BuildCacheFor(configuration.Metadata)
+		promotedTags[string(api.PipelineImageStreamTagReferenceBinaries)] = api.BuildCacheFor(configuration.Metadata)
 	}
 	return promotedTags, names
-}
-
-func BuildCacheFor(metadata api.Metadata) api.ImageStreamTagReference {
-	tag := metadata.Branch
-	if metadata.Variant != "" {
-		tag = fmt.Sprintf("%s-%s", tag, metadata.Variant)
-	}
-	return api.ImageStreamTagReference{
-		Namespace: "build-cache",
-		Name:      fmt.Sprintf("%s-%s", metadata.Org, metadata.Repo),
-		Tag:       tag,
-	}
 }
 
 func (s *promotionStep) Requires() []api.StepLink {

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -489,7 +489,7 @@ func TestBuildCacheFor(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		if diff := cmp.Diff(testCase.output, BuildCacheFor(testCase.input)); diff != "" {
+		if diff := cmp.Diff(testCase.output, api.BuildCacheFor(testCase.input)); diff != "" {
 			t.Errorf("got incorrect ist for build cache: %v", diff)
 		}
 	}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -314,7 +314,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 	}
 	if len(fromTag) > 0 {
 		build.Spec.Output.ImageLabels = append(build.Spec.Output.ImageLabels, buildapi.ImageLabel{
-			Name:  fmt.Sprintf("io.openshift.ci.from.%s", fromTag),
+			Name:  api.ImageVersionLabel(fromTag),
 			Value: fromTagDigest,
 		})
 	}


### PR DESCRIPTION
ci-operator: validate that build_root ISTags are fully formed

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: clean up build root step generation

There's no place where any of the weird "test-base" stuff is used and
the previous commit validates as much. I'm not sure what it was for and
it's not documented anywhere. I removed that handler and fixed the git
base / project build options to pass through the full struct, instead of
cherry-picking some options and silently dropping the rest.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

ci-operator: optionally use build cache for the root

When the user asks us to, we can determine if the build cache we have
published for the repo is up-to-date. If it is, we should use it for our
build root instead of the build root that would otherwise be used. In
cases where we can't resolve it or the cache is stale, fall back to the
original root.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @petr-muller @alvaroaleman 

need to think about how this might be e2e tested or it's worth it
