### PR TITLE
test injection: respect `releases.latest` in the base

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -128,8 +128,13 @@ func (config *ReleaseBuildConfiguration) WithPresubmitFrom(source *ReleaseBuildC
 		result.BaseImages[name] = isTagRef
 	}
 
+	var hasLatestRelease bool
+	if result.Releases != nil {
+		_, hasLatestRelease = result.Releases[LatestReleaseName]
+	}
+
 	for name, release := range source.Releases {
-		if name == "latest" && result.ReleaseTagConfiguration != nil {
+		if name == LatestReleaseName && (result.ReleaseTagConfiguration != nil || hasLatestRelease) {
 			continue
 		}
 		if result.Releases == nil {

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -152,6 +152,13 @@ func TestWithPresubmitFrom(t *testing.T) {
 			expected:     &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{ReleaseTagConfiguration: &baseReleaseTagConfiguration}},
 			defaultTests: true,
 		},
+		{
+			name:         "latest release from source is not added if base has releases.latest",
+			base:         &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{Releases: map[string]UnresolvedRelease{LatestReleaseName: {Release: &Release{Version: "4.9.base"}}}}},
+			source:       &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{Releases: map[string]UnresolvedRelease{"latest": {Release: &Release{Version: "4.9.source"}}}}},
+			expected:     &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{Releases: map[string]UnresolvedRelease{LatestReleaseName: {Release: &Release{Version: "4.9.base"}}}}},
+			defaultTests: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`releases.latest` serves as an installation or upgrade target, so we must respect its definition in the base in order to correctly build the ephemeral release including the images built in the tested PR

/cc @openshift/test-platform 