### PR TITLE
ci-operator: set higher build loglevel

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -298,7 +298,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 						From:                    from,
 						ForcePull:               true,
 						NoCache:                 true,
-						Env:                     []corev1.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "0"}}, // this mirrors the default and is done for documentary purposes
+						Env:                     []corev1.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "6"}}, // we want more logs for debugging
 						ImageOptimizationPolicy: &layer,
 					},
 				},

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -66,7 +66,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"clone_uri":"https://github.com/org/repo.git"}],"oauth_token_file":"/oauth-token","fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"path_alias":"somewhere/else"}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA"}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA","path_alias":"this/is/nuts","workdir":true}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -69,7 +69,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "0"
+        value: "6"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"clone_uri":"ssh://git@github.com/org/repo.git"}],"key_files":["/sshprivatekey"],"fail":true}'
       forcePull: true


### PR DESCRIPTION
We want to investigate why a build takes so long. Today, the default log
level does not give us enough verbosity to tell.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>