### PR TITLE
[DPTP-2354] Fix flaky test TestWaitForConditionOnObject

### DIFF
--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -760,7 +760,7 @@ func TestWaitForConditionOnObject(t *testing.T) {
 			client: fakectrlruntimeclient.NewFakeClient(aPod()),
 			objectFunc: func(client ctrlruntimeclient.Client) error {
 				// wait for watch being ready
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				ctx := context.TODO()
 				pod := &coreapi.Pod{}
 				if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: podName, Namespace: ns}, pod); err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2354

I can reproduce the failure and verify the fix with:
```
go test -race -count=100 -run TestWaitForConditionOnObject  ./pkg/steps/
ok  	github.com/openshift/ci-tools/pkg/steps	41.790s
```

/cc @openshift/openshift-team-developer-productivity-test-platform 

