### PR TITLE
ci-operator: label release pods with their release name

### DIFF
--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -46,6 +46,7 @@ type PodStepConfiguration struct {
 	As                 string
 	From               api.ImageStreamTagReference
 	Commands           string
+	Labels             map[string]string
 	ServiceAccountName string
 	Secrets            []*api.Secret
 	MemoryBackedVolume *api.MemoryBackedVolume
@@ -272,7 +273,7 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 	}
 
 	artifactDir := s.name
-	pod, err := generateBasePod(s.jobSpec, map[string]string{}, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
+	pod, err := generateBasePod(s.jobSpec, s.config.Labels, s.config.As, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -199,6 +199,7 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 			Name: streamName,
 			Tag:  "cli",
 		},
+		Labels:             map[string]string{releaseLabel: s.name},
 		ServiceAccountName: "ci-operator",
 		Commands: fmt.Sprintf(`
 set -xeuo pipefail

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -152,6 +152,7 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      targetCLI,
 			Namespace: s.jobSpec.Namespace(),
+			Labels:    map[string]string{releaseLabel: s.name},
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: coreapi.RestartPolicyNever,
@@ -232,6 +233,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 			Name: streamName,
 			Tag:  "cli",
 		},
+		Labels:             map[string]string{releaseLabel: s.name},
 		ServiceAccountName: "ci-operator",
 		Secrets:            secrets,
 		Commands:           commands,

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -20,7 +20,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
-const releaseConfigAnnotation = "release.openshift.io/config"
+const (
+	releaseConfigAnnotation = "release.openshift.io/config"
+	releaseLabel            = "ci.openshift.io/release"
+)
 
 // stableImagesTagStep is used when no release configuration is necessary
 type stableImagesTagStep struct {

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -116,6 +116,9 @@ const (
 )
 
 func labelsFor(spec *api.JobSpec, base map[string]string) map[string]string {
+	if base == nil {
+		base = map[string]string{}
+	}
 	base[LabelMetadataOrg] = spec.Metadata.Org
 	base[LabelMetadataRepo] = spec.Metadata.Repo
 	base[LabelMetadataBranch] = spec.Metadata.Branch


### PR DESCRIPTION
Release pods vary only by the CI Operator configuration, not the
specific target that ends up running them. It is important to be able to
detect that a Pod is being run for a release, in some manner that's less
fragile than searching for a prefix on the Pod name.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 