### PR TITLE
pod-scaler: use our own flag set

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -93,8 +93,11 @@ func (o *options) validate() error {
 }
 
 func main() {
-	opts := bindOptions(flag.CommandLine)
-	flag.Parse()
+	flagSet := flag.NewFlagSet("", flag.ExitOnError)
+	opts := bindOptions(flagSet)
+	if err := flagSet.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatal("failed to parse flags")
+	}
 	if err := opts.validate(); err != nil {
 		logrus.WithError(err).Fatal("Failed to validate flags")
 	}


### PR DESCRIPTION
Someone, somewhere, is binding flags to the global set. I don't really care who it is or why, but I just want this tool to work in it's own space:

```
$ pod-scaler
pod-scaler flag redefined: kubeconfig
panic: pod-scaler flag redefined: kubeconfig

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc0001b48a0, 0x21f09e0, 0xc00030f580, 0x1ed03a0, 0xa, 0x1f5c63f, 0x6e)
	/usr/local/go/src/flag/flag.go:871 +0x485
flag.(*FlagSet).StringVar(...)
	/usr/local/go/src/flag/flag.go:760
main.bindOptions(0xc0001b48a0, 0xc000076720)
	/home/stevekuznetsov/code/openshift/ci-tools/src/github.com/openshift/ci-tools/cmd/pod-scaler/main.go:51 +0xf7
main.main()
	/home/stevekuznetsov/code/openshift/ci-tools/src/github.com/openshift/ci-tools/cmd/pod-scaler/main.go:96 +0x3f
```

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>