### PR TITLE
pkg/validation: reject duplicated image/test name

### DIFF
--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -156,8 +156,13 @@ func (v *Validator) validateConfiguration(ctx *configContext, config *api.Releas
 
 	validationErrors = append(validationErrors, validateReleases("releases", config.Releases, config.ReleaseTagConfiguration != nil)...)
 	validationErrors = append(validationErrors, validateImages(ctx.addField("images"), config.Images)...)
-	validationErrors = append(validationErrors, v.validateTestStepConfiguration(ctx, "tests", config.Tests, config.ReleaseTagConfiguration, releases, resolved)...)
-
+	if tests := config.Tests; len(tests) != 0 {
+		images := sets.NewString()
+		for _, i := range config.Images {
+			images.Insert(string(i.To))
+		}
+		validationErrors = append(validationErrors, v.validateTestStepConfiguration(ctx, "tests", config.Tests, config.ReleaseTagConfiguration, releases, images, resolved)...)
+	}
 	// this validation brings together a large amount of data from separate
 	// parts of the configuration, so it's written as a standalone method
 	validationErrors = append(validationErrors, validateTestStepDependencies(config)...)

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -113,7 +113,14 @@ func IsValidReference(step api.LiteralTestStep) []error {
 	return v.IsValidReference(step)
 }
 
-func (v *Validator) validateTestStepConfiguration(configCtx *configContext, fieldRoot string, input []api.TestStepConfiguration, release *api.ReleaseTagConfiguration, releases sets.String, resolved bool) []error {
+func (v *Validator) validateTestStepConfiguration(
+	configCtx *configContext,
+	fieldRoot string,
+	input []api.TestStepConfiguration,
+	release *api.ReleaseTagConfiguration,
+	releases, images sets.String,
+	resolved bool,
+) []error {
 	var validationErrors []error
 
 	// check for test.As duplicates
@@ -127,6 +134,8 @@ func (v *Validator) validateTestStepConfiguration(configCtx *configContext, fiel
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'images' because it gets confused with '[images]' target", fieldRootN))
 		} else if strings.HasPrefix(test.As, string(api.PipelineImageStreamTagReferenceIndexImage)) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should begin with 'ci-index' because it gets confused with 'ci-index' and `ci-index-...` targets", fieldRootN))
+		} else if images.Has(test.As) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: duplicated name %q already declared in 'images'", fieldRootN, test.As))
 		} else if len(validation.IsDNS1123Subdomain(test.As)) != 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' is not a valid Kubernetes object name", fieldRootN, test.As))
 		}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -500,7 +500,7 @@ func TestValidateTests(t *testing.T) {
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()
-			if errs := v.validateTestStepConfiguration(newConfigContext(), "tests", tc.tests, tc.release, tc.releases, tc.resolved); len(errs) > 0 && tc.expectedValid {
+			if errs := v.validateTestStepConfiguration(newConfigContext(), "tests", tc.tests, tc.release, tc.releases, sets.NewString(), tc.resolved); len(errs) > 0 && tc.expectedValid {
 				t.Errorf("expected to be valid, got: %v", errs)
 			} else if !tc.expectedValid && len(errs) == 0 {
 				t.Error("expected to be invalid, but returned valid")


### PR DESCRIPTION
As seen in:

https://github.com/openshift/release/blob/7babc432cc74ce456a0a3c41919d0c9095dcfedc/ci-operator/config/redhat-et/microshift/redhat-et-microshift-main.yaml#L76

```
$ go run ./cmd/ci-operator-checkconfig --config-dir redhat-et/
ERRO[0000] Failed to load CI Operator configuration      error="invalid ci-operator config: invalid configuration: tests[2].as: duplicated name \"test-smoke\" already declared in 'images'" source-file=redhat-et/microshift/redhat-et-microshift-main.yaml
ERRO[0000]                                               error="error reading configuration files: invalid ci-operator config: invalid configuration: tests[2].as: duplicated name \"test-smoke\" already declared in 'images'"
FATA[0000] error validating configuration files
exit status 1
```