### PR TITLE
Stop running checks against roe/release

### DIFF
--- a/cmd/cvp-trigger/README.md
+++ b/cmd/cvp-trigger/README.md
@@ -14,17 +14,17 @@ See the [Triggered Job Interface](#triggered-job-interface) section for details
  about the parametrization.
 
 The `cpaas-cvp-optional-operator-common-tests` job runs ci-operator using
-a config stored in [redhat-operator-ecosystem](https://github.com/redhat-operator-ecosystem/release/tree/master/ci-operator/config/redhat-operator-ecosystem/playground).
+a config stored in [redhat-openshift-ecosystem](https://github.com/redhat-openshift-ecosystem/release/tree/master/ci-operator/config/redhat-openshift-ecosystem/playground).
 The exact configuration to use is inferred from the desired OCP version. For
 example, for OCP version 4.5, ci-operator uses the config for the
-artificial `cvp-ocp-4.5` branch of the `redhat-operator-ecosystem/playground`
+artificial `cvp-ocp-4.5` branch of the `redhat-openshift-ecosystem/playground`
 repository. The ci-operator targets a test with a name inferred from the desired
 cloud platform. For example, when `aws` is requested, ci-operator targets the
 `cvp-common-aws` test from the config. This example shows how the job calls
 ci-operator:
 
 ```console
-$  ci-operator --org=redhat-operator-ecosystem \
+$  ci-operator --org=redhat-openshift-ecosystem \
                --repo=playground \
                --branch=cvp-ocp-$(OCP_VERSION) \
                --target=cvp-common-$(CLOUD_PLATFORM) \

--- a/cmd/cvp-trigger/main_test.go
+++ b/cmd/cvp-trigger/main_test.go
@@ -567,11 +567,11 @@ func Test_toJson(t *testing.T) {
 }
 
 func Test_getJobArtifactsURL(t *testing.T) {
-	org := "redhat-operator-ecosystem"
+	org := "redhat-openshift-ecosystem"
 	repo := "playground"
 	bucket := "origin-ci-test"
 	browserPrefix := "https://gcsweb-ci.svc.ci.openshift.org/gcs/"
-	jobName := "periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws"
+	jobName := "periodic-ci-redhat-openshift-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws"
 
 	prowConfig := &prowconfig.Config{
 		JobConfig: prowconfig.JobConfig{},
@@ -615,7 +615,7 @@ func Test_getJobArtifactsURL(t *testing.T) {
 				},
 				config: prowConfig,
 			},
-			want: "https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws/100",
+			want: "https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/periodic-ci-redhat-openshift-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws/100",
 		},
 		{
 			name: "Returns artifacts URL when we have Spec.ExtraRefs",
@@ -636,7 +636,7 @@ func Test_getJobArtifactsURL(t *testing.T) {
 				},
 				config: prowConfig,
 			},
-			want: "https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/periodic-ci-redhat-operator-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws/101",
+			want: "https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/logs/periodic-ci-redhat-openshift-ecosystem-playground-cvp-ocp-4.4-cvp-common-aws/101",
 		},
 	}
 	for _, tt := range tests {

--- a/test/validate-checkconfig.sh
+++ b/test/validate-checkconfig.sh
@@ -12,7 +12,7 @@ failure=0
 # The `openshift/release` registry is used for all repositories.
 registry="${clonedir}/openshift/ci-operator/step-registry"
 
-for org in openshift redhat-operator-ecosystem; do
+for org in openshift redhat-openshift-ecosystem; do
   git clone "https://github.com/${org}/release.git" --depth 1 "${clonedir}/${org}"
 
   # We need to enter the git directory and run git commands from there, our git

--- a/test/validate-checkconfig.sh
+++ b/test/validate-checkconfig.sh
@@ -12,7 +12,9 @@ failure=0
 # The `openshift/release` registry is used for all repositories.
 registry="${clonedir}/openshift/ci-operator/step-registry"
 
-for org in openshift redhat-openshift-ecosystem; do
+# We no longer have any production config in redhat-openshift-ecosystem
+# for org in openshift redhat-openshift-ecosystem; do
+for org in openshift; do
   git clone "https://github.com/${org}/release.git" --depth 1 "${clonedir}/${org}"
 
   # We need to enter the git directory and run git commands from there, our git

--- a/test/validate-prowgen-breaking-changes.sh
+++ b/test/validate-prowgen-breaking-changes.sh
@@ -9,7 +9,7 @@ trap 'rm -rf "${workdir}"' EXIT
 clonedir="${workdir}/release"
 failure=0
 
-for org in openshift redhat-operator-ecosystem; do
+for org in openshift redhat-openshift-ecosystem; do
   rm -rf "${clonedir}"
   git clone "https://github.com/${org}/release.git" --depth 1 "${clonedir}"
 

--- a/test/validate-prowgen-breaking-changes.sh
+++ b/test/validate-prowgen-breaking-changes.sh
@@ -9,7 +9,9 @@ trap 'rm -rf "${workdir}"' EXIT
 clonedir="${workdir}/release"
 failure=0
 
-for org in openshift redhat-openshift-ecosystem; do
+# We no longer have any production config in redhat-openshift-ecosystem
+# for org in openshift redhat-openshift-ecosystem; do
+for org in openshift; do
   rm -rf "${clonedir}"
   git clone "https://github.com/${org}/release.git" --depth 1 "${clonedir}"
 


### PR DESCRIPTION
- rename: redhat-operator-ecosystem -> redhat-openshift-ecosystem
- Stop checking r-o-e config in CI jobs

We no longer have any production config in that repository, and there are no
immediate plans to start using it again, so we may as well stop special-casing
it. If we start using it, it will need a ton of more work anyways.

https://github.com/openshift/release/pull/20857 is the companion PR in o/release
