### PR TITLE
clusterimageset-updater: add diffutils to image

### DIFF
--- a/images/clusterimageset-updater/Dockerfile
+++ b/images/clusterimageset-updater/Dockerfile
@@ -1,4 +1,8 @@
 FROM centos:8
+LABEL maintainer="apavel@redhat.com"
+
+RUN dnf install --nogpg -y diffutils && \
+      dnf clean all
 
 ADD clusterimageset-updater /usr/bin/clusterimageset-updater
 


### PR DESCRIPTION
This PR adds the diffutils package to the `clusterimagset-updater` image
to allow the image to be used for validation presubmits.

/cc @stevekuznetsov 