### PR TITLE
move disruption job runs to its own table

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/bypass_linter.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/bypass_linter.go
@@ -9,6 +9,7 @@ func init() {
 	if rand == -1 {
 		fmt.Print(unifiedBackendDisruptionSchema)
 		fmt.Print(jobSchema)
+		fmt.Print(jobRunSchema)
 	}
 }
 

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types.go
@@ -26,16 +26,6 @@ type AggregatedTestRunRow struct {
 	//JobLabels            []string
 }
 
-type JobRunRow struct {
-	Name       string
-	JobName    string
-	Status     string
-	StartTime  time.Time
-	EndTime    time.Time
-	ReleaseTag string
-	Cluster    string
-}
-
 const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -18,7 +18,7 @@ SELECT
   Jobs.FromRelease as FromRelease,
   if(Jobs.FromRelease="",false,true) as IsUpgrade,
 FROM openshift-ci-data-analysis.ci_data.BackendDisruption
-INNER JOIN openshift-ci-data-analysis.ci_data.JobRuns on BackendDisruption.JobRunName = JobRuns.Name
+INNER JOIN openshift-ci-data-analysis.ci_data.BackendDisruption_JobRuns as JobRuns on BackendDisruption.JobRunName = JobRuns.Name
 INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.JobName
 `
 )

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -1,0 +1,65 @@
+package jobrunaggregatorapi
+
+import "time"
+
+const (
+	LegacyJobRunTableName     = "JobRuns"
+	DisruptionJobRunTableName = "BackendDisruption_JobRuns"
+
+	jobRunSchema = `
+[
+  {
+    "name": "Name",
+    "description": "name of the jobrun (the long number)",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "JobName",
+    "description": "name of the job from CI",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Status",
+    "description": "error, failure, success",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "StartTime",
+    "description": "time the jobrun started",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "EndTime",
+    "description": "time the jobrun started",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "ReleaseTag",
+    "description": "",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "Cluster",
+    "description": "the build farm cluster that the CI job ran on: build01, build02, build03, vsphere, etc",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+]
+`
+)
+
+type JobRunRow struct {
+	Name       string
+	JobName    string
+	Status     string
+	StartTime  time.Time
+	EndTime    time.Time
+	ReleaseTag string
+	Cluster    string
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
@@ -12,9 +12,7 @@ const (
 	BigQueryProjectID   = "openshift-ci-data-analysis"
 	CIDataSetID         = "ci_data"
 	JobRunTableName     = "JobRuns"
-	JobTableName        = "Job"
 	TestRunTableName    = "TestRuns"
-	UnifiedTestRunTable = "UnifiedTestRuns"
 	PerDayTestRunTable  = "TestRunSummaryPerDay"
 	PerWeekTestRunTable = "TestRunSummaryPerWeek"
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locators.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locators.go
@@ -32,7 +32,7 @@ type analysisJobAggregator struct {
 	// bigquery dataset.
 	startTime time.Time
 
-	ciDataClient  CIDataClient
+	ciDataClient  AggregationJobClient
 	ciGCSClient   CIGCSClient
 	gcsClient     *storage.Client
 	gcsBucketName string
@@ -41,7 +41,7 @@ type analysisJobAggregator struct {
 func NewPayloadAnalysisJobLocator(
 	jobName, payloadTag string,
 	startTime time.Time,
-	ciDataClient CIDataClient,
+	ciDataClient AggregationJobClient,
 	ciGCSClient CIGCSClient,
 	gcsClient *storage.Client,
 	gcsBucketName string) JobRunLocator {

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/summarize_results.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/summarize_results.go
@@ -18,14 +18,15 @@ import (
 type JobRunsBigQuerySummarizerOptions struct {
 	Frequency       string
 	SummaryDuration time.Duration
-	CIDataClient    jobrunaggregatorlib.CIDataClient
+	JobLister       jobrunaggregatorlib.JobLister
+	CIDataClient    jobrunaggregatorlib.TestRunSummarizerClient
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 
 	AggregatedTestRunInserter BigQueryInserter
 }
 
 func (o *JobRunsBigQuerySummarizerOptions) Run(ctx context.Context) error {
-	jobs, err := o.CIDataClient.ListAllJobs(ctx)
+	jobs, err := o.JobLister.ListAllJobs(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get jobs: %w", err)
 	}
@@ -73,7 +74,7 @@ type JobRunBigQuerySummarizerOptions struct {
 	Frequency string
 
 	SummaryDuration           time.Duration
-	CIDataClient              jobrunaggregatorlib.CIDataClient
+	CIDataClient              jobrunaggregatorlib.TestRunSummarizerClient
 	AggregatedTestRunInserter BigQueryInserter
 }
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -25,7 +25,7 @@ func wantsDisruptionData(job jobrunaggregatorapi.JobRow) bool {
 }
 
 type allJobsLoaderOptions struct {
-	ciDataClient jobrunaggregatorlib.CIDataClient
+	ciDataClient jobrunaggregatorlib.JobLister
 	// GCSClient is used to read the prowjob data
 	gcsClient jobrunaggregatorlib.CIGCSClient
 
@@ -83,7 +83,6 @@ func (o *allJobsLoaderOptions) newJobBigQueryLoaderOptions(job jobrunaggregatora
 
 	return &jobLoaderOptions{
 		jobName:                   job.JobName,
-		ciDataClient:              o.ciDataClient,
 		gcsClient:                 o.gcsClient,
 		numberOfConcurrentReaders: 20,
 		jobRunInserter:            o.jobRunInserter,
@@ -100,8 +99,6 @@ func (o *allJobsLoaderOptions) newJobBigQueryLoaderOptions(job jobrunaggregatora
 type jobLoaderOptions struct {
 	jobName string
 
-	// CIDataClient is used to read the last inserted results for a job
-	ciDataClient jobrunaggregatorlib.CIDataClient
 	// GCSClient is used to read the prowjob data
 	gcsClient jobrunaggregatorlib.CIGCSClient
 


### PR DESCRIPTION
This allows us to treat the jobrun entry as authoritative during upload so that we avoid duplicate rows for job runs and become much more efficient.