### PR TITLE
build_root: use new image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
-  namespace: openshift
-  name: release
-  tag: golang-1.16-vault-typescript
+  namespace: ci
+  name: ci-tools-build-root
+  tag: latest


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform

Part of [DPTP-2349](https://issues.redhat.com/browse/DPTP-2349)

Follow-up to https://github.com/openshift/release/pull/19698