### PR TITLE
Respect stricter feature branch names in config resolver

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -445,7 +445,7 @@ func generatePresubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.Po
 	return &prowconfig.Presubmit{
 		JobBase:   base,
 		AlwaysRun: true,
-		Brancher:  prowconfig.Brancher{Branches: sets.NewString(exactlyBranch(info.Branch), featureBranch(info.Branch)).List()},
+		Brancher:  prowconfig.Brancher{Branches: sets.NewString(ExactlyBranch(info.Branch), FeatureBranch(info.Branch)).List()},
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/prow/%s", shortName),
 		},
@@ -462,7 +462,7 @@ func generatePostsubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.P
 	base := generateJobBase(name, jc.PostsubmitPrefix, info, podSpec, false, pathAlias, jobRelease, skipCloning)
 	return &prowconfig.Postsubmit{
 		JobBase:  base,
-		Brancher: prowconfig.Brancher{Branches: []string{exactlyBranch(info.Branch)}},
+		Brancher: prowconfig.Brancher{Branches: []string{ExactlyBranch(info.Branch)}},
 	}
 }
 
@@ -618,19 +618,19 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 	return base
 }
 
-// exactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
+// ExactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
 // '^master$' for 'master'. If the given branch name already looks like a regex, return it unchanged.
-func exactlyBranch(branch string) string {
+func ExactlyBranch(branch string) string {
 	if !jc.SimpleBranchRegexp.MatchString(branch) {
 		return branch
 	}
 	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
 }
 
-// featureBranch returns a regex string that matches feature branch prefixes for the given branch name:
+// FeatureBranch returns a regex string that matches feature branch prefixes for the given branch name:
 // I.e. returns '^master-' for 'master'. If the given branch name already looks like a regex,
 // return it unchanged.
-func featureBranch(branch string) string {
+func FeatureBranch(branch string) string {
 	if !jc.SimpleBranchRegexp.MatchString(branch) {
 		return branch
 	}


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/2199 changed feature branches in Prowgen, but there is a similar capability in config-resolver that needs to be changed too.

Fixes the following error in https://prow.ci.openshift.org/?job=*-release-4.10-images

```
ERRO[2021-08-05T11:12:39Z] Failed to load arguments.                     error=failed to load configuration: got unexpected http 404 status code from configresolver: failed to get config: found more than one matching config for branch release-4.10 on repo openshift/node-feature-discovery
```