### PR TITLE
rehearse: do not create imports on app.ci

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -526,8 +526,8 @@ func setupDependencies(
 var second = time.Second
 
 func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client, ists apihelper.ImageStreamTagMap, clusterName, namespace string, istImportClient ctrlruntimeclient.Client, log *logrus.Entry) error {
-	if clusterName == "api.ci" {
-		log.Info("Not creating imports on api.ci cluster as its authoritative source for all imagestreams")
+	if clusterName == "app.ci" {
+		log.Info("Not creating imports on app.ci cluster as its authoritative source for all imagestreams")
 		return nil
 	}
 

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -87,8 +87,8 @@ func TestEnsureImageStreamTags(t *testing.T) {
 			},
 		},
 		{
-			name:          "Api.ci cluster imports are skipped",
-			targetCluster: utilpointer.StringPtr("api.ci"),
+			name:          "app.ci cluster imports are skipped",
+			targetCluster: utilpointer.StringPtr("app.ci"),
 		},
 	}
 


### PR DESCRIPTION
Previously, pj-rehearse created testimagestreamtagimports on app.ci and the controller choked on them:

```json
{
   "cluster":"app.ci",
   "component":"dptp-controller-manager",
   "controller":"test_images_distributor",
   "error":"no client for cluster app.ci available",
   "file":"/go/src/github.com/openshift/ci-tools/pkg/controller/test-images-distributor/test_images_distributor.go:177",
   "func":"github.com/openshift/ci-tools/pkg/controller/test-images-distributor.(*reconciler).Reconcile",
   "kubernetes":{
      "container_image":"image-registry.openshift-image-registry.svc:5000/ci/dptp-controller-manager@sha256:87c24b0df1bbf6c62631c38f4fd87dc3962a02c87956b0cc62d3627c95b59c37",
      "container_name":"dptp-controller-manager",
      "pod_ip":"10.129.3.74",
      "pod_ips":[
         "10.129.3.74"
      ],
      "pod_labels":{
         "app":"dptp-controller-manager",
         "pod-template-hash":"d9fd7fc95"
      },
      "pod_name":"dptp-controller-manager-d9fd7fc95-87xmk",
      "pod_namespace":"ci",
      "pod_node_name":"ip-10-0-143-109.ec2.internal",
      "pod_uid":"7447a8bc-a0cd-4761-926c-1885b1523892"
   },
   "level":"error",
   "msg":"Reconciliation failed",
   "request":"app.ci_ibm-gate-secrets/iks:4.6",
   "severity":"error",
   "source_type":"kubernetes_logs",
   "stream":"stderr",
   "time":"2021-04-07T11:42:59Z"
}
```