### PR TITLE
Use different secrets and leases for new packet cluster profiles

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1268,11 +1268,12 @@ func (p ClusterProfile) LeaseType() string {
 		return "openstack-ppc64le-quota-slice"
 	case ClusterProfileOvirt:
 		return "ovirt-quota-slice"
+	case ClusterProfilePacket:
+		return "packet-quota-slice"
 	case
-		ClusterProfilePacket,
 		ClusterProfilePacketAssisted,
 		ClusterProfilePacketSNO:
-		return "packet-quota-slice"
+		return "packet-edge-qouta-slice"
 	case ClusterProfileVSphere:
 		return "vsphere-quota-slice"
 	case ClusterProfileKubevirt:

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -505,12 +505,16 @@ func generatePeriodicForTest(name string, info *ProwgenInfo, podSpec *corev1.Pod
 }
 
 func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterType string) corev1.Volume {
-	// AWS-2 and CPaaS and GCP2 need a different secret that should be provided to jobs
+	// AWS-2 and CPaaS and GCP2 PacketAssisted and PacketSNO need a different secret that should be provided to jobs
 	if profile == cioperatorapi.ClusterProfileAWSCPaaS {
 		clusterType = string(profile)
 	} else if profile == cioperatorapi.ClusterProfileAWS2 {
 		clusterType = string(profile)
 	} else if profile == cioperatorapi.ClusterProfileGCP2 {
+		clusterType = string(profile)
+	} else if profile == cioperatorapi.ClusterProfilePacketAssisted {
+		clusterType = string(profile)
+	} else if profile == cioperatorapi.ClusterProfilePacketSNO {
 		clusterType = string(profile)
 	}
 	ret := corev1.Volume{


### PR DESCRIPTION
We actually need different secrets for the new packet cluster profiles.