### PR TITLE
Clean up testimagestreamtagimport CRs after seven days

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler"
 	serviceaccountsecretrefresher "github.com/openshift/ci-tools/pkg/controller/serviceaccount_secret_refresher"
 	testimagesdistributor "github.com/openshift/ci-tools/pkg/controller/test-images-distributor"
+	"github.com/openshift/ci-tools/pkg/controller/testimagestreamimportcleaner"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/util"
@@ -43,6 +44,7 @@ var allControllers = sets.NewString(
 	promotionreconciler.ControllerName,
 	testimagesdistributor.ControllerName,
 	serviceaccountsecretrefresher.ControllerName,
+	testimagestreamimportcleaner.ControllerName,
 )
 
 type options struct {
@@ -398,6 +400,12 @@ func main() {
 			if err := serviceaccountsecretrefresher.AddToManager(clusterName, clusterMgr, opts.serviceAccountSecretRefresherOptions.enabledNamespaces.StringSet(), opts.serviceAccountSecretRefresherOptions.removeOldSecrets); err != nil {
 				logrus.WithError(err).Fatalf("Failed to add the %s controller to the %s cluster", serviceaccountsecretrefresher.ControllerName, clusterName)
 			}
+		}
+	}
+
+	if opts.enabledControllersSet.Has(testimagestreamimportcleaner.ControllerName) {
+		if err := testimagestreamimportcleaner.AddToManager(mgr, allManagers); err != nil {
+			logrus.WithError(err).Fatal("Failed to construct the testimagestreamimportcleaner controller")
 		}
 	}
 

--- a/pkg/controller/testimagestreamimportcleaner/README.md
+++ b/pkg/controller/testimagestreamimportcleaner/README.md
@@ -1,0 +1,6 @@
+# testimagestreamimportcleaner
+
+A simplistic controller that deletes all testimagestreamimport custom resources
+that are older than seven days. Jobs create these to request the `test_images_distributor`
+to import an image. To avoid importing an image indefinitely as soon as it has been used
+once, we need to clean them up.

--- a/pkg/controller/testimagestreamimportcleaner/testimagestreamimportcleaner.go
+++ b/pkg/controller/testimagestreamimportcleaner/testimagestreamimportcleaner.go
@@ -1,0 +1,65 @@
+package testimagestreamimportcleaner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
+)
+
+const ControllerName = "testimagestreamimportcleaner"
+
+func AddToManager(
+	mgr manager.Manager,
+	allManagers map[string]manager.Manager,
+) error {
+	for clusterName, clusterManager := range allManagers {
+		c, err := controller.New(ControllerName+"_"+clusterName, mgr, controller.Options{
+			Reconciler:              &reconciler{client: clusterManager.GetClient(), now: time.Now},
+			MaxConcurrentReconciles: 10,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to construct controller for cluster %s: %w", clusterName, err)
+		}
+		if err := c.Watch(source.NewKindWithCache(&testimagestreamtagimportv1.TestImageStreamTagImport{}, clusterManager.GetCache()), &handler.EnqueueRequestForObject{}); err != nil {
+			return fmt.Errorf("failed to watch testimagestreamtagimports in cluster %s: %w", clusterName, err)
+		}
+		if err := mgr.Add(c); err != nil {
+			return fmt.Errorf("failed to add controller for cluster %s to manager: %w", clusterName, err)
+		}
+	}
+
+	return nil
+}
+
+type reconciler struct {
+	client ctrlruntimeclient.Client
+	now    func() time.Time
+}
+
+const sevenDays = 7 * 24 * time.Hour
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	var tagImport testimagestreamtagimportv1.TestImageStreamTagImport
+	if err := r.client.Get(ctx, req.NamespacedName, &tagImport); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed to get %s: %w", req, err)
+	}
+
+	if age := r.now().Sub(tagImport.CreationTimestamp.Time); age < sevenDays {
+		return reconcile.Result{RequeueAfter: sevenDays - age}, nil
+	}
+
+	return reconcile.Result{}, r.client.Delete(ctx, &tagImport)
+}

--- a/pkg/controller/testimagestreamimportcleaner/testimagestreamimportcleaner_test.go
+++ b/pkg/controller/testimagestreamimportcleaner/testimagestreamimportcleaner_test.go
@@ -1,0 +1,84 @@
+package testimagestreamimportcleaner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	t.Parallel()
+
+	now := time.Time{}.Add(2 * sevenDays)
+	testCases := []struct {
+		name   string
+		client ctrlruntimeclient.Client
+
+		expectReconcileResult reconcile.Result
+		expectImport          bool
+	}{
+		{
+			name:   "Not found is swallowed",
+			client: fakectrlruntimeclient.NewFakeClient(),
+		},
+		{
+			name: "ReconcileAfter is returned for item younger seven days",
+			client: fakectrlruntimeclient.NewFakeClient(&testimagestreamtagimportv1.TestImageStreamTagImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "name",
+					Namespace:         "namespace",
+					CreationTimestamp: metav1.Time{Time: now.Add(-6 * 24 * time.Hour)},
+				},
+			}),
+			expectReconcileResult: reconcile.Result{RequeueAfter: 24 * time.Hour},
+			expectImport:          true,
+		},
+		{
+			name: "Item older seven days gets deleted",
+			client: fakectrlruntimeclient.NewFakeClient(&testimagestreamtagimportv1.TestImageStreamTagImport{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "name",
+					Namespace:         "namespace",
+					CreationTimestamp: metav1.Time{},
+				},
+			}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &reconciler{
+				client: tc.client,
+				now:    func() time.Time { return now },
+			}
+
+			result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "namespace", Name: "name"}})
+			if err != nil {
+				t.Fatalf("reconcile failed: %v", err)
+			}
+			if diff := cmp.Diff(result, tc.expectReconcileResult); diff != "" {
+				t.Errorf("reconcile result differs from expected: %s", diff)
+			}
+
+			var list testimagestreamtagimportv1.TestImageStreamTagImportList
+			if err := r.client.List(context.Background(), &list); err != nil {
+				t.Fatalf("failed to list testimagestreamtagimports: %v", err)
+			}
+			hasImport := len(list.Items) > 0
+
+			if hasImport != tc.expectImport {
+				t.Errorf("expected import to exist: %t, import did exist: %t", tc.expectImport, hasImport)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a small controller that will delete all
testimagestreamtagimport custom resources that are seven days or older
old. This prevents us from importing images indefinitely just because
one test once needed them.

Ref https://issues.redhat.com/browse/DPTP-1640

/cc @openshift/openshift-team-developer-productivity-test-platform 