### PR TITLE
rehearse: properly deduplicate rehearsed periodics

### DIFF
--- a/cmd/generate-registry-metadata/main_test.go
+++ b/cmd/generate-registry-metadata/main_test.go
@@ -28,6 +28,11 @@ func TestGenerateMetadata(t *testing.T) {
 		name:    "Registry",
 		regPath: "../../test/multistage-registry/registry",
 		expectedMetadata: api.RegistryMetadata{
+
+			"ipi-changed-workflow.yaml": {
+				Path:   "ipi-changed/ipi-changed-workflow.yaml",
+				Owners: owners1,
+			},
 			"ipi-deprovision-chain.yaml": {
 				Path:   "ipi/deprovision/ipi-deprovision-chain.yaml",
 				Owners: owners2,

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -779,6 +779,15 @@ func TestRegistry(t *testing.T) {
 				}},
 				Observers: &api.Observers{Disable: []string{"resourcewatcher"}},
 			},
+			"ipi-changed": {
+				Pre: []api.TestStep{{
+					Chain: &installChain,
+				}},
+				Post: []api.TestStep{{
+					Chain: &deprovisionChain,
+				}},
+				Observers: &api.Observers{Disable: []string{"resourcewatcher"}},
+			},
 		}
 
 		expectedObservers = registry.ObserverByName{

--- a/test/integration/pj-rehearse/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -83,6 +83,19 @@ tests:
         requests:
           cpu: 1000m
           memory: 2Gi
+- as: changed-and-uses-changed-workflow
+  cron: '@yearly'
+  steps:
+    cluster_profile: ""
+    test:
+    - as: e2e
+      commands: make integration
+      from: my-image
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+    workflow: ipi-changed
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -1,0 +1,48 @@
+periodics:
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: trooper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=changed-and-uses-changed-workflow
+      - --CHANGED-CI-OPERATOR-PARAMS
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -673,6 +673,180 @@
   kind: ProwJob
   metadata:
     annotations:
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
+    creationTimestamp: null
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      ci.openshift.org/rehearse: "1234"
+      created-by-prow: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      pj-rehearse.openshift.io/source-type: changedPeriodic
+      prow.k8s.io/job: rehearse-1234-periodic-ci-super-trooper-master-changed-and-uses
+      prow.k8s.io/refs.org: openshift
+      prow.k8s.io/refs.pull: "1234"
+      prow.k8s.io/refs.repo: release
+      prow.k8s.io/type: presubmit
+    name: test-prowjob
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: default
+    context: ci/rehearse/periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
+    decoration_config:
+      gcs_configuration:
+        bucket: origin-ci-test
+        default_org: openshift
+        default_repo: origin
+        path_strategy: single
+      gcs_credentials_secret: gce-sa-credentials-gcs-publisher
+      grace_period: 15s
+      skip_cloning: true
+      timeout: 4h0m0s
+      utility_images:
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20190129-0a3c54c
+        initupload: gcr.io/k8s-prow/initupload:v20190129-0a3c54c
+        sidecar: gcr.io/k8s-prow/sidecar:v20190129-0a3c54c
+    extra_refs:
+    - base_ref: master
+      org: super
+      repo: trooper
+      workdir: true
+    job: rehearse-1234-periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=changed-and-uses-changed-workflow
+        - --CHANGED-CI-OPERATOR-PARAMS
+        command:
+        - ci-operator
+        env:
+        - name: CONFIG_SPEC
+          value: |
+            base_images:
+              base:
+                name: origin-v4.0
+                namespace: openshift
+                tag: base
+            build_root:
+              image_stream_tag:
+                name: release
+                namespace: openshift
+                tag: golang-1.10
+            images:
+            - from: base
+              to: test-image
+            resources:
+              '*':
+                limits:
+                  cpu: 500Mi
+                requests:
+                  cpu: 10Mi
+            tag_specification:
+              name: origin-v4.0
+              namespace: openshift
+            tests:
+            - as: changed-and-uses-changed-workflow
+              cron: '@yearly'
+              literal_steps:
+                cluster_profile: ""
+                post:
+                - as: ipi-deprovision-must-gather
+                  commands: |
+                    gather
+                  from: installer
+                  resources:
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+                - as: ipi-deprovision-deprovision
+                  commands: |
+                    openshift-cluster destroy
+                  from: installer
+                  resources:
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+                pre:
+                - as: ipi-install-rbac
+                  commands: |
+                    setup-rbac-2
+                  from: installer
+                  resources:
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+                - as: ipi-install-install
+                  commands: |
+                    openshift-cluster install --newFlag
+                  env:
+                  - default: test parameter default
+                    name: TEST_PARAMETER
+                  from: installer
+                  resources:
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+                test:
+                - as: e2e
+                  commands: make integration
+                  from: my-image
+                  resources:
+                    requests:
+                      cpu: 1000m
+                      memory: 2Gi
+            zz_generated_metadata:
+              branch: master
+              org: super
+              repo: trooper
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    refs:
+      base_ref: master
+      base_sha: test_sha
+      org: openshift
+      pulls:
+      - author: petr-muller
+        number: 1234
+        sha: test_sha
+      repo: release
+    report: true
+    rerun_command: /test pj-rehearse
+    type: presubmit
+  status:
+    startTime: 2020-06-22T22:25:00Z
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-custom
     creationTimestamp: null
     labels:

--- a/test/integration/pj-rehearse/master/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -72,6 +72,19 @@ tests:
         requests:
           cpu: 1000m
           memory: 2Gi
+- as: changed-and-uses-changed-workflow
+  cron: '@yearly'
+  steps:
+    cluster_profile: ""
+    test:
+    - as: e2e
+      commands: make integration
+      from: my-image
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi
+    workflow: ipi
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -1,0 +1,47 @@
+periodics:
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: trooper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=changed-and-uses-changed-workflow
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/test/multistage-registry/registry/ipi-changed/OWNERS
+++ b/test/multistage-registry/registry/ipi-changed/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- AlexNPavel
+- stevekuznetsov
+
+reviewers:
+- AlexNPavel
+- stevekuznetsov

--- a/test/multistage-registry/registry/ipi-changed/ipi-changed-workflow.metadata.json
+++ b/test/multistage-registry/registry/ipi-changed/ipi-changed-workflow.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "ipi-changed/ipi-changed-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"AlexNPavel",
+			"stevekuznetsov"
+		],
+		"reviewers": [
+			"AlexNPavel",
+			"stevekuznetsov"
+		]
+	}
+}

--- a/test/multistage-registry/registry/ipi-changed/ipi-changed-workflow.yaml
+++ b/test/multistage-registry/registry/ipi-changed/ipi-changed-workflow.yaml
@@ -1,0 +1,12 @@
+workflow:
+  as: ipi-changed
+  steps:
+    pre:
+    - chain: ipi-install
+    post:
+    - chain: ipi-deprovision
+    observers:
+      disable:
+      - resourcewatcher
+  documentation: |-
+    The IPI workflow provides pre- and post- steps that provision and deprovision an OpenShift cluster on a target IaaS platform, allowing job authors to inject their own end-to-end test logic.

--- a/test/multistage-registry/registry2/ipi-changed/OWNERS
+++ b/test/multistage-registry/registry2/ipi-changed/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- AlexNPavel
+- stevekuznetsov
+
+reviewers:
+- AlexNPavel
+- stevekuznetsov

--- a/test/multistage-registry/registry2/ipi-changed/ipi-changed-workflow.metadata.json
+++ b/test/multistage-registry/registry2/ipi-changed/ipi-changed-workflow.metadata.json
@@ -1,0 +1,13 @@
+{
+	"path": "ipi-changed/ipi-changed-workflow.yaml",
+	"owners": {
+		"approvers": [
+			"AlexNPavel",
+			"stevekuznetsov"
+		],
+		"reviewers": [
+			"AlexNPavel",
+			"stevekuznetsov"
+		]
+	}
+}

--- a/test/multistage-registry/registry2/ipi-changed/ipi-changed-workflow.yaml
+++ b/test/multistage-registry/registry2/ipi-changed/ipi-changed-workflow.yaml
@@ -1,0 +1,12 @@
+workflow:
+  as: ipi-changed
+  steps:
+    pre:
+    - chain: ipi-install
+    post:
+    - chain: ipi-deprovision
+    observers:
+      disable:
+      - resourcewatcher
+  documentation: |-
+    All your documentation are belong to us.


### PR DESCRIPTION
/hold
Needs https://github.com/openshift/ci-tools/pull/1846

Deduplication happens on `main()`-level so adding a new integration test (which fails with the original version), for which I needed to add some test registry content to be changed.

Fixes: [DPTP-2108](https://issues.redhat.com/browse/DPTP-2108)