### PR TITLE
pod-scaler: frontend: correctly serve content

### DIFF
--- a/cmd/pod-scaler/frontend/webpack.common.js
+++ b/cmd/pod-scaler/frontend/webpack.common.js
@@ -4,7 +4,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const Dotenv = require('dotenv-webpack');
 const BG_IMAGES_DIRNAME = 'bgimages';
-const ASSET_PATH = process.env.ASSET_PATH || '/';
+const ASSET_PATH = process.env.ASSET_PATH || '/static/';
 module.exports = env => {
 
   return {

--- a/test/e2e/pod-scaler/local/main.go
+++ b/test/e2e/pod-scaler/local/main.go
@@ -74,7 +74,7 @@ func main() {
 			return []string{}
 		}, func(port, healthPort string) []string {
 			return []string{}
-		}, "API_ENDPOINT="+uiHost, "PATH="+os.Getenv("PATH"))
+		}, "API_ENDPOINT="+uiHost, "PATH="+os.Getenv("PATH"), "ASSET_PATH=/")
 		devUi.RunFromFrameworkRunner(t, interrupts.Context(), true)
 	}
 	interrupts.WaitForGracefulShutdown()


### PR DESCRIPTION
We need the default handler to always give the user our single-page app,
so that our React routing can handle the path. We prefix our static
content in Webpack and then un-prefix it in the server so that we know
which files should be coming from the embedded filesystem.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Fixes [DPTP-2447](https://issues.redhat.com/browse/DPTP-2447)
/assign @emilvberglind 