### PR TITLE
prevent NPE when missing prowjob in the GCS bucket

### DIFF
--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -221,6 +221,10 @@ func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// this can happen if there is no prowjob.json, so no work to do.
+	if jobRun == nil {
+		return nil
+	}
 
 	// TODO we *could* read to see if we've already uploaded this.  That doesn't see necessary based on how
 	//  we decide to pull the data to upload though.
@@ -263,6 +267,10 @@ func (o *jobRunLoaderOptions) readJobRunFromGCS(ctx context.Context) (jobrunaggr
 	jobRunInfo, err := o.gcsClient.ReadJobRunFromGCS(ctx, o.jobName, o.hobRunID)
 	if err != nil {
 		return nil, err
+	}
+	// this can happen if there is no prowjob.json
+	if jobRunInfo == nil {
+		return nil, nil
 	}
 	prowjob, err := jobRunInfo.GetProwJob(ctx)
 	if err != nil {


### PR DESCRIPTION
> Analyzing jobrun/periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial/1446020106684469248.
reading job run periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-techpreview-serial/1446020106684469248.
  removing "periodic-ci-openshift-release-master-nightly-4.10-e2e-azure"/"1450639311958446080" because it doesn't have a prowjob.json
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x1307f93]

> goroutine 1158 [running]:
github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader.(*jobRunLoaderOptions).readJobRunFromGCS(0xc00091f0e0, {0x1820608, 0xc000040020})
	/home/deads/workspaces/ci-tools/src/github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go:267 +0x73
github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader.(*jobRunLoaderOptions).Run(0xc00091f0e0, {0x1820608, 0xc000040020})
	/home/deads/workspaces/ci-tools/src/github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go:220 +0x14e
github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader.(*jobLoaderOptions).Run.func2()
	/home/deads/workspaces/ci-tools/src/github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go:163 +0xa5
created by github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader.(*jobLoaderOptions).Run
	/home/deads/workspaces/ci-tools/src/github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go:159 +0x2f6

/assign @stbenjam 
