### PR TITLE
Testimagedistributor: Fix pull spec construction from istag

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -47,14 +47,14 @@ func DomainForService(service Service) string {
 // PublicDomainForImage replaces the registry service DNS name and port with the public domain for the registry for the given cluster
 // It will raise an error when the cluster is not recognized
 func PublicDomainForImage(ClusterName, potentiallyPrivate string) (string, error) {
-	d, err := domainForClusterName(ClusterName)
+	d, err := RegistryDomainForClusterName(ClusterName)
 	if err != nil {
 		return "", err
 	}
 	return strings.ReplaceAll(potentiallyPrivate, "image-registry.openshift-image-registry.svc:5000", d), nil
 }
 
-func domainForClusterName(ClusterName string) (string, error) {
+func RegistryDomainForClusterName(ClusterName string) (string, error) {
 	switch ClusterName {
 	case string(ClusterAPPCI):
 		return ServiceDomainAPPCIRegistry, nil

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -313,7 +313,7 @@ func TestReconcile(t *testing.T) {
 				Images: []imagev1.ImageImportSpec{{
 					From: corev1.ObjectReference{
 						Kind: "DockerImage",
-						Name: "registry.svc.ci.openshift.org/ocp/4.4@sha256:a273f5ac7f1ad8f7ffab45205ac36c8dff92d9107ef3ae429eeb135fa8057b8b",
+						Name: "registry.ci.openshift.org/ns/4.2@sha256:a273f5ac7f1ad8f7ffab45205ac36c8dff92d9107ef3ae429eeb135fa8057b8b",
 					},
 					To:              &corev1.LocalObjectReference{Name: "Question"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: "Local"},


### PR DESCRIPTION
Using `Image.DockerImageReference` can ocasionally refer to an invalid
image, update the construction of the pull spec as advised by the image
registry team.

Ref https://issues.redhat.com/browse/DPTP-2421

/assign @emilvberglind 