### PR TITLE
pod-scaler: de-race startup

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -29,11 +29,11 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, cpu, memory []*cacheReloader, mutateResources bool) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, loaders map[string][]*cacheReloader, mutateResources bool) {
 	logger := logrus.WithField("component", "admission")
 	logger.Info("Initializing admission webhook server.")
 	health := pjutil.NewHealthOnPort(healthPort)
-	resources := newResourceServer(cpu, memory, health)
+	resources := newResourceServer(loaders, health)
 	decoder, err := admission.NewDecoder(scheme.Scheme)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create decoder from scheme.")

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -226,14 +226,14 @@ func mainAdmission(opts *options, cache cache) {
 		logrus.WithError(err).Fatal("Failed to construct client.")
 	}
 
-	cpuLoaders, memoryLoaders := loaders(cache)
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, cpuLoaders, memoryLoaders, opts.mutateResources)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, loaders(cache), opts.mutateResources)
 }
 
-func loaders(cache cache) (cpu, memory []*cacheReloader) {
+func loaders(cache cache) map[string][]*cacheReloader {
+	l := map[string][]*cacheReloader{}
 	for _, prefix := range []string{prowjobsCachePrefix, podsCachePrefix, stepsCachePrefix} {
-		cpu = append(cpu, newReloader(prefix+"/"+MetricNameCPUUsage, cache))
-		memory = append(memory, newReloader(prefix+"/"+MetricNameMemoryWorkingSet, cache))
+		l[MetricNameCPUUsage] = append(l[MetricNameCPUUsage], newReloader(prefix+"/"+MetricNameCPUUsage, cache))
+		l[MetricNameMemoryWorkingSet] = append(l[MetricNameMemoryWorkingSet], newReloader(prefix+"/"+MetricNameMemoryWorkingSet, cache))
 	}
-	return cpu, memory
+	return l
 }


### PR DESCRIPTION
We were not correctly managing concurrency when loading data. This
resulted in incomplete loaded state for the first reload tick when very
small (short) data loads occurred, as in end-to-end tests.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 