### PR TITLE
ci-operator: label namespaces for auto-scaling pods

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -37,6 +37,8 @@ const (
 	HiveControlPlaneKubeconfigSecret = "app.ci-hive-credentials"
 	// HiveControlPlaneKubeconfigSecretArg is the flag to ci-operator
 	HiveControlPlaneKubeconfigSecretArg = "--hive-kubeconfig=/secrets/app.ci-hive-credentials/kubeconfig"
+
+	AutoScalePodsLabel = "ci.openshift.io/scale-pods"
 )
 
 var (


### PR DESCRIPTION
A mutating admission webhook in the critical path for Pods can cause
some serious issues when it misbehaves, so we want to select the
namespaces for which our Pod auto-scaler runs. We can label job
namespaces to allow for this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part of [DPTP-1822](https://issues.redhat.com/browse/DPTP-1822)