### PR TITLE
Fix secret-generator validation to still work with vault_dptp_prefix

### DIFF
--- a/cmd/ci-secret-generator/main.go
+++ b/cmd/ci-secret-generator/main.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -325,12 +326,13 @@ func validateContexts(contexts []secretbootstrap.BitWardenContext, config secret
 		var found bool
 		for _, secret := range config.Secrets {
 			for _, haystack := range secret.From {
+				haystack.BWItem = strings.TrimPrefix(haystack.BWItem, config.VaultDPTPPRefix+"/")
 				if reflect.DeepEqual(needle, haystack) {
 					found = true
 				}
 				for _, dc := range haystack.DockerConfigJSONData {
 					ctx := secretbootstrap.BitWardenContext{
-						BWItem:     dc.BWItem,
+						BWItem:     strings.TrimPrefix(dc.BWItem, config.VaultDPTPPRefix+"/"),
 						Attachment: dc.AuthBitwardenAttachment,
 					}
 					if reflect.DeepEqual(needle, ctx) {

--- a/cmd/ci-secret-generator/main_test.go
+++ b/cmd/ci-secret-generator/main_test.go
@@ -179,3 +179,60 @@ func TestVault(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateContexts(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		cfg          secretgenerator.Config
+		bootstrapCfg secretbootstrap.Config
+	}{
+		{
+			name: "Directly found",
+			cfg:  secretgenerator.Config{{ItemName: "some-item", Fields: []secretgenerator.FieldGenerator{{Name: "field"}}}},
+			bootstrapCfg: secretbootstrap.Config{Secrets: []secretbootstrap.SecretConfig{{
+				From: map[string]secretbootstrap.BitWardenContext{"": {BWItem: "some-item", Field: "field"}},
+			}}},
+		},
+		{
+			name: "Directly found dockerconfigjson",
+			cfg:  secretgenerator.Config{{ItemName: "some-item", Attachments: []secretgenerator.FieldGenerator{{Name: "field"}}}},
+			bootstrapCfg: secretbootstrap.Config{Secrets: []secretbootstrap.SecretConfig{{
+				From: map[string]secretbootstrap.BitWardenContext{"": {DockerConfigJSONData: []secretbootstrap.DockerConfigJSONData{{
+					BWItem: "some-item", AuthBitwardenAttachment: "field",
+				}}}},
+			}}},
+		},
+		{
+			name: "Strip prefix",
+			cfg:  secretgenerator.Config{{ItemName: "some-item", Fields: []secretgenerator.FieldGenerator{{Name: "field"}}}},
+			bootstrapCfg: secretbootstrap.Config{
+				VaultDPTPPRefix: "dptp",
+				Secrets: []secretbootstrap.SecretConfig{{
+					From: map[string]secretbootstrap.BitWardenContext{"": {BWItem: "some-item", Field: "field"}},
+				}},
+			},
+		},
+		{
+			name: "Strip prefix dockerconfigjson",
+			cfg:  secretgenerator.Config{{ItemName: "some-item", Attachments: []secretgenerator.FieldGenerator{{Name: "field"}}}},
+			bootstrapCfg: secretbootstrap.Config{
+				VaultDPTPPRefix: "dptp",
+				Secrets: []secretbootstrap.SecretConfig{{
+					From: map[string]secretbootstrap.BitWardenContext{"": {DockerConfigJSONData: []secretbootstrap.DockerConfigJSONData{{
+						BWItem: "dptp/some-item", AuthBitwardenAttachment: "field",
+					}}}},
+				}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateContexts(bitwardenContextsFor(tc.cfg), tc.bootstrapCfg); err != nil {
+				t.Errorf("validation failed unexpectedly: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The deserialization prepends it to the path, so we have to strip it
prior to comparing as the generator operates directly on the dptp vault
path.