### PR TITLE
pod-scaler: fix a round-tripping bug in the UI

### DIFF
--- a/cmd/pod-scaler/frontend.go
+++ b/cmd/pod-scaler/frontend.go
@@ -132,7 +132,7 @@ func endpoints() map[string]metadataQueryMapping {
 				{query: ContainerQuery, field: func(meta *pod_scaler.FullMetadata) *string { return &meta.Container }},
 			},
 			postProcess: func(meta *pod_scaler.FullMetadata) {
-				meta.Pod += fmt.Sprintf("%s-%s", meta.Target, meta.Step)
+				meta.Pod = fmt.Sprintf("%s-%s", meta.Target, meta.Step)
 			},
 		},
 		"builds": {
@@ -165,6 +165,9 @@ func endpoints() map[string]metadataQueryMapping {
 				{query: VariantQuery, field: func(meta *pod_scaler.FullMetadata) *string { return &meta.Metadata.Variant }, optional: true},
 				{query: TargetQuery, field: func(meta *pod_scaler.FullMetadata) *string { return &meta.Target }},
 				{query: ContainerQuery, field: func(meta *pod_scaler.FullMetadata) *string { return &meta.Container }},
+			},
+			postProcess: func(meta *pod_scaler.FullMetadata) {
+				meta.Pod = meta.Target
 			},
 		},
 		"rpms": {

--- a/cmd/pod-scaler/frontend_test.go
+++ b/cmd/pod-scaler/frontend_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	pod_scaler "github.com/openshift/ci-tools/pkg/pod-scaler"
+)
+
+func TestMetadataQueryMappingRoundTripping(t *testing.T) {
+	metas := []pod_scaler.FullMetadata{
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Target:    "target",
+			Step:      "step",
+			Pod:       "target-step",
+			Container: "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Pod:       "pod-build",
+			Container: "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Target:    "target",
+			Pod:       "target",
+			Container: "container",
+		},
+		{
+			Metadata: api.Metadata{
+				Org:     "org",
+				Repo:    "repo",
+				Branch:  "branch",
+				Variant: "variant",
+			},
+			Container: "rpm-repo",
+		},
+		{
+			Target:    "target",
+			Container: "container",
+		},
+	}
+
+	for _, meta := range metas {
+		ptr := &meta
+		original := *ptr
+		for name, mapping := range endpoints() {
+			if !mapping.matches(&meta) {
+				continue
+			}
+			nodes := mapping.nodesFromMeta(&meta)
+			if nodes == nil {
+				continue
+			}
+			if diff := cmp.Diff(original, meta); diff != "" {
+				t.Fatalf("%s: mutated meta: %v", name, diff)
+			}
+			r, err := http.NewRequest(http.MethodGet, "whatever.com", &bytes.Buffer{})
+			if err != nil {
+				t.Fatalf("%s: could not make request: %v", name, err)
+			}
+			q := r.URL.Query()
+			for _, node := range nodes {
+				q.Set(node.Field, node.Name)
+			}
+			r.URL.RawQuery = q.Encode()
+			roundTripped, err := mapping.metadataFromQuery(&fakeWriter{}, r)
+			if err != nil {
+				t.Fatalf("%s: could not get round tripped meta: %v", name, err)
+			}
+			if diff := cmp.Diff(original, roundTripped); diff != "" {
+				t.Fatalf("%s: did not round-trip meta: %v", name, diff)
+			}
+		}
+	}
+}
+
+type fakeWriter struct{}
+
+func (w *fakeWriter) Header() http.Header        { return nil }
+func (w *fakeWriter) Write([]byte) (int, error)  { return 0, nil }
+func (w *fakeWriter) WriteHeader(statusCode int) {}


### PR DESCRIPTION
We only want to show a minimal set of fields to the UI for selecting the
correct background data, allowing the views to omit things that are not
important in the context of a specific type of data (pods, RPMs, etc).
We need to ensure that all of these transforms round-trip correctly.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes 