### PR TITLE
Minor Output Tweaks

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	// reportAddress is the default result aggregator address in api.ci
+	// reportAddress is the default result aggregator address in app.ci
 	reportAddress = "https://result-aggregator-ci.apps.ci.l2s4.p1.openshiftapps.com"
 )
 
@@ -125,7 +125,7 @@ func (r *reporter) Report(err error) {
 		reportMsg = fmt.Sprintf("Reporting job state '%s' with reason '%s'", request.State, request.Reason)
 	}
 
-	logrus.Infof(reportMsg)
+	logrus.Debugf(reportMsg)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/result", r.address), bytes.NewReader(data))
 	if err != nil {
 		logrus.Tracef("could not create report request: %v", err)

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -299,7 +299,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 						From:                    from,
 						ForcePull:               true,
 						NoCache:                 true,
-						Env:                     []corev1.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "6"}}, // we want more logs for debugging
+						Env:                     []corev1.EnvVar{{Name: "BUILD_LOGLEVEL", Value: "0"}}, // this mirrors the default and is done for documentary purposes
 						ImageOptimizationPolicy: &layer,
 					},
 				},

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -66,7 +66,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"clone_uri":"https://github.com/org/repo.git"}],"oauth_token_file":"/oauth-token","fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"path_alias":"somewhere/else"}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA"}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -61,7 +61,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}]},{"org":"org","repo":"other","base_ref":"master","base_sha":"masterSHA","path_alias":"this/is/nuts","workdir":true}],"fail":true}'
       forcePull: true

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -69,7 +69,7 @@ spec:
     dockerStrategy:
       env:
       - name: BUILD_LOGLEVEL
-        value: "6"
+        value: "0"
       - name: CLONEREFS_OPTIONS
         value: '{"src_root":"/go","log":"/dev/null","git_user_name":"ci-robot","git_user_email":"ci-robot@openshift.io","refs":[{"org":"org","repo":"repo","base_ref":"master","base_sha":"masterSHA","pulls":[{"number":1,"author":"","sha":"pullSHA"}],"clone_uri":"ssh://git@github.com/org/repo.git"}],"key_files":["/sshprivatekey"],"fail":true}'
       forcePull: true


### PR DESCRIPTION
ci-operator: hide reporting log line

This isn't something users ever need to see.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

Revert "ci-operator: set higher build loglevel"

This reverts commit 85a8cf5ef823bfbe122f8bd7593280acd4965450.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 

I'm reverting the build log level as we 1) have loads of logs to look at in GCS now and 2) it is SO VERBOSE