### PR TITLE
Ci-Secret-Bootstrap: Fix validation

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -692,7 +692,6 @@ func getUnusedBWItems(config secretbootstrap.Config, client secrets.ReadOnlyClie
 
 	unused := make(map[string]*comparable)
 	for itemName, item := range allSecretStoreItems {
-		itemName := strings.TrimPrefix(itemName, config.VaultDPTPPRefix+"/")
 		l := logrus.WithField("bw_item", itemName)
 		if item.LastChanged().After(allowUnusedAfter) {
 			logrus.WithFields(logrus.Fields{

--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -684,7 +684,7 @@ func insertIfNotEmpty(s sets.String, items ...string) sets.String {
 }
 
 func getUnusedBWItems(config secretbootstrap.Config, client secrets.ReadOnlyClient, bwAllowUnused sets.String, allowUnusedAfter time.Time) error {
-	allSecretStoreItems, err := client.GetInUseInformationForAllItems()
+	allSecretStoreItems, err := client.GetInUseInformationForAllItems(config.VaultDPTPPRefix)
 	if err != nil {
 		return fmt.Errorf("failed to get in-use information from secret store: %w", err)
 	}

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -2497,25 +2497,6 @@ func TestGetUnusedBWItems(t *testing.T) {
 			expectedBitwardenErr: "Unused bw item: 'item-name-1'",
 			expectedVaultErr:     "Unused bw item: 'item-name-1'",
 		},
-		{
-			id: "Unused item check prepends vault dptp prefix if present",
-			bwItems: []bitwarden.Item{
-				{
-					Name:   "prefix/item-name-1",
-					Fields: []bitwarden.Field{{Name: "field-name-1", Value: "value-1"}},
-				},
-			},
-			config: secretbootstrap.Config{
-				VaultDPTPPRefix: "prefix",
-				Secrets: []secretbootstrap.SecretConfig{
-					{
-						From: map[string]secretbootstrap.BitWardenContext{
-							"1": {BWItem: "item-name-1", Field: "field-name-1"},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/secrets/bitwarden.go
+++ b/pkg/secrets/bitwarden.go
@@ -24,7 +24,7 @@ func NewBitwardenClient(bw bitwarden.Client) Client {
 	return &bitwardenClient{Client: bw}
 }
 
-func (bw *bitwardenClient) GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error) {
+func (bw *bitwardenClient) GetInUseInformationForAllItems(_ string) (map[string]SecretUsageComparer, error) {
 	allItems := bw.GetAllItems()
 
 	result := map[string]SecretUsageComparer{}

--- a/pkg/secrets/client.go
+++ b/pkg/secrets/client.go
@@ -14,7 +14,7 @@ type ReadOnlyClient interface {
 	GetFieldOnItem(itemName, fieldName string) ([]byte, error)
 	GetAttachmentOnItem(itemName, attachmentName string) ([]byte, error)
 	GetPassword(itemName string) ([]byte, error)
-	GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error)
+	GetInUseInformationForAllItems(optionalPrefix string) (map[string]SecretUsageComparer, error)
 	GetUserSecrets() (map[types.NamespacedName]map[string]string, error)
 	Logout() ([]byte, error)
 	HasItem(itemname string) (bool, error)
@@ -49,7 +49,7 @@ func NewDryRunClient(output *os.File) (Client, error) {
 	return &dryRunClient{Client: c}, nil
 }
 
-func (*dryRunClient) GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error) {
+func (*dryRunClient) GetInUseInformationForAllItems(_ string) (map[string]SecretUsageComparer, error) {
 	return nil, nil
 }
 

--- a/pkg/secrets/vault.go
+++ b/pkg/secrets/vault.go
@@ -99,8 +99,12 @@ func (c *vaultClient) GetPassword(itemName string) ([]byte, error) {
 	return c.getSecretAtPath(itemName, "password")
 }
 
-func (c *vaultClient) GetInUseInformationForAllItems() (map[string]SecretUsageComparer, error) {
-	allKeys, err := c.upstream.ListKVRecursively(c.prefix)
+func (c *vaultClient) GetInUseInformationForAllItems(optionalSubPath string) (map[string]SecretUsageComparer, error) {
+	prefix := c.prefix
+	if optionalSubPath != "" {
+		prefix = prefix + "/" + optionalSubPath
+	}
+	allKeys, err := c.upstream.ListKVRecursively(prefix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The previous change of stripping the prefix is plain wrong. We simply have to add `dptp` to the `--allow-unused` arg, as its relativ to the root, ref:  https://github.com/openshift/release/pull/18279

The second commit makes us only check dptps items rather than everything.