### PR TITLE
DPTP-2523: Clear out lastLoaded CachedQuery once used

### DIFF
--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -87,10 +87,13 @@ func (c *cacheReloader) reload() {
 	logger.Debug("Newer update loaded.")
 }
 
+// data returns the lastLoaded CachedQuery and clears it to conserve memory
 func (c *cacheReloader) data() *pod_scaler.CachedQuery {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	return c.lastLoaded
+	lastLoaded := c.lastLoaded
+	c.lastLoaded = nil
+	return lastLoaded
 }
 
 func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, health *pjutil.Health, logger *logrus.Entry) {

--- a/cmd/pod-scaler/frontend.go
+++ b/cmd/pod-scaler/frontend.go
@@ -470,7 +470,7 @@ func (s *frontendServer) digestCPU(data *pod_scaler.CachedQuery) {
 }
 
 func (s *frontendServer) digestMemory(data *pod_scaler.CachedQuery) {
-	s.logger.Debugf("Digesting new CPU consumption metrics.")
+	s.logger.Debugf("Digesting new Memory consumption metrics.")
 	s.digestData(data, corev1.ResourceMemory, memRequestQuantile)
 }
 

--- a/cmd/vault-secret-collection-manager/main_test.go
+++ b/cmd/vault-secret-collection-manager/main_test.go
@@ -44,7 +44,7 @@ func TestSecretCollectionManager(t *testing.T) {
 		}
 	}()
 
-	testhelper.WaitForHTTP200(fmt.Sprintf("http://%s/healthz", managerListenAddr), "secret-collection-manager", t)
+	testhelper.WaitForHTTP200(fmt.Sprintf("http://%s/healthz", managerListenAddr), "secret-collection-manager", 90, t)
 	t.Cleanup(func() {
 		if err := server.Close(); err != nil {
 			t.Errorf("failed to close server: %v", err)

--- a/cmd/vault-subpath-proxy/main_test.go
+++ b/cmd/vault-subpath-proxy/main_test.go
@@ -84,7 +84,7 @@ path "secret/metadata/team-1/*" {
 			t.Errorf("failed to close proxy: %v", err)
 		}
 	})
-	testhelper.WaitForHTTP200("http://127.0.0.1:"+proxyServerPort+"/v1/sys/health", "vault-subpath-proxy", t)
+	testhelper.WaitForHTTP200("http://127.0.0.1:"+proxyServerPort+"/v1/sys/health", "vault-subpath-proxy", 90, t)
 
 	rootProxy, err := vaultclient.New("http://127.0.0.1:"+proxyServerPort, testhelper.VaultTestingRootToken)
 	if err != nil {

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -102,6 +102,6 @@ func UI(t testhelper.TestingTInterface, dataDir string, parent context.Context, 
 	podScaler.RunFromFrameworkRunner(t, parent, stream)
 	podScalerHost := "http://" + serverHostname + ":" + podScaler.ClientFlags()[0]
 	t.Logf("pod-scaler UI is running at %s", podScalerHost)
-	podScaler.Ready(t)
+	podScaler.Ready(t, func(o *testhelper.ReadyOptions) { o.WaitFor = 200 })
 	return podScalerHost
 }


### PR DESCRIPTION
The lastLoaded CachedQuery is very large. Once it is digested there is no reason for it to hang around. This significantly reduces the memory use of the pod-scaler. See pprof results for running the `local-pod-scaler-ui` make target before and after this change:
![before_change](https://user-images.githubusercontent.com/1794300/135518625-bb5f46f3-865b-4ab8-afa8-ae314624fa3f.png)
 
![after_change](https://user-images.githubusercontent.com/1794300/135518641-b70e4f69-78e8-481b-a054-7d9b29e45121.png)

I also added the ability to specify the amount of seconds to wait for an accessory service to be ready. 90 seconds was not enough for me to run the `local-pod-scaler-ui` target locally, it actually took around 180 seconds each time.