### PR TITLE
repo-init: use releases.integration instead of tag_spec

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -527,9 +527,20 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 			Namespace: originConfig.Namespace,
 			Name:      originConfig.Name,
 		}
-		generated.Configuration.ReleaseTagConfiguration = &api.ReleaseTagConfiguration{
-			Namespace: originConfig.Namespace,
-			Name:      originConfig.Name,
+		generated.Configuration.Releases = map[string]api.UnresolvedRelease{
+			api.InitialReleaseName: {
+				Integration: &api.Integration{
+					Namespace: originConfig.Namespace,
+					Name:      originConfig.Name,
+				},
+			},
+			api.LatestReleaseName: {
+				Integration: &api.Integration{
+					Namespace:          originConfig.Namespace,
+					Name:               originConfig.Name,
+					IncludeBuiltImages: true,
+				},
+			},
 		}
 		if config.PromotesWithOpenShift {
 			workflow := "openshift-e2e-aws"

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -367,9 +367,20 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 						Name:      "version",
 					},
 					InputConfiguration: api.InputConfiguration{
-						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-							Namespace: "promote",
-							Name:      "version",
+						Releases: map[string]api.UnresolvedRelease{
+							api.InitialReleaseName: {
+								Integration: &api.Integration{
+									Namespace: "promote",
+									Name:      "version",
+								},
+							},
+							api.LatestReleaseName: {
+								Integration: &api.Integration{
+									Namespace:          "promote",
+									Name:               "version",
+									IncludeBuiltImages: true,
+								},
+							},
 						},
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{
@@ -417,9 +428,20 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 						Name:      "version",
 					},
 					InputConfiguration: api.InputConfiguration{
-						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
-							Namespace: "promote",
-							Name:      "version",
+						Releases: map[string]api.UnresolvedRelease{
+							api.InitialReleaseName: {
+								Integration: &api.Integration{
+									Namespace: "promote",
+									Name:      "version",
+								},
+							},
+							api.LatestReleaseName: {
+								Integration: &api.Integration{
+									Namespace:          "promote",
+									Name:               "version",
+									IncludeBuiltImages: true,
+								},
+							},
 						},
 						BuildRootImage: &api.BuildRootImageConfiguration{
 							ImageStreamTagReference: &api.ImageStreamTagReference{

--- a/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -7,6 +7,16 @@ canonical_go_repository: k8s.io/cool
 promotion:
   name: "4.3"
   namespace: ocp
+releases:
+  initial:
+    integration:
+      name: "4.3"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "4.3"
+      namespace: ocp
 resources:
   '*':
     limits:
@@ -14,9 +24,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tag_specification:
-  name: "4.3"
-  namespace: ocp
 tests:
 - as: unit
   commands: make test-unit

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -12,6 +12,16 @@ build_root:
 promotion:
   name: "4.3"
   namespace: ocp
+releases:
+  initial:
+    integration:
+      name: "4.3"
+      namespace: ocp
+  latest:
+    integration:
+      include_built_images: true
+      name: "4.3"
+      namespace: ocp
 resources:
   '*':
     limits:
@@ -19,9 +29,6 @@ resources:
     requests:
       cpu: 100m
       memory: 200Mi
-tag_specification:
-  name: "4.3"
-  namespace: ocp
 test_binary_build_commands: make test-install
 tests:
 - as: e2e-aws

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -71,6 +71,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --secret-dir=/usr/local/e2e-cluster-profile
         - --target=e2e
         command:
@@ -84,6 +85,9 @@ presubmits:
         volumeMounts:
         - mountPath: /etc/boskos
           name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
           readOnly: true
         - mountPath: /usr/local/e2e-cluster-profile
           name: cluster-profile
@@ -104,6 +108,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: cluster-profile
         projected:
           sources:
@@ -138,6 +145,7 @@ presubmits:
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --lease-server-credentials-file=/etc/boskos/credentials
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
         - --secret-dir=/usr/local/e2e-aws-cluster-profile
         - --target=e2e-aws
         command:
@@ -151,6 +159,9 @@ presubmits:
         volumeMounts:
         - mountPath: /etc/boskos
           name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
           readOnly: true
         - mountPath: /usr/local/e2e-aws-cluster-profile
           name: cluster-profile
@@ -171,6 +182,9 @@ presubmits:
           - key: credentials
             path: credentials
           secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
       - name: cluster-profile
         projected:
           sources:


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Part of [DPTP-2431](https://issues.redhat.com/browse/DPTP-2431)
/assign @emilvberglind 