### PR TITLE
Use the same key name in oauth secret with upstream

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	oauthTokenPath = "/usr/local/github-credentials"
-	oauthKey       = "oauth"
+	oauthKey       = "oauth-token"
 )
 
 type ProwgenInfo struct {

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
@@ -4,7 +4,7 @@ containers:
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-credentials-file=/etc/report/credentials
   - --target=target
-  - --oauth-token-path=/usr/local/github-credentials/oauth
+  - --oauth-token-path=/usr/local/github-credentials/oauth-token
   command:
   - ci-operator
   image: ci-operator:latest

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job_with_skip_cloning_false.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job_with_skip_cloning_false.yaml
@@ -4,7 +4,7 @@ containers:
   - --gcs-upload-secret=/secrets/gcs/service-account.json
   - --report-credentials-file=/etc/report/credentials
   - --target=target
-  - --oauth-token-path=/usr/local/github-credentials/oauth
+  - --oauth-token-path=/usr/local/github-credentials/oauth-token
   command:
   - ci-operator
   image: ci-operator:latest

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --report-credentials-file=/etc/report/credentials
         - --target=unit
         command:

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
@@ -22,7 +22,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --report-credentials-file=/etc/report/credentials
         - --target=unit
         command:

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -18,7 +18,7 @@ periodics:
     - args:
       - --gcs-upload-secret=/secrets/gcs/service-account.json
       - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-      - --oauth-token-path=/usr/local/github-credentials/oauth
+      - --oauth-token-path=/usr/local/github-credentials/oauth-token
       - --report-credentials-file=/etc/report/credentials
       - --secret-dir=/usr/local/e2e-nightly-cluster-profile
       - --target=e2e-nightly

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -18,7 +18,7 @@ postsubmits:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --image-mirror-push-secret=/etc/push-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --promote
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --report-credentials-file=/etc/report/credentials
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --target=e2e
@@ -102,7 +102,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --report-credentials-file=/etc/report/credentials
         - --target=[images]
         - --target=[release:latest]
@@ -159,7 +159,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --oauth-token-path=/usr/local/github-credentials/oauth
+        - --oauth-token-path=/usr/local/github-credentials/oauth-token
         - --report-credentials-file=/etc/report/credentials
         - --target=unit
         command:


### PR DESCRIPTION
When `decoration_config.oauth_token_secret` is specified, the upstream code creates a volume using a specific name for the key. In order to use it we need to generate the same key name.

This change needs:

- Change the secret's key name in Vault
- Regenerate the jobs


Eventually, we can change the upstream code to respect the key name value from `decoration_config.oauth_token_secret.key`

/cc @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>