### PR TITLE
pkg/validation: also validate `from_image`

### DIFF
--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -133,11 +133,6 @@ func (v *Validator) validateConfiguration(ctx *configContext, config *api.Releas
 	for name := range releases {
 		releases.Insert(name)
 	}
-	validationErrors = append(validationErrors, v.validateTestStepConfiguration("tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
-
-	// this validation brings together a large amount of data from separate
-	// parts of the configuration, so it's written as a standalone method
-	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	if config.Operator != nil {
 		// validateOperator needs a method that maps `substitute.with` values to image links
 		// to validate the value is meaningful in the context of the configuration
@@ -161,6 +156,11 @@ func (v *Validator) validateConfiguration(ctx *configContext, config *api.Releas
 
 	validationErrors = append(validationErrors, validateReleases("releases", config.Releases, config.ReleaseTagConfiguration != nil)...)
 	validationErrors = append(validationErrors, validateImages(ctx.addField("images"), config.Images)...)
+	validationErrors = append(validationErrors, v.validateTestStepConfiguration(ctx, "tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
+
+	// this validation brings together a large amount of data from separate
+	// parts of the configuration, so it's written as a standalone method
+	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)
 	var lines []string
 	for _, err := range validationErrors {
 		if err == nil {

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -421,7 +421,7 @@ func (v *Validator) validateTestConfigurationType(fieldRoot string, test api.Tes
 	}
 	typeCount := 0
 	if cluster := test.Cluster; cluster != "" && !api.ValidClusterNames.Has(string(cluster)) {
-		validationErrors = append(validationErrors, fmt.Errorf("%s.cluster is not a vailid cluster: %s", fieldRoot, string(cluster)))
+		validationErrors = append(validationErrors, fmt.Errorf("%s.cluster is not a valid cluster: %s", fieldRoot, string(cluster)))
 	}
 	if testConfig := test.ContainerTestConfiguration; testConfig != nil {
 		typeCount++

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -1336,7 +1336,7 @@ func TestValidateTestConfigurationType(t *testing.T) {
 					},
 				},
 			},
-			expected: []error{fmt.Errorf("test.cluster is not a vailid cluster: bar")},
+			expected: []error{fmt.Errorf("test.cluster is not a valid cluster: bar")},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -871,7 +871,7 @@ func TestValidateTestSteps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			context := newContext("test", nil, tc.releases)
 			if tc.seen != nil {
-				context.seen = tc.seen
+				context.namesSeen = tc.seen
 			}
 			v := NewValidator()
 			ret := v.validateTestSteps(context, testStageTest, tc.steps, &tc.clusterClaim)
@@ -912,7 +912,7 @@ func TestValidatePostSteps(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			context := newContext("test", nil, tc.releases)
 			if tc.seen != nil {
-				context.seen = tc.seen
+				context.namesSeen = tc.seen
 			}
 			v := NewValidator()
 			ret := v.validateTestSteps(context, testStagePost, tc.steps, nil)

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -500,7 +500,7 @@ func TestValidateTests(t *testing.T) {
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()
-			if errs := v.validateTestStepConfiguration("tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
+			if errs := v.validateTestStepConfiguration(newConfigContext(), "tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")
@@ -869,7 +869,7 @@ func TestValidateTestSteps(t *testing.T) {
 		clusterClaim: api.ClaimRelease{ReleaseName: "myclaim-as", OverrideName: "myclaim"},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			context := newContext("test", nil, tc.releases)
+			context := newContext("test", nil, tc.releases, make(testInputImages))
 			if tc.seen != nil {
 				context.namesSeen = tc.seen
 			}
@@ -910,7 +910,7 @@ func TestValidatePostSteps(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			context := newContext("test", nil, tc.releases)
+			context := newContext("test", nil, tc.releases, make(testInputImages))
 			if tc.seen != nil {
 				context.namesSeen = tc.seen
 			}
@@ -948,7 +948,7 @@ func TestValidateParameters(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewValidator()
-			err := v.validateLiteralTestStep(newContext("test", tc.env, tc.releases), testStageTest, api.LiteralTestStep{
+			err := v.validateLiteralTestStep(newContext("test", tc.env, tc.releases, make(testInputImages)), testStageTest, api.LiteralTestStep{
 				As:       "as",
 				From:     "from",
 				Commands: "commands",
@@ -1210,7 +1210,7 @@ func TestValidateLeases(t *testing.T) {
 				MultiStageTestConfigurationLiteral: &tc.test,
 			}
 			v := NewValidator()
-			err := v.validateTestConfigurationType("tests[0]", test, nil, nil, true)
+			err := v.validateTestConfigurationType("tests[0]", test, nil, nil, make(testInputImages), true)
 			if diff := diff.ObjectReflectDiff(tc.err, err); diff != "<no diffs>" {
 				t.Errorf("unexpected error: %s", diff)
 			}
@@ -1341,7 +1341,7 @@ func TestValidateTestConfigurationType(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewValidator()
-			actual := v.validateTestConfigurationType("test", tc.test, nil, nil, false)
+			actual := v.validateTestConfigurationType("test", tc.test, nil, nil, make(testInputImages), false)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("expected differs from actual: %s", diff)
 			}


### PR DESCRIPTION
This reinstates the validation attempted in
https://github.com/openshift/ci-tools/pull/2062 which had to be reverted in
https://github.com/openshift/ci-tools/pull/2118.

The implementation now properly considers `from_image` fields across all steps
in all tests in the configuration.  The check which will be introduced in
https://github.com/openshift/ci-tools/pull/2134 will also guarantee that the
validation is correct.

/hold

for #2134