### PR TITLE
pkg/defaults: move defaulting code to `pkg/api`

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -48,6 +48,14 @@ func (config *ReleaseBuildConfiguration) Default() {
 			}
 		}
 	}
+	for alias, target := range config.InputConfiguration.BaseImages {
+		target.As = alias
+		config.InputConfiguration.BaseImages[alias] = target
+	}
+	for alias, target := range config.InputConfiguration.BaseRPMImages {
+		target.As = alias
+		config.InputConfiguration.BaseRPMImages[alias] = target
+	}
 	for i := range config.RawSteps {
 		if test := config.RawSteps[i].TestStepConfiguration; test != nil {
 			defTest(test)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -553,17 +553,6 @@ func stepConfigsForBuild(
 	if config.InputConfiguration.BaseRPMImages == nil {
 		config.InputConfiguration.BaseRPMImages = make(map[string]api.ImageStreamTagReference)
 	}
-
-	// ensure the "As" field is set to the provided alias.
-	for alias, target := range config.InputConfiguration.BaseImages {
-		target.As = alias
-		config.InputConfiguration.BaseImages[alias] = target
-	}
-	for alias, target := range config.InputConfiguration.BaseRPMImages {
-		target.As = alias
-		config.InputConfiguration.BaseRPMImages[alias] = target
-	}
-
 	if target := config.InputConfiguration.BuildRootImage; target != nil {
 		if target.FromRepository {
 			istTagRef, err := buildRootImageStreamFromRepository(readFile)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -546,13 +546,6 @@ func stepConfigsForBuild(
 	second time.Duration,
 ) ([]api.StepConfiguration, error) {
 	var buildSteps []api.StepConfiguration
-
-	if config.InputConfiguration.BaseImages == nil {
-		config.InputConfiguration.BaseImages = make(map[string]api.ImageStreamTagReference)
-	}
-	if config.InputConfiguration.BaseRPMImages == nil {
-		config.InputConfiguration.BaseRPMImages = make(map[string]api.ImageStreamTagReference)
-	}
 	if target := config.InputConfiguration.BuildRootImage; target != nil {
 		if target.FromRepository {
 			istTagRef, err := buildRootImageStreamFromRepository(readFile)

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -771,6 +771,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 
 			client := fakectrlruntimeclient.NewFakeClient()
 
+			testCase.input.Default()
 			rawSteps, err := stepConfigsForBuild(context.Background(), client, testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, &imageConfigs, time.Nanosecond)
 			if err != nil {
 				t.Fatalf("failed to get stepConfigsForBuild: %v", err)


### PR DESCRIPTION
Breaking these minor ones from another change set as they are fairly
independent.