### PR TITLE
[DPTP-2541] Initial implementation of the job-trigger-controller-manager

### DIFF
--- a/cmd/job-trigger-controller-manager/main.go
+++ b/cmd/job-trigger-controller-manager/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/bombsimon/logrusr"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/rest"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/logrusutil"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	prpqv1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+	"github.com/openshift/ci-tools/pkg/controller/prpqr_reconciler"
+)
+
+type options struct {
+	namespace string
+	dryRun    bool
+}
+
+func gatherOptions() (*options, error) {
+	o := &options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
+	fs.StringVar(&o.namespace, "namespace", "ci", "In which namespace the operation will take place")
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return o, fmt.Errorf("failed to parse flags: %w", err)
+	}
+	return o, nil
+}
+
+func main() {
+	logrusutil.ComponentInit()
+	controllerruntime.SetLogger(logrusr.NewLogger(logrus.StandardLogger()))
+
+	o, err := gatherOptions()
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to get options")
+	}
+
+	ctx := controllerruntime.SetupSignalHandler()
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to load in-cluster config")
+	}
+
+	mgr, err := controllerruntime.NewManager(cfg, controllerruntime.Options{
+		DryRunClient: o.dryRun,
+		Logger:       ctrlruntimelog.NullLogger{},
+	})
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to construct manager")
+	}
+
+	if err := prowv1.AddToScheme(mgr.GetScheme()); err != nil {
+		logrus.WithError(err).Fatal("Failed to add prowv1 to scheme")
+	}
+
+	if err := prpqv1.AddToScheme(mgr.GetScheme()); err != nil {
+		logrus.WithError(err).Fatal("Failed to add prpqv1 to scheme")
+	}
+
+	if err := prpqr_reconciler.AddToManager(mgr, o.namespace); err != nil {
+		logrus.WithError(err).Fatal("Failed to add prpqr_reconciler to manager")
+	}
+
+	if err := mgr.Start(ctx); err != nil {
+		logrus.WithError(err).Fatal("Manager ended with error")
+	}
+
+	logrus.Info("Process ended gracefully")
+}

--- a/pkg/api/pullrequestpayloadqualification/v1/types.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/types.go
@@ -7,6 +7,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
+const (
+	PullRequestPayloadQualificationRunLabel = "pullrequestpayloadqualificationruns.ci.openshift.io"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PullRequestPayloadQualificationRun represents the intent to run a battery of OCP release

--- a/pkg/api/pullrequestpayloadqualification/v1/types_test.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/types_test.go
@@ -1,0 +1,14 @@
+package v1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/steps/utils"
+)
+
+func TestPullRequestPayloadQualificationRunLabel(t *testing.T) {
+	if !reflect.DeepEqual(utils.Trim63(PullRequestPayloadQualificationRunLabel), PullRequestPayloadQualificationRunLabel) {
+		t.Fatalf("value of PullRequestPayloadQualificationRunLabel is too big")
+	}
+}

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
@@ -1,0 +1,123 @@
+package pjstatussyncer
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/types"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
+)
+
+const (
+	controllerName = "prowjob_status_syncer"
+)
+
+func AddToManager(mgr controllerruntime.Manager, ns string) error {
+	ctrl, err := controller.New(controllerName, mgr, controller.Options{
+		MaxConcurrentReconciles: 1,
+		Reconciler: &reconciler{
+			logger: logrus.WithField("controller", controllerName),
+
+			client: mgr.GetClient(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	// Watch only on updates
+	predicateFuncs := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool { return false },
+		DeleteFunc: func(event.DeleteEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if _, ok := e.ObjectNew.GetLabels()[v1.PullRequestPayloadQualificationRunLabel]; !ok {
+				return false
+			}
+
+			if e.ObjectNew.GetNamespace() != ns {
+				return false
+			}
+
+			return true
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+
+	if err := ctrl.Watch(source.NewKindWithCache(&prowv1.ProwJob{}, mgr.GetCache()), pjHandler(), predicateFuncs); err != nil {
+		return fmt.Errorf("failed to create watch: %w", err)
+	}
+
+	return nil
+}
+
+func pjHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) []reconcile.Request {
+		pj, ok := o.(*prowv1.ProwJob)
+		if !ok {
+			logrus.WithField("type", fmt.Sprintf("%T", o)).Error("Got object that was not a ProwJob")
+			return nil
+		}
+
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}},
+		}
+	})
+}
+
+var _ reconcile.Reconciler = &reconciler{}
+
+type reconciler struct {
+	logger *logrus.Entry
+	client ctrlruntimeclient.Client
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request controllerruntime.Request) (controllerruntime.Result, error) {
+	log := r.logger.WithField("request", request.String())
+	err := r.reconcile(ctx, log, request)
+	if err != nil {
+		log.WithError(err).Error("Reconciliation failed")
+	}
+	return reconcile.Result{}, controllerutil.SwallowIfTerminal(err)
+}
+
+func (r *reconciler) reconcile(ctx context.Context, log *logrus.Entry, req controllerruntime.Request) error {
+	logger := log.WithField("namespace", req.Namespace).WithField("name", req.Name)
+	logger.Info("Starting reconciliation")
+
+	pj := &prowv1.ProwJob{}
+	if err := r.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: req.Namespace, Name: req.Name}, pj); err != nil {
+		return fmt.Errorf("failed to get the ProwJob: %s in namespace %s: %w", req.Name, req.Namespace, err)
+	}
+
+	prpqrName := pj.Labels[v1.PullRequestPayloadQualificationRunLabel]
+	prpqr := &v1.PullRequestPayloadQualificationRun{}
+	if err := r.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: req.Namespace, Name: prpqrName}, prpqr); err != nil {
+		return fmt.Errorf("failed to get the PullRequestPayloadQualificationRun: %s in namespace %s: %w", prpqrName, req.Namespace, err)
+	}
+	for i, job := range prpqr.Status.Jobs {
+		if job.ProwJob == pj.Name && !reflect.DeepEqual(pj.Status, job.Status) {
+			prpqr.Status.Jobs[i].Status = pj.Status
+
+			logger.WithField("to_state", pj.Status.State).Info("Updating PullRequestPayloadQualificationRun...")
+			if err := r.client.Update(ctx, prpqr); err != nil {
+				return fmt.Errorf("failed to update PullRequestPayloadQualificationRun %s: %w", prpqr.Name, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer_test.go
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer_test.go
@@ -1,0 +1,104 @@
+package pjstatussyncer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name        string
+		prowjobs    []ctrlruntimeclient.Object
+		pjMutations func(pj ctrlruntimeclient.Object, client ctrlruntimeclient.Client, t *testing.T)
+		prpqr       []ctrlruntimeclient.Object
+		expected    []v1.PullRequestPayloadQualificationRun
+	}{
+		{
+			name: "basic case",
+			prowjobs: []ctrlruntimeclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-pj", Namespace: "test-namespace", Labels: map[string]string{"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test"}},
+					Status:     prowv1.ProwJobStatus{StartTime: metav1.Time{Time: time.Now()}},
+				},
+			},
+			pjMutations: func(obj ctrlruntimeclient.Object, client ctrlruntimeclient.Client, t *testing.T) {
+				pj, _ := obj.(*prowv1.ProwJob)
+				pj.Status.State = prowv1.SuccessState
+
+				if err := client.Update(context.Background(), pj); err != nil {
+					t.Fatal(err)
+				}
+			},
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Status: v1.PullRequestPayloadTestStatus{
+						Jobs: []v1.PullRequestPayloadJobStatus{
+							{
+								ReleaseJobName: "release-job-name",
+								ProwJob:        "test-pj",
+								Status:         prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+							},
+						},
+					},
+				},
+			},
+
+			expected: []v1.PullRequestPayloadQualificationRun{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Status: v1.PullRequestPayloadTestStatus{
+						Jobs: []v1.PullRequestPayloadJobStatus{
+							{
+								ReleaseJobName: "release-job-name",
+								ProwJob:        "test-pj",
+								Status:         prowv1.ProwJobStatus{State: prowv1.SuccessState},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		r := &reconciler{
+			logger: logrus.WithField("test-name", tc.name),
+			client: fakectrlruntimeclient.NewClientBuilder().WithObjects(append(tc.prowjobs, tc.prpqr...)...).Build(),
+		}
+
+		for _, pj := range tc.prowjobs {
+			if tc.pjMutations != nil {
+				tc.pjMutations(pj, r.client, t)
+			}
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: pj.GetNamespace(), Name: pj.GetName()}}
+			if err := r.reconcile(context.Background(), r.logger, req); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		var actualPrpqr v1.PullRequestPayloadQualificationRunList
+		if err := r.client.List(context.Background(), &actualPrpqr); err != nil {
+			t.Fatal(err)
+		}
+
+		if diff := cmp.Diff(actualPrpqr.Items, tc.expected, cmpopts.IgnoreFields(prowv1.ProwJobStatus{}, "StartTime"), cmpopts.IgnoreFields(v1.PullRequestPayloadQualificationRun{}, "TypeMeta.Kind", "TypeMeta.APIVersion", "ResourceVersion")); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -1,0 +1,190 @@
+package prpqr_reconciler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pjutil"
+	utilpointer "k8s.io/utils/pointer"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+	"github.com/openshift/ci-tools/pkg/controller/prpqr_reconciler/pjstatussyncer"
+	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
+)
+
+const (
+	controllerName = "prpqr_reconciler"
+)
+
+func AddToManager(mgr manager.Manager, ns string) error {
+	if err := pjstatussyncer.AddToManager(mgr, ns); err != nil {
+		return fmt.Errorf("failed to construct pjstatussyncer: %w", err)
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		MaxConcurrentReconciles: 1,
+		Reconciler: &reconciler{
+			logger: logrus.WithField("controller", controllerName),
+			client: mgr.GetClient(),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to construct controller: %w", err)
+	}
+
+	// Watch only on Create events
+	predicateFuncs := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetNamespace() == ns
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+	if err := c.Watch(source.NewKindWithCache(&v1.PullRequestPayloadQualificationRun{}, mgr.GetCache()), prpqrHandler(), predicateFuncs); err != nil {
+		return fmt.Errorf("failed to create watch for PullRequestPayloadQualificationRun: %w", err)
+	}
+
+	return nil
+}
+
+func prpqrHandler() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(o ctrlruntimeclient.Object) []reconcile.Request {
+		prpqr, ok := o.(*v1.PullRequestPayloadQualificationRun)
+		if !ok {
+			logrus.WithField("type", fmt.Sprintf("%T", o)).Error("Got object that was not a PullRequestPayloadQualificationRun")
+			return nil
+		}
+
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Namespace: prpqr.Namespace, Name: prpqr.Name}},
+		}
+	})
+}
+
+type reconciler struct {
+	logger *logrus.Entry
+	client ctrlruntimeclient.Client
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := r.logger.WithField("request", req.String())
+	err := r.reconcile(ctx, req, logger)
+	if err != nil {
+		logger.WithError(err).Error("Reconciliation failed")
+	} else {
+		logger.Info("Finished reconciliation")
+	}
+	return reconcile.Result{}, controllerutil.SwallowIfTerminal(err)
+}
+
+func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logger *logrus.Entry) error {
+	logger = logger.WithField("namespace", req.Namespace).WithField("prpqr_name", req.Name)
+	logger.Info("Starting reconciliation")
+
+	prpqr := &v1.PullRequestPayloadQualificationRun{}
+	if err := r.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: req.Namespace, Name: req.Name}, prpqr); err != nil {
+		return fmt.Errorf("failed to get the PullRequestPayloadQualificationRun: %s in namespace %s: %w", req.Name, req.Namespace, err)
+	}
+
+	prowjobs := generateProwjobs(prpqr.Spec.PullRequest.Org, prpqr.Spec.PullRequest.Repo, prpqr.Spec.PullRequest.BaseRef, req.Name, req.Namespace)
+	for _, pj := range prowjobs {
+		logger = logger.WithFields(logrus.Fields{"name": pj.Name, "namespace": req.Namespace})
+
+		err := r.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: pj.Namespace, Name: pj.Name}, &prowv1.ProwJob{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get the PullRequestPayloadQualificationRun: %s in namespace %s: %w", req.Name, req.Namespace, err)
+		}
+
+		if !kerrors.IsNotFound(err) {
+			continue
+		}
+
+		logger.Info("Creating prowjob...")
+		if err := r.client.Create(ctx, &pj); err != nil {
+			return fmt.Errorf("failed to create prowjob: %w", err)
+		}
+
+		// There is some delay until it gets back to our cache, so block until we can retrieve
+		// it successfully.
+		key := ctrlruntimeclient.ObjectKey{Namespace: pj.Namespace, Name: pj.Name}
+		if err := wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+			if err := r.client.Get(ctx, key, &prowv1.ProwJob{}); err != nil {
+				if kerrors.IsNotFound(err) {
+					return false, nil
+				}
+				return false, fmt.Errorf("getting prowJob failed: %w", err)
+			}
+			return true, nil
+		}); err != nil {
+			return fmt.Errorf("failed to wait for created ProwJob to appear in cache: %w", err)
+		}
+
+		prpqr.Status.Jobs = append(prpqr.Status.Jobs, v1.PullRequestPayloadJobStatus{
+			ReleaseJobName: pj.Spec.Job,
+			ProwJob:        pj.Name,
+			Status:         pj.Status,
+		})
+
+		logger.Info("Updating PullRequestPayloadQualificationRun...")
+		if err := r.client.Update(ctx, prpqr); err != nil {
+			return fmt.Errorf("failed to update PullRequestPayloadQualificationRun %s: %w", prpqr.Name, err)
+		}
+
+	}
+	return nil
+}
+
+// TODO: Currently we create a single dummy prowjob just for testing. The actual implementation
+// will be introduced in https://issues.redhat.com/browse/DPTP-2577
+func generateProwjobs(org, repo, branch, prpqrName, prpqrNamespace string) []prowv1.ProwJob {
+	labels := map[string]string{
+		v1.PullRequestPayloadQualificationRunLabel: prpqrName,
+	}
+
+	base := prowconfig.JobBase{
+		Agent: string(prowv1.KubernetesAgent),
+		Name:  fmt.Sprintf("dummy-pj-for-%s", prpqrName),
+		Spec: &corev1.PodSpec{
+			Containers: []corev1.Container{{Image: "centos:8", Command: []string{"sleep"}, Args: []string{"100"}}},
+		},
+
+		UtilityConfig: prowconfig.UtilityConfig{
+			Decorate: utilpointer.BoolPtr(true),
+		},
+	}
+
+	extraRefs := prowv1.Refs{
+		Org:     org,
+		Repo:    repo,
+		BaseRef: branch,
+	}
+	base.ExtraRefs = []prowv1.Refs{extraRefs}
+
+	periodicJob := prowconfig.Periodic{
+		JobBase: base,
+		Cron:    "@yearly",
+	}
+
+	pj := pjutil.NewProwJob(pjutil.PeriodicSpec(periodicJob), labels, nil)
+	pj.Name = fmt.Sprintf("dummy-pj-for-%s", prpqrName)
+	pj.Namespace = prpqrNamespace
+	return []prowv1.ProwJob{pj}
+}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -1,0 +1,69 @@
+package prpqr_reconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+)
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name     string
+		prpqr    *v1.PullRequestPayloadQualificationRun
+		expected *v1.PullRequestPayloadQualificationRun
+	}{
+		{
+			name: "basic case",
+			prpqr: &v1.PullRequestPayloadQualificationRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+				Spec: v1.PullRequestPayloadTestSpec{
+					PullRequest: v1.PullRequestUnderTest{
+						Org:         "droslean",
+						Repo:        "test",
+						BaseRef:     "12345",
+						BaseSHA:     "123456",
+						PullRequest: v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}},
+					Jobs: v1.PullRequestPayloadJobSpec{
+						ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+						Jobs: []v1.ReleaseJobSpec{
+							{
+								CIOperatorConfig: api.Metadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"},
+								Test:             "test-name"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		r := &reconciler{
+			logger: logrus.WithField("test-name", tc.name),
+			client: fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.prpqr).Build(),
+		}
+		req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "test-namespace", Name: "prpqr-test"}}
+		if err := r.reconcile(context.Background(), req, r.logger); err != nil {
+			t.Fatal(err)
+		}
+		expectedProwjobs := generateProwjobs(tc.prpqr.Spec.PullRequest.Org, tc.prpqr.Spec.PullRequest.Repo, tc.prpqr.Spec.PullRequest.BaseRef, tc.prpqr.Name, tc.prpqr.Namespace)
+		var actualProwjobs prowv1.ProwJobList
+		if err := r.client.List(context.Background(), &actualProwjobs); err != nil {
+			t.Fatal(err)
+		}
+		if diff := cmp.Diff(actualProwjobs.Items, expectedProwjobs, cmpopts.IgnoreFields(prowv1.ProwJob{}, "ResourceVersion", "Status.StartTime")); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+}


### PR DESCRIPTION
/cc @openshift/test-platform 

The tool includes two controllers. The `prpqr_reconciler` is responsible to watch create events for `prpqr` objects. It generates the corresponding `prowjobs` and updates the Status of the `prpqr` object.

The `prowjob_status_syncer` controller is responsible to watch `prowjobs` update events that hold the `pullrequestpayloadqualificationruns.ci.openshift.io` label, and updating the status in the corresponding `prpqr` object.


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>