### PR TITLE
pkg: Allow alternative reference-step command file extensions

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -186,7 +186,6 @@ func GetChangedTemplates(path, baseRev string) ([]string, error) {
 
 func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node, error) {
 	// if a commands script changed, mark reference as changed
-	filename = strings.ReplaceAll(filename, load.CommandsSuffix, load.RefSuffix)
 	var node registry.Node
 	var ok bool
 	switch {
@@ -196,6 +195,9 @@ func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node
 		node, ok = graph.Chains[strings.TrimSuffix(filename, load.ChainSuffix)]
 	case strings.HasSuffix(filename, load.WorkflowSuffix):
 		node, ok = graph.Workflows[strings.TrimSuffix(filename, load.WorkflowSuffix)]
+	case strings.Contains(filename, load.CommandsSuffix):
+		extension := filepath.Ext(filename)
+		node, ok = graph.References[strings.TrimSuffix(filename[0:len(filename)-len(extension)], load.CommandsSuffix)]
 	default:
 		return nil, fmt.Errorf("invalid step filename: %s", filename)
 	}
@@ -213,7 +215,7 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 		return changes, err
 	}
 	for _, c := range revChanges {
-		if filepath.Ext(c) == ".yaml" || strings.HasSuffix(c, load.CommandsSuffix) {
+		if filepath.Ext(c) == ".yaml" || strings.HasSuffix(c, fmt.Sprintf("%s%s", load.CommandsSuffix, filepath.Ext(c))) {
 			node, err := loadRegistryStep(filepath.Base(c), graph)
 			if err != nil {
 				return changes, err

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -43,7 +43,7 @@ const (
 	ChainSuffix    = "-chain.yaml"
 	WorkflowSuffix = "-workflow.yaml"
 	ObserverSuffix = "-observer.yaml"
-	CommandsSuffix = "-commands.sh"
+	CommandsSuffix = "-commands" // excluding the file extension
 	MetadataSuffix = ".metadata.json"
 )
 
@@ -370,8 +370,8 @@ func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainB
 				if strings.TrimSuffix(filepath.Base(path), ObserverSuffix) != observer.Observer.Name {
 					return fmt.Errorf("filename %s does not match name of chain; filename should be %s", filepath.Base(path), fmt.Sprint(prefix, ObserverSuffix))
 				}
-				if !flat && observer.Observer.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
-					return fmt.Errorf("observer %s has invalid command file path; command should be set to %s", observer.Observer.Name, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
+				if !flat && observer.Observer.Commands != fmt.Sprintf("%s%s%s", prefix, CommandsSuffix, filepath.Ext(observer.Observer.Commands)) {
+					return fmt.Errorf("observer %s has invalid command file path; command should be set to %s (with an optional extension like .sh)", observer.Observer.Name, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
 				}
 				command, err := gzip.ReadFileMaybeGZIP(filepath.Join(dir, observer.Observer.Commands))
 				if err != nil {
@@ -381,7 +381,7 @@ func Registry(root string, flat bool) (registry.ReferenceByName, registry.ChainB
 				documentation[observer.Observer.Name] = observer.Observer.Documentation
 				observer.Observer.Documentation = ""
 				observers[observer.Observer.Name] = observer.Observer.Observer
-			} else if strings.HasSuffix(path, CommandsSuffix) {
+			} else if strings.HasSuffix(path, fmt.Sprintf("%s%s", CommandsSuffix, filepath.Ext(path))) {
 				// ignore
 			} else if filepath.Base(path) == config.ConfigVersionFileName {
 				if version, err := gzip.ReadFileMaybeGZIP(path); err == nil {
@@ -424,8 +424,8 @@ func loadReference(bytes []byte, baseDir, prefix string, flat bool) (string, str
 	if err != nil {
 		return "", "", api.LiteralTestStep{}, err
 	}
-	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s", prefix, CommandsSuffix) {
-		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
+	if !flat && step.Reference.Commands != fmt.Sprintf("%s%s%s", prefix, CommandsSuffix, filepath.Ext(step.Reference.Commands)) {
+		return "", "", api.LiteralTestStep{}, fmt.Errorf("reference %s has invalid command file path; command should be set to %s (with an optional extension like .sh)", step.Reference.As, fmt.Sprintf("%s%s", prefix, CommandsSuffix))
 	}
 	command, err := gzip.ReadFileMaybeGZIP(filepath.Join(baseDir, step.Reference.Commands))
 	if err != nil {


### PR DESCRIPTION
2a31056baf (#1776) pivoted to directly executing command files allowing non-shell via shebangs.  But writing Python in a file with a `*.sh` extension isn't all that intuitive, and also confuses some editors.  This commit softens things to allow any extension.

Ideally we'd load the reference YAML and [pull commands out of there][1].  This would require some rewrites, since a bunch of these existing handlers are file-based, with `GetChangedRegistrySteps` logic like:

1. Get a set of changed files.
2. Iterate over the files to see if they seem to match a step.
3. Return any identified steps.

Instead we'd want:

1. Get a set of changed files.
2. Iterate over the nodes in the registry.
3. For each node, get the set of files consumed (e.g. both the ref YAML and command file for a reference step).
4. Mark the node as changed if there is any overlap between the changed-files set and the node-consumed-files sets.
5. Return any identified steps.

But that's a bigger pivot, so punting for now.

[1]: https://github.com/openshift/release/blob/66ee37c6805b900b1dc1d537126956b352286cbb/ci-operator/step-registry/ipi/install/install/ipi-install-install-ref.yaml#L5