### PR TITLE
ci-operator: don't record SA namespaces for censoring

### DIFF
--- a/pkg/steps/secretrecordingclient/client.go
+++ b/pkg/steps/secretrecordingclient/client.go
@@ -104,11 +104,20 @@ func (c *client) record(obj ctrlruntimeclient.Object) {
 }
 
 func (c *client) recordSecret(secret *v1.Secret) {
+	_, isServiceAccountCredential := secret.Labels["kubernetes.io/service-account.name"]
 	var values []string
-	for _, value := range secret.Data {
+	for key, value := range secret.Data {
+		if isServiceAccountCredential && key == "namespace" {
+			// this will in no case be a useful thing to censor
+			continue
+		}
 		values = append(values, string(value))
 	}
-	for _, value := range secret.StringData {
+	for key, value := range secret.StringData {
+		if isServiceAccountCredential && key == "namespace" {
+			// this will in no case be a useful thing to censor
+			continue
+		}
 		values = append(values, value)
 	}
 	for _, key := range []string{"openshift.io/token-secret.value", "kubectl.kubernetes.io/last-applied-configuration"} {


### PR DESCRIPTION
This was somehow lost from the previous commits which handled this case.
There is no world in which the Namespace in which we work is secret, as
we create it for the test and it's entirely a derivative value from our
inputs. This is a silly hack but there's no real better way of ignoring
it.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 