### PR TITLE
Allow for configurable shm-size

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -50,6 +50,8 @@ const (
 	OauthTokenSecretName = "github-credentials-openshift-ci-robot-private-git-cloner"
 
 	GroupSuffix = "-group"
+
+	ShmResource = "ci-operator.openshift.io/shm"
 )
 
 var (

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -474,7 +474,7 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 			continue
 		}
 		allResources := &resources
-		if !resources.Limits.Name(api.ShmResource, resource.BinarySI).IsZero() {
+		if !resources.Requests.Name(api.ShmResource, resource.BinarySI).IsZero() {
 			// If shm is in Limits it must also be in Requests
 			allResources = resources.DeepCopy()
 			logrus.Info("removing shm from resources for container")

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -13,6 +13,7 @@ import (
 	coreapi "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -472,6 +473,14 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 			errs = append(errs, err)
 			continue
 		}
+		allResources := &resources
+		if !resources.Limits.Name(api.ShmResource, resource.BinarySI).IsZero() {
+			// If shm is in Limits it must also be in Requests
+			allResources = resources.DeepCopy()
+			logrus.Info("removing shm from resources for container")
+			delete(resources.Requests, api.ShmResource)
+			delete(resources.Limits, api.ShmResource)
+		}
 		if step.BestEffort != nil && *step.BestEffort {
 			bestEffort.Insert(name)
 		}
@@ -566,6 +575,10 @@ func (s *multiStageTestStep) generatePods(steps []api.LiteralTestStep, env []cor
 				{Name: "KUBECONFIG", Value: filepath.Join(SecretMountPath, "kubeconfig")},
 				{Name: "KUBEADMIN_PASSWORD_FILE", Value: filepath.Join(SecretMountPath, "kubeadmin-password")},
 			}...)
+		}
+		shmSize := allResources.Requests.Name(api.ShmResource, resource.BinarySI)
+		if !shmSize.IsZero() {
+			addDshmVolume(shmSize, pod, container)
 		}
 		if s.profile != "" {
 			addProfile(s.profileSecretName(), s.profile, pod)
@@ -724,6 +737,21 @@ func addCredentials(credentials []api.CredentialReference, pod *coreapi.Pod) {
 			MountPath: credential.MountPath,
 		})
 	}
+}
+
+func addDshmVolume(shmSize *resource.Quantity, pod *coreapi.Pod, container *coreapi.Container) {
+	logrus.Infof("Adding Dshm Volume to pod: %s", pod.Name)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
+		Name: "dshm",
+		VolumeSource: coreapi.VolumeSource{
+			EmptyDir: &coreapi.EmptyDirVolumeSource{
+				Medium:    coreapi.StorageMediumMemory,
+				SizeLimit: shmSize}},
+	})
+	container.VolumeMounts = append(container.VolumeMounts, coreapi.VolumeMount{
+		Name:      "dshm",
+		MountPath: "/dev/shm",
+	})
 }
 
 func volumeName(ns, name string) string {

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -167,6 +167,7 @@ func TestGeneratePods(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil)
+	step.test[0].Resources = api.ResourceRequirements{Requests: api.ResourceList{"shm": "2G"}}
 	env := []coreapi.EnvVar{
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -167,7 +167,7 @@ func TestGeneratePods(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil)
-	step.test[0].Resources = api.ResourceRequirements{Requests: api.ResourceList{"shm": "2G"}}
+	step.test[0].Resources = api.ResourceRequirements{Requests: api.ResourceList{api.ShmResource: "2G"}}
 	env := []coreapi.EnvVar{
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},

--- a/pkg/steps/multi_stage_test.go
+++ b/pkg/steps/multi_stage_test.go
@@ -167,7 +167,9 @@ func TestGeneratePods(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil)
-	step.test[0].Resources = api.ResourceRequirements{Requests: api.ResourceList{api.ShmResource: "2G"}}
+	step.test[0].Resources = api.ResourceRequirements{
+		Requests: api.ResourceList{api.ShmResource: "2G"},
+		Limits:   api.ResourceList{api.ShmResource: "2G"}}
 	env := []coreapi.EnvVar{
 		{Name: "RELEASE_IMAGE_INITIAL", Value: "release:initial"},
 		{Name: "RELEASE_IMAGE_LATEST", Value: "release:latest"},

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -80,7 +80,7 @@
       name: test
       resources:
         requests:
-          shm: 2G
+          ci-operator.openshift.io/shm: 2G
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
       - mountPath: /logs

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -78,7 +78,9 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: pipeline:src
       name: test
-      resources: {}
+      resources:
+        requests:
+          shm: 2G
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
       - mountPath: /logs
@@ -89,6 +91,8 @@
         name: home
       - mountPath: /tmp/entrypoint-wrapper
         name: entrypoint-wrapper
+      - mountPath: /dev/shm
+        name: dshm
       - mountPath: /var/run/secrets/ci.openshift.io/cluster-profile
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
@@ -147,6 +151,10 @@
         secretName: k8-secret
     - emptyDir: {}
       name: entrypoint-wrapper
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 2G
+      name: dshm
     - name: cluster-profile
       secret:
         secretName: test-cluster-profile

--- a/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestGeneratePods.yaml
@@ -78,9 +78,7 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage
       image: pipeline:src
       name: test
-      resources:
-        requests:
-          ci-operator.openshift.io/shm: 2G
+      resources: {}
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
       - mountPath: /logs

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -235,6 +235,28 @@ func TestValidateResources(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		{
+			name: "valid shm value passes",
+			input: api.ResourceConfiguration{
+				"*": api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ShmResource: "2G",
+					},
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "too large of shm value makes an error",
+			input: api.ResourceConfiguration{
+				"*": api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.ShmResource: "3G",
+					},
+				},
+			},
+			expectedErr: true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateResources("", testCase.input)

--- a/test/e2e/multi-stage/config.yaml
+++ b/test/e2e/multi-stage/config.yaml
@@ -112,6 +112,19 @@ tests:
     steps:
       test:
         - ref: timeout
+  - as: shm-increase
+    steps:
+      test:
+        - as: step-with-increased-shm
+          commands: echo Success
+          from: os
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
+              ci-operator.openshift.io/shm: 2G
+            limits:
+              ci-operator.openshift.io/shm: 2G
 
 zz_generated_metadata:
   branch: master

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -187,6 +187,16 @@ func TestMultiStage(t *testing.T) {
 				`verify-releases-latest-cli succeeded`,
 			},
 		},
+		{
+			name:    "request for increased shm-size",
+			args:    []string{"--unresolved-config=config.yaml", "--target=shm-increase"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output: []string{
+				`Adding Dshm Volume to pod: shm-increase-step-with-increased-shm`,
+				`Container test in pod shm-increase-step-with-increased-shm completed successfully`,
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Allowing for the increase in shm-size to facilitate passing Selenium tests for the QE effort.

Following the implementation details from: https://docs.google.com/document/d/1jfgIBqND5DtuzJY9nJG9G9FeHoDqqqqDl8H3ZU2QT7k/edit#heading=h.66y4kqbj468a

/label tide/merge-method-squash