### PR TITLE
Switching to base64.StdEncoding.DecodeString() for decoding binary file content

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -373,8 +373,8 @@ func constructSecrets(ctx context.Context, config secretbootstrap.Config, client
 						return
 					}
 					if cfg.From[key].Base64Decode {
-						decoded := make([]byte, base64.StdEncoding.DecodedLen(len(value)))
-						if _, err := base64.StdEncoding.Decode(decoded, value); err != nil {
+						decoded, err := base64.StdEncoding.DecodeString(string(value))
+						if err != nil {
 							errChan <- fmt.Errorf(`failed to base64-decode config.%d."%s": %w`, idx, key, err)
 							return
 						}


### PR DESCRIPTION
The current method appears to be subtly changing the original encoded string just enough to make the resultant file not be recognized as `binary` and ultimately it fails to load via openpgp.  Switching to the `DecodeString` method produces the exact same output as the string value that is stored in Vault.