### PR TITLE
pkg/steps/cluster_claim: use `PollImmediate`

### DIFF
--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -120,7 +120,7 @@ func acquireCluster(ctx context.Context, clusterClaim api.ClusterClaim, hiveClie
 	}
 	logrus.Info("Waiting for the claimed cluster to be ready.")
 	claim = &hivev1.ClusterClaim{}
-	if err := wait.Poll(15*time.Second, clusterClaim.Timeout.Duration, func() (bool, error) {
+	if err := wait.PollImmediate(15*time.Second, clusterClaim.Timeout.Duration, func() (bool, error) {
 		if err := hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: claimName, Namespace: claimNamespace}, claim); err != nil {
 			return false, fmt.Errorf("failed to get cluster claim %s in namespace %s: %w", claim.Name, claim.Namespace, err)
 		}


### PR DESCRIPTION
Noticed while executing unit tests locally, where `Poll` adds an
unconditional, uninterruptible 15s delay.

```
$ time go test --count 1 ./pkg/steps
^C
ok      github.com/openshift/ci-tools/pkg/steps 16.138s

real    0m18.531s
user    0m6.471s
sys     0m0.708s
```

```
time="2021-05-11T14:02:56Z" level=info msg="Waiting for the claimed cluster to be ready."
time="2021-05-11T14:03:11Z" level=info msg="The claimed cluster is ready."
```

With this change:

```
$ time go test --count 1 ./pkg/steps
ok      github.com/openshift/ci-tools/pkg/steps 1.137s

real    0m3.119s
user    0m5.136s
sys     0m0.573s
```