### PR TITLE
rehearsal: label the context we're rehearsing

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -37,7 +37,11 @@ import (
 )
 
 const (
-	rehearseLabel                = "ci.openshift.org/rehearse"
+	// Label is the label key for the pull request we are rehearsing for
+	Label = "ci.openshift.io/rehearse"
+	// LabelContext exposes the context the job would have had running normally
+	LabelContext = "ci.openshift.io/rehearse.context"
+
 	defaultRehearsalRerunCommand = "/test pj-rehearse"
 	defaultRehearsalTrigger      = `(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$`
 	logRehearsalJob              = "rehearsal-job"
@@ -151,7 +155,8 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	if rehearsal.Labels == nil {
 		rehearsal.Labels = make(map[string]string, 1)
 	}
-	rehearsal.Labels[rehearseLabel] = strconv.Itoa(prNumber)
+	rehearsal.Labels[Label] = strconv.Itoa(prNumber)
+	rehearsal.Labels[LabelContext] = shortName
 
 	return &rehearsal, nil
 }
@@ -838,7 +843,7 @@ func (e *Executor) ExecuteJobs() (bool, error) {
 		return true, fmt.Errorf("failed to submit all rehearsal jobs")
 	}
 
-	selector := ctrlruntimeclient.MatchingLabels{rehearseLabel: strconv.Itoa(e.prNumber)}
+	selector := ctrlruntimeclient.MatchingLabels{Label: strconv.Itoa(e.prNumber)}
 
 	names := sets.NewString()
 	for _, job := range pjs {

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -306,7 +306,7 @@ func makeTestingPresubmit(name, context, branch string) *prowconfig.Presubmit {
 		JobBase: prowconfig.JobBase{
 			Agent:  "kubernetes",
 			Name:   name,
-			Labels: map[string]string{rehearseLabel: "123", jobconfig.CanBeRehearsedLabel: "true"},
+			Labels: map[string]string{Label: "123", jobconfig.CanBeRehearsedLabel: "true"},
 			Spec: &v1.PodSpec{
 				Containers: []v1.Container{{
 					Command: []string{"ci-operator"},
@@ -431,7 +431,7 @@ func makeTestingProwJob(namespace, jobName, context string, refs *pjapi.Refs, or
 				"prow.k8s.io/refs.repo": refs.Repo,
 				"prow.k8s.io/type":      "presubmit",
 				"prow.k8s.io/refs.pull": strconv.Itoa(refs.Pulls[0].Number),
-				rehearseLabel:           strconv.Itoa(refs.Pulls[0].Number),
+				Label:                   strconv.Itoa(refs.Pulls[0].Number),
 			},
 			Annotations: map[string]string{"prow.k8s.io/job": jobName},
 		},

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -5,7 +5,8 @@ branches:
 context: ci/rehearse/org/repo/branch/test
 hidden: true
 labels:
-  ci.openshift.org/rehearse: "123"
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
 rerun_command: /test pj-rehearse

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
@@ -9,7 +9,8 @@ extra_refs:
   repo: repo
   workdir: true
 labels:
-  ci.openshift.org/rehearse: "123"
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
 rerun_command: /test pj-rehearse

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
@@ -15,7 +15,8 @@ extra_refs:
   skip_submodules: true
   workdir: true
 labels:
-  ci.openshift.org/rehearse: "123"
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
 rerun_command: /test pj-rehearse

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
@@ -9,7 +9,8 @@ extra_refs:
   repo: repo
   workdir: true
 labels:
-  ci.openshift.org/rehearse: "123"
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
 rerun_command: /test pj-rehearse

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -4,7 +4,8 @@ branches:
 - ^branch$
 context: ci/rehearse/org/repo/branch/test
 labels:
-  ci.openshift.org/rehearse: "123"
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
 rerun_command: /test pj-rehearse

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -151,7 +151,8 @@
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-e2e
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: ""
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPeriodic
@@ -284,7 +285,8 @@
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-no-ciop
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: ""
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPeriodic
@@ -360,7 +362,8 @@
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-periodic-with-unresolved-config
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: ""
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPeriodic
@@ -501,7 +504,8 @@
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-duper-periodic-with-unresolved-config-no-target
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: ""
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPeriodic
@@ -690,7 +694,8 @@
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: ""
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPeriodic
@@ -866,7 +871,8 @@
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-custom
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: custom
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig
@@ -981,7 +987,8 @@
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: images
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig
@@ -1108,7 +1115,8 @@
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-cluster-profile-test-profile
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: test-profile
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedClusterProfile
@@ -1239,7 +1247,8 @@
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-cmd
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: cmd
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPresubmit
@@ -1347,7 +1356,8 @@
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-master-e2e-aws
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: e2e-aws
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPresubmit
@@ -1478,7 +1488,8 @@
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-e2e-aws
     creationTimestamp: null
     labels:
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: e2e-aws
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPresubmit
@@ -1610,7 +1621,8 @@
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: multistage
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
@@ -1785,7 +1797,8 @@
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: multistage5
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPresubmit
@@ -1923,7 +1936,8 @@
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/prowgen-controlled: "true"
-      ci.openshift.org/rehearse: "1234"
+      ci.openshift.io/rehearse: "1234"
+      ci.openshift.io/rehearse.context: unit
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig


### PR DESCRIPTION
When a user looks at a Pod created by this tool, they cannot
programmatically get the context which the rehearsed job would have
triggered, as we change the context to prepend a rehearsal prefix, etc.
This change exposes the value of the context through labels.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>