### PR TITLE
ci-operator: log multi-line together

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -253,11 +253,7 @@ func main() {
 			message.WriteString(fmt.Sprintf("\n  * %s", err.Error()))
 		}
 		logrus.Error("Some steps failed:")
-		for _, line := range strings.Split(message.String(), "\n") {
-			if strings.TrimSpace(line) != "" {
-				logrus.Error(line)
-			}
-		}
+		logrus.Error(message.String())
 		opt.Report(defaulted...)
 		os.Exit(1)
 	}

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -798,11 +798,11 @@ func podLogNewFailedContainers(podClient PodClient, pod *coreapi.Pod, completed 
 			if _, err := io.Copy(logs, s); err != nil {
 				logrus.WithError(err).Warnf("Unable to copy log output from failed pod container %s.", status.Name)
 			}
-			s.Close()
-			logrus.Infof("Logs for container %s in pod %s:", status.Name, pod.Name)
-			for _, line := range strings.Split(logs.String(), "\n") {
-				logrus.Info(line)
+			if err := s.Close(); err != nil {
+				logrus.WithError(err).Warnf("Unable to close log output from failed pod container %s.", status.Name)
 			}
+			logrus.Infof("Logs for container %s in pod %s:", status.Name, pod.Name)
+			logrus.Info(logs.String())
 		} else {
 			logrus.WithError(err).Warnf("error: Unable to retrieve logs from failed pod container %s.", status.Name)
 		}


### PR DESCRIPTION
Originally, multi-line errors were expanded to allow for readable output
when using JSON-formatted logs. However, we've since changed to use more
human-friendly formatting anyway, so we don't need to split this
manually any longer. By splitting, we made it impossible for the censor
to work on ci-operator output.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 