### PR TITLE
Revert "prowgen: generate stricter `branch:` stanzas for presubmits"

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -51,8 +50,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/rhel-images
     decorate: true
     decoration_config:
@@ -53,8 +52,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/rhel-unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -51,8 +50,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -445,7 +445,7 @@ func generatePresubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.Po
 	return &prowconfig.Presubmit{
 		JobBase:   base,
 		AlwaysRun: true,
-		Brancher:  prowconfig.Brancher{Branches: sets.NewString(exactlyBranch(info.Branch), featureBranch(info.Branch)).List()},
+		Brancher:  prowconfig.Brancher{Branches: []string{info.Branch}},
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/prow/%s", shortName),
 		},
@@ -458,7 +458,7 @@ func generatePostsubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.P
 	base := generateJobBase(name, jc.PostsubmitPrefix, info, podSpec, false, pathAlias, jobRelease, skipCloning)
 	return &prowconfig.Postsubmit{
 		JobBase:  base,
-		Brancher: prowconfig.Brancher{Branches: []string{exactlyBranch(info.Branch)}},
+		Brancher: prowconfig.Brancher{Branches: []string{makeBranchExplicit(info.Branch)}},
 	}
 }
 
@@ -616,23 +616,14 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 // not.
 var simpleBranchRegexp = regexp.MustCompile(`^[\w\-.]+$`)
 
-// exactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
-// '^master$' for 'master'. If the given branch name already looks like a regex, return it unchanged.
-func exactlyBranch(branch string) string {
+// makeBranchExplicit updates the provided branch to prevent wildcard matches to the given branch
+// if the branch value does not appear to contain an explicit regex pattern. I.e. 'master'
+// is turned into '^master$'.
+func makeBranchExplicit(branch string) string {
 	if !simpleBranchRegexp.MatchString(branch) {
 		return branch
 	}
 	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
-}
-
-// featureBranch returns a regex string that matches feature branch prefixes for the given branch name:
-// I.e. returns '^master-' for 'master'. If the given branch name already looks like a regex,
-// return it unchanged.
-func featureBranch(branch string) string {
-	if !simpleBranchRegexp.MatchString(branch) {
-		return branch
-	}
-	return fmt.Sprintf("^%s-", regexp.QuoteMeta(branch))
 }
 
 // IsGenerated returns true if the job was generated using prowgen

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -58,8 +58,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^branch$
-    - ^branch-
+    - branch
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -1,8 +1,7 @@
 agent: kubernetes
 always_run: true
 branches:
-- ^branch$
-- ^branch-
+- branch
 context: ci/prow/also-testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -1,8 +1,7 @@
 agent: kubernetes
 always_run: true
 branches:
-- ^branch$
-- ^branch-
+- branch
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
@@ -1,8 +1,7 @@
 agent: kubernetes
 always_run: true
 branches:
-- ^branch$
-- ^branch-
+- branch
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
@@ -1,8 +1,7 @@
 agent: kubernetes
 always_run: true
 branches:
-- ^branch$
-- ^branch-
+- branch
 context: ci/prow/testname
 decorate: true
 labels:

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -85,8 +84,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -142,8 +140,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/test
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/ci-index
     decorate: true
     decoration_config:
@@ -51,8 +50,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/ci-index-my-bundle
     decorate: true
     decoration_config:
@@ -99,8 +97,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -173,8 +170,7 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -236,8 +232,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -284,8 +279,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/steps
     decorate: true
     decoration_config:
@@ -339,8 +333,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -387,8 +380,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/variant-images
     decorate: true
     decoration_config:
@@ -439,8 +431,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     context: ci/prow/variant-unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master-removed-promotion$
-    - ^master-removed-promotion-
+    - master-removed-promotion
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^release-3\.11$
-    - ^release-3\.11-
+    - release-3.11
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -62,8 +61,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^release-3\.11$
-    - ^release-3\.11-
+    - release-3.11
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -110,8 +108,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^release-3\.11$
-    - ^release-3\.11-
+    - release-3.11
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -52,8 +51,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -54,8 +53,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^nonstandard$
-    - ^nonstandard-
+    - nonstandard
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/cmd
     decorate: true
@@ -52,8 +51,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true
@@ -119,8 +117,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/e2e-aws
     decorate: true
@@ -186,8 +183,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/race
     decorate: true
@@ -235,8 +231,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - master
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -3,8 +3,7 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^nonstandard$
-    - ^nonstandard-
+    - nonstandard
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true


### PR DESCRIPTION
Reverts openshift/ci-tools#2136

/cc @openshift/openshift-team-developer-productivity-test-platform 

This change generates jobs with multiple branches which broke the rehearse tool.

```yaml
    branches:
    - ^master$
    - ^master-
```


follow-up https://github.com/openshift/release/pull/20014