### PR TITLE
Revert "CI-Operator: Stop writing step graph out"

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -696,20 +696,15 @@ func (o *options) Run() []error {
 	}
 
 	graph := calculateGraph(nodes)
-	if o.artifactDir != "" {
-		defer func() {
-			serializedGraph, err := json.Marshal(graph)
-			if err != nil {
-				logrus.WithError(err).Error("Failed to marshal graph")
-				return
-			}
+	defer func() {
+		serializedGraph, err := json.Marshal(graph)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to marshal graph")
+			return
+		}
 
-			dest := filepath.Join(o.artifactDir, api.CIOperatorStepGraphJSONFilename)
-			if err := ioutil.WriteFile(dest, serializedGraph, 0644); err != nil {
-				logrus.WithError(err).Error("Failed to write serialized step graph")
-			}
-		}()
-	}
+		_ = api.SaveArtifact(o.censor, api.CIOperatorStepGraphJSONFilename, serializedGraph)
+	}()
 
 	if err := validateGraph(nodes); err != nil {
 		return err

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap/zapcore"
+
 	appsv1 "k8s.io/api/apps/v1"
 	authapi "k8s.io/api/authorization/v1"
 	coreapi "k8s.io/api/core/v1"

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -696,6 +696,21 @@ func (o *options) Run() []error {
 	}
 
 	graph := calculateGraph(nodes)
+	if o.artifactDir != "" {
+		defer func() {
+			serializedGraph, err := json.Marshal(graph)
+			if err != nil {
+				logrus.WithError(err).Error("Failed to marshal graph")
+				return
+			}
+
+			dest := filepath.Join(o.artifactDir, api.CIOperatorStepGraphJSONFilename)
+			if err := ioutil.WriteFile(dest, serializedGraph, 0644); err != nil {
+				logrus.WithError(err).Error("Failed to write serialized step graph")
+			}
+		}()
+	}
+
 	if err := validateGraph(nodes); err != nil {
 		return err
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -114,9 +115,11 @@ func verifyMetadata(jobSpec *api.JobSpec, namespace string, customMetadata map[s
 	metadataFile := filepath.Join(tempDir, "metadata.json")
 
 	// Verify without custom metadata
+	c := secrets.NewDynamicCensor()
 	o := &options{
 		jobSpec:   jobSpec,
 		namespace: namespace,
+		censor:    &c,
 	}
 
 	if err := o.writeMetadataJSON(); err != nil {

--- a/pkg/api/env.go
+++ b/pkg/api/env.go
@@ -1,10 +1,38 @@
 package api
 
-import "os"
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/secretutil"
+)
 
 // prowArtifactsEnv is the directory Prow wants us to put artifacts into for upload
 const prowArtifactsEnv string = "ARTIFACTS"
 
 func Artifacts() (string, bool) {
 	return os.LookupEnv(prowArtifactsEnv)
+}
+
+// SaveArtifact saves the data under the path relative to the artifact directory.
+// If no artifact directory is set, we no-op.
+func SaveArtifact(censor secretutil.Censorer, relPath string, data []byte) error {
+	artifactDir, set := os.LookupEnv(prowArtifactsEnv)
+	if !set {
+		return nil
+	}
+	censor.Censor(&data)
+	path := filepath.Join(artifactDir, relPath)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0777); err != nil {
+		logrus.WithError(err).Warn("Unable to create artifact directory.")
+		return err
+	}
+	if err := ioutil.WriteFile(path, data, 0644); err != nil {
+		logrus.WithError(err).Errorf("Failed to write %s", relPath)
+		return err
+	}
+	return nil
 }

--- a/pkg/api/env.go
+++ b/pkg/api/env.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/secretutil"
 )
 

--- a/pkg/steps/secretrecordingclient/client.go
+++ b/pkg/steps/secretrecordingclient/client.go
@@ -104,7 +104,7 @@ func (c *client) record(obj ctrlruntimeclient.Object) {
 }
 
 func (c *client) recordSecret(secret *v1.Secret) {
-	_, isServiceAccountCredential := secret.Labels["kubernetes.io/service-account.name"]
+	isServiceAccountCredential := secret.Type == v1.SecretTypeServiceAccountToken
 	var values []string
 	for key, value := range secret.Data {
 		if isServiceAccountCredential && key == "namespace" {

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -27,6 +27,20 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
+  - as: with-credentials
+    steps:
+      test:
+        - as: consume
+          commands: test -f /auth/kubeconfig
+          from: os
+          credentials:
+          - mount_path: /auth
+            name: ci-operator
+            namespace: test-credentials
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
   - as: without-references
     steps:
       test:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -62,6 +62,13 @@ func TestMultiStage(t *testing.T) {
 			output:  []string{`Skipping optional step skip-on-success-skip-on-success-post-step`},
 		},
 		{
+			name:    "step with credentials",
+			args:    []string{"--unresolved-config=config.yaml", "--target=with-credentials"},
+			env:     []string{depsJobSpec},
+			success: true,
+			output:  []string{`Container test in pod with-credentials-consume completed successfully`},
+		},
+		{
 			name:    "step with timeout",
 			args:    []string{"--unresolved-config=config.yaml", "--target=timeout"},
 			env:     []string{defaultJobSpec},


### PR DESCRIPTION
ci-operator: add a utility to write censored artifacts

We want to make sure that we censor anything we're writing to artifacts
from this process as we often interact with secrets during runtime for
the first time, so we can't be certain that out-of-process censoring
will do anything sensible. A helper makes it easier for an engineer to
do the right thing.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Revert "CI-Operator: Stop writing step graph out"

This reverts commit 4b978f02018eb00ed5dccb1850a8f295d57bd4d9.

---

ci-operator: use the artifacts helper to write the graph

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @alvaroaleman 

Tested locally, produces output like this:

```
$ cat /tmp/artifacts/TestMultiStage_step_with_credentials/ci-operator-step-graph.json | jq '.[0].manifests[] | select(.metadata.name=="ci-operator") | select(.kind=="Secret")'
{
  "kind": "Secret",
  "apiVersion": "v1",
  "metadata": {
    "name": "ci-operator",
    "namespace": "test-credentials",
    "selfLink": "/api/v1/namespaces/test-credentials/secrets/ci-operator",
    "uid": "c2ff507b-154a-4093-b55c-51d4ed82f628",
    "resourceVersion": "538689868",
    "creationTimestamp": "2020-05-20T21:03:46Z",
    "labels": {
      "dptp.openshift.io/requester": "ci-secret-bootstrap"
    }
  },
  "data": {
    "kubeconfig": "********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************"
  },
  "type": "Opaque"
}
```

DO NOT MERGE BEFORE https://github.com/kubernetes/test-infra/pull/21593
/hold