### PR TITLE
Disable e2e tests with claims

### DIFF
--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -161,6 +161,7 @@ func TestMultiStage(t *testing.T) {
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
 			cmd.AddArgs(testCase.args...)
 			if testCase.needHive {
+				t.Skip("https://issues.redhat.com/browse/HIVE-1585")
 				cmd.AddArgs(framework.HiveKubeconfigFlag(t))
 				// The job name will be used as claim name and e2e tests from different PRs make make claims from the same namespace.
 				// The job name should be unique.


### PR DESCRIPTION
Due to https://coreos.slack.com/archives/CE3ETN3J8/p1627493669210600?thread_ts=1626290803.340800&cid=CE3ETN3J8

Those tests are blocking merging on the repo.

/cc @openshift/openshift-team-developer-productivity-test-platform 