### PR TITLE
ci-operator-prowgen: resolve configurations

### DIFF
--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -222,7 +222,7 @@ tests:
 				t.Fatalf("Unexpected error writing old postsubmits: %v", err)
 			}
 
-			if err := config.OperateOnCIOperatorConfig(fullConfigPath, generateJobsToDir(baseProwConfigDir)); err != nil {
+			if err := config.OperateOnCIOperatorConfig(fullConfigPath, generateJobsToDir(baseProwConfigDir, nil)); err != nil {
 				t.Fatalf("Unexpected error generating jobs from config: %v", err)
 			}
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -161,7 +161,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 				secrets = append(secrets, &api.Secret{Name: api.HiveControlPlaneKubeconfigSecret})
 			}
 			podSpec = generateCiOperatorPodSpec(info, secrets, []string{element.As}, additionalArgs...)
-		} else if element.MultiStageTestConfiguration != nil {
+		} else if element.MultiStageTestConfiguration != nil || element.MultiStageTestConfigurationLiteral != nil {
 			podSpec = generatePodSpecMultiStage(info, &element, configSpec.Releases != nil || element.ClusterClaim != nil)
 		} else {
 			var release string
@@ -309,7 +309,12 @@ func generateCiOperatorPodSpec(info *ProwgenInfo, secrets []*cioperatorapi.Secre
 }
 
 func generatePodSpecMultiStage(info *ProwgenInfo, test *cioperatorapi.TestStepConfiguration, needsPullSecret bool) *corev1.PodSpec {
-	profile := test.MultiStageTestConfiguration.ClusterProfile
+	var profile api.ClusterProfile
+	if test.MultiStageTestConfiguration != nil {
+		profile = test.MultiStageTestConfiguration.ClusterProfile
+	} else {
+		profile = test.MultiStageTestConfigurationLiteral.ClusterProfile
+	}
 	var secrets []*cioperatorapi.Secret
 	if needsPullSecret {
 		// If the ci-operator configuration resolves an official release,

--- a/test/integration/ci-operator-prowgen.sh
+++ b/test/integration/ci-operator-prowgen.sh
@@ -16,7 +16,7 @@ cp -a "${suite_dir}/input/jobs/." "${actual}"
 os::test::junit::declare_suite_start "integration/ci-operator-prowgen"
 # This test validates the ci-operator-prowgen tool
 
-os::cmd::expect_success "ci-operator-prowgen --from-dir ${suite_dir}/input/config --to-dir ${actual}"
+os::cmd::expect_success "ci-operator-prowgen --registry ${suite_dir}/input/registry --from-dir ${suite_dir}/input/config --to-dir ${actual}"
 os::integration::compare "${actual}" "${suite_dir}/output/jobs"
 
 os::test::junit::declare_suite_end

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -73,6 +73,13 @@ tests:
           requests:
             cpu: 100m
             memory: 200Mi
+- as: registry
+  steps:
+    workflow: workflow
+- as: registry-with-profile
+  steps:
+    cluster_profile: aws
+    workflow: workflow
 - as: informer
   commands: make unit
   container:

--- a/test/integration/ci-operator-prowgen/input/registry/workflow/workflow-workflow.yaml
+++ b/test/integration/ci-operator-prowgen/input/registry/workflow/workflow-workflow.yaml
@@ -1,0 +1,2 @@
+workflow:
+  as: workflow

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -286,6 +286,120 @@ presubmits:
     branches:
     - ^master$
     - ^master-
+    context: ci/prow/registry
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-super-duper-master-registry
+    rerun_command: /test registry
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=registry
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )registry,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/registry-with-profile
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/prowgen-controlled: "true"
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-super-duper-master-registry-with-profile
+    rerun_command: /test registry-with-profile
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/usr/local/registry-with-profile-cluster-profile
+        - --target=registry-with-profile
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /usr/local/registry-with-profile-cluster-profile
+          name: cluster-profile
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: cluster-profile
+        projected:
+          sources:
+          - secret:
+              name: cluster-secrets-aws
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )registry-with-profile,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
     context: ci/prow/steps
     decorate: true
     decoration_config:


### PR DESCRIPTION
`prowgen` needs to resolve the configurations it loads in order to make
decisions based on fields declared in the step registry.

Neither job generation nor execution time are affected for the
configuration in `openshift/release`.