### PR TITLE
Sprint automation: Only consider TODO issues

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -349,7 +349,7 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 }
 
 func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, userId string) error {
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT labels=ready) AND created >= -30d AND status!=Obsolete`, jira.ProjectDPTP), nil)
+	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT labels=ready) AND created >= -30d AND status = "To Do"`, jira.ProjectDPTP), nil)
 	if err := jirautil.JiraError(response, err); err != nil {
 		return fmt.Errorf("could not query for Jira issues: %w", err)
 	}


### PR DESCRIPTION
Once an issue left TODO, it is implicit that it was ready to work on.

Ref https://issues.redhat.com/browse/DPTP-2465

/cc @openshift/test-platform 