### PR TITLE
Wait for pod deletion during cleanup

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -367,6 +367,11 @@ func (s *multiStageTestStep) runSteps(
 				}
 				if err := s.client.Delete(cleanupCtx, &pod); err != nil && !kerrors.IsNotFound(err) {
 					errs = append(errs, fmt.Errorf("failed to delete pod %s with label %s=%s: %w", pod.Name, MultiStageTestLabel, s.name, err))
+					continue
+				}
+				if err := waitForPodDeletion(s.client, s.jobSpec.Namespace(), pod.Name, pod.UID); err != nil {
+					errs = append(errs, fmt.Errorf("failed waiting for pod %s with label %s=%s to be deleted: %w", pod.Name, MultiStageTestLabel, s.name, err))
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
Noted this condition with the current implementation:
```
$ oc get pods -n ci-op-bn8cmi7b
NAME                                READY   STATUS        RESTARTS   AGE
launch-openshift-cluster-bot-rbac   0/2     Completed     0          7m5s
launch-osd-create-create            2/2     Terminating   0          6m55s
launch-osd-delete-delete            0/2     Completed     0          60s
```