### PR TITLE
pkg/load: add flags to load registry docs/metadata

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -114,7 +114,7 @@ func (o *options) loadResolver(path string) error {
 	if path == "" {
 		return nil
 	}
-	refs, chains, workflows, _, _, observers, err := load.Registry(path, false)
+	refs, chains, workflows, _, _, observers, err := load.Registry(path, load.RegistryFlag(0))
 	if err != nil {
 		return err
 	}

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -204,7 +204,7 @@ func rehearseMain() error {
 	var observers registry.ObserverByName
 
 	if !o.noRegistry {
-		refs, chains, workflows, _, _, observers, err = load.Registry(filepath.Join(o.releaseRepoPath, config.RegistryPath), false)
+		refs, chains, workflows, _, _, observers, err = load.Registry(filepath.Join(o.releaseRepoPath, config.RegistryPath), load.RegistryFlag(0))
 		if err != nil {
 			logger.WithError(err).Error("could not load step registry")
 			return fmt.Errorf(misconfigurationOutput)

--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -206,7 +206,7 @@ func loadResolver(path string) (registry.Resolver, error) {
 	if path == "" {
 		return nil, nil
 	}
-	refs, chains, workflows, _, _, observers, err := load.Registry(path, false)
+	refs, chains, workflows, _, _, observers, err := load.Registry(path, load.RegistryFlag(0))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -30,7 +30,7 @@ type registryAgent struct {
 	registryPath  string
 	generation    int
 	errorMetrics  *prometheus.CounterVec
-	flatRegistry  bool
+	flags         load.RegistryFlag
 	references    registry.ReferenceByName
 	chains        registry.ChainByName
 	workflows     registry.WorkflowByName
@@ -86,8 +86,16 @@ func NewRegistryAgent(registryPath string, opts ...RegistryAgentOption) (Registr
 	if opt.FlatRegistry == nil {
 		opt.FlatRegistry = utilpointer.BoolPtr(true)
 	}
-
-	a := &registryAgent{registryPath: registryPath, lock: &sync.RWMutex{}, errorMetrics: opt.ErrorMetric, flatRegistry: *opt.FlatRegistry}
+	var flags load.RegistryFlag
+	if *opt.FlatRegistry {
+		flags |= load.RegistryFlat
+	}
+	a := &registryAgent{
+		registryPath: registryPath,
+		lock:         &sync.RWMutex{},
+		errorMetrics: opt.ErrorMetric,
+		flags:        flags,
+	}
 	// Load config once so we fail early if that doesn't work and are ready as soon as we return
 	if err := a.loadRegistry(); err != nil {
 		return nil, fmt.Errorf("failed to load registry: %w", err)
@@ -124,7 +132,7 @@ func (a *registryAgent) loadRegistry() error {
 		a.lock.Lock()
 		defer a.lock.Unlock()
 		startTime := time.Now()
-		references, chains, workflows, documentation, metadata, observers, err := load.Registry(a.registryPath, a.flatRegistry)
+		references, chains, workflows, documentation, metadata, observers, err := load.Registry(a.registryPath, a.flags)
 		if err != nil {
 			a.recordError("failed to load ci-operator registry")
 			return time.Duration(0), fmt.Errorf("failed to load ci-operator registry (%w)", err)

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -86,7 +86,7 @@ func NewRegistryAgent(registryPath string, opts ...RegistryAgentOption) (Registr
 	if opt.FlatRegistry == nil {
 		opt.FlatRegistry = utilpointer.BoolPtr(true)
 	}
-	var flags load.RegistryFlag
+	flags := load.RegistryMetadata | load.RegistryDocumentation
 	if *opt.FlatRegistry {
 		flags |= load.RegistryFlat
 	}

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -38,6 +38,8 @@ type ResolverInfo struct {
 	Variant string
 }
 
+type RegistryFlag uint8
+
 const (
 	RefSuffix      = "-ref.yaml"
 	ChainSuffix    = "-chain.yaml"
@@ -45,6 +47,10 @@ const (
 	ObserverSuffix = "-observer.yaml"
 	CommandsSuffix = "-commands.sh"
 	MetadataSuffix = ".metadata.json"
+)
+
+const (
+	RegistryFlat = RegistryFlag(1) << iota
 )
 
 // ByOrgRepo maps org --> repo --> list of branched and variant configs
@@ -174,7 +180,7 @@ func Config(path, unresolvedPath, registryPath string, info *ResolverInfo) (*api
 		return nil, fmt.Errorf("invalid configuration: %w\nvalue:\n%s", err, raw)
 	}
 	if registryPath != "" {
-		refs, chains, workflows, _, _, observers, err := Registry(registryPath, false)
+		refs, chains, workflows, _, _, observers, err := Registry(registryPath, RegistryFlag(0))
 		if err != nil {
 			return nil, fmt.Errorf("failed to load registry: %w", err)
 		}
@@ -268,7 +274,8 @@ func literalConfigFromResolver(raw []byte, address string) (*api.ReleaseBuildCon
 
 // Registry takes the path to a registry config directory and returns the full set of references, chains,
 // and workflows that the registry's Resolver needs to resolve a user's MultiStageTestConfiguration
-func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string, api.RegistryMetadata, registry.ObserverByName, error) {
+func Registry(root string, flags RegistryFlag) (registry.ReferenceByName, registry.ChainByName, registry.WorkflowByName, map[string]string, api.RegistryMetadata, registry.ObserverByName, error) {
+	flat := flags&RegistryFlat != 0
 	references := registry.ReferenceByName{}
 	chains := registry.ChainByName{}
 	workflows := registry.WorkflowByName{}

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -819,7 +819,7 @@ func TestRegistry(t *testing.T) {
 		testCases = []struct {
 			name          string
 			registryDir   string
-			flatRegistry  bool
+			flags         RegistryFlag
 			references    registry.ReferenceByName
 			chains        registry.ChainByName
 			workflows     registry.WorkflowByName
@@ -828,16 +828,15 @@ func TestRegistry(t *testing.T) {
 		}{{
 			name:          "Read registry",
 			registryDir:   "../../test/multistage-registry/registry",
-			flatRegistry:  false,
 			references:    expectedReferences,
 			chains:        expectedChains,
 			workflows:     expectedWorkflows,
 			observers:     expectedObservers,
 			expectedError: false,
 		}, {
-			name:         "Read configmap style registry",
-			registryDir:  "../../test/multistage-registry/configmap",
-			flatRegistry: true,
+			name:        "Read configmap style registry",
+			registryDir: "../../test/multistage-registry/configmap",
+			flags:       RegistryFlat,
 			references: registry.ReferenceByName{
 				"ipi-install-install": {
 					As:       "ipi-install-install",
@@ -858,7 +857,6 @@ func TestRegistry(t *testing.T) {
 		}, {
 			name:          "Read registry with ref where name and filename don't match",
 			registryDir:   "../../test/multistage-registry/invalid-filename",
-			flatRegistry:  false,
 			references:    nil,
 			chains:        nil,
 			workflows:     nil,
@@ -866,7 +864,6 @@ func TestRegistry(t *testing.T) {
 		}, {
 			name:          "Read registry where ref has an extra, invalid field",
 			registryDir:   "../../test/multistage-registry/invalid-field",
-			flatRegistry:  false,
 			references:    nil,
 			chains:        nil,
 			workflows:     nil,
@@ -874,7 +871,6 @@ func TestRegistry(t *testing.T) {
 		}, {
 			name:          "Read registry where ref has command containing trap without grace period specified",
 			registryDir:   "../../test/multistage-registry/trap-without-grace-period",
-			flatRegistry:  false,
 			references:    nil,
 			chains:        nil,
 			workflows:     nil,
@@ -882,7 +878,6 @@ func TestRegistry(t *testing.T) {
 		}, {
 			name:          "Read registry where ref has best effort defined without timeout",
 			registryDir:   "../../test/multistage-registry/best-effort-without-timeout",
-			flatRegistry:  false,
 			references:    nil,
 			chains:        nil,
 			workflows:     nil,
@@ -891,7 +886,7 @@ func TestRegistry(t *testing.T) {
 	)
 
 	for _, testCase := range testCases {
-		references, chains, workflows, _, _, observers, err := Registry(testCase.registryDir, testCase.flatRegistry)
+		references, chains, workflows, _, _, observers, err := Registry(testCase.registryDir, testCase.flags)
 		if err == nil && testCase.expectedError == true {
 			t.Errorf("%s: got no error when error was expected", testCase.name)
 		}
@@ -936,7 +931,7 @@ func TestRegistry(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(path, deprovisionGatherRef), fileData, 0664); err != nil {
 		t.Fatalf("failed to populate temp reference file: %v", err)
 	}
-	_, _, _, _, _, _, err = Registry(temp, false)
+	_, _, _, _, _, _, err = Registry(temp, RegistryFlag(0))
 	if err == nil {
 		t.Error("got no error when expecting error on incorrect reference name")
 	}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -287,7 +287,7 @@ func TestInlineCiopConfig(t *testing.T) {
 		},
 	}
 
-	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -548,7 +548,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 		failToCreate: sets.NewString("rehearse-123-job2"),
 	}}
 
-	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -618,7 +618,7 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 		},
 	}}
 
-	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}
@@ -735,7 +735,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 		},
 	}
 
-	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, false)
+	references, chains, workflows, _, _, observers, err := load.Registry(testingRegistry, load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to read registry: %v", err)
 	}

--- a/pkg/webreg/graphviz_test.go
+++ b/pkg/webreg/graphviz_test.go
@@ -90,7 +90,7 @@ const deprovisionChain = `digraph Webreg {
 }`
 
 func TestChainDotFile(t *testing.T) {
-	_, chains, _, _, _, _, err := load.Registry("../../test/multistage-registry/registry", false)
+	_, chains, _, _, _, _, err := load.Registry("../../test/multistage-registry/registry", load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to load registry: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestChainDotFile(t *testing.T) {
 }
 
 func TestWorkflowDotFile(t *testing.T) {
-	_, chains, workflows, _, _, _, err := load.Registry("../../test/multistage-registry/registry", false)
+	_, chains, workflows, _, _, _, err := load.Registry("../../test/multistage-registry/registry", load.RegistryFlag(0))
 	if err != nil {
 		t.Fatalf("Failed to load registry: %v", err)
 	}


### PR DESCRIPTION
All uses of the registry outside the agent ignore these, there is no reason
to store them in the first place.