### PR TITLE
prowgen: mutator to make ci-op inject test from elsewhere

### DIFF
--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
@@ -1,0 +1,33 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  - --target=test-2
+  - --with-test-from=org-2/repo-2@branch-2__variant-2:test-2
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
@@ -1,0 +1,33 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  - --target=test-1
+  - --with-test-from=org-1/repo-1@branch-1:test-1
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator


### PR DESCRIPTION
Add a mutator for prowgen's podspec builder that adds the necessary parameter to ci-operator.