### PR TITLE
Vault secret collection manager: Create users if they dont exist

### DIFF
--- a/cmd/vault-secret-collection-manager/docker-compose.yaml
+++ b/cmd/vault-secret-collection-manager/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       # the interaction with aliases
       vault auth enable userpass
       # Create some users, they must pre-exist
-      for user in admin another-user third-user; do
+      for user in another-user third-user; do
         vault write auth/userpass/users/$$user password=false
         vault write identity/entity name=$$user policies=default
         vault write identity/entity-alias name=$$user \

--- a/cmd/vault-secret-collection-manager/main_test.go
+++ b/cmd/vault-secret-collection-manager/main_test.go
@@ -48,21 +48,10 @@ func TestSecretCollectionManager(t *testing.T) {
 		if _, err := client.Logical().Write(fmt.Sprintf("/auth/userpass/users/%s", user), map[string]interface{}{"password": "password"}); err != nil {
 			t.Fatalf("failed to create userpass user %s: %v", user, err)
 		}
-		identity, err := client.CreateIdentity(user, []string{"default"})
-		if err != nil {
-			t.Fatalf("failed to create identity for user %s: %v", user, err)
-		}
-		if _, err := client.Logical().Write("identity/entity-alias", map[string]interface{}{
-			"name":           user,
-			"canonical_id":   identity.ID,
-			"mount_accessor": mountAccessor,
-		}); err != nil {
-			t.Fatalf("failed to create identity alias for user %s in mount_accessor %s: %v", user, mountAccessor, err)
-		}
 	}
 
 	managerListenAddr := "127.0.0.1:" + testhelper.GetFreePort(t)
-	server := server(client, "secret/self-managed", managerListenAddr)
+	server := server(client, "userpass", "secret/self-managed", managerListenAddr)
 	go func() {
 		if err := server.ListenAndServe(); err != http.ErrServerClosed {
 			t.Errorf("failed to start secret-collection-manager: %v", err)


### PR DESCRIPTION
Currently, users have to first log into vault and then into the secret
collection manager, otherwise it will fail as the user doesn't exist.
This fixes that.

Ref https://issues.redhat.com/browse/DPTP-2196

/cc @openshift/openshift-team-developer-productivity-test-platform 