### PR TITLE
DPTP-1463: Log the source from where an image was resolved

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -452,6 +452,11 @@ type StepConfiguration struct {
 type InputImageTagStepConfiguration struct {
 	BaseImage ImageStreamTagReference         `json:"base_image"`
 	To        PipelineImageStreamTagReference `json:"to,omitempty"`
+
+	// The Source denotes what caused this image to get loaded. In the event
+	// that the image was loaded as a result of a test step, the source will
+	// contain the name of the test.
+	Source string `json:"source,omitempty"`
 }
 
 // OutputImageTagStepConfiguration describes a step that
@@ -1488,4 +1493,9 @@ const (
 	ReleaseImageStream = "release"
 
 	ComponentFormatReplacement = "${component}"
+
+	ImageStreamSourceRoot    = "root"
+	ImageStreamSourceBase    = "base_image"
+	ImageStreamSourceBaseRpm = "base_rpm_image"
+	ImageStreamSourceTest    = `test step "%s"`
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -373,6 +373,7 @@ func stepsForStepImages(
 			config := api.InputImageTagStepConfiguration{
 				BaseImage: *subStep.FromImage,
 				To:        link,
+				Source:    fmt.Sprintf(api.ImageStreamSourceTest, subStep.As),
 			}
 			if _, ok := inputImages[config]; ok {
 				continue
@@ -515,6 +516,7 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 					BaseImage: *isTagRef,
 					To:        api.PipelineImageStreamTagReferenceRoot,
+					Source:    api.ImageStreamSourceRoot,
 				}})
 		} else if gitSourceRef := target.ProjectImageBuild; gitSourceRef != nil {
 			buildSteps = append(buildSteps, api.StepConfiguration{
@@ -583,6 +585,7 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 		buildSteps = append(buildSteps, api.StepConfiguration{InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 			BaseImage: defaultImageFromReleaseTag(baseImage, config.ReleaseTagConfiguration),
 			To:        api.PipelineImageStreamTagReference(alias),
+			Source:    api.ImageStreamSourceBase,
 		}})
 	}
 
@@ -591,6 +594,7 @@ func stepConfigsForBuild(config *api.ReleaseBuildConfiguration, jobSpec *api.Job
 		buildSteps = append(buildSteps, api.StepConfiguration{InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 			BaseImage: defaultImageFromReleaseTag(target, config.ReleaseTagConfiguration),
 			To:        intermediateTag,
+			Source:    api.ImageStreamSourceBaseRpm,
 		}})
 
 		buildSteps = append(buildSteps, api.StepConfiguration{RPMImageInjectionStepConfiguration: &api.RPMImageInjectionStepConfiguration{

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -84,7 +84,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}},
 		},
@@ -126,7 +127,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "org-repo",
 						Tag:       "branch",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}},
 		},
@@ -160,7 +162,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "stream-name",
 						Tag:       "stream-tag",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}},
 			readFile: func(filename string) ([]byte, error) {
@@ -208,7 +211,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
@@ -254,7 +258,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
@@ -309,7 +314,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
@@ -359,7 +365,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
@@ -414,7 +421,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
@@ -424,7 +432,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Tag:       "tag",
 						As:        "name",
 					},
-					To: api.PipelineImageStreamTagReference("name"),
+					To:     api.PipelineImageStreamTagReference("name"),
+					Source: "base_image",
 				},
 			}},
 		},
@@ -467,7 +476,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 							Name:      "root-name",
 							Tag:       "manual",
 						},
-						To: api.PipelineImageStreamTagReferenceRoot,
+						To:     api.PipelineImageStreamTagReferenceRoot,
+						Source: string(api.PipelineImageStreamTagReferenceRoot),
 					},
 				},
 				{
@@ -484,7 +494,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 							Tag:       "tag",
 							As:        "name",
 						},
-						To: api.PipelineImageStreamTagReference("name"),
+						To:     api.PipelineImageStreamTagReference("name"),
+						Source: "base_image",
 					},
 				},
 				{
@@ -536,7 +547,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: api.PipelineImageStreamTagReferenceRoot,
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
@@ -546,7 +558,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Tag:       "tag",
 						As:        "name",
 					},
-					To: api.PipelineImageStreamTagReference("name-without-rpms"),
+					To:     api.PipelineImageStreamTagReference("name-without-rpms"),
+					Source: "base_rpm_image",
 				},
 			}, {
 				RPMImageInjectionStepConfiguration: &api.RPMImageInjectionStepConfiguration{
@@ -607,7 +620,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: "root",
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
@@ -684,7 +698,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Name:      "root-name",
 						Tag:       "manual",
 					},
-					To: "root",
+					To:     api.PipelineImageStreamTagReferenceRoot,
+					Source: string(api.PipelineImageStreamTagReferenceRoot),
 				},
 			}, {
 				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -49,7 +49,11 @@ func (s *inputImageTagStep) Inputs() (api.InputDefinition, error) {
 		return nil, fmt.Errorf("could not resolve base image: %w", err)
 	}
 
-	logrus.Debugf("Resolved %s to %s.", s.config.BaseImage.ISTagName(), from.Image.Name)
+	if s.config.Source != "" {
+		logrus.Debugf("Resolved %s (%s) to %s.", s.config.BaseImage.ISTagName(), s.config.Source, from.Image.Name)
+	} else {
+		logrus.Debugf("Resolved %s to %s.", s.config.BaseImage.ISTagName(), from.Image.Name)
+	}
 	s.imageName = from.Image.Name
 	return api.InputDefinition{from.Image.Name}, nil
 }

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -220,6 +220,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            name: ' '\n" +
 	"            namespace: ' '\n" +
 	"            tag: ' '\n" +
+	"        # The Source denotes what caused this image to get loaded. In the event\n" +
+	"        # that the image was loaded as a result of a test step, the source will\n" +
+	"        # contain the name of the test.\n" +
+	"        source: ' '\n" +
 	"        to: ' '\n" +
 	"      output_image_tag_step:\n" +
 	"        from: ' '\n" +


### PR DESCRIPTION
[DPTP-1463](https://issues.redhat.com/browse/DPTP-1463): Log the source from where an image was resolved. For example, if an image is resolved as a result of a step-ref test, then output the name of the test.