### PR TITLE
prowgen: incldue ci-pull-credentials for tests with cluster-claim

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -155,7 +155,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 		if element.ContainerTestConfiguration != nil {
 			podSpec = generateCiOperatorPodSpec(info, element.Secrets, []string{element.As})
 		} else if element.MultiStageTestConfiguration != nil {
-			podSpec = generatePodSpecMultiStage(info, &element, configSpec.Releases != nil)
+			podSpec = generatePodSpecMultiStage(info, &element, configSpec.Releases != nil || element.ClusterClaim != nil)
 		} else {
 			var release string
 			if c := configSpec.ReleaseTagConfiguration; c != nil {

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -105,6 +105,16 @@ func TestGeneratePodSpecMultiStage(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "cluster-claim",
+			test: &ciop.TestStepConfiguration{
+				As:           "test",
+				ClusterClaim: &ciop.ClusterClaim{},
+				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+					ClusterProfile: ciop.ClusterProfileAWS,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_cluster_claim.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_cluster_claim.yaml
@@ -1,0 +1,57 @@
+containers:
+- args:
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --report-credentials-file=/etc/report/credentials
+  - --target=test
+  - --secret-dir=/secrets/ci-pull-credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --lease-server-credentials-file=/etc/boskos/credentials
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/ci-pull-credentials
+    name: ci-pull-credentials
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator
+- name: ci-pull-credentials
+  secret:
+    secretName: ci-pull-credentials
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-aws
+- name: boskos
+  secret:
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials


### PR DESCRIPTION
Currently, multistage tests only include `ci-pull-credentials` if the
`configSpec` has a release. It should also include the credentials if
the test specifies a cluster claim.

/cc @hongkailiu 