### PR TITLE
rehearse: fix buggy subset selection

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -592,14 +592,15 @@ func determineSubsetToRehearse(presubmitsToRehearse []*prowconfig.Presubmit, reh
 	}
 
 	maxJobsPerSourceType := rehearsalLimit / len(presubmitsBySourceType)
-	toRehearse := []*prowconfig.Presubmit{}
-	dropped := []*prowconfig.Presubmit{}
+	var toRehearse []*prowconfig.Presubmit
+	var dropped []*prowconfig.Presubmit
 
 	for _, jobs := range presubmitsBySourceType {
 		if len(jobs) > maxJobsPerSourceType {
-			toRehearse = append(toRehearse, jobs[:maxJobsPerSourceType]...)
 			dropped = append(dropped, jobs[maxJobsPerSourceType:]...)
+			jobs = jobs[:maxJobsPerSourceType]
 		}
+		toRehearse = append(toRehearse, jobs...)
 	}
 
 	// There are two ways that we will hit this check. First, jobs from a specific resource are less than the

--- a/cmd/pj-rehearse/main_test.go
+++ b/cmd/pj-rehearse/main_test.go
@@ -274,6 +274,20 @@ func TestDetermineSubsetToRehearse(t *testing.T) {
 				{JobBase: prowconfig.JobBase{Name: "rehearsal-9", Labels: map[string]string{config.SourceTypeLabel: "changedTemplate"}}},
 			},
 		},
+		{
+			id: "all sources are represented even when initial sets are skewed",
+			presubmitsToRehearse: []*prowconfig.Presubmit{
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-1", Labels: map[string]string{config.SourceTypeLabel: "changedPresubmit"}}},
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-2", Labels: map[string]string{config.SourceTypeLabel: "changedPeriodic"}}},
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-3", Labels: map[string]string{config.SourceTypeLabel: "changedPeriodic"}}},
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-4", Labels: map[string]string{config.SourceTypeLabel: "changedPeriodic"}}},
+			},
+			rehearsalLimit: 2,
+			expected: []*prowconfig.Presubmit{
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-1", Labels: map[string]string{config.SourceTypeLabel: "changedPresubmit"}}},
+				{JobBase: prowconfig.JobBase{Name: "rehearsal-2", Labels: map[string]string{config.SourceTypeLabel: "changedPeriodic"}}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When the source sets were unbalanced by size in a way that one source
set would fit into its part of the quota and the other would not, we
would actually *not* include the smaller set in the final rehearsal set.
The whole set would be eventually backfilled from dropped jobs, which
only come from the originally larger source sets, entirelly pressing the
smaller (and usually more important) source sets from rehearsals.

/cc @droslean @stevekuznetsov 