### PR TITLE
pkg/steps/bundle_source: use `testing.TempDir`

### DIFF
--- a/pkg/steps/bundle_source_test.go
+++ b/pkg/steps/bundle_source_test.go
@@ -49,10 +49,7 @@ func TestReplaceCommand(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skipf("skipping test on %s OS", runtime.GOOS)
 	}
-	temp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Failed to create temporary directory for unit test: %v", err)
-	}
+	temp := t.TempDir()
 	if err := exec.Command("cp", "-a", "testdata/4.6", temp).Run(); err != nil {
 		t.Fatalf("Failed to copy testdata to tempdir: %v", err)
 	}


### PR DESCRIPTION
The tests leak a directory in `/tmp`:

```
$ find /tmp -name another-manifest.yml 2> /dev/null
/tmp/960074342/4.6/another-manifest.yml
/tmp/683052059/4.6/another-manifest.yml
/tmp/231724004/4.6/another-manifest.yml
/tmp/832461060/4.6/another-manifest.yml
/tmp/026997805/4.6/another-manifest.yml
…
```