### PR TITLE
prowgen: generate conditionally triggered jobs correctly

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -408,7 +408,7 @@ func main() {
 
 	configs, err := getAllConfigs(o.releaseRepoPath)
 	if err != nil {
-		logrus.Fatal("couldn't get the prow and ci-operator configs")
+		logrus.WithError(err).Fatal("couldn't get the prow and ci-operator configs")
 	}
 	prowConfig := configs.Prow.ProwConfig
 

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -430,9 +430,11 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 	}
 	if new.RunIfChanged != "" {
 		merged.RunIfChanged = new.RunIfChanged
+		merged.AlwaysRun = new.AlwaysRun
 	}
 	if new.SkipIfOnlyChanged != "" {
 		merged.SkipIfOnlyChanged = new.SkipIfOnlyChanged
+		merged.AlwaysRun = new.AlwaysRun
 	}
 
 	return merged

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -398,7 +398,7 @@ func TestMergePresubmits(t *testing.T) {
 					MaxConcurrency: 10,
 					Cluster:        "somewhere",
 				},
-				AlwaysRun: true,
+				AlwaysRun: false,
 				Reporter: prowconfig.Reporter{
 					Context:    "context",
 					SkipReport: true,

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -449,7 +449,7 @@ func generatePresubmitForTest(name string, info *ProwgenInfo, podSpec *corev1.Po
 	base := generateJobBase(name, jc.PresubmitPrefix, info, podSpec, true, pathAlias, jobRelease, skipCloning)
 	return &prowconfig.Presubmit{
 		JobBase:   base,
-		AlwaysRun: true,
+		AlwaysRun: runIfChanged == "" && skipIfOnlyChanged == "",
 		Brancher:  prowconfig.Brancher{Branches: sets.NewString(ExactlyBranch(info.Branch), FeatureBranch(info.Branch)).List()},
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/prow/%s", shortName),

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
@@ -1,5 +1,5 @@
 agent: kubernetes
-always_run: true
+always_run: false
 branches:
 - ^branch$
 - ^branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
@@ -1,5 +1,5 @@
 agent: kubernetes
-always_run: true
+always_run: false
 branches:
 - ^branch$
 - ^branch-


### PR DESCRIPTION
Conditionally triggered jobs (ones with `run_if_changed` and `skipIfOnlyChanged`) need to be generated as `always_run: false` to beconsistent.

Followup to https://github.com/openshift/ci-tools/pull/2221
