### PR TITLE
Testimagedistributor: Log error and ignore requestst w/o cluster in app.ci

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -662,7 +662,7 @@ func TestTestImageStramTagImportHandlerRoundTrips(t *testing.T) {
 	queue := &hijackingQueue{}
 
 	event := event.CreateEvent{Object: obj}
-	testImageStreamTagImportHandler().Create(event, queue)
+	testImageStreamTagImportHandler(logrus.NewEntry(logrus.StandardLogger())).Create(event, queue)
 
 	if n := len(queue.received); n != 1 {
 		t.Fatalf("expected exactly one reconcile request, got %d(%v)", n, queue.received)


### PR DESCRIPTION
If there is a testimagestreamtagimport on app.ci that doesn't have the
cluster set, we will currently fail with `no client for cluster  available`
which is impossible to understand without looking at the code.

Ref https://issues.redhat.com/browse/DPTP-2373

/cc @openshift/openshift-team-developer-productivity-test-platform 