### PR TITLE
[ci-operator-prowgen] Add an oauth config to the private jobs that need to clone the source

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -45,6 +45,9 @@ const (
 	APPCIKubeAPIURL = "https://api.ci.l2s4.p1.openshiftapps.com:6443"
 
 	DefaultLeaseEnv = "LEASED_RESOURCE"
+
+	OauthTokenSecretKey  = "oauth"
+	OauthTokenSecretName = "github-credentials-openshift-ci-robot-private-git-cloner"
 )
 
 var (

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -614,7 +614,10 @@ func generateJobBase(name, prefix string, info *ProwgenInfo, podSpec *corev1.Pod
 	var decorationConfig *prowv1.DecorationConfig
 	if skipCloning {
 		decorationConfig = &prowv1.DecorationConfig{SkipCloning: utilpointer.BoolPtr(true)}
+	} else if !skipCloning && info.Config.Private {
+		decorationConfig = &prowv1.DecorationConfig{OauthTokenSecret: &prowv1.OauthTokenSecret{Key: api.OauthTokenSecretKey, Name: api.OauthTokenSecretName}}
 	}
+
 	base := prowconfig.JobBase{
 		Agent:  string(prowv1.KubernetesAgent),
 		Labels: labels,

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -726,6 +726,17 @@ func TestGenerateJobBase(t *testing.T) {
 			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
 			clone:   true,
 		},
+		{
+			testName: "private jobs without skipcloning should contain oauth_token_secret config",
+			name:     "test",
+			prefix:   "pull",
+			info: &ProwgenInfo{
+				Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				Config:   config.Prowgen{Private: true, Expose: true},
+			},
+			podSpec: &corev1.PodSpec{Containers: []corev1.Container{{Name: "test"}}},
+			clone:   true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_private_jobs_without_skipcloning_should_contain_oauth_token_secret_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_private_jobs_without_skipcloning_should_contain_oauth_token_secret_config.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
+labels:
+  ci-operator.openshift.io/prowgen-controlled: newly-generated
+name: pull-ci-org-repo-branch-test
+spec:
+  containers:
+  - name: test
+    resources: {}


### PR DESCRIPTION
Since we now allow users to have a `.ci-operator.yaml` file that holds information about the root image build. The jobs that point to private repositories in order to clone the source they need to use OAuth authentication.   
This PR makes sure that private jobs with `skip_cloning: false` will include the necessary `decoration_config.oauth_token_secret`

https://issues.redhat.com/browse/DPTP-2470

/cc @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>