### PR TITLE
Re-add tide merge method sharding

### DIFF
--- a/cmd/determinize-prow-config/main.go
+++ b/cmd/determinize-prow-config/main.go
@@ -72,7 +72,7 @@ func updateProwConfig(configDir, shardingBaseDir string) error {
 	if shardingBaseDir != "" {
 		additionalConfigs = append(additionalConfigs, shardingBaseDir)
 	}
-	if err := agent.Start(configPath, "", additionalConfigs, ""); err != nil {
+	if err := agent.Start(configPath, "", additionalConfigs, "_prowconfig.yaml"); err != nil {
 		return fmt.Errorf("could not load Prow configuration: %w", err)
 	}
 
@@ -239,7 +239,7 @@ func shardProwConfig(pc *prowconfig.ProwConfig, target afero.Fs) (*prowconfig.Pr
 	for orgOrgRepoString, mergeMethod := range pc.Tide.MergeType {
 		var orgRepo prowconfig.OrgRepo
 		if idx := strings.Index(orgOrgRepoString, "/"); idx != -1 {
-			orgRepo.Org = orgOrgRepoString[:idx+1]
+			orgRepo.Org = orgOrgRepoString[:idx]
 			orgRepo.Repo = orgOrgRepoString[idx+1:]
 		} else {
 			orgRepo.Org = orgOrgRepoString

--- a/cmd/determinize-prow-config/main.go
+++ b/cmd/determinize-prow-config/main.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -19,6 +20,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 	"sigs.k8s.io/yaml"
 
@@ -203,29 +205,57 @@ func updatePluginConfig(configDir string) error {
 // in order to avoid serializing empty structs.
 type prowConfigWithPointers struct {
 	BranchProtection *prowconfig.BranchProtection `json:"branch-protection,omitempty"`
+	Tide             *tideConfig                  `json:"tide,omitempty"`
+}
+
+type tideConfig struct {
+	MergeType map[string]github.PullRequestMergeType `json:"merge_method,omitempty"`
 }
 
 func shardProwConfig(pc *prowconfig.ProwConfig, target afero.Fs) (*prowconfig.ProwConfig, error) {
+	configsByOrgRepo := map[prowconfig.OrgRepo]*prowConfigWithPointers{}
 	for org, orgConfig := range pc.BranchProtection.Orgs {
 		for repo, repoConfig := range orgConfig.Repos {
-			cfg := prowConfigWithPointers{BranchProtection: &prowconfig.BranchProtection{
+			if configsByOrgRepo[prowconfig.OrgRepo{Org: org, Repo: repo}] == nil {
+				configsByOrgRepo[prowconfig.OrgRepo{Org: org, Repo: repo}] = &prowConfigWithPointers{}
+			}
+			configsByOrgRepo[prowconfig.OrgRepo{Org: org, Repo: repo}].BranchProtection = &prowconfig.BranchProtection{
 				Orgs: map[string]prowconfig.Org{org: {Repos: map[string]prowconfig.Repo{repo: repoConfig}}},
-			}}
-			if err := mkdirAndWrite(target, filepath.Join(org, repo, config.SupplementalProwConfigFileName), cfg); err != nil {
-				return nil, fmt.Errorf("failed to write config for repo %s/%s: %w", org, repo, err)
 			}
 			delete(pc.BranchProtection.Orgs[org].Repos, repo)
 		}
 
 		if isPolicySet(orgConfig.Policy) {
-			cfg := prowConfigWithPointers{BranchProtection: &prowconfig.BranchProtection{
+			if configsByOrgRepo[prowconfig.OrgRepo{Org: org}] == nil {
+				configsByOrgRepo[prowconfig.OrgRepo{Org: org}] = &prowConfigWithPointers{}
+			}
+			configsByOrgRepo[prowconfig.OrgRepo{Org: org}].BranchProtection = &prowconfig.BranchProtection{
 				Orgs: map[string]prowconfig.Org{org: orgConfig},
-			}}
-			if err := mkdirAndWrite(target, filepath.Join(org, config.SupplementalProwConfigFileName), cfg); err != nil {
-				return nil, fmt.Errorf("failed to write config for org %s: %w", org, err)
 			}
 		}
 		delete(pc.BranchProtection.Orgs, org)
+	}
+
+	for orgOrgRepoString, mergeMethod := range pc.Tide.MergeType {
+		var orgRepo prowconfig.OrgRepo
+		if idx := strings.Index(orgOrgRepoString, "/"); idx != -1 {
+			orgRepo.Org = orgOrgRepoString[:idx+1]
+			orgRepo.Repo = orgOrgRepoString[idx+1:]
+		} else {
+			orgRepo.Org = orgOrgRepoString
+		}
+
+		if configsByOrgRepo[orgRepo] == nil {
+			configsByOrgRepo[orgRepo] = &prowConfigWithPointers{}
+		}
+		configsByOrgRepo[orgRepo].Tide = &tideConfig{MergeType: map[string]github.PullRequestMergeType{orgOrgRepoString: mergeMethod}}
+		delete(pc.Tide.MergeType, orgOrgRepoString)
+	}
+
+	for orgOrRepo, cfg := range configsByOrgRepo {
+		if err := mkdirAndWrite(target, filepath.Join(orgOrRepo.Org, orgOrRepo.Repo, config.SupplementalProwConfigFileName), cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	return pc, nil

--- a/cmd/determinize-prow-config/main_test.go
+++ b/cmd/determinize-prow-config/main_test.go
@@ -172,6 +172,52 @@ func TestShardProwConfig(t *testing.T) {
 				}, "\n"),
 			},
 		},
+		{
+			name: "Org and repo branchprotection and mergemethod config gets written out",
+			in: &config.ProwConfig{
+				BranchProtection: config.BranchProtection{
+					Orgs: map[string]config.Org{
+						"openshift": {
+							Policy: config.Policy{Protect: utilpointer.BoolPtr(false)},
+							Repos: map[string]config.Repo{
+								"release": {Policy: config.Policy{Protect: utilpointer.BoolPtr(false)}},
+							},
+						},
+					},
+				},
+				Tide: config.Tide{
+					MergeType: map[string]github.PullRequestMergeType{
+						"openshift":         github.MergeSquash,
+						"openshift/release": github.MergeRebase,
+					},
+				},
+			},
+
+			expectedShardFiles: map[string]string{
+				"openshift/_prowconfig.yaml": strings.Join([]string{
+					"branch-protection:",
+					"  orgs:",
+					"    openshift:",
+					"      protect: false",
+					"tide:",
+					"  merge_method:",
+					"    openshift: squash",
+					"",
+				}, "\n"),
+				"openshift/release/_prowconfig.yaml": strings.Join([]string{
+					"branch-protection:",
+					"  orgs:",
+					"    openshift:",
+					"      repos:",
+					"        release:",
+					"          protect: false",
+					"tide:",
+					"  merge_method:",
+					"    openshift/release: rebase",
+					"",
+				}, "\n"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Ref https://issues.redhat.com/browse/DPTP-2110

There were two issues with the initial version:
* The tool didn't load the additional config, so any pre-existing
  additional config was always overwritten if new config for the same
  org or repo was sharded out
* There was an off-by-one when splitting an org/repo string in the tide
  merge method sharding, which resulted in org//repo strings, which got
  silently sanitized on write, which resulted in only one of merge
  method or branchproteciton config being written out (which one depends
  on map order, which is random)

This change produces https://github.com/openshift/release/pull/18171 which seems correct.

/cc @openshift/openshift-team-developer-productivity-test-platform 