### PR TITLE
pod-scaler: ui: store data in files, not memory

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -56,6 +56,7 @@ type consumerOptions struct {
 	port   int
 	uiPort int
 
+	dataDir              string
 	certDir              string
 	mutateResourceLimits bool
 }
@@ -75,6 +76,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&o.loglevel, "loglevel", "debug", "Logging level.")
 	fs.StringVar(&o.logStyle, "log-style", "json", "Logging style: json or text.")
 	fs.StringVar(&o.cacheDir, "cache-dir", "", "Local directory holding cache data (for development mode).")
+	fs.StringVar(&o.dataDir, "data-dir", "", "Local directory to cache UI data into.")
 	fs.StringVar(&o.cacheBucket, "cache-bucket", "", "GCS bucket name holding cached Prometheus data.")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "File where GCS credentials are stored.")
 	return &o
@@ -95,6 +97,9 @@ func (o *options) validate() error {
 	case "consumer.ui":
 		if o.uiPort == 0 {
 			return errors.New("--ui-port is required")
+		}
+		if o.dataDir == "" {
+			return errors.New("--data-dir is required")
 		}
 	case "consumer.admission":
 		if o.port == 0 {
@@ -217,7 +222,7 @@ func mainProduce(opts *options, cache cache) {
 }
 
 func mainUI(opts *options, cache cache) {
-	go serveUI(opts.uiPort, opts.instrumentationOptions.HealthPort, loaders(cache))
+	go serveUI(opts.uiPort, opts.instrumentationOptions.HealthPort, opts.dataDir, loaders(cache))
 }
 
 func mainAdmission(opts *options, cache cache) {

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -91,6 +91,7 @@ func UI(t testhelper.TestingTInterface, dataDir string, parent context.Context, 
 		"--log-style=text",
 		"--cache-dir", dataDir,
 		"--mode=consumer.ui",
+		"--data-dir", t.TempDir(),
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)


### PR DESCRIPTION
We don't need the speed of main memory for this, so just write things to
disk.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 