### PR TITLE
cluster claims: override release payload images

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -92,8 +92,14 @@ func (config *ReleaseBuildConfiguration) DependencyParts(dependency StepDependen
 		name = parts[1]
 		explicit = true
 	}
-	if claimRelease != nil && ReleaseStreamFor(claimRelease.OverrideName) == stream {
-		stream = ReleaseStreamFor(claimRelease.ReleaseName)
+	if claimRelease != nil {
+		if stream == ReleaseImageStream && claimRelease.OverrideName == name {
+			// handle release images like `release:latest`
+			name = claimRelease.ReleaseName
+		} else if stream == ReleaseStreamFor(claimRelease.OverrideName) {
+			// handle images from release streams like `stable:cli`
+			stream = ReleaseStreamFor(claimRelease.ReleaseName)
+		}
 	}
 	return stream, name, explicit
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -358,6 +358,7 @@ func stepForTest(
 			}
 			hasReleaseStep = true
 			claimRelease := c.ClusterClaim.ClaimRelease(c.As)
+			logrus.Infof("Resolved release %s to %s", claimRelease.ReleaseName, pullSpec)
 			importStep := releasesteps.ImportReleaseStep(claimRelease.ReleaseName, pullSpec, false, config.Resources, podClient, jobSpec, pullSecret)
 			testSteps = append(testSteps, importStep)
 			addProvidesForStep(step, params)

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -762,6 +762,15 @@ func TestReleaseBuildConfiguration_DependencyParts(t *testing.T) {
 			expectedTag:    "really",
 			explicit:       true,
 		},
+		{
+			name:           "release payload image gets overridden by cluster claim",
+			config:         &api.ReleaseBuildConfiguration{},
+			claimRelease:   &api.ClaimRelease{ReleaseName: "latest-e2e-claim", OverrideName: "latest"},
+			dependency:     api.StepDependency{Name: "release:latest"},
+			expectedStream: "release",
+			expectedTag:    "latest-e2e-claim",
+			explicit:       true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -222,6 +222,9 @@ func validateTestStepDependencies(config *api.ReleaseBuildConfiguration) []error
 				if releaseName != "" {
 					implicitlyConfigured := (releaseName == api.InitialReleaseName || releaseName == api.LatestReleaseName) && config.InputConfiguration.ReleaseTagConfiguration != nil
 					_, explicitlyConfigured := config.InputConfiguration.Releases[releaseName]
+					if claimRelease != nil {
+						explicitlyConfigured = explicitlyConfigured || releaseName == claimRelease.ReleaseName
+					}
 					if !(implicitlyConfigured || explicitlyConfigured) {
 						errs = append(errs, validationError(fmt.Sprintf("this dependency requires a %q release, which is not configured", releaseName)))
 					}

--- a/test/e2e/multi-stage/cluster-claim.yaml
+++ b/test/e2e/multi-stage/cluster-claim.yaml
@@ -1,3 +1,8 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: '7'
 releases:
   latest:   # include `latest` as a release to verify that `latest` is automatically overridden when using claims
     release:
@@ -66,6 +71,29 @@ tests:
             requests:
               cpu: 100m
               memory: 200Mi
+  - as: e2e-claim-depend-on-release-image
+    cluster_claim:
+      architecture: amd64
+      cloud: aws
+      owner: fake
+      product: ocp
+      timeout: 3m # a claim from a fake pool should become ready very soon
+      version: "4.7"
+    steps:
+      test:
+        - as: claim-step
+          commands: |
+            set -x
+            cmp "${KUBECONFIG}" /secrets/e2e-claim-depend-on-release-image-hive-admin-kubeconfig/kubeconfig
+            echo "$(RELEASE_IMAGE_LATEST)"
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          dependencies:
+          - env: RELEASE_IMAGE_LATEST
+            name: release:latest
 zz_generated_metadata:
   branch: master
   org: test

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -147,6 +147,13 @@ func TestMultiStage(t *testing.T) {
 			success:  true,
 			output:   []string{`Imported release 4.7.17`, `to tag release:custom-e2e-claim-as-custom`, `e2e-claim-as-custom-claim-step succeeded`},
 		},
+		{
+			name:     "e2e-claim depends on release image",
+			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim-depend-on-release-image"},
+			needHive: true,
+			success:  true,
+			output:   []string{`Imported release 4.7.17`, `to tag release:latest-e2e-claim-depend-on-release-image`, `e2e-claim-depend-on-release-image-claim-step succeeded`},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
The current support for overriding releases for tests using cluster
claims supports overriding release streams, but not release payloads.
This PR adds support for overriding release payload images as well.