### PR TITLE
ci-operator: wait for 30min before giving up on Pods

### DIFF
--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -559,7 +559,7 @@ func waitForPodCompletionOrTimeout(ctx context.Context, podClient PodClient, nam
 
 	podCheckTicker := time.NewTicker(10 * time.Second)
 	defer podCheckTicker.Stop()
-	podStartTimeout := 15 * time.Minute
+	podStartTimeout := 30 * time.Minute
 	var podSeenRunning bool
 
 	for {


### PR DESCRIPTION
Ultimately, our hard time-out on waiting for a Pod to reach the Running
phase was written to catch issues like ImagePullBackOff which do not
terminate the Pod but do cause it to hang forever waiting for e.g.
credentials. This is a defense mechanism to ensure that jobs finish
running and not time out themselves. We do not need it to be very
efficient. We are currently killing Pods that took a while to start the
Pod sandbox with an overly agressive timeout.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 