### PR TITLE
pkg/steps: remove unreliable test

### DIFF
--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -190,7 +190,6 @@ func TestStepsRun(t *testing.T) {
 				},
 				{
 					name:      "rpm",
-					runErr:    context.Canceled,
 					shouldRun: true,
 					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
 					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},
@@ -247,7 +246,6 @@ func TestStepsRun(t *testing.T) {
 				},
 				{
 					name:      "rpm",
-					runErr:    context.Canceled,
 					shouldRun: true,
 					requires:  []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceBinaries)},
 					creates:   []api.StepLink{api.InternalImageLink(api.PipelineImageStreamTagReferenceRPMs)},


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2351

This test case cannot be structured as it is because the code it tests
is based on a `select` statement:

https://github.com/openshift/ci-tools/blob/f8fac1599dad2eeb98b1771c9e4ced716d1f0364/pkg/steps/run.go#L49

In the (very unlikely, but seen repeatedly in CI) scenario that the
statement chooses to keep processing steps before acknowledging the
cancellation, the extra error will be reported.  This can be simulated
with the following code, which fails in the same manner 100% of the
time on my machine (it otherwise never fails):

```diff
 	var executionErrors []error
 	var stepDetails []api.CIOperatorStepDetails
 	for {
+		for i := 0; i < 5; i++ {
+			select {
+			case out := <-executionResults:
…
+			case <-done:
…
+			}
+		}
 		select {
 		case <-ctxDone:
 			executionErrors = append(executionErrors, results.ForReason("interrupted").ForError(errors.New("execution cancelled")))
```

The test is not useful as it is irrelevant whether additional errors are
reported when the execution is cancelled, so it is removed.