### PR TITLE
promotion: correctly handle multiple promotion names

### DIFF
--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -546,8 +546,8 @@ func TestGetPromotionPod(t *testing.T) {
 		{
 			name: "basic case",
 			imageMirror: map[string]string{
-				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62": "registy.ci.openshift.org/ci/applyconfig:latest",
-				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb":                                                              "registy.ci.openshift.org/ci/bin:latest",
+				"registy.ci.openshift.org/ci/applyconfig:latest": "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62",
+				"registy.ci.openshift.org/ci/bin:latest":         "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
 			},
 			namespace: "ci-op-zyvwvffx",
 		},
@@ -613,8 +613,47 @@ func TestGetImageMirror(t *testing.T) {
 				},
 			},
 			expected: map[string]string{
-				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb": "registry.ci.openshift.org/ci/a:latest",
-				"docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd": "registry.ci.openshift.org/ci/c:latest",
+				"registry.ci.openshift.org/ci/a:latest": "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
+				"registry.ci.openshift.org/ci/c:latest": "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd",
+			},
+		},
+		{
+			name: "image promoted to multiple names",
+			tags: map[string][]api.ImageStreamTagReference{
+				"b": {
+					{Namespace: "ci", Name: "a", Tag: "promoted"},
+					{Namespace: "ci", Name: "a", Tag: "also-promoted"},
+				},
+				"d": {
+					{Namespace: "ci", Name: "c", Tag: "latest"},
+				},
+			},
+			pipeline: &imageapi.ImageStream{
+				Status: imageapi.ImageStreamStatus{
+					Tags: []imageapi.NamedTagEventList{
+						{
+							Tag: "b",
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
+								},
+							},
+						},
+						{
+							Tag: "d",
+							Items: []imageapi.TagEvent{
+								{
+									DockerImageReference: "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]string{
+				"registry.ci.openshift.org/ci/a:promoted":      "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
+				"registry.ci.openshift.org/ci/a:also-promoted": "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb",
+				"registry.ci.openshift.org/ci/c:latest":        "docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:ddd",
 			},
 		},
 	}


### PR DESCRIPTION
Promotion correctly tracks multiple promotion destinations for a name, but previously we compressed the items into a map keyed by source, so each source only had a single destination in promotion mapping, leading to some destinations to be silently skipped.

Key the interface map with destinations, so that we can have multiple destinations with the same source.

Caused `ocp/4.6:base` to be pruned because it is not promoted correctly:

https://github.com/openshift/release/blob/b3157f4134f53a0da4c592c1f3fc254407245760/ci-operator/config/openshift/images/openshift-images-release-4.6.yaml#L47-L53

ci-operator [claims to promote ](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-images-release-4.6-images/1440213018985107456#1:build-log.txt%3A37)the image:

```
INFO[2021-09-21T07:19:09Z] Promoting tags to ocp/4.6:${component}: base, base-7, base-8, egress-dns-proxy, egress-http-proxy, egress-router, keepalived-ipfailover, pod 
```

But it lies, the promotion mapping is missing the `base` destination:

```console
$ oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson
          --continue-on-error=true --max-per-registry=20
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:0dc7ce22af8ae9fad69fe786d3bbaf269eff49d4514749f154644ef3d82b228b=registry.ci.openshift.org/ocp/4.6:base-7
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:21200161d347a8942fcb5ab65307a799002183f482a674010df2a6e7e9897f59=registry.ci.openshift.org/ocp/4.6:egress-router
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:21a6647fec454c7cc221e73aa11137babf4e53e4c9c9f56512ad56f088323abc=registry.ci.openshift.org/ocp/4.6:egress-dns-proxy
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:5966a26211b7b2a9ca9e097443275883e33a71eca198fae88e3fa69cb5916a43=registry.ci.openshift.org/ocp/4.6:pod
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:682e34710efee868e3ab4e9ca4f4400018e86728f8f189c4e99a74d800171b8a=registry.ci.openshift.org/ocp/4.6:base-8
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:94fb5dfc81d377a80c7e2bcc9b8248eb24ff100fa7a1cc30e29372545ca16b5a=registry.ci.openshift.org/ocp/4.6:egress-http-proxy
          registry.build02.ci.openshift.org/ci-op-403v81nb/pipeline@sha256:967aabb37e5fe1ff176db5ee937299188f63a8e02d44f4d7a90f4e63f8137b4b=registry.ci.openshift.org/ocp/4.6:keepalived-ipfailover
```

It is also suspicious that the `ocp/4.6:base` is now gone, probably pruned by a recent governor run. The governor does not seem to use this code to determine which images are promoted and which are not, so it may actually have a similar bug , I'll investigage.