### PR TITLE
Re-Add test-image-distributor distributes images from new config instantly

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -23,6 +24,7 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -783,4 +785,82 @@ type noOpRegistryResolver struct{}
 
 func (noOpRegistryResolver) ResolveConfig(cfg api.ReleaseBuildConfiguration) (api.ReleaseBuildConfiguration, error) {
 	return cfg, nil
+}
+
+func TestSourceForConfigChangeChannel(t *testing.T) {
+	t.Parallel()
+
+	type requestWithCluster struct {
+		cluster string
+		request types.NamespacedName
+	}
+
+	buildClusters := sets.NewString("build01", "build02")
+	testCases := []struct {
+		name   string
+		change agents.IndexDelta
+
+		expected []requestWithCluster
+	}{
+		{
+			name:   "Config was added, we trigger an event per cluster",
+			change: agents.IndexDelta{IndexKey: "namespace/name:tag", Added: []*api.ReleaseBuildConfiguration{{}}},
+
+			expected: []requestWithCluster{
+				{cluster: "build01", request: types.NamespacedName{Namespace: "namespace", Name: "name:tag"}},
+				{cluster: "build02", request: types.NamespacedName{Namespace: "namespace", Name: "name:tag"}},
+			},
+		},
+		{
+			name:   "Config was removed, we don't trigger an event",
+			change: agents.IndexDelta{IndexKey: "namespace/name:tag", Removed: []*api.ReleaseBuildConfiguration{{}}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			changeChannel := make(chan agents.IndexDelta)
+
+			source := sourceForConfigChangeChannel(buildClusters, changeChannel)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			queue := &hijackingQueue{}
+
+			if err := source.InjectStopChannel(ctx.Done()); err != nil {
+				t.Fatalf("failed to inject stop channel into source: %v", err)
+			}
+			if err := source.Start(ctx, &handler.EnqueueRequestForObject{}, queue); err != nil {
+				t.Fatalf("failed to start source: %v", err)
+			}
+			changeChannel <- tc.change
+			close(changeChannel)
+
+			// The source copies the data from the input channel to the workqueue asynchronously
+			// and there is no way for us to properly synchronize that so instead we just wait.
+			// We can not poll because for negative testcases (expect no request) that would instanly
+			// succeed and later events won't make the test fail correctly.
+			time.Sleep(10 * time.Second)
+			queue.lock.Lock()
+			if len(queue.received) != len(tc.expected) {
+				t.Errorf("expected to get %d events, got %d", len(tc.expected), len(queue.received))
+			}
+
+			var actual []requestWithCluster
+			for _, request := range queue.received {
+				cluster, namespacedName, err := decodeRequest(request)
+				if err != nil {
+					t.Errorf("failed to decode request %s: %v", request, err)
+					continue
+				}
+				actual = append(actual, requestWithCluster{cluster: cluster, request: namespacedName})
+			}
+			if diff := cmp.Diff(tc.expected, actual, cmp.AllowUnexported(requestWithCluster{})); diff != "" {
+				t.Errorf("expected requests differ from actual: %s", diff)
+			}
+
+		})
+	}
 }

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -205,6 +205,9 @@ func (a *configAgent) SubscribeToIndexChanges(indexName string) (<-chan IndexDel
 		return nil, fmt.Errorf("index %s does not exist", indexName)
 	}
 
+	if a.indexSubscribers == nil {
+		a.indexSubscribers = map[string][]chan IndexDelta{}
+	}
 	newChan := make(chan IndexDelta)
 	a.indexSubscribers[indexName] = append(a.indexSubscribers[indexName], newChan)
 	return newChan, nil

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -2,6 +2,7 @@ package agents
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"sync"
 	"time"
@@ -13,6 +14,12 @@ import (
 	"github.com/openshift/ci-tools/pkg/load"
 )
 
+type IndexDelta struct {
+	IndexKey string
+	Added    []*api.ReleaseBuildConfiguration
+	Removed  []*api.ReleaseBuildConfiguration
+}
+
 // ConfigAgent is an interface that can load configs from disk into
 // memory and retrieve them when provided with a config.Info.
 type ConfigAgent interface {
@@ -23,20 +30,22 @@ type ConfigAgent interface {
 	GetGeneration() int
 	AddIndex(indexName string, indexFunc IndexFn) error
 	GetFromIndex(indexName string, indexKey string) ([]*api.ReleaseBuildConfiguration, error)
+	SubscribeToIndexChanges(indexName string) (<-chan IndexDelta, error)
 }
 
 // IndexFn can be used to add indexes to the ConfigAgent
 type IndexFn func(api.ReleaseBuildConfiguration) []string
 
 type configAgent struct {
-	lock         *sync.RWMutex
-	configs      load.ByOrgRepo
-	configPath   string
-	generation   int
-	errorMetrics *prometheus.CounterVec
-	indexFuncs   map[string]IndexFn
-	indexes      map[string]configIndex
-	reloadConfig func() error
+	lock             *sync.RWMutex
+	configs          load.ByOrgRepo
+	configPath       string
+	generation       int
+	errorMetrics     *prometheus.CounterVec
+	indexFuncs       map[string]IndexFn
+	indexes          map[string]configIndex
+	indexSubscribers map[string][]chan IndexDelta
+	reloadConfig     func() error
 }
 
 type configIndex map[string][]*api.ReleaseBuildConfiguration
@@ -188,6 +197,19 @@ func (a *configAgent) AddIndex(indexName string, indexFunc IndexFn) error {
 	return nil
 }
 
+func (a *configAgent) SubscribeToIndexChanges(indexName string) (<-chan IndexDelta, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	if _, found := a.indexes[indexName]; !found {
+		return nil, fmt.Errorf("index %s does not exist", indexName)
+	}
+
+	newChan := make(chan IndexDelta)
+	a.indexSubscribers[indexName] = append(a.indexSubscribers[indexName], newChan)
+	return newChan, nil
+}
+
 // loadFilenameToConfig generates a new filenameToConfig map.
 func (a *configAgent) loadFilenameToConfig() error {
 	logrus.Debug("Reloading configs")
@@ -213,6 +235,8 @@ func (a *configAgent) loadFilenameToConfig() error {
 }
 
 func (a *configAgent) buildIndexes() {
+	oldIndexes := a.indexes
+
 	a.indexes = map[string]configIndex{}
 	for indexName, indexFunc := range a.indexFuncs {
 		// Make sure the index always exists even if empty, otherwise we return a confusing
@@ -239,5 +263,89 @@ func (a *configAgent) buildIndexes() {
 				}
 			}
 		}
+
+		// Building the diff is expensive, so cache it in case we have multiple
+		// subscribers.
+		var changes []IndexDelta
+		for _, channel := range a.indexSubscribers[indexName] {
+			if changes == nil {
+				changes = buildIndexDelta(oldIndexes[indexName], a.indexes[indexName])
+			}
+
+			// This might block, so do it in a new goroutine
+			channel := channel
+			go func() {
+				for _, change := range changes {
+					channel <- change
+				}
+			}()
+		}
 	}
+}
+
+// configByFilenameFromIndex constructs a map indexKey -> Metadata -> config for the config
+// in the provided index. It uses the fact that Metadata is unique per config to speed up
+// looking up specific values in an index.
+func configByFilenameFromIndex(index configIndex) map[string]map[api.Metadata]*api.ReleaseBuildConfiguration {
+	result := make(map[string]map[api.Metadata]*api.ReleaseBuildConfiguration, len(index))
+	for indexKey, indexValues := range index {
+		if _, ok := result[indexKey]; !ok {
+			result[indexKey] = make(map[api.Metadata]*api.ReleaseBuildConfiguration, len(indexValues))
+		}
+		for idx, config := range indexValues {
+			result[indexKey][config.Metadata] = indexValues[idx]
+		}
+	}
+
+	return result
+}
+
+func buildIndexDelta(oldIndex, newIndex configIndex) []IndexDelta {
+	changesByKey := map[string]*IndexDelta{}
+
+	oldIndexesMappedByMetadata := configByFilenameFromIndex(oldIndex)
+	newIndexedMappedByMetadata := configByFilenameFromIndex(newIndex)
+
+	alreadyProcessed := map[string]map[api.Metadata]struct{}{}
+
+	for indexKey, configMap := range oldIndexesMappedByMetadata {
+		alreadyProcessed[indexKey] = map[api.Metadata]struct{}{}
+		for key, value := range configMap {
+			alreadyProcessed[indexKey][key] = struct{}{}
+			if reflect.DeepEqual(newIndexedMappedByMetadata[indexKey][key], value) {
+				continue
+			}
+			if changesByKey[indexKey] == nil {
+				changesByKey[indexKey] = &IndexDelta{IndexKey: indexKey}
+			}
+			changesByKey[indexKey].Removed = append(changesByKey[indexKey].Removed, configMap[key])
+			if newValue := newIndexedMappedByMetadata[indexKey][key]; newValue != nil {
+				changesByKey[indexKey].Added = append(changesByKey[indexKey].Added, newValue)
+			}
+		}
+	}
+	for indexKey, configMap := range newIndexedMappedByMetadata {
+		for key, value := range configMap {
+			if _, ok := alreadyProcessed[indexKey][key]; ok {
+				continue
+			}
+			if reflect.DeepEqual(oldIndexesMappedByMetadata[indexKey][key], value) {
+				continue
+			}
+			if changesByKey[indexKey] == nil {
+				changesByKey[indexKey] = &IndexDelta{IndexKey: indexKey}
+			}
+			changesByKey[indexKey].Added = append(changesByKey[indexKey].Added, configMap[key])
+			if oldValue := oldIndexesMappedByMetadata[indexKey][key]; oldValue != nil {
+				changesByKey[indexKey].Removed = append(changesByKey[indexKey].Removed, oldValue)
+			}
+		}
+	}
+
+	var result []IndexDelta
+	for _, value := range changesByKey {
+		result = append(result, *value)
+	}
+
+	return result
 }


### PR DESCRIPTION
Ref https://issues.redhat.com/browse/DPTP-2218

Re-adds https://github.com/openshift/ci-tools/pull/2057 which was reverted in https://github.com/openshift/ci-tools/pull/2061

The second commit fixes the issue which made us panic.

/cc @openshift/openshift-team-developer-productivity-test-platform 