### PR TITLE
Tolerate neither of `skip_if/run_if` changes in jobs if one is set in ci-op config

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -473,11 +473,8 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 	if old.Cluster != "" {
 		merged.Cluster = old.Cluster
 	}
-	if new.RunIfChanged != "" {
+	if new.RunIfChanged != "" || new.SkipIfOnlyChanged != "" {
 		merged.RunIfChanged = new.RunIfChanged
-		merged.AlwaysRun = new.AlwaysRun
-	}
-	if new.SkipIfOnlyChanged != "" {
 		merged.SkipIfOnlyChanged = new.SkipIfOnlyChanged
 		merged.AlwaysRun = new.AlwaysRun
 	}


### PR DESCRIPTION
If either of these is set on ci-operator level, *both* ones must not be manually changed in the job (otherwise we may end up with a job having both).