### PR TITLE
pod-scaler: misc flag improvements

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -45,8 +45,8 @@ type options struct {
 }
 
 type producerOptions struct {
-	kubeconfig string
-
+	kubeconfig   string
+	once         bool
 	ignoreLatest time.Duration
 }
 
@@ -63,6 +63,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&o.mode, "mode", "", "Which mode to run in.")
 	fs.StringVar(&o.kubeconfig, "kubeconfig", "", "Path to a ~/.kube/config to use for querying Prometheuses. Each context will be considered a cluster to query.")
 	fs.DurationVar(&o.ignoreLatest, "ignore-latest", 0, "Duration of latest time series to ignore when querying Prometheus. For instance, 1h will ignore the latest hour of data.")
+	fs.BoolVar(&o.once, "produce-once", false, "Query Prometheus and refresh cached data only once before exiting.")
 	fs.IntVar(&o.port, "port", 0, "Port to serve admission webhooks on.")
 	fs.IntVar(&o.uiPort, "ui-port", 0, "Port to serve frontend on.")
 	fs.StringVar(&o.certDir, "serving-cert-dir", "", "Path to directory with serving certificate and key for the admission webhook server.")
@@ -205,7 +206,7 @@ func mainProduce(opts *options, cache cache) {
 		logger.Debugf("Loaded Prometheus client.")
 	}
 
-	go produce(clients, cache, opts.ignoreLatest)
+	go produce(clients, cache, opts.ignoreLatest, opts.once)
 }
 
 func mainAdmission(opts *options) {

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -46,6 +46,8 @@ type options struct {
 
 type producerOptions struct {
 	kubeconfig string
+
+	ignoreLatest time.Duration
 }
 
 type consumerOptions struct {
@@ -60,6 +62,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	o.instrumentationOptions.AddFlags(fs)
 	fs.StringVar(&o.mode, "mode", "", "Which mode to run in.")
 	fs.StringVar(&o.kubeconfig, "kubeconfig", "", "Path to a ~/.kube/config to use for querying Prometheuses. Each context will be considered a cluster to query.")
+	fs.DurationVar(&o.ignoreLatest, "ignore-latest", 0, "Duration of latest time series to ignore when querying Prometheus. For instance, 1h will ignore the latest hour of data.")
 	fs.IntVar(&o.port, "port", 0, "Port to serve admission webhooks on.")
 	fs.IntVar(&o.uiPort, "ui-port", 0, "Port to serve frontend on.")
 	fs.StringVar(&o.certDir, "serving-cert-dir", "", "Path to directory with serving certificate and key for the admission webhook server.")
@@ -202,7 +205,7 @@ func mainProduce(opts *options, cache cache) {
 		logger.Debugf("Loaded Prometheus client.")
 	}
 
-	go produce(clients, cache)
+	go produce(clients, cache, opts.ignoreLatest)
 }
 
 func mainAdmission(opts *options) {


### PR DESCRIPTION
pod-scaler: allow bounding query upper time limit

With --ignore-latest <duration> the pod scaler can now ignore the latest
<duration> of data from Prometheus. This may be useful in production to
not read data from tests still in progress, but is more useful in tests
to configure which data should be read in any one execution.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

pod-scaler: allow producing just once

Running through all the queries and writing out the cached data just
once instead of on an interval is useful in testing.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @openshift/openshift-team-developer-productivity-test-platform 