### PR TITLE
Fix not defined: -github-endpoint

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -97,11 +97,11 @@ type serviceAccountSecretRefresherOptions struct {
 
 func newOpts() (*options, error) {
 	opts := &options{GitHubOptions: &flagutil.GitHubOptions{}}
-	opts.addDefaults()
-	opts.GitHubOptions.AddFlags(flag.CommandLine)
-	opts.GitHubOptions.AllowAnonymous = true
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	opts.prowconfig.AddFlags(fs)
+	opts.addDefaults()
+	opts.GitHubOptions.AddFlags(fs)
+	opts.GitHubOptions.AllowAnonymous = true
 	fs.StringVar(&opts.leaderElectionNamespace, "leader-election-namespace", "ci", "The namespace to use for leaderelection")
 	fs.StringVar(&opts.kubeconfig, "kubeconfig", "", "The kubeconfig to use. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted.")
 	fs.StringVar(&opts.kubeconfigDir, "kubeconfig-dir", "", "Path to the directory containing kubeconfig files. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted.")

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -99,34 +100,29 @@ func newOpts() (*options, error) {
 	opts.addDefaults()
 	opts.GitHubOptions.AddFlags(flag.CommandLine)
 	opts.GitHubOptions.AllowAnonymous = true
-	opts.prowconfig.AddFlags(flag.CommandLine)
-	flag.StringVar(&opts.leaderElectionNamespace, "leader-election-namespace", "ci", "The namespace to use for leaderelection")
-	// Controller-Runtimes root package imports the package that sets this flag
-	kubeconfigFlagDescription := "The kubeconfig to use. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted."
-	if f := flag.Lookup("kubeconfig"); f != nil {
-		f.Usage = kubeconfigFlagDescription
-		// https://i.kym-cdn.com/entries/icons/original/000/018/012/this_is_fine.jpeg
-		defer func() { opts.kubeconfig = f.Value.String() }()
-	} else {
-		flag.StringVar(&opts.kubeconfig, "kubeconfig", "", kubeconfigFlagDescription)
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	opts.prowconfig.AddFlags(fs)
+	fs.StringVar(&opts.leaderElectionNamespace, "leader-election-namespace", "ci", "The namespace to use for leaderelection")
+	fs.StringVar(&opts.kubeconfig, "kubeconfig", "", "The kubeconfig to use. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted.")
+	fs.StringVar(&opts.kubeconfigDir, "kubeconfig-dir", "", "Path to the directory containing kubeconfig files. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted.")
+	fs.StringVar(&opts.ciOperatorconfigPath, "ci-operator-config-path", "", "Path to the ci operator config")
+	fs.StringVar(&opts.stepConfigPath, "step-config-path", "", "Path to the registries step configuration")
+	fs.StringVar(&opts.leaderElectionSuffix, "leader-election-suffix", "", "Suffix for the leader election lock. Useful for local testing. If set, --dry-run must be set as well")
+	fs.Var(&opts.enabledControllers, "enable-controller", fmt.Sprintf("Enabled controllers. Available controllers are: %v. Can be specified multiple times. Defaults to %v", allControllers.List(), opts.enabledControllers.Strings()))
+	fs.Var(&opts.testImagesDistributorOptions.additionalImageStreamTagsRaw, "testImagesDistributorOptions.additional-image-stream-tag", "An imagestreamtag that will be distributed even if no test explicitly references it. It must be in namespace/name:tag format (e.G `ci/clonerefs:latest`). Can be passed multiple times.")
+	fs.Var(&opts.testImagesDistributorOptions.additionalImageStreamsRaw, "testImagesDistributorOptions.additional-image-stream", "An imagestream that will be distributed even if no test explicitly references it. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
+	fs.Var(&opts.testImagesDistributorOptions.additionalImageStreamNamespacesRaw, "testImagesDistributorOptions.additional-image-stream-namespace", "A namespace in which imagestreams will be distributed even if no test explicitly references them (e.G `ci`). Can be passed multiple times.")
+	fs.Var(&opts.testImagesDistributorOptions.forbiddenRegistriesRaw, "testImagesDistributorOptions.forbidden-registry", "The hostname of an image registry from which there is no synchronization of its images. Can be passed multiple times.")
+	fs.Var(&opts.testImagesDistributorOptions.ignoreClusterNamesRaw, "testImagesDistributorOptions.ignore-cluster-name", "The cluster name to which there is no synchronization of test images. Can be passed multiple times.")
+	fs.DurationVar(&opts.blockProfileRate, "block-profile-rate", time.Duration(0), "The block profile rate. Set to non-zero to enable.")
+	fs.StringVar(&opts.registryClusterName, "registry-cluster-name", "app.ci", "the cluster name on which the CI central registry is running")
+	fs.Var(&opts.serviceAccountSecretRefresherOptions.enabledNamespaces, "serviceAccountRefresherOptions.enabled-namespace", "A namespace for which the serviceaccount_secret_refresher should be enabled. Can be passed multiple times.")
+	fs.BoolVar(&opts.serviceAccountSecretRefresherOptions.removeOldSecrets, "serviceAccountRefresherOptions.remove-old-secrets", false, "whether the serviceaccountsecretrefresher should delete secrets older than 30 days")
+	fs.Var(&opts.imagePusherOptions.imageStreamsRaw, "imagePusherOptions.image-stream", "An imagestream that will be synced. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
+	fs.BoolVar(&opts.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatal("could not parse args")
 	}
-	flag.StringVar(&opts.kubeconfigDir, "kubeconfig-dir", "", "Path to the directory containing kubeconfig files. All contexts in it will be considered a build cluster. If it does not have a context named 'app.ci', loading in-cluster config will be attempted.")
-	flag.StringVar(&opts.ciOperatorconfigPath, "ci-operator-config-path", "", "Path to the ci operator config")
-	flag.StringVar(&opts.stepConfigPath, "step-config-path", "", "Path to the registries step configuration")
-	flag.StringVar(&opts.leaderElectionSuffix, "leader-election-suffix", "", "Suffix for the leader election lock. Useful for local testing. If set, --dry-run must be set as well")
-	flag.Var(&opts.enabledControllers, "enable-controller", fmt.Sprintf("Enabled controllers. Available controllers are: %v. Can be specified multiple times. Defaults to %v", allControllers.List(), opts.enabledControllers.Strings()))
-	flag.Var(&opts.testImagesDistributorOptions.additionalImageStreamTagsRaw, "testImagesDistributorOptions.additional-image-stream-tag", "An imagestreamtag that will be distributed even if no test explicitly references it. It must be in namespace/name:tag format (e.G `ci/clonerefs:latest`). Can be passed multiple times.")
-	flag.Var(&opts.testImagesDistributorOptions.additionalImageStreamsRaw, "testImagesDistributorOptions.additional-image-stream", "An imagestream that will be distributed even if no test explicitly references it. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
-	flag.Var(&opts.testImagesDistributorOptions.additionalImageStreamNamespacesRaw, "testImagesDistributorOptions.additional-image-stream-namespace", "A namespace in which imagestreams will be distributed even if no test explicitly references them (e.G `ci`). Can be passed multiple times.")
-	flag.Var(&opts.testImagesDistributorOptions.forbiddenRegistriesRaw, "testImagesDistributorOptions.forbidden-registry", "The hostname of an image registry from which there is no synchronization of its images. Can be passed multiple times.")
-	flag.Var(&opts.testImagesDistributorOptions.ignoreClusterNamesRaw, "testImagesDistributorOptions.ignore-cluster-name", "The cluster name to which there is no synchronization of test images. Can be passed multiple times.")
-	flag.DurationVar(&opts.blockProfileRate, "block-profile-rate", time.Duration(0), "The block profile rate. Set to non-zero to enable.")
-	flag.StringVar(&opts.registryClusterName, "registry-cluster-name", "app.ci", "the cluster name on which the CI central registry is running")
-	flag.Var(&opts.serviceAccountSecretRefresherOptions.enabledNamespaces, "serviceAccountRefresherOptions.enabled-namespace", "A namespace for which the serviceaccount_secret_refresher should be enabled. Can be passed multiple times.")
-	flag.BoolVar(&opts.serviceAccountSecretRefresherOptions.removeOldSecrets, "serviceAccountRefresherOptions.remove-old-secrets", false, "whether the serviceaccountsecretrefresher should delete secrets older than 30 days")
-	flag.Var(&opts.imagePusherOptions.imageStreamsRaw, "imagePusherOptions.image-stream", "An imagestream that will be synced. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
-	flag.BoolVar(&opts.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
-	flag.Parse()
 
 	var errs []error
 	if opts.leaderElectionNamespace == "" {

--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -52,15 +52,7 @@ type options struct {
 func parseOptions() *options {
 	opts := &options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	// Controller-Runtimes root package imports the package that sets this flag
-	kubeconfigFlagDescription := "Path to the kubeconfig file to use for CLI requests."
-	if f := fs.Lookup("kubeconfig"); f != nil {
-		f.Usage = kubeconfigFlagDescription
-		// https://i.kym-cdn.com/entries/icons/original/000/018/012/this_is_fine.jpeg
-		defer func() { opts.kubeconfig = f.Value.String() }()
-	} else {
-		fs.StringVar(&opts.kubeconfig, "kubeconfig", "", kubeconfigFlagDescription)
-	}
+	fs.StringVar(&opts.kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
 	fs.StringVar(&opts.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	fs.StringVar(&opts.ciOperatorconfigPath, "ci-operator-config-path", "", "Path to the ci operator config")
 	fs.BoolVar(&opts.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
@@ -69,7 +61,7 @@ func parseOptions() *options {
 	fs.StringVar(&opts.openshiftMappingDir, "openshift-mapping-dir", "", "Path to the openshift mapping directory")
 	fs.StringVar(&opts.openshiftMappingConfigPath, "openshift-mapping-config", "", "Path to the openshift mapping config file")
 	if err := fs.Parse(os.Args[1:]); err != nil {
-		logrus.WithError(err).Fatal("could not parse input")
+		logrus.WithError(err).Fatal("could not parse args")
 	}
 	return opts
 }


### PR DESCRIPTION
```
$ oc --context app.ci --namespace ci logs --selector app=dptp-controller-manager --tail=-1
flag provided but not defined: -github-endpoint
```

The fix is in the 2nd commit.

/cc @openshift/test-platform 
