### PR TITLE
Abuse determinize-prow-config to implement 4.9 FF (no merge)

### DIFF
--- a/cmd/determinize-prow-config/main.go
+++ b/cmd/determinize-prow-config/main.go
@@ -11,10 +11,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	prowconfig "k8s.io/test-infra/prow/config"
@@ -169,6 +172,17 @@ func shardProwConfig(pc *prowconfig.ProwConfig, target afero.Fs) (*prowconfig.Pr
 		delete(pc.Tide.MergeType, orgOrgRepoString)
 	}
 
+	ocpFeatureFreezeRepos := sets.NewString()
+	ocpFeatureFreezeExemptRepos := sets.NewString("openshift/cluster-logging-operator",
+		"openshift/console",
+		"openshift/console-operator",
+		"openshift/elasticsearch-operator",
+		"openshift/elasticsearch-proxy",
+		"openshift/origin-aggregated-logging",
+		"openshift/builder",
+		"openshift/cluster-samples-operator",
+	)
+
 	for _, query := range pc.Tide.Queries {
 		for _, org := range query.Orgs {
 			if configsByOrgRepo[prowconfig.OrgRepo{Org: org}] == nil {
@@ -204,9 +218,26 @@ func shardProwConfig(pc *prowconfig.ProwConfig, target afero.Fs) (*prowconfig.Pr
 			queryCopy.Orgs = nil
 			queryCopy.Repos = []string{repo}
 			configsByOrgRepo[orgRepo].Tide.Queries = append(configsByOrgRepo[orgRepo].Tide.Queries, *queryCopy)
+			sort.Strings(queryCopy.IncludedBranches)
+			sort.Strings(queryCopy.ExcludedBranches)
+
+			if isOcpFeatureFreezeRepo(queryCopy) && !ocpFeatureFreezeExemptRepos.Has(repo) {
+				ocpFeatureFreezeRepos.Insert(repo)
+			}
 		}
 	}
 	pc.Tide.Queries = nil
+
+	for repo := range ocpFeatureFreezeExemptRepos {
+		slashSplit := strings.Split(repo, "/")
+		orgRepo := prowconfig.OrgRepo{Org: slashSplit[0], Repo: slashSplit[1]}
+		ensureOcpFeatureFreezeExemptCriteria(&(configsByOrgRepo[orgRepo].Tide.Queries), repo)
+	}
+	for repo := range ocpFeatureFreezeRepos {
+		slashSplit := strings.Split(repo, "/")
+		orgRepo := prowconfig.OrgRepo{Org: slashSplit[0], Repo: slashSplit[1]}
+		ensureOcpFeatureFreezeCriteria(&(configsByOrgRepo[orgRepo].Tide.Queries), repo)
+	}
 
 	for orgOrRepo, cfg := range configsByOrgRepo {
 		if err := prowconfigsharding.MkdirAndWrite(target, filepath.Join(orgOrRepo.Org, orgOrRepo.Repo, config.SupplementalProwConfigFileName), cfg); err != nil {
@@ -215,6 +246,87 @@ func shardProwConfig(pc *prowconfig.ProwConfig, target afero.Fs) (*prowconfig.Pr
 	}
 
 	return pc, nil
+}
+
+func ensureOcpFeatureFreezeCriteria(queries *prowconfig.TideQueries, repo string) {
+	for i := range *queries {
+		included := sets.NewString((*queries)[i].IncludedBranches...)
+		if !(included.Equal(sets.NewString("master")) ||
+			included.Equal(sets.NewString("main")) ||
+			included.Equal(sets.NewString("master", "main"))) {
+			continue
+		}
+		labels := sets.NewString((*queries)[i].Labels...)
+		if labels.Has("bugzilla/valid-bug") {
+			return
+		}
+		(*queries)[i].Labels = append((*queries)[i].Labels, "bugzilla/valid-bug")
+		sort.Strings((*queries)[i].Labels)
+		return
+	}
+	logrus.Warnf("Could not ensure OCP Feature Freeze merge criteria on %s", repo)
+}
+
+func ensureOcpFeatureFreezeExemptCriteria(queries *prowconfig.TideQueries, repo string) {
+	var mainQuery *prowconfig.TideQuery
+	var hasBugQuery, hasApprovalQuery bool
+	approvalLabels := sets.NewString("px-approved", "docs-approved", "qe-approved")
+	for i := range *queries {
+		included := sets.NewString((*queries)[i].IncludedBranches...)
+		if !(included.Equal(sets.NewString("master")) ||
+			included.Equal(sets.NewString("main")) ||
+			included.Equal(sets.NewString("master", "main"))) {
+			continue
+		}
+		mainQuery, _ = deepCopyTideQuery(&(*queries)[i])
+
+		labels := sets.NewString((*queries)[i].Labels...)
+
+		if labels.Has("bugzilla/valid-bug") {
+			hasBugQuery = true
+			continue
+		}
+		if labels.IsSuperset(approvalLabels) {
+			hasApprovalQuery = true
+			continue
+		}
+		// It's neither, so we make it the bug query
+		(*queries)[i].Labels = append((*queries)[i].Labels, "bugzilla/valid-bug")
+		hasBugQuery = true
+		sort.Strings((*queries)[i].Labels)
+	}
+
+	if mainQuery == nil {
+		logrus.Warnf("Could not ensure OCP Feature Freeze-exempt merge criteria on %s", repo)
+		return
+	}
+	mainQuery.Labels = sets.NewString(mainQuery.Labels...).Difference(approvalLabels.Union(sets.NewString("bugzilla/valid-bug"))).List()
+	if !hasBugQuery {
+		mainQuery.Labels = append(mainQuery.Labels, "bugzilla/valid-bug")
+		sort.Strings(mainQuery.Labels)
+		*queries = append(*queries, *mainQuery)
+	}
+	if !hasApprovalQuery {
+		mainQuery.Labels = append(mainQuery.Labels, approvalLabels.List()...)
+		sort.Strings(mainQuery.Labels)
+		*queries = append(*queries, *mainQuery)
+	}
+}
+
+func isOcpFeatureFreezeRepo(query *prowconfig.TideQuery) bool {
+	if !(reflect.DeepEqual(query.IncludedBranches, []string{"release-4.8"}) ||
+		reflect.DeepEqual(query.IncludedBranches, []string{"openshift-4.8"}) ||
+		reflect.DeepEqual(query.IncludedBranches, []string{"openshift-4.8", "release-4.8"})) {
+		return false
+	}
+
+	for _, label := range query.Labels {
+		if label == "group-lead-approved" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func deepCopyTideQuery(q *prowconfig.TideQuery) (*prowconfig.TideQuery, error) {


### PR DESCRIPTION
Several notes:

- OCP repos are identified by a presence of a `group-lead-approved`-guarded `release-4.8` branch query
- OCP repos exempt from feature freeze process are allowlisted, and follow what was manually set up for openshift/builder repository: overlapping queries that merge either on valid bugs (one query) or three approvals (second query)
- Non-exempt repositories simply add valid-bug requirement for their master/main branch

The resulting configuration is unfornunately not in the canonical ordering (as all the sorting etc is done *before* the config is sharded, but we modify it on shard writes. You need to run `make prow-config` again after running this.