### PR TITLE
sprint-automation: search for more issues to intake

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -350,7 +350,7 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 }
 
 func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, userId string) error {
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT labels=ready) AND created >= startOfWeek()`, jira.ProjectDPTP), nil)
+	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT labels=ready) AND created >= -30d`, jira.ProjectDPTP), nil)
 	if err := jirautil.JiraError(response, err); err != nil {
 		return fmt.Errorf("could not query for Jira issues: %w", err)
 	}


### PR DESCRIPTION
We previously only looked at issues filed in the last week, as we had
never done intake before and did not want to swamp people with long
lists. We've had intake for a while now and do not want anything to fall
in the cracks, so add 30d here to effectively give three intake shifts a
chance to move a card to ready.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>