### PR TITLE
ci-operator: use lowercase login for setting up author RBAC

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1310,7 +1310,7 @@ func (o *options) initializeNamespace() error {
 func generateAuthorAccessRoleBinding(namespace string, authors []string) *rbacapi.RoleBinding {
 	var subjects []rbacapi.Subject
 	for _, author := range authors {
-		subjects = append(subjects, rbacapi.Subject{Kind: "Group", Name: author + api.GroupSuffix})
+		subjects = append(subjects, rbacapi.Subject{Kind: "Group", Name: strings.ToLower(author) + api.GroupSuffix})
 	}
 	return &rbacapi.RoleBinding{
 		ObjectMeta: meta.ObjectMeta{

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -844,6 +844,21 @@ func TestGenerateAuthorAccessRoleBinding(t *testing.T) {
 				},
 			},
 		},
+		{
+			id:      "gh username with uppercase is lowercased",
+			authors: []string{"USER"},
+			expected: &rbacapi.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-op-author-access",
+					Namespace: "ci-op-xxxx",
+				},
+				Subjects: []rbacapi.Subject{{Kind: "Group", Name: "user-group"}},
+				RoleRef: rbacapi.RoleRef{
+					Kind: "ClusterRole",
+					Name: "admin",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Looks like our group data source is feeding us lowecase variants of GH usernames, our groups are all lowecase. See e.g.:

```console
$ b01 get group alexnpavel-group
NAME               USERS
alexnpavel-group   alexnpavel, apavel
```

Therefore we need to use lowecase in ci-operator when setting up author RBAC.