### PR TITLE
Add git command to determinize-ci-operator,ci-operator-prowgen,ci-operator-checkconfig images

### DIFF
--- a/images/ci-operator-checkconfig/Dockerfile
+++ b/images/ci-operator-checkconfig/Dockerfile
@@ -1,5 +1,8 @@
 FROM centos:8
 LABEL maintainer="skuznets@redhat.com"
 
+RUN dnf install --nogpg -y git && \
+      dnf clean all
+
 ADD ci-operator-checkconfig /usr/bin/ci-operator-checkconfig
 ENTRYPOINT ["/usr/bin/ci-operator-checkconfig"]

--- a/images/ci-operator-prowgen/Dockerfile
+++ b/images/ci-operator-prowgen/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 LABEL maintainer="skuznets@redhat.com"
 
-RUN dnf install --nogpg -y diffutils && \
+RUN dnf install --nogpg -y diffutils git && \
       dnf clean all
 
 ADD ci-operator-prowgen /usr/bin/ci-operator-prowgen

--- a/images/determinize-ci-operator/Dockerfile
+++ b/images/determinize-ci-operator/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 LABEL maintainer="skuznets@redhat.com"
 
-RUN dnf install --nogpg -y diffutils && \
+RUN dnf install --nogpg -y diffutils git && \
       dnf clean all
 
 ADD determinize-ci-operator /usr/bin/determinize-ci-operator


### PR DESCRIPTION
/cc @openshift/test-platform 

follow-up of https://github.com/openshift/ci-tools/pull/2137

In order to use the new feature that was added in https://github.com/openshift/ci-tools/pull/2137, the images need to have the `git` command.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>