### PR TITLE
ci-operator: actually order topologically

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1782,9 +1782,6 @@ func nodeNames(nodes []*api.StepNode) []string {
 func topologicalSort(graph api.StepGraph) (api.OrderedStepList, []error) {
 	var ret api.OrderedStepList
 	var satisfied []api.StepLink
-	graph.IterateAllEdges(func(inner *api.StepNode) {
-		satisfied = append(satisfied, inner.Step.Creates()...)
-	})
 	seen := make(map[api.Step]struct{})
 	for len(graph) > 0 {
 		var changed bool
@@ -1802,6 +1799,7 @@ func topologicalSort(graph api.StepGraph) (api.OrderedStepList, []error) {
 				waiting = append(waiting, node)
 				continue
 			}
+			satisfied = append(satisfied, node.Step.Creates()...)
 			ret = append(ret, node)
 			seen[node.Step] = struct{}{}
 			changed = true

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -403,7 +403,7 @@ func TestBuildPartialGraph(t *testing.T) {
 			targetName: "[images]",
 			expectedErrors: []error{
 				errors.New("steps are missing dependencies"),
-				errors.New(`step [output::] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>`),
+				errors.New(`step [output::] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>, <&api.internalImageStreamTagLink{name:"pipeline", tag:"oc-bin-image", unsatisfiableError:""}>`),
 				errors.New(`step oc-bin-image is missing dependencies: "cli" is neither an imported nor a built image`),
 			},
 		},

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -417,7 +417,7 @@ func TestBuildPartialGraph(t *testing.T) {
 			}
 
 			// Apparently we only coincidentally validate the graph during the topologicalSort we do prior to printing it
-			_, errs := topologicalSort(graph)
+			_, errs := graph.TopologicalSort()
 			testhelper.Diff(t, "errors", errs, tc.expectedErrors, testhelper.EquateErrorMessage)
 		})
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -411,13 +411,13 @@ func TestBuildPartialGraph(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			steps, err := api.BuildPartialGraph(tc.input, []string{tc.targetName})
+			graph, err := api.BuildPartialGraph(tc.input, []string{tc.targetName})
 			if err != nil {
 				t.Fatalf("failed to build graph: %v", err)
 			}
 
 			// Apparently we only coincidentally validate the graph during the topologicalSort we do prior to printing it
-			_, errs := topologicalSort(steps)
+			_, errs := topologicalSort(graph)
 			testhelper.Diff(t, "errors", errs, tc.expectedErrors, testhelper.EquateErrorMessage)
 		})
 	}

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -175,12 +175,12 @@ func TestBuildGraph(t *testing.T) {
 	var testCases = []struct {
 		name   string
 		input  []Step
-		output []*StepNode
+		output StepGraph
 	}{
 		{
 			name:  "basic graph",
 			input: []Step{root, other, src, bin, testBin, rpm, unrelated, final},
-			output: []*StepNode{{
+			output: StepGraph{{
 				Step: root,
 				Children: []*StepNode{{
 					Step: src,
@@ -215,7 +215,7 @@ func TestBuildGraph(t *testing.T) {
 		{
 			name:  "duplicate links",
 			input: []Step{duplicateRoot, duplicateSrc},
-			output: []*StepNode{{
+			output: StepGraph{{
 				Step: duplicateRoot,
 				Children: []*StepNode{{
 					Step:     duplicateSrc,
@@ -263,14 +263,14 @@ func TestValidateGraph(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		expected bool
-		graph    []*StepNode
+		graph    StepGraph
 	}{{
 		name:     "empty graph",
 		expected: true,
 	}, {
 		name:     "valid graph",
 		expected: true,
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -282,7 +282,7 @@ func TestValidateGraph(t *testing.T) {
 	}, {
 		name:     "valid graph, duplicate steps",
 		expected: true,
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -297,7 +297,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}, {
 		name: "invalid graph",
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -312,7 +312,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}, {
 		name: "invalid graph, duplicate steps",
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &invalid0},
@@ -327,7 +327,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateGraph(tc.graph)
+			err := tc.graph.Validate()
 			if (err == nil) != tc.expected {
 				t.Errorf("got %v, want %v", err == nil, tc.expected)
 			}

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -19,7 +19,7 @@ type message struct {
 	stepDetails     api.CIOperatorStepDetails
 }
 
-func Run(ctx context.Context, graph []*api.StepNode) (*junit.TestSuites, []api.CIOperatorStepDetails, []error) {
+func Run(ctx context.Context, graph api.StepGraph) (*junit.TestSuites, []api.CIOperatorStepDetails, []error) {
 	var seen []api.StepLink
 	executionResults := make(chan message)
 	done := make(chan bool)


### PR DESCRIPTION
pkg/api: introduce names for step lists

The `[]*StepNode` type is used in several places to mean either a graph
(list of root vertices) or a flat list (topologically sorted).  This
commits gives these two distinct types.

---

Revert "Avoid printing error for step whose dependency lacks a dependency"

This reverts commit c675c3c4d3b86ad47a368ccb9e98abf34e501d04.

---

ci-operator: move `TopologicalSort` to `pkg/api`

---

Includes https://github.com/openshift/ci-tools/pull/2435.

https://issues.redhat.com/browse/DPTP-2261