### PR TITLE
Add QE's e2e tests into testgrid

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -329,7 +329,8 @@ func main() {
 				strings.Contains(name, "-origin-"),
 				// these prefixes control whether a job is ocp or okd going forward
 				strings.HasPrefix(name, "periodic-ci-openshift-release-master-ci-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"):
+				strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"),
+				strings.HasPrefix(name, "periodic-ci-openshift-verification-tests-master-"):
 				stream = "ocp"
 			case strings.Contains(name, "-okd-"):
 				stream = "okd"


### PR DESCRIPTION
We add QE's tests into `_allow-list.yaml` in https://github.com/openshift/release/pull/21706
but it is failing with `unrecognized release type in job` in https://prow.ci.openshift.org/log?job=periodic-prow-auto-testgrid-generator&id=1446264366310625280