### PR TITLE
CI-Operator-Yaml-Creator: Set build_root.from_repository if config is current

### DIFF
--- a/cmd/ci-operator-yaml-creator/README.md
+++ b/cmd/ci-operator-yaml-creator/README.md
@@ -3,3 +3,5 @@
 A small tool that will create a PullRequest with a `.ci-operator.yaml` file for the `main`/`master` branch of all repositories
 that are built by ART, don't have `build_root_image.from_repository: true` and where there is currently no `.ci-operator.yaml`
 file matching the `build_root` configured in openshift/release.
+
+If the `.ci-operator.yaml` is already up-to-date, it will set `build_root.from_repository: true`


### PR DESCRIPTION
This change makes the CI-Operator-Yaml-Creator also update the release
repo config if the .ci-operator.yaml is already current. I initially
planned to write a second tool for this but realized it is much easier
to just add it here.

Ref https://issues.redhat.com/browse/DPTP-2245

/assign @jupierce 

Is this intended to be run as an one-off btw or should it run periodically?