### PR TITLE
images: add clusterimageset-updater to config-brancher image

### DIFF
--- a/images/autoconfigbrancher/Dockerfile
+++ b/images/autoconfigbrancher/Dockerfile
@@ -11,6 +11,7 @@ ADD determinize-prow-config /usr/bin/determinize-prow-config
 ADD template-deprecator /usr/bin/template-deprecator
 ADD registry-replacer /usr/bin/registry-replacer
 ADD ci-operator-yaml-creator /usr/bin/ci-operator-yaml-creator
+ADD clusterimageset-updater /usr/bin/clusterimageset-updater
 
 RUN dnf install -y git && \
     dnf clean all && \


### PR DESCRIPTION
The `autoconfigbrancher` image needs the `clusterimageset-updater` binary.