### PR TITLE
prowgen: sort test fixtures

### DIFF
--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_a_ure_2_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_a_ure_2_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-azure-2
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_2_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_2_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-aws-2
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-aws
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_aws_cpaas_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-aws-cpaas
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_cluster_claim.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_cluster_claim.yaml
@@ -1,11 +1,11 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
   - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
-  - --target=test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
   - --secret-dir=/secrets/ci-pull-credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -15,32 +15,32 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /secrets/ci-pull-credentials
+    name: ci-pull-credentials
+    readOnly: true
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /secrets/hive-hive-credentials
+    name: hive-hive-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /secrets/ci-pull-credentials
-    name: ci-pull-credentials
-    readOnly: true
-  - mountPath: /secrets/hive-hive-credentials
-    name: hive-hive-credentials
-    readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
 - name: hive-hive-credentials
   secret:
     secretName: hive-hive-credentials
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_gcp_2_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_gcp_2_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -51,9 +51,9 @@ volumes:
         name: cluster-secrets-gcp-openshift-gce-devel-ci-2
     - configMap:
         name: cluster-profile-gcp-openshift-gce-devel-ci-2
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_hypershift_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_hypershift_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-hypershift
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_ibmcloud_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_ibmcloud_cluster_profile.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --lease-server-credentials-file=/etc/boskos/credentials
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/secrets/ci-pull-credentials
   - --secret-dir=/usr/local/test-cluster-profile
-  - --lease-server-credentials-file=/etc/boskos/credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,31 +16,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
+  - mountPath: /etc/boskos
+    name: boskos
     readOnly: true
   - mountPath: /secrets/ci-pull-credentials
     name: ci-pull-credentials
     readOnly: true
   - mountPath: /usr/local/test-cluster-profile
     name: cluster-profile
-  - mountPath: /etc/boskos
-    name: boskos
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
@@ -49,9 +49,9 @@ volumes:
     sources:
     - secret:
         name: cluster-secrets-ibmcloud
-- name: boskos
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_test_step_with_lease.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_test_step_with_lease.yaml
@@ -1,11 +1,11 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/secrets/ci-pull-credentials
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/secrets/ci-pull-credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -15,35 +15,35 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /secrets/ci-pull-credentials
+    name: ci-pull-credentials
+    readOnly: true
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /secrets/ci-pull-credentials
-    name: ci-pull-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- name: ci-pull-credentials
-  secret:
-    secretName: ci-pull-credentials
 - name: boskos
   secret:
     items:
     - key: credentials
       path: credentials
     secretName: boskos-credentials
+- name: ci-pull-credentials
+  secret:
+    secretName: ci-pull-credentials
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_test_with_lease.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecMultiStage_test_with_lease.yaml
@@ -1,11 +1,11 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/secrets/ci-pull-credentials
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/secrets/ci-pull-credentials
+  - --target=test
   command:
   - ci-operator
   image: ci-operator:latest
@@ -15,35 +15,35 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /secrets/ci-pull-credentials
+    name: ci-pull-credentials
+    readOnly: true
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /secrets/ci-pull-credentials
-    name: ci-pull-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- name: ci-pull-credentials
-  secret:
-    secretName: ci-pull-credentials
 - name: boskos
   secret:
     items:
     - key: credentials
       path: credentials
     secretName: boskos-credentials
+- name: ci-pull-credentials
+  secret:
+    secretName: ci-pull-credentials
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_0.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_0.yaml
@@ -1,10 +1,10 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-credentials-file=/etc/report/credentials
-  - --target=test
   - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
   - --template=/usr/local/test
   command:
   - ci-operator
@@ -13,10 +13,10 @@ containers:
     value: gcp
   - name: JOB_NAME_SAFE
     value: test
-  - name: TEST_COMMAND
-    value: commands
   - name: RPM_REPO_OPENSHIFT_ORIGIN
     value: https://artifacts-rpms-openshift-origin-ci-rpms.apps.ci.l2s4.p1.openshiftapps.com/openshift-origin-v4.0/
+  - name: TEST_COMMAND
+    value: commands
   image: ci-operator:latest
   imagePullPolicy: Always
   name: ""
@@ -24,31 +24,22 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-e2e.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-e2e.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-e2e
-  name: job-definition
 - name: cluster-profile
   projected:
     sources:
@@ -56,3 +47,12 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
+- configMap:
+    name: prow-job-cluster-launch-e2e
+  name: job-definition
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_1.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_1.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/usr/local/test-cluster-profile
-  - --template=/usr/local/test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
+  - --template=/usr/local/test
   command:
   - ci-operator
   env:
@@ -23,42 +23,42 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-e2e.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-installer-e2e.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-installer-e2e
-  name: job-definition
-- name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
 - name: boskos
   secret:
     items:
     - key: credentials
       path: credentials
     secretName: boskos-credentials
+- name: cluster-profile
+  projected:
+    sources:
+    - secret:
+        name: cluster-secrets-aws
+- configMap:
+    name: prow-job-cluster-launch-installer-e2e
+  name: job-definition
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_2.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/usr/local/test-cluster-profile
-  - --template=/usr/local/test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
+  - --template=/usr/local/test
   command:
   - ci-operator
   env:
@@ -25,34 +25,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-installer-custom-test-image
-  name: job-definition
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: cluster-profile
   projected:
     sources:
@@ -60,9 +57,12 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
-- name: boskos
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_3.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/usr/local/test-cluster-profile
-  - --template=/usr/local/test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
+  - --template=/usr/local/test
   command:
   - ci-operator
   env:
@@ -25,34 +25,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-installer-custom-test-image
-  name: job-definition
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: cluster-profile
   projected:
     sources:
@@ -60,9 +57,12 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
-- name: boskos
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_4.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_4.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/usr/local/test-cluster-profile
-  - --template=/usr/local/test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
+  - --template=/usr/local/test
   command:
   - ci-operator
   env:
@@ -25,34 +25,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-installer-custom-test-image
-  name: job-definition
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: cluster-profile
   projected:
     sources:
@@ -60,9 +57,12 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
-- name: boskos
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_5.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpecTemplate_testcase_5.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
-  - --target=test
-  - --secret-dir=/usr/local/test-cluster-profile
-  - --template=/usr/local/test
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --lease-server-credentials-file=/etc/boskos/credentials
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/usr/local/test-cluster-profile
+  - --target=test
+  - --template=/usr/local/test
   command:
   - ci-operator
   env:
@@ -25,34 +25,31 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /etc/boskos
+    name: boskos
+    readOnly: true
+  - mountPath: /usr/local/test-cluster-profile
+    name: cluster-profile
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /usr/local/test
+    name: job-definition
+    subPath: cluster-launch-installer-custom-test-image.yaml
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
-    readOnly: true
-  - mountPath: /etc/boskos
-    name: boskos
-    readOnly: true
-  - mountPath: /usr/local/test-cluster-profile
-    name: cluster-profile
-  - mountPath: /usr/local/test
-    name: job-definition
-    subPath: cluster-launch-installer-custom-test-image.yaml
 serviceAccountName: ci-operator
 volumes:
-- name: pull-secret
+- name: boskos
   secret:
-    secretName: registry-pull-credentials
-- name: result-aggregator
-  secret:
-    secretName: result-aggregator
-- configMap:
-    name: prow-job-cluster-launch-installer-custom-test-image
-  name: job-definition
+    items:
+    - key: credentials
+      path: credentials
+    secretName: boskos-credentials
 - name: cluster-profile
   projected:
     sources:
@@ -60,9 +57,12 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
-- name: boskos
+- configMap:
+    name: prow-job-cluster-launch-installer-custom-test-image
+  name: job-definition
+- name: pull-secret
   secret:
-    items:
-    - key: credentials
-      path: credentials
-    secretName: boskos-credentials
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_and_secret_are_included_in_podspec.yaml
@@ -1,12 +1,12 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --promote
+  - --report-credentials-file=/etc/report/credentials
+  - --secret-dir=/secrets/secret-name
   - --some=thing
   - --target=target
-  - --secret-dir=/secrets/secret-name
   command:
   - ci-operator
   image: ci-operator:latest
@@ -16,14 +16,14 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
     readOnly: true
   - mountPath: /secrets/secret-name
     name: secret-name

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_additional_args_are_included_in_podspec.yaml
@@ -1,9 +1,9 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
-  - --report-credentials-file=/etc/report/credentials
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --promote
+  - --report-credentials-file=/etc/report/credentials
   - --some=thing
   - --target=target
   command:
@@ -15,14 +15,14 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
     readOnly: true
 serviceAccountName: ci-operator
 volumes:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_multiple_targets.yaml
@@ -1,11 +1,11 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-credentials-file=/etc/report/credentials
-  - --target=target
-  - --target=more
   - --target=and-more
+  - --target=more
+  - --target=target
   command:
   - ci-operator
   image: ci-operator:latest
@@ -15,14 +15,14 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
     readOnly: true
 serviceAccountName: ci-operator
 volumes:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job.yaml
@@ -1,10 +1,10 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --oauth-token-path=/usr/local/github-credentials/oauth
   - --report-credentials-file=/etc/report/credentials
   - --target=target
-  - --oauth-token-path=/usr/local/github-credentials/oauth
   command:
   - ci-operator
   image: ci-operator:latest
@@ -14,26 +14,26 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
   - mountPath: /usr/local/github-credentials
     name: github-credentials-openshift-ci-robot-private-git-cloner
     readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: github-credentials-openshift-ci-robot-private-git-cloner
+  secret:
+    secretName: github-credentials-openshift-ci-robot-private-git-cloner
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator
-- name: github-credentials-openshift-ci-robot-private-git-cloner
-  secret:
-    secretName: github-credentials-openshift-ci-robot-private-git-cloner

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job_with_skip_cloning_false.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_private_job_with_skip_cloning_false.yaml
@@ -1,10 +1,10 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --oauth-token-path=/usr/local/github-credentials/oauth
   - --report-credentials-file=/etc/report/credentials
   - --target=target
-  - --oauth-token-path=/usr/local/github-credentials/oauth
   command:
   - ci-operator
   image: ci-operator:latest
@@ -14,17 +14,17 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
-  - mountPath: /etc/report
-    name: result-aggregator
-    readOnly: true
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
   - mountPath: /usr/local/github-credentials
     name: github-credentials-openshift-ci-robot-private-git-cloner
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
     readOnly: true
 serviceAccountName: ci-operator
 volumes:

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_standard_use_case.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePodSpec_standard_use_case.yaml
@@ -1,7 +1,7 @@
 containers:
 - args:
-  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
   - --report-credentials-file=/etc/report/credentials
   - --target=target
   command:
@@ -13,14 +13,14 @@ containers:
     requests:
       cpu: 10m
   volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
-    readOnly: true
-  - mountPath: /secrets/gcs
-    name: gcs-credentials
     readOnly: true
 serviceAccountName: ci-operator
 volumes:


### PR DESCRIPTION
This change only changes the test data to make changes in
https://github.com/openshift/ci-tools/pull/2284 smaller. The changes in
that PR use the same sorting code in actual prowgen.

Sort:
- Parameters (ci-operator does not have positional arguments, so it is
  safe do do so as long as all params are in `--key=value` form)
- Envvars by name
- Volume mounts by volume name
- Volumes by name
