### PR TITLE
cmd/publicize: fix temporal test failure

### DIFF
--- a/cmd/publicize/server_test.go
+++ b/cmd/publicize/server_test.go
@@ -424,29 +424,31 @@ and the repository exists.
 	}
 
 	for _, tc := range testCases {
-		if err := tc.privateGitRepo(); err != nil {
-			t.Fatalf("test id: %s: %v", tc.id, err)
-		}
+		t.Run(tc.id, func(t *testing.T) {
+			if err := tc.privateGitRepo(); err != nil {
+				t.Fatal(err)
+			}
 
-		if err := tc.publicGitRepo(); err != nil {
-			t.Fatalf("test id: %s: %v", tc.id, err)
-		}
+			if err := tc.publicGitRepo(); err != nil {
+				t.Fatal(err)
+			}
 
-		headCommitRef, err := s.mergeAndPushToRemote(privateOrg, privateRepo, publicOrg, publicRepo, tc.remoteResolver, tc.branch, false)
-		if err != nil && tc.errExpectedMsg == "" {
-			t.Fatalf("test id: %s\nerror not expected: %v", tc.id, err)
-		}
+			headCommitRef, err := s.mergeAndPushToRemote(privateOrg, privateRepo, publicOrg, publicRepo, tc.remoteResolver, tc.branch, false)
+			if err != nil && tc.errExpectedMsg == "" {
+				t.Fatalf("error not expected: %v", err)
+			}
 
-		if err != nil && !strings.HasPrefix(err.Error(), tc.errExpectedMsg) {
-			t.Fatal(cmp.Diff(err.Error(), tc.errExpectedMsg))
-		}
+			if err != nil && !strings.HasPrefix(err.Error(), tc.errExpectedMsg) {
+				t.Fatal(cmp.Diff(err.Error(), tc.errExpectedMsg))
+			}
 
-		if err == nil && len(headCommitRef) != 40 {
-			t.Fatalf("expected a head commit ref to be 40 chars long: %s", headCommitRef)
-		}
+			if err == nil && len(headCommitRef) != 40 {
+				t.Fatalf("expected a head commit ref to be 40 chars long: %s", headCommitRef)
+			}
 
-		if err := localgit.Clean(); err != nil {
-			t.Fatalf("couldn't clean temporary folders: %v", err)
-		}
+			if err := localgit.Clean(); err != nil {
+				t.Fatalf("couldn't clean temporary folders: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The test creates two repositories using `test-infra`'s
`LocalGit::MakeFakeRepo` and attempts to use them as an
upstream/downstream pair.  However, if a change of the seconds on the
clock happens between the creation of each, the hashes of the generated
commits will not match, resulting in `git` errors due to incompatible
histories.

Adding a 1-second `sleep` call between the creation of the repositories
reproduces the failure consistently.

Sample failure:

```
time="2021-05-12T19:22:55Z" level=info msg="Creating a mirror of the repo at /tmp/gitcache624379900/openshift/test" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Creating a mirror of the repo at /tmp/gitcache624379900/openshift/test" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Creating a clone of the repo at /tmp/gitrepo615166251 from /tmp/gitcache624379900/openshift/test" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Checking out \"refs/heads/master\"" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Fetching refs/heads/master from /tmp/localgit720827089/openshift-priv/test" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Configuring \"user.name\"=\"Foo Bar\"" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Configuring \"user.email\"=\"foobar@redhat.com\"" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Configuring \"commit.gpgsign\"=\"false\"" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=info msg="Merging \"FETCH_HEAD\" using the \"merge\" strategy" client=git org=openshift repo=test
time="2021-05-12T19:22:55Z" level=warning msg="Error merging \"FETCH_HEAD\": fatal: refusing to merge unrelated histories\n" client=git error="exit status 128" org=openshift repo=test
--- FAIL: TestMergeAndPushToRemote (0.05s)
    server_test.go:437: test id: nothing to merge, no error expected
        error not expected: couldn't merge openshift/test, merge --abort failed with reason: error aborting merge of "FETCH_HEAD": exit status 128 fatal: There is no merge to abort (MERGE_HEAD missing).
FAIL
FAIL    github.com/openshift/ci-tools/cmd/publicize     0.069s
FAIL
```

Commit hashes in a successful execution:

```
commit d575e295e1d25257f73bb6ac195005184a94b6d8 (HEAD, origin/master, origin/HEAD, master)
Author: test test <test@test.test>
Date:   Thu May 13 11:19:34 2021 +0000

    wow
commit d575e295e1d25257f73bb6ac195005184a94b6d8 (HEAD, origin/master, origin/HEAD, master)
Author: test test <test@test.test>
Date:   Thu May 13 11:19:34 2021 +0000

    wow
```

Commit hashes in a failed execution:

```
commit 8e9cc7690b87e0e8eb289135213c6feea987d181 (HEAD, origin/master, origin/HEAD, master)
Author: test test <test@test.test>
Date:   Thu May 13 11:19:35 2021 +0000

    wow
commit d575e295e1d25257f73bb6ac195005184a94b6d8
Author: test test <test@test.test>
Date:   Thu May 13 11:19:34 2021 +0000

    wow
```

The code under test operates on real repositories, so this is an
incorrect, fictitious test scenario.  The issue is solved by amending
the original commit with a fixed time.