### PR TITLE
Release: Fix importing for non-amd64 architectures

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -897,9 +897,9 @@ func resolveCLIOverrideImage(architecture api.ReleaseArchitecture, version strin
 	if version == "" {
 		return nil, errors.New("non-amd64 releases require a version to be configured")
 	}
-	// Should never happen™ but better than a NPD below when stripping everything after the Y stream
-	if len(version) < 3 {
-		return nil, fmt.Errorf("version %q has less than three digits", version)
+	majorMinor, err := official.ExtractMajorMinor(version)
+	if err != nil {
+		return nil, err
 	}
-	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "ocp", Name: version[:3]}, nil
+	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "ocp", Name: majorMinor}, nil
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -901,5 +901,5 @@ func resolveCLIOverrideImage(architecture api.ReleaseArchitecture, version strin
 	if err != nil {
 		return nil, err
 	}
-	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "ocp", Name: majorMinor}, nil
+	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "ocp", Name: majorMinor + ":cli"}, nil
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -16,6 +16,7 @@ import (
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreclientset "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -167,6 +168,8 @@ func fromConfig(
 			// factor release steps into something more reusable
 			hasReleaseStep = true
 			var value string
+			var overrideCLIReleaseExtractImage *coreapi.ObjectReference
+			var overrideCLIResolveErr error
 			if env := utils.ReleaseImageEnv(resolveConfig.Name); params.HasInput(env) {
 				value, err = params.Get(env)
 				if err != nil {
@@ -177,17 +180,20 @@ func fromConfig(
 				switch {
 				case resolveConfig.Candidate != nil:
 					value, err = candidate.ResolvePullSpec(httpClient, *resolveConfig.Candidate)
+					overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Candidate.Architecture, resolveConfig.Candidate.Version)
 				case resolveConfig.Release != nil:
 					value, _, err = official.ResolvePullSpecAndVersion(httpClient, *resolveConfig.Release)
+					overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Release.Architecture, resolveConfig.Release.Version)
 				case resolveConfig.Prerelease != nil:
 					value, err = prerelease.ResolvePullSpec(httpClient, *resolveConfig.Prerelease)
+					overrideCLIReleaseExtractImage, overrideCLIResolveErr = resolveCLIOverrideImage(resolveConfig.Prerelease.Architecture, resolveConfig.Prerelease.VersionBounds.Lower)
 				}
-				if err != nil {
+				if err := utilerrors.NewAggregate([]error{err, overrideCLIResolveErr}); err != nil {
 					return nil, nil, results.ForReason("resolving_release").ForError(fmt.Errorf("failed to resolve release %s: %w", resolveConfig.Name, err))
 				}
 				logrus.Infof("Resolved release %s to %s", resolveConfig.Name, value)
 			}
-			step := releasesteps.ImportReleaseStep(resolveConfig.Name, value, false, config.Resources, podClient, jobSpec, pullSecret)
+			step := releasesteps.ImportReleaseStep(resolveConfig.Name, value, false, config.Resources, podClient, jobSpec, pullSecret, overrideCLIReleaseExtractImage)
 			buildSteps = append(buildSteps, step)
 			addProvidesForStep(step, params)
 			continue
@@ -245,7 +251,7 @@ func fromConfig(
 						return nil, nil, results.ForReason("reading_release").ForError(fmt.Errorf("failed to read input release pullSpec %s: %w", name, err))
 					}
 					logrus.Infof("Resolved release %s to %s", name, pullSpec)
-					releaseStep = releasesteps.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, jobSpec, pullSecret)
+					releaseStep = releasesteps.ImportReleaseStep(name, pullSpec, true, config.Resources, podClient, jobSpec, pullSecret, nil)
 				} else {
 					releaseStep = releasesteps.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, jobSpec)
 				}
@@ -360,7 +366,7 @@ func stepForTest(
 			hasReleaseStep = true
 			claimRelease := c.ClusterClaim.ClaimRelease(c.As)
 			logrus.Infof("Resolved release %s to %s", claimRelease.ReleaseName, pullSpec)
-			importStep := releasesteps.ImportReleaseStep(claimRelease.ReleaseName, pullSpec, false, config.Resources, podClient, jobSpec, pullSecret)
+			importStep := releasesteps.ImportReleaseStep(claimRelease.ReleaseName, pullSpec, false, config.Resources, podClient, jobSpec, pullSecret, nil)
 			testSteps = append(testSteps, importStep)
 			addProvidesForStep(step, params)
 		}
@@ -882,4 +888,18 @@ func getClusterPoolPullSpec(ctx context.Context, claim *api.ClusterClaim, hiveCl
 	}
 
 	return clusterImageSet.Spec.ReleaseImage, nil
+}
+
+func resolveCLIOverrideImage(architecture api.ReleaseArchitecture, version string) (*coreapi.ObjectReference, error) {
+	if architecture == "" || architecture == api.ReleaseArchitectureAMD64 {
+		return nil, nil
+	}
+	if version == "" {
+		return nil, errors.New("non-amd64 releases require a version to be configured")
+	}
+	// Should never happen™ but better than a NPD below when stripping everything after the Y stream
+	if len(version) < 3 {
+		return nil, fmt.Errorf("version %q has less than three digits", version)
+	}
+	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: "ocp", Name: version[:3]}, nil
 }

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -414,6 +414,7 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 				Namespace: s.jobSpec.Namespace(),
 				Name:      overrideCLIStreamName + ":latest",
 			},
+			LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
 			Tag: &imagev1.TagReference{
 				ReferencePolicy: imagev1.TagReferencePolicy{
 					Type: imagev1.LocalTagReferencePolicy,

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -448,7 +448,7 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 	}
 
 	targetCLI := fmt.Sprintf("%s-cli", target)
-	if _, err := steps.RunPod(context.TODO(), s.client, &coreapi.Pod{
+	if _, err := steps.RunPod(ctx, s.client, &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      targetCLI,
 			Namespace: s.jobSpec.Namespace(),
@@ -468,7 +468,7 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 		return nil, fmt.Errorf("unable to find the 'cli' image in the provided release image: %w", err)
 	}
 	pod := &coreapi.Pod{}
-	if err := s.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: targetCLI}, pod); err != nil {
+	if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: targetCLI}, pod); err != nil {
 		return nil, fmt.Errorf("unable to extract the 'cli' image from the release image: %w", err)
 	}
 	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -26,7 +26,7 @@ releases:
         lower: "4.4.0"
         upper: "4.5.0-0"
   mainframe:
-    release:
+    candidate:
       product: ocp
       architecture: ppc64le
       version: "4.8"

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -29,6 +29,7 @@ releases:
     candidate:
       product: ocp
       architecture: ppc64le
+      stream: ci
       version: "4.8"
 resources:
   '*':

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -26,11 +26,10 @@ releases:
         lower: "4.4.0"
         upper: "4.5.0-0"
   mainframe:
-    candidate:
-      product: ocp
-      architecture: ppc64le
-      stream: ci
-      version: "4.8"
+    release:
+      version: "4.7"
+      channel: stable
+      architecture: s390x
 resources:
   '*':
     limits:

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -25,6 +25,11 @@ releases:
       version_bounds:
         lower: "4.4.0"
         upper: "4.5.0-0"
+  mainframe:
+    release:
+      product: ocp
+      architecture: ppc64le
+      version: "4.8"
 resources:
   '*':
     limits:

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -187,6 +187,10 @@ func TestDynamicReleases(t *testing.T) {
 			name:    "success on prerelease release",
 			release: "pre",
 		},
+		{
+			name:    "successfully imports release for different arch",
+			release: "mainframe",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Ref https://issues.redhat.com/browse/DPTP-2265

Makes us use a harcoded y-stream version of the `oc` image when importing a non-amd64 release as we can not resolve the correct one because we can not run the `cluster-version-operator` as it will be for the wrong arch