### PR TITLE
ci-op validation: allow not having tests/images when promoting additional images

### DIFF
--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -375,7 +375,8 @@ func validateReleaseTagConfiguration(fieldRoot string, input api.ReleaseTagConfi
 func validateReleaseBuildConfiguration(input *api.ReleaseBuildConfiguration, org, repo string) []error {
 	var validationErrors []error
 
-	if len(input.Tests) == 0 && len(input.Images) == 0 {
+	// Third conjunct is a corner case, the config can e.g. promote its `src`
+	if len(input.Tests) == 0 && len(input.Images) == 0 && (input.PromotionConfiguration == nil || len(input.PromotionConfiguration.AdditionalImages) == 0) {
 		validationErrors = append(validationErrors, errors.New("you must define at least one test or image build in 'tests' or 'images'"))
 	}
 


### PR DESCRIPTION
Hit this case in a rehearsal:

```yaml
build_root:
  image_stream_tag:
    name: release
    namespace: openshift
    tag: golang-1.15
promotion:
  additional_images:
    cluster-api-actuator-pkg: src
  name: "4.10"
  namespace: ocp
resources:
  '*':
    requests:
      cpu: 100m
      memory: 200Mi
tag_specification:
  name: "4.10"
  namespace: ocp
zz_generated_metadata:
  branch: release-4.10
  org: openshift
  repo: cluster-api-actuator-pkg
```

In theory we should check if referenced names exist but I think that
goes beyond basic validation.
