### PR TITLE
ci-operator: better report error

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -145,6 +145,6 @@ func (r *reporter) Report(err error) {
 	}()
 	if resp != nil && resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		logrus.Tracef("response for report was not 200: %v", body)
+		logrus.Tracef("response for report was not 200: %v", string(body))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes 

```
{"level":"trace","msg":"response for report was not 200: [99 108 117 115 116 101 114 32 102 105 101 108 100 32 105 110 32 114 101 113 117 101 115 116 32 105 115 32 101 109 112 116 121]","time":"2021-04-27T21:47:52Z"}
```

@openshift/openshift-team-developer-productivity-test-platform 