### PR TITLE
ci-operator: expose OO_* variables even without cluster profile

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -275,6 +275,13 @@ func (s *multiStageTestStep) environment(ctx context.Context) ([]coreapi.EnvVar,
 		}
 		ret = append(ret, coreapi.EnvVar{Name: l.Env, Value: val})
 	}
+
+	if optionalOperator, err := resolveOptionalOperator(s.params); err != nil {
+		return nil, err
+	} else if optionalOperator != nil {
+		ret = append(ret, optionalOperator.asEnv()...)
+	}
+
 	if s.profile != "" {
 		secret := s.profileSecretName()
 		if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: secret}, &coreapi.Secret{}); err != nil {
@@ -286,11 +293,6 @@ func (s *multiStageTestStep) environment(ctx context.Context) ([]coreapi.EnvVar,
 				return nil, err
 			}
 			ret = append(ret, coreapi.EnvVar{Name: e, Value: val})
-		}
-		if optionalOperator, err := resolveOptionalOperator(s.params); err != nil {
-			return nil, err
-		} else if optionalOperator != nil {
-			ret = append(ret, optionalOperator.asEnv()...)
 		}
 	}
 	return ret, nil
@@ -514,7 +516,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 			pod.OwnerReferences = append(pod.OwnerReferences, *owner)
 		}
 		if s.profile != "" && s.clusterClaim != nil {
-			//should never happen
+			// should never happen
 			errs = append(errs, fmt.Errorf("cannot set both cluster_profile and cluster_claim in a test"))
 		}
 		if s.clusterClaim != nil {
@@ -857,7 +859,7 @@ func getClusterClaimPodParams(secretVolumeMounts []coreapi.VolumeMount) ([]corea
 			}
 		}
 		if !foundMountPath {
-			//should never happen
+			// should never happen
 			errs = append(errs, fmt.Errorf("failed to find foundMountPath %s to create secret %s", mountPath, secretName))
 		}
 	}

--- a/pkg/steps/optional_operators.go
+++ b/pkg/steps/optional_operators.go
@@ -8,17 +8,17 @@ import (
 )
 
 const (
-	//OOIndex is a text placeholder
+	// OOIndex is a text placeholder
 	OOIndex = "OO_INDEX"
-	//OOPackage is a text placeholder
+	// OOPackage is a text placeholder
 	OOPackage = "OO_PACKAGE"
-	//OOChannel is a text placeholder
+	// OOChannel is a text placeholder
 	OOChannel = "OO_CHANNEL"
-	//OOBundle is a text placeholder
+	// OOBundle is a text placeholder
 	OOBundle = "OO_BUNDLE"
-	//OOInstallNamespace is a text placeholder
+	// OOInstallNamespace is a text placeholder
 	OOInstallNamespace = "OO_INSTALL_NAMESPACE"
-	//OOTargetNamespaces is a text placeholder
+	// OOTargetNamespaces is a text placeholder
 	OOTargetNamespaces = "OO_TARGET_NAMESPACES"
 )
 
@@ -52,6 +52,10 @@ type getter interface {
 func resolveOptionalOperator(parameters getter) (*optionalOperator, error) {
 	var err error
 	var oo optionalOperator
+
+	if parameters == nil {
+		return nil, nil
+	}
 
 	required := map[string]*string{
 		OOIndex:   &oo.Index,


### PR DESCRIPTION
The `OO_*` variables were only propagated to Pods in the presence of a cluster profile. For no good reason. :facepalm: 

/cc @dirgim @stevekuznetsov 