### PR TITLE
Vault Secret Collection Manager Edit Members: Allow filtering

### DIFF
--- a/cmd/vault-secret-collection-manager/index.template.html
+++ b/cmd/vault-secret-collection-manager/index.template.html
@@ -45,7 +45,10 @@
           <tbody>
             <tr class="user-edit-table">
               <td class="user-edit-table"><select name="CurrentMembers" id="currentMembersSelection" multiple></select></td>
-              <td class="user-edit-table"><select name="ALlUsers" id="allUsersSelection" multiple></select></td>
+              <td class="user-edit-table">
+                <datalist id="all-members"></datalist>
+                <input list="all-members" id="allUsersInput">
+              </td>
             </tr>
             <tr class="user-edit-table">
               <td class="user-edit-table"><button type="button" id="removeMemberButton" class="blue-button small-button">Remove</button></td>

--- a/cmd/vault-secret-collection-manager/index.ts
+++ b/cmd/vault-secret-collection-manager/index.ts
@@ -29,9 +29,9 @@ function hideModal() {
     currentMembersSelect.removeChild(child);
   }
 
-  const allUsersSelect = document.getElementById('allUsersSelection') as HTMLSelectElement;
-  for (const child of Array.from(allUsersSelect.children)) {
-    allUsersSelect.removeChild(child);
+  const allUsersDataList = document.getElementById('all-members') as HTMLDataListElement;
+  for (const child of Array.from(allUsersDataList.children)) {
+    allUsersDataList.removeChild(child);
   }
 
   // We must detach edit member event handler, as it is scoped to a collection. It is not possible to loop over them,
@@ -65,23 +65,24 @@ function editMembersEventHandler(collection: secretCollection) {
           currentMembersSelect.appendChild(optionWithValue(existingMember));
         }
 
-        let allMembersSelect = document.getElementById('allUsersSelection') as HTMLSelectElement;
+        let allMembersDatalist = document.getElementById('all-members') as HTMLDataListElement;
         for (const user of Array.from(allUsers)) {
           if (collection.members.includes(user)) {
             continue;
           }
-          let newUserOption = document.createElement('option') as HTMLOptionElement;
-          allMembersSelect.appendChild(optionWithValue(user));
+          allMembersDatalist.appendChild(optionWithValue(user));
         }
 
         let removeMemberButton = document.getElementById('removeMemberButton') as HTMLButtonElement;
         removeMemberButton.addEventListener('click', () => {
-          moveSelectedOptions(currentMembersSelect, allMembersSelect);
+          moveSelectedOptions(currentMembersSelect, allMembersDatalist, '');
         });
 
         let addMemberButton = document.getElementById('addMemberButton') as HTMLButtonElement;
         addMemberButton.addEventListener('click', () => {
-          moveSelectedOptions(allMembersSelect, currentMembersSelect);
+          const allUsersInput = document.getElementById('allUsersInput') as HTMLInputElement;
+          moveSelectedOptions(allMembersDatalist, currentMembersSelect, allUsersInput.value);
+          allUsersInput.value = '';
         });
 
         document.getElementById('updateMemberSubmitButton')?.addEventListener('click', () => {
@@ -112,10 +113,10 @@ function editMembersEventHandler(collection: secretCollection) {
   }
 }
 
-function moveSelectedOptions(source: HTMLSelectElement, target: HTMLSelectElement): void {
+function moveSelectedOptions(source: HTMLSelectElement | HTMLDataListElement, target: HTMLSelectElement | HTMLDataListElement, elementName: string): void {
   for (let optionRaw of Array.from(source.children)) {
     let option = optionRaw as HTMLOptionElement;
-    if (!option.selected) {
+    if (!option.selected && (elementName === '' || option.value !== elementName )) {
       continue;
     }
     target.appendChild(option.cloneNode(true));


### PR DESCRIPTION
This changes the secret collection manager to use a datalist for the all
members field instead of a multiselect. This allows ppl to either see
all entries as a suggestion or to just start typing which is useful in
our production case where there are lots of users.
<img width="616" alt="datalist-0" src="https://user-images.githubusercontent.com/6496100/119546421-e7996800-bd61-11eb-9d2e-391f87b72d7d.png">

<img width="596" alt="datalist1" src="https://user-images.githubusercontent.com/6496100/119546433-eb2cef00-bd61-11eb-8a3b-9bd5422d8d90.png">
<img width="572" alt="dl3" src="https://user-images.githubusercontent.com/6496100/119546509-fd0e9200-bd61-11eb-8827-874c09099ccf.png">

Ref https://issues.redhat.com/browse/DPTP-2192
/cc @openshift/openshift-team-developer-productivity-test-platform 
