### PR TITLE
ci-operator: propagate contexts as necessary

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -418,7 +418,7 @@ func (s *multiStageTestStep) runSteps(
 					errs = append(errs, fmt.Errorf("failed to delete pod %s with label %s=%s: %w", pod.Name, MultiStageTestLabel, s.name, err))
 					continue
 				}
-				if err := waitForPodDeletion(s.client, s.jobSpec.Namespace(), pod.Name, pod.UID); err != nil {
+				if err := waitForPodDeletion(cleanupCtx, s.client, s.jobSpec.Namespace(), pod.Name, pod.UID); err != nil {
 					errs = append(errs, fmt.Errorf("failed waiting for pod %s with label %s=%s to be deleted: %w", pod.Name, MultiStageTestLabel, s.name, err))
 					continue
 				}
@@ -828,7 +828,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	start := time.Now()
 	logrus.Infof("Running step %s.", pod.Name)
 	client := s.client.WithNewLoggingClient()
-	if _, err := createOrRestartPod(client, pod); err != nil {
+	if _, err := createOrRestartPod(ctx, client, pod); err != nil {
 		return fmt.Errorf("failed to create or restart %s pod: %w", pod.Name, err)
 	}
 	newPod, err := waitForPodCompletion(ctx, client, pod.Namespace, pod.Name, notifier, false)

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -106,7 +106,7 @@ func (s *podStep) run(ctx context.Context) error {
 		}
 	}()
 
-	pod, err = createOrRestartPod(s.client, pod)
+	pod, err = createOrRestartPod(ctx, s.client, pod)
 	if err != nil {
 		return fmt.Errorf("failed to create or restart %s pod: %w", s.name, err)
 	}
@@ -355,7 +355,7 @@ func getSecretVolumeMountFromSecret(secretMountPath string, secretIndex int) []c
 // This pod will not be able to gather artifacts, nor will it report log messages
 // unless it fails.
 func RunPod(ctx context.Context, podClient PodClient, pod *coreapi.Pod) (*coreapi.Pod, error) {
-	pod, err := createOrRestartPod(podClient, pod)
+	pod, err := createOrRestartPod(ctx, podClient, pod)
 	if err != nil {
 		return pod, err
 	}


### PR DESCRIPTION
It is not clear why these were never propagated in the first place. We
use the central context in normal flows and the cleanup context in
post-interrupt code.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 