### PR TITLE
Allow for custombuild strategy

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1359,6 +1359,11 @@ type ProjectDirectoryImageBuildInputs struct {
 	// that will populate the build context for the Dockerfile or
 	// alter the input image for a multi-stage build.
 	Inputs map[string]ImageBuildInputs `json:"inputs,omitempty"`
+
+	// CustomBuildStrategy indicates that the image should be executed as
+	// a custom build strategy insttead of a Docker Build Strategy (default).
+	// The image must support the Custom Build API and emit an OCI Container.
+	CustomBuildStrategy bool `json:"custom_build_strategy,omitempty"`
 }
 
 // PullSpecSubstitution contains a name of a pullspec that needs to

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -71,6 +71,7 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 		},
 		fromDigest,
 		"",
+		false,
 		s.resources,
 		s.pullSecret,
 	)

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -51,7 +51,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 				URI: cloneURI,
 				Ref: refs.BaseRef,
 			},
-		}, "", s.config.DockerfilePath, s.resources, s.pullSecret))
+		}, "", s.config.DockerfilePath, s.config.CustomBuildStrategy, s.resources, s.pullSecret))
 	}
 
 	return fmt.Errorf("nothing to build source image from, no refs")

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -75,6 +75,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 		},
 		fromDigest,
 		"",
+		false,
 		s.resources,
 		s.pullSecret,
 	)

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -52,6 +52,7 @@ func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 		},
 		fromDigest,
 		"",
+		false,
 		s.resources,
 		s.pullSecret,
 	))

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -57,6 +57,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		},
 		fromDigest,
 		s.config.DockerfilePath,
+		s.config.CustomBuildStrategy,
 		s.resources,
 		s.pullSecret,
 	)

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -56,6 +56,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 		},
 		fromDigest,
 		"",
+		false,
 		s.resources,
 		s.pullSecret,
 	))


### PR DESCRIPTION
The CoreOS team needs the ability to use custom build strategies to emit
ostree containers; these containers are not buildable using Docker
builds.

Signed-off-by: Ben Howard <ben.howard@redhat.com>