### PR TITLE
prowgen: add setting to skip rehearsal for a presubmit job

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -485,9 +485,16 @@ type PipelineImageCacheStepConfiguration struct {
 type TestStepConfiguration struct {
 	// As is the name of the test.
 	As string `json:"as"`
+
 	// Commands are the shell commands to run in
 	// the repository root to execute tests.
 	Commands string `json:"commands,omitempty"`
+
+	// SkipRehearsal indicates that the "can-be-rehearsed"
+	// label is to be omitted. This only applies to presubmit
+	// jobs. Postsubmit jobs will never be rehearsed. Periodic
+	// jobs will always be rehearsed.
+	SkipRehearsal bool `json:"skip_rehearsal,omitempty"`
 
 	// Secret is an optional secret object which
 	// will be mounted inside the test container.

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -194,15 +194,17 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	tests := []struct {
 		description string
 
-		test       string
-		repoInfo   *ProwgenInfo
-		jobRelease string
-		clone      bool
-	}{{
-		description: "presubmit for standard test",
-		test:        "testname",
-		repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-	},
+		test          string
+		repoInfo      *ProwgenInfo
+		jobRelease    string
+		clone         bool
+		skipRehearsal bool
+	}{
+		{
+			description: "presubmit for standard test",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+		},
 		{
 			description: "presubmit for a test in a variant config",
 			test:        "testname",
@@ -221,11 +223,17 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			jobRelease:  "4.6",
 			clone:       true,
 		},
+		{
+			description:   "presubmit for skip rehearsal",
+			test:          "testname",
+			repoInfo:      &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			skipRehearsal: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			// podSpec tested in generatePodSpec
-			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, nil, nil, tc.jobRelease, !tc.clone))
+			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, nil, nil, tc.jobRelease, !tc.clone, !tc.skipRehearsal))
 		})
 	}
 }
@@ -347,6 +355,18 @@ func TestGenerateJobs(t *testing.T) {
 				Tests: []ciop.TestStepConfiguration{
 					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}},
 					{As: "leTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}}},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		}, {
+			id: "two tests and empty Images with one test skip rehearsal",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}},
+					{As: "leTest", SkipRehearsal: true, ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}}},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_skip_rehearsal.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_skip_rehearsal.yaml
@@ -1,0 +1,11 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-derTest
+  - always_run: false
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: newly-generated
+    name: pull-ci-organization-repository-branch-leTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_skip_rehearsal.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_skip_rehearsal.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+always_run: true
+branches:
+- branch
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)


### PR DESCRIPTION
We have several pre-submit jobs that, while they can be rehearsed, will always fail rehearsal.

Our end-to-end tests checkout and spin up a pretty large kubernetes cluster and then installs our ACM product on it - just for the rehearsal to fail.

I looked through the ci-tools code to see if there was an option to prevent a test from being rehearsed, but couldn't find anything.

This PR adds a "SkipRehearsal" option to TestStepConfiguration that, if set, would not put the "can-be-rehearsed" label on a pre-submit job.

This setting is ignored for periodic and postsubmit jobs. Periodic jobs will always be rehearsed while postsubmit jobs will never be rehearsed.

I ran `make generate` locally to update the documentation, but it didn't seem to change anything. I'm using a Mac, so that may affect it.