### PR TITLE
ci-operator: set $KUBECONFIG regardless of cluster_profile

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -527,13 +527,14 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 				// We mount them here to the test container.
 				container.VolumeMounts = append(container.VolumeMounts, clusterClaimMount...)
 			}
-		}
-		if s.profile != "" {
-			addProfile(s.profileSecretName(), s.profile, pod)
+		} else {
 			container.Env = append(container.Env, []coreapi.EnvVar{
 				{Name: "KUBECONFIG", Value: filepath.Join(SecretMountPath, "kubeconfig")},
 				{Name: "KUBEADMIN_PASSWORD_FILE", Value: filepath.Join(SecretMountPath, "kubeadmin-password")},
 			}...)
+		}
+		if s.profile != "" {
+			addProfile(s.profileSecretName(), s.profile, pod)
 		}
 		if step.Cli != "" {
 			addCliInjector(step.Cli, pod)

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -66,14 +66,14 @@
         value: release:latest
       - name: LEASED_RESOURCE
         value: uuid
-      - name: CLUSTER_TYPE
-        value: aws
-      - name: CLUSTER_PROFILE_DIR
-        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: pipeline:src
@@ -222,14 +222,14 @@
         value: release:latest
       - name: LEASED_RESOURCE
         value: uuid
-      - name: CLUSTER_TYPE
-        value: aws
-      - name: CLUSTER_PROFILE_DIR
-        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: stable:image1
@@ -377,14 +377,14 @@
         value: release:latest
       - name: LEASED_RESOURCE
         value: uuid
-      - name: CLUSTER_TYPE
-        value: aws
-      - name: CLUSTER_PROFILE_DIR
-        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: stable-initial:installer
@@ -538,14 +538,14 @@
         value: release:latest
       - name: LEASED_RESOURCE
         value: uuid
-      - name: CLUSTER_TYPE
-        value: aws
-      - name: CLUSTER_PROFILE_DIR
-        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: pipeline:src


### PR DESCRIPTION
When a workflow wants to expose a $KUBECONFIG via the $SHARED_DIR
without having to rely on cluster_profile, it should be able to.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @bbguimaraes 