### PR TITLE
steps/release: Create release should qualify version

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -188,7 +188,7 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		prefix = releaseConfig.Name
 	}
 	now := time.Now().UTC().Truncate(time.Second)
-	version := fmt.Sprintf("%s.test-%s-%s", prefix, now.Format("2006-01-02-150405"), s.jobSpec.Namespace())
+	version := fmt.Sprintf("%s.test-%s-%s-%s", prefix, now.Format("2006-01-02-150405"), s.jobSpec.Namespace(), s.name)
 
 	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	logrus.Infof("Creating release image %s.", destination)


### PR DESCRIPTION
CVO does not support upgrading between two releases that have the
same version number because cluster-operators require a unique
version number to reach level. In CI we can very rarely create
both the initial and latest releases at the same timestamp (cluster
bot, rollback tests, some periodics), and so when ci-operator
generates versions it should clearly separate by the release name
(initial and latest).

Example: 

this cluster-bot job https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1389581141689765888 tests upgrading from a given PR to the same PR.  The two release images are created at the exact same time:

```
[36mINFO[0m[2021-05-04T14:08:07Z] Creating release image registry.build01.ci.openshift.org/ci-ln-l9w46sb/release:initial. 
[36mINFO[0m[2021-05-04T14:08:07Z] Creating release image registry.build01.ci.openshift.org/ci-ln-l9w46sb/release:latest.
```

and thus race - in this case they get the same version number.  Since a given ci-operator run can only have one release per name, disambiguating prevents conflicts (even going to millisecond time resolution wouldn't guarantee we didn't conflict).