### PR TITLE
payload-testing-prow-plugin: use configAgent to load configs

### DIFF
--- a/cmd/payload-testing-prow-plugin/filetestresolver.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver.go
@@ -2,49 +2,34 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
-	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/config"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 )
 
 type fileTestResolver struct {
-	// TODO: Refresh when the data on files change
-	tuples map[string]api.MetadataWithTest
-}
-
-func newFileTestResolver(dir string) (testResolver, error) {
-	ret := &fileTestResolver{
-		tuples: map[string]api.MetadataWithTest{},
-	}
-	if err := config.OperateOnCIOperatorConfigDir(dir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
-		if !strings.HasPrefix(filepath.Base(info.Filename), "openshift-release-master") {
-			return nil
-		}
-		for _, element := range configuration.Tests {
-			if element.Cron != nil || element.Interval != nil || element.ReleaseController {
-				jobName := configuration.Metadata.JobName(jc.PeriodicPrefix, element.As)
-				ret.tuples[jobName] = api.MetadataWithTest{
-					Metadata: configuration.Metadata,
-					Test:     element.As,
-				}
-				logrus.WithField("jobName", jobName).WithField("test", element.As).Info("loaded job for test")
-			}
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("failed to operate on ci operator config dir %s: %w", dir, err)
-	}
-	return ret, nil
+	configAgent agents.ConfigAgent
 }
 
 func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
-	if jt, ok := r.tuples[job]; ok {
-		return jt, nil
+	byOrgRepo := r.configAgent.GetAll()
+	if v, ok := byOrgRepo["openshift"]; ok {
+		if configurations, configOK := v["release"]; configOK {
+			for _, configuration := range configurations {
+				for _, element := range configuration.Tests {
+					if element.Cron != nil || element.Interval != nil || element.ReleaseController {
+						jobName := configuration.Metadata.JobName(jc.PeriodicPrefix, element.As)
+						if jobName == job {
+							return api.MetadataWithTest{
+								Metadata: configuration.Metadata,
+								Test:     element.As,
+							}, nil
+						}
+					}
+				}
+			}
+		}
 	}
 	return api.MetadataWithTest{}, fmt.Errorf("failed to resolve job %s", job)
 }

--- a/cmd/payload-testing-prow-plugin/filetestresolver_test.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver_test.go
@@ -1,63 +1,91 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
-func TestNewFileTestResolver(t *testing.T) {
+func TestFileTestResolver(t *testing.T) {
 	testCases := []struct {
-		name          string
-		dir           string
-		expected      *fileTestResolver
-		expectedError error
+		name      string
+		dir       string
+		verifyFun func(testResolver testResolver) error
 	}{
 		{
 			name: "basic case",
 			dir:  filepath.Join("testdata", "config"),
-			expected: &fileTestResolver{
-				tuples: map[string]api.MetadataWithTest{
-					"periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-serial": {
-						Metadata: api.Metadata{
-							Org:     "openshift",
-							Repo:    "release",
-							Branch:  "master",
-							Variant: "nightly-4.10",
-						},
-						Test: "e2e-aws-serial",
-					},
-					"periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi": {
-						Metadata: api.Metadata{
-							Org:     "openshift",
-							Repo:    "release",
-							Branch:  "master",
-							Variant: "nightly-4.10",
-						},
-						Test: "e2e-metal-ipi",
-					},
+			verifyFun: func(testResolver testResolver) error {
+				actual, actualErr := testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-serial")
+				expected := api.MetadataWithTest{Metadata: api.Metadata{
+					Org:     "openshift",
+					Repo:    "release",
+					Branch:  "master",
+					Variant: "nightly-4.10",
 				},
+					Test: "e2e-aws-serial",
+				}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					return fmt.Errorf("actual differs from expected: %s", diff)
+				}
+				if diff := cmp.Diff(nil, actualErr, testhelper.EquateErrorMessage); diff != "" {
+					return fmt.Errorf("actualErr differs from expected: %s", diff)
+				}
+
+				actual, actualErr = testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi")
+				expected = api.MetadataWithTest{Metadata: api.Metadata{
+					Org:     "openshift",
+					Repo:    "release",
+					Branch:  "master",
+					Variant: "nightly-4.10",
+				},
+					Test: "e2e-metal-ipi",
+				}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					return fmt.Errorf("actual differs from expected: %s", diff)
+				}
+				if diff := cmp.Diff(nil, actualErr, testhelper.EquateErrorMessage); diff != "" {
+					return fmt.Errorf("actualErr differs from expected: %s", diff)
+				}
+
+				actual, actualErr = testResolver.resolve("periodic-ci-openshift-api-master-build")
+				expected = api.MetadataWithTest{}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					return fmt.Errorf("actual differs from expected: %s", diff)
+				}
+				if diff := cmp.Diff(fmt.Errorf("failed to resolve job periodic-ci-openshift-api-master-build"), actualErr, testhelper.EquateErrorMessage); diff != "" {
+					return fmt.Errorf("actualErr differs from expected: %s", diff)
+				}
+
+				actual, actualErr = testResolver.resolve("some-job")
+				expected = api.MetadataWithTest{}
+				if diff := cmp.Diff(expected, actual); diff != "" {
+					return fmt.Errorf("actual differs from expected: %s", diff)
+				}
+				if diff := cmp.Diff(fmt.Errorf("failed to resolve job some-job"), actualErr, testhelper.EquateErrorMessage); diff != "" {
+					return fmt.Errorf("actualErr differs from expected: %s", diff)
+				}
+
+				return nil
 			},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, actualError := newFileTestResolver(tc.dir)
-			v, ok := actual.(*fileTestResolver)
-			if !ok {
-				t.Fatalf("returned unexpected type")
+			configAgent, err := agents.NewConfigAgent(tc.dir)
+			if err != nil {
+				t.Fatalf("Failed to get config agent: %v", err)
 			}
-			if diff := cmp.Diff(tc.expected, v, cmp.Comparer(func(x, y fileTestResolver) bool {
-				return cmp.Diff(x.tuples, y.tuples) == ""
-			})); diff != "" {
-				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
-			}
-			if diff := cmp.Diff(tc.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
-				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+			if tc.verifyFun != nil {
+				if err := tc.verifyFun(&fileTestResolver{configAgent: configAgent}); err != nil {
+					t.Errorf("unexpected error occurred: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
With the agent, we get the reload for free upon the changes of configs on files which come from a configMap.

/cc @openshift/test-platform 