### PR TITLE
ci-operator: log aliases of imported images

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -467,7 +467,11 @@ func (config InputImageTagStepConfiguration) FormattedSources() string {
 		case ImageStreamSourceTest:
 			tests.Insert(source.Name)
 		default:
-			formattedSources = append(formattedSources, string(source.SourceType))
+			item := string(source.SourceType)
+			if source.Name != "" {
+				item += ": " + source.Name
+			}
+			formattedSources = append(formattedSources, item)
 		}
 	}
 
@@ -476,7 +480,7 @@ func (config InputImageTagStepConfiguration) FormattedSources() string {
 
 	}
 
-	return strings.Join(formattedSources, ",")
+	return strings.Join(formattedSources, "|")
 
 }
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -306,9 +306,11 @@ func TestInputImageTagStepConfiguration(t *testing.T) {
 			},
 			{
 				SourceType: ImageStreamSourceBase,
+				Name:       "os",
 			},
 			{
 				SourceType: ImageStreamSourceBaseRpm,
+				Name:       "rpms",
 			},
 			{
 				SourceType: ImageStreamSourceTest,
@@ -319,7 +321,7 @@ func TestInputImageTagStepConfiguration(t *testing.T) {
 				Name:       "test2",
 			},
 		},
-		expectedFormattedSources: "root,base_image,base_rpm_image,test steps: test1,test2",
+		expectedFormattedSources: "root|base_image: os|base_rpm_image: rpms|test steps: test1,test2",
 	}}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -619,7 +619,7 @@ func stepConfigsForBuild(
 				BaseImage: defaultImageFromReleaseTag(baseImage, config.ReleaseTagConfiguration),
 				To:        api.PipelineImageStreamTagReference(alias),
 			},
-			Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase}},
+			Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase, Name: alias}},
 		}
 		buildSteps = append(buildSteps, api.StepConfiguration{InputImageTagStepConfiguration: &config})
 
@@ -633,7 +633,7 @@ func stepConfigsForBuild(
 				BaseImage: defaultImageFromReleaseTag(target, config.ReleaseTagConfiguration),
 				To:        intermediateTag,
 			},
-			Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBaseRpm}},
+			Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBaseRpm, Name: alias}},
 		}
 		buildSteps = append(buildSteps, api.StepConfiguration{InputImageTagStepConfiguration: &config})
 		*imageConfigs = append(*imageConfigs, &config)

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -450,7 +450,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 						},
 						To: api.PipelineImageStreamTagReference("name"),
 					},
-					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase}},
+					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase, Name: "name"}},
 				},
 			}},
 		},
@@ -516,7 +516,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 							},
 							To: api.PipelineImageStreamTagReference("name"),
 						},
-						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase}},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBase, Name: "name"}},
 					},
 				},
 				{
@@ -584,7 +584,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 						},
 						To: api.PipelineImageStreamTagReference("name-without-rpms"),
 					},
-					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBaseRpm}},
+					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceBaseRpm, Name: "name"}},
 				},
 			}, {
 				RPMImageInjectionStepConfiguration: &api.RPMImageInjectionStepConfiguration{


### PR DESCRIPTION
Improves [DPTP-1463](https://issues.redhat.com/browse/DPTP-1463)

https://github.com/openshift/ci-tools/pull/1962 added better logging for imported images, but it only logs that an image is a base image, but not under which name does it figure in the ci-op config.

/cc @emilvberglind 