### PR TITLE
Replace the dots in secret name when used as volume name

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -680,14 +680,15 @@ func addSharedDirSecret(secret string, pod *coreapi.Pod) {
 func addCredentials(credentials []api.CredentialReference, pod *coreapi.Pod) {
 	for _, credential := range credentials {
 		name := fmt.Sprintf("%s-%s", credential.Namespace, credential.Name)
+		volumeName := fmt.Sprintf("%s-%s", credential.Namespace, strings.ReplaceAll(credential.Name, ".", "-"))
 		pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
-			Name: name,
+			Name: volumeName,
 			VolumeSource: coreapi.VolumeSource{
 				Secret: &coreapi.SecretVolumeSource{SecretName: name},
 			},
 		})
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, coreapi.VolumeMount{
-			Name:      name,
+			Name:      volumeName,
 			MountPath: credential.MountPath,
 		})
 	}

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -620,6 +620,24 @@ func TestAddCredentials(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name: "dots in volume name are replaced",
+			credentials: []api.CredentialReference{
+				{Namespace: "ns", Name: "app.ci-hive-credentials", MountPath: "/tmp"},
+			},
+			pod: coreapi.Pod{Spec: coreapi.PodSpec{
+				Containers: []coreapi.Container{{VolumeMounts: []coreapi.VolumeMount{}}},
+				Volumes:    []coreapi.Volume{},
+			}},
+			expected: coreapi.Pod{Spec: coreapi.PodSpec{
+				Containers: []coreapi.Container{{VolumeMounts: []coreapi.VolumeMount{
+					{Name: "ns-app-ci-hive-credentials", MountPath: "/tmp"},
+				}}},
+				Volumes: []coreapi.Volume{
+					{Name: "ns-app-ci-hive-credentials", VolumeSource: coreapi.VolumeSource{Secret: &coreapi.SecretVolumeSource{SecretName: "ns-app.ci-hive-credentials"}}},
+				},
+			}},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
To fix https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/17833/rehearse-17833-pull-ci-openshift-ci-tools-master-e2e/1384131862435205120#1:build-log.txt%3A18

/cc @openshift/openshift-team-developer-productivity-test-platform 