### PR TITLE
sprint-automation: allow hiding issues from intake

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -342,9 +342,9 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 	responseChannel, responseTimestamp, err := slackClient.PostMessage(channelID, slack.MsgOptionText("Jira card digest.", false), slack.MsgOptionBlocks(blocks...))
 	if err != nil {
 		return fmt.Errorf("failed to post to channel: %w", err)
-	} else {
-		logrus.Infof("Posted team digest in channel %s at %s", responseChannel, responseTimestamp)
 	}
+
+	logrus.Infof("Posted team digest in channel %s at %s", responseChannel, responseTimestamp)
 	return nil
 }
 
@@ -380,9 +380,9 @@ func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, use
 	responseChannel, responseTimestamp, err := slackClient.PostMessage(userId, slack.MsgOptionText("Jira card digest.", false), slack.MsgOptionBlocks(blocks...))
 	if err != nil {
 		return fmt.Errorf("failed to message @dptp-intake: %w", err)
-	} else {
-		logrus.Infof("Posted intake digest in channel %s at %s", responseChannel, responseTimestamp)
 	}
+
+	logrus.Infof("Posted intake digest in channel %s at %s", responseChannel, responseTimestamp)
 	return nil
 }
 

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -349,7 +349,7 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 }
 
 func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, userId string) error {
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT labels=ready) AND created >= -30d AND status = "To Do"`, jira.ProjectDPTP), nil)
+	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT (labels=ready OR labels=no-intake)) AND created >= -30d AND status = "To Do"`, jira.ProjectDPTP), nil)
 	if err := jirautil.JiraError(response, err); err != nil {
 		return fmt.Errorf("could not query for Jira issues: %w", err)
 	}


### PR DESCRIPTION
It's useful when I'm breaking something down into cards, top-down. I don't
necessarily want to do it all at once. This label means I take responsibility
to finalize the card for intake to review it.
