### PR TITLE
ci-operator: update the label set we use on Pods

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -484,7 +484,12 @@ func (o *options) Complete() error {
 		jobSpec.Refs = spec.Refs
 	}
 	jobSpec.BaseNamespace = o.baseNamespace
+	target := "all"
+	if len(o.targets.values) > 0 {
+		target = o.targets.values[0]
+	}
 	o.jobSpec = jobSpec
+	o.jobSpec.Target = target
 
 	info := o.getResolverInfo(jobSpec)
 
@@ -503,6 +508,7 @@ func (o *options) Complete() error {
 		o.jobSpec.Refs.PathAlias = *config.CanonicalGoRepository
 	}
 	o.configSpec = config
+	o.jobSpec.Metadata = config.Metadata
 	if err := validation.IsValidResolvedConfiguration(o.configSpec); err != nil {
 		return results.ForReason("validating_config").ForError(err)
 	}

--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -25,6 +25,9 @@ type JobSpec struct {
 
 	// if set, any new artifacts will be a child of this object
 	owner *meta.OwnerReference
+
+	Metadata Metadata
+	Target   string
 }
 
 // Namespace returns the namespace of the job. Must not be evaluated

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -480,7 +480,8 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 		} else {
 			commands = []string{"/bin/bash", "-c", CommandPrefix + step.Commands}
 		}
-		pod, err := generateBasePod(s.jobSpec, name, multiStageTestStepContainerName, commands, image, resources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
+		labels := map[string]string{LabelMetadataStep: step.As}
+		pod, err := generateBasePod(s.jobSpec, labels, name, multiStageTestStepContainerName, commands, image, resources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -134,6 +134,13 @@ func TestGeneratePods(t *testing.T) {
 	}
 
 	jobSpec := api.JobSpec{
+		Metadata: api.Metadata{
+			Org:     "org",
+			Repo:    "repo",
+			Branch:  "base ref",
+			Variant: "variant",
+		},
+		Target: "target",
 		JobSpec: prowdapi.JobSpec{
 			Job:       "job",
 			BuildID:   "build id",

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -174,6 +174,7 @@ func PodStep(name string, config PodStepConfiguration, resources api.ResourceCon
 
 func generateBasePod(
 	jobSpec *api.JobSpec,
+	baseLabels map[string]string,
 	name string,
 	containerName string,
 	command []string,
@@ -193,7 +194,7 @@ func generateBasePod(
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
 			Name:      name,
-			Labels:    defaultPodLabels(jobSpec),
+			Labels:    labelsFor(jobSpec, baseLabels),
 			Annotations: map[string]string{
 				JobSpecAnnotation:                     jobSpec.RawSpec(),
 				annotationContainersForSubTestResults: containerName,
@@ -229,7 +230,7 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 	}
 
 	artifactDir := s.name
-	pod, err := generateBasePod(s.jobSpec, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
+	pod, err := generateBasePod(s.jobSpec, map[string]string{}, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -37,6 +37,13 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 	jobName := "very-cool-prow-job"
 	pjID := "prow-job-id"
 	jobSpec := &api.JobSpec{
+		Metadata: api.Metadata{
+			Org:     "org",
+			Repo:    "repo",
+			Branch:  "base-ref",
+			Variant: "variant",
+		},
+		Target: "target",
 		JobSpec: downwardapi.JobSpec{
 			Job:       jobName,
 			BuildID:   buildID,

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -60,9 +60,7 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 		return fmt.Errorf("could not find source ImageStreamTag for RPM repo deployment: %w", err)
 	}
 
-	labelSet := defaultPodLabels(s.jobSpec)
-	labelSet[AppLabel] = RPMRepoName
-	labelSet[TTLIgnoreLabel] = "true"
+	labelSet := labelsFor(s.jobSpec, map[string]string{AppLabel: RPMRepoName, TTLIgnoreLabel: "true"})
 	selectorSet := map[string]string{
 		AppLabel: RPMRepoName,
 	}

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -4,14 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: buildId
-    ci.openshift.io/refs.branch: master
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: ""
+    ci.openshift.io/metadata.org: ""
+    ci.openshift.io/metadata.repo: ""
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: src
-    job: job
-    prow.k8s.io/id: prowJobId
   name: src
   namespace: namespace
 spec:

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -6,13 +6,14 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
-      build-id: build id
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step0
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
       ci.openshift.io/multi-stage-test: test
-      ci.openshift.io/refs.branch: base ref
-      ci.openshift.io/refs.org: org
-      ci.openshift.io/refs.repo: repo
       created-by-ci: "true"
-      job: job
     name: test-step0
     namespace: namespace
   spec:
@@ -157,13 +158,14 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
-      build-id: build id
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step1
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
       ci.openshift.io/multi-stage-test: test
-      ci.openshift.io/refs.branch: base ref
-      ci.openshift.io/refs.org: org
-      ci.openshift.io/refs.repo: repo
       created-by-ci: "true"
-      job: job
     name: test-step1
     namespace: namespace
   spec:
@@ -308,13 +310,14 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
-      build-id: build id
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step2
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
       ci.openshift.io/multi-stage-test: test
-      ci.openshift.io/refs.branch: base ref
-      ci.openshift.io/refs.org: org
-      ci.openshift.io/refs.repo: repo
       created-by-ci: "true"
-      job: job
     name: test-step2
     namespace: namespace
   spec:

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -7,13 +7,12 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: test-build-id
-    ci.openshift.io/refs.branch: base-ref
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: base-ref
+    ci.openshift.io/metadata.org: org
+    ci.openshift.io/metadata.repo: repo
+    ci.openshift.io/metadata.target: target
+    ci.openshift.io/metadata.variant: variant
     created-by-ci: "true"
-    job: very-cool-prow-job
-    prow.k8s.io/id: prow-job-id
   name: TestName
   namespace: TestNamespace
   resourceVersion: "1"

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -7,13 +7,12 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
-    build-id: test-build-id
-    ci.openshift.io/refs.branch: base-ref
-    ci.openshift.io/refs.org: org
-    ci.openshift.io/refs.repo: repo
+    ci.openshift.io/metadata.branch: base-ref
+    ci.openshift.io/metadata.org: org
+    ci.openshift.io/metadata.repo: repo
+    ci.openshift.io/metadata.target: target
+    ci.openshift.io/metadata.variant: variant
     created-by-ci: "true"
-    job: very-cool-prow-job
-    prow.k8s.io/id: prow-job-id
   name: TestName
   namespace: TestNamespace
   resourceVersion: "1"


### PR DESCRIPTION
The intent of adding labels to the Pods we create was always two-fold:
first, help administrators identify Pods as they relate to jobs and
steps. Second, allow for the labels to end up in Prometheus to help us
track metrics across job runs. Unfortunately, the previous label set
fell short in the second case:

 - we added the full job name as a label, which was trimmed to fit in
   most cases and in some cases the trimming left only the org/repo/etc
   parts, making it not actually useful as an identifier
 - we did not label the target that ci-operator executed, just fields
   like the full job name which might include it as a suffix
 - we did not label the multi-stage step name, now allowing us to
   discern individual usage metrics
 - we labeled the build and Prow job IDs, which are unique and not
   ultimately useful to selecting anything

This patch changes the label set slightly to make it more useful.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Needed for [DPTP-1822](https://issues.redhat.com/browse/DPTP-1822)