### PR TITLE
Fix ci-secret-bootstrap user sync

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -481,6 +481,7 @@ func TestCompleteOptions(t *testing.T) {
 			},
 			expectedBWPassword: "topSecret",
 			expectedConfig: secretbootstrap.Config{
+				ClusterGroups: map[string][]string{"group-a": {"default"}},
 				Secrets: []secretbootstrap.SecretConfig{{
 					From: map[string]secretbootstrap.BitWardenContext{"key-name-1": {BWItem: "item-name-1", Field: "field-name-1"}},
 					To:   []secretbootstrap.SecretContext{{Cluster: "default", Namespace: "ns", Name: "name"}},
@@ -524,16 +525,6 @@ func TestValidateCompletedOptions(t *testing.T) {
 				"default": configDefault,
 				"build01": configBuild01,
 			},
-		},
-		{
-			name:     "empty config",
-			given:    options{},
-			expected: fmt.Errorf("no secrets found to sync"),
-		},
-		{
-			name:     "empty config with cluster filter",
-			given:    options{cluster: "cluster"},
-			expected: fmt.Errorf("no secrets found to sync for --cluster=cluster"),
 		},
 		{
 			name: "empty to",

--- a/pkg/api/secretbootstrap/secretboostrap_test.go
+++ b/pkg/api/secretbootstrap/secretboostrap_test.go
@@ -69,6 +69,60 @@ func TestResolving(t *testing.T) {
 			config:        Config{Secrets: []SecretConfig{{To: []SecretContext{{ClusterGroups: []string{"a"}}}}}},
 			expectedError: "item secrets.0.to.0 references inexistent cluster_group a",
 		},
+		{
+			name: "DPTP prefix gets added to normal BW items",
+			config: Config{
+				VaultDPTPPRefix: "prefix",
+				Secrets: []SecretConfig{{
+					From: map[string]BitWardenContext{"...": {BWItem: "foo", Field: "bar"}},
+					To: []SecretContext{{
+						Cluster:   "foo",
+						Namespace: "namspace",
+						Name:      "name",
+						Type:      corev1.SecretTypeBasicAuth,
+					}},
+				}},
+			},
+			expectedConfig: Config{
+				VaultDPTPPRefix: "prefix",
+				Secrets: []SecretConfig{{
+					From: map[string]BitWardenContext{"...": {BWItem: "prefix/foo", Field: "bar"}},
+					To: []SecretContext{{
+						Cluster:   "foo",
+						Namespace: "namspace",
+						Name:      "name",
+						Type:      corev1.SecretTypeBasicAuth,
+					}},
+				}},
+			},
+		},
+		{
+			name: "DPTP prefix gets added to dockerconfigjson BW items",
+			config: Config{
+				VaultDPTPPRefix: "prefix",
+				Secrets: []SecretConfig{{
+					From: map[string]BitWardenContext{"...": {DockerConfigJSONData: []DockerConfigJSONData{{BWItem: "foo", AuthBitwardenAttachment: "bar"}}}},
+					To: []SecretContext{{
+						Cluster:   "foo",
+						Namespace: "namspace",
+						Name:      "name",
+						Type:      corev1.SecretTypeBasicAuth,
+					}},
+				}},
+			},
+			expectedConfig: Config{
+				VaultDPTPPRefix: "prefix",
+				Secrets: []SecretConfig{{
+					From: map[string]BitWardenContext{"...": {DockerConfigJSONData: []DockerConfigJSONData{{BWItem: "prefix/foo", AuthBitwardenAttachment: "bar"}}}},
+					To: []SecretContext{{
+						Cluster:   "foo",
+						Namespace: "namspace",
+						Name:      "name",
+						Type:      corev1.SecretTypeBasicAuth,
+					}},
+				}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
There were two issues:
* We had a Config struct in our options, but didn't unmarshal into that
  but into a different var, then filter the secrets, the copy only the
  secrets property in our config in the options, dropping all other
  settings including the UserSecretsTargetClusters along the way
* We operate under a prefix, but the user secrets are elsewhere. This
  adds a new option for a dptp prefix that gets appended to the normal
  prefix, which allows us to set the normal prefix to the basepath of
  the kv store

completed by https://github.com/openshift/release/pull/18216