### PR TITLE
Collect additional info for release tables

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_release.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_release.go
@@ -8,6 +8,12 @@ type ReleaseRow struct {
 	// the release after it's "fully baked."
 	Phase string `bigquery:"phase"`
 
+	// Release contains the X.Y version of the payload, e.g. 4.8
+	Release string `bigquery:"release"`
+
+	// Architecture contains the architecture for the release, e.g. amd64
+	Architecture string `bigquery:"architecture"`
+
 	// ReleaseTag contains the release version, e.g. 4.8.0-0.nightly-2021-10-28-013428.
 	ReleaseTag string `bigquery:"releaseTag"`
 
@@ -55,8 +61,8 @@ type ReleaseRepositoryRow struct {
 // ReleasePullRequestRow represents a pull request that was included for the first time
 // in a release payload.
 type ReleasePullRequestRow struct {
-	// ID typically contains the GitHub pull request number.
-	ID string `bigquery:"id"`
+	// PullRequestID contains the GitHub pull request number.
+	PullRequestID string `bigquery:"pullRequestID"`
 
 	// ReleaseTag is the OpenShift version, e.g. 4.8.0-0.nightly-2021-10-28-013428.
 	ReleaseTag string `bigquery:"releaseTag"`

--- a/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser.go
@@ -143,7 +143,7 @@ func (c *Changelog) PullRequests() []jobrunaggregatorapi.ReleasePullRequestRow {
 					}
 					if strings.Contains(url, "github.com") {
 						row.URL = url
-						row.ID = strings.ReplaceAll(text, "#", "")
+						row.PullRequestID = strings.ReplaceAll(text, "#", "")
 					}
 					if strings.Contains(url, "bugzilla.redhat.com") {
 						row.BugURL = url

--- a/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser_test.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser_test.go
@@ -210,12 +210,12 @@ func TestChangelog_PullRequests(t *testing.T) {
 			root: soup.HTMLParse(simpleChangelog),
 			want: []jobrunaggregatorapi.ReleasePullRequestRow{
 				{
-					ID:          "583",
-					ReleaseTag:  "test",
-					Name:        "kuryr-cni, kuryr-controller",
-					Description: "Rebase openshift/kuryr-kubernetes from",
-					BugURL:      "",
-					URL:         "https://github.com/openshift/kuryr-kubernetes/pull/583",
+					PullRequestID: "583",
+					ReleaseTag:    "test",
+					Name:          "kuryr-cni, kuryr-controller",
+					Description:   "Rebase openshift/kuryr-kubernetes from",
+					BugURL:        "",
+					URL:           "https://github.com/openshift/kuryr-kubernetes/pull/583",
 				},
 			},
 		},

--- a/pkg/jobrunaggregator/releasebigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/cmd.go
@@ -16,6 +16,7 @@ type BigQueryReleaseUploadFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 	Releases        []string
+	Architectures   []string
 }
 
 func NewBigQueryReleaseUploadFlags() *BigQueryReleaseUploadFlags {
@@ -29,6 +30,7 @@ func (f *BigQueryReleaseUploadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.DataCoordinates.BindFlags(fs)
 	f.Authentication.BindFlags(fs)
 	fs.StringArrayVar(&f.Releases, "releases", f.Releases, "openshift releases to collect data from")
+	fs.StringArrayVar(&f.Architectures, "architectures", f.Architectures, "architectures to collect data from")
 }
 
 func NewBigQueryReleaseUploadFlagsCommand() *cobra.Command {
@@ -89,17 +91,17 @@ func (f *BigQueryReleaseUploadFlags) ToOptions(ctx context.Context) (*allRelease
 	ciDataSet := client.Dataset(f.DataCoordinates.DataSetID)
 
 	return &allReleaseUploaderOptions{
-		ciDataClient: ciDataClient,
-		ciDataSet:    ciDataSet,
-		httpClient:   httpClient,
-		releases:     f.Releases,
+		ciDataClient:  ciDataClient,
+		ciDataSet:     ciDataSet,
+		httpClient:    httpClient,
+		releases:      f.Releases,
+		architectures: f.Architectures,
 	}, nil
 }
 
 type BigQueryReleaseTableCreateFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
-	Releases        []string
 }
 
 func NewBigQueryReleaseTableCreateFlags() *BigQueryReleaseTableCreateFlags {

--- a/pkg/jobrunaggregator/releasebigqueryloader/types.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/types.go
@@ -5,8 +5,9 @@ import "time"
 // ReleaseTags represents the type returned from a release controller endpoint
 // like https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.9.0-0.nightly/tags
 type ReleaseTags struct {
-	Name string       `json:"name"`
-	Tags []ReleaseTag `json:"tags"`
+	Name         string       `json:"name"`
+	Tags         []ReleaseTag `json:"tags"`
+	Architecture string       `json:"architecture"`
 }
 
 // ReleaseTag is an individual release tag.


### PR DESCRIPTION
This adds support for multi-arch (s390x and arm64), as well as
collecting the X.Y release in addition to the tag (for easier
use with Sippy).

Usage:

```
$ job-run-aggregator upload-releases --bigquery-dataset ci_data --google-service-account-credential-file <creds.json> --releases 4.10.0-0.nightly --releases 4.10.0-0.ci --releases 4.9.0-0.nightly --releases 4.9.0-0.ci --releases 4.8.0-0.nightly --releases 4.8.0-0.ci --architectures amd64 --architectures arm64 --architectures s390x
```