### PR TITLE
Vault: Retry more to account for temporary down single active replica

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1342,7 +1342,7 @@ Code: 404. Errors:
 				client := vaultClientFromTestItems(tc.items)
 
 				var actualErrorMsg string
-				actual, actualError := constructSecrets(context.TODO(), tc.config, client, 10)
+				actual, actualError := constructSecrets(tc.config, client)
 				if actualError != nil {
 					actualErrorMsg = actualError.Error()
 				}
@@ -2748,7 +2748,6 @@ func TestIntegration(t *testing.T) {
 			vaultAddr := testhelper.Vault(t)
 
 			o := options{
-				maxConcurrency: 1,
 				force:          tc.force,
 				config:         tc.config,
 				secretsGetters: tc.secretGetters,

--- a/pkg/vaultclient/vaultclient_test.go
+++ b/pkg/vaultclient/vaultclient_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -76,7 +78,7 @@ func TestListKVRecursively(t *testing.T) {
 	}
 	expected := []string{"secret/item", "secret/nested/item", "secret/self-managed/mine-alone/my-secret"}
 
-	if diff := cmp.Diff(result, expected); diff != "" {
+	if diff := cmp.Diff(sets.NewString(result...).List(), expected); diff != "" {
 		t.Errorf("actual resutl differs from expected: %v", diff)
 	}
 }


### PR DESCRIPTION
If the active vault replica goes down, the two retries the vault client
does by default are almost never enough. This change increases them to
eight, which made me unable to reproduce the EOF errors we regularly saw
in CI before

Ref https://issues.redhat.com/browse/DPTP-2224
/cc @openshift/openshift-team-developer-productivity-test-platform 