### PR TITLE
pkg/validation: validate targets are unique

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/defaults"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
 	"github.com/openshift/ci-tools/pkg/steps/release"
@@ -134,6 +135,10 @@ func (o *options) validateConfiguration(
 		} else if err := validator.IsValidResolvedConfiguration(&c); err != nil {
 			return err
 		}
+	}
+	graphConf := defaults.FromConfigStatic(configuration)
+	if err := validation.IsValidGraphConfiguration(graphConf.Steps); err != nil {
+		return err
 	}
 	for _, tag := range release.PromotedTags(configuration) {
 		seenCh <- promotedTag{tag, repoInfo}

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -519,6 +519,9 @@ func (o *options) Complete() error {
 		return results.ForReason("validating_config").ForError(err)
 	}
 	o.graphConfig = defaults.FromConfigStatic(o.configSpec)
+	if err := validation.IsValidGraphConfiguration(o.graphConfig.Steps); err != nil {
+		return results.ForReason("validating_config").ForError(err)
+	}
 	if o.verbose {
 		config, _ := yaml.Marshal(o.configSpec)
 		logrus.WithField("config", string(config)).Trace("Resolved configuration.")

--- a/pkg/validation/graph.go
+++ b/pkg/validation/graph.go
@@ -1,0 +1,59 @@
+package validation
+
+import (
+	"fmt"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+// IsValidGraphConfiguration verifies the intermediary configuration is correct.
+// This is the ideal place for validations since the graph configuration is the
+// intermediary structure between the input configuration and the final
+// execution graph.  Validations done here take advantage of all the parsing
+// logic that has already been applied.
+func IsValidGraphConfiguration(rawSteps []api.StepConfiguration) error {
+	var ret []error
+	names := sets.NewString()
+	addName := func(n string) {
+		if names.Has(n) {
+			ret = append(ret, fmt.Errorf("configuration contains duplicate target: %s", n))
+		} else {
+			names.Insert(n)
+		}
+	}
+	for _, s := range rawSteps {
+		if c := s.InputImageTagStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.PipelineImageCacheStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.SourceStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.BundleSourceStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.IndexGeneratorStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.ProjectDirectoryImageBuildStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.RPMImageInjectionStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.RPMServeStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.OutputImageTagStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.ReleaseImagesTagStepConfiguration; c != nil {
+			addName(c.InputsName())
+			addName(c.TargetName(api.InitialReleaseName))
+			addName(c.TargetName(api.LatestReleaseName))
+		} else if c := s.ResolvedReleaseImagesStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.TestStepConfiguration; c != nil {
+			addName(c.TargetName())
+		} else if c := s.ProjectDirectoryImageBuildInputs; c != nil {
+			addName(string(api.PipelineImageStreamTagReferenceRoot))
+		}
+	}
+	return utilerrors.NewAggregate(ret)
+}

--- a/pkg/validation/graph_test.go
+++ b/pkg/validation/graph_test.go
@@ -1,0 +1,154 @@
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/defaults"
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestIsValidGraph_Names(t *testing.T) {
+	tests := func(names ...string) (ret []api.TestStepConfiguration) {
+		for _, n := range names {
+			ret = append(ret, api.TestStepConfiguration{
+				As:                         n,
+				ContainerTestConfiguration: &api.ContainerTestConfiguration{},
+			})
+		}
+		return
+	}
+	errs := func(msgs ...string) error {
+		var ret []error
+		for _, m := range msgs {
+			ret = append(ret, fmt.Errorf("configuration contains duplicate target: %s", m))
+		}
+		return utilerrors.NewAggregate(ret)
+	}
+	for _, tc := range []struct {
+		name     string
+		config   api.ReleaseBuildConfiguration
+		expected error
+	}{{
+		name: "valid",
+	}, {
+		name: "duplicate input image",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				BaseImages: map[string]api.ImageStreamTagReference{
+					"duplicate": {},
+				},
+			},
+			Tests: tests("[input:duplicate]"),
+		},
+		expected: errs("[input:duplicate]"),
+	}, {
+		name: "duplicate directory builds",
+		config: api.ReleaseBuildConfiguration{
+			BinaryBuildCommands:     "binary build commands",
+			TestBinaryBuildCommands: "test binary build commands",
+			RpmBuildCommands:        "RPM build commands",
+			Tests:                   tests("bin", "test-bin", "rpms"),
+		},
+		expected: errs("bin", "test-bin", "rpms"),
+	}, {
+		name:     "duplicate source build",
+		config:   api.ReleaseBuildConfiguration{Tests: tests("src")},
+		expected: errs("src"),
+	}, {
+		name: "duplicate operator source",
+		config: api.ReleaseBuildConfiguration{
+			Operator: &api.OperatorStepConfiguration{},
+			Tests:    tests("src-bundle"),
+		},
+		expected: errs("src-bundle"),
+	}, {
+		name: "duplicate operator bundle",
+		config: api.ReleaseBuildConfiguration{
+			Operator: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{As: "bundle"}},
+			},
+			Tests: tests("bundle"),
+		},
+		expected: errs("bundle"),
+	}, {
+		name: "duplicate operator index",
+		config: api.ReleaseBuildConfiguration{
+			Operator: &api.OperatorStepConfiguration{
+				Bundles: []api.Bundle{{As: "bundle"}},
+			},
+			Tests: tests("ci-index-bundle-gen"),
+		},
+		expected: errs("ci-index-bundle-gen"),
+	}, {
+		name: "duplicate image build",
+		config: api.ReleaseBuildConfiguration{
+			Images: []api.ProjectDirectoryImageBuildStepConfiguration{{
+				To: "duplicate",
+			}},
+			Tests: tests("duplicate"),
+		},
+		expected: errs("duplicate"),
+	}, {
+		name: "duplicate base RPM image",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				BaseRPMImages: map[string]api.ImageStreamTagReference{
+					"duplicate": {},
+				},
+			},
+			Tests: tests("duplicate"),
+		},
+		expected: errs("duplicate"),
+	}, {
+		name: "duplicate RPM server",
+		config: api.ReleaseBuildConfiguration{
+			RpmBuildCommands: "RPM build commands",
+			Tests:            tests("[serve:rpms]"),
+		},
+		expected: errs("[serve:rpms]"),
+	}, {
+		name: "duplicate tag specification",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				ReleaseTagConfiguration: &api.ReleaseTagConfiguration{},
+			},
+			Tests: tests("[release-inputs]", "[release:initial]", "[release:latest]"),
+		},
+		expected: errs("[release-inputs]", "[release:initial]", "[release:latest]"),
+	}, {
+		name: "duplicate releases",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				Releases: map[string]api.UnresolvedRelease{"release": {}},
+			},
+			Tests: tests("[release:release]"),
+		},
+		expected: errs("[release:release]"),
+	}, {
+		name: "duplicate build root",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				BuildRootImage: &api.BuildRootImageConfiguration{
+					ProjectImageBuild: &api.ProjectDirectoryImageBuildInputs{},
+				},
+			},
+			Tests: tests("root"),
+		},
+		expected: errs("root"),
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			graphConf := defaults.FromConfigStatic(&tc.config)
+			graphConf.Steps = append(graphConf.Steps, api.StepConfiguration{
+				SourceStepConfiguration: &api.SourceStepConfiguration{
+					To: api.PipelineImageStreamTagReferenceSource,
+				},
+			})
+			err := IsValidGraphConfiguration(graphConf.Steps)
+			testhelper.Diff(t, "error", err, tc.expected, testhelper.EquateErrorMessage)
+		})
+	}
+}


### PR DESCRIPTION
One unfortunate aspect of the current static validation is that it is done
on the unprocessed input configuration.  This results in significant
duplication between validation and parsing code.  This change attempts to
move to a more tenable position by performing validation on the graph
configuration structures, which are much closer to the final execution
graph.

https://issues.redhat.com/browse/DPTP-2388 is implemented in this change as
well as a PoC.

---

Use the naming methods and graph configuration data added in the previous
commits to validate that all targets in a `ci-operator` configuration are
unique.

Add this validation to the configuration loading process in
`ci-operator` and make `checkconfig` build and validate the static portion
of the graph.

/hold

built on top of / includes https://github.com/openshift/ci-tools/pull/2211.