### PR TITLE
ci-operator: pre-censor fields before encoding output

### DIFF
--- a/pkg/api/env.go
+++ b/pkg/api/env.go
@@ -19,6 +19,14 @@ func Artifacts() (string, bool) {
 
 // SaveArtifact saves the data under the path relative to the artifact directory.
 // If no artifact directory is set, we no-op.
+// A note on censoring: SaveArtifact will ensure that the raw data being written
+// to an artifact file is censored, but care must be taken by the callers of this
+// utility to pre-censor fields that get materially changed or reformatted during
+// encoding. For example, if a secret value contains newlines or quotes, then is
+// used as a field in a JSON or XML representation, when the value is encoded into
+// the `data []byte` that's passed here, censoring the raw bytes will not be sufficient
+// as they will be materially different from the actual secret value. (A literal
+// newline in the raw secret will be an escaped `\n` in the encoded bytes.)
 func SaveArtifact(censor secretutil.Censorer, relPath string, data []byte) error {
 	artifactDir, set := os.LookupEnv(prowArtifactsEnv)
 	if !set {

--- a/pkg/junit/censor.go
+++ b/pkg/junit/censor.go
@@ -1,0 +1,36 @@
+package junit
+
+import "k8s.io/test-infra/prow/secretutil"
+
+// CensorTestSuite censors secret data in user-provided fields of a jUnit test suite.
+func CensorTestSuite(censor secretutil.Censorer, testSuite *TestSuite) {
+	if testSuite == nil {
+		return
+	}
+	testSuite.Name = censored(censor, testSuite.Name)
+	for i := range testSuite.Properties {
+		testSuite.Properties[i].Name = censored(censor, testSuite.Properties[i].Name)
+		testSuite.Properties[i].Value = censored(censor, testSuite.Properties[i].Value)
+	}
+	for i := range testSuite.TestCases {
+		testSuite.TestCases[i].Name = censored(censor, testSuite.TestCases[i].Name)
+		if testSuite.TestCases[i].SkipMessage != nil {
+			testSuite.TestCases[i].SkipMessage.Message = censored(censor, testSuite.TestCases[i].SkipMessage.Message)
+		}
+		if testSuite.TestCases[i].FailureOutput != nil {
+			testSuite.TestCases[i].FailureOutput.Output = censored(censor, testSuite.TestCases[i].FailureOutput.Output)
+			testSuite.TestCases[i].FailureOutput.Message = censored(censor, testSuite.TestCases[i].FailureOutput.Message)
+		}
+		testSuite.TestCases[i].SystemOut = censored(censor, testSuite.TestCases[i].SystemOut)
+		testSuite.TestCases[i].SystemErr = censored(censor, testSuite.TestCases[i].SystemErr)
+	}
+	for i := range testSuite.Children {
+		CensorTestSuite(censor, testSuite.Children[i])
+	}
+}
+
+func censored(censor secretutil.Censorer, value string) string {
+	raw := []byte(value)
+	censor.Censor(&raw)
+	return string(raw)
+}

--- a/pkg/junit/censor_test.go
+++ b/pkg/junit/censor_test.go
@@ -1,0 +1,108 @@
+package junit
+
+import (
+	"testing"
+
+	"k8s.io/test-infra/prow/secretutil"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestCensorTestSuite(t *testing.T) {
+	censorer := secretutil.NewCensorer()
+	censorer.Refresh("secret")
+	input := TestSuite{
+		Name: "some secret",
+		Properties: []*TestSuiteProperty{
+			{Name: "secret things", Value: "secret values"},
+			{Name: "also secret things", Value: "really secret values"},
+		},
+		TestCases: []*TestCase{
+			{
+				Name:        "somehow secret",
+				SkipMessage: &SkipMessage{Message: "skipped due to secret"},
+				FailureOutput: &FailureOutput{
+					Message: "failed due to secret",
+					Output:  "secret failure output",
+				},
+				SystemOut: "output containing secret",
+				SystemErr: "error containing secret",
+			},
+			{
+				Name:        "somehow also secret",
+				SkipMessage: &SkipMessage{Message: "also skipped due to secret"},
+				FailureOutput: &FailureOutput{
+					Message: "also failed due to secret",
+					Output:  "also secret failure output",
+				},
+				SystemOut: "also output containing secret",
+				SystemErr: "also error containing secret",
+			},
+		},
+		Children: []*TestSuite{
+			{
+				Name: "some nested secret",
+				Properties: []*TestSuiteProperty{
+					{Name: "nested secret things", Value: "nested secret values"},
+					{Name: "also nested secret things", Value: "really nested secret values"},
+				},
+				TestCases: []*TestCase{
+					{
+						Name:        "somehow nested secret",
+						SkipMessage: &SkipMessage{Message: "skipped due to nested secret"},
+						FailureOutput: &FailureOutput{
+							Message: "failed due to nested secret",
+							Output:  "nested secret failure output",
+						},
+						SystemOut: "output containing nested secret",
+						SystemErr: "error containing nested secret",
+					},
+					{
+						Name:        "somehow also nested secret",
+						SkipMessage: &SkipMessage{Message: "also skipped due to nested secret"},
+						FailureOutput: &FailureOutput{
+							Message: "also failed due to nested secret",
+							Output:  "also nested secret failure output",
+						},
+						SystemOut: "also output containing nested secret",
+						SystemErr: "also error containing nested secret",
+					},
+				},
+				Children: []*TestSuite{
+					{
+						Name: "some very nested secret",
+						Properties: []*TestSuiteProperty{
+							{Name: "very nested secret things", Value: "very nested secret values"},
+							{Name: "also very nested secret things", Value: "really very nested secret values"},
+						},
+						TestCases: []*TestCase{
+							{
+								Name:        "somehow very nested secret",
+								SkipMessage: &SkipMessage{Message: "skipped due to very nested secret"},
+								FailureOutput: &FailureOutput{
+									Message: "failed due to very nested secret",
+									Output:  "very nested secret failure output",
+								},
+								SystemOut: "output containing very nested secret",
+								SystemErr: "error containing very nested secret",
+							},
+							{
+								Name:        "somehow also very nested secret",
+								SkipMessage: &SkipMessage{Message: "also skipped due to very nested secret"},
+								FailureOutput: &FailureOutput{
+									Message: "also failed due to very nested secret",
+									Output:  "also very nested secret failure output",
+								},
+								SystemOut: "also output containing very nested secret",
+								SystemErr: "also error containing very nested secret",
+							},
+						},
+						Children: nil,
+					},
+				},
+			},
+		},
+	}
+	CensorTestSuite(censorer, &input)
+	testhelper.CompareWithFixture(t, input)
+}

--- a/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
+++ b/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
@@ -1,0 +1,177 @@
+Children:
+- Children:
+  - Children: null
+    Duration: 0
+    Name: some very nested ******
+    NumFailed: 0
+    NumSkipped: 0
+    NumTests: 0
+    Properties:
+    - Name: very nested ****** things
+      Value: very nested ****** values
+      XMLName:
+        Local: ""
+        Space: ""
+    - Name: also very nested ****** things
+      Value: really very nested ****** values
+      XMLName:
+        Local: ""
+        Space: ""
+    TestCases:
+    - Classname: ""
+      Duration: 0
+      FailureOutput:
+        Message: failed due to very nested ******
+        Output: very nested ****** failure output
+        XMLName:
+          Local: ""
+          Space: ""
+      Name: somehow very nested ******
+      SkipMessage:
+        Message: skipped due to very nested ******
+        XMLName:
+          Local: ""
+          Space: ""
+      SystemErr: error containing very nested ******
+      SystemOut: output containing very nested ******
+      XMLName:
+        Local: ""
+        Space: ""
+    - Classname: ""
+      Duration: 0
+      FailureOutput:
+        Message: also failed due to very nested ******
+        Output: also very nested ****** failure output
+        XMLName:
+          Local: ""
+          Space: ""
+      Name: somehow also very nested ******
+      SkipMessage:
+        Message: also skipped due to very nested ******
+        XMLName:
+          Local: ""
+          Space: ""
+      SystemErr: also error containing very nested ******
+      SystemOut: also output containing very nested ******
+      XMLName:
+        Local: ""
+        Space: ""
+    XMLName:
+      Local: ""
+      Space: ""
+  Duration: 0
+  Name: some nested ******
+  NumFailed: 0
+  NumSkipped: 0
+  NumTests: 0
+  Properties:
+  - Name: nested ****** things
+    Value: nested ****** values
+    XMLName:
+      Local: ""
+      Space: ""
+  - Name: also nested ****** things
+    Value: really nested ****** values
+    XMLName:
+      Local: ""
+      Space: ""
+  TestCases:
+  - Classname: ""
+    Duration: 0
+    FailureOutput:
+      Message: failed due to nested ******
+      Output: nested ****** failure output
+      XMLName:
+        Local: ""
+        Space: ""
+    Name: somehow nested ******
+    SkipMessage:
+      Message: skipped due to nested ******
+      XMLName:
+        Local: ""
+        Space: ""
+    SystemErr: error containing nested ******
+    SystemOut: output containing nested ******
+    XMLName:
+      Local: ""
+      Space: ""
+  - Classname: ""
+    Duration: 0
+    FailureOutput:
+      Message: also failed due to nested ******
+      Output: also nested ****** failure output
+      XMLName:
+        Local: ""
+        Space: ""
+    Name: somehow also nested ******
+    SkipMessage:
+      Message: also skipped due to nested ******
+      XMLName:
+        Local: ""
+        Space: ""
+    SystemErr: also error containing nested ******
+    SystemOut: also output containing nested ******
+    XMLName:
+      Local: ""
+      Space: ""
+  XMLName:
+    Local: ""
+    Space: ""
+Duration: 0
+Name: some ******
+NumFailed: 0
+NumSkipped: 0
+NumTests: 0
+Properties:
+- Name: '****** things'
+  Value: '****** values'
+  XMLName:
+    Local: ""
+    Space: ""
+- Name: also ****** things
+  Value: really ****** values
+  XMLName:
+    Local: ""
+    Space: ""
+TestCases:
+- Classname: ""
+  Duration: 0
+  FailureOutput:
+    Message: failed due to ******
+    Output: '****** failure output'
+    XMLName:
+      Local: ""
+      Space: ""
+  Name: somehow ******
+  SkipMessage:
+    Message: skipped due to ******
+    XMLName:
+      Local: ""
+      Space: ""
+  SystemErr: error containing ******
+  SystemOut: output containing ******
+  XMLName:
+    Local: ""
+    Space: ""
+- Classname: ""
+  Duration: 0
+  FailureOutput:
+    Message: also failed due to ******
+    Output: also ****** failure output
+    XMLName:
+      Local: ""
+      Space: ""
+  Name: somehow also ******
+  SkipMessage:
+    Message: also skipped due to ******
+    XMLName:
+      Local: ""
+      Space: ""
+  SystemErr: also error containing ******
+  SystemOut: also output containing ******
+  XMLName:
+    Local: ""
+    Space: ""
+XMLName:
+  Local: ""
+  Space: ""


### PR DESCRIPTION
When user secrets end up in our output files *and* they include
characters that are invalid in the encoding we're going to use to write
those files (like JSON or XML), we end up not censoring anything since
the encoded content we run the censorer over does not contain the actual
secret data. Pre-censoring fields in these structs is fragile, but a
reasonable compromise to writing custom, complex and also fragile
reflection-based implementations that would attempt to operate over
different structs generically. When we use `api.SaveArtifact` we must
remember to pre-censor as necessary beforehand.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 