### PR TITLE
private-org-sync: include output when git ls-remote fails

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -149,7 +149,7 @@ func getRemoteBranchHeads(logger *logrus.Entry, git gitFunc, repoDir, remote str
 		return nil, err
 	}
 	if exitCode != 0 {
-		return nil, fmt.Errorf("ls-remote failed: (exit code=%d)", exitCode)
+		return nil, fmt.Errorf("ls-remote failed: (exit code=%d output=%s)", exitCode, out)
 	}
 
 	out = strings.TrimSpace(out)


### PR DESCRIPTION
We're getting random errors like the following which are really not that helpful. Before we add retrying, it would be nice to know what is actually happening.

```
time="2021-06-23T09:13:55Z" level=error msg="Failed to determine branch HEADs in source" branch=origin-4.3-kubernetes-1.16.0-beta.1 destination=openshift-priv/kubernetes-apimachinery@origin-4.3-kubernetes-1.16.0-beta.1 error="ls-remote failed: (exit code=128)" local-repo=/tmp/934508300/openshift/kubernetes-apimachinery org=openshift repo=kubernetes-apimachinery source=openshift/kubernetes-apimachinery@origin-4.3-kubernetes-1.16.0-beta.1 source-file=openshift-kubernetes-apimachinery-origin-4.3-kubernetes-1.16.0-beta.1.yaml variant= 
```

/cc @droslean 