### PR TITLE
ignore aggregation result for generic upgrade test run

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -247,6 +247,11 @@ func testShouldAlwaysPass(name string) bool {
 			return true
 		}
 	}
+	if strings.Contains(name, `Cluster should remain functional during upgrade`) {
+		// this test is a side-effect of other tests.  For the purpose of aggregation, we can have each individual job run
+		// fail this test, but the aggregated output can be successful.
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
This test is a side-effect of other tests.  For the purpose of aggregation, we can have each individual job run fail this test, but the aggregated output can be successful.

