### PR TITLE
[CVP-2390] Add a new parameter CUSTOM_SCORECARD_TEST to CVP trigger.

### DIFF
--- a/cmd/cvp-trigger/README.md
+++ b/cmd/cvp-trigger/README.md
@@ -77,5 +77,6 @@ CVP Trigger must load the configuration for the
    the existing OperatorGroup's target namespace set will be replaced. The special
    value "!install" will set the target namespace to the operator's installation
    namespace.
+- `CUSTOM_SCORECARD_TESTCASE`: Optional. Name of the custom scorecard test which is to be run.
 - `PYXIS_URL`: Optional. URL that contains specific cvp product package name for specific ISV
    with unique pid.

--- a/cmd/cvp-trigger/main.go
+++ b/cmd/cvp-trigger/main.go
@@ -36,42 +36,45 @@ import (
 )
 
 const (
-	bundleImageRefOption       = "bundle-image-ref"
-	channelOption              = "channel"
-	indexImageRefOption        = "index-image-ref"
-	installNamespaceOption     = "install-namespace"
-	jobConfigPathOption        = "job-config-path"
-	jobNameOption              = "job-name"
-	ocpVersionOption           = "ocp-version"
-	operatorPackageNameOptions = "operator-package-name"
-	outputFilePathOption       = "output-path"
-	prowConfigPathOption       = "prow-config-path"
-	releaseImageRefOption      = "release-image-ref"
-	targetNamespacesOption     = "target-namespaces"
+	bundleImageRefOption          = "bundle-image-ref"
+	channelOption                 = "channel"
+	indexImageRefOption           = "index-image-ref"
+	installNamespaceOption        = "install-namespace"
+	jobConfigPathOption           = "job-config-path"
+	jobNameOption                 = "job-name"
+	ocpVersionOption              = "ocp-version"
+	operatorPackageNameOptions    = "operator-package-name"
+	outputFilePathOption          = "output-path"
+	prowConfigPathOption          = "prow-config-path"
+	releaseImageRefOption         = "release-image-ref"
+	targetNamespacesOption        = "target-namespaces"
+	customScorecardTestcaseOption = "custom-scorecard-testcase"
 
-	BundleImage      = "BUNDLE_IMAGE"
-	Channel          = "OO_CHANNEL"
-	IndexImage       = "OO_INDEX"
-	InstallNamespace = "OO_INSTALL_NAMESPACE"
-	Package          = "OO_PACKAGE"
-	TargetNamespaces = "OO_TARGET_NAMESPACES"
-	PyxisUrl         = "PYXIS_URL"
+	BundleImage             = "BUNDLE_IMAGE"
+	Channel                 = "OO_CHANNEL"
+	IndexImage              = "OO_INDEX"
+	InstallNamespace        = "OO_INSTALL_NAMESPACE"
+	Package                 = "OO_PACKAGE"
+	TargetNamespaces        = "OO_TARGET_NAMESPACES"
+	CustomScorecardTestcase = "CUSTOM_SCORECARD_TESTCASE"
+	PyxisUrl                = "PYXIS_URL"
 )
 
 type options struct {
-	bundleImageRef      string
-	channel             string
-	indexImageRef       string
-	installNamespace    string
-	jobName             string
-	prowconfig          configflagutil.ConfigOptions
-	ocpVersion          string
-	operatorPackageName string
-	outputPath          string
-	releaseImageRef     string
-	targetNamespaces    string
-	pyxisUrl            string
-	dryRun              bool
+	bundleImageRef          string
+	channel                 string
+	indexImageRef           string
+	installNamespace        string
+	jobName                 string
+	prowconfig              configflagutil.ConfigOptions
+	ocpVersion              string
+	operatorPackageName     string
+	outputPath              string
+	releaseImageRef         string
+	targetNamespaces        string
+	pyxisUrl                string
+	customScorecardTestcase string
+	dryRun                  bool
 }
 
 type jobResult interface {
@@ -110,6 +113,7 @@ func (o *options) gatherOptions() {
 	fs.StringVar(&o.releaseImageRef, releaseImageRefOption, "", "Pull spec of a specific release payload image used for OCP deployment.")
 	fs.StringVar(&o.targetNamespaces, targetNamespacesOption, "", "A comma-separated list of namespaces the operator will target. If empty, all namespaces are targeted")
 	fs.StringVar(&o.pyxisUrl, PyxisUrl, "", "URL that contains specific cvp product package name for specific ISV with unique pid")
+	fs.StringVar(&o.customScorecardTestcase, customScorecardTestcaseOption, "", "Name of custom scorecard testcase that needs to be executed")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Executes a dry-run, displaying the job YAML without submitting the job to Prow")
 }
 
@@ -231,6 +235,9 @@ func main() {
 	}
 	if o.targetNamespaces != "" {
 		params[TargetNamespaces] = o.targetNamespaces
+	}
+	if o.customScorecardTestcase != "" {
+		params[CustomScorecardTestcase] = o.customScorecardTestcase
 	}
 
 	depOverrides := map[string]string{

--- a/cmd/cvp-trigger/main_test.go
+++ b/cmd/cvp-trigger/main_test.go
@@ -136,16 +136,17 @@ func Test_options_validate(t *testing.T) {
 	}
 
 	type fields struct {
-		bundleImageRef string
-		channel        string
-		indexImageRef  string
-		jobConfigPath  string
-		jobName        string
-		ocpVersion     string
-		outputPath     string
-		packageName    string
-		prowConfigPath string
-		dryRun         bool
+		bundleImageRef          string
+		channel                 string
+		indexImageRef           string
+		jobConfigPath           string
+		jobName                 string
+		ocpVersion              string
+		outputPath              string
+		packageName             string
+		prowConfigPath          string
+		customScorecardTestcase string
+		dryRun                  bool
 	}
 	tests := []struct {
 		name    string
@@ -155,16 +156,17 @@ func Test_options_validate(t *testing.T) {
 		{
 			name: "valid options",
 			fields: fields{
-				prowConfigPath: "/not/empty",
-				jobConfigPath:  "/also/not/empty",
-				jobName:        "some-job",
-				bundleImageRef: "master",
-				indexImageRef:  "latest",
-				ocpVersion:     "4.5",
-				outputPath:     "/output/path",
-				packageName:    "foo",
-				channel:        "bar",
-				dryRun:         false,
+				prowConfigPath:          "/not/empty",
+				jobConfigPath:           "/also/not/empty",
+				jobName:                 "some-job",
+				bundleImageRef:          "master",
+				indexImageRef:           "latest",
+				ocpVersion:              "4.5",
+				outputPath:              "/output/path",
+				packageName:             "foo",
+				channel:                 "bar",
+				customScorecardTestcase: "somescorecard",
+				dryRun:                  false,
 			},
 			wantErr: false,
 		},
@@ -378,11 +380,12 @@ func Test_options_validate(t *testing.T) {
 					ConfigPath:    tt.fields.prowConfigPath,
 					JobConfigPath: tt.fields.jobConfigPath,
 				},
-				jobName:             tt.fields.jobName,
-				ocpVersion:          tt.fields.ocpVersion,
-				operatorPackageName: tt.fields.packageName,
-				outputPath:          tt.fields.outputPath,
-				dryRun:              tt.fields.dryRun,
+				jobName:                 tt.fields.jobName,
+				ocpVersion:              tt.fields.ocpVersion,
+				operatorPackageName:     tt.fields.packageName,
+				outputPath:              tt.fields.outputPath,
+				customScorecardTestcase: tt.fields.customScorecardTestcase,
+				dryRun:                  tt.fields.dryRun,
 			}
 			if err := o.validateOptions(); (err != nil) != tt.wantErr {
 				t.Errorf("validateOptions() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Add a new parameter "CUSTOM_SCORECARD_TEST" as a optional parmeter to the CVP trigger. 
