### PR TITLE
Increase timeout for pulling image secrets

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1178,7 +1178,7 @@ func (o *options) initializeNamespace() error {
 
 	pullStart := time.Now()
 	var imagePullSecretsMinted bool
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 119; i++ {
 		imagePullSecretsMinted = true
 		serviceAccounts := map[string]*coreapi.ServiceAccount{
 			"builder": {},
@@ -1193,7 +1193,7 @@ func (o *options) initializeNamespace() error {
 		if imagePullSecretsMinted {
 			break
 		}
-		logrus.Debugf("[%d/30] Image pull secrets in namespace not yet ready, sleeping for a second...", i)
+		logrus.Debugf("[%d/120] Image pull secrets in namespace not yet ready, sleeping for a second...", i)
 		time.Sleep(time.Second)
 	}
 	logrus.Debugf("Spent %v waiting for image pull secrets to initialize in the new namespace.", time.Since(pullStart))


### PR DESCRIPTION
We have noticed that sometimes 31 seconds isn't enough , which can be
caused to some networking downtime, or just a service maintenance.

We think that 120s (2 min) is a good timeout value to wait for the
secrets to be available and after that raise an error.

We hope that this will cause less flaking errors in our CI jobs, when
pulling image secrets.

Example of the error:

```
[31mERRO[0m[2021-10-01T02:41:04Z] Timed out waiting for image pull secrets in the test namespace.
[36mINFO[0m[2021-10-01T02:41:04Z] Ran for 31s
[31mERRO[0m[2021-10-01T02:41:04Z] Some steps failed:
[31mERRO[0m[2021-10-01T02:41:04Z]
  * could not initialize namespace: timed out waiting for image pull secrets
```
