### PR TITLE
Embed `api.Metadata` in `ResolverInfo`

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1980,7 +1980,9 @@ func (o *options) getResolverInfo(jobSpec *api.JobSpec) *load.ResolverInfo {
 	// address and variant can only be set via options
 	info := &load.ResolverInfo{
 		Address: o.resolverAddress,
-		Variant: o.variant,
+		Metadata: api.Metadata{
+			Variant: o.variant,
+		},
 	}
 
 	allRefs := jobSpec.ExtraRefs

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -228,9 +228,11 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "testOrganization",
-			Repo:    "testRepo",
-			Branch:  "testBranch",
+			Metadata: api.Metadata{
+				Org:    "testOrganization",
+				Repo:   "testRepo",
+				Branch: "testBranch",
+			},
 		},
 	}, {
 		name: "JobSpec Refs w/ variant set via flag",
@@ -249,10 +251,12 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "testOrganization",
-			Repo:    "testRepo",
-			Branch:  "testBranch",
-			Variant: "v2",
+			Metadata: api.Metadata{
+				Org:     "testOrganization",
+				Repo:    "testRepo",
+				Branch:  "testBranch",
+				Variant: "v2",
+			},
 		},
 	}, {
 		name: "Ref with ExtraRefs",
@@ -275,9 +279,11 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "testOrganization",
-			Repo:    "testRepo",
-			Branch:  "testBranch",
+			Metadata: api.Metadata{
+				Org:    "testOrganization",
+				Repo:   "testRepo",
+				Branch: "testBranch",
+			},
 		},
 	}, {
 		name: "Incomplete refs not used",
@@ -299,9 +305,11 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "anotherOrganization",
-			Repo:    "anotherRepo",
-			Branch:  "anotherBranch",
+			Metadata: api.Metadata{
+				Org:    "anotherOrganization",
+				Repo:   "anotherRepo",
+				Branch: "anotherBranch",
+			},
 		},
 	}, {
 		name: "Refs with single field overridden by options",
@@ -321,10 +329,12 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "testOrganization",
-			Repo:    "anotherRepo",
-			Branch:  "testBranch",
-			Variant: "v2",
+			Metadata: api.Metadata{
+				Org:     "testOrganization",
+				Repo:    "anotherRepo",
+				Branch:  "testBranch",
+				Variant: "v2",
+			},
 		},
 	}, {
 		name: "Only options",
@@ -338,10 +348,12 @@ func TestGetResolverInfo(t *testing.T) {
 		jobSpec: &api.JobSpec{},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "testOrganization",
-			Repo:    "testRepo",
-			Branch:  "testBranch",
-			Variant: "v2",
+			Metadata: api.Metadata{
+				Org:     "testOrganization",
+				Repo:    "testRepo",
+				Branch:  "testBranch",
+				Variant: "v2",
+			},
 		},
 	}, {
 		name: "All fields overridden by options",
@@ -363,10 +375,12 @@ func TestGetResolverInfo(t *testing.T) {
 		},
 		expected: &load.ResolverInfo{
 			Address: configResolverAddress,
-			Org:     "anotherOrganization",
-			Repo:    "anotherRepo",
-			Branch:  "anotherBranch",
-			Variant: "v2",
+			Metadata: api.Metadata{
+				Org:     "anotherOrganization",
+				Repo:    "anotherRepo",
+				Branch:  "anotherBranch",
+				Variant: "v2",
+			},
 		},
 	}}
 	for _, testCase := range testCases {

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -36,6 +36,16 @@ func (m *Metadata) IsComplete() error {
 	return nil
 }
 
+// AsString returns a string representation of the metadata suitable for using
+// in human-oriented output
+func (m *Metadata) AsString() string {
+	identifier := fmt.Sprintf("%s/%s@%s", m.Org, m.Repo, m.Branch)
+	if m.Variant != "" {
+		identifier = fmt.Sprintf("%s [%s]", identifier, m.Variant)
+	}
+	return identifier
+}
+
 // TestNameFromJobName returns the name of the test from a given job name and prefix
 func (m *Metadata) TestNameFromJobName(jobName, prefix string) string {
 	return strings.TrimPrefix(jobName, m.JobName(prefix, ""))

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -31,11 +31,7 @@ import (
 // ResolverInfo contains the data needed to get a config from the configresolver
 type ResolverInfo struct {
 	Address string
-	Org     string
-	Repo    string
-	Branch  string
-	// Variant is optional
-	Variant string
+	api.Metadata
 }
 
 type RegistryFlag uint8

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -191,11 +191,7 @@ func Config(path, unresolvedPath, registryPath string, info *ResolverInfo) (*api
 }
 
 func configFromResolver(info *ResolverInfo) (*api.ReleaseBuildConfiguration, error) {
-	identifier := fmt.Sprintf("%s/%s@%s", info.Org, info.Repo, info.Branch)
-	if info.Variant != "" {
-		identifier = fmt.Sprintf("%s [%s]", identifier, info.Variant)
-	}
-	logrus.Infof("Loading configuration from %s for %s", info.Address, identifier)
+	logrus.Infof("Loading configuration from %s for %s", info.Address, info.AsString())
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/config", info.Address), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for configresolver: %w", err)

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -679,11 +679,11 @@ func TestConfigFromResolver(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s: Failed to marshal parsedConfig to JSON: %v", t.Name(), err)
 	}
-	info := ResolverInfo{Org: "openshift", Repo: "hyperkube", Branch: "master"}
+	metadata := api.Metadata{Org: "openshift", Repo: "hyperkube", Branch: "master"}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			server := httptest.NewServer(testCase.handlerWrapper(t, jsonConfig))
-			info.Address = server.URL
+			info := ResolverInfo{Address: server.URL, Metadata: metadata}
 			config, err := configFromResolver(&info)
 			if err == nil && testCase.expectedError {
 				t.Errorf("%s: expected an error, but got none", testCase.name)


### PR DESCRIPTION
`ResolverInfo` contains the same data with the same semantics, so using `api.Metadata` will allow using its helpders when working with resolver info
