### PR TITLE
cluster_claim: always delete claim

### DIFF
--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -63,7 +63,13 @@ func (s *clusterClaimStep) run(ctx context.Context) error {
 	}
 	clusterClaim, err := acquireCluster(ctx, *s.clusterClaim, s.hiveClient, s.client, *s.jobSpec)
 	if err != nil {
-		return results.ForReason("acquiring_cluster_claim").ForError(err)
+		acquireErr := results.ForReason("acquiring_cluster_claim").ForError(err)
+		// always attempt to delete claim if one exists
+		var releaseErr error
+		if clusterClaim != nil {
+			releaseErr = results.ForReason("releasing_cluster_claim").ForError(releaseCluster(ctx, s.hiveClient, clusterClaim))
+		}
+		return aggregateWrappedErrorAndReleaseError(acquireErr, releaseErr)
 	}
 
 	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
@@ -130,17 +136,17 @@ func acquireCluster(ctx context.Context, clusterClaim api.ClusterClaim, hiveClie
 		}
 		return false, nil
 	}); err != nil {
-		return nil, fmt.Errorf("failed to wait for created cluster claim to become running: %w", err)
+		return claim, fmt.Errorf("failed to wait for created cluster claim to become running: %w", err)
 	}
 	logrus.Info("The claimed cluster is ready.")
 	clusterDeploymentName := claim.Spec.Namespace
 	clusterDeploymentNamespace := claim.Spec.Namespace
 	clusterDeployment := &hivev1.ClusterDeployment{}
 	if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: clusterDeploymentName, Namespace: clusterDeploymentNamespace}, clusterDeployment); err != nil {
-		return nil, fmt.Errorf("failed to get cluster deployment %s in namespace %s: %w", clusterDeploymentName, clusterDeploymentNamespace, err)
+		return claim, fmt.Errorf("failed to get cluster deployment %s in namespace %s: %w", clusterDeploymentName, clusterDeploymentNamespace, err)
 	}
 	if clusterDeployment.Spec.ClusterMetadata == nil {
-		return nil, fmt.Errorf("got nil cluster metadata from cluster deployment %s in namespace %s", clusterDeploymentName, clusterDeploymentNamespace)
+		return claim, fmt.Errorf("got nil cluster metadata from cluster deployment %s in namespace %s", clusterDeploymentName, clusterDeploymentNamespace)
 	}
 	kubeconfigSecretName := clusterDeployment.Spec.ClusterMetadata.AdminKubeconfigSecretRef.Name
 	passwordSecretName := clusterDeployment.Spec.ClusterMetadata.AdminPasswordSecretRef.Name
@@ -148,14 +154,14 @@ func acquireCluster(ctx context.Context, clusterClaim api.ClusterClaim, hiveClie
 	for src, dst := range map[string]string{kubeconfigSecretName: api.HiveAdminKubeconfigSecret, passwordSecretName: api.HiveAdminPasswordSecret} {
 		srcSecret := &corev1.Secret{}
 		if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: src, Namespace: clusterDeploymentNamespace}, srcSecret); err != nil {
-			return nil, fmt.Errorf("failed to get secret %s in namespace %s: %w", kubeconfigSecretName, clusterDeploymentNamespace, err)
+			return claim, fmt.Errorf("failed to get secret %s in namespace %s: %w", kubeconfigSecretName, clusterDeploymentNamespace, err)
 		}
 		dstSecret, err := mutate(srcSecret, dst, jobSpec.Namespace())
 		if err != nil {
-			return nil, fmt.Errorf("failed to mutate secret: %w", err)
+			return claim, fmt.Errorf("failed to mutate secret: %w", err)
 		}
 		if _, err := util.UpsertImmutableSecret(ctx, client, dstSecret); err != nil {
-			return nil, fmt.Errorf("failed to upsert immutable secret %s in namespace %s: %w", dstSecret.Name, dstSecret.Namespace, err)
+			return claim, fmt.Errorf("failed to upsert immutable secret %s in namespace %s: %w", dstSecret.Name, dstSecret.Namespace, err)
 		}
 	}
 	return claim, nil


### PR DESCRIPTION
The current code immediately exits with an error if the `acquireClaim`
function fails without deleting the created claim. This PR makes the
`acquireClaim` function always return the claim if one is made, even on
error, and the `releaseCluster` function is run even when `aquireClaim`
fails.

/cc @hongkailiu 