### PR TITLE
exlude packet from mounting any cluster-profiles config map

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -556,7 +556,10 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAWSCPaaS,
 		cioperatorapi.ClusterProfileOSDEphemeral,
 		cioperatorapi.ClusterProfileAWS2,
-		cioperatorapi.ClusterProfileHyperShift:
+		cioperatorapi.ClusterProfileHyperShift,
+		cioperatorapi.ClusterProfilePacket,
+		cioperatorapi.ClusterProfilePacketAssisted,
+		cioperatorapi.ClusterProfilePacketSNO:
 	default:
 		ret.VolumeSource.Projected.Sources = append(ret.VolumeSource.Projected.Sources, corev1.VolumeProjection{
 			ConfigMap: &corev1.ConfigMapProjection{


### PR DESCRIPTION
/cc @openshift/test-platform 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>