### PR TITLE
Set DPTP as exclusive reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,3 +9,10 @@ approvers:
 - alvaroaleman
 - emilvberglind
 - smg247
+reviewers:
+- bbguimaraes
+- droslean
+- hongkailiu
+- petr-muller
+- emilvberglind
+- smg247


### PR DESCRIPTION
This change will avoid selecting Steve, Alvaro and Alex from being assigned to PRs.
