### PR TITLE
DPTP-2243: provide CLI injection for cluster claim tests

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -768,6 +768,9 @@ type LiteralTestStep struct {
 	// Cli is the (optional) name of the release from which the `oc` binary
 	// will be injected into this step.
 	Cli string `json:"cli,omitempty"`
+	// ClusterClaimCLI defines if this step should inject the `oc` binary for
+	// the cluster claimed by this step. Requires test to define a cluster claim.
+	ClusterClaimCLI *bool `json:"cluster_claim_cli,omitempty"`
 	// Observers are the observers that should be running
 	Observers []string `json:"observers,omitempty"`
 	// RunAsScript defines if this step should be executed as a script mounted

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -332,7 +332,7 @@ func stepForTest(
 ) ([]api.Step, error) {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		leases := leasesForTest(test)
-		if len(leases) != 0 {
+		if len(leases) != 0 || c.ClusterClaim != nil {
 			params = api.NewDeferredParameters(params)
 		}
 		step := steps.MultiStageTestStep(*c, config, params, podClient, jobSpec, leases)
@@ -342,6 +342,7 @@ func stepForTest(
 		}
 		if c.ClusterClaim != nil {
 			step = steps.ClusterClaimStep(c.As, c.ClusterClaim, hiveClient, client, jobSpec, step)
+			addProvidesForStep(step, params)
 		}
 		newSteps := stepsForStepImages(client, jobSpec, inputImages, test, imageConfigs)
 		return append([]api.Step{step}, newSteps...), nil

--- a/pkg/steps/cluster_claim_test.go
+++ b/pkg/steps/cluster_claim_test.go
@@ -58,6 +58,9 @@ func aClusterDeployment() *hivev1.ClusterDeployment {
 				},
 			},
 		},
+		Status: hivev1.ClusterDeploymentStatus{
+			CLIImage: &[]string{"quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:725f4165c9a3327bea15daf342adc6542f308be829e66d3b4d43abd9ad2f9bef"}[0],
+		},
 	}
 }
 

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods_Inject_CLI.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods_Inject_CLI.yaml
@@ -1,0 +1,173 @@
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step0
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step0
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: CLI_DIR
+        value: /cli
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /cli
+        name: cli
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    - args:
+      - /usr/bin/oc
+      - /cli
+      command:
+      - /bin/cp
+      image: stable:cli
+      name: inject-cli
+      resources: {}
+      volumeMounts:
+      - mountPath: /cli
+        name: cli
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - emptyDir: {}
+      name: cli
+    - name: test
+      secret:
+        secretName: test
+  status: {}

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods_cluster_claim_with_CLI_injected.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods_cluster_claim_with_CLI_injected.yaml
@@ -1,0 +1,172 @@
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step0
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step0
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /secrets/hive-admin-kubeconfig/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /secrets/hive-admin-password/password
+      - name: CLI_DIR
+        value: /cli
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /secrets/hive-admin-kubeconfig
+        name: ""
+      - mountPath: /secrets/hive-admin-password
+        name: ""
+      - mountPath: /cli
+        name: cli
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret","/secrets/hive-admin-kubeconfig","/secrets/hive-admin-password"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+      - mountPath: /secrets/hive-admin-kubeconfig
+        name: ""
+      - mountPath: /secrets/hive-admin-password
+        name: ""
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    - args:
+      - /usr/bin/oc
+      - /cli
+      command:
+      - /bin/cp
+      image: pullspec
+      name: inject-cli
+      resources: {}
+      volumeMounts:
+      - mountPath: /cli
+        name: cli
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - emptyDir: {}
+      name: cli
+    - name: test
+      secret:
+        secretName: test
+  status: {}

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods_simple.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods_simple.yaml
@@ -1,0 +1,636 @@
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step0
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step0
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step0","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step1
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step1
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: stable:image1
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step1","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step2
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step2
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/var/run/configmaps/ci.openshift.io/multi-stage/step2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: stable-initial:installer
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+      - mountPath: /var/run/configmaps/ci.openshift.io/multi-stage
+        name: commands-script
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step2","dry_run":false},"entries":[{"args":["/var/run/configmaps/ci.openshift.io/multi-stage/step2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+    - configMap:
+        defaultMode: 511
+        name: test-commands
+      name: commands-script
+  status: {}
+- metadata:
+    annotations:
+      ci-operator.openshift.io/container-sub-tests: test
+      ci-operator.openshift.io/save-container-logs: "true"
+      ci.openshift.io/job-spec: ""
+    creationTimestamp: null
+    labels:
+      OPENSHIFT_CI: "true"
+      ci.openshift.io/metadata.branch: base_ref
+      ci.openshift.io/metadata.org: org
+      ci.openshift.io/metadata.repo: repo
+      ci.openshift.io/metadata.step: step3
+      ci.openshift.io/metadata.target: target
+      ci.openshift.io/metadata.variant: variant
+      ci.openshift.io/multi-stage-test: test
+      created-by-ci: "true"
+    name: test-step3
+    namespace: namespace
+  spec:
+    containers:
+    - args:
+      - /tools/entrypoint
+      command:
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      env:
+      - name: BUILD_ID
+        value: build id
+      - name: CI
+        value: "true"
+      - name: JOB_NAME
+        value: job
+      - name: JOB_SPEC
+        value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
+          job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+      - name: JOB_TYPE
+        value: postsubmit
+      - name: OPENSHIFT_CI
+        value: "true"
+      - name: PROW_JOB_ID
+        value: prow job id
+      - name: PULL_BASE_REF
+        value: base ref
+      - name: PULL_BASE_SHA
+        value: base sha
+      - name: PULL_REFS
+        value: base ref:base sha
+      - name: REPO_NAME
+        value: repo
+      - name: REPO_OWNER
+        value: org
+      - name: ENTRYPOINT_OPTIONS
+        value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand3"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      - name: ARTIFACT_DIR
+        value: /logs/artifacts
+      - name: NAMESPACE
+        value: namespace
+      - name: JOB_NAME_SAFE
+        value: test
+      - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: RELEASE_IMAGE_INITIAL
+        value: release:initial
+      - name: RELEASE_IMAGE_LATEST
+        value: release:latest
+      - name: LEASED_RESOURCE
+        value: uuid
+      - name: KUBECONFIG
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBEADMIN_PASSWORD_FILE
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_TYPE
+        value: aws
+      - name: CLUSTER_PROFILE_DIR
+        value: /var/run/secrets/ci.openshift.io/cluster-profile
+      - name: SHARED_DIR
+        value: /var/run/secrets/ci.openshift.io/multi-stage
+      image: pipeline:src
+      name: test
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /tools
+        name: tools
+      - mountPath: /alabama
+        name: home
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+      - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
+        name: cluster-profile
+      - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
+        name: test
+    - command:
+      - /sidecar
+      env:
+      - name: JOB_SPEC
+      - name: SIDECAR_OPTIONS
+        value: '{"gcs_options":{"items":["/logs/artifacts"],"sub_dir":"artifacts/test/step3","dry_run":false},"entries":[{"args":["/bin/bash","-c","#!/bin/bash\nset
+          -eu\ncommand3"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}],"ignore_interrupts":true,"censoring_options":{"secret_directories":["/secret"]}}'
+      image: sidecar
+      name: sidecar
+      resources: {}
+      volumeMounts:
+      - mountPath: /logs
+        name: logs
+      - mountPath: /secret
+        name: secret
+    dnsConfig:
+      nameservers:
+      - nameserver1
+      - nameserver2
+      searches:
+      - my.dns.search1
+      - my.dns.search2
+    dnsPolicy: None
+    initContainers:
+    - args:
+      - /entrypoint
+      - /tools/entrypoint
+      command:
+      - /bin/cp
+      image: entrypoint
+      name: place-entrypoint
+      resources: {}
+      volumeMounts:
+      - mountPath: /tools
+        name: tools
+    - args:
+      - /bin/entrypoint-wrapper
+      - /tmp/entrypoint-wrapper/entrypoint-wrapper
+      command:
+      - cp
+      image: registry.ci.openshift.org/ci/entrypoint-wrapper:latest
+      name: cp-entrypoint-wrapper
+      resources: {}
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
+      - mountPath: /tmp/entrypoint-wrapper
+        name: entrypoint-wrapper
+    restartPolicy: Never
+    serviceAccountName: test
+    terminationGracePeriodSeconds: 18
+    volumes:
+    - emptyDir: {}
+      name: logs
+    - emptyDir: {}
+      name: tools
+    - emptyDir: {}
+      name: home
+    - name: secret
+      secret:
+        secretName: k8-secret
+    - emptyDir: {}
+      name: entrypoint-wrapper
+    - name: cluster-profile
+      secret:
+        secretName: test-cluster-profile
+    - name: test
+      secret:
+        secretName: test
+  status: {}

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -36,7 +36,7 @@ func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo stri
 	validationErrors = append(validationErrors, validateReleaseBuildConfiguration(config, org, repo)...)
 	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage, len(config.Images) > 0)...)
 	releases := sets.NewString()
-	for name := range releases {
+	for name := range config.Releases {
 		releases.Insert(name)
 	}
 	validationErrors = append(validationErrors, validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -494,6 +494,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"                  # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  # Commands is the command(s) that will be run inside the image.\n" +
 	"                  commands: ' '\n" +
 	"                  # Credentials defines the credentials we'll mount into this step.\n" +
@@ -580,6 +583,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"                  # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  # Commands is the command(s) that will be run inside the image.\n" +
 	"                  commands: ' '\n" +
 	"                  # Credentials defines the credentials we'll mount into this step.\n" +
@@ -666,6 +672,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"                  # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  # Commands is the command(s) that will be run inside the image.\n" +
 	"                  commands: ' '\n" +
 	"                  # Credentials defines the credentials we'll mount into this step.\n" +
@@ -828,6 +837,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  commands: ' '\n" +
 	"                  credentials:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -890,6 +900,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  commands: ' '\n" +
 	"                  credentials:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -952,6 +963,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"                  # will be injected into this step.\n" +
 	"                  cli: ' '\n" +
+	"                  cluster_claim_cli: false\n" +
 	"                  commands: ' '\n" +
 	"                  credentials:\n" +
 	"                    # LiteralTestStep is a full test step definition.\n" +
@@ -1184,6 +1196,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"              # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"              cluster_claim_cli: false\n" +
 	"              # Commands is the command(s) that will be run inside the image.\n" +
 	"              commands: ' '\n" +
 	"              # Credentials defines the credentials we'll mount into this step.\n" +
@@ -1270,6 +1285,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"              # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"              cluster_claim_cli: false\n" +
 	"              # Commands is the command(s) that will be run inside the image.\n" +
 	"              commands: ' '\n" +
 	"              # Credentials defines the credentials we'll mount into this step.\n" +
@@ -1356,6 +1374,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              # ClusterClaimCLI defines if this step should inject the `oc` binary for\n" +
+	"              # the cluster claimed by this step. Requires test to define a cluster claim.\n" +
+	"              cluster_claim_cli: false\n" +
 	"              # Commands is the command(s) that will be run inside the image.\n" +
 	"              commands: ' '\n" +
 	"              # Credentials defines the credentials we'll mount into this step.\n" +
@@ -1518,6 +1539,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              cluster_claim_cli: false\n" +
 	"              commands: ' '\n" +
 	"              credentials:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -1580,6 +1602,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              cluster_claim_cli: false\n" +
 	"              commands: ' '\n" +
 	"              credentials:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +
@@ -1642,6 +1665,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              # Cli is the (optional) name of the release from which the `oc` binary\n" +
 	"              # will be injected into this step.\n" +
 	"              cli: ' '\n" +
+	"              cluster_claim_cli: false\n" +
 	"              commands: ' '\n" +
 	"              credentials:\n" +
 	"                # LiteralTestStep is a full test step definition.\n" +

--- a/test/e2e/multi-stage/cluster-claim.yaml
+++ b/test/e2e/multi-stage/cluster-claim.yaml
@@ -1,8 +1,8 @@
 base_images:
-  cli:
-    name: "4.8"
-    namespace: ocp
-    tag: cli
+  base:
+    name: centos
+    namespace: ci
+    tag: "8"
 resources:
   '*':
     limits:
@@ -20,12 +20,13 @@ tests:
       version: "4.7"
     steps:
       test:
-        - as: claim-step
+        - as: claim-step-with-cli
           commands: |
             set -x
             cmp "${KUBECONFIG}" /secrets/hive-admin-kubeconfig/kubeconfig
             oc config view
-          from: cli
+          from: base
+          cluster_claim_cli: true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
This PR adds a new field to multistage test steps to allow injecting the
CLI for tests using cluster claims. It also adds extra config validation
and unit tests for both the new and existing CLI injection support.