### PR TITLE
Stop retries in promotion

### DIFF
--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -6,27 +6,12 @@ spec:
   containers:
   - args:
     - |-
-      set -e
-      retry() {
-        retries=3
-
-        count=0
-        delay=1
-        until "$@"; do
-          rc=$?
-          count=$(( count + 1 ))
-          if [ $count -lt "$retries" ]; then
-            echo "Retry $count/$retries exited $rc, retrying in $delay seconds..." >/dev/stderr
-            sleep $delay
-          else
-            echo "Retry $count/$retries exited $rc, no more retries left." >/dev/stderr
-            return $rc
-          fi
-          delay=$(( delay * 3 ))
-        done
-        return 0
-      }
-      retry oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true --max-per-registry=20 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registy.ci.openshift.org/ci/applyconfig:latest docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registy.ci.openshift.org/ci/bin:latest
+      oc image mirror
+      --registry-config=/etc/push-secret/.dockerconfigjson
+      --continue-on-error=true
+      --max-per-registry=20
+      docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registy.ci.openshift.org/ci/applyconfig:latest
+      docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registy.ci.openshift.org/ci/bin:latest
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
We had issues in promotion and use [retries](https://github.com/openshift/ci-tools/pull/1555/commits/fbd752b0ea26533c455afaf88fb456ad36c22118) in our bash to work it around. The [potential fix](https://github.com/openshift/oc/pull/706) has been merged  for some time. @ricardomaraschini asked me if it helped. I am going to revert the retries (which hides the underlying problem) and provide him our answer. I tried to reproduce it locally at the time. 4.6 reproduced. Not 4.7, master at the time, even before the fix was merged. We are using 4.8:cli in promotion pod. I feel it is relatively safe.

/cc @alvaroaleman @stevekuznetsov 