### PR TITLE
testhelper: attempt to make global map global

### DIFF
--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -250,7 +250,11 @@ func (a *Accessory) ClientFlags() []string {
 	return a.clientFlags(a.port, a.healthPort)
 }
 
-var ports = sync.Map{}
+var ports sync.Map
+
+func init() {
+	ports = sync.Map{}
+}
 
 // GetFreePort asks the kernel for a free open port that is ready to use.
 func GetFreePort(t TestingTInterface) string {


### PR DESCRIPTION
The Go reference [1] says:

> If multiple packages import a package, the imported package will be
> initialized only once.

However, something seems wrong with this. It may be the case that the
map in this helper package is being initialized more than once. Perhaps
doing it in an `init()` will help?

[1] https://golang.org/ref/spec#Package_initialization

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>