### PR TITLE
pkg/defaults: split configuration parsing

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -358,6 +358,7 @@ type options struct {
 	inputHash                  string
 	secrets                    []*coreapi.Secret
 	templates                  []*templateapi.Template
+	graphConfig                api.GraphConfiguration
 	configSpec                 *api.ReleaseBuildConfiguration
 	jobSpec                    *api.JobSpec
 	clusterConfig              *rest.Config
@@ -517,7 +518,7 @@ func (o *options) Complete() error {
 	if err := validation.IsValidResolvedConfiguration(o.configSpec); err != nil {
 		return results.ForReason("validating_config").ForError(err)
 	}
-
+	o.graphConfig = defaults.FromConfigStatic(o.configSpec)
 	if o.verbose {
 		config, _ := yaml.Marshal(o.configSpec)
 		logrus.WithField("config", string(config)).Trace("Resolved configuration.")
@@ -792,7 +793,7 @@ func (o *options) Run() []error {
 	o.resolveConsoleHost()
 
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost)
+	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -284,6 +284,15 @@ type GraphConfiguration struct {
 	Steps []StepConfiguration
 }
 
+func (c *GraphConfiguration) InputImages() (ret []*InputImageTagStepConfiguration) {
+	for _, s := range c.Steps {
+		if c := s.InputImageTagStepConfiguration; c != nil {
+			ret = append(ret, c)
+		}
+	}
+	return
+}
+
 // BuildGraph returns a graph or graphs that include
 // all steps given.
 func BuildGraph(steps []Step) []*StepNode {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -896,11 +896,9 @@ func TestStepConfigsForBuild(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			var imageConfigs []*api.InputImageTagStepConfiguration
-
 			client := fakectrlruntimeclient.NewFakeClient()
 
-			graphConf, actualError := stepConfigsForBuild(context.Background(), client, testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, &imageConfigs, time.Nanosecond, testCase.consoleHost)
+			graphConf, actualError := stepConfigsForBuild(context.Background(), client, testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, time.Nanosecond, testCase.consoleHost)
 			if diff := cmp.Diff(testCase.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("actualError does not match expectedError, diff: %s", diff)
 			}


### PR DESCRIPTION
Extract the static parts of the function which transforms the input
configuration into step configuration so it can be built and used for
validation.

Another subset of https://github.com/openshift/ci-tools/pull/2213.