### PR TITLE
promoted-image-governor: add logs after istag on app.ci is deleted

### DIFF
--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -555,6 +555,7 @@ func main() {
 		}); err != nil {
 			errs = append(errs, err)
 		}
+		logrus.WithField("tag", tag.ISTagName()).Info("image stream tag is deleted")
 	}
 	if len(errs) > 0 {
 		logrus.WithError(utilerrors.NewAggregate(errs)).Fatal("could not delete tags")


### PR DESCRIPTION
/cc @openshift/test-platform 