### PR TITLE
Remove BitWarden cli in the built images

### DIFF
--- a/images/ci-secret-bootstrap/Dockerfile
+++ b/images/ci-secret-bootstrap/Dockerfile
@@ -1,6 +1,4 @@
 FROM centos:8
 
-RUN dnf install -y nodejs && \
-    npm install -g @bitwarden/cli
 ADD ci-secret-bootstrap /usr/bin/ci-secret-bootstrap
 ENTRYPOINT ["/usr/bin/ci-secret-bootstrap"]

--- a/images/ci-secret-generator/Dockerfile
+++ b/images/ci-secret-generator/Dockerfile
@@ -6,9 +6,7 @@ COPY usr/bin/oc /usr/bin/oc
 
 COPY google-cloud-sdk.repo /etc/yum.repos.d/google-cloud-sdk.repo
 
-RUN  \
-	dnf install -y nodejs jq google-cloud-sdk && \
-	npm install -g @bitwarden/cli
+RUN dnf install -y jq google-cloud-sdk
 
 ADD ci-secret-generator /usr/bin/ci-secret-generator
 


### PR DESCRIPTION
We do not sync with BitWarden.
The installation waste our time?
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/2130/pull-ci-openshift-ci-tools-master-images/1410333666898350080

/cc @openshift/openshift-team-developer-productivity-test-platform 