### PR TITLE
dptp-controller-manager: distribute build caches even for repos with in-repo config

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -115,7 +115,7 @@ func newOpts() (*options, error) {
 	flag.Var(&opts.testImagesDistributorOptions.additionalImageStreamNamespacesRaw, "testImagesDistributorOptions.additional-image-stream-namespace", "A namespace in which imagestreams will be distributed even if no test explicitly references them (e.G `ci`). Can be passed multiple times.")
 	flag.Var(&opts.testImagesDistributorOptions.forbiddenRegistriesRaw, "testImagesDistributorOptions.forbidden-registry", "The hostname of an image registry from which there is no synchronization of its images. Can be passed multiple times.")
 	flag.DurationVar(&opts.blockProfileRate, "block-profile-rate", time.Duration(0), "The block profile rate. Set to non-zero to enable.")
-	flag.StringVar(&opts.registryClusterName, "registry-cluster-name", "api.ci", "the cluster name on which the CI central registry is running")
+	flag.StringVar(&opts.registryClusterName, "registry-cluster-name", "app.ci", "the cluster name on which the CI central registry is running")
 	flag.Var(&opts.serviceAccountSecretRefresherOptions.enabledNamespaces, "serviceAccountRefresherOptions.enabled-namespace", "A namespace for which the serviceaccount_secret_refresher should be enabled. Can be passed multiple times.")
 	flag.BoolVar(&opts.serviceAccountSecretRefresherOptions.removeOldSecrets, "serviceAccountRefresherOptions.remove-old-secrets", false, "whether the serviceaccountsecretrefresher should delete secrets older than 30 days")
 	flag.Var(&opts.imagePusherOptions.imageStreamsRaw, "imagePusherOptions.image-stream", "An imagestream that will be synced. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")

--- a/pkg/api/helper/imageextraction.go
+++ b/pkg/api/helper/imageextraction.go
@@ -33,9 +33,11 @@ func TestInputImageStreamTagsFromResolvedConfig(cfg api.ReleaseBuildConfiguratio
 
 	imageStreamTagReferenceMapIntoMap(cfg.BaseImages, result)
 	imageStreamTagReferenceMapIntoMap(cfg.BaseRPMImages, result)
-	if cfg.BuildRootImage != nil && cfg.BuildRootImage.ImageStreamTagReference != nil {
-		insert(*cfg.BuildRootImage.ImageStreamTagReference, result)
-		if cfg.InputConfiguration.BuildRootImage.UseBuildCache {
+	if cfg.BuildRootImage != nil {
+		if cfg.BuildRootImage.ImageStreamTagReference != nil {
+			insert(*cfg.BuildRootImage.ImageStreamTagReference, result)
+		}
+		if cfg.BuildRootImage.UseBuildCache {
 			insert(api.BuildCacheFor(cfg.Metadata), result)
 		}
 	}

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -155,7 +155,7 @@ func sourceForConfigChangeChannel(buildClusterNames sets.String, registryClient 
 				namespace = strings.TrimPrefix(namespace, "imagestream_")
 				var imagestream imagev1.ImageStream
 				if err := registryClient.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: name}, &imagestream); err != nil {
-					// Not found means user referenced an inexistent stream.
+					// Not found means user referenced an nonexistent stream.
 					if !apierrors.IsNotFound(err) {
 						logrus.WithError(err).WithField("name", namespace+"/"+name).Error("Failed to get imagestream")
 					}
@@ -200,7 +200,7 @@ func testImageStreamTagImportHandler() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) []reconcile.Request {
 		testimagestreamtagimport, ok := o.(*testimagestreamtagimportv1.TestImageStreamTagImport)
 		if !ok {
-			logrus.WithField("type", fmt.Sprintf("%T", o)).Error("Got object that was not an ImageStram")
+			logrus.WithField("type", fmt.Sprintf("%T", o)).Error("Got object that was not an ImageStream")
 			return nil
 		}
 		return []reconcile.Request{{NamespacedName: types.NamespacedName{

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -484,17 +484,17 @@ func leasesForTest(s *api.MultiStageTestConfigurationLiteral) (ret []api.StepLea
 // the root image.
 func rootImageResolver(client loggingclient.LoggingClient, ctx context.Context) func(root, cache *api.ImageStreamTagReference) (*api.ImageStreamTagReference, error) {
 	return func(root, cache *api.ImageStreamTagReference) (*api.ImageStreamTagReference, error) {
-		logrus.Debugf("Determining if build cache %s can be used in place of root %s\n", cache.ISTagName(), root.ISTagName())
+		logrus.Debugf("Determining if build cache %s can be used in place of root %s", cache.ISTagName(), root.ISTagName())
 		cacheTag := &imagev1.ImageStreamTag{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: cache.Namespace, Name: fmt.Sprintf("%s:%s", cache.Name, cache.Tag)}, cacheTag); err != nil {
 			if kapierrors.IsNotFound(err) {
-				logrus.Debugf("Build cache %s not found, falling back to %s\n", cache.ISTagName(), root.ISTagName())
+				logrus.Debugf("Build cache %s not found, falling back to %s", cache.ISTagName(), root.ISTagName())
 				// no build cache, use the normal root
 				return root, nil
 			}
 			return nil, fmt.Errorf("could not resolve build cache image stream tag %s: %w", cache.ISTagName(), err)
 		}
-		logrus.Debugf("Resolved build cache %s to %s\n", cache.ISTagName(), cacheTag.Image.Name)
+		logrus.Debugf("Resolved build cache %s to %s", cache.ISTagName(), cacheTag.Image.Name)
 		metadata := &docker10.DockerImage{}
 		if len(cacheTag.Image.DockerImageMetadata.Raw) == 0 {
 			return nil, fmt.Errorf("could not fetch Docker image metadata build cache %s", cache.ISTagName())
@@ -503,19 +503,19 @@ func rootImageResolver(client loggingclient.LoggingClient, ctx context.Context) 
 			return nil, fmt.Errorf("malformed Docker image metadata on build cache %s: %w", cache.ISTagName(), err)
 		}
 		prior := metadata.Config.Labels[api.ImageVersionLabel(api.PipelineImageStreamTagReferenceRoot)]
-		logrus.Debugf("Build cache %s is based on root image at %s\n", cache.ISTagName(), prior)
+		logrus.Debugf("Build cache %s is based on root image at %s", cache.ISTagName(), prior)
 
 		rootTag := &imagev1.ImageStreamTag{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: root.Namespace, Name: fmt.Sprintf("%s:%s", root.Name, root.Tag)}, rootTag); err != nil {
 			return nil, fmt.Errorf("could not resolve build root image stream tag %s: %w", root.ISTagName(), err)
 		}
-		logrus.Debugf("Resolved root image %s to %s\n", root.ISTagName(), rootTag.Image.Name)
+		logrus.Debugf("Resolved root image %s to %s", root.ISTagName(), rootTag.Image.Name)
 		current := rootTag.Image.Name
 		if prior == current {
-			logrus.Debugf("Using build cache %s as root image.\n", cache.ISTagName())
+			logrus.Debugf("Using build cache %s as root image.", cache.ISTagName())
 			return cache, nil
 		}
-		logrus.Debugf("Using default image %s as root image.\n", root.ISTagName())
+		logrus.Debugf("Using default image %s as root image.", root.ISTagName())
 		return root, nil
 	}
 }

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -233,7 +233,7 @@ func (a *configAgent) loadFilenameToConfig() error {
 		return err
 	}
 	configReloadTimeMetric.Observe(duration.Seconds())
-	logrus.WithField("duration", duration).Info("Configs reloaded")
+	logrus.WithField("duration", duration.String()).Info("Configs reloaded")
 	return nil
 }
 


### PR DESCRIPTION
dptp-controller-manager: update default registry cluster

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

dptp-controller-manager: fix bugs and typos in logs

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

dptp-controller-manager: distribute build caches even for in-repo config

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

hack: update the dptp-controller-manager runfile

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/assign @alvaroaleman 