### PR TITLE
CI-Secret-Bootstrap: Sync user secrets from Vault

### DIFF
--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -76,8 +76,9 @@ func LoadConfigFromFile(file string, config *Config) error {
 
 // Config is what we version in our repository
 type Config struct {
-	ClusterGroups map[string][]string `json:"cluster_groups,omitempty"`
-	Secrets       []SecretConfig      `json:"secret_configs"`
+	ClusterGroups             map[string][]string `json:"cluster_groups,omitempty"`
+	Secrets                   []SecretConfig      `json:"secret_configs"`
+	UserSecretsTargetClusters []string            `json:"user_secrets_target_clusters,omitempty"`
 }
 
 type configWithoutUnmarshaler Config

--- a/pkg/api/vault/vault.go
+++ b/pkg/api/vault/vault.go
@@ -3,4 +3,9 @@ package vault
 const (
 	SecretSyncTargetNamepaceKey = "secretsync/target-namespace"
 	SecretSyncTargetNameKey     = "secretsync/target-name"
+
+	// VaultSourceKey is the key in the resulting kubernetes secret
+	// that holds the vault path from which the user secret sync
+	// synced.
+	VaultSourceKey = "secretsync-vault-source-path"
 )

--- a/pkg/bitwarden/fake.go
+++ b/pkg/bitwarden/fake.go
@@ -18,9 +18,10 @@ func (f fakeClient) GetFieldOnItem(itemName, fieldName string) ([]byte, error) {
 					return []byte(field.Value), nil
 				}
 			}
+			return nil, fmt.Errorf("failed to find field %s in item %s", fieldName, itemName)
 		}
 	}
-	return nil, fmt.Errorf("failed to find field %s in item %s", fieldName, itemName)
+	return nil, fmt.Errorf("no item %s found", itemName)
 }
 
 func (f fakeClient) GetAllItems() []Item {

--- a/pkg/secrets/bitwarden.go
+++ b/pkg/secrets/bitwarden.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/bitwarden"
@@ -32,6 +33,11 @@ func (bw *bitwardenClient) GetInUseInformationForAllItems() (map[string]SecretUs
 	}
 
 	return result, nil
+}
+
+func (*bitwardenClient) GetUserSecrets() (map[types.NamespacedName]map[string]string, error) {
+	// This functionality doesn't exist for bitwarden, so it is implemented as a no-op.
+	return nil, nil
 }
 
 type bitwardenSecretUsageComparer struct {

--- a/pkg/secrets/client.go
+++ b/pkg/secrets/client.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/bitwarden"
@@ -14,6 +15,7 @@ type ReadOnlyClient interface {
 	GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error)
 	GetPassword(itemName string) ([]byte, error)
 	GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error)
+	GetUserSecrets() (map[types.NamespacedName]map[string]string, error)
 	Logout() ([]byte, error)
 }
 
@@ -47,5 +49,10 @@ func NewDryRunClient(output *os.File) (Client, error) {
 }
 
 func (*dryRunClient) GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error) {
+	return nil, nil
+}
+
+func (*dryRunClient) GetUserSecrets() (map[types.NamespacedName]map[string]string, error) {
+	// This functionality doesn't exist for bitwarden, so it is implemented as a no-op.
 	return nil, nil
 }


### PR DESCRIPTION
This change adds support to the secret bootstrapper to sync user secrets
from Vault. It will use specific keys in the Vault secret to figure out
the namespace/name it should sync to. The clusters need to be explicitly
configured. It is allowed to have secrets that contain both data from
the secret bootstrap config (owned by dptp) and user secrets but dptp
data takes precedence and we will error if an attempt to overwrite it is
made.

Ref https://issues.redhat.com/browse/DPTP-2070
/cc @openshift/openshift-team-developer-productivity-test-platform 