### PR TITLE
Bumper: Bump Makefile as well

### DIFF
--- a/cmd/autobumper/main.go
+++ b/cmd/autobumper/main.go
@@ -95,7 +95,7 @@ func main() {
 		GitHubToken:         string(sa.GetTokenGenerator(o.GitHubOptions.TokenPath)()),
 		GitName:             o.gitName,
 		GitEmail:            o.gitEmail,
-		IncludedConfigPaths: []string{"clusters/", "cluster/ci/config/prow/", "core-services/prow", "ci-operator/", "hack/"},
+		IncludedConfigPaths: []string{"Makefile", "clusters/", "cluster/ci/config/prow/", "core-services/prow", "ci-operator/", "hack/"},
 		ExtraFiles:          extraFiles,
 		TargetVersion:       "latest",
 		RemoteName:          fmt.Sprintf("https://github.com/%s/%s.git", o.githubLogin, githubRepo),


### PR DESCRIPTION
As it has references like this one: https://github.com/openshift/release/blob/79ab2207d6e19264092f661c3f03409fd2e1ff9d/Makefile#L58

/cc @openshift/openshift-team-developer-productivity-test-platform 