### PR TITLE
Revert "pkg/validation: also validate `from_image`"

### DIFF
--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -96,6 +96,11 @@ func validateConfiguration(ctx *configContext, config *api.ReleaseBuildConfigura
 	for name := range releases {
 		releases.Insert(name)
 	}
+	validationErrors = append(validationErrors, validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
+
+	// this validation brings together a large amount of data from separate
+	// parts of the configuration, so it's written as a standalone method
+	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	if config.Operator != nil {
 		// validateOperator needs a method that maps `substitute.with` values to image links
 		// to validate the value is meaningful in the context of the configuration
@@ -119,11 +124,6 @@ func validateConfiguration(ctx *configContext, config *api.ReleaseBuildConfigura
 
 	validationErrors = append(validationErrors, validateReleases("releases", config.Releases, config.ReleaseTagConfiguration != nil)...)
 	validationErrors = append(validationErrors, validateImages(ctx.addField("images"), config.Images)...)
-	validationErrors = append(validationErrors, validateTestStepConfiguration(ctx, "tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
-
-	// this validation brings together a large amount of data from separate
-	// parts of the configuration, so it's written as a standalone method
-	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -917,32 +917,9 @@ func TestPipelineImages(t *testing.T) {
 			Resources: resources,
 		},
 		expected: errors.New(`invalid configuration: images[0]: duplicate image name 'root' (previously defined by field 'build_root')`),
-	}, {
-		name: "multi-stage from_image",
-		conf: api.ReleaseBuildConfiguration{
-			Images:             makeImages("from_image"),
-			InputConfiguration: input,
-			Tests: []api.TestStepConfiguration{{
-				As: "test-name",
-				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
-					Test: []api.LiteralTestStep{{
-						As:       "step-name",
-						Commands: "commands",
-						FromImage: &api.ImageStreamTagReference{
-							Namespace: "ns",
-							Name:      "name",
-							Tag:       "from_image",
-						},
-						Resources: resources["*"],
-					}},
-				},
-			}},
-			Resources: resources,
-		},
-		expected: errors.New(`invalid configuration: tests[0].steps.test[0].from_image: duplicate image name 'from_image' (previously defined by field 'images[0]')`),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := IsValidConfiguration(&tc.conf, "org", "repo")
+			err := IsValidConfiguration(&tc.conf, "TODO", "TODO")
 			testhelper.Diff(t, "error", err, tc.expected, testhelper.EquateErrorMessage)
 		})
 	}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -499,7 +499,7 @@ func TestValidateTests(t *testing.T) {
 		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
-			if errs := validateTestStepConfiguration(newConfigContext(), "tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
+			if errs := validateTestStepConfiguration("tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")
@@ -872,7 +872,7 @@ func TestValidateTestSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(newConfigContext().addField("test"), context, testStageTest, tc.steps, &tc.clusterClaim)
+			ret := validateTestSteps(context, testStageTest, tc.steps, &tc.clusterClaim)
 			if len(ret) > 0 && len(tc.errs) == 0 {
 				t.Fatalf("Unexpected error %v", ret)
 			}
@@ -912,7 +912,7 @@ func TestValidatePostSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(newConfigContext().addField("test"), context, testStagePost, tc.steps, nil)
+			ret := validateTestSteps(context, testStagePost, tc.steps, nil)
 			if !errListMessagesEqual(ret, tc.errs) {
 				t.Fatal(diff.ObjectReflectDiff(ret, tc.errs))
 			}
@@ -944,7 +944,7 @@ func TestValidateParameters(t *testing.T) {
 		err:    []error{errors.New("test: unresolved parameter(s): [TEST1]")},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateLiteralTestStep(newConfigContext(), newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
+			err := validateLiteralTestStep(newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
 				As:       "as",
 				From:     "from",
 				Commands: "commands",
@@ -1205,7 +1205,7 @@ func TestValidateLeases(t *testing.T) {
 			test := api.TestStepConfiguration{
 				MultiStageTestConfigurationLiteral: &tc.test,
 			}
-			err := validateTestConfigurationType(newConfigContext(), "tests[0]", test, nil, nil, true)
+			err := validateTestConfigurationType("tests[0]", test, nil, nil, true)
 			if diff := diff.ObjectReflectDiff(tc.err, err); diff != "<no diffs>" {
 				t.Errorf("unexpected error: %s", diff)
 			}
@@ -1335,7 +1335,7 @@ func TestValidateTestConfigurationType(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := validateTestConfigurationType(newConfigContext(), "test", tc.test, nil, nil, false)
+			actual := validateTestConfigurationType("test", tc.test, nil, nil, false)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("expected differs from actual: %s", diff)
 			}


### PR DESCRIPTION
This reverts commit ddad6ec63d261b76a6c4c8926e5fb985b5b03a1b, partially
reverting https://github.com/openshift/ci-tools/pull/2062.

`from_image` needs special treatment as multiple entries in different steps can
alias each other.  I'll also look into why our validation did not catch this.