### PR TITLE
[autoconfigbrancher] Increase max-concurrency to 10 in ci-operator-yaml-creator step

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -145,7 +145,7 @@ func main() {
 			// their config to set .build_root.from_repository: true
 			command: "/usr/bin/ci-operator-yaml-creator",
 			arguments: []string{
-				"--max-concurrency", "1",
+				"--max-concurrency", "10",
 				"--github-token-path", "/etc/github/oauth",
 				"--github-endpoint", "http://ghproxy",
 				"--ci-operator-config-dir=ci-operator/config",


### PR DESCRIPTION
Fixes https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-config-brancher/1402943846769233920#1:build-log.txt%3A33

I don't know why, but increasing the max-concurrency solves the issue. My guess is that there is some bug in semaphore library maybe?

/cc @openshift/openshift-team-developer-productivity-test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>