### PR TITLE
pod-scaler: correctly compute start of query range

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -191,7 +191,7 @@ func (q *querier) execute(ctx context.Context, c *clusterMetadata, until time.Ti
 		return fmt.Errorf("could not determine Prometheus retention duration: %w", err)
 	}
 	r := prometheusapi.Range{
-		Start: until.Add(-time.Duration(retention)),
+		Start: time.Now().Add(-time.Duration(retention)),
 		End:   until,
 		Step:  1 * time.Minute,
 	}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform

Part of [DPTP-2349](https://issues.redhat.com/browse/DPTP-2349)