### PR TITLE
Optimize the sanitize tool

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -291,7 +291,7 @@ func dispatchJobs(ctx context.Context, prowJobConfigDir string, maxConcurrency i
 			switch o := o.(type) {
 			case configResult:
 				if !config.MatchingPathRegEx(o.path) {
-					results[o.cluster] = append(results[o.cluster], fmt.Sprintf(".*/%s$", o.filename))
+					results[o.cluster] = append(results[o.cluster], o.filename)
 				}
 			case error:
 				errs = append(errs, o)
@@ -358,7 +358,7 @@ func dispatchJobs(ctx context.Context, prowJobConfigDir string, maxConcurrency i
 
 	for cloudProvider, jobGroups := range config.BuildFarm {
 		for cluster := range jobGroups {
-			config.BuildFarm[cloudProvider][cluster] = dispatcher.Group{Paths: results[string(cluster)]}
+			config.BuildFarm[cloudProvider][cluster] = dispatcher.Filenames{FilenamesRaw: results[string(cluster)]}
 		}
 	}
 

--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 var (
 	c = dispatcher.Config{
 		Default: "api.ci",
-		BuildFarm: map[dispatcher.CloudProvider]dispatcher.JobGroups{
+		BuildFarm: map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames{
 			dispatcher.CloudAWS: {
 				api.ClusterBuild01: {},
 			},
@@ -143,7 +143,7 @@ func TestDispatchJobs(t *testing.T) {
 		config            *dispatcher.Config
 		jobVolumes        map[string]float64
 		expected          error
-		expectedBuildFarm map[dispatcher.CloudProvider]dispatcher.JobGroups
+		expectedBuildFarm map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames
 	}{
 		{
 			name:     "nil config",
@@ -159,9 +159,9 @@ func TestDispatchJobs(t *testing.T) {
 				"pull-ci-openshift-ci-tools-master-e2e":               12,
 				"pull-ci-openshift-cluster-etcd-operator-master-unit": 6,
 			},
-			expectedBuildFarm: map[dispatcher.CloudProvider]dispatcher.JobGroups{
-				"aws": {"build01": {Paths: []string{".*/ci-tools-presubmits.yaml$"}}},
-				"gcp": {"build02": {Paths: []string{".*/cluster-api-provider-gcp-presubmits.yaml$", ".*/cluster-etcd-operator-master-presubmits.yaml$", ".*/wildfly-operator-presubmits.yaml$"}}},
+			expectedBuildFarm: map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames{
+				"aws": {"build01": {FilenamesRaw: []string{"ci-tools-presubmits.yaml"}}},
+				"gcp": {"build02": {FilenamesRaw: []string{"cluster-api-provider-gcp-presubmits.yaml", "cluster-etcd-operator-master-presubmits.yaml", "wildfly-operator-presubmits.yaml"}}},
 			},
 		},
 	}

--- a/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
+++ b/pkg/dispatcher/testdata/TestLoadConfig/good_config_with_build_farm_with_jobs.yaml
@@ -24,7 +24,7 @@ groups:
 buildFarm:
   aws:
     build01:
-      paths:
-        - ".*some-build-farm-presubmits.yaml$"
+      filenames:
+        - "some-build-farm-presubmits.yaml"
   gcp: 
     build02: {}


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1623442582036900
TL;TR

The sanitize tool is slow because for each file (we have lots of them), we have to match the regex under `build_farm` in the config file. We do not need the regex match feature at all there. So we replace them with `sets.String.has()`.

This is a breaking change. We need a PR on the config file in release repo too.

Before the PR,
```console
time sanitize-prow-jobs --prow-jobs-dir ./ci-operator/jobs --config-path ./core-services/sanitize-prow-jobs/_config.yaml
sanitize-prow-jobs --prow-jobs-dir ./ci-operator/jobs --config-path   856.36s user 10.49s system 964% cpu 1:29.89 total
```

After,
```console
$ time sanitize-prow-jobs --prow-jobs-dir ./ci-operator/jobs --config-path ./core-services/sanitize-prow-jobs/_config.yaml
sanitize-prow-jobs --prow-jobs-dir ./ci-operator/jobs --config-path   31.00s user 4.33s system 878% cpu 4.024 total
```

/hold

/cc @stevekuznetsov 
