### PR TITLE
pkg/steps/lease: Log acquired leases at info level

### DIFF
--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -155,7 +155,7 @@ func acquireLeases(
 			errs = append(errs, results.ForReason(results.Reason("acquiring_lease:"+l.ResourceType)).WithError(err).Errorf("failed to acquire lease: %v", err))
 			break
 		}
-		logrus.Debugf("Acquired lease(s) for %s: %v", l.ResourceType, names)
+		logrus.Infof("Acquired %d lease(s) for %s: %v", l.Count, l.ResourceType, names)
 		l.resources = names
 	}
 	if errs != nil {

--- a/test/e2e/lease/e2e_test.go
+++ b/test/e2e/lease/e2e_test.go
@@ -58,7 +58,6 @@ func TestLeases(t *testing.T) {
 			success: true,
 			output: []string{
 				`Acquiring 1 lease(s) for aws-quota-slice`,
-				`Acquired lease(s) for aws-quota-slice`,
 				`Releasing leases for test success`,
 				`Releasing lease for aws-quota-slice`,
 			},
@@ -80,9 +79,7 @@ func TestLeases(t *testing.T) {
 			success: true,
 			output: []string{
 				`Acquiring 1 lease(s) for aws-quota-slice`,
-				`Acquired lease(s) for aws-quota-slice`,
 				`Acquiring 1 lease(s) for gcp-quota-slice`,
-				`Acquired lease(s) for gcp-quota-slice`,
 				`Releasing leases for test configurable-leases`,
 				`Releasing lease for aws-quota-slice`,
 				`Releasing lease for gcp-quota-slice`,
@@ -95,9 +92,7 @@ func TestLeases(t *testing.T) {
 			success: true,
 			output: []string{
 				`Acquiring 1 lease(s) for aws-quota-slice`,
-				`Acquired lease(s) for aws-quota-slice`,
 				`Acquiring 1 lease(s) for gcp-quota-slice`,
-				`Acquired lease(s) for gcp-quota-slice`,
 				`Releasing leases for test configurable-leases-registry`,
 				`Releasing lease for aws-quota-slice`,
 				`Releasing lease for gcp-quota-slice`,
@@ -110,9 +105,7 @@ func TestLeases(t *testing.T) {
 			success: true,
 			output: []string{
 				`Acquiring 3 lease(s) for aws-quota-slice`,
-				`Acquired lease(s) for aws-quota-slice`,
 				`Acquiring 5 lease(s) for gcp-quota-slice`,
-				`Acquired lease(s) for gcp-quota-slice`,
 				`Releasing leases for test configurable-leases-count`,
 				`Releasing lease for aws-quota-slice`,
 				`Releasing lease for gcp-quota-slice`,


### PR DESCRIPTION
Partially rolling back ef63f31f5b (#1834).  This gets the "which resource type?" and "which acquired name?" information up into the build log, so we can see which jobs are running in which AWS regions and such, instead of having to drop down from [the job][1]:

    INFO[2021-04-16T19:55:46Z] Acquiring leases for test launch
    INFO[2021-04-16T19:55:47Z] Running multi-stage test launch

into [ci-operator assets][2]:

    {"level":"debug","msg":"Acquired lease(s) for osd-ephemeral-quota-slice: [9096423b-d59e-491d-8ee2-f7de51139df1]","time":"2021-04-16T19:55:47Z"}

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-osd-ephemeral/1383146668190339072#1:build-log.txt%3A12
[2]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-osd-ephemeral/1383146668190339072/artifacts/ci-operator.log