### PR TITLE
pkg/release/official: Allow explicit version choices

### DIFF
--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -761,7 +761,7 @@ func (e environmentOverride) Get(name string) (string, error) {
 func TestFromConfig(t *testing.T) {
 	ns := "ns"
 	httpClient := release.NewFakeHTTPClient(func(req *http.Request) (*http.Response, error) {
-		content := `{"nodes": [{"version": "version", "payload": "payload"}]}`
+		content := `{"nodes": [{"version": "4.1.0", "payload": "payload"}]}`
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(content))),
@@ -995,7 +995,7 @@ func TestFromConfig(t *testing.T) {
 		config: api.ReleaseBuildConfiguration{
 			InputConfiguration: api.InputConfiguration{
 				Releases: map[string]api.UnresolvedRelease{
-					"release": {Release: &api.Release{Version: "version"}},
+					"release": {Release: &api.Release{Version: "4.1.0"}},
 				},
 			},
 		},
@@ -1008,7 +1008,7 @@ func TestFromConfig(t *testing.T) {
 		config: api.ReleaseBuildConfiguration{
 			InputConfiguration: api.InputConfiguration{
 				Releases: map[string]api.UnresolvedRelease{
-					"release": {Release: &api.Release{Version: "version"}},
+					"release": {Release: &api.Release{Version: "4.1.0"}},
 				},
 			},
 		},

--- a/pkg/release/official/client.go
+++ b/pkg/release/official/client.go
@@ -61,7 +61,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, release api.Rel
 		return "", "", fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 	if len(response.Nodes) == 0 {
-		return "", "", errors.New("failed to request latest release: server returned empty list of releases (despite status code 200)")
+		return "", "", fmt.Errorf("failed to request latest release from %s: server returned empty list of releases (despite status code 200)", req.URL.String())
 	}
 	pullspec, version := latestPullSpecAndVersion(response.Nodes)
 	return pullspec, version, nil


### PR DESCRIPTION
With this commit, we extend that support to allow explicit version choices like:

```yaml
releases:
  firstz:
    release:
      channel: stable
      version: 4.7.0
latest:
  candidate:
    product: ocp
    stream: nightly
    version: "4.7"
```

to allow for tests updating between 4.7.0 and the most recent 4.7 nightly.  These tests will in turn alert us to issues like "something new has landed in recent 4.7 nightlies that breaks rollbacks to 4.7.0".

For reasons that are not clear to me, 33c2eaa49b (#839) did not just pass the configured channel along to Cincinnati, but instead appended the major/minor from the requested version.  Before this commit, that logic assumed that the requested version was just a major.minor, and then selected the largest SemVer version from that channel.  So this commit jumps through some hoops to extract the major.minor string from the configured release and append it to the configured channel.

`processVersionChannel` is set up so that if someone actually configured:

```yaml
releases:
  firstz:
    release:
      channel: stable-4.7
      version: 4.7.0
```

it would pass that `stable-4.7` channel through to Cincinnati.  We're unlikely to need that, because `pkg/validation`'s `validateRelease` restricts `channel` to `candidate`, `fast`, or `stable`.  But this package doesn't need to know that, and supporting `stable-4.7` puts us in a good position if `pkg/validation` relaxes a bit in the future.

I'm also fixing a 4.4 -> 4.3 typo in the tests, because real stable-4.4 results would not include 4.2.z releases.  I moved all of the test-cases over to 4.3 to keep them consistent.