### PR TITLE
pkg/steps: do not mutate decoration configuration

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -417,14 +417,15 @@ func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.
 	if clone {
 		// Unless build_root.from_repository: true is set, the decorationConfig the ci-operator pod gets has cloning
 		// disabled.
+		decorationConfig := *decorationConfig
 		decorationConfig.SkipCloning = nil
 
 		codeMount, codeVolume := decorate.CodeMountAndVolume()
-		cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Refs: jobSpec.Refs, ExtraRefs: jobSpec.ExtraRefs, DecorationConfig: decorationConfig}}, codeMount, logMount)
+		cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Refs: jobSpec.Refs, ExtraRefs: jobSpec.ExtraRefs, DecorationConfig: &decorationConfig}}, codeMount, logMount)
 		if err != nil {
 			return fmt.Errorf("failed to construct clonerefs: %w", err)
 		}
-		initUpload, err := decorate.InitUpload(decorationConfig, blobStorageOptions, blobStorageMounts, &logMount, nil, rawJobSpec)
+		initUpload, err := decorate.InitUpload(&decorationConfig, blobStorageOptions, blobStorageMounts, &logMount, nil, rawJobSpec)
 		if err != nil {
 			return fmt.Errorf("failed to get initUpload container: %w", err)
 		}


### PR DESCRIPTION
The Prow decoration configuration is used to generate all pods, so it
cannot be modified while other threads may be using it:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/2237/pull-ci-openshift-ci-tools-master-e2e/1424849578909241344#1:build-log.txt%3A513

The structure is 160 bytes of 14 pointers and 2 slices (three pointers
each themselves), so copying it should be just a reasonably-efficient
`memcpy`.

https://issues.redhat.com/browse/DPTP-2437