### PR TITLE
Vault subpath proxy: Allow adding new values to secrets

### DIFF
--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -64,6 +65,16 @@ type namespacedNameKey struct {
 	key  string
 }
 
+func namespacedNameKeySliceContains(haystack []namespacedNameKey, needle namespacedNameKey) bool {
+	for _, hay := range haystack {
+		if reflect.DeepEqual(hay, needle) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (k *kvUpdateTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	l := logrus.WithFields(logrus.Fields{
 		"method": r.Method,
@@ -115,7 +126,7 @@ func (k *kvUpdateTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		errs = append(errs, fmt.Sprintf("secret %s in namespace %s cannot be used in a step: %s", body.Data[vault.SecretSyncTargetNameKey], body.Data[vault.SecretSyncTargetNamepaceKey], err.Error()))
 	}
 
-	keyConflictValidationErrs, err := k.validateKeysDontConflict(r.Context(), body.Data)
+	keyConflictValidationErrs, err := k.validateKeysDontConflict(r.Context(), r.URL.Path, body.Data)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to validate keys don't conflict")
 		errs = append(errs, "secret key validation check failed, please contact @dptp-helpdesk in #forum-testplatform")
@@ -138,11 +149,22 @@ func (k *kvUpdateTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		go k.syncSecret(body.Data)
 	}
 	if response.StatusCode > 199 && response.StatusCode < 300 {
-		path := strings.TrimPrefix(r.URL.Path, "/v1/")
-		k.updateKeyCacheForSecret(path, body.Data)
+		k.updateKeyCacheForSecret(r.URL.Path, body.Data)
 
 	}
 	return response, nil
+}
+
+func (k *kvUpdateTransport) kvCacheKeyFromURLPath(urlPath string) string {
+	urlPath = strings.TrimPrefix(urlPath, "/v1/")
+	// We use the item name as cache key, so we have to remove metadata/data from the path.
+	if strings.HasPrefix(urlPath, k.kvMountPath+"/metadata/") {
+		urlPath = strings.Replace(urlPath, "metadata/", "", 1)
+	}
+	if strings.HasPrefix(urlPath, k.kvMountPath+"/data/") {
+		urlPath = strings.Replace(urlPath, "data/", "", 1)
+	}
+	return urlPath
 }
 
 func (k *kvUpdateTransport) updateKeyCacheForSecret(path string, item map[string]string) {
@@ -150,13 +172,7 @@ func (k *kvUpdateTransport) updateKeyCacheForSecret(path string, item map[string
 		return
 	}
 
-	// We use the item name as cache key, so we have to remove metadata/data from the path.
-	if strings.HasPrefix(path, k.kvMountPath+"/metadata/") {
-		path = strings.Replace(path, "metadata/", "", 1)
-	}
-	if strings.HasPrefix(path, k.kvMountPath+"/data/") {
-		path = strings.Replace(path, "data/", "", 1)
-	}
+	path = k.kvCacheKeyFromURLPath(path)
 
 	k.existingSecretKeysByNamespaceNameLock.Lock()
 	defer k.existingSecretKeysByNamespaceNameLock.Unlock()
@@ -184,7 +200,7 @@ func (k *kvUpdateTransport) updateKeyCacheForSecret(path string, item map[string
 	}
 }
 
-func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, data map[string]string) (validationErrs []string, err error) {
+func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, path string, data map[string]string) (validationErrs []string, err error) {
 	if k.privilegedVaultClient == nil {
 		return nil, nil
 	}
@@ -197,6 +213,8 @@ func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, data m
 		return nil, err
 	}
 
+	path = k.kvCacheKeyFromURLPath(path)
+
 	k.existingSecretKeysByNamespaceNameLock.RLock()
 	defer k.existingSecretKeysByNamespaceNameLock.RUnlock()
 
@@ -205,7 +223,7 @@ func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, data m
 		if key == vault.SecretSyncTargetNamepaceKey || key == vault.SecretSyncTargetNameKey || key == vault.SecretSyncTargetClusterKey {
 			continue
 		}
-		if k.existingSecretKeysByNamespaceName[name].Has(key) {
+		if k.existingSecretKeysByNamespaceName[name].Has(key) && !namespacedNameKeySliceContains(k.existingSecretKeysByVaultSecretName[path], namespacedNameKey{name: name, key: key}) {
 			validationErrs = append(validationErrs, fmt.Sprintf("key %s in secret %s is already claimed", key, name))
 		}
 	}

--- a/cmd/vault-subpath-proxy/main_test.go
+++ b/cmd/vault-subpath-proxy/main_test.go
@@ -411,6 +411,16 @@ path "secret/metadata/team-1/*" {
 				},
 			},
 			{
+				name:             "Updating the previous secret and adding another key succeeds",
+				targetSecretName: "fourth-secret",
+				data: map[string]string{
+					"secretsync/target-namespace": "default",
+					"secretsync/target-name":      "secret",
+					"some-secret-key":             "some-value",
+					"some-secret-key-2":           "another-value",
+				},
+			},
+			{
 				name:             "Creating a secret with no target",
 				targetSecretName: "selfmanaged-secret",
 				data: map[string]string{


### PR DESCRIPTION
Currently, the proxy would refuse all changes where a key in a vault
entry targets a kube secret that is already targeted. This unfortuantely
included the case where the key from the same vault entry got another
key, making it impossible to add additional keys to vault entries.

This change fixes that.

Ref https://issues.redhat.com/browse/DPTP-2416