### PR TITLE
entrypoint-wrapper: label secret to be ignored in censor

### DIFF
--- a/cmd/entrypoint-wrapper/main.go
+++ b/cmd/entrypoint-wrapper/main.go
@@ -281,6 +281,10 @@ func createSecret(client coreclientset.SecretInterface, name, dir string, dry bo
 		return fmt.Errorf("failed to generate secret: %w", err)
 	}
 	secret.Name = name
+	if secret.Labels == nil {
+		secret.Labels = map[string]string{}
+	}
+	secret.Labels[steps.SkipCensoringLabel] = "true"
 	if dry {
 		err := encoder.Encode(secret, os.Stdout)
 		if err != nil {

--- a/test/entrypoint-wrapper-integration.sh
+++ b/test/entrypoint-wrapper-integration.sh
@@ -9,7 +9,7 @@ export CLI_DIR="/cli-dir"
 export NAMESPACE=test
 export JOB_NAME_SAFE=test
 ERR=${dir}/err.log
-SECRET='{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test","creationTimestamp":null},"data":{"test0.txt":"dGVzdDAK"},"type":"Opaque"}'
+SECRET='{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test","creationTimestamp":null,"labels":{"ci.openshift.io/skip-censoring":"true"}},"data":{"test0.txt":"dGVzdDAK"},"type":"Opaque"}'
 
 fail() {
     echo "$1"


### PR DESCRIPTION
We do not read/update/write the shared directory secret in the
entrypoint wrapper, we just create it from the values on disk since that
is technically authoritative for the data. It causes us to lose the
labels, though, so we need to set the censoring skip label here as well
or we will end up censoring random data that's useful to users.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>