### PR TITLE
Testimagestreamtagimport: Replace colons in label values

### DIFF
--- a/pkg/api/testimagestreamtagimport/v1/types.go
+++ b/pkg/api/testimagestreamtagimport/v1/types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/steps/utils"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -25,8 +27,8 @@ func (t *TestImageStreamTagImport) SetDeterministicName() {
 }
 
 const (
-	LabelKeyImageStreamNamespace = "imagestream-namespace"
-	LabelKeyImageStreamName      = "imagestream-name"
+	LabelKeyImageStreamTagNamespace = "imagestreamtag-namespace"
+	LabelKeyImageStreamTagName      = "imagestreamtag-name"
 )
 
 // WithImageStreamLabels sets namespace and name labels so we can easily
@@ -35,9 +37,19 @@ func (t *TestImageStreamTagImport) WithImageStreamLabels() *TestImageStreamTagIm
 	if t.Labels == nil {
 		t.Labels = map[string]string{}
 	}
-	t.Labels[LabelKeyImageStreamNamespace] = t.Spec.Namespace
-	t.Labels[LabelKeyImageStreamName] = t.Spec.Name
+	for k, v := range LabelsForImageStreamTag(t.Spec.Namespace, t.Spec.Name) {
+		t.Labels[k] = v
+	}
 	return t
+}
+
+// LabelsForImageStreamTag returns the labels by which testimagestreamtagimports
+// for a given imagestreamtag can be selected.
+func LabelsForImageStreamTag(namespace, name string) map[string]string {
+	return utils.SanitizeLabels(map[string]string{
+		LabelKeyImageStreamTagNamespace: namespace,
+		LabelKeyImageStreamTagName:      name,
+	})
 }
 
 type TestImageStreamTagImportSpec struct {

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -496,10 +496,7 @@ func testInputImageStreamTagFilterFactory(
 		// Because we don't know for which cluster the request is, this results in
 		// us importing it into all clusters which is an acceptable trade-off.
 		imports := &testimagestreamtagimportv1.TestImageStreamTagImportList{}
-		labels := ctrlruntimeclient.MatchingLabels{
-			testimagestreamtagimportv1.LabelKeyImageStreamNamespace: nn.Namespace,
-			testimagestreamtagimportv1.LabelKeyImageStreamName:      nn.Name,
-		}
+		labels := ctrlruntimeclient.MatchingLabels(testimagestreamtagimportv1.LabelsForImageStreamTag(nn.Namespace, nn.Name))
 		for _, client := range buildClusterClients {
 			if err := client.List(context.TODO(), imports, labels); err != nil {
 				l.WithError(err).Error("Failed to list testimagestreamtagimport")

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -726,7 +726,7 @@ func TestTestInputImageStreamTagFilterFactory(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name: "imagestreamtag is referenced by imagestreatag import",
+			name: "imagestreamtag is referenced by imagestreamtag import",
 			client: fakeclient.NewFakeClient((&testimagestreamtagimportv1.TestImageStreamTagImport{Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{
 				Namespace: namespace,
 				Name:      streamName + ":" + tagName,

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -34,6 +34,12 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
+func init() {
+	if err := imageapi.AddToScheme(scheme.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to register imagev1 scheme: %v", err))
+	}
+}
+
 func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration {
 	cfg.ClonerefsImage = api.ImageStreamTagReference{Namespace: "ci", Name: "managed-clonerefs", Tag: "latest"}
 	cfg.ClonerefsPath = "/clonerefs"
@@ -797,8 +803,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Namespace: "ci",
 						Name:      importName + "-" + importTag,
 						Labels: map[string]string{
-							"imagestream-namespace": importNS,
-							"imagestream-name":      importName + ":" + importTag,
+							"imagestreamtag-namespace": importNS,
+							"imagestreamtag-name":      importName + "_" + importTag,
 						},
 					},
 					Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{


### PR DESCRIPTION
Label values can not contain colons, thus the testimagestreamtagimport
creation currenty always fails.

Ref https://issues.redhat.com/browse/DPTP-1640

Sample where this failed due to the colons: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1400066650719391744#1:build-log.txt%3A12