### PR TITLE
Revert "DPTP-2244: Modify autoconfigbrancher to provide registry dir to registry-replacer."

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -159,7 +159,6 @@ func main() {
 				"--github-token-path", "/etc/github/oauth",
 				"--github-endpoint", "http://ghproxy",
 				"--config-dir", "./ci-operator/config",
-				"--registry", "./ci-operator/step-registry",
 				"--prune-unused-replacements",
 				"--prune-ocp-builder-replacements",
 				"--ensure-correct-promotion-dockerfile",


### PR DESCRIPTION
Reverts openshift/ci-tools#2073 as a followup to https://github.com/openshift/ci-tools/pull/2076

Temporary revert to fix https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-config-brancher/1405490361786175488#1:build-log.txt%3A62