### PR TITLE
DPTP-2244, DPTP-2345: Registry-replacer should prune unused base images.

### DIFF
--- a/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Unused_base_images_are_pruned.yaml
+++ b/cmd/registry-replacer/testdata/zz_fixture_TestReplacer_Unused_base_images_are_pruned.yaml
@@ -1,0 +1,29 @@
+base_images:
+  fresh_image:
+    name: fresh_image
+    namespace: namespace
+    tag: test-1.0
+  org_image_latest:
+    name: image
+    namespace: org
+    tag: latest
+images:
+- inputs:
+    image:
+      as:
+      - org/image
+    org_image_latest:
+      as:
+      - registry.svc.ci.openshift.org/org/image
+  to: cool_image
+tests:
+- as: ""
+  literal_steps:
+    cluster_profile: ""
+    test:
+    - from: fresh_image
+      resources: {}
+zz_generated_metadata:
+  branch: master
+  org: ""
+  repo: ""

--- a/test/validate-checkconfig.sh
+++ b/test/validate-checkconfig.sh
@@ -18,6 +18,14 @@ for org in openshift redhat-operator-ecosystem; do
   # We need to enter the git directory and run git commands from there, our git
   # is too old to know the `-C` option.
   pushd "${clonedir}/${org}"
+
+  # First we'll run registry-replacer to prune unused base images.
+  registry-replacer \
+    --config-dir ci-operator/config \
+    --registry "${registry}" \
+    --prune-unused-base-images=true \
+    --apply-replacements=false
+
   if ! ci-operator-checkconfig \
     --config-dir ci-operator/config \
     --registry "${registry}"


### PR DESCRIPTION
/hold

Round 2 of the registry replacer changes. I _think_ this should now account for all of the scenarios, including the ones that were previously missed. Let me know if I missed anything.