### PR TITLE
Revert "Use filepath.WalkDir instead of filepath.Walk"

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -11,7 +11,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -1392,7 +1391,7 @@ func (o *options) writeMetadataJSON() error {
 func (o *options) findCustomMetadataFile(artifactDir string) (customProwMetadataFile string, err error) {
 	// Try to find the custom prow metadata file. We assume that there's only one. If there's more than one,
 	// we'll just use the first one that we find.
-	err = filepath.WalkDir(artifactDir, func(path string, info fs.DirEntry, err error) error {
+	err = filepath.Walk(artifactDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}

--- a/cmd/generate-registry-metadata/main.go
+++ b/cmd/generate-registry-metadata/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"log"
 	"os"
@@ -47,7 +46,7 @@ func gatherOptions() (options, error) {
 
 func generateMetadata(registryPath string) (api.RegistryMetadata, error) {
 	metadata := make(map[string]api.RegistryInfo)
-	if err := filepath.WalkDir(registryPath, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(registryPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/ldap-users-from-github-owners-files/main.go
+++ b/cmd/ldap-users-from-github-owners-files/main.go
@@ -61,7 +61,7 @@ func getAllSecretUsers(repoBaseDir, repoSubDir string, mapping map[string]string
 	var errs []error
 	l := sync.Mutex{}
 	wg := sync.WaitGroup{}
-	_ = filepath.WalkDir(repoBaseDir+"/"+repoSubDir, func(path string, info fs.DirEntry, err error) error {
+	_ = filepath.Walk(repoBaseDir+"/"+repoSubDir, func(path string, info fs.FileInfo, err error) error {
 		if filepath.Base(path) != "OWNERS" {
 			return nil
 		}

--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -303,7 +302,7 @@ func dispatchJobs(ctx context.Context, prowJobConfigDir string, maxConcurrency i
 		close(readingDone)
 	}()
 
-	if err := filepath.WalkDir(prowJobConfigDir, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(prowJobConfigDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			objChan <- fmt.Errorf("failed to walk file/directory '%s'", path)
 			return nil

--- a/cmd/release-job-migrator/main.go
+++ b/cmd/release-job-migrator/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -379,7 +378,7 @@ func updateBaseImages(newImages, ciOpImages, replacementImages map[string]api.Im
 func run(o options) error {
 	// key: filename
 	jobs := make(map[string]prowconfig.JobConfig)
-	if err := filepath.WalkDir(o.jobDir, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(o.jobDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -585,7 +584,7 @@ func run(o options) error {
 	}
 
 	// update release-controller configs
-	if err := filepath.WalkDir(o.rcConfigDir, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(o.rcConfigDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/cmd/sanitize-prow-jobs/main.go
+++ b/cmd/sanitize-prow-jobs/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func determinizeJobs(prowJobConfigDir string, config *dispatcher.Config) error {
 	}()
 
 	wg := sync.WaitGroup{}
-	if err := filepath.WalkDir(prowJobConfigDir, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(prowJobConfigDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			errChan <- fmt.Errorf("failed to walk file/directory '%s'", path)
 			return nil

--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"math"
 	"os"
@@ -209,7 +208,7 @@ func main() {
 
 	// find the default type for jobs referenced by the release controllers
 	configuredJobs := make(map[string]string)
-	if err := filepath.WalkDir(o.releaseConfigDir, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(o.releaseConfigDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -327,7 +327,7 @@ func gatherAllOCPImageConfigs(ocpBuildDataDir string, majorMinor MajorMinor) (ma
 	errGroup := &errgroup.Group{}
 
 	path := filepath.Join(ocpBuildDataDir, "images")
-	if err := filepath.WalkDir(path, func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path"
@@ -111,7 +110,7 @@ func (i *Info) LogFields() logrus.Fields {
 	}
 }
 
-func isConfigFile(path string, info fs.DirEntry) bool {
+func isConfigFile(path string, info os.FileInfo) bool {
 	extension := filepath.Ext(path)
 	return !info.IsDir() && (extension == ".yaml" || extension == ".yml")
 }
@@ -143,7 +142,7 @@ func OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi
 }
 
 func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *Info) error) error {
-	return filepath.WalkDir(filepath.Join(configDir, subDir), func(path string, info fs.DirEntry, err error) error {
+	return filepath.Walk(filepath.Join(configDir, subDir), func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			logrus.WithField("source-file", path).WithError(err).Error("Failed to walk CI Operator configuration dir")
 			return err

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -2,7 +2,6 @@ package jobconfig
 
 import (
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -119,7 +118,7 @@ func OperateOnJobConfigDir(configDir string, callback func(*prowconfig.JobConfig
 }
 
 func OperateOnJobConfigSubdir(configDir, subDir string, callback func(*prowconfig.JobConfig, *Info) error) error {
-	if err := filepath.WalkDir(filepath.Join(configDir, subDir), func(path string, info fs.DirEntry, err error) error {
+	if err := filepath.Walk(filepath.Join(configDir, subDir), func(path string, info os.FileInfo, err error) error {
 		logger := logrus.WithField("source-file", path)
 		if err != nil {
 			logger.WithError(err).Error("Failed to walk file/directory")

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -83,7 +82,7 @@ func fromPath(path string) (filenameToConfig, error) {
 	lock := &sync.Mutex{}
 	errGroup := &errgroup.Group{}
 
-	err := filepath.WalkDir(path, func(path string, info fs.DirEntry, err error) error {
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		if info == nil || err != nil {
 			// file may not exist due to race condition between the reload and k8s removing deleted/moved symlinks in a confimap directory; ignore it
 			if os.IsNotExist(err) {
@@ -275,7 +274,7 @@ func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainB
 	observers := registry.ObserverByName{}
 	documentation := map[string]string{}
 	metadata := api.RegistryMetadata{}
-	err := filepath.WalkDir(root, func(path string, info fs.DirEntry, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if info != nil && strings.HasPrefix(info.Name(), "..") {
 			if info.IsDir() {
 				return filepath.SkipDir

--- a/pkg/rehearse/configmaps.go
+++ b/pkg/rehearse/configmaps.go
@@ -3,7 +3,7 @@ package rehearse
 import (
 	"context"
 	"fmt"
-	"io/fs"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -143,7 +143,7 @@ func (c *CMManager) createCM(name string, data []updateconfig.ConfigMapUpdate) e
 
 func genChanges(root string, patterns sets.String) ([]prowgithub.PullRequestChange, error) {
 	var ret []prowgithub.PullRequestChange
-	err := filepath.WalkDir(root, func(path string, info fs.DirEntry, err error) error {
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil || info.IsDir() {
 			return err
 		}


### PR DESCRIPTION
Reverts openshift/ci-tools#2036

Fixes: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-config-brancher/1402943846769233920#1:build-log.txt%3A33

