### PR TITLE
Fix typo in packet-edge boskos slice name

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1273,7 +1273,7 @@ func (p ClusterProfile) LeaseType() string {
 	case
 		ClusterProfilePacketAssisted,
 		ClusterProfilePacketSNO:
-		return "packet-edge-qouta-slice"
+		return "packet-edge-quota-slice"
 	case ClusterProfileVSphere:
 		return "vsphere-quota-slice"
 	case ClusterProfileKubevirt:


### PR DESCRIPTION
Seeing the following errors in boskos log:

```
msg=Acquire failed, error=resource type "packet-edge-qouta-slice" does not exist
```

The actual boskos config has this right:
https://github.com/openshift/release/blob/72dd5cea7b39ec1c03865000f2dce64cad1cc71e/core-services/prow/02_config/generate-boskos.py#L71-L73