### PR TITLE
Fix the identifier of clusterClaimLink

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -233,6 +233,7 @@ func Comparer() cmp.Option {
 		internalImageStreamLink{},
 		internalImageStreamTagLink{},
 		externalImageLink{},
+		clusterClaimLink{},
 	)
 }
 

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -139,7 +139,7 @@ func fromConfig(
 	for _, rawStep := range rawSteps {
 		if testStep := rawStep.TestStepConfiguration; testStep != nil {
 			if testStep.ClusterClaim != nil {
-				clusterClaimStep := steps.ClusterClaimStep(testStep.ClusterClaim, hiveClient, client, jobSpec)
+				clusterClaimStep := steps.ClusterClaimStep(testStep.As, testStep.ClusterClaim, hiveClient, client, jobSpec)
 				buildSteps = append(buildSteps, clusterClaimStep)
 			}
 			steps, err := stepForTest(config, params, podClient, leaseClient, templateClient, client, jobSpec, inputImages, testStep)

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1063,12 +1063,22 @@ func TestFromConfig(t *testing.T) {
 		name: "multi-stage test with a cluster claim",
 		config: api.ReleaseBuildConfiguration{
 			Tests: []api.TestStepConfiguration{{
-				As:                                 "test",
+				As:                                 "e2e",
 				ClusterClaim:                       &api.ClusterClaim{},
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{},
 			}},
 		},
-		expectedSteps: []string{"cluster_claim:____", "test", "[output-images]", "[images]"},
+		expectedSteps: []string{"cluster_claim_e2e:____", "e2e", "[output-images]", "[images]"},
+	}, {
+		name: "container test with a claim",
+		config: api.ReleaseBuildConfiguration{
+			Tests: []api.TestStepConfiguration{{
+				As:                         "e2e",
+				ClusterClaim:               &api.ClusterClaim{},
+				ContainerTestConfiguration: &api.ContainerTestConfiguration{},
+			}},
+		},
+		expectedSteps: []string{"cluster_claim_e2e:____", "e2e", "[output-images]", "[images]"},
 	}, {
 		name: "lease test",
 		config: api.ReleaseBuildConfiguration{

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -25,6 +25,7 @@ import (
 )
 
 type clusterClaimStep struct {
+	as           string
 	clusterClaim *api.ClusterClaim
 	hiveClient   ctrlruntimeclient.Client
 	client       loggingclient.LoggingClient
@@ -49,7 +50,7 @@ func (s *clusterClaimStep) Run(ctx context.Context) error {
 }
 
 func (s *clusterClaimStep) Name() string {
-	return fmt.Sprintf("cluster_claim:%s_%s_%s_%s_%s", s.clusterClaim.Product, s.clusterClaim.Version, s.clusterClaim.Architecture, s.clusterClaim.Cloud, s.clusterClaim.Owner)
+	return fmt.Sprintf("cluster_claim_%s:%s_%s_%s_%s_%s", s.as, s.clusterClaim.Product, s.clusterClaim.Version, s.clusterClaim.Architecture, s.clusterClaim.Cloud, s.clusterClaim.Owner)
 }
 
 func (s *clusterClaimStep) Description() string {
@@ -59,7 +60,7 @@ func (s *clusterClaimStep) Description() string {
 func (s *clusterClaimStep) Requires() []api.StepLink { return nil }
 
 func (s *clusterClaimStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ClusterClaimLink(s.Name())}
+	return []api.StepLink{api.ClusterClaimLink(s.as)}
 }
 
 func (s *clusterClaimStep) Provides() api.ParameterMap { return nil }
@@ -179,8 +180,9 @@ func mutate(secret *corev1.Secret, name, namespace string) (*corev1.Secret, erro
 	}, nil
 }
 
-func ClusterClaimStep(clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.Client, client loggingclient.LoggingClient, jobSpec *api.JobSpec) api.Step {
+func ClusterClaimStep(as string, clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.Client, client loggingclient.LoggingClient, jobSpec *api.JobSpec) api.Step {
 	ret := clusterClaimStep{
+		as:           as,
 		clusterClaim: clusterClaim,
 		hiveClient:   hiveClient,
 		client:       client,

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -126,7 +126,7 @@ func (s *podStep) SubTests() []*junit.TestCase {
 
 func (s *podStep) Requires() (ret []api.StepLink) {
 	if s.clusterClaim != nil {
-		ret = append(ret, api.ClusterClaimLink(s.name))
+		ret = append(ret, api.ClusterClaimLink(s.config.As))
 	}
 	if s.config.From.Name == api.PipelineImageStream {
 		ret = append(ret, api.InternalImageLink(api.PipelineImageStreamTagReference(s.config.From.Tag)))


### PR DESCRIPTION
Fix https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/17645/rehearse-17645-pull-ci-openshift-ci-ns-ttl-controller-master-e2e/1382050151790546944

The problem is that the name of cluster step is different from the one of multi-stage step and the one of pod step.

/cc @bbguimaraes 