### PR TITLE
[DPTP-2119] steps: clean up cluster claims when test ends

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -233,7 +233,6 @@ func Comparer() cmp.Option {
 		internalImageStreamLink{},
 		internalImageStreamTagLink{},
 		externalImageLink{},
-		clusterClaimLink{},
 	)
 }
 
@@ -559,28 +558,5 @@ func LinkForImage(imageStream, tag string) StepLink {
 	default:
 		// we have no idea what the user's configured
 		return nil
-	}
-}
-
-// ClusterClaimLink determines what dependent link is required
-// for a job to claim a cluster where name is the identifier to the link, such as the test name
-func ClusterClaimLink(name string) StepLink {
-	return &clusterClaimLink{name: name}
-}
-
-type clusterClaimLink struct {
-	name string
-}
-
-func (_ *clusterClaimLink) UnsatisfiableError() string {
-	return ""
-}
-
-func (l *clusterClaimLink) SatisfiedBy(other StepLink) bool {
-	switch link := other.(type) {
-	case *clusterClaimLink:
-		return l.name == link.name
-	default:
-		return false
 	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -138,11 +138,7 @@ func fromConfig(
 	}
 	for _, rawStep := range rawSteps {
 		if testStep := rawStep.TestStepConfiguration; testStep != nil {
-			if testStep.ClusterClaim != nil {
-				clusterClaimStep := steps.ClusterClaimStep(testStep.As, testStep.ClusterClaim, hiveClient, client, jobSpec)
-				buildSteps = append(buildSteps, clusterClaimStep)
-			}
-			steps, err := stepForTest(config, params, podClient, leaseClient, templateClient, client, jobSpec, inputImages, testStep)
+			steps, err := stepForTest(config, params, podClient, leaseClient, templateClient, client, hiveClient, jobSpec, inputImages, testStep)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -321,6 +317,7 @@ func stepForTest(
 	leaseClient *lease.Client,
 	templateClient steps.TemplateClient,
 	client loggingclient.LoggingClient,
+	hiveClient ctrlruntimeclient.Client,
 	jobSpec *api.JobSpec,
 	inputImages inputImageSet,
 	c *api.TestStepConfiguration,
@@ -334,6 +331,9 @@ func stepForTest(
 		if len(leases) != 0 {
 			step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace)
 			addProvidesForStep(step, params)
+		}
+		if c.ClusterClaim != nil {
+			step = steps.ClusterClaimStep(c.As, c.ClusterClaim, hiveClient, client, jobSpec, step)
 		}
 		return append([]api.Step{step}, stepsForStepImages(client, jobSpec, inputImages, test)...), nil
 	}
@@ -354,7 +354,11 @@ func stepForTest(
 		addProvidesForStep(step, params)
 		return []api.Step{step}, nil
 	}
-	return []api.Step{steps.TestStep(*c, config.Resources, podClient, jobSpec)}, nil
+	step := steps.TestStep(*c, config.Resources, podClient, jobSpec)
+	if c.ClusterClaim != nil {
+		step = steps.ClusterClaimStep(c.As, c.ClusterClaim, hiveClient, client, jobSpec, step)
+	}
+	return []api.Step{step}, nil
 }
 
 // stepsForStepImages creates steps that import images referenced in test steps.

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1074,7 +1074,7 @@ func TestFromConfig(t *testing.T) {
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{},
 			}},
 		},
-		expectedSteps: []string{"cluster-pool:fast-as-heck-aws:ocp-4.7-amd64-aws-dpp", "fast-as-heck-aws", "[output-images]", "[images]"},
+		expectedSteps: []string{"fast-as-heck-aws", "[output-images]", "[images]"},
 	}, {
 		name: "container test with a claim",
 		config: api.ReleaseBuildConfiguration{
@@ -1084,7 +1084,7 @@ func TestFromConfig(t *testing.T) {
 				ContainerTestConfiguration: &api.ContainerTestConfiguration{},
 			}},
 		},
-		expectedSteps: []string{"cluster-pool:e2e:----", "e2e", "[output-images]", "[images]"},
+		expectedSteps: []string{"e2e", "[output-images]", "[images]"},
 	}, {
 		name: "lease test",
 		config: api.ReleaseBuildConfiguration{

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/test-infra/prow/kube"
@@ -30,10 +31,11 @@ type clusterClaimStep struct {
 	hiveClient   ctrlruntimeclient.Client
 	client       loggingclient.LoggingClient
 	jobSpec      *api.JobSpec
+	wrapped      api.Step
 }
 
 func (s clusterClaimStep) Inputs() (api.InputDefinition, error) {
-	return nil, nil
+	return s.wrapped.Inputs()
 }
 
 var NoHiveClientErr = errors.New("step claims a cluster without providing a Hive client")
@@ -45,59 +47,69 @@ func (s *clusterClaimStep) Validate() error {
 	return nil
 }
 
+func (s *clusterClaimStep) Name() string                        { return s.wrapped.Name() }
+func (s *clusterClaimStep) Description() string                 { return s.wrapped.Description() }
+func (s *clusterClaimStep) Requires() []api.StepLink            { return s.wrapped.Requires() }
+func (s *clusterClaimStep) Creates() []api.StepLink             { return s.wrapped.Creates() }
+func (s *clusterClaimStep) Objects() []ctrlruntimeclient.Object { return s.wrapped.Objects() }
+func (s *clusterClaimStep) Provides() api.ParameterMap          { return s.wrapped.Provides() }
+
 func (s *clusterClaimStep) Run(ctx context.Context) error {
-	return results.ForReason("cluster_claim").ForError(s.run(ctx))
+	return results.ForReason("utilizing_cluster_claim").ForError(s.run(ctx))
 }
-
-func (s *clusterClaimStep) Name() string {
-	return fmt.Sprintf("cluster-pool:%s:%s-%s-%s-%s-%s", s.as, s.clusterClaim.Product, s.clusterClaim.Version, s.clusterClaim.Architecture, s.clusterClaim.Cloud, s.clusterClaim.Owner)
-}
-
-func (s *clusterClaimStep) Description() string {
-	return fmt.Sprintf("Claim a(n) %s cluster of version %s and architecture %s on cloud %s with %s's account", s.clusterClaim.Product, s.clusterClaim.Version, s.clusterClaim.Architecture, s.clusterClaim.Cloud, s.clusterClaim.Owner)
-}
-
-func (s *clusterClaimStep) Requires() []api.StepLink { return nil }
-
-func (s *clusterClaimStep) Creates() []api.StepLink {
-	return []api.StepLink{api.ClusterClaimLink(s.as)}
-}
-
-func (s *clusterClaimStep) Provides() api.ParameterMap { return nil }
-
-func (s *clusterClaimStep) Objects() []ctrlruntimeclient.Object { return s.client.Objects() }
 
 func (s *clusterClaimStep) run(ctx context.Context) error {
 	if s.clusterClaim == nil {
 		// should never happen
 		return fmt.Errorf("cannot claim a nil cluster")
 	}
+	clusterClaim, err := acquireCluster(ctx, *s.clusterClaim, s.hiveClient, s.client, *s.jobSpec)
+	if err != nil {
+		return err
+	}
+
+	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
+	logrus.Infof("Releasing cluster claims for test %s", s.Name())
+	releaseErr := results.ForReason("releasing_cluster_claim").ForError(releaseCluster(ctx, s.hiveClient, clusterClaim))
+
+	// we want a sensible output error for reporting, so we bubble up these individually
+	//if we can, as this is the only step that can have multiple errors
+	if wrappedErr != nil && releaseErr == nil {
+		return wrappedErr
+	} else if wrappedErr == nil && releaseErr != nil {
+		return releaseErr
+	} else {
+		return utilerrors.NewAggregate([]error{wrappedErr, releaseErr})
+	}
+}
+
+func acquireCluster(ctx context.Context, clusterClaim api.ClusterClaim, hiveClient ctrlruntimeclient.Client, client loggingclient.LoggingClient, jobSpec api.JobSpec) (*hivev1.ClusterClaim, error) {
 	clusterPools := &hivev1.ClusterPoolList{}
 	listOption := ctrlruntimeclient.MatchingLabels{
-		"product":      string(s.clusterClaim.Product),
-		"version":      s.clusterClaim.Version,
-		"architecture": string(s.clusterClaim.Architecture),
-		"cloud":        string(s.clusterClaim.Cloud),
-		"owner":        s.clusterClaim.Owner,
+		"product":      string(clusterClaim.Product),
+		"version":      clusterClaim.Version,
+		"architecture": string(clusterClaim.Architecture),
+		"cloud":        string(clusterClaim.Cloud),
+		"owner":        clusterClaim.Owner,
 	}
-	if err := s.hiveClient.List(ctx, clusterPools, listOption); err != nil {
-		return fmt.Errorf("failed to list cluster pools with list option %v: %w", listOption, err)
+	if err := hiveClient.List(ctx, clusterPools, listOption); err != nil {
+		return nil, fmt.Errorf("failed to list cluster pools with list option %v: %w", listOption, err)
 	}
 
 	l := len(clusterPools.Items)
 	if l == 0 {
-		return fmt.Errorf("failed to find a cluster pool providing the cluster: %v", listOption)
+		return nil, fmt.Errorf("failed to find a cluster pool providing the cluster: %v", listOption)
 	} else if l > 1 {
-		return fmt.Errorf("find %d cluster pools providing the cluster (%v): should be only one", len(clusterPools.Items), listOption)
+		return nil, fmt.Errorf("find %d cluster pools providing the cluster (%v): should be only one", len(clusterPools.Items), listOption)
 	}
 
 	clusterPool := clusterPools.Items[0]
-	claimName := s.jobSpec.ProwJobID
+	claimName := jobSpec.ProwJobID
 	claimNamespace := clusterPool.Namespace
 	// https://github.com/kubernetes/test-infra/blob/d14589b797fae426bb70cea4843fa46be50c6739/prow/pod-utils/decorate/podspec.go#L99-L101
-	jobNameForLabel := s.jobSpec.Job
+	jobNameForLabel := jobSpec.Job
 	if len(jobNameForLabel) > validation.LabelValueMaxLength {
-		jobNameForLabel = strings.TrimRight(s.jobSpec.Job[:validation.LabelValueMaxLength], ".-")
+		jobNameForLabel = strings.TrimRight(jobSpec.Job[:validation.LabelValueMaxLength], ".-")
 	}
 	claim := &hivev1.ClusterClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -105,7 +117,7 @@ func (s *clusterClaimStep) run(ctx context.Context) error {
 			Namespace: claimNamespace,
 			Labels: map[string]string{
 				kube.ProwJobAnnotation: jobNameForLabel,
-				kube.ProwBuildIDLabel:  s.jobSpec.BuildID,
+				kube.ProwBuildIDLabel:  jobSpec.BuildID,
 			},
 		},
 		Spec: hivev1.ClusterClaimSpec{
@@ -113,13 +125,13 @@ func (s *clusterClaimStep) run(ctx context.Context) error {
 			Lifetime:        &metav1.Duration{Duration: 4 * time.Hour},
 		},
 	}
-	if err := s.hiveClient.Create(ctx, claim); err != nil {
-		return fmt.Errorf("failed to created cluster claim %s in namespace %s: %w", claim.Name, claim.Namespace, err)
+	if err := hiveClient.Create(ctx, claim); err != nil {
+		return nil, fmt.Errorf("failed to created cluster claim %s in namespace %s: %w", claim.Name, claim.Namespace, err)
 	}
 	logrus.Info("Waiting for the claimed cluster to be ready.")
 	claim = &hivev1.ClusterClaim{}
-	if err := wait.Poll(15*time.Second, s.clusterClaim.Timeout.Duration, func() (bool, error) {
-		if err := s.hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: claimName, Namespace: claimNamespace}, claim); err != nil {
+	if err := wait.Poll(15*time.Second, clusterClaim.Timeout.Duration, func() (bool, error) {
+		if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: claimName, Namespace: claimNamespace}, claim); err != nil {
 			return false, fmt.Errorf("failed to get cluster claim %s in namespace %s: %w", claim.Name, claim.Namespace, err)
 		}
 		// https://github.com/openshift/hive/blob/a535d29c4d2dc4f7f9bf3f30098c69d9334bee2e/apis/hive/v1/clusterclaim_types.go#L18-L22
@@ -133,35 +145,35 @@ func (s *clusterClaimStep) run(ctx context.Context) error {
 		}
 		return false, nil
 	}); err != nil {
-		return fmt.Errorf("failed to wait for created cluster claim to become running: %w", err)
+		return nil, fmt.Errorf("failed to wait for created cluster claim to become running: %w", err)
 	}
 	logrus.Info("The claimed cluster is ready.")
 	clusterDeploymentName := claim.Spec.Namespace
 	clusterDeploymentNamespace := claim.Spec.Namespace
 	clusterDeployment := &hivev1.ClusterDeployment{}
-	if err := s.hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: clusterDeploymentName, Namespace: clusterDeploymentNamespace}, clusterDeployment); err != nil {
-		return fmt.Errorf("failed to get cluster deployment %s in namespace %s: %w", clusterDeploymentName, clusterDeploymentNamespace, err)
+	if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: clusterDeploymentName, Namespace: clusterDeploymentNamespace}, clusterDeployment); err != nil {
+		return nil, fmt.Errorf("failed to get cluster deployment %s in namespace %s: %w", clusterDeploymentName, clusterDeploymentNamespace, err)
 	}
 	if clusterDeployment.Spec.ClusterMetadata == nil {
-		return fmt.Errorf("got nil cluster metadata from cluster deployment %s in namespace %s", clusterDeploymentName, clusterDeploymentNamespace)
+		return nil, fmt.Errorf("got nil cluster metadata from cluster deployment %s in namespace %s", clusterDeploymentName, clusterDeploymentNamespace)
 	}
 	kubeconfigSecretName := clusterDeployment.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name
 	passwordSecretName := clusterDeployment.Spec.ClusterMetadata.AdminPasswordSecretRef.Name
 
 	for src, dst := range map[string]string{kubeconfigSecretName: api.HiveAdminKubeconfigSecret, passwordSecretName: api.HiveAdminPasswordSecret} {
 		srcSecret := &corev1.Secret{}
-		if err := s.hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: src, Namespace: clusterDeploymentNamespace}, srcSecret); err != nil {
-			return fmt.Errorf("failed to get secret %s in namespace %s: %w", kubeconfigSecretName, clusterDeploymentNamespace, err)
+		if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: src, Namespace: clusterDeploymentNamespace}, srcSecret); err != nil {
+			return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", kubeconfigSecretName, clusterDeploymentNamespace, err)
 		}
-		dstSecret, err := mutate(srcSecret, dst, s.jobSpec.Namespace())
+		dstSecret, err := mutate(srcSecret, dst, jobSpec.Namespace())
 		if err != nil {
-			return fmt.Errorf("failed to mutate secret: %w", err)
+			return nil, fmt.Errorf("failed to mutate secret: %w", err)
 		}
-		if _, err := util.UpsertImmutableSecret(ctx, s.client, dstSecret); err != nil {
-			return fmt.Errorf("failed to upsert immutable secret %s in namespace %s: %w", dstSecret.Name, dstSecret.Namespace, err)
+		if _, err := util.UpsertImmutableSecret(ctx, client, dstSecret); err != nil {
+			return nil, fmt.Errorf("failed to upsert immutable secret %s in namespace %s: %w", dstSecret.Name, dstSecret.Namespace, err)
 		}
 	}
-	return nil
+	return claim, nil
 }
 
 func mutate(secret *corev1.Secret, name, namespace string) (*corev1.Secret, error) {
@@ -184,13 +196,21 @@ func mutate(secret *corev1.Secret, name, namespace string) (*corev1.Secret, erro
 	}, nil
 }
 
-func ClusterClaimStep(as string, clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.Client, client loggingclient.LoggingClient, jobSpec *api.JobSpec) api.Step {
+func releaseCluster(ctx context.Context, hiveClient ctrlruntimeclient.Client, clusterClaim *hivev1.ClusterClaim) error {
+	if err := hiveClient.Delete(ctx, clusterClaim); err != nil {
+		return fmt.Errorf("failed to delete cluster claim %s in namespace %s: %w", clusterClaim.Name, clusterClaim.Namespace, err)
+	}
+	return nil
+}
+
+func ClusterClaimStep(as string, clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.Client, client loggingclient.LoggingClient, jobSpec *api.JobSpec, wrapped api.Step) api.Step {
 	ret := clusterClaimStep{
 		as:           as,
 		clusterClaim: clusterClaim,
 		hiveClient:   hiveClient,
 		client:       client,
 		jobSpec:      jobSpec,
+		wrapped:      wrapped,
 	}
 	return &ret
 }

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -197,7 +197,9 @@ func mutate(secret *corev1.Secret, name, namespace string) (*corev1.Secret, erro
 }
 
 func releaseCluster(ctx context.Context, hiveClient ctrlruntimeclient.Client, clusterClaim *hivev1.ClusterClaim) error {
+	logrus.Info("Deleting cluster claim.")
 	if err := hiveClient.Delete(ctx, clusterClaim); err != nil {
+		logrus.WithField("claim.Name", clusterClaim.Name).WithField("claim.Namespace", clusterClaim.Namespace).Debug("Failed to delete cluster claim.")
 		return fmt.Errorf("failed to delete cluster claim %s in namespace %s: %w", clusterClaim.Name, clusterClaim.Namespace, err)
 	}
 	return nil

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -197,9 +197,9 @@ func mutate(secret *corev1.Secret, name, namespace string) (*corev1.Secret, erro
 }
 
 func releaseCluster(ctx context.Context, hiveClient ctrlruntimeclient.Client, clusterClaim *hivev1.ClusterClaim) error {
-	logrus.Info("Deleting cluster claim.")
+	logrus.WithField("clusterClaim.Namespace", clusterClaim.Namespace).WithField("clusterClaim.Name", clusterClaim.Name).Debug("Deleting cluster claim.")
 	if err := hiveClient.Delete(ctx, clusterClaim); err != nil {
-		logrus.WithField("claim.Name", clusterClaim.Name).WithField("claim.Namespace", clusterClaim.Namespace).Debug("Failed to delete cluster claim.")
+		logrus.WithField("clusterClaim.Name", clusterClaim.Name).WithField("clusterClaim.Namespace", clusterClaim.Namespace).Debug("Failed to delete cluster claim.")
 		return fmt.Errorf("failed to delete cluster claim %s in namespace %s: %w", clusterClaim.Name, clusterClaim.Namespace, err)
 	}
 	return nil

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -214,9 +214,6 @@ func (s *multiStageTestStep) Requires() (ret []api.StepLink) {
 	if needsReleaseImage && !needsReleasePayload {
 		ret = append(ret, api.ReleaseImagesLink(api.LatestReleaseName))
 	}
-	if s.clusterClaim != nil {
-		ret = append(ret, api.ClusterClaimLink(s.name))
-	}
 	return
 }
 

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -85,16 +85,6 @@ func TestRequires(t *testing.T) {
 			api.InternalImageLink(
 				api.PipelineImageStreamTagReferenceSource),
 		},
-	}, {
-		name: "step claims a cluster",
-		steps: api.MultiStageTestConfigurationLiteral{
-			Test: []api.LiteralTestStep{{From: "pipeline:src"}},
-		},
-		req: []api.StepLink{
-			api.InternalImageLink(api.PipelineImageStreamTagReferenceSource),
-			api.ClusterClaimLink("some-e2e"),
-		},
-		clusterClaim: &api.ClusterClaim{},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			step := MultiStageTestStep(api.TestStepConfiguration{

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -125,9 +125,6 @@ func (s *podStep) SubTests() []*junit.TestCase {
 }
 
 func (s *podStep) Requires() (ret []api.StepLink) {
-	if s.clusterClaim != nil {
-		ret = append(ret, api.ClusterClaimLink(s.config.As))
-	}
 	if s.config.From.Name == api.PipelineImageStream {
 		ret = append(ret, api.InternalImageLink(api.PipelineImageStreamTagReference(s.config.From.Tag)))
 		return

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -301,15 +301,6 @@ func TestTestStepAndRequires(t *testing.T) {
 			},
 			expected: []api.StepLink{api.InternalImageLink("cli")},
 		},
-		{
-			name: "step claim",
-			config: api.TestStepConfiguration{
-				As:                         "some",
-				ClusterClaim:               &api.ClusterClaim{},
-				ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "cli"},
-			},
-			expected: []api.StepLink{api.ClusterClaimLink("some"), api.InternalImageLink("cli")},
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds deletion functionality for cluster claims to be deleted
when a test using one ends. This is handled in the same way as leases,
where the test step is wrapped in the cluster claim step. This allows
the cluster claim step to delete the claim after the test ends.

/cc @hongkailiu 