### PR TITLE
test: add index content test for optional operator e2e

### DIFF
--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -259,14 +259,17 @@ func TestOptionalOperators(t *testing.T) {
 		name       string
 		indexName  string
 		bundleName string
+		target     string
 	}{{
 		name:       "unnamed bundle",
 		indexName:  "ci-index",
 		bundleName: "ci-bundle1",
+		target:     "verify-db-unnamed",
 	}, {
 		name:       "named bundle",
 		indexName:  "ci-index-named-bundle",
 		bundleName: "named-bundle",
+		target:     "verify-db-named",
 	}}
 	for _, testCase := range testCases {
 		testCase := testCase
@@ -275,10 +278,9 @@ func TestOptionalOperators(t *testing.T) {
 				"--config=optional-operators.yaml",
 				framework.LocalPullSecretFlag(t),
 				framework.RemotePullSecretFlag(t),
-				fmt.Sprintf("--target=%s", testCase.indexName),
-				"--target=success",
+				fmt.Sprintf("--target=%s", testCase.target),
 			)
-			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"886f493b3b7db24450e80d41a6d4c801b3b49881","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
+			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"b439e7e55dcb924e8f372ae02566b5f7f003615d","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
 			cmd.AddEnv(framework.KubernetesClientEnv(t)...)
 			output, err := cmd.Run()
 			if err != nil {

--- a/test/e2e/simple/optional-operators.yaml
+++ b/test/e2e/simple/optional-operators.yaml
@@ -37,6 +37,60 @@ tag_specification:
   namespace: ocp
   name: "4.6"
 tests:
+- as: verify-db-unnamed
+  literal_steps:
+    test:
+    - as: verify
+      from: pipeline:ci-index
+      run_as_script: true
+      commands: |
+        #!/bin/sh
+        set -o nounset
+        set -o errexit
+        set -o pipefail
+        # need a writable directory for grpcurl binary and for index database during test; $HOME is always writable
+        cd $HOME
+        cp /database/index.db index.db
+        opm registry serve --database index.db &
+        OPM_PID=$!
+        trap 'kill -9 $OPM_PID' EXIT
+        wget -O - https://github.com/fullstorydev/grpcurl/releases/download/v1.8.0/grpcurl_1.8.0_linux_x86_64.tar.gz | tar xz grpcurl
+        chmod +x grpcurl
+        # grpcurl exits with 66 on bundle not found; should get error on fresh index
+        ./grpcurl -plaintext -d '{"pkgName":"kubevirt-hyperconverged","channelName":"stable","csvName":"kubevirt-hyperconverged-operator.v2.5.2"}' localhost:50051 api.Registry/GetBundle && rc=$? || rc=$?
+        if [ $rc -eq 0 ]; then
+          exit 1
+        fi
+        ./grpcurl -plaintext -d '{"pkgName":"metering-ocp","channelName":"test-channel","csvName":"metering-operator.v4.6.0"}' localhost:50051 api.Registry/GetBundle
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
+- as: verify-db-named
+  literal_steps:
+    test:
+    - as: verify
+      from: pipeline:ci-index-named-bundle
+      run_as_script: true
+      commands: |
+        #!/bin/sh
+        set -o nounset
+        set -o errexit
+        set -o pipefail
+        # need a writable directory for grpcurl binary and for index database during test; $HOME is always writable
+        cd $HOME
+        cp /database/index.db index.db
+        opm registry serve --database index.db &
+        OPM_PID=$!
+        trap 'kill -9 $OPM_PID' EXIT
+        wget -O - https://github.com/fullstorydev/grpcurl/releases/download/v1.8.0/grpcurl_1.8.0_linux_x86_64.tar.gz | tar xz grpcurl
+        # grpcurl exits with 66 on bundle not found; try to get one bundle from base index and the bundle built by ci-operator
+        ./grpcurl -plaintext -d '{"pkgName":"kubevirt-hyperconverged","channelName":"stable","csvName":"kubevirt-hyperconverged-operator.v2.5.2"}' localhost:50051 api.Registry/GetBundle
+        ./grpcurl -plaintext -d '{"pkgName":"metering-ocp","channelName":"test-channel","csvName":"metering-operator.v4.6.0"}' localhost:50051 api.Registry/GetBundle
+      resources:
+        requests:
+          cpu: 100m
+          memory: 100Mi
 - as: success
   literal_steps:
     test:


### PR DESCRIPTION
This PR adds a content test for the operator indices built by the
optional-operators e2e test. The way it is done is by running the
serving the opm registry in the index image and then using `grpcurl` to
identify whether certain CSVs exist. For the `ci-index-named-bundle`
image which has a `base_index`, we verify that both existing bundles and
the new bundle exist in the index. For the unnamed bundle, we verify
that the new bundle is in the index and a bundle that exists in the
`base_index` used for the other index image does not.

Due to a permission error that occurs during the test that doesn't occur
when the index image is actually run in the cluster, the `index.db` file
has to be moved to the `$HOME` directory, otherwise a permissions error
occurs when the database is being read.