### PR TITLE
pod-scaler: add an e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ TAGS ?= e2e,e2e_framework
 #   make e2e
 #   make e2e SUITE=multi-stage
 e2e: $(TMPDIR)/.boskos-credentials
-	BOSKOS_CREDENTIALS_FILE="$(TMPDIR)/boskos-credentials" PACKAGES="./test/e2e/..." TESTFLAGS="$(TESTFLAGS) -tags $(TAGS) -timeout 70m -parallel 100" hack/test-go.sh
+	BOSKOS_CREDENTIALS_FILE="$(TMPDIR)/.boskos-credentials" PACKAGES="./test/e2e/..." TESTFLAGS="$(TESTFLAGS) -tags $(TAGS) -timeout 70m -parallel 100" hack/test-go.sh
 .PHONY: e2e
 
 $(TMPDIR)/.boskos-credentials:

--- a/cmd/pod-scaler/producer_test.go
+++ b/cmd/pod-scaler/producer_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	prometheusapi "github.com/prometheus/client_golang/api/prometheus/v1"
+
+	pod_scaler "github.com/openshift/ci-tools/pkg/pod-scaler"
 )
 
 func TestQueriesByMetric(t *testing.T) {
@@ -161,5 +165,180 @@ func TestQueriesByMetric(t *testing.T) {
 	}
 	if diff := cmp.Diff(expected, queriesByMetric()); diff != "" {
 		t.Errorf("incorrect queries: %v", diff)
+	}
+}
+
+func TestDivideRange(t *testing.T) {
+	var testCases = []struct {
+		name      string
+		uncovered []pod_scaler.TimeRange
+		step      time.Duration
+		numSteps  int64
+		expected  []prometheusapi.Range
+	}{
+		{
+			name: "smaller range than one step",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 0, 20, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 100,
+			expected: nil,
+		},
+		{
+			name: "range is one step",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 1, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 100,
+			expected: nil,
+		},
+		{
+			name: "smaller range than one division",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 100,
+			expected: []prometheusapi.Range{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}},
+		},
+		{
+			name: "range fits exactly one division",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 10,
+			expected: []prometheusapi.Range{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}},
+		},
+		{
+			name: "range fits more than one division, evenly divisible",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 30, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 10,
+			expected: []prometheusapi.Range{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 0, 11, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 21, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 0, 22, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 30, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}},
+		},
+		{
+			name: "range fits more than one division, not evenly divisible",
+			uncovered: []pod_scaler.TimeRange{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 36, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 10,
+			expected: []prometheusapi.Range{{
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 0, 11, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 21, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 0, 22, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 32, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 0, 33, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 36, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}},
+		},
+		{
+			name: "uncovered ranges smaller than, and larger than divisions, both equally and unequally divisible",
+			uncovered: []pod_scaler.TimeRange{{ // this one is smaller than a step
+				Start: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 0, 0, 10, 0, time.UTC),
+			}, { // this one is smaller than a division
+				Start: time.Date(0, 0, 0, 1, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 1, 2, 0, 0, time.UTC),
+			}, { // this one is exactly one division
+				Start: time.Date(0, 0, 0, 2, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 2, 10, 0, 0, time.UTC),
+			}, { // this one is two divisions, evenly dividing
+				Start: time.Date(0, 0, 0, 3, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 3, 20, 0, 0, time.UTC),
+			}, { // this one is two divisions, not evenly dividing
+				Start: time.Date(0, 0, 0, 4, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 4, 17, 0, 0, time.UTC),
+			}},
+			step:     time.Minute,
+			numSteps: 10,
+			expected: []prometheusapi.Range{{
+				Start: time.Date(0, 0, 0, 1, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 1, 2, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 2, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 2, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 3, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 3, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 3, 11, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 3, 20, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 4, 0, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 4, 10, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}, {
+				Start: time.Date(0, 0, 0, 4, 11, 0, 0, time.UTC),
+				End:   time.Date(0, 0, 0, 4, 17, 0, 0, time.UTC),
+				Step:  time.Minute,
+			}},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := divideRange(testCase.uncovered, testCase.step, testCase.numSteps)
+			if diff := cmp.Diff(actual, testCase.expected); diff != "" {
+				t.Errorf("%s: got incorrect ranges: %v", testCase.name, diff)
+			}
+			seen := map[time.Time]interface{}{}
+			for i, item := range actual {
+				if item.End.Sub(item.Start) == 0 {
+					t.Errorf("%s: divided[%d]: got a 0-length range from %s to %s", testCase.name, i, item.Start.String(), item.End.String())
+				}
+				if _, ok := seen[item.Start]; ok {
+					t.Errorf("%s: divided[%d].start: overlaps with a boundary of another range", testCase.name, i)
+				}
+				seen[item.Start] = nil
+				if _, ok := seen[item.End]; ok {
+					t.Errorf("%s: divided[%d].end: overlaps with a boundary of another range", testCase.name, i)
+				}
+				seen[item.End] = nil
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/polyfloyd/go-errorlint v0.0.0-20200429095719-920be198a950
 	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
+	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/slack-go/slack v0.7.3

--- a/go.sum
+++ b/go.sum
@@ -1306,6 +1306,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
+github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quasilyte/go-ruleguard v0.1.2-0.20200318202121-b00d7a75d3d8/go.mod h1:CGFX09Ci3pq9QZdj86B+VGIdNj4VyCo2iPOGS9esB/k=

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -1,0 +1,117 @@
+// +build e2e
+
+package pod_scaler
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openhistogram/circonusllhist"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	pod_scaler "github.com/openshift/ci-tools/pkg/pod-scaler"
+	"github.com/openshift/ci-tools/pkg/testhelper"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/kubernetes"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/prometheus"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/run"
+)
+
+func TestProduce(t *testing.T) {
+	t.Parallel()
+	T := testhelper.NewT(interrupts.Context(), t)
+	prometheusAddr, info := prometheus.Initialize(T, T.TempDir())
+	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), prometheusAddr)
+
+	dataDir := T.TempDir()
+	// we need to run the data collection in order of largest offsets as smaller ones subsume the data
+	var offsets []time.Duration
+	for offset := range info.ByOffset {
+		offsets = append(offsets, offset)
+	}
+	sort.Slice(offsets, func(i, j int) bool {
+		return offsets[i] > offsets[j]
+	})
+	expected := prometheus.Data{ByFile: map[string]map[pod_scaler.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}}
+	for _, offset := range offsets {
+		// we expect the data from this offset and all earlier ones, too
+		data := info.ByOffset[offset]
+		for filename := range data.ByFile {
+			if _, ok := expected.ByFile[filename]; !ok {
+				expected.ByFile[filename] = map[pod_scaler.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
+			}
+			for identifier, hists := range data.ByFile[filename] {
+				expected.ByFile[filename][identifier] = append(expected.ByFile[filename][identifier], hists...)
+			}
+		}
+		run.Producer(T, dataDir, kubeconfigFile, offset)
+		check(t, dataDir, expected)
+	}
+}
+
+// we can't simply check static output files to determine that the producer worked as expected, for a number of reasons:
+// - the data structure we use to store the time ranges we've queried holds time stamps that are dynamically determined
+// - we store Prometheus data by series fingerprint, which we can't determine ahead of time
+func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
+	for filename, data := range checkAgainst.ByFile {
+		var c pod_scaler.CachedQuery
+		raw, err := ioutil.ReadFile(filepath.Join(dataDir, filename))
+		if err != nil {
+			t.Fatalf("%s: failed to read cache: %v", filename, err)
+		}
+		if err := json.Unmarshal(raw, &c); err != nil {
+			t.Fatalf("%s: failed to unmarshal cache: %v", filename, err)
+		}
+		actualIdentifiers, expectedIdentifiers := map[pod_scaler.FullMetadata]interface{}{}, map[pod_scaler.FullMetadata]interface{}{}
+		for item := range data {
+			expectedIdentifiers[item] = nil
+		}
+		for item := range c.DataByMetaData {
+			actualIdentifiers[item] = nil
+		}
+		if diff := cmp.Diff(actualIdentifiers, expectedIdentifiers); diff != "" {
+			t.Errorf("%s: did not get correct identifiers: %v", filename, diff)
+		}
+		for identifier := range c.DataByMetaData {
+			if actual, expected := len(c.DataByMetaData[identifier]), len(data[identifier]); actual != expected {
+				t.Errorf("%s: %s: expected %d histograms but got %d", filename, identifier.String(), expected, actual)
+			}
+			if strings.Contains(filename, "container_cpu_usage_seconds_total") {
+				// no sensible way to assert about histograms containing data using rate()
+				continue
+			}
+			for _, fingerprint := range c.DataByMetaData[identifier] {
+				hist := c.Data[fingerprint].Histogram()
+				var found bool
+				for _, other := range data[identifier] {
+					if hist.Equals(other.Histogram()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("%s: %s: did not expect %d samples: %v", filename, identifier.String(), hist.Count(), hist)
+				}
+			}
+			for _, item := range data[identifier] {
+				hist := item.Histogram()
+				var found bool
+				for _, fingerprint := range c.DataByMetaData[identifier] {
+					if hist.Equals(c.Data[fingerprint].Histogram()) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("%s: %s: did not find %d samples: %v", filename, identifier.String(), hist.Count(), hist)
+				}
+			}
+		}
+	}
+}

--- a/test/e2e/pod-scaler/kubernetes/kubernetes.go
+++ b/test/e2e/pod-scaler/kubernetes/kubernetes.go
@@ -1,0 +1,73 @@
+// +build e2e
+
+package kubernetes
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+// Fake serves fake data as if it were a k8s apiserver
+func Fake(t testhelper.TestingTInterface, tmpDir, prometheusAddr string) string {
+	k8sPort := testhelper.GetFreePort(t)
+	k8sAddr := "0.0.0.0:" + k8sPort
+	mux := http.NewServeMux()
+	mux.HandleFunc("/apis/route.openshift.io/v1/namespaces/openshift-monitoring/routes/prometheus-k8s", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Content-Type", "application/json")
+		if _, err := writer.Write([]byte(fmt.Sprintf(`{"spec":{"host":"%s"}}`, prometheusAddr))); err != nil {
+			http.Error(writer, err.Error(), 500)
+			return
+		}
+	})
+	server := &http.Server{
+		Addr:    k8sAddr,
+		Handler: mux,
+	}
+	interrupts.ListenAndServe(server, 10*time.Second)
+
+	kubeconfig := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"default": {
+				Server: k8sAddr,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"default": {
+				Cluster:   "default",
+				AuthInfo:  "user",
+				Namespace: "ns",
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"user": {
+				Username: "user",
+				Password: "pass",
+			},
+		},
+	}
+
+	kubeconfigFile, err := ioutil.TempFile(tmpDir, "kubeconfig")
+	if err != nil {
+		t.Fatalf("Failed to create temporary kubeconfig file: %v", err)
+	}
+	if err := kubeconfigFile.Close(); err != nil {
+		t.Fatalf("Failed to close temporary kubeconfig file: %v", err)
+	}
+	if err := clientcmd.ModifyConfig(&clientcmd.PathOptions{
+		GlobalFile: kubeconfigFile.Name(),
+		LoadingRules: &clientcmd.ClientConfigLoadingRules{
+			ExplicitPath: kubeconfigFile.Name(),
+		},
+	}, kubeconfig, false); err != nil {
+		t.Fatalf("Failed to write temporary kubeconfig file: %v", err)
+	}
+	return kubeconfigFile.Name()
+}

--- a/test/e2e/pod-scaler/local/main.go
+++ b/test/e2e/pod-scaler/local/main.go
@@ -1,0 +1,79 @@
+// +build e2e
+
+// This tool can run the pod-scaler locally, setting up dependencies in an ephemeral manner
+// and mimicking what the end-to-end tests do in order to facilitate high-fidelity local dev.
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/kubernetes"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/prometheus"
+	"github.com/openshift/ci-tools/test/e2e/pod-scaler/run"
+)
+
+func main() {
+	logger := logrus.WithField("component", "local-pod-scaler")
+	tmpDir, err := ioutil.TempDir("", "podscaler")
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to create temporary directory.")
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			logger.WithError(err).Error("Failed to clean up temporary directory.")
+		}
+	}()
+	t := &fakeT{
+		tmpDir: tmpDir,
+		logger: logger,
+	}
+	prometheusAddr, _ := prometheus.Initialize(t, tmpDir)
+	kubeconfigFile := kubernetes.Fake(t, tmpDir, prometheusAddr)
+
+	dataDir, err := ioutil.TempDir(tmpDir, "data")
+	if err != nil {
+		logger.WithError(err).Fatal("Failed to create temporary directory for data.")
+	}
+	run.Producer(t, dataDir, kubeconfigFile, 0*time.Second)
+	interrupts.WaitForGracefulShutdown()
+}
+
+type fakeT struct {
+	tmpDir string
+	logger *logrus.Entry
+}
+
+var _ testhelper.TestingTInterface = &fakeT{}
+
+func (t *fakeT) Cleanup(f func())                          { logrus.RegisterExitHandler(f) }
+func (t *fakeT) Deadline() (deadline time.Time, ok bool)   { return time.Time{}, false }
+func (t *fakeT) Error(args ...interface{})                 { t.logger.Error(args...) }
+func (t *fakeT) Errorf(format string, args ...interface{}) { t.logger.Errorf(format, args...) }
+func (t *fakeT) Fail()                                     { t.logger.Fatal("Fail called!") }
+func (t *fakeT) FailNow()                                  { t.logger.Fatal("FailNow called!") }
+func (t *fakeT) Failed() bool                              { return false }
+func (t *fakeT) Fatal(args ...interface{})                 { t.logger.Fatal(args...) }
+func (t *fakeT) Fatalf(format string, args ...interface{}) { t.logger.Fatalf(format, args...) }
+func (t *fakeT) Helper()                                   {}
+func (t *fakeT) Log(args ...interface{})                   { t.logger.Info(args...) }
+func (t *fakeT) Logf(format string, args ...interface{})   { t.logger.Infof(format, args...) }
+func (t *fakeT) Name() string                              { return "pod-scaler/local" }
+func (t *fakeT) Parallel()                                 {}
+func (t *fakeT) Skip(args ...interface{})                  { t.logger.Info(args...) }
+func (t *fakeT) SkipNow()                                  {}
+func (t *fakeT) Skipf(format string, args ...interface{})  { t.logger.Infof(format, args...) }
+func (t *fakeT) Skipped() bool                             { return false }
+func (t *fakeT) TempDir() string {
+	dir, err := ioutil.TempDir(t.tmpDir, "")
+	if err != nil {
+		t.logger.WithError(err).Fatal("Could not create temporary directory.")
+	}
+	return dir
+}

--- a/test/e2e/pod-scaler/prometheus/backfill.go
+++ b/test/e2e/pod-scaler/prometheus/backfill.go
@@ -1,0 +1,392 @@
+// +build e2e
+
+package prometheus
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/openhistogram/circonusllhist"
+	prometheus_client "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/prometheus/pkg/value"
+	uuid "github.com/satori/go.uuid"
+
+	"k8s.io/utils/pointer"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	pod_scaler "github.com/openshift/ci-tools/pkg/pod-scaler"
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+const (
+	// numSeries is the number of individual series of data generated for a given label set
+	numSeries = 10
+	// numSamples is the number of samples in an individual series
+	numSamples = 250
+	// samplingDuration is the duration between samples in a series
+	samplingDuration = time.Minute
+	// seriesDuration
+	seriesDuration = time.Duration(numSamples) * samplingDuration
+)
+
+type DataInStages struct {
+	ByOffset map[time.Duration]Data
+}
+
+type Data struct {
+	ByFile map[string]map[pod_scaler.FullMetadata][]*circonusllhist.HistogramWithoutLookups
+}
+
+func (d *DataInStages) record(offset time.Duration, metric string, labels seriesLabels, identifier pod_scaler.FullMetadata, data []float64) error {
+	hist := circonusllhist.New(circonusllhist.NoLookup(), circonusllhist.Size(1))
+	for _, v := range data {
+		if err := hist.RecordValue(v); err != nil {
+			return fmt.Errorf("could not insert value into histogram: %w", err)
+		}
+	}
+
+	if _, ok := d.ByOffset[offset]; !ok {
+		d.ByOffset[offset] = Data{
+			ByFile: map[string]map[pod_scaler.FullMetadata][]*circonusllhist.HistogramWithoutLookups{},
+		}
+	}
+	var file string
+	switch {
+	case labels["label_ci_openshift_io_metadata_step"] != "":
+		file = fmt.Sprintf("steps/%s.json", metric)
+	case labels["label_created_by_prow"] != "":
+		file = fmt.Sprintf("prowjobs/%s.json", metric)
+	default:
+		file = fmt.Sprintf("pods/%s.json", metric)
+	}
+	if _, ok := d.ByOffset[offset].ByFile[file]; !ok {
+		d.ByOffset[offset].ByFile[file] = map[pod_scaler.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
+	}
+
+	// round-tripping ensures we have a slice of buckets in the histogram that's as small as possible,
+	// which ends up being necessary for equality - the natural growth of the slice will lead to some
+	// unused capacity in the hist structure which trips the equality function up
+	withoutLookups := circonusllhist.NewHistogramWithoutLookups(hist)
+	raw, err := withoutLookups.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("could not serialize histogram: %w", err)
+	}
+	var copied circonusllhist.HistogramWithoutLookups
+	if err := json.Unmarshal(raw, &copied); err != nil {
+		return fmt.Errorf("could not deserialize histogram: %w", err)
+	}
+	d.ByOffset[offset].ByFile[file][identifier] = append(d.ByOffset[offset].ByFile[file][identifier], &copied)
+
+	return nil
+}
+
+// Backfill generates data and backfills it into Prometheus, returning the data written by stage.
+func Backfill(t testhelper.TestingTInterface, prometheusDir string, retentionPeriod time.Duration) *DataInStages {
+	rand.Seed(time.Now().UnixNano())
+	t.Log("Backfilling Prometheus data.")
+	generateStart := time.Now()
+	info, families := generateData(t, retentionPeriod)
+	t.Logf("Generated Prometheus data in %s.", time.Since(generateStart))
+
+	writeStart := time.Now()
+	prometheusBackfillFile, err := ioutil.TempFile(prometheusDir, "backfill")
+	if err != nil {
+		t.Fatalf("Could not create temporary file for Prometheus backfill: %v", err)
+	}
+	encoder := expfmt.NewEncoder(prometheusBackfillFile, expfmt.FmtOpenMetrics)
+	for _, family := range families {
+		if err := encoder.Encode(family); err != nil {
+			t.Fatalf("Failed to write Prometheus backfill data: %v", err)
+		}
+	}
+	closer := encoder.(expfmt.Closer)
+	if err := closer.Close(); err != nil {
+		t.Fatalf("Failed to close Prometheus backfill data: %v", err)
+	}
+	if err := prometheusBackfillFile.Close(); err != nil {
+		t.Fatalf("Failed to close temporary Prometheus backfill file: %v", err)
+	}
+	t.Logf("Wrote generated Prometheus data in %s.", time.Since(writeStart))
+
+	backfillStart := time.Now()
+	backfillArgs := []string{
+		"promtool", "tsdb", "create-blocks-from", "openmetrics",
+		prometheusBackfillFile.Name(),
+		prometheusDir,
+		"--quiet",
+		"--max-block-duration=10000h",
+	}
+	t.Logf("Running backfill: %v", strings.Join(backfillArgs, " "))
+	backfill := exec.Command(backfillArgs[0], backfillArgs[1:]...)
+	if out, err := backfill.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to backfill Prometheus: %v: %v", err, string(out))
+	}
+
+	t.Logf("Backfilled Prometheus data in %s.", time.Since(backfillStart))
+	return info
+}
+
+func generateData(t testhelper.TestingTInterface, retentionPeriod time.Duration) (*DataInStages, []*prometheus_client.MetricFamily) {
+	info := &DataInStages{ByOffset: map[time.Duration]Data{}}
+	metricTypePtr := func(metric prometheus_client.MetricType) *prometheus_client.MetricType { return &metric }
+	kubePodLabels := prometheus_client.MetricFamily{
+		Name:   pointer.StringPtr("kube_pod_labels"),
+		Type:   metricTypePtr(prometheus_client.MetricType_COUNTER),
+		Metric: []*prometheus_client.Metric{},
+	}
+	families := []*prometheus_client.MetricFamily{&kubePodLabels}
+	for metric, metadata := range metricGenerators() {
+		family := prometheus_client.MetricFamily{
+			Name:   pointer.StringPtr(metric),
+			Type:   metricTypePtr(metadata.metricType),
+			Metric: []*prometheus_client.Metric{},
+		}
+		for identifier, labels := range series() {
+			mean := float64(rand.Int31())
+			stddev := rand.Float64() * mean / 20.0
+			for _, offset := range offsets(retentionPeriod) {
+				for j := 0; j < numSeries; j++ {
+					labelPairs := labelsFor(labels)
+					var values []float64
+					start := time.Now().Add(-time.Duration(rand.Float64()*float64(retentionPeriod/2-seriesDuration)) - offset - seriesDuration).Round(1 * time.Minute)
+					for k := 0; k < numSamples; k++ {
+						ts := pointer.Int64Ptr(start.Add(time.Duration(k)*samplingDuration).UnixNano() / 1e6)
+
+						// record a new value in the metric we're generating
+						m := &prometheus_client.Metric{
+							Label:       labelPairs,
+							TimestampMs: ts,
+						}
+						metadata.addValue(m, rand.NormFloat64()*stddev+mean, float64(k))
+						family.Metric = append(family.Metric, m)
+
+						values = append(values, metadata.getValue(m))
+
+						// record a value in the kube_pod_labels metric, which we join on during queries
+						kubePodLabels.Metric = append(kubePodLabels.Metric, &prometheus_client.Metric{
+							Label:       labelPairs,
+							TimestampMs: ts,
+							Counter:     &prometheus_client.Counter{Value: pointer.Float64Ptr(1)},
+						})
+					}
+
+					// add a stale marker to the end of the series to ensure that Prometheus knows this data is done
+					stale := &prometheus_client.Metric{
+						Label:       labelPairs,
+						TimestampMs: pointer.Int64Ptr(start.Add(time.Duration(numSamples)*samplingDuration).UnixNano() / 1e6),
+					}
+					metadata.addValue(stale, math.Float64frombits(value.StaleNaN), 1)
+					family.Metric = append(family.Metric, stale)
+
+					if err := info.record(offset, metric, labels, identifier, values); err != nil {
+						t.Fatalf("could not record values into hist: %v", err)
+					}
+				}
+			}
+		}
+		families = append(families, &family)
+	}
+	return info, families
+}
+
+// metricGenerator describes a metric and closes over value operations on the Metric type
+type metricGenerator struct {
+	metricType prometheus_client.MetricType
+	addValue   func(*prometheus_client.Metric, float64, float64)
+	getValue   func(*prometheus_client.Metric) float64
+}
+
+func metricGenerators() map[string]metricGenerator {
+	return map[string]metricGenerator{
+		"container_cpu_usage_seconds_total": {
+			metricType: prometheus_client.MetricType_COUNTER,
+			addValue: func(metric *prometheus_client.Metric, f, j float64) {
+				metric.Counter = &prometheus_client.Counter{Value: pointer.Float64Ptr(f*j + 1)} // we're interested in measuring the rate
+			},
+			getValue: func(metric *prometheus_client.Metric) float64 {
+				return *metric.Counter.Value
+			},
+		},
+		"container_memory_working_set_bytes": {
+			metricType: prometheus_client.MetricType_GAUGE,
+			addValue: func(metric *prometheus_client.Metric, f, _ float64) {
+				metric.Gauge = &prometheus_client.Gauge{Value: pointer.Float64Ptr(f)}
+			},
+			getValue: func(metric *prometheus_client.Metric) float64 {
+				return *metric.Gauge.Value
+			},
+		},
+	}
+}
+
+// seriesLabels holds a Prometheus label set for a series of data
+type seriesLabels map[string]string
+
+func series() map[pod_scaler.FullMetadata]seriesLabels {
+	return map[pod_scaler.FullMetadata]seriesLabels{
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Target:    "target",
+			Step:      "step",
+			Pod:       "pod",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_ci":                    "true",
+			"label_ci_openshift_io_metadata_org":     "org",
+			"label_ci_openshift_io_metadata_repo":    "repo",
+			"label_ci_openshift_io_metadata_branch":  "branch",
+			"label_ci_openshift_io_metadata_variant": "variant",
+			"label_ci_openshift_io_metadata_target":  "target",
+			"label_ci_openshift_io_metadata_step":    "step",
+			"pod":                                    "pod",
+			"container":                              "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Pod:       "src-build",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_ci":                    "true",
+			"label_ci_openshift_io_metadata_org":     "org",
+			"label_ci_openshift_io_metadata_repo":    "repo",
+			"label_ci_openshift_io_metadata_branch":  "branch",
+			"label_ci_openshift_io_metadata_variant": "variant",
+			"label_ci_openshift_io_metadata_target":  "target",
+			"label_openshift_io_build_name":          "src",
+			"pod":                                    "src-build",
+			"container":                              "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Pod:       "release-latest-cli",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_ci":                    "true",
+			"label_ci_openshift_io_metadata_org":     "org",
+			"label_ci_openshift_io_metadata_repo":    "repo",
+			"label_ci_openshift_io_metadata_branch":  "branch",
+			"label_ci_openshift_io_metadata_variant": "variant",
+			"label_ci_openshift_io_metadata_target":  "target",
+			"label_ci_openshift_io_release":          "latest",
+			"pod":                                    "release-latest-cli",
+			"container":                              "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Container: "rpm-repo",
+		}: map[string]string{
+			"label_created_by_ci":                    "true",
+			"label_ci_openshift_io_metadata_org":     "org",
+			"label_ci_openshift_io_metadata_repo":    "repo",
+			"label_ci_openshift_io_metadata_branch":  "branch",
+			"label_ci_openshift_io_metadata_variant": "variant",
+			"label_ci_openshift_io_metadata_target":  "target",
+			"label_app":                              "rpm-repo",
+			"pod":                                    "rpm-repo-5d88d4fc4c-jg2xb",
+			"container":                              "rpm-repo",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			Target:    "context",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_prow":           "true",
+			"label_prow_k8s_io_refs_org":      "org",
+			"label_prow_k8s_io_refs_repo":     "repo",
+			"label_prow_k8s_io_refs_base_ref": "branch",
+			"label_prow_k8s_io_context":       "context",
+			"label_prow_k8s_io_job":           "pull-ci-org-repo-branch-context",
+			"pod":                             "d316d4cc-a438-11eb-b35f-0a580a800e92",
+			"container":                       "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:    "org",
+				Repo:   "repo",
+				Branch: "branch",
+			},
+			Target:    "context",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_prow":           "true",
+			"label_prow_k8s_io_refs_org":      "org",
+			"label_prow_k8s_io_refs_repo":     "repo",
+			"label_prow_k8s_io_refs_base_ref": "branch",
+			"label_prow_k8s_io_context":       "",
+			"label_prow_k8s_io_job":           "periodic-ci-org-repo-branch-context",
+			"label_prow_k8s_io_type":          "periodic",
+			"pod":                             "d316d4cc-a437-11eb-b35f-0a580a800e92",
+			"container":                       "container",
+		},
+		{
+			Target:    "periodic-handwritten-prowjob",
+			Container: "container",
+		}: map[string]string{
+			"label_created_by_prow":     "true",
+			"label_prow_k8s_io_context": "",
+			"label_prow_k8s_io_job":     "periodic-handwritten-prowjob",
+			"label_prow_k8s_io_type":    "periodic",
+			"pod":                       "d316d4cc-a437-11eb-b35f-0a580a800e92",
+			"container":                 "container",
+		},
+	}
+}
+
+// offsets determines the offsets we generate data around given a retention period. We want to generate data in every
+// interval so that in the future we can assert that incremental queries work to add new data to the dataset.
+func offsets(retentionPeriod time.Duration) []time.Duration {
+	return []time.Duration{0, retentionPeriod / 2}
+}
+
+// labelsFor turns a raw map of labels into a set of label pairs, adding random data for required but missing labels
+func labelsFor(raw map[string]string) []*prometheus_client.LabelPair {
+	localSet := map[string]string{}
+	for k, v := range raw {
+		localSet[k] = v
+	}
+	for _, required := range []string{"namespace", "pod", "container"} {
+		if _, set := localSet[required]; set {
+			continue
+		}
+		localSet[required] = uuid.NewV4().String()
+	}
+	var labels []*prometheus_client.LabelPair
+	for k, v := range localSet {
+		labels = append(labels, &prometheus_client.LabelPair{
+			Name:  pointer.StringPtr(k),
+			Value: pointer.StringPtr(v),
+		})
+	}
+	return labels
+}

--- a/test/e2e/pod-scaler/prometheus/prometheus.go
+++ b/test/e2e/pod-scaler/prometheus/prometheus.go
@@ -1,0 +1,88 @@
+// +build e2e
+
+package prometheus
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+// Initialize runs Prometheus with backfilled data under the given dir.
+func Initialize(t testhelper.TestingTInterface, tmpDir string) (string, *DataInStages) {
+	prometheusDir, err := ioutil.TempDir(tmpDir, "prometheus")
+	if err != nil {
+		t.Fatalf("Failed to create temporary directory for Prometheus: %v", err)
+	}
+	if err := os.Chmod(prometheusDir, 0777); err != nil {
+		t.Fatalf("Failed to open permissions in temporary directory for Prometheus: %v", err)
+	}
+	t.Logf("Prometheus data will be in %s", prometheusDir)
+
+	prometheusConfig := filepath.Join(prometheusDir, "prometheus.yaml")
+	if err := ioutil.WriteFile(prometheusConfig, []byte(`global:
+  scrape_interval: 15s`), 0666); err != nil {
+		t.Fatalf("Could not write Prometheus config file: %v", err)
+	}
+
+	prometheusHostname := "0.0.0.0"
+	prometheusFlags := []string{
+		"--config.file", prometheusConfig,
+		"--storage.tsdb.path", prometheusDir,
+		"--storage.tsdb.retention.time", "20d",
+		"--storage.tsdb.allow-overlapping-blocks",
+		"--log.level", "info",
+	}
+	prometheusCtx, prometheusCancel := context.WithCancel(interrupts.Context())
+	prometheusInitOutput := &bytes.Buffer{}
+	prometheusInit := exec.CommandContext(prometheusCtx, "prometheus",
+		append(prometheusFlags, "--web.listen-address", prometheusHostname+":"+testhelper.GetFreePort(t))...,
+	)
+	prometheusInit.Stdout = prometheusInitOutput
+	prometheusInit.Stderr = prometheusInitOutput
+	if err := prometheusInit.Start(); err != nil {
+		logrus.WithError(err).Fatal("Failed to initialize Prometheus.")
+	}
+
+	retentionPeriod := 20 * 24 * time.Hour
+	info := Backfill(t, prometheusDir, retentionPeriod)
+
+	// restart Prometheus to reload TSDB, by default this can take minutes without a restart
+	prometheusCancel()
+	if err := prometheusInit.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ProcessState.String() == "signal: killed" {
+			// this was us killing the process, ignore
+		} else {
+			logrus.WithError(err).Fatalf("Failed to initialize Prometheus: %v: %v", err, prometheusInitOutput.String())
+		}
+	}
+
+	prometheus := testhelper.NewAccessory("prometheus", prometheusFlags,
+		func(port, _ string) []string {
+			t.Logf("Prometheus starting on port %s", port)
+			return []string{"--web.listen-address", fmt.Sprintf("%s:%s", prometheusHostname, port)}
+		}, func(port, _ string) []string {
+			return []string{"--prometheus-endpoint", fmt.Sprintf("%s:%s", prometheusHostname, port)}
+		},
+	)
+	prometheus.RunFromFrameworkRunner(t, interrupts.Context())
+	// TODO: wait more intelligently
+	time.Sleep(1 * time.Second)
+	prometheusConnectionFlags := prometheus.ClientFlags()
+	// this is a hack, but whatever
+	prometheusAddr := prometheusConnectionFlags[1]
+	prometheusHost := "http://" + prometheusAddr
+	t.Logf("Prometheus is running at %s", prometheusHost)
+	return prometheusAddr, info
+}

--- a/test/e2e/pod-scaler/run/producer.go
+++ b/test/e2e/pod-scaler/run/producer.go
@@ -1,0 +1,32 @@
+// +build e2e
+
+package run
+
+import (
+	"fmt"
+	"os/exec"
+	"time"
+
+	"k8s.io/test-infra/prow/interrupts"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func Producer(t testhelper.TestingTInterface, dataDir, kubeconfigFile string, ignoreUntil time.Duration) {
+	podScalerFlags := []string{
+		"--loglevel=info",
+		"--log-style=text",
+		"--cache-dir", dataDir,
+		"--kubeconfig", kubeconfigFile,
+		"--mode=producer",
+		"--produce-once=true",
+		fmt.Sprintf("--ignore-latest=%s", ignoreUntil.String()),
+	}
+	start := time.Now()
+	t.Logf("Running pod-scaler %v", podScalerFlags)
+	podScaler := exec.CommandContext(interrupts.Context(), "pod-scaler", podScalerFlags...)
+	if out, err := podScaler.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to run pod-scaler: %v: %s", err, string(out))
+	}
+	t.Logf("Ran pod-scaler in %s", time.Since(start))
+}

--- a/test/images/e2e-bin/Dockerfile
+++ b/test/images/e2e-bin/Dockerfile
@@ -1,2 +1,0 @@
-FROM bin
-COPY boskos/app /go/bin/boskos

--- a/vendor/github.com/prometheus/prometheus/LICENSE
+++ b/vendor/github.com/prometheus/prometheus/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/prometheus/prometheus/NOTICE
+++ b/vendor/github.com/prometheus/prometheus/NOTICE
@@ -1,0 +1,87 @@
+The Prometheus systems and service monitoring server
+Copyright 2012-2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).
+
+
+The following components are included in this product:
+
+Bootstrap
+http://getbootstrap.com
+Copyright 2011-2014 Twitter, Inc.
+Licensed under the MIT License
+
+bootstrap3-typeahead.js
+https://github.com/bassjobsen/Bootstrap-3-Typeahead
+Original written by @mdo and @fat
+Copyright 2014 Bass Jobsen @bassjobsen
+Licensed under the Apache License, Version 2.0
+
+fuzzy
+https://github.com/mattyork/fuzzy
+Original written by @mattyork
+Copyright 2012 Matt York
+Licensed under the MIT License
+
+bootstrap-datetimepicker.js
+https://github.com/Eonasdan/bootstrap-datetimepicker
+Copyright 2015 Jonathan Peterson (@Eonasdan)
+Licensed under the MIT License
+
+moment.js
+https://github.com/moment/moment/
+Copyright JS Foundation and other contributors
+Licensed under the MIT License
+
+Rickshaw
+https://github.com/shutterstock/rickshaw
+Copyright 2011-2014 by Shutterstock Images, LLC
+See https://github.com/shutterstock/rickshaw/blob/master/LICENSE for license details
+
+mustache.js
+https://github.com/janl/mustache.js
+Copyright 2009 Chris Wanstrath (Ruby)
+Copyright 2010-2014 Jan Lehnardt (JavaScript)
+Copyright 2010-2015 The mustache.js community
+Licensed under the MIT License
+
+jQuery
+https://jquery.org
+Copyright jQuery Foundation and other contributors
+Licensed under the MIT License
+
+Protocol Buffers for Go with Gadgets
+http://github.com/gogo/protobuf/
+Copyright (c) 2013, The GoGo Authors.
+See source code for license details.
+
+Go support for leveled logs, analogous to
+https://code.google.com/p/google-glog/
+Copyright 2013 Google Inc.
+Licensed under the Apache License, Version 2.0
+
+Support for streaming Protocol Buffer messages for the Go language (golang).
+https://github.com/matttproud/golang_protobuf_extensions
+Copyright 2013 Matt T. Proud
+Licensed under the Apache License, Version 2.0
+
+DNS library in Go
+http://miek.nl/posts/2014/Aug/16/go-dns-package/
+Copyright 2009 The Go Authors, 2011 Miek Gieben
+See https://github.com/miekg/dns/blob/master/LICENSE for license details.
+
+LevelDB key/value database in Go
+https://github.com/syndtr/goleveldb
+Copyright 2012 Suryandaru Triandana
+See https://github.com/syndtr/goleveldb/blob/master/LICENSE for license details.
+
+gosnappy - a fork of code.google.com/p/snappy-go
+https://github.com/syndtr/gosnappy
+Copyright 2011 The Snappy-Go Authors
+See https://github.com/syndtr/gosnappy/blob/master/LICENSE for license details.
+
+go-zookeeper - Native ZooKeeper client for Go
+https://github.com/samuel/go-zookeeper
+Copyright (c) 2013, Samuel Stauffer <samuel@descolada.com>
+See https://github.com/samuel/go-zookeeper/blob/master/LICENSE for license details.

--- a/vendor/github.com/prometheus/prometheus/pkg/value/value.go
+++ b/vendor/github.com/prometheus/prometheus/pkg/value/value.go
@@ -1,0 +1,34 @@
+// Copyright 2016 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package value
+
+import (
+	"math"
+)
+
+const (
+	// NormalNaN is a quiet NaN. This is also math.NaN().
+	NormalNaN uint64 = 0x7ff8000000000001
+
+	// StaleNaN is a signalling NaN, due to the MSB of the mantissa being 0.
+	// This value is chosen with many leading 0s, so we have scope to store more
+	// complicated values in the future. It is 2 rather than 1 to make
+	// it easier to distinguish from the NormalNaN by a human when debugging.
+	StaleNaN uint64 = 0x7ff0000000000002
+)
+
+// IsStaleNaN returns true when the provided NaN value is a stale marker.
+func IsStaleNaN(v float64) bool {
+	return math.Float64bits(v) == StaleNaN
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -460,6 +460,7 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
+## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.26.0
 ## explicit
@@ -470,6 +471,9 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
+# github.com/prometheus/prometheus v2.5.0+incompatible
+## explicit
+github.com/prometheus/prometheus/pkg/value
 # github.com/ryanuber/go-glob v1.0.0
 github.com/ryanuber/go-glob
 # github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
pod-scaler: add e2e tests that use a real Prometheus

In these tests (and the local running mode for the pod-scaler in
general), we start by filling a Prometheus server with some fake data
using the new backfill command from `promtool`. Then, we run the
pod-scaler producer and assert something about the data we've fetched.
We cannot sensibly assert about the rates, so for now we just assert
about memory usage, but this should suffice as the content of a query
does not change how we get the data from Prometheus and store it. In the
time it took to write this e2e test, the following issues were resolved:

 - the promtool utility is extremely slow, we use the latest possible
   version now to take advantages of new patches I wrote to increase
   the speed it runs by 100x
 - there were two off-by-one errors in the way that we queried
   Prometheus which would lead to double-counted data points in rare
   cases

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 