### PR TITLE
clusterimageset-updater: always reconcile pools

### DIFF
--- a/cmd/clusterimageset-updater/main.go
+++ b/cmd/clusterimageset-updater/main.go
@@ -133,11 +133,7 @@ func main() {
 			isCurrent := false
 			for poolBounds := range poolFilesByBounds {
 				if poolBounds == *bounds {
-					if imageset.Spec.ReleaseImage == boundsToPullspec[poolBounds] {
-						isCurrent = true
-						delete(poolFilesByBounds, poolBounds)
-						delete(boundsToPullspec, poolBounds)
-					}
+					isCurrent = imageset.Spec.ReleaseImage == boundsToPullspec[poolBounds]
 					break
 				}
 			}


### PR DESCRIPTION
The updater previously contained an optimization that avoided updating
pools when a matching `ClusterImageSet` is up-to-date. This optimization
also skips reconciling the pool when it should be using such
clusterimageset but is not for any reason.

Remove this optimization: worst case is reading and writing several manifest files.

This fixes not updating hypershift pools after https://github.com/openshift/release/pull/23027 :

```diff
diff --git a/clusters/hive/pools/hypershift/hypershift-ocp-4-8-0-amd64-aws-us-east-1_clusterpool.yaml b/clusters/hive/pools/hypershift/hypershift-ocp-4-8-0-amd64-aws-us-east-1_clusterpool.yaml
index 602ca3e18d..20f7c21388 100644
--- a/clusters/hive/pools/hypershift/hypershift-ocp-4-8-0-amd64-aws-us-east-1_clusterpool.yaml
+++ b/clusters/hive/pools/hypershift/hypershift-ocp-4-8-0-amd64-aws-us-east-1_clusterpool.yaml
@@ -1,25 +1,25 @@
 apiVersion: hive.openshift.io/v1
 kind: ClusterPool
 metadata:
-  name: hypershift-ocp-4-8-amd64-aws-us-east-1
-  namespace: hypershift-cluster-pool
+  creationTimestamp: null
   labels:
-    product: ocp
-    version: "4.8"
     architecture: amd64
     cloud: aws
     owner: hypershift
+    product: ocp
     region: us-east-1
+    version: "4.8"
     version_lower: 4.8.0-0
     version_upper: 4.9.0-0
+  name: hypershift-ocp-4-8-amd64-aws-us-east-1
+  namespace: hypershift-cluster-pool
 spec:
   baseDomain: hive.hypershift.devcluster.openshift.com
   imageSetRef:
-    name: ocp-4.8.0-amd64
-  installAttemptsLimit: 3
+    name: ocp-release-4.8.18-x86-64-for-4.8.0-0-to-4.9.0-0
   installConfigSecretTemplateRef:
     name: install-config-aws-us-east-1
-  skipMachinePools: true
+  maxSize: 6
   platform:
     aws:
       credentialsSecretRef:
@@ -28,4 +28,7 @@ spec:
   pullSecretRef:
     name: pull-secret
   size: 6
-  maxSize: 6
+  skipMachinePools: true
+status:
+  ready: 0
+  size: 0
```

The diff also shows the bumper bug where it reverts `installAttemptsLimit` (likely because of old vendored hive, upgrade of which is blocked by a bug. see https://issues.redhat.com/browse/DPTP-2596)