### PR TITLE
pod-scaler: use standalone webhook handlers

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prowConfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
+	"k8s.io/test-infra/prow/simplifypath"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -20,15 +26,36 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
+// l keeps the tree legible
+func l(fragment string, children ...simplifypath.Node) simplifypath.Node {
+	return simplifypath.L(fragment, children...)
+}
+
+var (
+	admissionMetrics = metrics.NewMetrics("pod_scaler_admission")
+)
+
 func admit(port int, client buildclientv1.BuildV1Interface) {
 	logger := logrus.WithField("component", "admission")
+	logger.Info("Initializing admission webhook server.")
 	health := pjutil.NewHealth()
 	health.ServeReady()
-	httpServer := webhook.Server{Port: port}
-	httpServer.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client}})
-	if err := httpServer.StartStandalone(interrupts.Context(), nil); err != nil {
-		logrus.WithError(err).Error("Failed to serve admission webhooks.")
+	mutator, err := admission.StandaloneWebhook(&webhook.Admission{Handler: &podMutator{logger: logger, client: client}}, admission.StandaloneOptions{
+		MetricsPath: "/pods",
+	})
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create pod mutator.")
 	}
+	metrics.ExposeMetrics("pod_scaler_admission", prowConfig.PushGateway{}, flagutil.DefaultMetricsPort)
+	simplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root
+		l("pods"),
+	))
+	handler := metrics.TraceHandler(simplifier, admissionMetrics.HTTPRequestDuration, admissionMetrics.HTTPResponseSize)
+	mux := http.NewServeMux()
+	mux.Handle("/pods", handler(mutator))
+	httpServer := &http.Server{Addr: ":" + strconv.Itoa(port), Handler: mux}
+	logger.Info("Serving admission webhooks.")
+	interrupts.ListenAndServe(httpServer, 5*time.Second)
 }
 
 type podMutator struct {

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	k8s.io/test-infra v0.0.0-20210422095526-28747eb818b8
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 	sigs.k8s.io/boskos v0.0.0-20210210143059-9ac98d864d2a
-	sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210421233541-d5d255154adb
+	sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210423210739-b2c90ab82af8
 	sigs.k8s.io/controller-tools v0.3.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2429,8 +2429,8 @@ sigs.k8s.io/controller-runtime v0.5.0/go.mod h1:REiJzC7Y00U+2YkMbT8wxgrsX5USpXKG
 sigs.k8s.io/controller-runtime v0.5.4/go.mod h1:JZUwSMVbxDupo0lTJSSFP5pimEyxGynROImSsqIOx1A=
 sigs.k8s.io/controller-runtime v0.7.0-alpha.6.0.20201106193838-8d0107636985/go.mod h1:03b1n6EtlDvuBPPEOHadJUusruwLWgoT4BDCybMibnA=
 sigs.k8s.io/controller-runtime v0.8.3-0.20210301154926-12660d4f2255/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
-sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210421233541-d5d255154adb h1:cYAmu6QSfwWldC08r48Mc8EdfK7nF2G+qf5arcRlSf8=
-sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210421233541-d5d255154adb/go.mod h1:ufPDuvefw2Y1KnBgHQrLdOjueYlj+XJV2AszbT+WTxs=
+sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210423210739-b2c90ab82af8 h1:SXdqgS0F/9onrzSopL9JMeaWKuv6b77SV+F3CVI7OUI=
+sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210423210739-b2c90ab82af8/go.mod h1:ufPDuvefw2Y1KnBgHQrLdOjueYlj+XJV2AszbT+WTxs=
 sigs.k8s.io/controller-tools v0.2.1/go.mod h1:cenyhL7t2e7izk/Zy7ZxDqQ9YEj0niU5VDL1PWMgZ5s=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1295,7 +1295,7 @@ knative.dev/pkg/kmp
 sigs.k8s.io/boskos/client
 sigs.k8s.io/boskos/common
 sigs.k8s.io/boskos/storage
-# sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210421233541-d5d255154adb
+# sigs.k8s.io/controller-runtime v0.9.0-alpha.1.0.20210423210739-b2c90ab82af8
 ## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go
@@ -235,9 +235,7 @@ func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, err
 		opts.Scheme = scheme.Scheme
 	}
 
-	var err error
-	hook.decoder, err = NewDecoder(opts.Scheme)
-	if err != nil {
+	if err := hook.InjectScheme(opts.Scheme); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
vendor: bump sigs.k8s.io/controller-runtime

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

pod-scaler: use standalone webhook handlers

It seems like the standalone *server* requires that certificate
authentication is used, which does not really apply for in-cluster
servers, which can either run without TLS over the service network or
can have TLS terminated by the routing layer.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
Part of [DPTP-1822](https://issues.redhat.com/browse/DPTP-1822)
