### PR TITLE
e2e: don't run OO e2e by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ integration:
 .PHONY: integration
 
 TMPDIR ?= /tmp
-TAGS ?= e2e,e2e_framework,optional_operators
+TAGS ?= e2e,e2e_framework
 
 # Run e2e tests.
 #

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -14,7 +14,7 @@ if [[ -n ${CI:-} ]]; then touch cmd/vault-secret-collection-manager/index.js; fi
 
 # The thing has a -skip-{dirs,files} directive which is ignored by half the linters. Why is life so hard.
 targets="$(find . -maxdepth 1 -type d|egrep -v 'git|_output|hack|vendor|^\.$'|sed -E 's/(.*)/\1\/\.\.\./g'|tr '\n' ' ')"
-golangci-lint run --build-tags e2e
+golangci-lint run --build-tags e2e,e2e_framework,optional_operators
 
 cd $(dirname $0)/..
 


### PR DESCRIPTION
We now have a run_if_changed presubmit to trigger on changes to the OO
code for those, and a postsubmit with an alert to give more confidence.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 