### PR TITLE
dptp-cm: bump GH API budget 300->600

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -410,7 +410,7 @@ func main() {
 		// Also we have to keep in mind that we might end up multiple budgets per period, because the client-side
 		// reset is not synchronized with the github reset and we may get upgraded in which case we lose the bucket
 		// state.
-		gitHubClient.Throttle(300, 300)
+		gitHubClient.Throttle(600, 300)
 		promotionreconcilerOptions := promotionreconciler.Options{
 			DryRun:                opts.dryRun,
 			CIOperatorConfigAgent: ciOPConfigAgent,


### PR DESCRIPTION
We are throttled most of the time with 20+ delays, after moving dptp-cm
to GH Apps we should have enough token budget for the bump.