### PR TITLE
DPTP-2200: Support overriding a dependency with an external pull spec.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -798,6 +798,8 @@ type StepDependency struct {
 	Name string `json:"name"`
 	// Env is the environment variable that the image's pull spec is exposed with
 	Env string `json:"env"`
+	// PullSpec allows the ci-operator user to pass in an external pull-spec that should be used when resolving the dependency
+	PullSpec string `json:"-"`
 }
 
 // StepDNSConfig defines a resource that needs to be acquired prior to execution.


### PR DESCRIPTION
Allow a pull spec to be passed in to the ci-operator. This pull spec will override any dependency that matches the environment variable name. For example:

`--dependency-override-param=OO_INDEX=registry.mystuff.com:5000/pushed/myimage`

would override the `OO_INDEX` env param in any test step with the value `registry.mystuff.com:5000/pushed/myimage`. It is then up to the job to use that pull spec appropriately.