### PR TITLE
[schedule-generator] add the ability to validate the schedule configuration

### DIFF
--- a/cmd/branchingconfigmanagers/schedule-generator/main_test.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/main_test.go
@@ -2,7 +2,13 @@ package main
 
 import (
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -12,4 +18,103 @@ func TestReadSchedules(t *testing.T) {
 		t.Fatalf("could not read schedules: %v", err)
 	}
 	testhelper.CompareWithFixture(t, config)
+}
+
+func TestValidateSchedules(t *testing.T) {
+	testCases := []struct {
+		name           string
+		config         ocplifecycle.Config
+		expectedErrors string
+	}{
+		{
+			name: "happy case",
+			config: ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.9": {
+						{
+							Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+							When:  &metav1.Time{Time: time.Date(2000, 5, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventCodeFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 4, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventFeatureFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 3, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventOpen,
+							When:  &metav1.Time{Time: time.Date(2000, 2, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "sad case, dates are not sorted",
+			config: ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.9": {
+						{
+							Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+							When:  &metav1.Time{Time: time.Date(2000, 1, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventCodeFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 4, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventFeatureFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 3, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventOpen,
+							When:  &metav1.Time{Time: time.Date(2000, 2, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+					},
+				},
+			},
+			expectedErrors: "version 4.9: event `code-freeze` date is after event `generally-available`",
+		},
+		{
+			name: "sad case, unknown event",
+			config: ocplifecycle.Config{
+				"ocp": map[string][]ocplifecycle.LifecyclePhase{
+					"4.9": {
+						{
+							Event: "beer festival",
+							When:  &metav1.Time{Time: time.Date(2000, 5, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventCodeFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 4, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventFeatureFreeze,
+							When:  &metav1.Time{Time: time.Date(2000, 3, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventOpen,
+							When:  &metav1.Time{Time: time.Date(2000, 2, 1, 0, 0, 0, 0, metav1.Now().Location())},
+						},
+					},
+				},
+			},
+			expectedErrors: "unknown event: beer festival",
+		},
+	}
+
+	for _, tc := range testCases {
+		err := validateSchedules(tc.config)
+		if err == nil && tc.expectedErrors != "" {
+			t.Fatalf("expected error: %s but got nil", tc.expectedErrors)
+		}
+
+		if err != nil {
+			if diff := cmp.Diff(tc.expectedErrors, err.Error()); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+	}
 }

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.1.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.1.yaml
@@ -6,7 +6,7 @@ events:
     date: "2020-05-05T16:00:00Z"
   - name: "end-of-full-support"
     date: "2019-11-16T16:00:00Z"
-  - name: "general-availability"
+  - name: "generally-available"
     date: "2019-06-04T16:00:00Z"
   - name: "code-freeze"
     date: "2019-05-01T02:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.2.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.2.yaml
@@ -6,7 +6,7 @@ events:
     date: "2050-07-13T16:00:00Z"
   - name: "end-of-full-support"
     date: "2050-02-23T16:00:00Z"
-  - name: "general-availability"
+  - name: "generally-available"
     date: "2019-10-16T16:00:00Z"
   - name: "code-freeze"
     date: "2019-09-20T02:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.3.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/schedules/4.3.yaml
@@ -6,7 +6,7 @@ events:
     date: "2050-10-27T16:00:00Z"
   - name: "end-of-full-support"
     date: "2050-06-05T16:00:00Z"
-  - name: "general-availability"
+  - name: "generally-available"
     date: "2050-01-15T16:00:00Z"
   - name: "code-freeze"
     date: "2019-12-13T02:00:00Z"

--- a/cmd/branchingconfigmanagers/schedule-generator/testdata/zz_fixture_TestReadSchedules.yaml
+++ b/cmd/branchingconfigmanagers/schedule-generator/testdata/zz_fixture_TestReadSchedules.yaml
@@ -1,7 +1,9 @@
 ocp:
   "4.1":
-  - event: end-of-life
+  - event: end-of-maintenance-support
     when: "2020-05-05T16:00:00Z"
+  - event: end-of-full-support
+    when: "2019-11-16T16:00:00Z"
   - event: generally-available
     when: "2019-06-04T16:00:00Z"
   - event: code-freeze
@@ -11,7 +13,10 @@ ocp:
   - event: open
     when: "2019-04-27T00:00:00Z"
   "4.2":
-  - event: end-of-life
+  - event: end-of-maintenance-support
+    when: "2050-07-13T16:00:00Z"
+  - event: end-of-full-support
+    when: "2050-02-23T16:00:00Z"
   - event: generally-available
     when: "2019-10-16T16:00:00Z"
   - event: code-freeze
@@ -21,8 +26,12 @@ ocp:
   - event: open
     when: "2019-05-13T00:00:00Z"
   "4.3":
-  - event: end-of-life
+  - event: end-of-maintenance-support
+    when: "2050-10-27T16:00:00Z"
+  - event: end-of-full-support
+    when: "2050-06-05T16:00:00Z"
   - event: generally-available
+    when: "2050-01-15T16:00:00Z"
   - event: code-freeze
     when: "2020-12-13T02:00:00Z"
   - event: feature-freeze

--- a/cmd/branchingconfigmanagers/schedule-generator/types.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/types.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"sort"
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/ci-tools/pkg/api/ocplifecycle"
@@ -13,59 +9,19 @@ import (
 // Schedule holds events for a version
 type Schedule struct {
 	// Version is the version that this schedule applies to
-	Version Version `json:"version"`
+	Version ocplifecycle.MajorMinor `json:"version"`
 	// Events are the events for this schedule
 	Events []Event `json:"events,omitempty"`
-}
-
-// Version specifies an OCP release
-type Version struct {
-	// Major is the major version
-	Major int `json:"major"`
-	// Minor is the minor version
-	Minor int `json:"minor"`
 }
 
 // Event is a moment in the schedule we care about
 type Event struct {
 	// Name is the event we are specifying
-	Name LifecycleEvent `json:"name"`
+	Name ocplifecycle.LifecycleEvent `json:"name"`
 	// Date is the published date for this event
 	Date *metav1.Time `json:"date"`
 	// DisplayDate is the date at which automation should actually switch over
 	DisplayDate *metav1.Time `json:"display_date,omitempty"`
-}
-
-type LifecycleEvent string
-
-const (
-	// LifecycleEventOpen marks the moment that development branches open for changes.
-	LifecycleEventOpen LifecycleEvent = "open"
-	// LifecycleEventFeatureFreeze marks the moment that development branches close for new features.
-	// At this point it is expected that only stabilizing bug-fixes land in the branches.
-	LifecycleEventFeatureFreeze LifecycleEvent = "feature-freeze"
-	// LifecycleEventCodeFreeze marks the moment that development branches close for contribution.
-	// At this point it is expected that only urgent stabilizing bug-fixes land in the branches.
-	LifecycleEventCodeFreeze LifecycleEvent = "code-freeze"
-	// LifecycleEventGenerallyAvailable marks the moment that a version is available and the development
-	// branches begin to track the next release.
-	LifecycleEventGenerallyAvailable LifecycleEvent = "general-availability"
-	// LifecycleEventEndOfFullSupport marks the moment that a version is no longer supported fully.
-	LifecycleEventEndOfFullSupport LifecycleEvent = "end-of-full-support"
-	// LifecycleEventEndOfMaintenanceSupport marks the moment that a version is no longer supported.
-	LifecycleEventEndOfMaintenanceSupport LifecycleEvent = "end-of-maintenance-support"
-)
-
-func lifecycleEventFor(event LifecycleEvent) (ocplifecycle.LifecycleEvent, bool) {
-	mapping := map[LifecycleEvent]ocplifecycle.LifecycleEvent{
-		LifecycleEventOpen:                    ocplifecycle.LifecycleEventOpen,
-		LifecycleEventFeatureFreeze:           ocplifecycle.LifecycleEventFeatureFreeze,
-		LifecycleEventCodeFreeze:              ocplifecycle.LifecycleEventCodeFreeze,
-		LifecycleEventGenerallyAvailable:      ocplifecycle.LifecycleEventGenerallyAvailable,
-		LifecycleEventEndOfMaintenanceSupport: ocplifecycle.LifecycleEventEndOfLife,
-	}
-	mapped, exists := mapping[event]
-	return mapped, exists
 }
 
 const productOCP = "ocp"
@@ -79,28 +35,18 @@ func addToConfig(schedule Schedule, config *ocplifecycle.Config) *ocplifecycle.C
 	}
 	var phases []ocplifecycle.LifecyclePhase
 	for _, event := range schedule.Events {
-		phase, ok := lifecycleEventFor(event.Name)
-		if !ok {
-			continue
-		}
 		var date *metav1.Time
 		if event.DisplayDate != nil {
 			date = event.DisplayDate
 		} else {
 			date = event.Date
 		}
-		if time.Now().Before(date.Time) {
-			// we cannot expose future dates
-			date = nil
-		}
 		phases = append(phases, ocplifecycle.LifecyclePhase{
-			Event: phase,
+			Event: event.Name,
 			When:  date,
 		})
 	}
-	sort.Slice(phases, func(i, j int) bool {
-		return phases[j].When.Before(phases[i].When)
-	})
-	(*config)[productOCP][fmt.Sprintf("%d.%d", schedule.Version.Major, schedule.Version.Minor)] = phases
+
+	(*config)[productOCP][schedule.Version.String()] = phases
 	return config
 }

--- a/cmd/branchingconfigmanagers/schedule-generator/types_test.go
+++ b/cmd/branchingconfigmanagers/schedule-generator/types_test.go
@@ -20,8 +20,8 @@ func TestAddToConfig(t *testing.T) {
 		{
 			name: "nil config in",
 			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
-				Events:  []Event{{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}}},
+				Version: ocplifecycle.MajorMinor{Major: 4, Minor: 1},
+				Events:  []Event{{Name: ocplifecycle.LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}}},
 			},
 			config: nil,
 			expected: &ocplifecycle.Config{
@@ -36,8 +36,8 @@ func TestAddToConfig(t *testing.T) {
 		{
 			name: "updates existing date",
 			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
-				Events:  []Event{{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}}},
+				Version: ocplifecycle.MajorMinor{Major: 4, Minor: 1},
+				Events:  []Event{{Name: ocplifecycle.LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}}},
 			},
 			config: &ocplifecycle.Config{
 				"ocp": map[string][]ocplifecycle.LifecyclePhase{
@@ -59,38 +59,43 @@ func TestAddToConfig(t *testing.T) {
 		{
 			name: "adds new date",
 			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
+				Version: ocplifecycle.MajorMinor{Major: 4, Minor: 1},
 				Events: []Event{
-					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
-					{Name: LifecycleEventGenerallyAvailable, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}},
+					{Name: ocplifecycle.LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
+					{Name: ocplifecycle.LifecycleEventGenerallyAvailable, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}},
 				},
 			},
 			config: &ocplifecycle.Config{
 				"ocp": map[string][]ocplifecycle.LifecyclePhase{
-					"4.1": {{
-						Event: ocplifecycle.LifecycleEventOpen,
-						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
-					}},
+					"4.1": {
+						{
+							Event: ocplifecycle.LifecycleEventOpen,
+							When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+						},
+					},
 				},
 			},
 			expected: &ocplifecycle.Config{
 				"ocp": map[string][]ocplifecycle.LifecyclePhase{
-					"4.1": {{
-						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
-						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
-					}, {
-						Event: ocplifecycle.LifecycleEventOpen,
-						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
-					}},
+					"4.1": {
+						{
+							Event: ocplifecycle.LifecycleEventOpen,
+							When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
+						},
+						{
+							Event: ocplifecycle.LifecycleEventGenerallyAvailable,
+							When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
+						},
+					},
 				},
 			},
 		},
 		{
 			name: "adds new version",
 			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
+				Version: ocplifecycle.MajorMinor{Major: 4, Minor: 1},
 				Events: []Event{
-					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
+					{Name: ocplifecycle.LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
 				},
 			},
 			config: &ocplifecycle.Config{
@@ -108,40 +113,6 @@ func TestAddToConfig(t *testing.T) {
 						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
 					}},
 					"4.1": {{
-						Event: ocplifecycle.LifecycleEventOpen,
-						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
-					}},
-				},
-			},
-		},
-		{
-			name: "all mappings, output sorted correctly",
-			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
-				Events: []Event{
-					{Name: LifecycleEventOpen, Date: &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)}},
-					{Name: LifecycleEventFeatureFreeze, Date: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)}},
-					{Name: LifecycleEventCodeFreeze, Date: &metav1.Time{Time: time.Date(3, 3, 3, 3, 3, 3, 3, time.UTC)}},
-					{Name: LifecycleEventGenerallyAvailable, Date: &metav1.Time{Time: time.Date(4, 4, 4, 4, 4, 4, 4, time.UTC)}},
-					{Name: LifecycleEventEndOfFullSupport, Date: &metav1.Time{Time: time.Date(5, 5, 5, 5, 5, 5, 5, time.UTC)}},
-					{Name: LifecycleEventEndOfMaintenanceSupport, Date: &metav1.Time{Time: time.Date(6, 6, 6, 6, 6, 6, 6, time.UTC)}},
-				},
-			},
-			expected: &ocplifecycle.Config{
-				"ocp": map[string][]ocplifecycle.LifecyclePhase{
-					"4.1": {{
-						Event: ocplifecycle.LifecycleEventEndOfLife,
-						When:  &metav1.Time{Time: time.Date(6, 6, 6, 6, 6, 6, 6, time.UTC)},
-					}, {
-						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
-						When:  &metav1.Time{Time: time.Date(4, 4, 4, 4, 4, 4, 4, time.UTC)},
-					}, {
-						Event: ocplifecycle.LifecycleEventCodeFreeze,
-						When:  &metav1.Time{Time: time.Date(3, 3, 3, 3, 3, 3, 3, time.UTC)},
-					}, {
-						Event: ocplifecycle.LifecycleEventFeatureFreeze,
-						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
-					}, {
 						Event: ocplifecycle.LifecycleEventOpen,
 						When:  &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
 					}},
@@ -151,9 +122,9 @@ func TestAddToConfig(t *testing.T) {
 		{
 			name: "prefers display date",
 			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
+				Version: ocplifecycle.MajorMinor{Major: 4, Minor: 1},
 				Events: []Event{{
-					Name:        LifecycleEventOpen,
+					Name:        ocplifecycle.LifecycleEventOpen,
 					Date:        &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
 					DisplayDate: &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
 				}},
@@ -164,30 +135,6 @@ func TestAddToConfig(t *testing.T) {
 					"4.1": {{
 						Event: ocplifecycle.LifecycleEventOpen,
 						When:  &metav1.Time{Time: time.Date(2, 2, 2, 2, 2, 2, 2, time.UTC)},
-					}},
-				},
-			},
-		},
-		{
-			name: "hides future dates",
-			schedule: Schedule{
-				Version: Version{Major: 4, Minor: 1},
-				Events: []Event{{
-					Name:        LifecycleEventOpen,
-					Date:        &metav1.Time{Time: time.Date(1, 1, 1, 1, 1, 1, 1, time.UTC)},
-					DisplayDate: &metav1.Time{Time: time.Date(9999, 2, 2, 2, 2, 2, 2, time.UTC)},
-				}, {
-					Name: LifecycleEventGenerallyAvailable,
-					Date: &metav1.Time{Time: time.Date(9999, 1, 1, 1, 1, 1, 1, time.UTC)},
-				}},
-			},
-			config: nil,
-			expected: &ocplifecycle.Config{
-				"ocp": map[string][]ocplifecycle.LifecyclePhase{
-					"4.1": {{
-						Event: ocplifecycle.LifecycleEventOpen,
-					}, {
-						Event: ocplifecycle.LifecycleEventGenerallyAvailable,
 					}},
 				},
 			},

--- a/pkg/api/ocplifecycle/ocplifecycle.go
+++ b/pkg/api/ocplifecycle/ocplifecycle.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Config is an OCP lifecycle config. It holds a top-level product key (e.G. OCP)
@@ -38,11 +39,32 @@ const (
 	// LifecycleEventEndOfLife marks the moment that a version is no longer supported and release branches
 	// close for good for this version.
 	LifecycleEventEndOfLife LifecycleEvent = "end-of-life"
+	// LifecycleEventEndOfFullSupport marks the moment that a version is no longer supported fully.
+	LifecycleEventEndOfFullSupport LifecycleEvent = "end-of-full-support"
+	// LifecycleEventEndOfMaintenanceSupport marks the moment that a version is no longer supported.
+	LifecycleEventEndOfMaintenanceSupport LifecycleEvent = "end-of-maintenance-support"
 )
 
+func (le LifecycleEvent) Validate() error {
+	events := sets.NewString([]string{
+		string(LifecycleEventOpen),
+		string(LifecycleEventFeatureFreeze),
+		string(LifecycleEventCodeFreeze),
+		string(LifecycleEventGenerallyAvailable),
+		string(LifecycleEventEndOfLife),
+		string(LifecycleEventEndOfFullSupport),
+		string(LifecycleEventEndOfMaintenanceSupport),
+	}...)
+
+	if !events.Has(string(le)) {
+		return fmt.Errorf("unknown event: %s", le)
+	}
+	return nil
+}
+
 type MajorMinor struct {
-	Major int
-	Minor int
+	Major int `json:"major"`
+	Minor int `json:"minor"`
 }
 
 func (m MajorMinor) WithIncrementedMinor(increment int) MajorMinor {


### PR DESCRIPTION
/cc @openshift/test-platform 

This PR adds adds the ability in the tool to validate the schedule configuration. There is also some refactoring that removes the duplicated types and the mapping and uses the general types in ocplifestyle instead.

For better reviewing, enable `Hide whitespace` option.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>