### PR TITLE
skip empty files for junit aggregation

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -139,7 +139,11 @@ func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 	for _, junitFile := range j.GetGCSJunitPaths() {
 		junitContent, err := j.GetContent(ctx, junitFile)
 		if err != nil {
-			return nil, fmt.Errorf("error getting content for %q %q: %w", j.GetJobRunID(), junitFile, err)
+			return nil, fmt.Errorf("error getting content for jobrun/%v/%v %q: %w", j.GetJobName(), j.GetJobRunID(), junitFile, err)
+		}
+		// if the file was retrieve, but the content was empty, there is no work to be done.
+		if len(junitContent) == 0 {
+			continue
 		}
 
 		// try as testsuites first just in case we are one
@@ -153,7 +157,7 @@ func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 
 		currTestSuite := &junit.TestSuite{}
 		if testSuiteErr := xml.Unmarshal(junitContent, currTestSuite); testSuiteErr != nil {
-			return nil, fmt.Errorf("error parsing junit for %q %q: %w", j.GetJobRunID(), junitFile, testSuiteErr)
+			return nil, fmt.Errorf("error parsing junit for jobrun/%v/%v %q: %w", j.GetJobName(), j.GetJobRunID(), junitFile, testSuiteErr)
 		}
 		testSuites.Suites = append(testSuites.Suites, currTestSuite)
 	}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -215,7 +215,7 @@ type jobRunLoaderOptions struct {
 func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
 	defer close(o.doneUploading)
 
-	fmt.Printf("Analyzing jobrun/%q/%q.\n", o.jobName, o.hobRunID)
+	fmt.Printf("Analyzing jobrun/%v/%v.\n", o.jobName, o.hobRunID)
 
 	jobRun, err := o.readJobRunFromGCS(ctx)
 	if err != nil {
@@ -233,7 +233,7 @@ func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
 	}
 
 	if err := o.uploadJobRun(ctx, jobRun); err != nil {
-		return fmt.Errorf("jobRun/%q/%q failed to upload to bigquery: %w", o.jobName, o.hobRunID, err)
+		return fmt.Errorf("jobrun/%v/%v failed to upload to bigquery: %w", o.jobName, o.hobRunID, err)
 	}
 
 	return nil
@@ -244,13 +244,13 @@ func (o *jobRunLoaderOptions) uploadJobRun(ctx context.Context, jobRun jobrunagg
 	if err != nil {
 		return err
 	}
-	fmt.Printf("uploading prowjob.yaml: %q/%q\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+	fmt.Printf("uploading prowjob.yaml: jobrun/%v/%v\n", jobRun.GetJobName(), jobRun.GetJobRunID())
 	jobRunRow := newJobRunRow(jobRun, prowJob)
 	if err := o.jobRunInserter.Put(ctx, jobRunRow); err != nil {
 		return err
 	}
 
-	fmt.Printf("  uploading content: %q/%q\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+	fmt.Printf("  uploading content: jobrun/%v/%v\n", jobRun.GetJobName(), jobRun.GetJobRunID())
 	if err := o.jobRunUploader.uploadContent(ctx, jobRun, prowJob); err != nil {
 		return err
 	}
@@ -266,14 +266,14 @@ func (o *jobRunLoaderOptions) readJobRunFromGCS(ctx context.Context) (jobrunaggr
 	}
 	prowjob, err := jobRunInfo.GetProwJob(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get prowjob for %q/%q: %w", o.jobName, o.hobRunID, err)
+		return nil, fmt.Errorf("failed to get prowjob for jobrun/%v/%v: %w", o.jobName, o.hobRunID, err)
 	}
 	if prowjob.Status.CompletionTime == nil {
 		fmt.Printf("Removing %q/%q because it isn't finished\n", o.jobName, o.hobRunID)
 		return nil, nil
 	}
 	if _, err := jobRunInfo.GetAllContent(ctx); err != nil {
-		return nil, fmt.Errorf("failed to get all content for %q/%q: %w", o.jobName, o.hobRunID, err)
+		return nil, fmt.Errorf("failed to get all content for jobrun/%v/%v: %w", o.jobName, o.hobRunID, err)
 	}
 
 	return jobRunInfo, nil


### PR DESCRIPTION
found as 
> jobRun/\"release-openshift-ocp-installer-e2e-metal-serial-4.10\"/\"1440877727593795584\" failed to upload to bigquery: error parsing junit for \"1440877727593795584\" \"logs/release-openshift-ocp-installer-e2e-metal-serial-4.10/1440877727593795584/artifacts/e2e-metal-serial/junit/junit_install_status.xml\": EOF

on the dpcr cluster.

/assign @dgoodwin 