### PR TITLE
pkg/validation: validate all pipeline image inputs

### DIFF
--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -96,11 +96,6 @@ func validateConfiguration(ctx *configContext, config *api.ReleaseBuildConfigura
 	for name := range releases {
 		releases.Insert(name)
 	}
-	validationErrors = append(validationErrors, validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
-
-	// this validation brings together a large amount of data from separate
-	// parts of the configuration, so it's written as a standalone method
-	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	if config.Operator != nil {
 		// validateOperator needs a method that maps `substitute.with` values to image links
 		// to validate the value is meaningful in the context of the configuration
@@ -124,6 +119,11 @@ func validateConfiguration(ctx *configContext, config *api.ReleaseBuildConfigura
 
 	validationErrors = append(validationErrors, validateReleases("releases", config.Releases, config.ReleaseTagConfiguration != nil)...)
 	validationErrors = append(validationErrors, validateImages(ctx.addField("images"), config.Images)...)
+	validationErrors = append(validationErrors, validateTestStepConfiguration(ctx, "tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
+
+	// this validation brings together a large amount of data from separate
+	// parts of the configuration, so it's written as a standalone method
+	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -11,28 +11,70 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
+// configContext contains data structures used for validations across fields.
+type configContext struct {
+	field fieldPath
+	// Shared reference to a map containing pipeline image tags seen so far.
+	// All derivative contexts will point to the same map.
+	pipelineImages map[api.PipelineImageStreamTagReference]string
+}
+
+// newConfigContext creates a top-level, empty context.
+func newConfigContext() *configContext {
+	return &configContext{
+		pipelineImages: make(map[api.PipelineImageStreamTagReference]string),
+	}
+}
+
+func (c *configContext) errorf(format string, args ...interface{}) error {
+	return c.field.errorf(format, args...)
+}
+
+func (c *configContext) addField(name string) *configContext {
+	ret := *c
+	ret.field = ret.field.addField(name)
+	return &ret
+}
+
+func (c *configContext) addIndex(i int) *configContext {
+	ret := *c
+	ret.field = ret.field.addIndex(i)
+	return &ret
+}
+
+// addPipelineImage verifies that a pipeline image tag has not been seen.
+// An error containing the name of the original field is returned if the tag has
+// already been seen in the same configuration.
+func (c *configContext) addPipelineImage(name api.PipelineImageStreamTagReference) error {
+	previous, seen := c.pipelineImages[name]
+	if seen {
+		return c.errorf("duplicate image name '%s' (previously defined by field '%s')", string(name), previous)
+	}
+	c.pipelineImages[name] = string(c.field)
+	return nil
+}
+
 // ValidateAtRuntime validates all the configuration's values without knowledge of config
 // repo structure
 func IsValidRuntimeConfiguration(config *api.ReleaseBuildConfiguration) error {
-	return validateConfiguration(config, "", "", false)
+	return validateConfiguration(newConfigContext(), config, "", "", false)
 }
 
 // ValidateResolved behaves as ValidateAtRuntime and also validates that all
 // test steps are fully resolved.
 func IsValidResolvedConfiguration(config *api.ReleaseBuildConfiguration) error {
 	config.Default()
-	return validateConfiguration(config, "", "", true)
+	return validateConfiguration(newConfigContext(), config, "", "", true)
 }
 
 // Validate validates all the configuration's values.
 func IsValidConfiguration(config *api.ReleaseBuildConfiguration, org, repo string) error {
 	config.Default()
-	return validateConfiguration(config, org, repo, false)
+	return validateConfiguration(newConfigContext(), config, org, repo, false)
 }
 
-func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo string, resolved bool) error {
+func validateConfiguration(ctx *configContext, config *api.ReleaseBuildConfiguration, org, repo string, resolved bool) error {
 	var validationErrors []error
-
 	validationErrors = append(validationErrors, validateReleaseBuildConfiguration(config, org, repo)...)
 	validationErrors = append(validationErrors, validateBuildRootImageConfiguration("build_root", config.InputConfiguration.BuildRootImage, len(config.Images) > 0)...)
 	releases := sets.NewString()
@@ -44,11 +86,6 @@ func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo stri
 	// this validation brings together a large amount of data from separate
 	// parts of the configuration, so it's written as a standalone method
 	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
-
-	if config.Images != nil {
-		validationErrors = append(validationErrors, validateImages("images", config.Images)...)
-	}
-
 	if config.Operator != nil {
 		// validateOperator needs a method that maps `substitute.with` values to image links
 		// to validate the value is meaningful in the context of the configuration
@@ -56,7 +93,7 @@ func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo stri
 			imageStream, name, _ := config.DependencyParts(api.StepDependency{Name: image}, nil)
 			return api.LinkForImage(imageStream, name)
 		}
-		validationErrors = append(validationErrors, validateOperator("operator", config.Operator, linkForImage, config)...)
+		validationErrors = append(validationErrors, validateOperator(ctx.addField("operator"), config.Operator, linkForImage)...)
 	}
 
 	if config.InputConfiguration.BaseImages != nil {
@@ -78,7 +115,7 @@ func validateConfiguration(config *api.ReleaseBuildConfiguration, org, repo stri
 	}
 
 	validationErrors = append(validationErrors, validateReleases("releases", config.Releases, config.ReleaseTagConfiguration != nil)...)
-
+	validationErrors = append(validationErrors, validateImages(ctx.addField("images"), config.Images)...)
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {
@@ -136,19 +173,17 @@ func validateBuildRootImageStreamTag(fieldRoot string, buildRoot api.ImageStream
 	return validationErrors
 }
 
-func validateImages(fieldRoot string, input []api.ProjectDirectoryImageBuildStepConfiguration) []error {
+func validateImages(ctx *configContext, images []api.ProjectDirectoryImageBuildStepConfiguration) []error {
 	var validationErrors []error
-	seenNames := map[api.PipelineImageStreamTagReference]int{}
-	for num, image := range input {
-		fieldRootN := fmt.Sprintf("%s[%d]", fieldRoot, num)
+	for num, image := range images {
+		fieldRootN := fmt.Sprintf("%s[%d]", ctx.field, num)
+		ctxN := ctx.addIndex(num)
 		if image.To == "" {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` must be set", fieldRootN))
+			validationErrors = append(validationErrors, ctxN.errorf("`to` must be set"))
 		}
-		if idx, seen := seenNames[image.To]; seen {
-			fieldRootIdx := fmt.Sprintf("%s[%d]", fieldRoot, idx)
-			validationErrors = append(validationErrors, fmt.Errorf("%s: duplicate image name '%s' (previously seen in %s)", fieldRootN, string(image.To), fieldRootIdx))
+		if err := ctxN.addPipelineImage(image.To); err != nil {
+			validationErrors = append(validationErrors, err)
 		}
-		seenNames[image.To] = num
 		if image.To == api.PipelineImageStreamTagReferenceBundleSource {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceBundleSource))
 		}
@@ -159,47 +194,55 @@ func validateImages(fieldRoot string, input []api.ProjectDirectoryImageBuildStep
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot begin with %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImage))
 		}
 		if image.DockerfileLiteral != nil && (image.ContextDir != "" || image.DockerfilePath != "") {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: dockerfile_literal is mutually exclusive with context_dir and dockerfile_path", fieldRootN))
+			validationErrors = append(validationErrors, ctxN.errorf("dockerfile_literal is mutually exclusive with context_dir and dockerfile_path"))
 		}
 	}
 	return validationErrors
 }
 
-func validateOperator(fieldRoot string, input *api.OperatorStepConfiguration, linkForImage func(string) api.StepLink, config *api.ReleaseBuildConfiguration) []error {
+func validateOperator(ctx *configContext, input *api.OperatorStepConfiguration, linkForImage func(string) api.StepLink) []error {
 	var validationErrors []error
+	if err := ctx.addPipelineImage(api.PipelineImageStreamTagReferenceBundleSource); err != nil {
+		validationErrors = append(validationErrors, err)
+	}
 	for num, bundle := range input.Bundles {
-		fieldRootN := fmt.Sprintf("%s.bundles[%d]", fieldRoot, num)
-		if bundle.As != "" {
-			if config.IsBaseImage(bundle.As) {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.as: bundle name `%s` matches a base image", fieldRootN, bundle.As))
-			}
-			if config.BuildsImage(bundle.As) {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.as: bundle name `%s` matches image defined in `images`", fieldRootN, bundle.As))
-			}
+		ctxN := ctx.addField("bundles").addIndex(num)
+		ctxImage := ctxN
+		imageName := bundle.As
+		if imageName == "" {
+			imageName = api.BundleName(num)
+		} else {
+			ctxImage = ctxN.addField("as")
+		}
+		if err := ctxImage.addPipelineImage(api.PipelineImageStreamTagReference(imageName)); err != nil {
+			validationErrors = append(validationErrors, err)
+		}
+		if err := ctxImage.addPipelineImage(api.PipelineImageStreamTagReference(api.IndexName(imageName))); err != nil {
+			validationErrors = append(validationErrors, err)
 		}
 		if bundle.As == "" && bundle.BaseIndex != "" {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.base_index: base_index requires as to be set", fieldRootN))
+			validationErrors = append(validationErrors, ctxN.addField("base_index").errorf("base_index requires as to be set"))
 		}
 		if bundle.UpdateGraph != "" {
 			if bundle.BaseIndex == "" {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.update_graph: update_graph requires base_index to be set", fieldRootN))
+				validationErrors = append(validationErrors, ctxN.addField("update_graph").errorf("update_graph requires base_index to be set"))
 			}
 			if bundle.UpdateGraph != api.IndexUpdateSemver && bundle.UpdateGraph != api.IndexUpdateSemverSkippatch && bundle.UpdateGraph != api.IndexUpdateReplaces {
-				validationErrors = append(validationErrors, fmt.Errorf("%s.update_graph: update_graph must be %s, %s, or %s", fieldRootN, api.IndexUpdateSemver, api.IndexUpdateSemverSkippatch, api.IndexUpdateReplaces))
+				validationErrors = append(validationErrors, ctxN.addField("update_graph").errorf("update_graph must be %s, %s, or %s", api.IndexUpdateSemver, api.IndexUpdateSemverSkippatch, api.IndexUpdateReplaces))
 			}
 		}
 	}
 	for num, sub := range input.Substitutions {
-		fieldRootN := fmt.Sprintf("%s.substitute[%d]", fieldRoot, num)
+		ctxN := ctx.addField("substitute").addIndex(num)
 		if sub.PullSpec == "" {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.pullspec: must be set", fieldRootN))
+			validationErrors = append(validationErrors, ctxN.addField("pullspec").errorf("must be set"))
 		}
 		if sub.With == "" {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.with: must be set", fieldRootN))
+			validationErrors = append(validationErrors, ctxN.addField("with").errorf("must be set"))
 		}
 
 		if link := linkForImage(sub.With); link == nil {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.with: could not resolve '%s' to an image involved in the config", fieldRootN, sub.With))
+			validationErrors = append(validationErrors, ctxN.addField("with").errorf("could not resolve '%s' to an image involved in the config", sub.With))
 		}
 	}
 	return validationErrors

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -176,22 +176,12 @@ func validateBuildRootImageStreamTag(fieldRoot string, buildRoot api.ImageStream
 func validateImages(ctx *configContext, images []api.ProjectDirectoryImageBuildStepConfiguration) []error {
 	var validationErrors []error
 	for num, image := range images {
-		fieldRootN := fmt.Sprintf("%s[%d]", ctx.field, num)
 		ctxN := ctx.addIndex(num)
 		if image.To == "" {
 			validationErrors = append(validationErrors, ctxN.errorf("`to` must be set"))
 		}
 		if err := ctxN.addPipelineImage(image.To); err != nil {
 			validationErrors = append(validationErrors, err)
-		}
-		if image.To == api.PipelineImageStreamTagReferenceBundleSource {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot be %s", fieldRootN, api.PipelineImageStreamTagReferenceBundleSource))
-		}
-		if strings.HasPrefix(string(image.To), api.BundlePrefix) {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot begin with `%s`", fieldRootN, api.BundlePrefix))
-		}
-		if strings.HasPrefix(string(image.To), string(api.PipelineImageStreamTagReferenceIndexImage)) {
-			validationErrors = append(validationErrors, fmt.Errorf("%s: `to` cannot begin with %s", fieldRootN, api.PipelineImageStreamTagReferenceIndexImage))
 		}
 		if image.DockerfileLiteral != nil && (image.ContextDir != "" || image.DockerfilePath != "") {
 			validationErrors = append(validationErrors, ctxN.errorf("dockerfile_literal is mutually exclusive with context_dir and dockerfile_path"))

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -917,9 +917,32 @@ func TestPipelineImages(t *testing.T) {
 			Resources: resources,
 		},
 		expected: errors.New(`invalid configuration: images[0]: duplicate image name 'root' (previously defined by field 'build_root')`),
+	}, {
+		name: "multi-stage from_image",
+		conf: api.ReleaseBuildConfiguration{
+			Images:             makeImages("from_image"),
+			InputConfiguration: input,
+			Tests: []api.TestStepConfiguration{{
+				As: "test-name",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Test: []api.LiteralTestStep{{
+						As:       "step-name",
+						Commands: "commands",
+						FromImage: &api.ImageStreamTagReference{
+							Namespace: "ns",
+							Name:      "name",
+							Tag:       "from_image",
+						},
+						Resources: resources["*"],
+					}},
+				},
+			}},
+			Resources: resources,
+		},
+		expected: errors.New(`invalid configuration: tests[0].steps.test[0].from_image: duplicate image name 'from_image' (previously defined by field 'images[0]')`),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := IsValidConfiguration(&tc.conf, "TODO", "TODO")
+			err := IsValidConfiguration(&tc.conf, "org", "repo")
 			testhelper.Diff(t, "error", err, tc.expected, testhelper.EquateErrorMessage)
 		})
 	}

--- a/pkg/validation/field.go
+++ b/pkg/validation/field.go
@@ -21,6 +21,13 @@ func (f fieldPath) addIndex(i int) fieldPath {
 	return fieldPath(fmt.Sprintf("%s[%d]", f, i))
 }
 
+func (f fieldPath) addKey(k string) fieldPath {
+	if f == "" {
+		panic("no previous field name")
+	}
+	return fieldPath(fmt.Sprintf("%s[%s]", f, k))
+}
+
 func (f fieldPath) errorf(format string, args ...interface{}) error {
 	args = append([]interface{}{f}, args...)
 	return fmt.Errorf("%s: "+format, args...)

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -72,10 +72,10 @@ var trapPattern = regexp.MustCompile(`(^|\W)\s*trap\s*['"]?\w*['"]?\s*\w*`)
 // component, the image references exist in the test configuration, etc.) are
 // not performed.
 func IsValidReference(step api.LiteralTestStep) []error {
-	return validateLiteralTestStep(&context{field: fieldPath(step.As)}, testStageUnknown, step, nil)
+	return validateLiteralTestStep(nil, &context{field: fieldPath(step.As)}, testStageUnknown, step, nil)
 }
 
-func validateTestStepConfiguration(fieldRoot string, input []api.TestStepConfiguration, release *api.ReleaseTagConfiguration, releases sets.String, resolved bool) []error {
+func validateTestStepConfiguration(configCtx *configContext, fieldRoot string, input []api.TestStepConfiguration, release *api.ReleaseTagConfiguration, releases sets.String, resolved bool) []error {
 	var validationErrors []error
 
 	// check for test.As duplicates
@@ -156,7 +156,7 @@ func validateTestStepConfiguration(fieldRoot string, input []api.TestStepConfigu
 			}
 		}
 
-		validationErrors = append(validationErrors, validateTestConfigurationType(fieldRootN, test, release, releases, resolved)...)
+		validationErrors = append(validationErrors, validateTestConfigurationType(configCtx, fieldRootN, test, release, releases, resolved)...)
 	}
 	return validationErrors
 }
@@ -356,7 +356,7 @@ func searchForTestDuplicates(tests []api.TestStepConfiguration) []error {
 	return nil
 }
 
-func validateTestConfigurationType(fieldRoot string, test api.TestStepConfiguration, release *api.ReleaseTagConfiguration, releases sets.String, resolved bool) []error {
+func validateTestConfigurationType(configCtx *configContext, fieldRoot string, test api.TestStepConfiguration, release *api.ReleaseTagConfiguration, releases sets.String, resolved bool) []error {
 	var validationErrors []error
 	clusterCount := 0
 	if claim := test.ClusterClaim; claim != nil {
@@ -440,9 +440,9 @@ func validateTestConfigurationType(fieldRoot string, test api.TestStepConfigurat
 		}
 		context := newContext(fieldPath(fieldRoot), testConfig.Environment, releases)
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
-		validationErrors = append(validationErrors, validateTestSteps(context.addField("pre"), testStagePre, testConfig.Pre, claimRelease)...)
-		validationErrors = append(validationErrors, validateTestSteps(context.addField("test"), testStageTest, testConfig.Test, claimRelease)...)
-		validationErrors = append(validationErrors, validateTestSteps(context.addField("post"), testStagePost, testConfig.Post, claimRelease)...)
+		validationErrors = append(validationErrors, validateTestSteps(configCtx, context.addField("pre"), testStagePre, testConfig.Pre, claimRelease)...)
+		validationErrors = append(validationErrors, validateTestSteps(configCtx, context.addField("test"), testStageTest, testConfig.Test, claimRelease)...)
+		validationErrors = append(validationErrors, validateTestSteps(configCtx, context.addField("post"), testStagePost, testConfig.Post, claimRelease)...)
 	}
 	if testConfig := test.MultiStageTestConfigurationLiteral; testConfig != nil {
 		typeCount++
@@ -453,13 +453,13 @@ func validateTestConfigurationType(fieldRoot string, test api.TestStepConfigurat
 		}
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
 		for i, s := range testConfig.Pre {
-			validationErrors = append(validationErrors, validateLiteralTestStep(context.addField("pre").addIndex(i), testStagePre, s, claimRelease)...)
+			validationErrors = append(validationErrors, validateLiteralTestStep(configCtx, context.addField("pre").addIndex(i), testStagePre, s, claimRelease)...)
 		}
 		for i, s := range testConfig.Test {
-			validationErrors = append(validationErrors, validateLiteralTestStep(context.addField("test").addIndex(i), testStageTest, s, claimRelease)...)
+			validationErrors = append(validationErrors, validateLiteralTestStep(configCtx, context.addField("test").addIndex(i), testStageTest, s, claimRelease)...)
 		}
 		for i, s := range testConfig.Post {
-			validationErrors = append(validationErrors, validateLiteralTestStep(context.addField("post").addIndex(i), testStagePost, s, claimRelease)...)
+			validationErrors = append(validationErrors, validateLiteralTestStep(configCtx, context.addField("post").addIndex(i), testStagePost, s, claimRelease)...)
 		}
 	}
 	if typeCount == 0 {
@@ -478,12 +478,12 @@ func validateTestConfigurationType(fieldRoot string, test api.TestStepConfigurat
 	return validationErrors
 }
 
-func validateTestSteps(context *context, stage testStage, steps []api.TestStep, claimRelease *api.ClaimRelease) (ret []error) {
+func validateTestSteps(configCtx *configContext, context *context, stage testStage, steps []api.TestStep, claimRelease *api.ClaimRelease) (ret []error) {
 	for i, s := range steps {
 		contextI := context.addIndex(i)
 		ret = append(ret, validateTestStep(contextI, s)...)
 		if s.LiteralTestStep != nil {
-			ret = append(ret, validateLiteralTestStep(contextI, stage, *s.LiteralTestStep, claimRelease)...)
+			ret = append(ret, validateLiteralTestStep(configCtx, contextI, stage, *s.LiteralTestStep, claimRelease)...)
 		}
 	}
 	return
@@ -521,7 +521,7 @@ func validateTestStep(context *context, step api.TestStep) (ret []error) {
 	return
 }
 
-func validateLiteralTestStep(context *context, stage testStage, step api.LiteralTestStep, claimRelease *api.ClaimRelease) (ret []error) {
+func validateLiteralTestStep(configCtx *configContext, context *context, stage testStage, step api.LiteralTestStep, claimRelease *api.ClaimRelease) (ret []error) {
 	if len(step.As) == 0 {
 		ret = append(ret, context.errorf("`as` is required"))
 	} else if context.seen != nil {
@@ -544,6 +544,11 @@ func validateLiteralTestStep(context *context, stage testStage, step api.Literal
 		}
 		if step.FromImage.Tag == "" {
 			ret = append(ret, context.addField("from_image").errorf("`tag` is required"))
+		}
+		if configCtx != nil {
+			if err := configCtx.addField(string(context.field)).addField("from_image").addPipelineImage(api.PipelineImageStreamTagReference(step.FromImage.Tag)); err != nil {
+				ret = append(ret, err)
+			}
 		}
 	} else {
 		imageParts := strings.Split(step.From, ":")

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -499,7 +499,7 @@ func TestValidateTests(t *testing.T) {
 		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
-			if errs := validateTestStepConfiguration("tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
+			if errs := validateTestStepConfiguration(newConfigContext(), "tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")
@@ -872,7 +872,7 @@ func TestValidateTestSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(context, testStageTest, tc.steps, &tc.clusterClaim)
+			ret := validateTestSteps(newConfigContext().addField("test"), context, testStageTest, tc.steps, &tc.clusterClaim)
 			if len(ret) > 0 && len(tc.errs) == 0 {
 				t.Fatalf("Unexpected error %v", ret)
 			}
@@ -912,7 +912,7 @@ func TestValidatePostSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(context, testStagePost, tc.steps, nil)
+			ret := validateTestSteps(newConfigContext().addField("test"), context, testStagePost, tc.steps, nil)
 			if !errListMessagesEqual(ret, tc.errs) {
 				t.Fatal(diff.ObjectReflectDiff(ret, tc.errs))
 			}
@@ -944,7 +944,7 @@ func TestValidateParameters(t *testing.T) {
 		err:    []error{errors.New("test: unresolved parameter(s): [TEST1]")},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateLiteralTestStep(newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
+			err := validateLiteralTestStep(newConfigContext(), newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
 				As:       "as",
 				From:     "from",
 				Commands: "commands",
@@ -1205,7 +1205,7 @@ func TestValidateLeases(t *testing.T) {
 			test := api.TestStepConfiguration{
 				MultiStageTestConfigurationLiteral: &tc.test,
 			}
-			err := validateTestConfigurationType("tests[0]", test, nil, nil, true)
+			err := validateTestConfigurationType(newConfigContext(), "tests[0]", test, nil, nil, true)
 			if diff := diff.ObjectReflectDiff(tc.err, err); diff != "<no diffs>" {
 				t.Errorf("unexpected error: %s", diff)
 			}
@@ -1335,7 +1335,7 @@ func TestValidateTestConfigurationType(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := validateTestConfigurationType("test", tc.test, nil, nil, false)
+			actual := validateTestConfigurationType(newConfigContext(), "test", tc.test, nil, nil, false)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("expected differs from actual: %s", diff)
 			}


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2259

`ci-operator` currently has non-existent or inconsitent checks for whether the
`ImageStreamTag`s in the `pipeline` `ImageStream` conflict.  It is possible to
create configurations that result execution graphs with surprising and incorrect
behavior (see the Jira issue for examples).

A consistent set of validations is added, replacing existing ones where
appropriate, so that those configurations are not accepted.  Once we have proper
checking (see the task list below), the incorrect configuration presented in the
Jira issue will be rejected:

```
$ ci-operator-checkconfig --config-dir ci-operator/config --registry ci-operator/step-registry
ERRO[0000] Failed to load CI Operator configuration      error="invalid ci-operator config: invalid configuration: images[0]: duplicate image name 'elasticsearch-proxy' (previously defined by field 'base_images[elasticsearch-proxy]')" source-file=/home/bbguimaraes/src/release/ci-operator/config/openshift/elasticsearch-proxy/openshift-elasticsearch-proxy-master.yaml
error validating configuration files: invalid ci-operator config: invalid configuration: images[0]: duplicate image name 'elasticsearch-proxy' (previously defined by field 'base_images[elasticsearch-proxy]')
$ find ci-operator/config/openshift/elasticsearch-proxy/ -type f -exec sed -i '/^  elasticsearch-proxy:$/,+3d' {} +
$ ci-operator-checkconfig --config-dir ci-operator/config --registry ci-operator/step-registry
```

/hold

Issues still remaining before this can be adopted:

- [ ] fix configurations in `openshift/release`
- [ ] make these validations blocking in `ci-tools` and `openshift/release`
- [ ] make sure documentation reflects the validation