### PR TITLE
payload-testing-prow-plugin: suport both TokenPath and AppPrivateKeyPath

### DIFF
--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -50,7 +50,17 @@ func main() {
 		logger.Fatalf("Invalid options: %v", err)
 	}
 
-	if err := secret.Add(o.github.TokenPath, o.webhookSecretFile); err != nil {
+	var tokens []string
+
+	if o.github.TokenPath != "" {
+		tokens = append(tokens, o.github.TokenPath)
+	}
+	if o.github.AppPrivateKeyPath != "" {
+		tokens = append(tokens, o.github.AppPrivateKeyPath)
+	}
+	tokens = append(tokens, o.webhookSecretFile)
+
+	if err := secret.Add(tokens...); err != nil {
 		logger.WithError(err).Fatal("Error starting secrets agent.")
 	}
 


### PR DESCRIPTION
Copy the code from
https://github.com/kubernetes/test-infra/blob/b0f4e02cfc169ad923af07a6574220b7942d3324/prow/cmd/hook/main.go#L118-L127

So that we support github App auth as well.

/cc @openshift/test-platform 