### PR TITLE
ci-operator multi-stage: truncate duration message

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -803,7 +803,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	if err != nil {
 		verb = "failed"
 	}
-	logrus.Infof("Step %s %s after %s.", pod.Name, verb, duration.String())
+	logrus.Infof("Step %s %s after %s.", pod.Name, verb, duration.Truncate(time.Second))
 	s.subSteps = append(s.subSteps, api.CIOperatorStepDetailInfo{
 		StepName:    pod.Name,
 		Description: fmt.Sprintf("Run pod %s", pod.Name),


### PR DESCRIPTION
Currently:

```
INFO[2021-04-16T12:43:27Z] Step e2e-vsphere-csi-ipi-conf-vsphere-check succeeded after 10.046449097s.
…
INFO[2021-04-16T13:48:38Z] Ran for 2h31m6s
```

Hopefully no one is using the 13 orders of magnitude and we'll be fine
with just 4 =)