### PR TITLE
ci-operator: include images into release explicitly

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -243,6 +243,9 @@ type Integration struct {
 	Namespace string `json:"namespace"`
 	// Name is the name of the ImageStream
 	Name string `json:"name"`
+	// IncludeBuiltImages determines if the release we assemble will include
+	// images built during the test itself.
+	IncludeBuiltImages bool `json:"include_built_images,omitempty"`
 }
 
 // Candidate describes a validated candidate release payload
@@ -378,6 +381,10 @@ type ReleaseTagConfiguration struct {
 	// Name is the image stream name to use that contains all
 	// component tags.
 	Name string `json:"name"`
+
+	// IncludeBuiltImages determines if the release we assemble will include
+	// images built during the test itself.
+	IncludeBuiltImages bool `json:"include_built_images,omitempty"`
 }
 
 func (config ReleaseTagConfiguration) InputsName() string {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -199,8 +199,9 @@ func fromConfig(
 					// this is the one case where we're not importing a payload, we need to get the images and build one
 					snapshot := releasesteps.ReleaseSnapshotStep(resolveConfig.Name, *resolveConfig.Integration, podClient, jobSpec)
 					assemble := releasesteps.AssembleReleaseStep(resolveConfig.Name, &api.ReleaseTagConfiguration{
-						Namespace: resolveConfig.Integration.Namespace,
-						Name:      resolveConfig.Integration.Name,
+						Namespace:          resolveConfig.Integration.Namespace,
+						Name:               resolveConfig.Integration.Name,
+						IncludeBuiltImages: resolveConfig.Integration.IncludeBuiltImages,
 					}, config.Resources, podClient, jobSpec)
 					for _, s := range []api.Step{snapshot, assemble} {
 						buildSteps = append(buildSteps, s)
@@ -282,7 +283,10 @@ func fromConfig(
 					target := rawStep.ReleaseImagesTagStepConfiguration.TargetName(name)
 					releaseStep = releasesteps.ImportReleaseStep(name, target, pullSpec, true, config.Resources, podClient, jobSpec, pullSecret, nil)
 				} else {
-					releaseStep = releasesteps.AssembleReleaseStep(name, rawStep.ReleaseImagesTagStepConfiguration, config.Resources, podClient, jobSpec)
+					// for backwards compatibility, users get inclusion for free with tag_spec
+					cfg := *rawStep.ReleaseImagesTagStepConfiguration
+					cfg.IncludeBuiltImages = name == api.LatestReleaseName
+					releaseStep = releasesteps.AssembleReleaseStep(name, &cfg, config.Resources, podClient, jobSpec)
 				}
 				overridableSteps = append(overridableSteps, releaseStep)
 				addProvidesForStep(releaseStep, params)

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -231,7 +231,7 @@ oc adm release extract --from=%q --to=${ARTIFACT_DIR}/release-payload-%s
 }
 
 func (s *assembleReleaseStep) Requires() []api.StepLink {
-	if s.name == api.LatestReleaseName {
+	if s.config.IncludeBuiltImages {
 		return []api.StepLink{api.ImagesReadyLink()}
 	}
 	return []api.StepLink{api.ReleaseImagesLink(s.name)}

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -72,7 +72,7 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 			})
 		}
 	}
-	// the Create call mutates the input object (why... ?) so we need to copy it before returning
+	// the Create call mutates the input object, so we need to copy it before returning
 	created := snapshot.DeepCopy()
 	if err := client.Create(ctx, created); err != nil && !kerrors.IsAlreadyExists(err) {
 		return nil, nil, fmt.Errorf("could not create snapshot imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)

--- a/pkg/validation/release.go
+++ b/pkg/validation/release.go
@@ -45,7 +45,7 @@ func validateReleases(fieldRoot string, releases map[string]api.UnresolvedReleas
 		} else if set == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.%s: must set integration, candidate, prerelease or release", fieldRoot, name))
 		} else if release.Integration != nil {
-			validationErrors = append(validationErrors, validateIntegration(fmt.Sprintf("%s.%s", fieldRoot, name), *release.Integration)...)
+			validationErrors = append(validationErrors, validateIntegration(fmt.Sprintf("%s.%s", fieldRoot, name), name, *release.Integration)...)
 		} else if release.Candidate != nil {
 			validationErrors = append(validationErrors, validateCandidate(fmt.Sprintf("%s.%s", fieldRoot, name), *release.Candidate)...)
 		} else if release.Release != nil {
@@ -57,13 +57,16 @@ func validateReleases(fieldRoot string, releases map[string]api.UnresolvedReleas
 	return validationErrors
 }
 
-func validateIntegration(fieldRoot string, integration api.Integration) []error {
+func validateIntegration(fieldRoot, name string, integration api.Integration) []error {
 	var validationErrors []error
 	if integration.Name == "" {
 		validationErrors = append(validationErrors, fmt.Errorf("%s.name: must be set", fieldRoot))
 	}
 	if integration.Namespace == "" {
 		validationErrors = append(validationErrors, fmt.Errorf("%s.namespace: must be set", fieldRoot))
+	}
+	if integration.IncludeBuiltImages && name != api.LatestReleaseName {
+		validationErrors = append(validationErrors, fmt.Errorf("%s: only the `latest` release can set `include_built_images`", fieldRoot))
 	}
 	return validationErrors
 }

--- a/test/e2e/multi-stage/assembled-release-no-injection.yaml
+++ b/test/e2e/multi-stage/assembled-release-no-injection.yaml
@@ -1,0 +1,52 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: '7'
+  cli:
+    name: "4.9"
+    namespace: ocp
+    tag: cli
+raw_steps:
+  - output_image_tag_step:
+      from: cli
+      to:
+        name: stable
+        tag: cli
+releases:
+  latest:
+    integration:
+      namespace: ocp
+      name: "4.7"
+resources:
+  '*':
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 10m
+tests:
+  - as: verify-releases
+    steps:
+      test:
+        - as: latest-cli
+          commands: |-
+            raw_cli_ref="$( cluster-version-operator image cli )"
+            # we want only the SHA, since they will necessarily be in different streams
+            have="${raw_cli_ref##*@}"
+            want="${CLI##*@}"
+            if [[ "${want}" != "${have}" ]]; then
+              echo "[ERROR] Got CLI in release overrriden by pipeline image (but didn't want that), have ${have}, want ${want}"
+              exit 1
+            fi
+          from: "release:latest"
+          dependencies:
+            - name: "stable:cli"
+              env: "CLI"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: test
+  repo: test

--- a/test/e2e/multi-stage/assembled-release.yaml
+++ b/test/e2e/multi-stage/assembled-release.yaml
@@ -1,0 +1,53 @@
+base_images:
+  os:
+    name: centos
+    namespace: openshift
+    tag: '7'
+  cli:
+    name: "4.9"
+    namespace: ocp
+    tag: cli
+raw_steps:
+  - output_image_tag_step:
+      from: cli
+      to:
+        name: stable
+        tag: cli
+releases:
+  latest:
+    integration:
+      namespace: ocp
+      name: "4.7"
+      include_built_images: true
+resources:
+  '*':
+    limits:
+      cpu: 500m
+    requests:
+      cpu: 10m
+tests:
+  - as: verify-releases
+    steps:
+      test:
+        - as: latest-cli
+          commands: |-
+            raw_cli_ref="$( cluster-version-operator image cli )"
+            # we want only the SHA, since they will necessarily be in different streams
+            have="${raw_cli_ref##*@}"
+            want="${CLI##*@}"
+            if [[ "${want}" != "${have}" ]]; then
+              echo "[ERROR] Did not get CLI in release overrriden by pipeline image, have ${have}, want ${want}"
+              exit 1
+            fi
+          from: "release:latest"
+          dependencies:
+            - name: "pipeline:cli"
+              env: "CLI"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 10Mi
+zz_generated_metadata:
+  branch: master
+  org: test
+  repo: test

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -167,6 +167,26 @@ func TestMultiStage(t *testing.T) {
 				`verify-releases-latest succeeded`, `verify-releases-latest-cli succeeded`,
 			},
 		},
+		{
+			name:    "assembled release includes built image",
+			args:    []string{"--unresolved-config=assembled-release.yaml", "--target=verify-releases"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output: []string{
+				`Snapshot integration stream into release 4.7.`, `-latest to tag release:latest`,
+				`verify-releases-latest-cli succeeded`,
+			},
+		},
+		{
+			name:    "assembled release does not include built image when not asked to",
+			args:    []string{"--unresolved-config=assembled-release-no-injection.yaml", "--target=verify-releases"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output: []string{
+				`Snapshot integration stream into release 4.7.`, `-latest to tag release:latest`,
+				`verify-releases-latest-cli succeeded`,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Previously, we always did this for integration releases with the
`latest` name. This is hard(er) to document and annoying to reason
about, so we should expose this as an option.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @petr-muller @emilvberglind 