### PR TITLE
validate: remove wrong test and improve message

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -208,7 +208,7 @@ func (v *Validator) validateTestStepConfiguration(
 			// validate path only if name is passed
 			if secret.MountPath != "" {
 				if ok := filepath.IsAbs(secret.MountPath); !ok {
-					validationErrors = append(validationErrors, fmt.Errorf("%s.path: '%s' secret mount path is not valid value, should be ^((\\/*)\\w+)+", fieldRootN, secret.MountPath))
+					validationErrors = append(validationErrors, fmt.Errorf("%s.path: '%s' secret mount path must be an absolute path", fieldRootN, secret.MountPath))
 				}
 			}
 		}

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -238,22 +238,6 @@ func TestValidateTests(t *testing.T) {
 			release: &api.ReleaseTagConfiguration{Name: "origin-v3.11"},
 		},
 		{
-			id: "invalid secret mountPath",
-			tests: []api.TestStepConfiguration{
-				{
-					As:                         "test",
-					Commands:                   "commands",
-					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "src"},
-					Secret: &api.Secret{
-						Name:      "secret",
-						MountPath: "/path/to/secret:exec",
-					},
-				},
-			},
-			// TODO: The code actually just checks `filepath.IsAbs()`
-			// expectedError: errors.New(""),
-		},
-		{
 			id: "invalid secret name",
 			tests: []api.TestStepConfiguration{
 				{
@@ -382,7 +366,7 @@ func TestValidateTests(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New(`tests[0].path: 'path/to/secret' secret mount path is not valid value, should be ^((\/*)\w+)+`),
+			expectedError: errors.New(`tests[0].path: 'path/to/secret' secret mount path must be an absolute path`),
 		},
 		{
 			id:       "non-literal test is invalid in fully-resolved configuration",


### PR DESCRIPTION
>  The only requirement for mount paths is they should be absolute. That is tested correctly for credentials (validateCredentials in the same file) and is what should be done here too, IMO.

There's a test for absolute-ness of the mount path even for secrets (valid secret with invalid path), so the test just needs to be deleted, then.

Followup to https://github.com/openshift/ci-tools/pull/2293

/cc @bbguimaraes @stevekuznetsov 