### PR TITLE
ignore jobs we're aggregating that time out

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/types.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/types.go
@@ -1,7 +1,8 @@
 package jobrunaggregatoranalyzer
 
 type AggregationConfiguration struct {
-	IndividualJobs []JobRunInfo
+	UnfinishedJobs []JobRunInfo
+	FinishedJobs   []JobRunInfo
 }
 
 type JobRunInfo struct {


### PR DESCRIPTION
if job runs have timed out, we can ignore them for the purposes of aggregation.  This only becomes a practical problem if the jobs start running very very long.  