### PR TITLE
Check the length of secret names

### DIFF
--- a/cmd/vault-subpath-proxy/kv_key_validator.go
+++ b/cmd/vault-subpath-proxy/kv_key_validator.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/openshift/ci-tools/pkg/api/vault"
+	"github.com/openshift/ci-tools/pkg/steps"
 )
 
 // https://github.com/openshift/ci-tools/blob/7af2e075f381ecae1562d1406bad2c86a23e72a3/vendor/k8s.io/api/core/v1/types.go#L5748-L5749
@@ -60,6 +61,10 @@ func (k *kvKeyValidator) RoundTrip(r *http.Request) (*http.Response, error) {
 		if !secretKeyValidationRegex.MatchString(key) {
 			errs = append(errs, fmt.Sprintf("key %s is invalid: must match regex %s", key, secretKeyValidationRegexString))
 		}
+	}
+
+	if err := steps.ValidateSecretInStep(body.Data[vault.SecretSyncTargetNamepaceKey], body.Data[vault.SecretSyncTargetNameKey]); err != nil {
+		errs = append(errs, fmt.Sprintf("secret %s in namespace %s cannot be used in a step: %s", body.Data[vault.SecretSyncTargetNameKey], body.Data[vault.SecretSyncTargetNamepaceKey], err.Error()))
 	}
 
 	if len(errs) > 0 {

--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -8,6 +8,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/yaml"
 
+	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
@@ -108,6 +109,9 @@ func (c *Config) Validate() error {
 		}
 		k := -1
 		for j, secretContext := range secretConfig.To {
+			if err := steps.ValidateSecretInStep(secretContext.Namespace, secretContext.Name); err != nil {
+				errs = append(errs, fmt.Errorf("secret[%d] in secretConfig[%d] cannot be used in a step: %w", j, i, err))
+			}
 			if secretContext.Type == corev1.SecretTypeDockerConfigJson {
 				k = j
 			}

--- a/pkg/api/secretbootstrap/secretboostrap_test.go
+++ b/pkg/api/secretbootstrap/secretboostrap_test.go
@@ -253,6 +253,19 @@ func TestValidate(t *testing.T) {
 			}}},
 			expected: utilerrors.NewAggregate([]error{fmt.Errorf("config[0].from[some-key].attribute: only the 'password' is supported, not credentials")}),
 		},
+		{
+			name: "long name",
+			config: &Config{Secrets: []SecretConfig{{
+				From: map[string]BitWardenContext{
+					"some": {},
+				},
+				To: []SecretContext{{
+					Cluster:   "cl",
+					Namespace: "test-credentials",
+					Name:      "very-very-very-very-very-very-very-very-very-long",
+				}}}}},
+			expected: utilerrors.NewAggregate([]error{fmt.Errorf("secret[0] in secretConfig[0] cannot be used in a step: volumeName test-credentials-very-very-very-very-very-very-very-very-very-long: [must be no more than 63 characters]")}),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2065

The namespace and name of a secret used in a step's `credentials` are use to compose the volume's name in the pod of the step.

We have 2 sources of secrets:
- secret-bootstrap: validate its targeting secrets in the tools' config.
- self-service: validate in the proxy (the original validate is not enough because it check each of ns and name, we check here the 2 combined).

/cc @openshift/openshift-team-developer-productivity-test-platform 