### PR TITLE
Use the same arg in ci-operator-yaml-creator

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -147,7 +147,7 @@ func main() {
 			arguments: []string{
 				"--github-token-path", "/etc/github/oauth",
 				"--github-endpoint", "http://ghproxy",
-				"--ci-operator-config-dir=ci-operator/config",
+				"--ci-operator-config-dir=./ci-operator/config",
 				// Only update o/release
 				"--create-prs=false",
 			},


### PR DESCRIPTION
One thing looks special `the ci-operator-yaml-creator` is path, comparing to prowgen and other tools.

/cc @openshift/openshift-team-developer-productivity-test-platform 