### PR TITLE
Subpath proxy: Don't validate secrets with no target

### DIFF
--- a/cmd/vault-subpath-proxy/main_test.go
+++ b/cmd/vault-subpath-proxy/main_test.go
@@ -410,6 +410,20 @@ path "secret/metadata/team-1/*" {
 					"some-secret-key":             "some-value",
 				},
 			},
+			{
+				name:             "Creating a secret with no target",
+				targetSecretName: "selfmanaged-secret",
+				data: map[string]string{
+					"selfmanaged": "some-value",
+				},
+			},
+			{
+				name:             "Creating another secret with no target and the same key succeeds",
+				targetSecretName: "selfmanaged-secret-2",
+				data: map[string]string{
+					"selfmanaged": "some-value",
+				},
+			},
 		}
 		for _, tc := range keyConflictTestCases {
 			t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
As that defaults to '/' as target, so this can easily produce conflicts.
We already skip those when updating the cache, but not when validating.
This can result in pre-existing secrets ending up in the cache.