### PR TITLE
DPTP-2347: do not mirror postsubmits and periodics

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -155,6 +155,14 @@ func main() {
 			}
 			privatePromotionConfiguration(rbc.PromotionConfiguration)
 		}
+		// don't copy periodics and postsubmits
+		var tests []api.TestStepConfiguration
+		for _, test := range rbc.Tests {
+			if test.Cron == nil && test.Interval == nil && !test.Postsubmit {
+				tests = append(tests, test)
+			}
+		}
+		rbc.Tests = tests
 
 		repoInfo.Org = o.toOrg
 		rbc.Metadata.Org = o.toOrg

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
@@ -32,6 +32,21 @@ tests:
   commands: make test-unit
   container:
     from: src
+- as: post
+  commands: make push-stuff
+  container:
+    from: src
+  postsubmit: true
+- as: cronjob
+  commands: make e2e
+  container:
+    from: src
+  cron: 0 0 * * 1
+- as: interval-job
+  commands: make interval
+  container:
+    from: src
+  interval: 4h
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/ci-operator-config-mirror/input/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/super/duper/super-duper-master.yaml
@@ -32,6 +32,21 @@ tests:
   commands: make test-unit
   container:
     from: src
+- as: post
+  commands: make push-stuff
+  container:
+    from: src
+  postsubmit: true
+- as: cronjob
+  commands: make e2e
+  container:
+    from: src
+  cron: 0 0 * * 1
+- as: interval-job
+  commands: make interval
+  container:
+    from: src
+  interval: 4h
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
@@ -32,6 +32,21 @@ tests:
   commands: make test-unit
   container:
     from: src
+- as: post
+  commands: make push-stuff
+  container:
+    from: src
+  postsubmit: true
+- as: cronjob
+  commands: make e2e
+  container:
+    from: src
+  cron: 0 0 * * 1
+- as: interval-job
+  commands: make interval
+  container:
+    from: src
+  interval: 4h
 zz_generated_metadata:
   branch: master
   org: super

--- a/test/integration/ci-operator-config-mirror/output/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super/duper/super-duper-master.yaml
@@ -32,6 +32,21 @@ tests:
   commands: make test-unit
   container:
     from: src
+- as: post
+  commands: make push-stuff
+  container:
+    from: src
+  postsubmit: true
+- as: cronjob
+  commands: make e2e
+  container:
+    from: src
+  cron: 0 0 * * 1
+- as: interval-job
+  commands: make interval
+  container:
+    from: src
+  interval: 4h
 zz_generated_metadata:
   branch: master
   org: super


### PR DESCRIPTION
This PR updates ci-operator to ignore cloning postsubmits and periodics
in the config mirror command.