### PR TITLE
pod-scaler: correctly detect the end of query range

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -223,7 +223,7 @@ func (q *querier) execute(ctx context.Context, c *clusterMetadata, until time.Ti
 		numSteps := c.maxSize - 1
 		c.lock.RUnlock()
 		for {
-			if start == uncoveredRange.End {
+			if start.Equal(uncoveredRange.End) {
 				break
 			}
 			if int64(stop.Sub(start)/r.Step) > numSteps {


### PR DESCRIPTION
Using == was doing a comparison on the pointers, which did end up
terminating but not until we sent a spurious 0-length query.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform

Part of [DPTP-2349](https://issues.redhat.com/browse/DPTP-2349)