### PR TITLE
ci-operator: detect cycles in the execution graph

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1782,9 +1782,6 @@ func nodeNames(nodes []*api.StepNode) []string {
 func topologicalSort(graph api.StepGraph) (api.OrderedStepList, []error) {
 	var ret api.OrderedStepList
 	var satisfied []api.StepLink
-	graph.IterateAllEdges(func(inner *api.StepNode) {
-		satisfied = append(satisfied, inner.Step.Creates()...)
-	})
 	seen := make(map[api.Step]struct{})
 	for len(graph) > 0 {
 		var changed bool
@@ -1802,6 +1799,7 @@ func topologicalSort(graph api.StepGraph) (api.OrderedStepList, []error) {
 				waiting = append(waiting, node)
 				continue
 			}
+			satisfied = append(satisfied, node.Step.Creates()...)
 			ret = append(ret, node)
 			seen[node.Step] = struct{}{}
 			changed = true

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -403,7 +403,7 @@ func TestBuildPartialGraph(t *testing.T) {
 			targetName: "[images]",
 			expectedErrors: []error{
 				errors.New("steps are missing dependencies"),
-				errors.New(`step [output::] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>`),
+				errors.New(`step [output::] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>, <&api.internalImageStreamTagLink{name:"pipeline", tag:"oc-bin-image", unsatisfiableError:""}>`),
 				errors.New(`step oc-bin-image is missing dependencies: "cli" is neither an imported nor a built image`),
 			},
 		},

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -417,7 +417,7 @@ func TestBuildPartialGraph(t *testing.T) {
 			}
 
 			// Apparently we only coincidentally validate the graph during the topologicalSort we do prior to printing it
-			_, errs := topologicalSort(graph)
+			_, errs := graph.TopologicalSort()
 			testhelper.Diff(t, "errors", errs, tc.expectedErrors, testhelper.EquateErrorMessage)
 		})
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -411,13 +411,13 @@ func TestBuildPartialGraph(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			steps, err := api.BuildPartialGraph(tc.input, []string{tc.targetName})
+			graph, err := api.BuildPartialGraph(tc.input, []string{tc.targetName})
 			if err != nil {
 				t.Fatalf("failed to build graph: %v", err)
 			}
 
 			// Apparently we only coincidentally validate the graph during the topologicalSort we do prior to printing it
-			_, errs := topologicalSort(steps)
+			_, errs := topologicalSort(graph)
 			testhelper.Diff(t, "errors", errs, tc.expectedErrors, testhelper.EquateErrorMessage)
 		})
 	}

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -281,6 +281,10 @@ func TestTopologicalSort(t *testing.T) {
 	img1 := fakeSortStep{name: "img1", requires: []string{"bin"}}
 	img2 := fakeSortStep{name: "img2", requires: []string{"root"}}
 	missing0 := fakeSortStep{name: "missing0", requires: []string{"missing1"}}
+	cycle0 := fakeSortStep{name: "cycle0"}
+	cycle1 := fakeSortStep{name: "cycle1", requires: []string{"cycle0", "cycle3"}}
+	cycle2 := fakeSortStep{name: "cycle2", requires: []string{"cycle0", "cycle1"}}
+	cycle3 := fakeSortStep{name: "cycle3", requires: []string{"cycle0", "cycle2"}}
 	for _, tc := range []struct {
 		name     string
 		steps    []Step
@@ -300,6 +304,14 @@ func TestTopologicalSort(t *testing.T) {
 			errors.New("steps are missing dependencies"),
 		},
 		steps: []Step{&missing0},
+	}, {
+		name: "cycle",
+		expected: []error{
+			errors.New("cycle in graph: cycle0 -> cycle1 -> cycle2 -> cycle3 -> cycle1"),
+			errors.New("cycle in graph: cycle0 -> cycle2 -> cycle3 -> cycle1 -> cycle2"),
+			errors.New("cycle in graph: cycle0 -> cycle3 -> cycle1 -> cycle2 -> cycle3"),
+		},
+		steps: []Step{&cycle0, &cycle1, &cycle2, &cycle3},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			steps := make([]Step, len(tc.steps))

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -175,12 +175,12 @@ func TestBuildGraph(t *testing.T) {
 	var testCases = []struct {
 		name   string
 		input  []Step
-		output []*StepNode
+		output StepGraph
 	}{
 		{
 			name:  "basic graph",
 			input: []Step{root, other, src, bin, testBin, rpm, unrelated, final},
-			output: []*StepNode{{
+			output: StepGraph{{
 				Step: root,
 				Children: []*StepNode{{
 					Step: src,
@@ -215,7 +215,7 @@ func TestBuildGraph(t *testing.T) {
 		{
 			name:  "duplicate links",
 			input: []Step{duplicateRoot, duplicateSrc},
-			output: []*StepNode{{
+			output: StepGraph{{
 				Step: duplicateRoot,
 				Children: []*StepNode{{
 					Step:     duplicateSrc,
@@ -263,14 +263,14 @@ func TestValidateGraph(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
 		expected bool
-		graph    []*StepNode
+		graph    StepGraph
 	}{{
 		name:     "empty graph",
 		expected: true,
 	}, {
 		name:     "valid graph",
 		expected: true,
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -282,7 +282,7 @@ func TestValidateGraph(t *testing.T) {
 	}, {
 		name:     "valid graph, duplicate steps",
 		expected: true,
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -297,7 +297,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}, {
 		name: "invalid graph",
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &valid1},
@@ -312,7 +312,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}, {
 		name: "invalid graph, duplicate steps",
-		graph: []*StepNode{{
+		graph: StepGraph{{
 			Step: &valid0,
 			Children: []*StepNode{
 				{Step: &invalid0},
@@ -327,7 +327,7 @@ func TestValidateGraph(t *testing.T) {
 		}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateGraph(tc.graph)
+			err := tc.graph.Validate()
 			if (err == nil) != tc.expected {
 				t.Errorf("got %v, want %v", err == nil, tc.expected)
 			}

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -19,7 +19,7 @@ type message struct {
 	stepDetails     api.CIOperatorStepDetails
 }
 
-func Run(ctx context.Context, graph []*api.StepNode) (*junit.TestSuites, []api.CIOperatorStepDetails, []error) {
+func Run(ctx context.Context, graph api.StepGraph) (*junit.TestSuites, []api.CIOperatorStepDetails, []error) {
 	var seen []api.StepLink
 	executionResults := make(chan message)
 	done := make(chan bool)


### PR DESCRIPTION
- [x] https://github.com/openshift/ci-tools/pull/2435
- [ ] https://github.com/openshift/ci-tools/pull/2436
- [ ] https://github.com/openshift/ci-tools/pull/2437
- [ ] https://github.com/openshift/ci-tools/pull/2438

---

Some cases are already incidentally detected (from [DPTP-2261](https://issues.redhat.com/browse/DPTP-2261)):

```yaml
build_root:
  image_stream_tag: {name: release, namespace: openshift, tag: golang-1.15}
images:
- {from: root, to: root}
resources: {'*': {requests: {cpu: 200m, memory: 200Mi}}}
```

```
$ ci-operator --unresolved-config config.yaml
INFO[2021-10-15T19:48:12Z] unset version 0
ERRO[2021-10-15T19:48:13Z] Failed to load arguments.                     error=invalid configuration: images[0]: duplicate image name 'root' (previously defined by field 'build_root')
```

But others are still possible:

```yaml
build_root:
  image_stream_tag: {name: release, namespace: openshift, tag: golang-1.15}
images:
- {from: i2, to: i0}
- {from: i0, to: i1}
- {from: i1, to: i2}
resources: {'*': {requests: {cpu: 200m, memory: 200Mi}}}
```

```
$ ci-operator --unresolved-config config.yaml
INFO[2021-10-15T19:50:42Z] unset version 0
INFO[2021-10-15T19:50:42Z] Resolved source https://github.com/openshift/ci-tools to master@62e2d51d
INFO[2021-10-15T19:50:46Z] Using namespace https://console.build01.ci.openshift.org/k8s/cluster/projects/bbguimaraes
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc020d80370 stack=[0xc020d80000, 0xc040d80000]
fatal error: stack overflow
```

With this change:

```
INFO[2021-10-15T19:52:12Z] unset version 0
INFO[2021-10-15T19:52:12Z] Resolved source https://github.com/openshift/ci-tools to master@62e2d51d
INFO[2021-10-15T19:52:15Z] Using namespace https://console.build01.ci.openshift.org/k8s/cluster/projects/bbguimaraes
INFO[2021-10-15T19:52:15Z] Ran for 2s
ERRO[2021-10-15T19:52:15Z] Some steps failed:
ERRO[2021-10-15T19:52:15Z]
  * could not sort nodes
  * cycle in graph: [input:root] -> src -> i0 -> i1 -> i2 -> i0
  * cycle in graph: [input:root] -> src -> i1 -> i2 -> i0 -> i1
  * cycle in graph: [input:root] -> src -> i2 -> i0 -> i1 -> i2
```

Includes https://github.com/openshift/ci-tools/pull/2437.

https://issues.redhat.com/browse/DPTP-2261