### PR TITLE
test/e2e: log ports we acquire for debugging

### DIFF
--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -276,7 +276,9 @@ func GetFreePort(t TestingTInterface) string {
 		port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
 		if _, previouslyAllocated := ports.LoadOrStore(port, nil); !previouslyAllocated {
 			// we've never seen this before, we can use it
+			t.Logf("found a never-before-seen port, returning: %s", port)
 			return port
 		}
+		t.Logf("found a previously-seen port, retrying: %s", port)
 	}
 }


### PR DESCRIPTION
This should help us understand if we're racing with something else
in-process for this port or not.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

For [DPTP-2159](https://issues.redhat.com/browse/DPTP-2159)