### PR TITLE
Vault: Don't remove current token during refresh

### DIFF
--- a/pkg/vaultclient/vaultclient.go
+++ b/pkg/vaultclient/vaultclient.go
@@ -15,11 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func getKuberntesAuthToken(client *VaultClient, role string) (string, time.Duration, error) {
+func getKuberntesAuthToken(upstreamClient *VaultClient, role string) (string, time.Duration, error) {
 
 	// Clone the client before resetting the token
-	var err error
-	client.Client, err = client.Client.Clone()
+	client, err := upstreamClient.Client.Clone()
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to clone client: %w", err)
 	}


### PR DESCRIPTION
For the refresh request we must not use a token. To achieve that, we
currently remove the token for the entire vault client during refresh,
even though it is still valid.

This change makes the refreshing construct its private client copy and
only manipulate that.

Ref https://issues.redhat.com/browse/DPTP-2462

/cc @openshift/test-platform 