### PR TITLE
Disallow `secrets` in non-container tests, improve validation tests

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -133,7 +133,7 @@ func (v *Validator) validateTestStepConfiguration(
 		} else if test.As == "images" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'images' because it gets confused with '[images]' target", fieldRootN))
 		} else if strings.HasPrefix(test.As, string(api.PipelineImageStreamTagReferenceIndexImage)) {
-			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should begin with 'ci-index' because it gets confused with 'ci-index' and `ci-index-...` targets", fieldRootN))
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not begin with 'ci-index' because it gets confused with 'ci-index' and `ci-index-...` targets", fieldRootN))
 		} else if images.Has(test.As) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: duplicated name %q already declared in 'images'", fieldRootN, test.As))
 		} else if len(validation.IsDNS1123Subdomain(test.As)) != 0 {

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -189,6 +189,10 @@ func (v *Validator) validateTestStepConfiguration(
 			test.Secrets = append(test.Secrets, test.Secret)
 		}
 
+		if test.Secrets != nil && test.ContainerTestConfiguration == nil {
+			validationErrors = append(validationErrors, fmt.Errorf("%s: secret/secrets can be only used with container-based tests (use credentials in multi-stage tests)", fieldRootN))
+		}
+
 		seen := sets.NewString()
 		for _, secret := range test.Secrets {
 			// K8s object names must be valid DNS 1123 subdomains.

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/utils/diff"
@@ -524,6 +523,26 @@ func TestValidateTests(t *testing.T) {
 				Commands:          "commands",
 				RunIfChanged:      "^README.md$",
 				SkipIfOnlyChanged: "^OTHER_README.md$",
+			}},
+			expectedValid: false,
+		},
+		{
+			id: "secrets used on multi-stage tests",
+			tests: []api.TestStepConfiguration{{
+				As:                          "unit",
+				Commands:                    "commands",
+				Secrets:                     []*api.Secret{{Name: "secret"}},
+				MultiStageTestConfiguration: &api.MultiStageTestConfiguration{},
+			}},
+			expectedValid: false,
+		},
+		{
+			id: "secrets used on template tests",
+			tests: []api.TestStepConfiguration{{
+				As:       "unit",
+				Commands: "commands",
+				Secrets:  []*api.Secret{{Name: "secret"}},
+				OpenshiftInstallerClusterTestConfiguration: &api.OpenshiftInstallerClusterTestConfiguration{},
 			}},
 			expectedValid: false,
 		},


### PR DESCRIPTION
- Validate `secret/secrets` usage on non-container tests
- ci-op validation: improve tests and fix nits
