### PR TITLE
DPTP-2145 allow step run to gather the context cancelation errors but don't report them

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -650,6 +650,16 @@ func (o *options) Complete() error {
 	return nil
 }
 
+func excludeContextCancelledErrors(errs []error) []error {
+	var ret []error
+	for _, err := range errs {
+		if !errors.Is(err, context.Canceled) {
+			ret = append(ret, err)
+		}
+	}
+	return ret
+}
+
 func (o *options) Report(errs ...error) {
 	if len(errs) > 0 {
 		o.writeFailingJUnit(errs)
@@ -661,10 +671,12 @@ func (o *options) Report(errs ...error) {
 		return
 	}
 
-	for _, err := range errs {
+	errorToReport := excludeContextCancelledErrors(errs)
+	for _, err := range errorToReport {
 		reporter.Report(err)
 	}
-	if len(errs) == 0 {
+
+	if len(errorToReport) == 0 {
 		reporter.Report(nil)
 	}
 }

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -56,9 +56,7 @@ func Run(ctx context.Context, graph []*api.StepNode) (*junit.TestSuites, []api.C
 			stepDetails = append(stepDetails, out.stepDetails)
 			if out.err != nil {
 				testCase.FailureOutput = &junit.FailureOutput{Output: out.err.Error()}
-				if !errors.Is(out.err, context.Canceled) {
-					executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
-				}
+				executionErrors = append(executionErrors, results.ForReason("step_failed").WithError(out.err).Errorf("step %s failed: %v", out.node.Step.Name(), out.err))
 			} else {
 				seen = append(seen, out.node.Step.Creates()...)
 				if !interrupted {


### PR DESCRIPTION
/cc @openshift/openshift-team-developer-productivity-test-platform 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>