### PR TITLE
Add `checkconfig` validation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,10 @@ validate-registry-metadata:
 	test -z "$$(git status -s ./test/multistage-registry/registry | grep registry)"
 .PHONY: validate-registry-metadata
 
+validate-checkconfig:
+	test/validate-checkconfig.sh
+.PHONY: validate-checkconfig
+
 $(TMPDIR)/.ci-operator-kubeconfig:
 	oc --context $(CLUSTER) --as system:admin --namespace ci serviceaccounts create-kubeconfig ci-operator > $(TMPDIR)/.ci-operator-kubeconfig
 

--- a/test/validate-checkconfig.sh
+++ b/test/validate-checkconfig.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+clonedir="${workdir}/release"
+failure=0
+
+for org in openshift redhat-operator-ecosystem; do
+  rm -rf "${clonedir}"
+  git clone "https://github.com/${org}/release.git" --depth 1 "${clonedir}"
+
+  # We need to enter the git directory and run git commands from there, our git
+  # is too old to know the `-C` option.
+  pushd "${clonedir}"
+  if ! ci-operator-checkconfig \
+      --config-dir "${clonedir}/ci-operator/config" \
+      --registry "${clonedir}/ci-operator/step-registry"
+  then
+    echo "ERROR: Errors in $org/release"
+    echo
+    echo "ERROR: Running ci-operator-checkconfig in $org/release results in errors"
+    echo "ERROR: To avoid breaking $org/release for everyone you should make a PR there"
+    echo "ERROR: correcting these and merge it before this change to ci-tools"
+    failure=1
+  else
+    echo "Running ci-operator-checkconfig in $org/release does not result in errors, no corrections needed"
+  fi
+  popd
+done
+
+exit $failure


### PR DESCRIPTION
Based on `test/validate-prowgen-breaking-changes.sh`, with the
difference that this will be a required check.  Failures should always
be corrected prior to the introduction of new validations.