### PR TITLE
ci-operator: initialize a more intelligent logger

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 	"go.uber.org/zap/zapcore"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,6 +47,7 @@ import (
 	"k8s.io/klog/v2"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 	"k8s.io/test-infra/prow/version"
 	utilpointer "k8s.io/utils/pointer"
@@ -72,6 +74,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/util"
 	"github.com/openshift/ci-tools/pkg/validation"
@@ -172,11 +175,23 @@ var (
 const CustomProwMetadata = "custom-prow-metadata.json"
 
 func main() {
+	censor, closer, err := setupLogger()
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not set up logging.")
+	}
+	if closer != nil {
+		defer func() {
+			if err := closer.Close(); err != nil {
+				logrus.WithError(err).Warn("Could not close ci-operator log file.")
+			}
+		}()
+	}
 	// "i just doin't want spam"
 	klog.LogToStderr(false)
 	log.Printf("%s version %s", version.Name, version.Version)
 	flagSet := flag.NewFlagSet("", flag.ExitOnError)
 	opt := bindOptions(flagSet)
+	opt.censor = censor
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("failed to parse flags")
 	}
@@ -241,6 +256,38 @@ func main() {
 		os.Exit(1)
 	}
 	opt.Report()
+}
+
+// setupLogger sets up logrus to print all logs to a file and user-friendly logs to stdout
+func setupLogger() (*secrets.DynamicCensor, io.Closer, error) {
+	logrusutil.ComponentInit()
+	logrus.SetLevel(logrus.TraceLevel)
+	censor := secrets.NewDynamicCensor()
+	logrus.SetFormatter(logrusutil.NewFormatterWithCensor(logrus.StandardLogger().Formatter, &censor))
+	logrus.SetOutput(ioutil.Discard)
+	logrus.AddHook(&writer.Hook{
+		Writer: os.Stdout,
+		LogLevels: []logrus.Level{
+			logrus.InfoLevel,
+			logrus.WarnLevel,
+			logrus.ErrorLevel,
+			logrus.FatalLevel,
+			logrus.PanicLevel,
+		},
+	})
+	artifactDir, set := api.Artifacts()
+	if !set {
+		return &censor, nil, nil
+	}
+	verboseFile, err := os.Open(filepath.Join(artifactDir, "ci-operator.log"))
+	if err != nil {
+		return nil, nil, err
+	}
+	logrus.AddHook(&writer.Hook{
+		Writer:    verboseFile,
+		LogLevels: logrus.AllLevels,
+	})
+	return &censor, verboseFile, nil
 }
 
 type stringSlice struct {
@@ -320,6 +367,8 @@ type options struct {
 	cloneAuthConfig *steps.CloneAuthConfig
 
 	resultsOptions results.Options
+
+	censor *secrets.DynamicCensor
 }
 
 func bindOptions(flag *flag.FlagSet) *options {
@@ -578,7 +627,7 @@ func (o *options) Run() []error {
 		leaseClient = &o.leaseClient
 	}
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret)
+	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -31,10 +31,12 @@ import (
 	"github.com/openshift/ci-tools/pkg/release/official"
 	"github.com/openshift/ci-tools/pkg/release/prerelease"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/steps/clusterinstall"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 	releasesteps "github.com/openshift/ci-tools/pkg/steps/release"
+	"github.com/openshift/ci-tools/pkg/steps/secretrecordingclient"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
 	"github.com/openshift/ci-tools/pkg/util/watchingclient"
 )
@@ -58,8 +60,10 @@ func FromConfig(
 	requiredTargets []string,
 	cloneAuthConfig *steps.CloneAuthConfig,
 	pullSecret, pushSecret *coreapi.Secret,
+	censor *secrets.DynamicCensor,
 ) ([]api.Step, []api.Step, error) {
 	crclient, err := watchingclient.New(clusterConfig)
+	crclient = secretrecordingclient.Wrap(crclient, censor)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to construct client: %w", err)
 	}

--- a/pkg/steps/secretrecordingclient/client.go
+++ b/pkg/steps/secretrecordingclient/client.go
@@ -1,0 +1,132 @@
+package secretrecordingclient
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/ci-tools/pkg/secrets"
+	"github.com/openshift/ci-tools/pkg/util/watchingclient"
+)
+
+// Wrap wraps the upstream client, allowing us to intercept any secrets it might interact with.
+// This allows us to keep an up-to-date view of all of the secret data we may have come into contact
+// with while executing, and ensure that we censor all of that data before outputting it.
+func Wrap(upstream watchingclient.Client, censor *secrets.DynamicCensor) watchingclient.Client {
+	return &client{
+		upstream: upstream,
+		censor:   censor,
+	}
+}
+
+// client updates the censor when it interacts with secrets on the cluster
+type client struct {
+	upstream watchingclient.Client
+	censor   *secrets.DynamicCensor
+}
+
+func (c *client) Get(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object) error {
+	if err := c.upstream.Get(ctx, key, obj); err != nil {
+		return err
+	}
+	c.record(obj)
+	return nil
+}
+
+func (c *client) List(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	if err := c.upstream.List(ctx, list, opts...); err != nil {
+		return err
+	}
+	c.recordList(list)
+	return nil
+}
+
+func (c *client) Create(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+	if err := c.upstream.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	c.record(obj)
+	return nil
+}
+
+func (c *client) Delete(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteOption) error {
+	return c.upstream.Delete(ctx, obj, opts...)
+}
+
+func (c *client) Update(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.UpdateOption) error {
+	if err := c.upstream.Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+	c.record(obj)
+	return nil
+}
+
+func (c *client) Patch(ctx context.Context, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
+	if err := c.upstream.Patch(ctx, obj, patch, opts...); err != nil {
+		return err
+	}
+	c.record(obj)
+	return nil
+}
+
+func (c *client) DeleteAllOf(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteAllOfOption) error {
+	return c.upstream.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *client) Watch(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+	return c.upstream.Watch(ctx, obj, opts...)
+}
+
+func (c *client) recordList(obj ctrlruntimeclient.ObjectList) {
+	// this code will not handle unstructured.Unstructured, but we do not
+	// think that the controller-runtime client will ever give us that
+	secretList, ok := obj.(*v1.SecretList)
+	if !ok {
+		return
+	}
+	for i := range secretList.Items {
+		c.recordSecret(&secretList.Items[i])
+	}
+}
+
+func (c *client) record(obj ctrlruntimeclient.Object) {
+	// this code will not handle unstructured.Unstructured, but we do not
+	// think that the controller-runtime client will ever give us that
+	secret, ok := obj.(*v1.Secret)
+	if !ok {
+		return
+	}
+	c.recordSecret(secret)
+}
+
+func (c *client) recordSecret(secret *v1.Secret) {
+	var values []string
+	for _, value := range secret.Data {
+		values = append(values, string(value))
+	}
+	for _, value := range secret.StringData {
+		values = append(values, value)
+	}
+	for _, key := range []string{"openshift.io/token-secret.value", "kubectl.kubernetes.io/last-applied-configuration"} {
+		if _, ok := secret.Annotations[key]; ok {
+			values = append(values, secret.Annotations[key])
+		}
+	}
+	c.censor.AddSecrets(values...)
+}
+
+func (c *client) Status() ctrlruntimeclient.StatusWriter {
+	return c.upstream.Status()
+}
+
+func (c *client) Scheme() *runtime.Scheme {
+	return c.upstream.Scheme()
+}
+
+func (c *client) RESTMapper() meta.RESTMapper {
+	return c.upstream.RESTMapper()
+}

--- a/vendor/github.com/sirupsen/logrus/hooks/writer/README.md
+++ b/vendor/github.com/sirupsen/logrus/hooks/writer/README.md
@@ -1,0 +1,43 @@
+# Writer Hooks for Logrus
+
+Send logs of given levels to any object with `io.Writer` interface.
+
+## Usage
+
+If you want for example send high level logs to `Stderr` and
+logs of  normal execution to `Stdout`, you could do it like this:
+
+```go
+package main
+
+import (
+	"io/ioutil"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
+)
+
+func main() {
+	log.SetOutput(ioutil.Discard) // Send all logs to nowhere by default
+
+	log.AddHook(&writer.Hook{ // Send logs with level higher than warning to stderr
+		Writer: os.Stderr,
+		LogLevels: []log.Level{
+			log.PanicLevel,
+			log.FatalLevel,
+			log.ErrorLevel,
+			log.WarnLevel,
+		},
+	})
+	log.AddHook(&writer.Hook{ // Send info and debug logs to stdout
+		Writer: os.Stdout,
+		LogLevels: []log.Level{
+			log.InfoLevel,
+			log.DebugLevel,
+		},
+	})
+	log.Info("This will go to stdout")
+	log.Warn("This will go to stderr")
+}
+```

--- a/vendor/github.com/sirupsen/logrus/hooks/writer/writer.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/writer/writer.go
@@ -1,0 +1,29 @@
+package writer
+
+import (
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Hook is a hook that writes logs of specified LogLevels to specified Writer
+type Hook struct {
+	Writer    io.Writer
+	LogLevels []log.Level
+}
+
+// Fire will be called when some logging function is called with current hook
+// It will format log entry to string and write it to appropriate writer
+func (hook *Hook) Fire(entry *log.Entry) error {
+	line, err := entry.Bytes()
+	if err != nil {
+		return err
+	}
+	_, err = hook.Writer.Write(line)
+	return err
+}
+
+// Levels define on which log levels this hook would trigger
+func (hook *Hook) Levels() []log.Level {
+	return hook.LogLevels
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -465,6 +465,7 @@ github.com/shurcooL/graphql/internal/jsonutil
 ## explicit
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/test
+github.com/sirupsen/logrus/hooks/writer
 # github.com/slack-go/slack v0.7.3
 ## explicit
 github.com/slack-go/slack


### PR DESCRIPTION
Default censoring that is provided by `sidecar` has one draw-back: the
set of secrets that must be censored is loaded at start-up and must be
known ahead of time in order to be provided to the process. Inside of
the `ci-operator`, we routinely touch secret values via the Kubernetes
API at runtime. This means that the total set of secret values we may
possibly leak grows over time. Due to this, we cannot solely rely on the
censoring implemenation that runs out-of-process.

Also, today the `ci-operator` uses the `log` library for logging, in
contrast to pretty must every other part of the codebase and larger
ecosystem (Prow, Boskos, etc...). Censoring for the `logrus` library is
implemented, tried, and tested in production for a long time. We are
better off by migrating to `logrus` over time in order to consolidate
our codebase.

We have a similar issue in the `ci-secret-bootstrap` tool and already
have the `DynamicCensorer` utlity to handle this case. This patch does
two things:

- create an initial implementation of a `logrus` logger for
  `ci-operator` that not only censors by default but also shows only the
  most important messages to users in stdout, while at the same time
  funneling more specifc/spammy messages to a file which an
  administrator can read after a job failed.
- wire through a client shim that records the values of Secrets that
  `ci-operator` touches in the Kuberntes API while it runs, in order to
  ensure that the censoring provided by the logger cannot leak anything
  sensitive

Follow-up PRs will begin to move usage of `log` to `logrus` in our
code-base.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 