### PR TITLE
pod-scaler: don't double count data on query edges

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -230,7 +230,8 @@ func (q *querier) execute(ctx context.Context, c *clusterMetadata, until time.Ti
 				stop = start.Add(time.Duration(numSteps) * r.Step)
 			}
 			c.wg.Add(1)
-			go q.executeOverRange(ctx, c, prometheusapi.Range{Start: start, End: stop, Step: r.Step})
+			// subtracting 1s from the end will ensure we don't double-count samples on the edge, as ranges are inclusive
+			go q.executeOverRange(ctx, c, prometheusapi.Range{Start: start, End: stop.Add(-1 * time.Second), Step: r.Step})
 			start = stop
 			stop = uncoveredRange.End
 		}


### PR DESCRIPTION
Previously, we would double-count data that happened to be on an edge
between two queries. We can offset a query by 1s (smaller than the
Prometheus sampling interval) to remedy this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 

Part of [DPTP-2349](https://issues.redhat.com/browse/DPTP-2349)