### PR TITLE
test/e2e: do not escape expected string

### DIFF
--- a/test/e2e/framework/ci-operator.go
+++ b/test/e2e/framework/ci-operator.go
@@ -152,7 +152,7 @@ func (c *CiOperatorCommand) VerboseOutputContains(t *T, name string, fragments .
 	}
 	for _, item := range fragments {
 		if !bytes.Contains(verboseOutput, []byte(item)) {
-			t.Errorf("%s: could not find line %q in output; output:\n%v", name, item, string(verboseOutput))
+			t.Errorf("%s: could not find line in output\nline: %s\noutput:\n%v", name, item, string(verboseOutput))
 		}
 	}
 }


### PR DESCRIPTION
Seen in:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/1989/pull-ci-openshift-ci-tools-master-e2e/1394666825530216448

Before:

```
    ERRO[2021-05-18T15:51:07Z]   * could not run steps: step invalid-lease failed: failed to acquire lease for "azure4-quota-slice": resources not found
test.go:87: invalid lease fails: could not find line "step invalid-lease failed: failed to acquire lease for \"azure4-quota-slice\": resources not found" in output; output:
…
    {"level":"error","msg":"  * could not run steps: step invalid-lease failed: failed to acquire lease for \"azure4-quota-slice\": resources not found","time":"2021-05-18T15:51:07Z"}
```

After:

```
    ERRO[2021-05-18T15:57:32Z]   * could not run steps: step invalid-lease failed: failed to acquire lease for "azure4-quota-slice": resources not found
test.go:87: invalid lease fails: could not find line in output
    line: step invalid-lease failed: failed to acquire lease for "azure4-quota-slice": resources not found
    output:
…
    {"level":"error","msg":"  * could not run steps: step invalid-lease failed: failed to acquire lease for \"azure4-quota-slice\": resources not found","time":"2021-05-18T15:57:32Z"}
```