### PR TITLE
ci-op: swallow AlreadyExists errors on upserting ists

### DIFF
--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -72,10 +72,12 @@ func (s *outputImageTagStep) run(ctx context.Context) error {
 			ist.Tag = desired.Tag
 			return nil
 		})
-		if err != nil {
-			if errors.IsConflict(err) {
-				return false, nil
-			}
+		switch {
+		case err != nil && errors.IsConflict(err):
+			return false, nil
+		case err != nil && errors.IsAlreadyExists(err):
+			return true, nil
+		case err != nil:
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/1928 assumed we do not need to handle already exists but we do ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift-knative_serverless-operator/920/pull-ci-openshift-knative-serverless-operator-main-4.7-images/1387735829668958208))