### PR TITLE
branching: add a schedule generator utility

### DIFF
--- a/cmd/branchingconfigmanagers/schedule-generator/main.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/main.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/logrusutil"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	crcontrollerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
+)
+
+type options struct {
+	logLevel          string
+	scheduleDir       string
+	dryRun            bool
+	kubernetesOptions flagutil.KubernetesOptions
+}
+
+func gatherOptions() (*options, error) {
+	o := &options{kubernetesOptions: flagutil.KubernetesOptions{NOInClusterConfigDefault: true}}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), "Level at which to log output.")
+	fs.StringVar(&o.scheduleDir, "schedule-dir", "", "Directory holding schedules.")
+	o.kubernetesOptions.AddFlags(fs)
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Do not mutate cluster state.")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return o, fmt.Errorf("failed to parse flags: %w", err)
+	}
+	return o, nil
+}
+
+func validateOptions(o *options) error {
+	_, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		return fmt.Errorf("invalid --log-level: %w", err)
+	}
+	return o.kubernetesOptions.Validate(o.dryRun)
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	o, err := gatherOptions()
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to gather options")
+	}
+	if err := validateOptions(o); err != nil {
+		logrus.WithError(err).Fatalf("Invalid options")
+	}
+	level, _ := logrus.ParseLevel(o.logLevel)
+	logrus.SetLevel(level)
+
+	kubeConfigs, err := o.kubernetesOptions.LoadClusterConfigs(nil)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not load kube config")
+	}
+
+	schedules, err := readSchedules(o.scheduleDir)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not read schedules.")
+	}
+
+	raw, err := yaml.Marshal(schedules)
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not find marshal schedules")
+	}
+
+	var errors []error
+	for ctx, config := range kubeConfigs {
+		client, err := ctrlruntimeclient.New(&config, ctrlruntimeclient.Options{})
+		if err != nil {
+			errors = append(errors, fmt.Errorf("could not get client for cluster %q: %w", ctx, err))
+		}
+		if err := upsertConfigMap(string(raw), client); err != nil {
+			errors = append(errors, fmt.Errorf("could not upsert configmap for cluster %q: %w", ctx, err))
+		}
+	}
+	if len(errors) > 0 {
+		logrus.WithError(kerrors.NewAggregate(errors)).Fatal("Failed to update cluster state.")
+	}
+}
+
+func readSchedules(scheduleDir string) (*ocplifecycle.Config, error) {
+	var config *ocplifecycle.Config
+	if err := filepath.Walk(scheduleDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(info.Name()) != ".yaml" {
+			return nil
+		}
+		raw, err := ioutil.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("could not read file: %w", err)
+		}
+		var schedule Schedule
+		if err := yaml.Unmarshal(raw, &schedule); err != nil {
+			return fmt.Errorf("could not unmarshal file: %w", err)
+		}
+		config = addToConfig(schedule, config)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return config, nil
+}
+
+const (
+	scheduleNamespace = "ci"
+	scheduleConfigmap = "release-schedules"
+	scheduleKey       = "schedules.yaml"
+)
+
+func upsertConfigMap(schedules string, client ctrlruntimeclient.Client) error {
+	configmap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scheduleConfigmap,
+			Namespace: scheduleNamespace,
+		},
+	}
+	mutate := func() error {
+		if configmap.Data == nil {
+			configmap.Data = map[string]string{}
+		}
+		configmap.Data[scheduleKey] = schedules
+		return nil
+	}
+	_, err := crcontrollerutil.CreateOrUpdate(context.Background(), client, configmap, mutate)
+	return err
+}

--- a/cmd/branchingconfigmanagers/schedule-generator/main_test.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/main_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestReadSchedules(t *testing.T) {
+	config, err := readSchedules("testdata/schedules")
+	if err != nil {
+		t.Fatalf("could not read schedules: %v", err)
+	}
+	testhelper.CompareWithFixture(t, config)
+}

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.1.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.1.yaml
@@ -1,0 +1,16 @@
+version:
+  major: 4
+  minor: 1
+events:
+  - name: "end-of-maintenance-support"
+    date: "2020-05-05T16:00:00Z"
+  - name: "end-of-full-support"
+    date: "2019-11-16T16:00:00Z"
+  - name: "general-availability"
+    date: "2019-06-04T16:00:00Z"
+  - name: "code-freeze"
+    date: "2019-05-01T02:00:00Z"
+  - name: "feature-freeze"
+    date: "2019-04-27T02:00:00Z"
+  - name: "open"
+    date: "2019-04-27T00:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.2.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.2.yaml
@@ -1,0 +1,16 @@
+version:
+  major: 4
+  minor: 2
+events:
+  - name: "end-of-maintenance-support"
+    date: "2050-07-13T16:00:00Z"
+  - name: "end-of-full-support"
+    date: "2050-02-23T16:00:00Z"
+  - name: "general-availability"
+    date: "2019-10-16T16:00:00Z"
+  - name: "code-freeze"
+    date: "2019-09-20T02:00:00Z"
+  - name: "feature-freeze"
+    date: "2019-07-19T02:00:00Z"
+  - name: "open"
+    date: "2019-05-13T00:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.3.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.3.yaml
@@ -1,0 +1,17 @@
+version:
+  major: 4
+  minor: 3
+events:
+  - name: "end-of-maintenance-support"
+    date: "2050-10-27T16:00:00Z"
+  - name: "end-of-full-support"
+    date: "2050-06-05T16:00:00Z"
+  - name: "general-availability"
+    date: "2050-01-15T16:00:00Z"
+  - name: "code-freeze"
+    date: "2019-12-13T02:00:00Z"
+    display_date: "2020-12-13T02:00:00Z"
+  - name: "feature-freeze"
+    date: "2019-11-01T02:00:00Z"
+  - name: "open"
+    date: "2019-09-14T00:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/zz_fixture_TestReadSchedules.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/zz_fixture_TestReadSchedules.yaml
@@ -1,0 +1,31 @@
+ocp:
+  "4.1":
+  - event: end-of-life
+    when: "2020-05-05T16:00:00Z"
+  - event: generally-available
+    when: "2019-06-04T16:00:00Z"
+  - event: code-freeze
+    when: "2019-05-01T02:00:00Z"
+  - event: feature-freeze
+    when: "2019-04-27T02:00:00Z"
+  - event: open
+    when: "2019-04-27T00:00:00Z"
+  "4.2":
+  - event: end-of-life
+  - event: generally-available
+    when: "2019-10-16T16:00:00Z"
+  - event: code-freeze
+    when: "2019-09-20T02:00:00Z"
+  - event: feature-freeze
+    when: "2019-07-19T02:00:00Z"
+  - event: open
+    when: "2019-05-13T00:00:00Z"
+  "4.3":
+  - event: end-of-life
+  - event: generally-available
+  - event: code-freeze
+    when: "2020-12-13T02:00:00Z"
+  - event: feature-freeze
+    when: "2019-11-01T02:00:00Z"
+  - event: open
+    when: "2019-09-14T00:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/types.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/types.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
+)
+
+// Schedule holds events for a version
+type Schedule struct {
+	// Version is the version that this schedule applies to
+	Version Version `json:"version"`
+	// Events are the events for this schedule
+	Events []Event `json:"events,omitempty"`
+}
+
+// Version specifies an OCP release
+type Version struct {
+	// Major is the major version
+	Major int `json:"major"`
+	// Minor is the minor version
+	Minor int `json:"minor"`
+}
+
+// Event is a moment in the schedule we care about
+type Event struct {
+	// Name is the event we are specifying
+	Name LifecycleEvent `json:"name"`
+	// Date is the published date for this event
+	Date *metav1.Time `json:"date"`
+	// DisplayDate is the date at which automation should actually switch over
+	DisplayDate *metav1.Time `json:"display_date,omitempty"`
+}
+
+type LifecycleEvent string
+
+const (
+	// LifecycleEventOpen marks the moment that development branches open for changes.
+	LifecycleEventOpen LifecycleEvent = "open"
+	// LifecycleEventFeatureFreeze marks the moment that development branches close for new features.
+	// At this point it is expected that only stabilizing bug-fixes land in the branches.
+	LifecycleEventFeatureFreeze LifecycleEvent = "feature-freeze"
+	// LifecycleEventCodeFreeze marks the moment that development branches close for contribution.
+	// At this point it is expected that only urgent stabilizing bug-fixes land in the branches.
+	LifecycleEventCodeFreeze LifecycleEvent = "code-freeze"
+	// LifecycleEventGenerallyAvailable marks the moment that a version is available and the development
+	// branches begin to track the next release.
+	LifecycleEventGenerallyAvailable LifecycleEvent = "general-availability"
+	// LifecycleEventEndOfFullSupport marks the moment that a version is no longer supported fully.
+	LifecycleEventEndOfFullSupport LifecycleEvent = "end-of-full-support"
+	// LifecycleEventEndOfMaintenanceSupport marks the moment that a version is no longer supported.
+	LifecycleEventEndOfMaintenanceSupport LifecycleEvent = "end-of-maintenance-support"
+)
+
+func lifecycleEventFor(event LifecycleEvent) (ocplifecycle.LifecycleEvent, bool) {
+	mapping := map[LifecycleEvent]ocplifecycle.LifecycleEvent{
+		LifecycleEventOpen:                    ocplifecycle.LifecycleEventOpen,
+		LifecycleEventFeatureFreeze:           ocplifecycle.LifecycleEventFeatureFreeze,
+		LifecycleEventCodeFreeze:              ocplifecycle.LifecycleEventCodeFreeze,
+		LifecycleEventGenerallyAvailable:      ocplifecycle.LifecycleEventGenerallyAvailable,
+		LifecycleEventEndOfMaintenanceSupport: ocplifecycle.LifecycleEventEndOfLife,
+	}
+	mapped, exists := mapping[event]
+	return mapped, exists
+}
+
+const productOCP = "ocp"
+
+func addToConfig(schedule Schedule, config *ocplifecycle.Config) *ocplifecycle.Config {
+	if config == nil {
+		config = &ocplifecycle.Config{}
+	}
+	if productConfig := (*config)[productOCP]; productConfig == nil {
+		(*config)[productOCP] = map[string][]ocplifecycle.LifecyclePhase{}
+	}
+	var phases []ocplifecycle.LifecyclePhase
+	for _, event := range schedule.Events {
+		phase, ok := lifecycleEventFor(event.Name)
+		if !ok {
+			continue
+		}
+		var date *metav1.Time
+		if event.DisplayDate != nil {
+			date = event.DisplayDate
+		} else {
+			date = event.Date
+		}
+		if time.Now().Before(date.Time) {
+			// we cannot expose future dates
+			date = nil
+		}
+		phases = append(phases, ocplifecycle.LifecyclePhase{
+			Event: phase,
+			When:  date,
+		})
+	}
+	sort.Slice(phases, func(i, j int) bool {
+		return phases[j].When.Before(phases[i].When)
+	})
+	(*config)[productOCP][fmt.Sprintf("%d.%d", schedule.Version.Major, schedule.Version.Minor)] = phases
+	return config
+}

--- a/cmd/branchingconfigmanagers/schedule-generator/types_test.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/types_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
+)
+
+func TestAddToConfig(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		schedule         Schedule
+		config, expected *ocplifecycle.Config
+	}{
+		{
+			name: "nil config in",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events:  []Event{{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}}},
+			},
+			config: nil,
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "updates existing date",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events:  []Event{{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}}},
+			},
+			config: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "adds new date",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events: []Event{
+					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
+					{Name: LifecycleEventGenerallyAvailable, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}},
+				},
+			},
+			config: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+					}, {
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "adds new version",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events: []Event{
+					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
+				},
+			},
+			config: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.0": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.0": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "all mappings, output sorted correctly",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events: []Event{
+					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
+					{Name: LifecycleEventFeatureFreeze, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}},
+					{Name: LifecycleEventCodeFreeze, Date: &metav1.Time{Time: time.Date(3, 3, 3, 3, 3, 3, 3, time.UTC)}},
+					{Name: LifecycleEventGenerallyAvailable, Date: &metav1.Time{Time: time.Date(4, 4, 4, 4, 4, 4, 4, time.UTC)}},
+					{Name: LifecycleEventEndOfFullSupport, Date: &metav1.Time{Time: time.Date(5, 5, 5, 5, 5, 5, 5, time.UTC)}},
+					{Name: LifecycleEventEndOfMaintenanceSupport, Date: &metav1.Time{Time: time.Date(6, 6, 6, 6, 6, 6, 6, time.UTC)}},
+				},
+			},
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventEndOfLife,
+						When:  &metav1.Time{Time: time.Date(6, 6, 6, 6, 6, 6, 6, time.UTC)},
+					}, {
+						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+						When:  &metav1.Time{Time: time.Date(4, 4, 4, 4, 4, 4, 4, time.UTC)},
+					}, {
+						Event: ocplifecycle.LifecycleEventCodeFreeze,
+						When:  &metav1.Time{Time: time.Date(3, 3, 3, 3, 3, 3, 3, time.UTC)},
+					}, {
+						Event: ocplifecycle.LifecycleEventFeatureFreeze,
+						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+					}, {
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "prefers display date",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events: []Event{{
+					Name:        LifecycleEventOpen,
+					Date:        &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					DisplayDate: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+				}},
+			},
+			config: nil,
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+					}},
+				},
+			},
+		},
+		{
+			name: "hides future dates",
+			schedule: Schedule{
+				Version: Version{Major: 4, Minor: 1},
+				Events: []Event{{
+					Name:        LifecycleEventOpen,
+					Date:        &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+					DisplayDate: &metav1.Time{Time: time.Date(9999, 2, 2, 2, 2, 2, 2, time.UTC)},
+				}, {
+					Name: LifecycleEventGenerallyAvailable,
+					Date: &metav1.Time{Time: time.Date(9999, 1, 1, 1, 1, 1, 1, time.UTC)},
+				}},
+			},
+			config: nil,
+			expected: &ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.1": {{
+						Event: ocplifecycle.LifecycleEventOpen,
+					}, {
+						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+					}},
+				},
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			testCase.config = addToConfig(testCase.schedule, testCase.config)
+			if diff := cmp.Diff(testCase.expected, testCase.config); diff != "" {
+				t.Errorf("%s: got incorrect config after update: %v", testCase.name, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This will run on the schedules provided by the PM team to generate the
data our tools expect to operate on, committing it to build farms in a
config map for easy loading.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @petr-muller @alvaroaleman 