### PR TITLE
Misc updates to the pod-scaler

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -185,8 +185,14 @@ func mainProduce(opts *options, cache cache) {
 		if err != nil {
 			logger.WithError(err).Fatal("Failed to get Prometheus route.")
 		}
+		var addr string
+		if route.Spec.TLS != nil {
+			addr = "https://" + route.Spec.Host
+		} else {
+			addr = "http://" + route.Spec.Host
+		}
 		promClient, err := prometheusclient.NewClient(prometheusclient.Config{
-			Address:      "https://" + route.Spec.Host,
+			Address:      addr,
 			RoundTripper: transport.NewBearerAuthRoundTripper(config.BearerToken, prometheusclient.DefaultRoundTripper),
 		})
 		if err != nil {

--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/openhistogram/circonusllhist"
 	prometheusapi "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
@@ -78,7 +77,7 @@ func produce(clients map[string]prometheusapi.API, dataCache cache) {
 			query := query
 			logger := logrus.WithField("metric", name)
 			cache, err := loadCache(dataCache, name, logger)
-			if errors.Is(err, storage.ErrObjectNotExist) {
+			if errors.Is(err, notExist{}) {
 				ranges := map[string][]TimeRange{}
 				for cluster := range clients {
 					ranges[cluster] = []TimeRange{}

--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -90,7 +90,7 @@ func produce(clients map[string]prometheusapi.API, dataCache cache) {
 				}
 			} else if err != nil {
 				logrus.WithError(err).Error("Failed to load data from storage.")
-				return
+				continue
 			}
 			now := time.Now()
 			q := querier{
@@ -124,12 +124,10 @@ func produce(clients map[string]prometheusapi.API, dataCache cache) {
 					}
 				}()
 			}
-			go func() { // don't associate this with the context as we want to flush when interrupted
-				wg.Wait()
-				if err := storeCache(dataCache, name, cache, logger); err != nil {
-					logger.WithError(err).Error("Failed to write cached data.")
-				}
-			}()
+			wg.Wait()
+			if err := storeCache(dataCache, name, cache, logger); err != nil {
+				logger.WithError(err).Error("Failed to write cached data.")
+			}
 		}
 	}, 3*time.Hour)
 }

--- a/cmd/pod-scaler/storage.go
+++ b/cmd/pod-scaler/storage.go
@@ -85,7 +85,11 @@ func (l *localCache) load(_ context.Context, name string) (io.ReadCloser, error)
 }
 
 func (l *localCache) store(_ context.Context, name string) (io.WriteCloser, error) {
-	return os.Create(path.Join(l.dir, name))
+	cachePath := path.Join(l.dir, name)
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0777); err != nil {
+		return nil, err
+	}
+	return os.Create(cachePath)
 }
 
 func (l *localCache) lastUpdated(_ context.Context, name string) (time.Time, error) {

--- a/cmd/pod-scaler/storage.go
+++ b/cmd/pod-scaler/storage.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -48,7 +49,11 @@ var _ cache = &bucketCache{}
 
 func (b *bucketCache) load(ctx context.Context, name string) (io.ReadCloser, error) {
 	handle := b.bucket.Object(name)
-	return handle.NewReader(ctx)
+	rc, err := handle.NewReader(ctx)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		err = notExist{wrapped: err}
+	}
+	return rc, err
 }
 
 func (b *bucketCache) store(ctx context.Context, name string) (io.WriteCloser, error) {
@@ -72,7 +77,11 @@ type localCache struct {
 var _ cache = &localCache{}
 
 func (l *localCache) load(_ context.Context, name string) (io.ReadCloser, error) {
-	return os.Open(path.Join(l.dir, name))
+	rc, err := os.Open(path.Join(l.dir, name))
+	if os.IsNotExist(err) {
+		err = notExist{wrapped: err}
+	}
+	return rc, err
 }
 
 func (l *localCache) store(_ context.Context, name string) (io.WriteCloser, error) {
@@ -85,6 +94,24 @@ func (l *localCache) lastUpdated(_ context.Context, name string) (time.Time, err
 		return time.Time{}, fmt.Errorf("could not query cache for attributes: %w", err)
 	}
 	return info.ModTime(), nil
+}
+
+// notExist closes over the different ways in which storage libraries may expose a nonexistent file
+type notExist struct {
+	wrapped error
+}
+
+func (e notExist) Error() string {
+	return e.wrapped.Error()
+}
+
+func (e notExist) Is(err error) bool {
+	_, ok := err.(notExist)
+	return ok // we don't care what we're wrapping, all notExist are equivalent
+}
+
+func (e notExist) Unwrap() error {
+	return e.wrapped
 }
 
 // loadCache loads cached query data from the given storage loader.
@@ -119,7 +146,7 @@ func loadFrom(loader loader, metricName string) ([]byte, error) {
 	defer func() { cancel() }()
 	reader, err := loader.load(ctx, metricName+".json")
 	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
-		return nil, fmt.Errorf("could not read cached data: %w", err)
+		return nil, err
 	}
 	data, readErr := ioutil.ReadAll(reader)
 	if err := reader.Close(); err != nil {


### PR DESCRIPTION
pod-scaler: support http for prometheus

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

pod-scaler: close over different not exists errors

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

pod-scaler: create directory for cache when necessary

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

pod-scaler: query serially

We don't *need* to send off all of our requests all at once to every
single build farm at the same time, since we have no real requirement to
have the most up-to-date data at any point. In that vein, if we query
sequentially we can reduce the overall memory footprint of the producer
by only loading one dataset into memory at once.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 
