### PR TITLE
set namespace in source unittests to avoid stack traces

### DIFF
--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -354,6 +354,7 @@ func TestBuildFromSource(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			testCase.jobSpec.SetNamespace("test-namespace")
 			actual := buildFromSource(testCase.jobSpec, testCase.fromTag, testCase.toTag, testCase.source, testCase.fromTagDigest, testCase.dockerfilePath, testCase.resources, testCase.pullSecret, testCase.buildArgs)
 			testhelper.CompareWithFixture(t, actual)
 		})

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args__value.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args__value.yaml
@@ -11,6 +11,7 @@ metadata:
     ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: ""
+  namespace: test-namespace
 spec:
   nodeSelector: null
   output:
@@ -30,6 +31,7 @@ spec:
     to:
       kind: ImageStreamTag
       name: 'pipeline:'
+      namespace: test-namespace
   postCommit: {}
   resources: {}
   source:

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args__valueFrom.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args__valueFrom.yaml
@@ -11,6 +11,7 @@ metadata:
     ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
     creates: ""
+  namespace: test-namespace
 spec:
   nodeSelector: null
   output:
@@ -30,6 +31,7 @@ spec:
     to:
       kind: ImageStreamTag
       name: 'pipeline:'
+      namespace: test-namespace
   postCommit: {}
   resources: {}
   source:


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2247

/cc @openshift/openshift-team-developer-productivity-test-platform 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>