### PR TITLE
Add cluster profile for openstack-vh-mecha

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -981,6 +981,7 @@ const (
 	ClusterProfileLibvirtS390x       ClusterProfile = "libvirt-s390x"
 	ClusterProfileOpenStack          ClusterProfile = "openstack"
 	ClusterProfileOpenStackKuryr     ClusterProfile = "openstack-kuryr"
+	ClusterProfileOpenStackMecha     ClusterProfile = "openstack-vh-mecha"
 	ClusterProfileOpenStackOsuosl    ClusterProfile = "openstack-osuosl"
 	ClusterProfileOpenStackVexxhost  ClusterProfile = "openstack-vexxhost"
 	ClusterProfileOpenStackPpc64le   ClusterProfile = "openstack-ppc64le"
@@ -1016,6 +1017,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileLibvirtS390x,
 		ClusterProfileOpenStack,
 		ClusterProfileOpenStackKuryr,
+		ClusterProfileOpenStackMecha,
 		ClusterProfileOpenStackOsuosl,
 		ClusterProfileOpenStackVexxhost,
 		ClusterProfileOpenStackPpc64le,
@@ -1066,6 +1068,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "openstack"
 	case ClusterProfileOpenStackKuryr:
 		return "openstack-kuryr"
+	case ClusterProfileOpenStackMecha:
+		return "openstack-vh-mecha"
 	case ClusterProfileOpenStackOsuosl:
 		return "openstack-osuosl"
 	case ClusterProfileOpenStackVexxhost:
@@ -1123,6 +1127,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "openstack-quota-slice"
 	case ClusterProfileOpenStackKuryr:
 		return "openstack-kuryr-quota-slice"
+	case ClusterProfileOpenStackMecha:
+		return "openstack-vh-mecha-quota-slice"
 	case ClusterProfileOpenStackOsuosl:
 		return "openstack-osuosl-quota-slice"
 	case ClusterProfileOpenStackVexxhost:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -519,6 +519,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileLibvirtPpc64le,
 		cioperatorapi.ClusterProfileOpenStack,
 		cioperatorapi.ClusterProfileOpenStackKuryr,
+		cioperatorapi.ClusterProfileOpenStackMecha,
 		cioperatorapi.ClusterProfileOpenStackOsuosl,
 		cioperatorapi.ClusterProfileOpenStackVexxhost,
 		cioperatorapi.ClusterProfileOpenStackPpc64le,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -308,6 +308,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileLibvirtS390x,
 		api.ClusterProfileOpenStack,
 		api.ClusterProfileOpenStackKuryr,
+		api.ClusterProfileOpenStackMecha,
 		api.ClusterProfileOpenStackOsuosl,
 		api.ClusterProfileOpenStackVexxhost,
 		api.ClusterProfileOpenStackPpc64le,


### PR DESCRIPTION
We added a new OSP cloud that will be used in our CI, so we need this
new profile to be added into ci-tools.
