### PR TITLE
pod-scaler: mutate resource requests by default

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -29,7 +29,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, loaders map[string][]*cacheReloader, mutateResources bool) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool) {
 	logger := logrus.WithField("component", "admission")
 	logger.Info("Initializing admission webhook server.")
 	health := pjutil.NewHealthOnPort(healthPort)
@@ -42,7 +42,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 		Port:    port,
 		CertDir: certDir,
 	}
-	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResources: mutateResources}})
+	server.Register("/pods", &webhook.Admission{Handler: &podMutator{logger: logger, client: client, decoder: decoder, resources: resources, mutateResourceLimits: mutateResourceLimits}})
 	logger.Info("Serving admission webhooks.")
 	if err := server.StartStandalone(interrupts.Context(), nil); err != nil {
 		logrus.WithError(err).Fatal("Failed to serve webhooks.")
@@ -50,11 +50,11 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 }
 
 type podMutator struct {
-	logger          *logrus.Entry
-	client          buildclientv1.BuildV1Interface
-	resources       *resourceServer
-	mutateResources bool
-	decoder         *admission.Decoder
+	logger               *logrus.Entry
+	client               buildclientv1.BuildV1Interface
+	resources            *resourceServer
+	mutateResourceLimits bool
+	decoder              *admission.Decoder
 }
 
 func (m *podMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
@@ -81,9 +81,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		logger.WithError(err).Error("Failed to handle rehearsal Pod.")
 		return admission.Allowed("Failed to handle rehearsal Pod, ignoring.")
 	}
-	if m.mutateResources {
-		mutatePodResources(pod, m.resources)
-	}
+	mutatePodResources(pod, m.resources, m.mutateResourceLimits)
 
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {
@@ -196,13 +194,15 @@ func reconcileLimits(resources *corev1.ResourceRequirements) {
 	}
 }
 
-func mutatePodResources(pod *corev1.Pod, server *resourceServer) {
+func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool) {
 	for i := range pod.Spec.InitContainers {
 		meta := pod_scaler.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, pod.Spec.InitContainers[i].Name)
 		resources, recommendationExists := server.recommendedRequestFor(meta)
 		if recommendationExists {
 			useOursIfLarger(&resources, &pod.Spec.InitContainers[i].Resources)
-			reconcileLimits(&pod.Spec.InitContainers[i].Resources)
+			if mutateResourceLimits {
+				reconcileLimits(&pod.Spec.InitContainers[i].Resources)
+			}
 		}
 	}
 	for i := range pod.Spec.Containers {
@@ -210,7 +210,9 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer) {
 		resources, recommendationExists := server.recommendedRequestFor(meta)
 		if recommendationExists {
 			useOursIfLarger(&resources, &pod.Spec.Containers[i].Resources)
-			reconcileLimits(&pod.Spec.Containers[i].Resources)
+			if mutateResourceLimits {
+				reconcileLimits(&pod.Spec.Containers[i].Resources)
+			}
 		}
 	}
 }

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -55,8 +55,8 @@ type consumerOptions struct {
 	port   int
 	uiPort int
 
-	certDir         string
-	mutateResources bool
+	certDir              string
+	mutateResourceLimits bool
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -69,7 +69,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.IntVar(&o.port, "port", 0, "Port to serve admission webhooks on.")
 	fs.IntVar(&o.uiPort, "ui-port", 0, "Port to serve frontend on.")
 	fs.StringVar(&o.certDir, "serving-cert-dir", "", "Path to directory with serving certificate and key for the admission webhook server.")
-	fs.BoolVar(&o.mutateResources, "mutate-resources", false, "Enable resource mutation in the admission webhook.")
+	fs.BoolVar(&o.mutateResourceLimits, "mutate-resource-limits", false, "Enable resource limit mutation in the admission webhook.")
 	fs.StringVar(&o.loglevel, "loglevel", "debug", "Logging level.")
 	fs.StringVar(&o.logStyle, "log-style", "json", "Logging style: json or text.")
 	fs.StringVar(&o.cacheDir, "cache-dir", "", "Local directory holding cache data (for development mode).")
@@ -226,7 +226,7 @@ func mainAdmission(opts *options, cache cache) {
 		logrus.WithError(err).Fatal("Failed to construct client.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, loaders(cache), opts.mutateResources)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, loaders(cache), opts.mutateResourceLimits)
 }
 
 func loaders(cache cache) map[string][]*cacheReloader {

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
@@ -1,0 +1,48 @@
+  &v1.Pod{
+  	TypeMeta:   {},
+  	ObjectMeta: {Name: "tomutate", Labels: {"ci.openshift.io/metadata.branch": "branch", "ci.openshift.io/metadata.org": "org", "ci.openshift.io/metadata.repo": "repo", "ci.openshift.io/metadata.step": "step", "ci.openshift.io/metadata.target": "target", "ci.openshift.io/metadata.variant": "variant"}},
+  	Spec: v1.PodSpec{
+  		Volumes:        nil,
+  		InitContainers: nil,
+  		Containers: []v1.Container{
+  			{Name: "large", Resources: {Limits: {s"cpu": {i: {value: 400}, Format: "DecimalSI"}, s"memory": {i: {value: 40000000000}, Format: "BinarySI"}}, Requests: {s"cpu": {i: {value: 200}, Format: "DecimalSI"}, s"memory": {i: {value: 30000000000}, Format: "BinarySI"}}}},
+  			{
+  				... // 6 identical fields
+  				EnvFrom: nil,
+  				Env:     nil,
+  				Resources: v1.ResourceRequirements{
+  					Limits: {},
+  					Requests: v1.ResourceList{
+  						s"cpu":    {i: {value: 200}, Format: "DecimalSI"},
+- 						s"memory": {i: resource.int64Amount{value: 10000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
+  					},
+  				},
+  				VolumeMounts:  nil,
+  				VolumeDevices: nil,
+  				... // 11 identical fields
+  			},
+  			{
+  				... // 6 identical fields
+  				EnvFrom: nil,
+  				Env:     nil,
+  				Resources: v1.ResourceRequirements{
+  					Limits: {},
+  					Requests: v1.ResourceList{
+- 						s"cpu":    {i: resource.int64Amount{value: 10}, Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 100}, Format: "DecimalSI"},
+- 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
+  					},
+  				},
+  				VolumeMounts:  nil,
+  				VolumeDevices: nil,
+  				... // 11 identical fields
+  			},
+  		},
+  		EphemeralContainers: nil,
+  		RestartPolicy:       "",
+  		... // 30 identical fields
+  	},
+  	Status: {},
+  }

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -48,7 +48,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--log-style=text",
 		"--cache-dir", dataDir,
 		"--mode=consumer.admission",
-		"--mutate-resources",
+		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {


### PR DESCRIPTION
The server is already configured to only override resource requests when
the suggested value is *larger* than that present in the Pod, so we risk
nothing by turning on resource request suggestion. Limits, on the other
hand, can cause Pod eviction and require more thought.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/openshift-team-developer-productivity-test-platform 