### PR TITLE
Test Image distributor: Don't log notfound in configchange handler

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -155,7 +155,10 @@ func sourceForConfigChangeChannel(buildClusterNames sets.String, registryClient 
 				namespace = strings.TrimPrefix(namespace, "imagestream_")
 				var imagestream imagev1.ImageStream
 				if err := registryClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &imagestream); err != nil {
-					logrus.WithError(err).WithField("name", namespace+"/"+name).Error("Failed to get imagestream")
+					// Not found means user referenced an inexistent stream.
+					if !apierrors.IsNotFound(err) {
+						logrus.WithError(err).WithField("name", namespace+"/"+name).Error("Failed to get imagestream")
+					}
 					continue
 				}
 				for _, tag := range imagestream.Status.Tags {


### PR DESCRIPTION
Currently, if a ci-operator config change references a new imagestream,
we will get it and then distribute all tags in it. Sometimes ppl add
defunct config that references an inexistent stream, resulting in error
like this:

```
msg=Failed to get imagestream, error=ImageStream.image.openshift.io "4.9-priv" not found
```

This change supresses such error logs.

/cc @openshift/openshift-team-developer-productivity-test-platform 