### PR TITLE
Bugzilla backporter should sort semantically

### DIFF
--- a/cmd/bugzilla-backporter/main.go
+++ b/cmd/bugzilla-backporter/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"sort"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -82,9 +81,10 @@ func getAllTargetVersions(configFile string) ([]string, error) {
 		}
 	}
 	allTargetVersions := allTargetVersionsSet.List()
-	sort.SliceStable(allTargetVersions, func(i, j int) bool {
-		return allTargetVersions[i] < allTargetVersions[j]
-	})
+	err = backporter.SortTargetReleases(allTargetVersions, true)
+	if err != nil {
+		return nil, fmt.Errorf("unable to sort discovered target_releases %v: %w", allTargetVersions, err)
+	}
 	return allTargetVersions, nil
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2524

The introduction of 4.10 means that string based sort was no longer
successfully sorting target_releases correctly. Versions are now
parsed and sorted according to semver.
