### PR TITLE
Determinize Prow config: Fix dir for additional plugin configs

### DIFF
--- a/cmd/determinize-prow-config/main.go
+++ b/cmd/determinize-prow-config/main.go
@@ -192,7 +192,7 @@ func deduplicateTideQueries(queries prowconfig.TideQueries) (prowconfig.TideQuer
 func updatePluginConfig(configDir, shardingBaseDir string) error {
 	configPath := path.Join(configDir, config.PluginConfigFile)
 	agent := plugins.ConfigAgent{}
-	if err := agent.Load(configPath, []string{filepath.Dir(config.PluginConfigFile)}, "_pluginconfig.yaml", false); err != nil {
+	if err := agent.Load(configPath, []string{filepath.Dir(configPath)}, "_pluginconfig.yaml", false); err != nil {
 		return fmt.Errorf("could not load Prow plugin configuration: %w", err)
 	}
 	cfg := agent.Config()


### PR DESCRIPTION
Before this change, we looked at`filepath.Dir(config.PluginConfigFile)`
for additional plugin configs. Since `config.PluginConfigFile` is just a
filename, this resolves to `.` which is wrong (but happens to include
the correct files, as they are in a subdir) and always fails in Docker
with an error like `failed to walk .: lstat proc/1/fd/6: no such file or directory"`.

This changes it to correctly look at the dir of the entire plugin config
file path instead, which fixes above error.

Noticed in https://coreos.slack.com/archives/CBN38N3MW/p1622664617007600