### PR TITLE
test-images-distributor: distribute int. streams

### DIFF
--- a/pkg/api/helper/imageextraction.go
+++ b/pkg/api/helper/imageextraction.go
@@ -23,6 +23,26 @@ func MergeImageStreamTagMaps(target ImageStreamTagMap, toMerge ...ImageStreamTag
 	}
 }
 
+func TestInputImageStreamsFromResolvedConfig(cfg api.ReleaseBuildConfiguration) []types.NamespacedName {
+	s := map[types.NamespacedName]struct{}{}
+	add := func(ns, name string) {
+		s[types.NamespacedName{Namespace: ns, Name: name}] = struct{}{}
+	}
+	if c := cfg.ReleaseTagConfiguration; c != nil {
+		add(c.Namespace, c.Name)
+	}
+	for _, r := range cfg.Releases {
+		if i := r.Integration; i != nil {
+			add(i.Namespace, i.Name)
+		}
+	}
+	var ret []types.NamespacedName
+	for k := range s {
+		ret = append(ret, k)
+	}
+	return ret
+}
+
 // TestInputImageStreamTagsFromResolvedConfig returns all ImageStreamTags referenced anywhere in the config as input.
 // It only returns their namespace and name and drops the cluster field, as we plan to remove that.
 // The key is in namespace/name format.

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -613,9 +613,8 @@ func indexConfigsByTestInputImageStreamTag(resolver registryResolver) agents.Ind
 		for key := range m {
 			result = append(result, key)
 		}
-
-		if cfg.ReleaseTagConfiguration != nil {
-			result = append(result, indexKeyForImageStream(cfg.ReleaseTagConfiguration.Namespace, cfg.ReleaseTagConfiguration.Name))
+		for _, r := range apihelper.TestInputImageStreamsFromResolvedConfig(cfg) {
+			result = append(result, indexKeyForImageStream(r.Namespace, r.Name))
 		}
 		return result
 	}

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -728,6 +728,45 @@ func TestTestInputImageStreamTagFilterFactory(t *testing.T) {
 			expectedResult: true,
 		},
 		{
+			name: "imagestream is referenced by integration stream",
+			config: api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						api.InitialReleaseName: {
+							Integration: &api.Integration{
+								Namespace: namespace,
+								Name:      streamName,
+							},
+						},
+						api.LatestReleaseName: {
+							Integration: &api.Integration{
+								Namespace:          namespace,
+								Name:               streamName,
+								IncludeBuiltImages: true,
+							},
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "imagestream is referenced by non-integration stream",
+			config: api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						api.LatestReleaseName: {
+							Release: &api.Release{
+								Version:      "v",
+								Channel:      api.ReleaseChannelStable,
+								Architecture: api.ReleaseArchitectureAMD64,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "imagestreamtag is referenced by imagestreamtag import",
 			client: fakeclient.NewFakeClient((&testimagestreamtagimportv1.TestImageStreamTagImport{Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{
 				Namespace: namespace,


### PR DESCRIPTION
`releases.*.integration` has supplanted `tag_specification`, but the
distributor has not been updated to distribute them yet.