### PR TITLE
secret bootstrap: create nonexistent namespaces

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
-	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/ci-tools/pkg/api/secretbootstrap"
@@ -1543,6 +1542,32 @@ func TestUpdateSecrets(t *testing.T) {
 		expectedSecretsOnBuild01 []coreapi.Secret
 	}{
 		{
+			name: "namespace is created when it does not exist",
+			secretsMap: map[string][]*coreapi.Secret{
+				"default": {
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "prod-secret-1",
+							Namespace: "create-this-namespace",
+							Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
+						},
+						Data: map[string][]byte{"secret": []byte("value")},
+					},
+				},
+			},
+			force: true,
+			expectedSecretsOnDefault: []coreapi.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "prod-secret-1",
+						Namespace: "create-this-namespace",
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
+					},
+					Data: map[string][]byte{"secret": []byte("value")},
+				},
+			},
+		},
+		{
 			name: "basic case with force",
 			existSecretsOnDefault: []runtime.Object{
 				&coreapi.Secret{
@@ -1936,7 +1961,7 @@ func TestUpdateSecrets(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			fkcDefault := fake.NewSimpleClientset(tc.existSecretsOnDefault...)
 			fkcBuild01 := fake.NewSimpleClientset(tc.existSecretsOnBuild01...)
-			clients := map[string]coreclientset.SecretsGetter{
+			clients := map[string]Getter{
 				"default": fkcDefault.CoreV1(),
 				"build01": fkcBuild01.CoreV1(),
 			}


### PR DESCRIPTION
Resolves failures such as [this one](https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-private/logs/periodic-ci-secret-bootstrap/1391791192831692800#1:build-log.txt%3A3866):

```
failed to update secrets: [error creating secret api.**:grafana-loki/grafana-config: namespaces \"grafana-loki\" not found ...
```

I'm convinced that creating namespaces is the right thing to do for this automation b/c we have no other way how to enforce a presence of certain namespace on all clusters.

I added a test to describe that this is an intentional behavior, but unfortunately the test passes even if I comment the new code out: the underlying fake client do not seem to be able to fake an error like that (or I did not find a way to coerce it).