### PR TITLE
pkg/results: flatten error trees

### DIFF
--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -387,7 +387,7 @@ func TestErrWroteJUnit(t *testing.T) {
 	if !errors.Is(defaulted, &errWroteJUnit{}) {
 		t.Error("expected the top-level error to still expose that we wrote jUnit")
 	}
-	testhelper.Diff(t, "full reason", results.FullReason(defaulted), "something")
+	testhelper.Diff(t, "reasons", results.Reasons(defaulted), []string{"something"})
 }
 
 func TestBuildPartialGraph(t *testing.T) {

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -387,9 +387,7 @@ func TestErrWroteJUnit(t *testing.T) {
 	if !errors.Is(defaulted, &errWroteJUnit{}) {
 		t.Error("expected the top-level error to still expose that we wrote jUnit")
 	}
-	if results.FullReason(defaulted) != "something" {
-		t.Errorf(`expected full reason for error to be "something", but got %q"`, results.FullReason(defaulted))
-	}
+	testhelper.Diff(t, "full reason", results.FullReason(defaulted), "something")
 }
 
 func TestBuildPartialGraph(t *testing.T) {

--- a/pkg/results/error.go
+++ b/pkg/results/error.go
@@ -33,25 +33,6 @@ func (e *Error) Is(target error) bool {
 	return is
 }
 
-// FullReason provides the chain of error reasons, divided by colons
-func (e *Error) FullReason() string {
-	reasonedError := &Error{}
-	if !errors.As(e.wrapped, &reasonedError) {
-		return string(e.reason)
-	}
-	return fmt.Sprintf("%s:%s", e.reason, reasonedError.FullReason())
-}
-
-// FullReason attempts to get the full reason from an error, or uses
-// unknown when it's not something we can do
-func FullReason(err error) string {
-	reasonedError := &Error{}
-	if !errors.As(err, &reasonedError) {
-		return string(ReasonUnknown)
-	}
-	return reasonedError.FullReason()
-}
-
 // Reasons provides the chains of error reasons.
 // Each item in the return value is a single chain divided by colons.  Aggregate
 // errors — those whose type provides an `Errors` method returning a list of

--- a/pkg/results/error_test.go
+++ b/pkg/results/error_test.go
@@ -12,15 +12,15 @@ import (
 
 func TestError(t *testing.T) {
 	base := errors.New("failure")
-	testhelper.Diff(t, "reason for base error", FullReason(base), "unknown")
+	testhelper.Diff(t, "reasons for base error", Reasons(base), []string(nil))
 	initial := ForReason("oops").WithError(base).Errorf("couldn't do it")
-	testhelper.Diff(t, "reason for initial error", FullReason(initial), "oops")
+	testhelper.Diff(t, "reasons for initial error", Reasons(initial), []string{"oops"})
 	second := ForReason("whoopsie").WithError(initial).Errorf("couldn't do it")
-	testhelper.Diff(t, "reason for second error", FullReason(second), "whoopsie:oops")
+	testhelper.Diff(t, "reasons for second error", Reasons(second), []string{"whoopsie:oops"})
 	third := ForReason("argh").WithError(second).Errorf("couldn't do it")
-	testhelper.Diff(t, "reason for third error", FullReason(third), "argh:whoopsie:oops")
+	testhelper.Diff(t, "reasons for third error", Reasons(third), []string{"argh:whoopsie:oops"})
 	simple := ForReason("simple").ForError(base)
-	testhelper.Diff(t, "reason for simple error", FullReason(simple), "simple")
+	testhelper.Diff(t, "reasons for simple error", Reasons(simple), []string{"simple"})
 
 	none := ForReason("fake").ForError(nil)
 	if none != nil {
@@ -32,9 +32,9 @@ func TestError(t *testing.T) {
 		t.Errorf("expected a wrapped nil error to be nil, got %v", alsoNone)
 	}
 	withDefault := DefaultReason(base)
-	testhelper.Diff(t, "reason for defaulted error", FullReason(withDefault), "unknown")
+	testhelper.Diff(t, "reasons for defaulted error", Reasons(withDefault), []string{"unknown"})
 	unchanged := DefaultReason(initial)
-	testhelper.Diff(t, "reason for unchanged error", FullReason(unchanged), "oops")
+	testhelper.Diff(t, "reasons for unchanged error", Reasons(unchanged), []string{"oops"})
 }
 
 func TestComplexError(t *testing.T) {
@@ -54,7 +54,7 @@ func TestComplexError(t *testing.T) {
 	}
 
 	err := run()
-	testhelper.Diff(t, "reason for top-level error", FullReason(err), "higher_level_thing:root_thing")
+	testhelper.Diff(t, "reasons for top-level error", Reasons(err), []string{"higher_level_thing:root_thing"})
 }
 
 func TestReasons(t *testing.T) {

--- a/pkg/results/error_test.go
+++ b/pkg/results/error_test.go
@@ -3,30 +3,21 @@ package results
 import (
 	"errors"
 	"testing"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestError(t *testing.T) {
 	base := errors.New("failure")
-	if actual, expected := FullReason(base), "unknown"; actual != expected {
-		t.Errorf("got incorrect reason for base error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for base error", FullReason(base), "unknown")
 	initial := ForReason("oops").WithError(base).Errorf("couldn't do it")
-	if actual, expected := FullReason(initial), "oops"; actual != expected {
-		t.Errorf("got incorrect reason for initial error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for initial error", FullReason(initial), "oops")
 	second := ForReason("whoopsie").WithError(initial).Errorf("couldn't do it")
-	if actual, expected := FullReason(second), "whoopsie:oops"; actual != expected {
-		t.Errorf("got incorrect reason for second error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for second error", FullReason(second), "whoopsie:oops")
 	third := ForReason("argh").WithError(second).Errorf("couldn't do it")
-	if actual, expected := FullReason(third), "argh:whoopsie:oops"; actual != expected {
-		t.Errorf("got incorrect reason for third error; expected %s, got %v", expected, actual)
-	}
-
+	testhelper.Diff(t, "reason for third error", FullReason(third), "argh:whoopsie:oops")
 	simple := ForReason("simple").ForError(base)
-	if actual, expected := FullReason(simple), "simple"; actual != expected {
-		t.Errorf("got incorrect reason for simple error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for simple error", FullReason(simple), "simple")
 
 	none := ForReason("fake").ForError(nil)
 	if none != nil {
@@ -38,13 +29,9 @@ func TestError(t *testing.T) {
 		t.Errorf("expected a wrapped nil error to be nil, got %v", alsoNone)
 	}
 	withDefault := DefaultReason(base)
-	if actual, expected := FullReason(withDefault), "unknown"; actual != expected {
-		t.Errorf("got incorrect reason for defaulted error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for defaulted error", FullReason(withDefault), "unknown")
 	unchanged := DefaultReason(initial)
-	if actual, expected := FullReason(unchanged), "oops"; actual != expected {
-		t.Errorf("got incorrect reason for unchanged error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for unchanged error", FullReason(unchanged), "oops")
 }
 
 func TestComplexError(t *testing.T) {
@@ -64,7 +51,5 @@ func TestComplexError(t *testing.T) {
 	}
 
 	err := run()
-	if actual, expected := FullReason(err), "higher_level_thing:root_thing"; actual != expected {
-		t.Errorf("got incorrect reason for top-level error; expected %s, got %v", expected, actual)
-	}
+	testhelper.Diff(t, "reason for top-level error", FullReason(err), "higher_level_thing:root_thing")
 }

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -155,7 +155,7 @@ func acquireLeases(
 			if err == lease.ErrNotFound {
 				printResourceMetrics(client, l.ResourceType)
 			}
-			errs = append(errs, results.ForReason(results.Reason("acquiring_lease:"+l.ResourceType)).WithError(err).Errorf("failed to acquire lease: %v", err))
+			errs = append(errs, results.ForReason(results.Reason("acquiring_lease")).WithError(err).Errorf("failed to acquire lease for %q: %v", l.ResourceType, err))
 			break
 		}
 		logrus.Infof("Acquired %d lease(s) for %s: %v", l.Count, l.ResourceType, names)

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -149,12 +149,12 @@ func TestError(t *testing.T) {
 	}{{
 		name:            "first acquire fails",
 		failures:        sets.NewString("acquire owner rtype0 free leased random"),
-		expectedReasons: []string{"utilizing_lease:acquiring_lease:rtype0"},
+		expectedReasons: []string{"utilizing_lease:acquiring_lease"},
 		expected:        []string{"acquire owner rtype0 free leased random"},
 	}, {
 		name:            "second acquire fails",
 		failures:        sets.NewString("acquire owner rtype1 free leased random"),
-		expectedReasons: []string{"utilizing_lease:acquiring_lease:rtype1"},
+		expectedReasons: []string{"utilizing_lease:acquiring_lease"},
 		expected: []string{
 			"acquire owner rtype0 free leased random",
 			"acquire owner rtype1 free leased random",

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 type stepNeedsLease struct {
@@ -139,34 +141,29 @@ func TestError(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, tc := range []struct {
-		name     string
-		runFails bool
-		failures sets.String
-		expected []string
+		name            string
+		runFails        bool
+		failures        sets.String
+		expectedReasons []string
+		expected        []string
 	}{{
-		name:     "first acquire fails",
-		failures: sets.NewString("acquire owner rtype0 free leased random"),
-		expected: []string{"acquire owner rtype0 free leased random"},
+		name:            "first acquire fails",
+		failures:        sets.NewString("acquire owner rtype0 free leased random"),
+		expectedReasons: []string{"utilizing_lease:acquiring_lease:rtype0"},
+		expected:        []string{"acquire owner rtype0 free leased random"},
 	}, {
-		name:     "second acquire fails",
-		failures: sets.NewString("acquire owner rtype1 free leased random"),
+		name:            "second acquire fails",
+		failures:        sets.NewString("acquire owner rtype1 free leased random"),
+		expectedReasons: []string{"utilizing_lease:acquiring_lease:rtype1"},
 		expected: []string{
 			"acquire owner rtype0 free leased random",
 			"acquire owner rtype1 free leased random",
 			"releaseone owner rtype0_0 free",
 		},
 	}, {
-		name:     "first release fails",
-		failures: sets.NewString("releaseone owner rtype0_0 free"),
-		expected: []string{
-			"acquire owner rtype0 free leased random",
-			"acquire owner rtype1 free leased random",
-			"releaseone owner rtype0_0 free",
-			"releaseone owner rtype1_1 free",
-		},
-	}, {
-		name:     "second release fails",
-		failures: sets.NewString("releaseone owner rtype1_1 free"),
+		name:            "first release fails",
+		failures:        sets.NewString("releaseone owner rtype0_0 free"),
+		expectedReasons: []string{"utilizing_lease:releasing_lease"},
 		expected: []string{
 			"acquire owner rtype0 free leased random",
 			"acquire owner rtype1 free leased random",
@@ -174,8 +171,33 @@ func TestError(t *testing.T) {
 			"releaseone owner rtype1_1 free",
 		},
 	}, {
-		name:     "run fails",
+		name:            "second release fails",
+		failures:        sets.NewString("releaseone owner rtype1_1 free"),
+		expectedReasons: []string{"utilizing_lease:releasing_lease"},
+		expected: []string{
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+			"releaseone owner rtype1_1 free",
+		},
+	}, {
+		name:            "run fails",
+		runFails:        true,
+		expectedReasons: []string{"utilizing_lease:executing_test"},
+		expected: []string{
+			"acquire owner rtype0 free leased random",
+			"acquire owner rtype1 free leased random",
+			"releaseone owner rtype0_0 free",
+			"releaseone owner rtype1_1 free",
+		},
+	}, {
+		name:     "run and release fail",
 		runFails: true,
+		failures: sets.NewString("releaseone owner rtype1_1 free"),
+		expectedReasons: []string{
+			"utilizing_lease:executing_test",
+			"utilizing_lease:releasing_lease",
+		},
 		expected: []string{
 			"acquire owner rtype0 free leased random",
 			"acquire owner rtype1 free leased random",
@@ -187,9 +209,11 @@ func TestError(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls)
 			s := stepNeedsLease{fail: tc.runFails}
-			if LeaseStep(&client, leases, &s, func() string { return "" }).Run(ctx) == nil {
+			err := LeaseStep(&client, leases, &s, func() string { return "" }).Run(ctx)
+			if err == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
+			testhelper.Diff(t, "reasons", results.Reasons(err), tc.expectedReasons)
 			if !reflect.DeepEqual(calls, tc.expected) {
 				t.Fatalf("wrong calls to the lease client: %s", diff.ObjectDiff(calls, tc.expected))
 			}

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -300,11 +300,17 @@ func TestStepsRun(t *testing.T) {
 
 			var expectedErrorsString []string
 			for _, e := range tc.errExpected {
-				expectedErrorsString = append(expectedErrorsString, fmt.Sprintf("%s: %s", e.(*results.Error).FullReason(), e.Error()))
+				s := e.Error()
+				for _, r := range results.Reasons(e) {
+					expectedErrorsString = append(expectedErrorsString, fmt.Sprintf("%s: %s", r, s))
+				}
 			}
 			var actualErrorsString []string
 			for _, e := range errs {
-				actualErrorsString = append(actualErrorsString, fmt.Sprintf("%s: %s", e.(*results.Error).FullReason(), e.Error()))
+				s := e.Error()
+				for _, r := range results.Reasons(e) {
+					actualErrorsString = append(actualErrorsString, fmt.Sprintf("%s: %s", r, s))
+				}
 			}
 			sort.Strings(expectedErrorsString)
 			sort.Strings(actualErrorsString)

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -173,3 +173,10 @@ func cleanRVAndTypeMeta(r runtime.Object) {
 		typeObject.SetGroupVersionKind(schema.GroupVersionKind{})
 	}
 }
+
+func Diff(t *testing.T, name string, x, y interface{}, opts ...cmp.Option) {
+	t.Helper()
+	if diff := cmp.Diff(x, y, opts...); diff != "" {
+		t.Errorf("unexpected %s: %s", name, diff)
+	}
+}

--- a/test/e2e/lease/e2e_test.go
+++ b/test/e2e/lease/e2e_test.go
@@ -69,7 +69,7 @@ func TestLeases(t *testing.T) {
 			success: false,
 			output: []string{
 				`Acquiring 1 lease(s) for azure4-quota-slice`,
-				`step invalid-lease failed: failed to acquire lease for "azure4-quota-slice": resources not found`,
+				`step invalid-lease failed: failed to acquire lease for \"azure4-quota-slice\": resources not found`,
 			},
 		},
 		{

--- a/test/e2e/lease/e2e_test.go
+++ b/test/e2e/lease/e2e_test.go
@@ -69,7 +69,7 @@ func TestLeases(t *testing.T) {
 			success: false,
 			output: []string{
 				`Acquiring 1 lease(s) for azure4-quota-slice`,
-				`step invalid-lease failed: failed to acquire lease: resources not found`,
+				`step invalid-lease failed: failed to acquire lease for "azure4-quota-slice": resources not found`,
 			},
 		},
 		{


### PR DESCRIPTION
The `Aggregate` error type from `apimachinery` explicitly does not support
`Errors.As`:

```go
// Errors.As() is not supported, because the caller presumably cares
// about a specific error of potentially multiple that match the given
// type.
```

This breaks the causal chain in the `FullReason` method.  This change adds
a function that flattens trees of arbitrarily-nested
`results.Error` and `Aggregate`-like errors into a list while preserving
the hierarchy, so that all errors reported have the correct reason.

https://issues.redhat.com/browse/DPTP-2214