### PR TITLE
DPTP-2269: Add dependency overrides at test level.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -882,7 +882,11 @@ type MultiStageTestConfiguration struct {
 	AllowBestEffortPostSteps *bool `json:"allow_best_effort_post_steps,omitempty"`
 	// Observers are the observers that should be running
 	Observers *Observers `json:"observers,omitempty"`
+	// DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever
+	// be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.
+	DependencyOverrides DependencyOverrides `json:"dependency_overrides,omitempty"`
 }
+type DependencyOverrides map[string]string
 
 // MultiStageTestConfigurationLiteral is a form of the MultiStageTestConfiguration that does not include
 // references. It is the type that MultiStageTestConfigurations are converted to when parsed by the
@@ -915,6 +919,9 @@ type MultiStageTestConfigurationLiteral struct {
 	AllowBestEffortPostSteps *bool `json:"allow_best_effort_post_steps,omitempty"`
 	// Observers are the observers that need to be run
 	Observers []Observer `json:"observers,omitempty"`
+	// DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever
+	// be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.
+	DependencyOverrides DependencyOverrides `json:"dependency_overrides,omitempty"`
 }
 
 // TestEnvironment has the values of parameters for multi-stage tests.

--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -98,6 +98,7 @@ func (r *registry) Resolve(name string, config api.MultiStageTestConfiguration) 
 		AllowSkipOnSuccess:       config.AllowSkipOnSuccess,
 		AllowBestEffortPostSteps: config.AllowBestEffortPostSteps,
 		Leases:                   config.Leases,
+		DependencyOverrides:      config.DependencyOverrides,
 	}
 	stack := stackForTest(name, config.Environment, config.Dependencies)
 	if config.Workflow != nil {

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -417,6 +417,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            # Dependencies holds override values for dependency parameters.\n" +
 	"            dependencies:\n" +
 	"                \"\": \"\"\n" +
+	"            # DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever\n" +
+	"            # be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.\n" +
+	"            dependency_overrides:\n" +
+	"                \"\": \"\"\n" +
 	"            # DnsConfig for step's Pod.\n" +
 	"            dnsConfig:\n" +
 	"                # Nameservers is a list of IP addresses that will be used as DNS servers for the Pod\n" +
@@ -758,6 +762,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            cluster_profile: ' '\n" +
 	"            # Dependencies holds override values for dependency parameters.\n" +
 	"            dependencies:\n" +
+	"                \"\": \"\"\n" +
+	"            # DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever\n" +
+	"            # be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.\n" +
+	"            dependency_overrides:\n" +
 	"                \"\": \"\"\n" +
 	"            # DnsConfig for step's Pod.\n" +
 	"            dnsConfig:\n" +
@@ -1107,6 +1115,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # Dependencies holds override values for dependency parameters.\n" +
 	"        dependencies:\n" +
 	"            \"\": \"\"\n" +
+	"        # DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever\n" +
+	"        # be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.\n" +
+	"        dependency_overrides:\n" +
+	"            \"\": \"\"\n" +
 	"        # DnsConfig for step's Pod.\n" +
 	"        dnsConfig:\n" +
 	"            # Nameservers is a list of IP addresses that will be used as DNS servers for the Pod\n" +
@@ -1448,6 +1460,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        cluster_profile: ' '\n" +
 	"        # Dependencies holds override values for dependency parameters.\n" +
 	"        dependencies:\n" +
+	"            \"\": \"\"\n" +
+	"        # DependencyOverrides allows a step to override a dependency with a fully-qualified pullspec. This will probably only ever\n" +
+	"        # be used with rehearsals. Otherwise, the overrides should be passed in as parameters to ci-operator.\n" +
+	"        dependency_overrides:\n" +
 	"            \"\": \"\"\n" +
 	"        # DnsConfig for step's Pod.\n" +
 	"        dnsConfig:\n" +


### PR DESCRIPTION
[DPTP-2269](https://issues.redhat.com/browse/DPTP-2269) allows steps to override dependencies with fully-qualified pullspecs. This is needed for rehearsals.