### PR TITLE
e2e: stop using obsolete OCP in simple tests

### DIFF
--- a/test/e2e/simple/artifacts/junit_operator.xml
+++ b/test/e2e/simple/artifacts/junit_operator.xml
@@ -3,7 +3,7 @@
     <testcase name="All images are built and tagged into stable" time="whatever"></testcase>
     <testcase name="Clone the correct source code into an image and tag it as src" time="whatever"></testcase>
     <testcase name="Create the release image &#34;latest&#34; containing all images built by this job" time="whatever"></testcase>
-    <testcase name="Find all of the input images from ocp/4.5:${component} and tag them into the output image stream" time="whatever"></testcase>
+    <testcase name="Find all of the input images from ocp/4.10:${component} and tag them into the output image stream" time="whatever"></testcase>
     <testcase name="Find the input image root and tag it into the pipeline" time="whatever"></testcase>
     <testcase name="Run template template - branch-ci-openshift-ci-tools-master-ci-operator-e2e container setup" time="whatever"></testcase>
     <testcase name="Run template template - branch-ci-openshift-ci-tools-master-ci-operator-e2e container teardown" time="whatever"></testcase>

--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -17,14 +17,14 @@ releases:
       product: ocp
       architecture: amd64
       stream: nightly
-      version: "4.5"
+      version: "4.10"
       relative: 1
   pre:
     prerelease:
       product: ocp
       version_bounds:
         lower: "4.4.0"
-        upper: "4.5.0-0"
+        upper: "4.10.0-0"
   mainframe:
     release:
       version: "4.7"

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -286,7 +286,7 @@ func TestLiteralDynamicRelease(t *testing.T) {
 		},
 		{
 			name:    "nightly release",
-			release: resolveSpec("https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.5.0-0.nightly/latest?rel=1"),
+			release: resolveSpec("https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.10.0-0.nightly/latest?rel=1"),
 			target:  "latest",
 		},
 		{
@@ -296,7 +296,7 @@ func TestLiteralDynamicRelease(t *testing.T) {
 		},
 		{
 			name:    "built release",
-			release: resolveSpec("https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.5.0-0.nightly/latest?rel=1"),
+			release: resolveSpec("https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.10.0-0.nightly/latest?rel=1"),
 			target:  "assembled",
 		},
 	}

--- a/test/e2e/simple/template-config.yaml
+++ b/test/e2e/simple/template-config.yaml
@@ -1,6 +1,6 @@
 tag_specification:
   namespace: ocp
-  name: "4.5"
+  name: "4.10"
 build_root:
   image_stream_tag:
     name: release


### PR DESCRIPTION
We are hitting a consistency problem in the 4.5 imagestream, likely caused by recent pruning of the images:

```
error: unable to create a release: operator "cluster-node-tuning-operator" contained an invalid image-references file: no input image tag named "cluster-node-tuned"
```

This also happens in r-c, see https://amd64.ocp.releases.ci.openshift.org/#4.5.0-0.ci

There is no reason why our PRs should be blocked on this, let's use a current version for our tests. 4.5 is EOL and apparently nobody even cares about this failure showing up in r-c for 4 weeks.