### PR TITLE
sanitize-prow-jobs: enforce explicit regex branchers

### DIFF
--- a/test/validate-generation-breaking-changes.sh
+++ b/test/validate-generation-breaking-changes.sh
@@ -34,6 +34,20 @@ for org in openshift; do
     echo "Running Prowgen in $org/release does not result in changes, no followups needed"
   fi
 
+  echo >&2 "$(date --iso-8601=seconds) Executing sanitize-prow-jobs"
+  sanitize-prow-jobs --prow-jobs-dir ci-operator/jobs --config-path core-services/sanitize-prow-jobs/_config.yaml
+  out="$(git status --porcelain)"
+  if [[ -n "$out" ]]; then
+    echo "ERROR: Changes in $org/release:"
+    git diff
+    echo "ERROR: Running sanitize-prow-jobs in $org/release results in changes ^^^"
+    echo "ERROR: To avoid breaking $org/release for everyone you should regenerate"
+    echo "ERROR: the jobs there and merge the changes ASAP after this change"
+    failure=1
+  else
+    echo "Running sanitize-prow-jobs in $org/release does not result in changes, no followups needed"
+  fi
+
   CONFIG="${clonedir}/core-services/prow/02_config"
   if [[ -d "${CONFIG}" ]]; then
     echo >&2 "$(date --iso-8601=seconds) Executing determinize-prow-config"


### PR DESCRIPTION
Brancher items are (suprisingly) regexes that make jobs trigger on
submatch, which causes trouble e.g. by making a:

```yaml
branches:
- release-4.1
```

job to trigger on `release-4.10` branch PRs. We deal with this in
generated jobs by generating appropriate explicit brancher stanzas, but
handcrafted jobs flew under the radar.

We can use `sanitize-prow-jobs` to enforce this on handcrafted jobs,
too.

/cc @hongkailiu 
/cc @openshift/test-platform 
Needed for [DPTP-2605](https://issues.redhat.com/browse/DPTP-2605)

This is expected to break the `breaking-changes` job until https://github.com/openshift/release/pull/23380 is merged