### PR TITLE
cmd/autoowners: Don't pull OWNERS_ALIASES when there is no OWNERS

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -186,7 +186,7 @@ func getOwnersHTTP(fg FileGetter, orgRepo orgRepo, filenames ownersconfig.Filena
 			if _, nf := err.(*github.FileNotFound); nf {
 				logrus.WithField("orgRepo", orgRepo.repoString()).WithField("filename", filename).
 					Debug("Not found file in the upstream repo")
-				continue
+				break
 			}
 			return httpResult, err
 		}

--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -367,10 +367,8 @@ aliases:
 				Organization: "org4",
 				Repository:   "repo4",
 			},
-			expectedHTTPResult: httpResult{
-				repoAliases: ra,
-			},
-			expectedError: nil,
+			expectedHTTPResult: httpResult{},
+			expectedError:      nil,
 		},
 		{
 			description: "owner is with normal error",


### PR DESCRIPTION
Seen in an `autoowners` call:

```console
$ go run ./cmd/autoowners -debug-mode -dry-run -target-dir ../origin -target-subdir test -config-subdir extended
...
INFO[0000] ListOrgMembers(openshift, all)                client=github
INFO[0002] handling repo ...                             orgRepo=util/image
INFO[0002] GetFile(util, image, OWNERS, )                client=github
DEBU[0002] GetFile(util, image, OWNERS, ) finished       client=github duration=574.249751ms
DEBU[0002] Not found file in the upstream repo           filename=OWNERS orgRepo=util/image
INFO[0002] GetFile(util, image, OWNERS_ALIASES, )        client=github
DEBU[0003] GetFile(util, image, OWNERS_ALIASES, ) finished  client=github duration=479.108876ms
DEBU[0003] Not found file in the upstream repo           filename=OWNERS_ALIASES orgRepo=util/image
WARN[0003] Ignoring the repo with no OWNERS file in the upstream repo.  orgRepo=util/image
...
```

No need to hit GitHub for `OWNERS_ALIASES` unless we have successfully retrieved an `OWNERS` which might reference aliases.

The `continue` I'm replacing is [from][1] 3d0c6cc25b (#115).

[1]: https://github.com/openshift/ci-tools/commit/3d0c6cc25babef8ac0f3c7500edcb4447477534a#diff-d9fc97e94b9e2c25a3bd5eec3f3439e533b9d2d347be59f97d10506f7d61574dR147