### PR TITLE
Allow `skip_if_only_changed` in jobs

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -416,6 +416,7 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 
 	merged.AlwaysRun = old.AlwaysRun
 	merged.RunIfChanged = old.RunIfChanged
+	merged.SkipIfOnlyChanged = old.SkipIfOnlyChanged
 	merged.Optional = old.Optional
 	merged.MaxConcurrency = old.MaxConcurrency
 	merged.SkipReport = old.SkipReport

--- a/test/integration/ci-operator-prowgen/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -84,3 +84,12 @@ presubmits:
             cpu: 10m
       serviceAccountName: ci-operator
     trigger: '(?m)^/test (?:.*? )?images(?: .*?)?$'
+  - agent: jenkins
+    name: pull-ci-super-duper-skippy
+    always_run: false
+    context: ci/openshift-jenkins/skippy
+    labels:
+      master: ci.openshift.redhat.com
+    rerun_command: /test skippy
+    skip_if_only_changed: changes
+    trigger: ((?m)^/test( all| skippy),?(\s+|$))

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -486,3 +486,12 @@ presubmits:
     name: pull-ci-super-duper-oldschool
     rerun_command: /test oldschool
     trigger: ((?m)^/test( all| oldschool),?(\s+|$))
+  - agent: jenkins
+    always_run: false
+    context: ci/openshift-jenkins/skippy
+    labels:
+      master: ci.openshift.redhat.com
+    name: pull-ci-super-duper-skippy
+    rerun_command: /test skippy
+    skip_if_only_changed: changes
+    trigger: ((?m)^/test( all| skippy),?(\s+|$))

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
@@ -44,28 +44,6 @@ tide:
   context_options: {}
   max_goroutines: 20
   queries:
-  - includedBranches:
-    - openshift-4.1
-    - release-4.0
-    - release-4.1
-    - release-4.2
-    - release-4.3
-    - release-4.4
-    labels:
-    - approved
-    - bugzilla/valid-bug
-    - cherry-pick-approved
-    - lgtm
-    missingLabels:
-    - bugzilla/invalid-bug
-    - do-not-merge/blocked-paths
-    - do-not-merge/hold
-    - do-not-merge/invalid-owners-file
-    - do-not-merge/work-in-progress
-    - needs-rebase
-    repos:
-    - openshift/cluster-version-operator
-    - org/repo
   - excludedBranches:
     - openshift-4.1
     - release-4.0
@@ -89,5 +67,27 @@ tide:
     - org/repo
     - org/other
     - org/third
+  - includedBranches:
+    - openshift-4.1
+    - release-4.0
+    - release-4.1
+    - release-4.2
+    - release-4.3
+    - release-4.4
+    labels:
+    - approved
+    - bugzilla/valid-bug
+    - cherry-pick-approved
+    - lgtm
+    missingLabels:
+    - bugzilla/invalid-bug
+    - do-not-merge/blocked-paths
+    - do-not-merge/hold
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/work-in-progress
+    - needs-rebase
+    repos:
+    - openshift/cluster-version-operator
+    - org/repo
   status_update_period: 1m0s
   sync_period: 1m0s


### PR DESCRIPTION
Like `run_if_changed`, allow `skip_if_only_changed` to be specified directly in job configs without being overwritten by `make jobs`.