### PR TITLE
Determinize Prow config: Shard prow config

### DIFF
--- a/cmd/determinize-prow-config/main_test.go
+++ b/cmd/determinize-prow-config/main_test.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"io/fs"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/gofuzz"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	fuzz "github.com/google/gofuzz"
+	"github.com/spf13/afero"
 
 	"k8s.io/test-infra/prow/config"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // TestDeduplicateTideQueriesDoesntLoseData simply uses deduplicateTideQueries
@@ -66,6 +72,112 @@ func TestDeduplicateTideQueries(t *testing.T) {
 			}
 			if diff := cmp.Diff(result, tc.expected); diff != "" {
 				t.Errorf("Result differs from expected: %v", diff)
+			}
+		})
+	}
+}
+
+func TestShardProwConfig(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   *config.ProwConfig
+
+		expectedConfig     config.ProwConfig
+		expectedShardFiles map[string]string
+	}{
+		{
+			name: "Org and repo config get written out",
+			in: &config.ProwConfig{
+				BranchProtection: config.BranchProtection{
+					Orgs: map[string]config.Org{
+						"openshift": {
+							Policy: config.Policy{Protect: utilpointer.BoolPtr(false)},
+							Repos: map[string]config.Repo{
+								"release": {Policy: config.Policy{Protect: utilpointer.BoolPtr(false)}},
+							},
+						},
+					},
+				},
+			},
+
+			expectedShardFiles: map[string]string{
+				"openshift/_prowconfig.yaml": strings.Join([]string{
+					"branch-protection:",
+					"  orgs:",
+					"    openshift:",
+					"      protect: false",
+					"",
+				}, "\n"),
+				"openshift/release/_prowconfig.yaml": strings.Join([]string{
+					"branch-protection:",
+					"  orgs:",
+					"    openshift:",
+					"      repos:",
+					"        release:",
+					"          protect: false",
+					"",
+				}, "\n"),
+			},
+		},
+		{
+			name: "Empty org config is not serialized",
+			in: &config.ProwConfig{
+				BranchProtection: config.BranchProtection{
+					Orgs: map[string]config.Org{
+						"openshift": {
+							Repos: map[string]config.Repo{
+								"release": {Policy: config.Policy{Protect: utilpointer.BoolPtr(false)}},
+							},
+						},
+					},
+				},
+			},
+
+			expectedShardFiles: map[string]string{
+				"openshift/release/_prowconfig.yaml": strings.Join([]string{
+					"branch-protection:",
+					"  orgs:",
+					"    openshift:",
+					"      repos:",
+					"        release:",
+					"          protect: false",
+					"",
+				}, "\n"),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			afs := afero.NewMemMapFs()
+			newConfig, err := shardProwConfig(tc.in, afs)
+			if err != nil {
+				t.Fatalf("shardProwConfig failed: %v", err)
+			}
+			if diff := cmp.Diff(&tc.expectedConfig, newConfig, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("config with extracted shards differs from expected: %s", diff)
+			}
+
+			shardedConfigFiles := map[string]string{}
+			if err := afero.Walk(afs, "", func(path string, info fs.FileInfo, err error) error {
+				if err != nil || info.IsDir() {
+					return err
+				}
+				if filepath.Base(path) != "_prowconfig.yaml" {
+					t.Errorf("found file %s which doesn't have the expected _prowconfig.yaml name", path)
+				}
+				data, err := afero.ReadFile(afs, path)
+				if err != nil {
+					t.Errorf("failed to read file %s: %v", path, err)
+				}
+				shardedConfigFiles[path] = string(data)
+				return nil
+			}); err != nil {
+				t.Errorf("waking the fs failed: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedShardFiles, shardedConfigFiles); diff != "" {
+				t.Errorf("actual sharded config differs from expected:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -23,6 +23,8 @@ const (
 	ConfigInRepoPath = "core-services/prow/02_config/_config.yaml"
 	// ProwConfigFile is the filename where Prow config lives
 	ProwConfigFile = "_config.yaml"
+	// SupplementalProwConfigFileName is the name of supplemental prow config files.
+	SupplementalProwConfigFileName = "_prowconfig.yaml"
 	// PluginConfigFile is the filename where plugins live
 	PluginConfigFile = "_plugins.yaml"
 	// PluginConfigInRepoPath is the prow plugin config path from release repo


### PR DESCRIPTION
This PR makes determinize-prow-config shard by org repo. It is written
under the assumption that we will add a knob upstream to make the
filename for the supplemental files configurable because:
* We want both Prow and plugin configs in there
* We want to add the basedir as an additional folder, but we do not want
  the main config to be considered a supplemental config, as that will
  fail the merging. Not adding the basedir would mean to add each org
  folder seperately.