### PR TITLE
configresolver: add an endpoint to inject a test into a config

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -143,28 +143,21 @@ func injectTestFromQuery(w http.ResponseWriter, r *http.Request) (api.Metadata, 
 		}
 		return metadata, test, err
 	}
-	metadata.Org = r.URL.Query().Get(injectFromOrgQuery)
-	if metadata.Org == "" {
-		webreg.MissingQuery(w, injectFromOrgQuery)
-		return metadata, test, fmt.Errorf("missing query %s", injectFromOrgQuery)
-	}
-	metadata.Repo = r.URL.Query().Get(injectFromRepoQuery)
-	if metadata.Repo == "" {
-		webreg.MissingQuery(w, injectFromRepoQuery)
-		return metadata, "", fmt.Errorf("missing query %s", injectFromRepoQuery)
-	}
-	metadata.Branch = r.URL.Query().Get(injectFromBranchQuery)
-	if metadata.Branch == "" {
-		webreg.MissingQuery(w, injectFromBranchQuery)
-		return metadata, test, fmt.Errorf("missing query %s", injectFromVariantQuery)
+
+	for query, field := range map[string]*string{
+		injectFromOrgQuery:    &metadata.Org,
+		injectFromRepoQuery:   &metadata.Repo,
+		injectFromBranchQuery: &metadata.Branch,
+		injectTestQuery:       &test,
+	} {
+		value := r.URL.Query().Get(query)
+		if value == "" {
+			webreg.MissingQuery(w, query)
+			return metadata, test, fmt.Errorf("missing query %s", query)
+		}
+		*field = value
 	}
 	metadata.Variant = r.URL.Query().Get(injectFromVariantQuery)
-
-	test = r.URL.Query().Get(injectTestQuery)
-	if test == "" {
-		webreg.MissingQuery(w, injectTestQuery)
-		return metadata, test, fmt.Errorf("missing query %s", injectTestQuery)
-	}
 
 	return metadata, test, nil
 }

--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -103,7 +103,11 @@ func resolveConfig(configAgent agents.ConfigAgent, registryAgent agents.Registry
 		}
 		metadata, err := webreg.MetadataFromQuery(w, r)
 		if err != nil {
+			// MetadataFromQuery deals with setting status code and writing response
+			// so we need to just log the error here
 			metrics.RecordError("invalid query", configresolverMetrics.ErrorRate)
+			logrus.WithError(err).Warning("failed to read query from request")
+			return
 		}
 		logger := logrus.WithFields(api.LogFieldsFor(metadata))
 
@@ -174,7 +178,11 @@ func resolveConfigWithInjectedTest(configAgent agents.ConfigAgent, registryAgent
 		}
 		metadata, err := webreg.MetadataFromQuery(w, r)
 		if err != nil {
+			// MetadataFromQuery deals with setting status code and writing response
+			// so we need to just log the error here
 			metrics.RecordError("invalid query", configresolverMetrics.ErrorRate)
+			logrus.WithError(err).Warning("failed to read query from request")
+			return
 		}
 		logger := logrus.WithFields(api.LogFieldsFor(metadata))
 
@@ -189,7 +197,11 @@ func resolveConfigWithInjectedTest(configAgent agents.ConfigAgent, registryAgent
 
 		injectFromMetadata, test, err := injectTestFromQuery(w, r)
 		if err != nil {
+			// injectTestFromQuery deals with setting status code and writing response
+			// so we need to just log the error here
 			metrics.RecordError("invalid query", configresolverMetrics.ErrorRate)
+			logrus.WithError(err).Warning("failed to read query from request")
+			return
 		}
 		injectFromConfig, err := configAgent.GetMatchingConfig(injectFromMetadata)
 		if err != nil {

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1510,28 +1510,23 @@ func MetadataFromQuery(w http.ResponseWriter, r *http.Request) (api.Metadata, er
 		}
 		return api.Metadata{}, err
 	}
-	org := r.URL.Query().Get(OrgQuery)
-	if org == "" {
-		MissingQuery(w, OrgQuery)
-		return api.Metadata{}, fmt.Errorf("missing query %s", OrgQuery)
+
+	var metadata api.Metadata
+	for query, field := range map[string]*string{
+		OrgQuery:    &metadata.Org,
+		RepoQuery:   &metadata.Repo,
+		BranchQuery: &metadata.Branch,
+	} {
+		value := r.URL.Query().Get(query)
+		if value == "" {
+			MissingQuery(w, query)
+			return metadata, fmt.Errorf("missing query %s", query)
+		}
+		*field = value
 	}
-	repo := r.URL.Query().Get(RepoQuery)
-	if repo == "" {
-		MissingQuery(w, RepoQuery)
-		return api.Metadata{}, fmt.Errorf("missing query %s", RepoQuery)
-	}
-	branch := r.URL.Query().Get(BranchQuery)
-	if branch == "" {
-		MissingQuery(w, BranchQuery)
-		return api.Metadata{}, fmt.Errorf("missing query %s", BranchQuery)
-	}
-	variant := r.URL.Query().Get(VariantQuery)
-	return api.Metadata{
-		Org:     org,
-		Repo:    repo,
-		Branch:  branch,
-		Variant: variant,
-	}, nil
+	metadata.Variant = r.URL.Query().Get(VariantQuery)
+
+	return metadata, nil
 }
 
 func MissingQuery(w http.ResponseWriter, field string) {

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -1512,17 +1512,17 @@ func MetadataFromQuery(w http.ResponseWriter, r *http.Request) (api.Metadata, er
 	}
 	org := r.URL.Query().Get(OrgQuery)
 	if org == "" {
-		missingQuery(w, OrgQuery)
+		MissingQuery(w, OrgQuery)
 		return api.Metadata{}, fmt.Errorf("missing query %s", OrgQuery)
 	}
 	repo := r.URL.Query().Get(RepoQuery)
 	if repo == "" {
-		missingQuery(w, RepoQuery)
+		MissingQuery(w, RepoQuery)
 		return api.Metadata{}, fmt.Errorf("missing query %s", RepoQuery)
 	}
 	branch := r.URL.Query().Get(BranchQuery)
 	if branch == "" {
-		missingQuery(w, BranchQuery)
+		MissingQuery(w, BranchQuery)
 		return api.Metadata{}, fmt.Errorf("missing query %s", BranchQuery)
 	}
 	variant := r.URL.Query().Get(VariantQuery)
@@ -1534,7 +1534,7 @@ func MetadataFromQuery(w http.ResponseWriter, r *http.Request) (api.Metadata, er
 	}, nil
 }
 
-func missingQuery(w http.ResponseWriter, field string) {
+func MissingQuery(w http.ResponseWriter, field string) {
 	w.WriteHeader(http.StatusBadRequest)
 	fmt.Fprintf(w, "%s query missing or incorrect", field)
 }
@@ -1549,7 +1549,7 @@ func jobHandler(regAgent agents.RegistryAgent, confAgent agents.ConfigAgent, w h
 	}
 	test := r.URL.Query().Get(TestQuery)
 	if test == "" {
-		missingQuery(w, TestQuery)
+		MissingQuery(w, TestQuery)
 		return
 	}
 	configs, err := confAgent.GetMatchingConfig(metadata)

--- a/test/integration/ci-operator-configresolver.sh
+++ b/test/integration/ci-operator-configresolver.sh
@@ -25,6 +25,9 @@ os::integration::configresolver::check_log
 os::cmd::expect_success "curl -X POST -H 'Content-Type: application/json' --data @${BASETMPDIR}/unresolved-config.json 'http://127.0.0.1:8080/resolve' >${actual}/resolved-config.json"
 os::integration::compare "${actual}/resolved-config.json" "${expected}/resolved-config.json"
 os::integration::configresolver::check_log
+os::cmd::expect_success "curl 'http://127.0.0.1:8080/configWithInjectedTest?org=openshift&repo=installer&branch=release-4.2&injectTestFromOrg=openshift&injectTestFromRepo=release&injectTestFromBranch=master&injectTestFromVariant=ci-4.9&injectTest=e2e' >${actual}/openshift-installer-release-4.2-injected.json"
+os::integration::compare "${actual}/openshift-installer-release-4.2-injected.json" "${expected}/openshift-installer-release-4.2-injected.json"
+os::integration::configresolver::check_log
 
 generation="$( os::integration::configresolver::generation::config )"
 mv "${BASETMPDIR}/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml" "${BASETMPDIR}/configs/release-4.2/openshift-installer-release-4.2.yaml"

--- a/test/integration/ci-operator-configresolver/configs/master/openshift-release-master__ci-4.9.yaml
+++ b/test/integration/ci-operator-configresolver/configs/master/openshift-release-master__ci-4.9.yaml
@@ -1,0 +1,34 @@
+zz_generated_metadata:
+  org: openshift
+  repo: release
+  branch: master
+  variant: ci-4.9
+base_images:
+  release-job-base:
+    name: "4.2"
+    namespace: ocp
+    tag: release-job-base
+resources:
+  '*':
+    limits:
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 200Mi
+tests:
+- as: e2e-aws
+  commands: TEST_SUITE=openshift/conformance/parallel run-tests
+  openshift_installer:
+    cluster_profile: aws
+- as: e2e
+  steps:
+    cluster_profile: azure4
+    workflow: ipi
+    test:
+    - as: e2e
+      from: my-image
+      commands: make azure-e2e
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 2Gi

--- a/test/integration/ci-operator-configresolver/configs/release-4.2/openshift-installer-release-4.2.yaml
+++ b/test/integration/ci-operator-configresolver/configs/release-4.2/openshift-installer-release-4.2.yaml
@@ -12,6 +12,9 @@ build_root:
     name: release
     namespace: openshift
     tag: golang-1.10
+images:
+- to: installer
+  from: base
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-configresolver/expected/openshift-installer-release-4.2-injected.json
+++ b/test/integration/ci-operator-configresolver/expected/openshift-installer-release-4.2-injected.json
@@ -9,6 +9,11 @@
       "namespace": "ocp",
       "name": "4.2",
       "tag": "base"
+    },
+    "release-job-base": {
+      "namespace": "ocp",
+      "name": "4.2",
+      "tag": "release-job-base"
     }
   },
   "build_root": {
@@ -26,21 +31,7 @@
   ],
   "tests": [
     {
-      "as": "unit",
-      "commands": "go test ./pkg/...",
-      "container": {
-        "from": "src"
-      }
-    },
-    {
-      "as": "e2e-aws",
-      "commands": "TEST_SUITE=openshift/conformance/parallel run-tests",
-      "openshift_installer": {
-        "cluster_profile": "aws"
-      }
-    },
-    {
-      "as": "e2e-azure",
+      "as": "e2e",
       "literal_steps": {
         "cluster_profile": "azure4",
         "pre": [
@@ -81,93 +72,6 @@
             "as": "e2e",
             "from": "my-image",
             "commands": "make azure-e2e",
-            "resources": {
-              "requests": {
-                "cpu": "1000m",
-                "memory": "2Gi"
-              }
-            }
-          }
-        ],
-        "post": [
-          {
-            "as": "ipi-deprovision-must-gather",
-            "from": "installer",
-            "commands": "gather\n",
-            "resources": {
-              "requests": {
-                "cpu": "1000m",
-                "memory": "2Gi"
-              }
-            }
-          },
-          {
-            "as": "ipi-deprovision-deprovision",
-            "from": "installer",
-            "commands": "openshift-cluster destroy\n",
-            "resources": {
-              "requests": {
-                "cpu": "1000m",
-                "memory": "2Gi"
-              }
-            }
-          }
-        ],
-        "observers": [
-          {
-            "name": "resourcewatcher",
-            "from_image": {
-              "namespace": "ocp",
-              "name": "resourcewatcher",
-              "tag": "latest"
-            },
-            "commands": "#!/bin/bash\n\nsleep 300"
-          }
-        ]
-      }
-    },
-    {
-      "as": "e2e-gcp",
-      "literal_steps": {
-        "cluster_profile": "gcp",
-        "pre": [
-          {
-            "as": "ipi-install-rbac",
-            "from": "installer",
-            "commands": "setup-rbac\n",
-            "resources": {
-              "requests": {
-                "cpu": "1000m",
-                "memory": "2Gi"
-              }
-            }
-          },
-          {
-            "as": "ipi-install-install",
-            "from": "installer",
-            "commands": "openshift-cluster install\n",
-            "resources": {
-              "requests": {
-                "cpu": "1000m",
-                "memory": "2Gi"
-              }
-            },
-            "env": [
-              {
-                "name": "TEST_PARAMETER",
-                "default": "test parameter default"
-              }
-            ],
-            "observers": [
-              "resourcewatcher"
-            ]
-          }
-        ],
-        "test": [
-          {
-            "as": "e2e",
-            "from": "my-image",
-            "commands": "make custom-e2e",
             "resources": {
               "requests": {
                 "cpu": "1000m",


### PR DESCRIPTION
Builds over https://github.com/openshift/ci-tools/pull/2193 and adds a new `/configWithInjectedTest` endpoint that uses serves configs created by code https://github.com/openshift/ci-tools/pull/2193 . I was deciding between adding a new endpoint and just adding new set of query inputs to the existing `/config` one, but I think I will want to add more injection behavior in the future ("inject test with workflow X from the registry") so I think separate endpoint is better.