### PR TITLE
test-images-distributor: stop generating requests for disabled clusters

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -662,7 +662,7 @@ func TestTestImageStramTagImportHandlerRoundTrips(t *testing.T) {
 	queue := &hijackingQueue{}
 
 	event := event.CreateEvent{Object: obj}
-	testImageStreamTagImportHandler(logrus.NewEntry(logrus.StandardLogger())).Create(event, queue)
+	testImageStreamTagImportHandler(logrus.NewEntry(logrus.StandardLogger()), sets.NewString()).Create(event, queue)
 
 	if n := len(queue.received); n != 1 {
 		t.Fatalf("expected exactly one reconcile request, got %d(%v)", n, queue.received)


### PR DESCRIPTION
We have handled it in the reconcile function:

https://github.com/openshift/ci-tools/blob/f96d4cad19030ad3fb827b55966869a78dca0154/pkg/controller/test-images-distributor/test_images_distributor.go#L292-L295

However, the requests should not even be generated in the first place.

/cc @alvaroaleman 