### PR TITLE
e2e: backfill data into prometheus in a deterministic order

### DIFF
--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -31,6 +32,7 @@ import (
 )
 
 func TestProduce(t *testing.T) {
+	rand.Seed(4641280330504625122)
 	t.Parallel()
 	T := testhelper.NewT(interrupts.Context(), t)
 	prometheusAddr, info := prometheus.Initialize(T, T.TempDir())


### PR DESCRIPTION
This allows us to know ahead of time given a seed what the values will
be in Prometheus and therefore in the pod-scaler.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @emilvberglind 
