### PR TITLE
pod-scaler: improve component labels in logs

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -30,7 +30,7 @@ import (
 )
 
 func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool) {
-	logger := logrus.WithField("component", "admission")
+	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Info("Initializing admission webhook server.")
 	health := pjutil.NewHealthOnPort(healthPort)
 	resources := newResourceServer(loaders, health)

--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -18,7 +18,7 @@ func newReloader(name string, cache cache) *cacheReloader {
 		name:  name,
 		cache: cache,
 		logger: logrus.WithFields(logrus.Fields{
-			"component": "reloader",
+			"component": "pod-scaler reloader",
 			"metric":    name,
 		}),
 		lock: &sync.RWMutex{},

--- a/cmd/pod-scaler/frontend.go
+++ b/cmd/pod-scaler/frontend.go
@@ -197,7 +197,7 @@ var (
 )
 
 func serveUI(port, healthPort int, loaders map[string][]*cacheReloader) {
-	logger := logrus.WithField("component", "frontend")
+	logger := logrus.WithField("component", "pod-scaler frontend")
 	server := &frontendServer{
 		logger:     logger,
 		lock:       sync.RWMutex{},

--- a/cmd/pod-scaler/resources.go
+++ b/cmd/pod-scaler/resources.go
@@ -14,7 +14,7 @@ import (
 )
 
 func newResourceServer(loaders map[string][]*cacheReloader, health *pjutil.Health) *resourceServer {
-	logger := logrus.WithField("component", "request_server")
+	logger := logrus.WithField("component", "pod-scaler request server")
 	server := &resourceServer{
 		logger:     logger,
 		lock:       sync.RWMutex{},


### PR DESCRIPTION
In dptp-triage tooling, `component` is usually the high-level component that emitted an error, and e.g. `admission` is not high-level component. Alternatively, we could set `component` to `pod-scaler` in all these and use something like `subcomponent` but IMO this has better UX
