### PR TITLE
prowgen: generate stricter `branch:` stanzas for presubmits

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/rhel-images
     decorate: true
     decoration_config:
@@ -52,7 +53,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/rhel-unit
     decorate: true
     decoration_config:

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -34,6 +34,11 @@ const (
 	PeriodicPrefix         = "periodic"
 )
 
+// SimpleBranchRegexp matches a branch name that does not appear to be a regex (lacks wildcard,
+// group, or other modifiers). For instance, `master` is considered simple, `master-.*` would
+// not.
+var SimpleBranchRegexp = regexp.MustCompile(`^[\w\-.]+$`)
+
 // Info describes the metadata for a Prow job configuration file
 type Info struct {
 	Org    string

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -613,15 +613,10 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 	return base
 }
 
-// simpleBranchRegexp matches a branch name that does not appear to be a regex (lacks wildcard,
-// group, or other modifiers). For instance, `master` is considered simple, `master-.*` would
-// not.
-var simpleBranchRegexp = regexp.MustCompile(`^[\w\-.]+$`)
-
 // exactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
 // '^master$' for 'master'. If the given branch name already looks like a regex, return it unchanged.
 func exactlyBranch(branch string) string {
-	if !simpleBranchRegexp.MatchString(branch) {
+	if !jc.SimpleBranchRegexp.MatchString(branch) {
 		return branch
 	}
 	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
@@ -631,7 +626,7 @@ func exactlyBranch(branch string) string {
 // I.e. returns '^master-' for 'master'. If the given branch name already looks like a regex,
 // return it unchanged.
 func featureBranch(branch string) string {
-	if !simpleBranchRegexp.MatchString(branch) {
+	if !jc.SimpleBranchRegexp.MatchString(branch) {
 		return branch
 	}
 	return fmt.Sprintf("^%s-", regexp.QuoteMeta(branch))

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -58,7 +58,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - branch
+    - ^branch$
+    - ^branch-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/also-testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 decoration_config:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_job_release_specified_and_clone.yaml
@@ -1,7 +1,8 @@
 agent: kubernetes
 always_run: true
 branches:
-- branch
+- ^branch$
+- ^branch-
 context: ci/prow/testname
 decorate: true
 labels:

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -84,7 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -140,7 +142,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/test
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/ci-index
     decorate: true
     decoration_config:
@@ -50,7 +51,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/ci-index-my-bundle
     decorate: true
     decoration_config:
@@ -97,7 +99,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/e2e
     decorate: true
     decoration_config:
@@ -170,7 +173,8 @@ presubmits:
   - agent: kubernetes
     always_run: false
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -232,7 +236,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -279,7 +284,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/steps
     decorate: true
     decoration_config:
@@ -333,7 +339,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -380,7 +387,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/variant-images
     decorate: true
     decoration_config:
@@ -431,7 +439,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/variant-unit
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master-removed-promotion
+    - ^master-removed-promotion$
+    - ^master-removed-promotion-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -61,7 +62,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/lint
     decorate: true
     decoration_config:
@@ -108,7 +110,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - release-3.11
+    - ^release-3\.11$
+    - ^release-3\.11-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -36,7 +36,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ciop-cfg-change
+    - ^ciop-cfg-change$
+    - ^ciop-cfg-change-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -86,7 +86,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -85,7 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -161,7 +162,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage
     decorate: true
     decoration_config:
@@ -208,7 +210,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage2
     decorate: true
     decoration_config:
@@ -255,7 +258,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage3
     decorate: true
     decoration_config:
@@ -320,7 +324,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage4
     decorate: true
     decoration_config:
@@ -367,7 +372,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage5
     decorate: true
     decoration_config:
@@ -414,7 +420,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -36,7 +36,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ciop-cfg-change
+    - ^ciop-cfg-change$
+    - ^ciop-cfg-change-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - cluster-profile
+    - ^cluster-profile$
+    - ^cluster-profile-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -81,7 +81,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -85,7 +85,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/images
     decorate: true
     decoration_config:
@@ -161,7 +162,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage
     decorate: true
     decoration_config:
@@ -208,7 +210,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage2
     decorate: true
     decoration_config:
@@ -255,7 +258,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage3
     decorate: true
     decoration_config:
@@ -320,7 +324,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/multistage4
     decorate: true
     decoration_config:
@@ -367,7 +372,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -51,7 +52,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -53,7 +54,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - nonstandard
+    - ^nonstandard$
+    - ^nonstandard-
     cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/cmd
     decorate: true
@@ -51,7 +52,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true
@@ -117,7 +119,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/e2e-aws
     decorate: true
@@ -183,7 +186,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/race
     decorate: true
@@ -231,7 +235,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: api.ci
     context: ci/prow/unit
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - nonstandard
+    - ^nonstandard$
+    - ^nonstandard-
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true


### PR DESCRIPTION
- prowgen: generate stricter `branch:` stanzas for presubmits
- prowgen: regenerate pj-rehearse test data
- pj-rehearse: handle presubmits with multiple branches

Reintroduce https://github.com/openshift/ci-tools/pull/2136 that needed to be
reverted because pj-rehearse was unable to handle the new presubmit shape. I
regenerated the pj-reharse test data to reflect the change in Prowgen and
therefore reproduce the pj-rehearse problem. Then I fixed pj-rehearse by
processing all `Brancher` items in a presubmit and extracting a "simple name"
from what is potentially a regex. If at least one branch name is successfully
extracted, it is used for rehearsal.

Resolves: [DPTP-2414](https://issues.redhat.com/browse/DPTP-2414)
Doc update: https://github.com/openshift/ci-tools/pull/2199
o/release update: https://github.com/openshift/release/pull/20738