### PR TITLE
test/e2e: remove resource limits in ci-op configs

### DIFF
--- a/test/e2e/lease/config.yaml
+++ b/test/e2e/lease/config.yaml
@@ -10,8 +10,6 @@ releases:
       version: "4.4"
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/assembled-release-no-injection.yaml
+++ b/test/e2e/multi-stage/assembled-release-no-injection.yaml
@@ -20,8 +20,6 @@ releases:
       name: "4.7"
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/assembled-release.yaml
+++ b/test/e2e/multi-stage/assembled-release.yaml
@@ -21,8 +21,6 @@ releases:
       include_built_images: true
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/best-effort.yaml
+++ b/test/e2e/multi-stage/best-effort.yaml
@@ -5,8 +5,6 @@ base_images:
     tag: '7'
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/cluster-claim.yaml
+++ b/test/e2e/multi-stage/cluster-claim.yaml
@@ -14,8 +14,6 @@ releases:
       version: "4.5"
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -9,8 +9,6 @@ base_images:
     tag: '3.10'
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/configs/master/..2019_11_15_19_57_20.547184898/test-test-master.yaml
+++ b/test/e2e/multi-stage/configs/master/..2019_11_15_19_57_20.547184898/test-test-master.yaml
@@ -5,8 +5,6 @@ base_images:
     tag: '7'
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -10,8 +10,6 @@ build_root:
     tag: golang-1.14
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tag_specification:

--- a/test/e2e/multi-stage/integration-releases.yaml
+++ b/test/e2e/multi-stage/integration-releases.yaml
@@ -15,8 +15,6 @@ releases:
       name: "4.7"
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/multi-stage/names.yaml
+++ b/test/e2e/multi-stage/names.yaml
@@ -5,8 +5,6 @@ base_images:
     tag: '7'
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/optional-operators/optional-operators.yaml
+++ b/test/e2e/optional-operators/optional-operators.yaml
@@ -14,8 +14,6 @@ build_root:
     tag: golang-1.14
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 operator:

--- a/test/e2e/simple/config.yaml
+++ b/test/e2e/simple/config.yaml
@@ -5,8 +5,6 @@ base_images:
     tag: '7'
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -36,8 +36,6 @@ releases:
       name: "4.7"
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:

--- a/test/e2e/simple/template-config.yaml
+++ b/test/e2e/simple/template-config.yaml
@@ -8,8 +8,6 @@ build_root:
     tag: golang-1.14
 resources:
   '*':
-    limits:
-      cpu: 500m
     requests:
       cpu: 10m
 tests:


### PR DESCRIPTION
Resource limits should not be set in ci-op configs. This PR removes the
resources limit from all ci-op configs used in the e2e tests.

/cc @stevekuznetsov 