### PR TITLE
[WIP] ci-operator: add support for (optional) CLUSTER_OWNER to determine lease type

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1267,10 +1267,14 @@ func (p ClusterProfile) LeaseType() string {
 }
 
 // LeaseTypeFromClusterType maps cluster types to lease types
-func LeaseTypeFromClusterType(t string) (string, error) {
+func LeaseTypeFromClusterType(t, owner string) (string, error) {
 	switch t {
 	case "aws", "aws-arm64", "alibaba", "azure4", "azure-arc", "azurestack", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas", "osd-ephemeral":
-		return t + "-quota-slice", nil
+		leaseType := t
+		if owner != "" {
+			leaseType = fmt.Sprintf("%s-%s", t, owner)
+		}
+		return leaseType + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -291,7 +291,8 @@ func fromConfig(
 				if err != nil {
 					return nil, nil, fmt.Errorf("failed to get \"CLUSTER_TYPE\" parameter: %w", err)
 				}
-				lease, err := api.LeaseTypeFromClusterType(clusterType)
+				clusterOwner, _ := params.Get("CLUSTER_OWNER")
+				lease, err := api.LeaseTypeFromClusterType(clusterType, clusterOwner)
 				if err != nil {
 					return nil, nil, fmt.Errorf("cannot resolve lease type from cluster type: %w", err)
 				}


### PR DESCRIPTION
This PR adds the possibility to use, optionally, the env var `CLUSTER_OWNER` to determine the effective lease type requested to Boskos.
The original request came from https://github.com/openshift/release/pull/21071 where (specifically for the Packet profile) there was the need to specify which Equinix project the instance should be accounted for (but still the cluster profile remains the same).
The idea is to allow each team (or owner) to specify its own quota based on its own budget in the [Boskos configuration](https://github.com/openshift/release/blob/0017d437faeb1a00496c318c59a9f5a1b6ba1f66/core-services/prow/02_config/_boskos.yaml#L725-L728)
