### PR TITLE
promoted-image-governor: less verbose while explaining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,5 +359,5 @@ promoted-image-governor: $(TMPDIR)/.promoted-image-governor-kubeconfig
 
 explain: $(TMPDIR)/.promoted-image-governor-kubeconfig
 	@[[ $$istag ]] || (echo "ERROR: \$$istag must be set"; exit 1)
-	go run  ./cmd/promoted-image-governor --kubeconfig=$(TMPDIR)/.promoted-image-governor-kubeconfig --ci-operator-config-path=$(release_folder)/ci-operator/config --release-controller-mirror-config-dir=$(release_folder)/core-services/release-controller/_releases --explain $(istag) --dry-run=true
+	@go run  ./cmd/promoted-image-governor --kubeconfig=$(TMPDIR)/.promoted-image-governor-kubeconfig --ci-operator-config-path=$(release_folder)/ci-operator/config --release-controller-mirror-config-dir=$(release_folder)/core-services/release-controller/_releases --explain $(istag) --dry-run=true --log-level=fatal
 .PHONY: explain

--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -410,10 +410,6 @@ func main() {
 	}
 
 	ctx := interrupts.Context()
-	toDelete, err := tagsToDelete(ctx, client, promotedTags, opts.ignoredImageStreamTags, imageStreamRefs)
-	if err != nil {
-		logrus.WithError(err).Fatal("could not get tags to delete")
-	}
 
 	if len(opts.explains) > 0 {
 		w := tabwriter.NewWriter(os.Stdout, 20, 30, 1, ' ', tabwriter.AlignRight)
@@ -435,6 +431,11 @@ func main() {
 		}
 		w.Flush()
 		return
+	}
+
+	toDelete, err := tagsToDelete(ctx, client, promotedTags, opts.ignoredImageStreamTags, imageStreamRefs)
+	if err != nil {
+		logrus.WithError(err).Fatal("could not get tags to delete")
 	}
 
 	var errs []error


### PR DESCRIPTION
Follow up https://issues.redhat.com/browse/DPTP-2472?focusedCommentId=18930981&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18930981

/cc @petr-muller 

```
I0902 17:41:56.744282   56701 request.go:665] Waited for 1.137930975s due to client-side throttling, not priority and fairness, request: GET:https://api.ci.l2s4.p1.openshiftapps.com:6443/apis/hiveinternal.openshift.io/v1alpha1?timeout=32s
                   tag               explanation
 ci/applyconfig:latest openshift/ci-tools@master
```

We still have the above log and i feel it is hard to remove that
```
rg "due to client-side throttling"
vendor/k8s.io/client-go/rest/request.go
593:            message = fmt.Sprintf("Waited for %v due to client-side throttling, not priority and fairness, request: %s:%s", latency, r.verb, r.URL().String())
```

