### PR TITLE
Vault proxy: Validate key conflicts

### DIFF
--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -198,7 +198,7 @@ func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, data m
 
 	name := types.NamespacedName{Namespace: data[vault.SecretSyncTargetNamepaceKey], Name: data[vault.SecretSyncTargetNameKey]}
 	for key := range data {
-		if key == vault.SecretSyncTargetNamepaceKey || key == vault.SecretSyncTargetNameKey {
+		if key == vault.SecretSyncTargetNamepaceKey || key == vault.SecretSyncTargetNameKey || key == vault.SecretSyncTargetClusterKey {
 			continue
 		}
 		if k.existingSecretKeysByNamespaceName[name].Has(key) {

--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -152,7 +152,6 @@ func (k *kvUpdateTransport) updateKeyCacheForSecret(path string, item map[string
 	defer k.existingSecretKeysByNamespaceNameLock.Unlock()
 
 	// Clear old entries associated with us
-	fmt.Printf("---\nPath: %s\nData: %v\n", path, k.existingSecretKeysByVaultSecretName)
 	for _, existingEntry := range k.existingSecretKeysByVaultSecretName[path] {
 		k.existingSecretKeysByNamespaceName[existingEntry.name].Delete(existingEntry.key)
 	}

--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -43,10 +43,14 @@ type kvUpdateTransport struct {
 	// sync to complete. Should only be enabled in tests.
 	synchronousSecretSync bool
 
-	privilegedVaultClient                 *vaultclient.VaultClient
+	privilegedVaultClient *vaultclient.VaultClient
+	// existingSecretKeysByNamespaceName is used in the key validation.
 	existingSecretKeysByNamespaceName     map[types.NamespacedName]sets.String
 	existingSecretKeysByNamespaceNameLock sync.RWMutex
-	existingSecretKeysByVaultSecretName   map[string][]namespacedNameKey
+	// existingSecretKeysByVaultSecretName is used as an index for updating
+	// the key cache (existingSecretKeysByNamespaceName) when Vault entries
+	// get updated/deleted.
+	existingSecretKeysByVaultSecretName map[string][]namespacedNameKey
 }
 
 type namespacedNameKey struct {

--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -150,13 +150,15 @@ func (k *kvUpdateTransport) updateKeyCacheForSecret(path string, item map[string
 		return
 	}
 
-	// Some requests like deletions operate on metadata, while most like create and update
-	// operate on data. We use the path as cache identifier, so we must treat them as
-	// equal. Only replace a prefix to not mess things up if someone makes their secret
-	// name end with metadata.
-	if strings.HasPrefix(path, k.kvMountPath+"/metadata") {
-		path = strings.Replace(path, "metadata/", "data/", 1)
+	// We use the item name as cache key, so we have to remove metadata/data from the path.
+	if strings.HasPrefix(path, k.kvMountPath+"/metadata/") {
+		path = strings.Replace(path, "metadata/", "", 1)
 	}
+	if strings.HasPrefix(path, k.kvMountPath+"/data/") {
+		path = strings.Replace(path, "data/", "", 1)
+	}
+	fmt.Printf("got update request for path %q, cache:\n%v\n", path, k.existingSecretKeysByVaultSecretName)
+	defer func() { fmt.Printf("Cache post update of %q:\n%v\n", path, k.existingSecretKeysByVaultSecretName) }()
 
 	k.existingSecretKeysByNamespaceNameLock.Lock()
 	defer k.existingSecretKeysByNamespaceNameLock.Unlock()

--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -53,6 +53,12 @@ type kvUpdateTransport struct {
 	existingSecretKeysByVaultSecretName map[string][]namespacedNameKey
 }
 
+func (k *kvUpdateTransport) initialize() {
+	for err := k.populateKeyCache(context.Background()); err != nil; {
+		logrus.WithError(err).Error("failed to populate key cache")
+	}
+}
+
 type namespacedNameKey struct {
 	name types.NamespacedName
 	key  string
@@ -204,6 +210,10 @@ func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, data m
 }
 
 func (k *kvUpdateTransport) populateKeyCache(ctx context.Context) (err error) {
+	if k.privilegedVaultClient == nil {
+		return nil
+	}
+
 	k.existingSecretKeysByNamespaceNameLock.Lock()
 	defer k.existingSecretKeysByNamespaceNameLock.Unlock()
 

--- a/cmd/vault-subpath-proxy/main.go
+++ b/cmd/vault-subpath-proxy/main.go
@@ -119,7 +119,9 @@ func createProxyServer(vaultAddr string, listenAddr string, kvMountPath string, 
 	}
 
 	proxy := httputil.NewSingleHostReverseProxy(vaultURL)
-	proxy.Transport = &kvUpdateTransport{kvMountPath: kvMountPath, upstream: http.DefaultTransport, kubeClients: clients, privilegedVaultClient: privilegedVaultClient}
+	transport := &kvUpdateTransport{kvMountPath: kvMountPath, upstream: http.DefaultTransport, kubeClients: clients, privilegedVaultClient: privilegedVaultClient}
+	transport.initialize()
+	proxy.Transport = transport
 	injector := &kvSubPathInjector{
 		upstream:    retryablehttp.NewClient().StandardClient().Transport,
 		kvMountPath: kvMountPath,


### PR DESCRIPTION
This change makes the vault proxy check for conflicts and error if one is found.

Sample in the UI:

<img width="993" alt="vault-kv-conflict" src="https://user-images.githubusercontent.com/6496100/126378022-c401f97f-1519-4b69-b728-3b8977793ed8.png">


Ref https://issues.redhat.com/browse/DPTP-2206

/label tide/merge-method-squash
/cc @openshift/openshift-team-developer-productivity-test-platform 