### PR TITLE
testhelper: use a file to share port state

### DIFF
--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -250,12 +249,6 @@ func (a *Accessory) ClientFlags() []string {
 	return a.clientFlags(a.port, a.healthPort)
 }
 
-var ports sync.Map
-
-func init() {
-	ports = sync.Map{}
-}
-
 // GetFreePort asks the kernel for a free open port that is ready to use.
 func GetFreePort(t TestingTInterface) string {
 	for {
@@ -268,16 +261,45 @@ func GetFreePort(t TestingTInterface) string {
 		if err != nil {
 			t.Fatalf("could not listen on free port: %v", err)
 		}
-		defer func() {
-			if err := l.Close(); err != nil {
+		defer func(c io.Closer) {
+			if err := c.Close(); err != nil {
 				t.Errorf("could not close listener: %v", err)
 			}
-		}()
+		}(l)
 		port := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
-		if _, previouslyAllocated := ports.LoadOrStore(port, nil); !previouslyAllocated {
+		// Tests run in -parallel will run in separate processes, so we must use the file-system
+		// for sharing state and locking across them to coordinate who gets which port. Without
+		// some mechanism for sharing state, the following race is possible:
+		// - process A calls net.ListenTCP() to resolve a new port
+		// - process A calls l.Close() to close the listener to allow accessory to use it
+		// - process B calls net.ListenTCP() and resolves the same port
+		// - process A attempts to use the port, fails as it is in use
+		// Therefore, holding the listener open is our kernel-based lock for this process, and while
+		// we hold it open we must record our intent to disk.
+		lockDir := filepath.Join(os.TempDir(), "ci-tools-e2e-ports")
+		if err := os.MkdirAll(lockDir, 0777); err != nil {
+			t.Fatalf("could not create port lockfile dir: %v", err)
+		}
+		lockFile := filepath.Join(lockDir, port)
+		if _, err := os.Stat(lockFile); os.IsNotExist(err) {
 			// we've never seen this before, we can use it
+			f, err := os.Create(lockFile)
+			if err != nil {
+				t.Fatalf("could not record port lockfile: %v", err)
+			}
+			if err := f.Close(); err != nil {
+				t.Errorf("could not close port lockfile: %v", err)
+			}
+			// the lifecycle of an accessory (and thereby its ports) is the test lifecycle
+			t.Cleanup(func() {
+				if err := os.Remove(lockFile); err != nil {
+					t.Errorf("failed to remove port lockfile: %v", err)
+				}
+			})
 			t.Logf("found a never-before-seen port, returning: %s", port)
 			return port
+		} else if err != nil {
+			t.Fatalf("could not access port lockfile: %v", err)
 		}
 		t.Logf("found a previously-seen port, retrying: %s", port)
 	}


### PR DESCRIPTION
We need to use a global marker of state to share the intent to use ports
as the in-memory lock we had in the past could not handle the case where
tests were run in parallel in separate processes.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

This should fix a number of flakes in e2e

/assign @openshift/openshift-team-developer-productivity-test-platform 