### PR TITLE
add namespace and name in error log when failing to resolve an image

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -42,11 +42,13 @@ func (s *inputImageTagStep) Inputs() (api.InputDefinition, error) {
 		return api.InputDefinition{s.imageName}, nil
 	}
 	from := imagev1.ImageStreamTag{}
+	namespace := s.config.BaseImage.Namespace
+	name := fmt.Sprintf("%s:%s", s.config.BaseImage.Name, s.config.BaseImage.Tag)
 	if err := s.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{
-		Namespace: s.config.BaseImage.Namespace,
-		Name:      fmt.Sprintf("%s:%s", s.config.BaseImage.Name, s.config.BaseImage.Tag),
+		Namespace: namespace,
+		Name:      name,
 	}, &from); err != nil {
-		return nil, fmt.Errorf("could not resolve base image: %w", err)
+		return nil, fmt.Errorf("could not resolve base image from %s/%s: %w", namespace, name, err)
 	}
 
 	if len(s.config.Sources) > 0 {

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -49,11 +49,13 @@ func (s *outputImageTagStep) run(ctx context.Context) error {
 		logrus.Infof("Tagging %s into %s", s.config.From, s.config.To.ISTagName())
 	}
 	from := &imagev1.ImageStreamTag{}
+	namespace := s.jobSpec.Namespace()
+	name := fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From)
 	if err := s.client.Get(ctx, crclient.ObjectKey{
-		Namespace: s.jobSpec.Namespace(),
-		Name:      fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.From),
+		Namespace: namespace,
+		Name:      name,
 	}, from); err != nil {
-		return fmt.Errorf("could not resolve base image: %w", err)
+		return fmt.Errorf("could not resolve base image from %s/%s: %w", namespace, name, err)
 	}
 	desired := s.imageStreamTag(from.Image.Name)
 	ist := &imagev1.ImageStreamTag{


### PR DESCRIPTION
Inspired by https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/18238/rehearse-18238-promote-release-openshift-okd-machine-os-content-e2e-aws-4.8/1397096765055832064

The error log is not clear enough, so the user wasn't able to determine if his env var was resolved or not.

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>