### PR TITLE
ci-operator-yaml-creator: Ignore variants

### DIFF
--- a/cmd/ci-operator-yaml-creator/main.go
+++ b/cmd/ci-operator-yaml-creator/main.go
@@ -157,7 +157,7 @@ func process(
 		if !filter(metadata) {
 			return nil
 		}
-		if cfg.BuildRootImage == nil || cfg.BuildRootImage.FromRepository || (metadata.Metadata.Branch != "master" && metadata.Metadata.Branch != "main") {
+		if cfg.BuildRootImage == nil || cfg.BuildRootImage.FromRepository || metadata.Variant != "" || (metadata.Metadata.Branch != "master" && metadata.Metadata.Branch != "main") {
 			return nil
 		}
 

--- a/cmd/ci-operator-yaml-creator/main_test.go
+++ b/cmd/ci-operator-yaml-creator/main_test.go
@@ -61,6 +61,12 @@ func TestProcessing(t *testing.T) {
 			},
 		},
 		{
+			name: "Variant is set, nothing to do",
+			inputModify: func(p *processInput) {
+				p.metadata.Variant = "OKD"
+			},
+		},
+		{
 			name: ".ci-operator.yaml already correct, build_root.from_repository gets set to true",
 			inputModify: func(p *processInput) {
 				p.ciOperatorYaml = `


### PR DESCRIPTION
Not doing this makes us race when a variant is present and update the PR
with the first variant and then the second on, visible e.G. on
https://github.com/openshift/origin/pull/26227