### PR TITLE
prowgen: generate stricter `branch:` stanzas for presubmits

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/rhel-images
     decorate: true
     decoration_config:
@@ -52,7 +53,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/rhel-unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -445,7 +445,7 @@ func generatePresubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.Po
 	return &prowconfig.Presubmit{
 		JobBase:   base,
 		AlwaysRun: true,
-		Brancher:  prowconfig.Brancher{Branches: []string{info.Branch}},
+		Brancher:  prowconfig.Brancher{Branches: sets.NewString(exactlyBranch(info.Branch), featureBranch(info.Branch)).List()},
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/prow/%s", shortName),
 		},
@@ -458,7 +458,7 @@ func generatePostsubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.P
 	base := generateJobBase(name, jc.PostsubmitPrefix, info, podSpec, false, pathAlias, jobRelease, skipCloning)
 	return &prowconfig.Postsubmit{
 		JobBase:  base,
-		Brancher: prowconfig.Brancher{Branches: []string{makeBranchExplicit(info.Branch)}},
+		Brancher: prowconfig.Brancher{Branches: []string{exactlyBranch(info.Branch)}},
 	}
 }
 
@@ -616,14 +616,23 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 // not.
 var simpleBranchRegexp = regexp.MustCompile(`^[\w\-.]+$`)
 
-// makeBranchExplicit updates the provided branch to prevent wildcard matches to the given branch
-// if the branch value does not appear to contain an explicit regex pattern. I.e. 'master'
-// is turned into '^master$'.
-func makeBranchExplicit(branch string) string {
+// exactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
+// '^master$' for 'master'. If the given branch name already looks like a regex, return it unchanged.
+func exactlyBranch(branch string) string {
 	if !simpleBranchRegexp.MatchString(branch) {
 		return branch
 	}
 	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
+}
+
+// featureBranch returns a regex string that matches feature branch prefixes for the given branch name:
+// I.e. returns '^master-' for 'master'. If the given branch name already looks like a regex,
+// return it unchanged.
+func featureBranch(branch string) string {
+	if !simpleBranchRegexp.MatchString(branch) {
+		return branch
+	}
+	return fmt.Sprintf("^%s-", regexp.QuoteMeta(branch))
 }
 
 // IsGenerated returns true if the job was generated using prowgen

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -58,7 +58,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/also-testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 labels:

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -84,7 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -140,7 +142,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/test
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/ci-index
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/ci-index-my-bundle
     decorate: true
     decoration_config:
@@ -97,7 +99,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -170,7 +173,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -232,7 +236,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -279,7 +284,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/steps
     decorate: true
     decoration_config:
@@ -333,7 +339,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -380,7 +387,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/variant-images
     decorate: true
     decoration_config:
@@ -431,7 +439,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/variant-unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master-removed-promotion
+    - ^master-removed-promotion$
+    - ^master-removed-promotion-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -61,7 +62,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -108,7 +110,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -51,7 +52,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -53,7 +54,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - nonstandard
+    - ^nonstandard$
+    - ^nonstandard-
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/cmd
     decorate: true
@@ -51,7 +52,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true
@@ -117,7 +119,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/e2e-aws
     decorate: true
@@ -183,7 +186,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/race
     decorate: true
@@ -231,7 +235,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - nonstandard
+    - ^nonstandard$
+    - ^nonstandard-
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true


### PR DESCRIPTION
In the past, we considered any `$branch$suffix` a feature branch of
"base" CI branch (e.g. PRs to `master-next` would receive presubmits
from `master` config). We need to make this convention stricter to not
break on `4.10`, because the current convention means that
`release-4.10` is a feature branch for `release-4.1`.

All generated presubmits now have two items in their `branches:` stanza.
One item that matches exactly the branch (`^branch$`), just like
postsubmits have, and one item that matches branches with `$base-`
prefix. Practically this means that we enforce exactly the `-` separator
for a branch to be considered a feature branch.
