### PR TITLE
cluster-init: updatePromotedImageGovernor

### DIFF
--- a/cmd/cluster-init/main.go
+++ b/cmd/cluster-init/main.go
@@ -126,6 +126,7 @@ const (
 	ciOperator                 = "ci-operator"
 	buildFarm                  = "build-farm"
 	githubLdapUserGroupCreator = "github-ldap-user-group-creator"
+	promotedImageGovernor      = "promoted-image-governor"
 	ci                         = "ci"
 )
 

--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -55,6 +55,7 @@ func updateCiSecretBootstrapConfig(o options, c *secretbootstrap.Config) error {
 		updateDPTPControllerManagerSecret,
 		updateRehearseSecret,
 		updateGithubLdapUserGroupCreatorSecret,
+		updatePromotedImageGovernor,
 		updateChatBotSecret,
 		updateExistingRegistryPullCredentialsAllSecrets,
 		updateSecret(generateRegistryPushCredentialsSecret),
@@ -205,6 +206,14 @@ func updateRehearseSecret(c *secretbootstrap.Config, o options) error {
 func updateGithubLdapUserGroupCreatorSecret(c *secretbootstrap.Config, o options) error {
 	keyAndField := serviceAccountKubeconfigPath(githubLdapUserGroupCreator, o.clusterName)
 	return updateSecretItemContext(c, githubLdapUserGroupCreator, string(api.ClusterAPPCI), keyAndField, secretbootstrap.ItemContext{
+		Field: keyAndField,
+		Item:  buildUFarm,
+	})
+}
+
+func updatePromotedImageGovernor(c *secretbootstrap.Config, o options) error {
+	keyAndField := serviceAccountKubeconfigPath(promotedImageGovernor, o.clusterName)
+	return updateSecretItemContext(c, promotedImageGovernor, string(api.ClusterAPPCI), keyAndField, secretbootstrap.ItemContext{
 		Field: keyAndField,
 		Item:  buildUFarm,
 	})

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -186,6 +186,17 @@ secret_configs:
     name: github-ldap-user-group-creator
     namespace: ci
 - from:
+    sa.promoted-image-governor.build01.config:
+      field: sa.promoted-image-governor.build01.config
+      item: build_farm
+    sa.promoted-image-governor.newCluster.config:
+      field: sa.promoted-image-governor.newCluster.config
+      item: build_farm
+  to:
+  - cluster: app.ci
+    name: promoted-image-governor
+    namespace: ci
+- from:
     sa.ci-chat-bot.arm01.config:
       field: sa.ci-chat-bot.arm01.config
       item: ci-chat-bot

--- a/test/integration/cluster-init/create/input/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/input/core-services/ci-secret-bootstrap/_config.yaml
@@ -153,6 +153,14 @@ secret_configs:
         name: github-ldap-user-group-creator
         namespace: ci
   - from:
+      sa.promoted-image-governor.build01.config:
+        field: sa.promoted-image-governor.build01.config
+        item: build_farm
+    to:
+      - cluster: app.ci
+        name: promoted-image-governor
+        namespace: ci
+  - from:
       sa.ci-chat-bot.arm01.config:
         field: sa.ci-chat-bot.arm01.config
         item: ci-chat-bot

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -186,6 +186,17 @@ secret_configs:
     name: github-ldap-user-group-creator
     namespace: ci
 - from:
+    sa.promoted-image-governor.build01.config:
+      field: sa.promoted-image-governor.build01.config
+      item: build_farm
+    sa.promoted-image-governor.existingCluster.config:
+      field: sa.promoted-image-governor.existingCluster.config
+      item: build_farm
+  to:
+  - cluster: app.ci
+    name: promoted-image-governor
+    namespace: ci
+- from:
     sa.ci-chat-bot.arm01.config:
       field: sa.ci-chat-bot.arm01.config
       item: ci-chat-bot

--- a/test/integration/cluster-init/update/input/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/input/core-services/ci-secret-bootstrap/_config.yaml
@@ -160,6 +160,14 @@ secret_configs:
         name: github-ldap-user-group-creator
         namespace: ci
   - from:
+      sa.promoted-image-governor.build01.config:
+        field: sa.promoted-image-governor.build01.config
+        item: build_farm
+    to:
+      - cluster: app.ci
+        name: promoted-image-governor
+        namespace: ci
+  - from:
       sa.ci-chat-bot.arm01.config:
         field: sa.ci-chat-bot.arm01.config
         item: ci-chat-bot


### PR DESCRIPTION
Found the issue while working on https://github.com/openshift/release/pull/22861

```console
$ cluster=build03 make config_updater_vault_secret
...
{"component":"ci-secret-generator","error":"could not find context {build_farm sa.promoted-image-governor.build03.config [] false} in bootstrap config","file":"/go/src/github.com/openshift/ci-tools/cmd/ci-secret-generator/main.go:195","func":"main.main","level":"error","msg":"Invalid entry","severity":"error","time":"2021-10-20T13:14:19Z"}
```

/cc @openshift/test-platform 