### PR TITLE
CI-Operator: Expose run_if_changed/skip_if only_changed

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -591,6 +591,12 @@ type TestStepConfiguration struct {
 	// ClusterClaim claims an OpenShift cluster and exposes environment variable ${KUBECONFIG} to the test container
 	ClusterClaim *ClusterClaim `json:"cluster_claim,omitempty"`
 
+	// RunIfChanged is a regex that will result in the test only running if something that matches it was changed.
+	RunIfChanged string `json:"run_if_changed,omitempty"`
+
+	// SkipIfOnlyChanged is a regex that will result in the test being skipped if all changed files match that regex.
+	SkipIfOnlyChanged string `json:"skip_if_only_changed,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
 	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -428,6 +428,12 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 	if old.Cluster != "" {
 		merged.Cluster = old.Cluster
 	}
+	if new.RunIfChanged != "" {
+		merged.RunIfChanged = new.RunIfChanged
+	}
+	if new.SkipIfOnlyChanged != "" {
+		merged.SkipIfOnlyChanged = new.SkipIfOnlyChanged
+	}
 
 	return merged
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -229,10 +229,12 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 	tests := []struct {
 		description string
 
-		test       string
-		repoInfo   *ProwgenInfo
-		jobRelease string
-		clone      bool
+		test              string
+		repoInfo          *ProwgenInfo
+		jobRelease        string
+		clone             bool
+		runIfChanged      string
+		skipIfOnlyChanged string
 	}{{
 		description: "presubmit for standard test",
 		test:        "testname",
@@ -256,11 +258,25 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			jobRelease:  "4.6",
 			clone:       true,
 		},
+		{
+			description:  "presubmit with run_if_changed",
+			test:         "testname",
+			repoInfo:     &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			jobRelease:   "4.6",
+			runIfChanged: "^README.md$",
+		},
+		{
+			description:       "presubmit with skip_if_only_changed",
+			test:              "testname",
+			repoInfo:          &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			jobRelease:        "4.6",
+			skipIfOnlyChanged: "^README.md$",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			// podSpec tested in generatePodSpec
-			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, nil, nil, tc.jobRelease, !tc.clone))
+			testhelper.CompareWithFixture(t, generatePresubmitForTest(tc.test, tc.repoInfo, nil, nil, tc.jobRelease, !tc.clone, tc.runIfChanged, tc.skipIfOnlyChanged))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
@@ -1,0 +1,17 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+run_if_changed: ^README.md$
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
@@ -1,0 +1,17 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+  job-release: "4.6"
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+skip_if_only_changed: ^README.md$
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -161,6 +161,12 @@ func (v *Validator) validateTestStepConfiguration(
 		if test.Interval != nil && test.ReleaseController {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `interval` cannot be set for release controller jobs", fieldRootN))
 		}
+		if (test.Cron != nil || test.Interval != nil) && (test.RunIfChanged != "" || test.SkipIfOnlyChanged != "") {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `cron` and `interval` are mutually exclusive with `run_if_changed`/`skip_if_only_changed`", fieldRootN))
+		}
+		if test.RunIfChanged != "" && test.SkipIfOnlyChanged != "" {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: `run_if_changed` and `skip_if_only_changed` are mutually exclusive", fieldRootN))
+		}
 
 		if test.Interval != nil {
 			if _, err := time.ParseDuration(*test.Interval); err != nil {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -497,6 +497,36 @@ func TestValidateTests(t *testing.T) {
 			},
 			expectedValid: false,
 		},
+		{
+			id: "cron is mutually exclusive with run_if_changed",
+			tests: []api.TestStepConfiguration{{
+				As:           "Unit",
+				Commands:     "commands",
+				Cron:         &cronString,
+				RunIfChanged: "^README.md$",
+			}},
+			expectedValid: false,
+		},
+		{
+			id: "interval is mutually exclusive with run_if_changed",
+			tests: []api.TestStepConfiguration{{
+				As:           "Unit",
+				Commands:     "commands",
+				Interval:     &intervalString,
+				RunIfChanged: "^README.md$",
+			}},
+			expectedValid: false,
+		},
+		{
+			id: "Run if changed and skip_if_only_changed are mutually exclusive",
+			tests: []api.TestStepConfiguration{{
+				As:                "Unit",
+				Commands:          "commands",
+				RunIfChanged:      "^README.md$",
+				SkipIfOnlyChanged: "^OTHER_README.md$",
+			}},
+			expectedValid: false,
+		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -735,6 +735,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            cluster_profile: ' '\n" +
 	"        openshift_installer_upi_src:\n" +
 	"            cluster_profile: ' '\n" +
+	"        # RunIfChanged is a regex that will result in the test only running if something that matches it was changed.\n" +
+	"        run_if_changed: ' '\n" +
 	"        # Secret is an optional secret object which\n" +
 	"        # will be mounted inside the test container.\n" +
 	"        # You cannot set the Secret and Secrets attributes\n" +
@@ -755,6 +757,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              mount_path: ' '\n" +
 	"              # Secret name, used inside test containers\n" +
 	"              name: ' '\n" +
+	"        # SkipIfOnlyChanged is a regex that will result in the test being skipped if all changed files match that regex.\n" +
+	"        skip_if_only_changed: ' '\n" +
 	"        steps:\n" +
 	"            # AllowBestEffortPostSteps defines if any `post` steps can be ignored when\n" +
 	"            # they fail. The given step must explicitly ask for being ignored by setting\n" +
@@ -1439,6 +1443,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        cluster_profile: ' '\n" +
 	"      openshift_installer_upi_src:\n" +
 	"        cluster_profile: ' '\n" +
+	"      # RunIfChanged is a regex that will result in the test only running if something that matches it was changed.\n" +
+	"      run_if_changed: ' '\n" +
 	"      # Secret is an optional secret object which\n" +
 	"      # will be mounted inside the test container.\n" +
 	"      # You cannot set the Secret and Secrets attributes\n" +
@@ -1459,6 +1465,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          mount_path: ' '\n" +
 	"          # Secret name, used inside test containers\n" +
 	"          name: ' '\n" +
+	"      # SkipIfOnlyChanged is a regex that will result in the test being skipped if all changed files match that regex.\n" +
+	"      skip_if_only_changed: ' '\n" +
 	"      steps:\n" +
 	"        # AllowBestEffortPostSteps defines if any `post` steps can be ignored when\n" +
 	"        # they fail. The given step must explicitly ask for being ignored by setting\n" +


### PR DESCRIPTION
This change exposes run_if_changed/skip_if only_changed in the
ci-operator config.

Ref https://issues.redhat.com/browse/DPTP-2301

/cc @openshift/openshift-team-developer-productivity-test-platform 