### PR TITLE
rehearse: strip reporter_config from rehearsals

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -155,6 +155,9 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	rehearsal.Labels[LabelContext] = shortName
 	rehearsal.Labels = utils.SanitizeLabels(rehearsal.Labels)
 
+	// rehearsals should not report anything via Slack etc
+	rehearsal.ReporterConfig = nil
+
 	return &rehearsal, nil
 }
 

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -385,6 +385,12 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 	}
 	hiddenPresubmit.Hidden = true
 
+	reportingPresubmit := &prowconfig.Presubmit{}
+	if err := deepcopy.Copy(reportingPresubmit, sourcePresubmit); err != nil {
+		t.Fatalf("deepcopy failed: %v", err)
+	}
+	reportingPresubmit.ReporterConfig = &pjapi.ReporterConfig{Slack: &pjapi.SlackReporterConfig{}}
+
 	testCases := []struct {
 		testID   string
 		refs     *pjapi.Refs
@@ -414,6 +420,11 @@ func TestMakeRehearsalPresubmit(t *testing.T) {
 			testID:   "job that belong to the same org but different repo than refs",
 			refs:     &pjapi.Refs{Org: "org", Repo: "anotherRepo"},
 			original: sourcePresubmit,
+		},
+		{
+			testID:   "reporting configuration is stripped from rehearsals to avoid polluting",
+			refs:     &pjapi.Refs{Org: "anotherOrg", Repo: "anotherRepo"},
+			original: reportingPresubmit,
 		},
 	}
 

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
@@ -1,0 +1,26 @@
+agent: kubernetes
+always_run: false
+branches:
+- ^branch$
+context: ci/rehearse/org/repo/branch/test
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+  workdir: true
+labels:
+  ci.openshift.io/rehearse: "123"
+  ci.openshift.io/rehearse.context: test
+name: rehearse-123-pull-ci-org-repo-branch-test
+optional: true
+rerun_command: /test pj-rehearse
+spec:
+  containers:
+  - args:
+    - arg1
+    - arg2
+    command:
+    - ci-operator
+    name: ""
+    resources: {}
+trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'


### PR DESCRIPTION
Jobs are rehearsed for various reasons all the time, polluting the
channels where the original (usually important) jobs report their
results.

Resolves: [DPTP-2190](https://issues.redhat.com/browse/DPTP-2190)
