### PR TITLE
pod-scaler: admission: improve error messages for rehearsals

### DIFF
--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -147,13 +147,18 @@ func sanitizeFilename(s string) string {
 var (
 	// EquateErrorMessage reports errors to be equal if both are nil
 	// or both have the same message.
-	//https://github.com/google/go-cmp/issues/24#issuecomment-317635190
-	EquateErrorMessage = cmp.Comparer(func(x, y error) bool {
-		if x == nil || y == nil {
-			return x == nil && y == nil
+	EquateErrorMessage = cmp.FilterValues(func(x, y interface{}) bool {
+		_, ok1 := x.(error)
+		_, ok2 := y.(error)
+		return ok1 && ok2
+	}, cmp.Comparer(func(x, y interface{}) bool {
+		xe := x.(error)
+		ye := y.(error)
+		if xe == nil || ye == nil {
+			return xe == nil && ye == nil
 		}
-		return x.Error() == y.Error()
-	})
+		return xe.Error() == ye.Error()
+	}))
 
 	// RuntimeObjectIgnoreRvTypeMeta compares two kubernetes objects, ignoring their resource
 	// version and TypeMeta. It is what you want 99% of the time.

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -75,10 +76,16 @@ func TestEquateErrorMessage(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "wrap error: false",
+			name:     "wrapped errors of fmt type are the same",
 			x:        fmt.Errorf("wrap error: same error"),
 			y:        fmt.Errorf("wrap error: %w", fmt.Errorf("same error")),
-			expected: false,
+			expected: true,
+		},
+		{
+			name:     "wrapped errors of different type are the same",
+			x:        errors.New("wrap error: same error"),
+			y:        fmt.Errorf("wrap error: %w", fmt.Errorf("same error")),
+			expected: true,
 		},
 		{
 			name:     "wrap error: true",


### PR DESCRIPTION
With a better understanding of what is erroring we can determine when we
should just ignore this.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @openshift/test-platform 