### PR TITLE
Bootstrap item validation: Correctly strip prefix

### DIFF
--- a/pkg/api/secretgenerator/secretgenerator.go
+++ b/pkg/api/secretgenerator/secretgenerator.go
@@ -59,11 +59,8 @@ func (c Config) itemsByName() map[string][]SecretItem {
 }
 
 func (c Config) IsItemGenerated(name string) bool {
-	byName := c.itemsByName()
-	if _, ok := byName[name]; ok {
-		return true
-	}
-	return false
+	_, ok := c.itemsByName()[name]
+	return ok
 }
 
 func (c Config) IsFieldGenerated(name, component string) bool {


### PR DESCRIPTION
We insert the VaultDPTPPrefix into all item names during deserialization
in the bootstrapper and give the generator the same prefix as CLI arg.

This means that the generator config has the items without that prefix
so we need to strip it before we check in the generator config if it
exists.

/cc @droslean @petr-muller 

Responsible for e.G. the incorrect failure here: https://github.com/openshift/release/pull/18643