### PR TITLE
ci-op: fix rolebinding/ci-op-author-access creating

### DIFF
--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -844,6 +844,21 @@ func TestGenerateAuthorAccessRoleBinding(t *testing.T) {
 				},
 			},
 		},
+		{
+			id:      "no duplicated authors",
+			authors: []string{"a", "a"},
+			expected: &rbacapi.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-op-author-access",
+					Namespace: "ci-op-xxxx",
+				},
+				Subjects: []rbacapi.Subject{{Kind: "Group", Name: "a-group"}},
+				RoleRef: rbacapi.RoleRef{
+					Kind: "ClusterRole",
+					Name: "admin",
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- remove the loop on authors: this bug should have been there before the group support feature. This should help https://coreos.slack.com/archives/CEKNRGF25/p1633445908185500
- handle the duplicated authors. https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1445412322951565312/artifacts/initial/ci-operator.log Not sure where the authors came from though.

/cc @openshift/test-platform 