### PR TITLE
openstack: Rename massopencloud cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1055,7 +1055,7 @@ const (
 	ClusterProfileIBMCloud              ClusterProfile = "ibmcloud"
 	ClusterProfileLibvirtPpc64le        ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtS390x          ClusterProfile = "libvirt-s390x"
-	ClusterProfileOpenStack             ClusterProfile = "openstack"
+	ClusterProfileOpenStackMOC          ClusterProfile = "openstack-moc"
 	ClusterProfileOpenStackKuryr        ClusterProfile = "openstack-kuryr"
 	ClusterProfileOpenStackMechaCentral ClusterProfile = "openstack-vh-mecha-central"
 	ClusterProfileOpenStackMechaAz0     ClusterProfile = "openstack-vh-mecha-az0"
@@ -1096,7 +1096,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileIBMCloud,
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtS390x,
-		ClusterProfileOpenStack,
+		ClusterProfileOpenStackMOC,
 		ClusterProfileOpenStackKuryr,
 		ClusterProfileOpenStackMechaCentral,
 		ClusterProfileOpenStackMechaAz0,
@@ -1154,8 +1154,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-ppc64le"
 	case ClusterProfileLibvirtS390x:
 		return "libvirt-s390x"
-	case ClusterProfileOpenStack:
-		return "openstack"
+	case ClusterProfileOpenStackMOC:
+		return "openstack-moc"
 	case ClusterProfileOpenStackKuryr:
 		return "openstack-kuryr"
 	case ClusterProfileOpenStackMechaCentral:
@@ -1223,8 +1223,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "libvirt-ppc64le-quota-slice"
 	case ClusterProfileLibvirtS390x:
 		return "libvirt-s390x-quota-slice"
-	case ClusterProfileOpenStack:
-		return "openstack-quota-slice"
+	case ClusterProfileOpenStackMOC:
+		return "openstack-moc-quota-slice"
 	case ClusterProfileOpenStackKuryr:
 		return "openstack-kuryr-quota-slice"
 	case ClusterProfileOpenStackMechaCentral:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -544,7 +544,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,
-		cioperatorapi.ClusterProfileOpenStack,
+		cioperatorapi.ClusterProfileOpenStackMOC,
 		cioperatorapi.ClusterProfileOpenStackKuryr,
 		cioperatorapi.ClusterProfileOpenStackMechaCentral,
 		cioperatorapi.ClusterProfileOpenStackMechaAz0,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -406,7 +406,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileIBMCloud,
 		api.ClusterProfileLibvirtPpc64le,
 		api.ClusterProfileLibvirtS390x,
-		api.ClusterProfileOpenStack,
+		api.ClusterProfileOpenStackMOC,
 		api.ClusterProfileOpenStackKuryr,
 		api.ClusterProfileOpenStackMechaCentral,
 		api.ClusterProfileOpenStackMechaAz0,


### PR DESCRIPTION
While there are no jobs running on MOC due to a downtime, rename its
cluster profile to something less confusing.