### PR TITLE
Generalize image revert script

### DIFF
--- a/hack/revert-any-ci-image.sh
+++ b/hack/revert-any-ci-image.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Sets the `latest` tag of any imagestream in `ci` namespace to previous image
+#
+# Used to quickly revert broken images after a bad merge, to avoid waiting for
+# lenghtly image builds after the bad code revert
+
+set -euo pipefail
+
+IMAGE=${1:-}
+
+if [[ -z $IMAGE ]]; then
+  echo "Sets the 'latest' tag of any imagestream in 'ci' namespace to previous image"
+  echo "  (used to quickly revert broken images after a bad merge, to avoid waiting for lengthy image builds after the bad code revert)"
+  echo ""
+  echo "  Usage:   revert-any-ci-image.sh <IMAGE>"
+  echo "  Example: revert-any-ci-image.sh ci-operator"
+  exit 1
+fi
+
+
+OLD_LATEST="$(oc --context app.ci get is $1 -n ci -o jsonpath={.status.tags[?\(@.tag==\"latest\"\)].items[1].dockerImageReference}|cut -d '@' -f2)"
+
+oc --context app.ci tag "ci/$1@$OLD_LATEST" "ci/$1:latest"

--- a/hack/revert-ci-operator.sh
+++ b/hack/revert-ci-operator.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-
-OLD_LATEST="$(oc --context app.ci get is ci-operator -n ci -o jsonpath={.status.tags[?\(@.tag==\"latest\"\)].items[1].dockerImageReference}|cut -d '@' -f2)"
-
-echo "execute \`oc --context app.ci tag ci/ci-operator@$OLD_LATEST ci/ci-operator:latest\`"


### PR DESCRIPTION
- Use to revert any image, not just ci-operator
- Execute the command directly instead of just printing it
