### PR TITLE
Vault accessory: Use testing.T instead of testhelper.T

### DIFF
--- a/cmd/ci-secret-generator/main_test.go
+++ b/cmd/ci-secret-generator/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"sort"
 	"testing"
 
@@ -399,8 +398,7 @@ func TestBitwardenContextsFor(t *testing.T) {
 
 func TestVault(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	vault, err := vaultclient.New("http://"+testhelper.Vault(ctx, testhelper.NewT(ctx, t)), testhelper.VaultTestingRootToken)
+	vault, err := vaultclient.New("http://"+testhelper.Vault(t), testhelper.VaultTestingRootToken)
 	if err != nil {
 		t.Fatalf("failed to create Vault client: %v", err)
 	}

--- a/cmd/vault-secret-collection-manager/main_test.go
+++ b/cmd/vault-secret-collection-manager/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -17,11 +16,9 @@ import (
 	"github.com/openshift/ci-tools/pkg/vaultclient"
 )
 
-func TestSecretCollectionManager(tt *testing.T) {
-	tt.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	t := testhelper.NewT(ctx, tt)
-	vaultAddr := testhelper.Vault(ctx, t)
+func TestSecretCollectionManager(t *testing.T) {
+	t.Parallel()
+	vaultAddr := testhelper.Vault(t)
 
 	client, err := vaultclient.New("http://"+vaultAddr, testhelper.VaultTestingRootToken)
 	if err != nil {
@@ -67,8 +64,7 @@ func TestSecretCollectionManager(tt *testing.T) {
 	managerListenAddr := "127.0.0.1:" + testhelper.GetFreePort(t)
 	server := server(client, "secret/self-managed", managerListenAddr)
 	go func() {
-		if err := server.ListenAndServe(); err != nil && ctx.Err() == nil {
-			cancel()
+		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			t.Errorf("failed to start secret-collection-manager: %v", err)
 		}
 	}()

--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -21,7 +21,7 @@ import (
 )
 
 // ArtifactDir determines where artifacts should for for a test case.
-func ArtifactDir(t *T) string {
+func ArtifactDir(t TestingTInterface) string {
 	var baseDir string
 	if dir, set := os.LookupEnv("ARTIFACT_DIR"); set {
 		baseDir = dir
@@ -120,8 +120,21 @@ type Accessory struct {
 	clientFlags PortFlags
 }
 
-// Run begins the accessory process. This call is not blocking.
-func (a *Accessory) Run(t *T, parentCtx context.Context) {
+// run begins the accessory process. Only test/e2e/framework.Run
+// is allowed to call this as it required additional synchronization or your
+// tests might pass incorrectly.
+func (a *Accessory) RunFromFrameworkRunner(t *T, parentCtx context.Context) {
+	a.run(parentCtx, t, t.Fatalf)
+}
+
+// run begins the accessory process. this call is not blocking.
+// Because testing.T does not allow to call Fatalf in a distinct
+// goroutine, this will use Errorf instead.
+func (a *Accessory) Run(t *testing.T) {
+	a.run(context.Background(), t, t.Errorf)
+}
+
+func (a *Accessory) run(parentCtx context.Context, t TestingTInterface, failfunc func(format string, args ...interface{})) {
 	a.port, a.healthPort = GetFreePort(t), GetFreePort(t)
 	ctx, cancel := context.WithCancel(parentCtx)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
@@ -136,7 +149,7 @@ func (a *Accessory) Run(t *T, parentCtx context.Context) {
 	artifactDir := ArtifactDir(t)
 	logFile, err := os.Create(filepath.Join(artifactDir, fmt.Sprintf("%s.log", a.command)))
 	if err != nil {
-		t.Fatalf("could not create log file: %v", err)
+		failfunc("could not create log file: %v", err)
 	}
 	log := bytes.Buffer{}
 	tee := io.TeeReader(&log, logFile)
@@ -153,9 +166,10 @@ func (a *Accessory) Run(t *T, parentCtx context.Context) {
 		if err != nil && ctx.Err() == nil {
 			// we care about errors in the process that did not result from the
 			// context expiring and us killing it
-			t.Fatalf("`%s` failed: %v logs:\n%v", a.command, err, string(data))
+			failfunc("`%s` failed: %v logs:\n%v", a.command, err, string(data))
 		}
 	}()
+
 }
 
 type ReadyOptions struct {
@@ -167,7 +181,7 @@ type ReadyOptions struct {
 type ReadyOption func(*ReadyOptions)
 
 // Ready returns when the accessory process is ready to serve data.
-func (a *Accessory) Ready(t *T, o ...ReadyOption) {
+func (a *Accessory) Ready(t TestingTInterface, o ...ReadyOption) {
 	opts := ReadyOptions{ReadyURL: fmt.Sprintf("http://127.0.0.1:%s/healthz/ready", a.healthPort)}
 	for _, o := range o {
 		o(&opts)

--- a/pkg/testhelper/vault.go
+++ b/pkg/testhelper/vault.go
@@ -1,17 +1,17 @@
 package testhelper
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"testing"
 )
 
 const VaultTestingRootToken = "jpuxZFWWFW7vM882GGX2aWOE"
 
 // Vault constructs a running Vault instance ready for testing. It returns its addess.
 // VaultTestingRootToken is the initial root token.
-func Vault(ctx context.Context, t *T) string {
+func Vault(t *testing.T) string {
 	if _, err := exec.LookPath("vault"); err != nil {
 		if _, runningInCi := os.LookupEnv("CI"); runningInCi {
 			t.Fatalf("could not find vault in path: %v", err)
@@ -31,7 +31,7 @@ func Vault(ctx context.Context, t *T) string {
 		// and make sure that this is always writeable.
 		fmt.Sprintf("HOME=%s", t.TempDir()),
 	)
-	vault.Run(t, ctx)
+	vault.Run(t)
 	vault.Ready(t, func(o *ReadyOptions) { o.ReadyURL = fmt.Sprintf("http://127.0.0.1:%s/v1/sys/health", vaultListenPort) })
 
 	return "127.0.0.1:" + vaultListenPort

--- a/pkg/vaultclient/vaultclient_test.go
+++ b/pkg/vaultclient/vaultclient_test.go
@@ -1,7 +1,6 @@
 package vaultclient
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,10 +53,7 @@ func TestMetadataDataInsertion(t *testing.T) {
 
 func TestListKVRecursively(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	tt := testhelper.NewT(ctx, t)
-	vaultAddr := testhelper.Vault(ctx, tt)
+	vaultAddr := testhelper.Vault(t)
 
 	client, err := New("http://"+vaultAddr, testhelper.VaultTestingRootToken)
 	if err != nil {

--- a/pkg/vaultclient/vaultclient_test.go
+++ b/pkg/vaultclient/vaultclient_test.go
@@ -80,3 +80,47 @@ func TestListKVRecursively(t *testing.T) {
 		t.Errorf("actual resutl differs from expected: %v", diff)
 	}
 }
+
+func TestUpsertDoesntCreateANewRevisionWhenDataDoesntChange(t *testing.T) {
+	t.Parallel()
+
+	vaultAddr := testhelper.Vault(t)
+
+	client, err := New("http://"+vaultAddr, testhelper.VaultTestingRootToken)
+	if err != nil {
+		t.Fatalf("failed to construct vault client: %v", err)
+	}
+
+	if err := client.UpsertKV("secret/item", map[string]string{"some": "data"}); err != nil {
+		t.Fatalf("failed to upsecret secret/item: %v", err)
+	}
+	if err := client.UpsertKV("secret/item", map[string]string{"some": "data"}); err != nil {
+		t.Fatalf("failed to upsecret secret/item: %v", err)
+	}
+
+	data, err := client.GetKV("secret/item")
+	if err != nil {
+		t.Fatalf("failed to get data: %v", err)
+	}
+
+	if data.Metadata.Version != 1 {
+		t.Errorf("Expcted version to be 1, was %d", data.Metadata.Version)
+	}
+
+	newData := map[string]string{"new": "data"}
+	if err := client.UpsertKV("secret/item", newData); err != nil {
+		t.Fatalf("failed to upsecret secret/item: %v", err)
+	}
+
+	data, err = client.GetKV("secret/item")
+	if err != nil {
+		t.Fatalf("failed to get data: %v", err)
+	}
+	if diff := cmp.Diff(newData, data.Data); diff != "" {
+		t.Errorf("data in secret store differs from updated data: %s", diff)
+	}
+	if data.Metadata.Version != 2 {
+		t.Errorf("expected versio to be 2, was %d", data.Metadata.Version)
+	}
+
+}

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -70,7 +70,7 @@ func Run(top *testing.T, name string, f TestFunc, accessories ...*Accessory) {
 		for _, accessory := range accessories {
 			// binding the accessory to ctx ensures its lifetime is only
 			// as long as the test we are running in this specific case
-			accessory.Run(bottom, ctx)
+			accessory.RunFromFrameworkRunner(bottom, ctx)
 			cmd.AddArgs(accessory.ClientFlags()...)
 			go func(a *Accessory) {
 				defer wg.Done()

--- a/test/e2e/secret-generator/e2e_test.go
+++ b/test/e2e/secret-generator/e2e_test.go
@@ -4,7 +4,6 @@ package secret_generator
 
 import (
 	"bytes"
-	"context"
 	"os/exec"
 	"testing"
 
@@ -13,8 +12,7 @@ import (
 
 func TestGeneratorBootstrap(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	addr := "http://" + testhelper.Vault(ctx, testhelper.NewT(ctx, t))
+	addr := "http://" + testhelper.Vault(t)
 	cmd := func(cmd string, args ...string) *exec.Cmd {
 		ret := exec.Command(cmd, append(
 			args,


### PR DESCRIPTION
testhelpers.T must be run from the testframeworks Run method to ensure
proper synchronization, otherwise it will not wait correctly and swallow
Errorf and Fatalf calls, making failing tests appear as if they
succeeded.

This changes the accessory to also allow testing.T, and adds a strongly
worded warning when using testhelper.T. The main drawback is that
failures in the accessory can not Fatalf the test anymore, as that is
not allowed from a distinct goroutine. In all practical terms this is of
little relevance for tests that have a runtime of <10 seconds like the
Vault tests.