### PR TITLE
prowgen: add release-informing job type

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -525,6 +525,12 @@ type TestStepConfiguration struct {
 	// create a periodic job instead of a presubmit
 	Interval *string `json:"interval,omitempty"`
 
+	// ReleaseController configures prowgen to create a periodic that
+	// does not get run by prow and instead is run by release-controller.
+	// The job must be configured as a verification or periodic job in a
+	// release-controller config file when this field is set to `true`.
+	ReleaseController bool `json:"release_controller,omitempty"`
+
 	// Postsubmit configures prowgen to generate the job as a postsubmit rather than a presubmit
 	Postsubmit bool `json:"postsubmit,omitempty"`
 

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -21,14 +21,16 @@ import (
 )
 
 const (
-	CanBeRehearsedLabel = "pj-rehearse.openshift.io/can-be-rehearsed"
-	CanBeRehearsedValue = "true"
-	SSHBastionLabel     = "dptp.openshift.io/ssh-bastion"
-	ProwJobLabelVariant = "ci-operator.openshift.io/variant"
-	JobReleaseKey       = "job-release"
-	PresubmitPrefix     = "pull"
-	PostsubmitPrefix    = "branch"
-	PeriodicPrefix      = "periodic"
+	CanBeRehearsedLabel    = "pj-rehearse.openshift.io/can-be-rehearsed"
+	CanBeRehearsedValue    = "true"
+	SSHBastionLabel        = "dptp.openshift.io/ssh-bastion"
+	ProwJobLabelVariant    = "ci-operator.openshift.io/variant"
+	ReleaseControllerLabel = "ci-operator.openshift.io/release-controller"
+	ReleaseControllerValue = "true"
+	JobReleaseKey          = "job-release"
+	PresubmitPrefix        = "pull"
+	PostsubmitPrefix       = "branch"
+	PeriodicPrefix         = "periodic"
 )
 
 // Info describes the metadata for a Prow job configuration file

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -260,12 +260,13 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 	tests := []struct {
 		description string
 
-		test       string
-		repoInfo   *ProwgenInfo
-		jobRelease string
-		clone      bool
-		cron       string
-		interval   string
+		test              string
+		repoInfo          *ProwgenInfo
+		jobRelease        string
+		clone             bool
+		cron              string
+		interval          string
+		releaseController bool
 	}{
 		{
 			description: "periodic for standard test",
@@ -301,11 +302,18 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			clone:       true,
 			cron:        "@yearly",
 		},
+		{
+			description:       "release controller job",
+			test:              "testname",
+			repoInfo:          &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			jobRelease:        "4.6",
+			releaseController: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			// podSpec tested in generatePodSpec
-			testhelper.CompareWithFixture(t, generatePeriodicForTest(tc.test, tc.repoInfo, nil, true, tc.cron, tc.interval, nil, tc.jobRelease, !tc.clone))
+			testhelper.CompareWithFixture(t, generatePeriodicForTest(tc.test, tc.repoInfo, nil, true, tc.cron, tc.interval, tc.releaseController, nil, tc.jobRelease, !tc.clone))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_release_controller_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_release_controller_job.yaml
@@ -1,0 +1,15 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+  ci-operator.openshift.io/release-controller: "true"
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -80,6 +80,12 @@ func validateTestStepConfiguration(fieldRoot string, input []api.TestStepConfigu
 		if test.Cron != nil && test.Interval != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `interval` and `cron` cannot both be set", fieldRootN))
 		}
+		if test.Cron != nil && test.ReleaseController {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `cron` cannot be set for release controller jobs", fieldRootN))
+		}
+		if test.Interval != nil && test.ReleaseController {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `interval` cannot be set for release controller jobs", fieldRootN))
+		}
 
 		if test.Interval != nil {
 			if _, err := time.ParseDuration(*test.Interval); err != nil {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -448,6 +448,32 @@ func TestValidateTests(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			id: "cron and releaseInforming together are invalid",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					Cron:                       &cronString,
+					ReleaseController:          true,
+				},
+			},
+			expectedValid: false,
+		},
+		{
+			id: "interval and releaseInforming together are invalid",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "unit",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+					ReleaseController:          true,
+					Interval:                   &intervalString,
+				},
+			},
+			expectedValid: false,
+		},
+		{
 			id: "invalid cron",
 			tests: []api.TestStepConfiguration{
 				{

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -78,6 +78,11 @@ tests:
           requests:
             cpu: 100m
             memory: 200Mi
+- as: informer
+  commands: make unit
+  container:
+    from: src
+  release_controller: true
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -211,3 +211,50 @@ periodics:
     - name: result-aggregator
       secret:
         secretName: result-aggregator
+- agent: kubernetes
+  cron: '@yearly'
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: super
+    repo: duper
+  labels:
+    ci-operator.openshift.io/prowgen-controlled: "true"
+    ci-operator.openshift.io/release-controller: "true"
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-super-duper-master-informer
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=informer
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator


### PR DESCRIPTION
This PR adds support for defining jobs as release-informing to prevent
confusion when a periodic job is configured via release-controller
instead of a prowjob or ci-operator config. A `release-controller` PR
will be created to validate that all jobs defined in the
release-controller periodics are appropriately labelled as release
informers and that all jobs with the label are in the release-controller
periodics configs.