### PR TITLE
pkg/validation: cache expensive regexp operation

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -405,9 +405,10 @@ func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainB
 		return nil, nil, nil, nil, nil, nil, err
 	}
 	// validate the integrity of each reference
+	v := validation.NewValidator()
 	var validationErrors []error
 	for _, r := range references {
-		if err := validation.IsValidReference(r); err != nil {
+		if err := v.IsValidReference(r); err != nil {
 			validationErrors = append(validationErrors, err...)
 		}
 	}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -499,7 +499,8 @@ func TestValidateTests(t *testing.T) {
 		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
-			if errs := validateTestStepConfiguration("tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
+			v := newSingleUseValidator()
+			if errs := v.validateTestStepConfiguration("tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")
@@ -872,7 +873,8 @@ func TestValidateTestSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(context, testStageTest, tc.steps, &tc.clusterClaim)
+			v := NewValidator()
+			ret := v.validateTestSteps(context, testStageTest, tc.steps, &tc.clusterClaim)
 			if len(ret) > 0 && len(tc.errs) == 0 {
 				t.Fatalf("Unexpected error %v", ret)
 			}
@@ -912,7 +914,8 @@ func TestValidatePostSteps(t *testing.T) {
 			if tc.seen != nil {
 				context.seen = tc.seen
 			}
-			ret := validateTestSteps(context, testStagePost, tc.steps, nil)
+			v := NewValidator()
+			ret := v.validateTestSteps(context, testStagePost, tc.steps, nil)
 			if !errListMessagesEqual(ret, tc.errs) {
 				t.Fatal(diff.ObjectReflectDiff(ret, tc.errs))
 			}
@@ -944,7 +947,8 @@ func TestValidateParameters(t *testing.T) {
 		err:    []error{errors.New("test: unresolved parameter(s): [TEST1]")},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateLiteralTestStep(newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
+			v := NewValidator()
+			err := v.validateLiteralTestStep(newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
 				As:       "as",
 				From:     "from",
 				Commands: "commands",
@@ -1205,7 +1209,8 @@ func TestValidateLeases(t *testing.T) {
 			test := api.TestStepConfiguration{
 				MultiStageTestConfigurationLiteral: &tc.test,
 			}
-			err := validateTestConfigurationType("tests[0]", test, nil, nil, true)
+			v := NewValidator()
+			err := v.validateTestConfigurationType("tests[0]", test, nil, nil, true)
 			if diff := diff.ObjectReflectDiff(tc.err, err); diff != "<no diffs>" {
 				t.Errorf("unexpected error: %s", diff)
 			}
@@ -1335,7 +1340,8 @@ func TestValidateTestConfigurationType(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := validateTestConfigurationType("test", tc.test, nil, nil, false)
+			v := NewValidator()
+			actual := v.validateTestConfigurationType("test", tc.test, nil, nil, false)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("expected differs from actual: %s", diff)
 			}


### PR DESCRIPTION
Currently, based on my `checkconfig` branch which resolves all
configurations:

```
$ cmd='ci-operator-checkconfig --config-dir ci-operator/config --registry ci-operator/step-registry'
$ time $cmd

real    0m26.624s
user    0m27.529s
sys     0m0.284s
$ perf record -g $cmd
$ perf report -F overhead_children,overhead,symbol -g none | sed -n '9p;/validateCommands/,+4p'
    88.81%     0.00%  [.] github.com/openshift/ci-tools/pkg/validation.validateCommands
    66.85%     8.34%  [.] regexp.(*machine).match
    34.45%    33.11%  [.] regexp.(*machine).add
    31.90%    10.83%  [.] regexp.(*machine).step
    19.70%     1.01%  [.] regexp.(*Regexp).backtrack
```

With these changes:

```
$ time $cmd

real    0m2.242s
user    0m3.144s
sys     0m0.145s
$ perf record -g $cmd
$ perf report -F overhead_children,overhead,symbol -g none | sed -n '9p;/validateCommands/p'
     3.68%     0.03%  [.] github.com/openshift/ci-tools/pkg/validation.(*Validator).validateCommands
```

Multi-threaded:

```
$ time $cmd --concurrency 4

real    0m1.732s
user    0m3.777s
sys     0m0.189s
```

/hold

Let's not deploy on Friday night =)