### PR TITLE
cluster-init: generate jobs with explicit branchers

### DIFF
--- a/cmd/cluster-init/main.go
+++ b/cmd/cluster-init/main.go
@@ -69,11 +69,11 @@ func validateOptions(o options) []error {
 		}
 	}
 	if o.releaseRepo == "" {
-		//If the release repo is missing, further checks won't be possible
+		// If the release repo is missing, further checks won't be possible
 		errs = append(errs, errors.New("--release-repo must be provided"))
 	} else {
 		if o.createPR {
-			//make sure the release repo is on the master branch and clean
+			// make sure the release repo is on the master branch and clean
 			if err := os.Chdir(o.releaseRepo); err != nil {
 				errs = append(errs, err)
 			} else {

--- a/cmd/cluster-init/update_jobs.go
+++ b/cmd/cluster-init/update_jobs.go
@@ -100,7 +100,7 @@ func generatePostsubmit(clusterName string) prowconfig.Postsubmit {
 			},
 		},
 		Brancher: prowconfig.Brancher{
-			Branches: []string{"master"},
+			Branches: []string{jobconfig.ExactlyBranch("master")},
 		},
 	}
 }
@@ -142,7 +142,7 @@ func generatePresubmit(clusterName string) prowconfig.Presubmit {
 		Trigger:      prowconfig.DefaultTriggerFor(clusterName + "-dry"),
 		RerunCommand: prowconfig.DefaultRerunCommandFor(clusterName + "-dry"),
 		Brancher: prowconfig.Brancher{
-			Branches: []string{"master"},
+			Branches: []string{jobconfig.ExactlyBranch("master"), jobconfig.FeatureBranch("master")},
 		},
 		Reporter: prowconfig.Reporter{
 			Context: fmt.Sprintf("ci/build-farm/%s-dry", clusterName),

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -732,3 +732,22 @@ func Prune(jobConfig *prowconfig.JobConfig, generator Generator, pruneLabels lab
 
 	return &pruned, nil
 }
+
+// FeatureBranch returns a regex string that matches feature branch prefixes for the given branch name:
+// I.e. returns '^master-' for 'master'. If the given branch name already looks like a regex,
+// return it unchanged.
+func FeatureBranch(branch string) string {
+	if !SimpleBranchRegexp.MatchString(branch) {
+		return branch
+	}
+	return fmt.Sprintf("^%s-", regexp.QuoteMeta(branch))
+}
+
+// ExactlyBranch returns a regex string that matches exactly the given branch name: I.e. returns
+// '^master$' for 'master'. If the given branch name already looks like a regex, return it unchanged.
+func ExactlyBranch(branch string) string {
+	if !SimpleBranchRegexp.MatchString(branch) {
+		return branch
+	}
+	return fmt.Sprintf("^%s$", regexp.QuoteMeta(branch))
+}

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -11,8 +11,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/load"
-	"github.com/openshift/ci-tools/pkg/prowgen"
 )
 
 type IndexDelta struct {
@@ -135,7 +135,7 @@ func (a *configAgent) GetMatchingConfig(metadata api.Metadata) (api.ReleaseBuild
 	}
 	var matchingConfigs []api.ReleaseBuildConfiguration
 	for _, config := range repoConfigs {
-		for _, f := range []func(string) string{prowgen.ExactlyBranch, prowgen.FeatureBranch} {
+		for _, f := range []func(string) string{jobconfig.ExactlyBranch, jobconfig.FeatureBranch} {
 			r, err := regexp.Compile(f(config.Metadata.Branch))
 			if err != nil {
 				return api.ReleaseBuildConfiguration{}, fmt.Errorf("could not compile regex for %s/%s@%s: %w", metadata.Org, metadata.Repo, config.Metadata.Branch, err)

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
@@ -38,7 +38,7 @@ postsubmits:
           secretName: config-updater
   - agent: kubernetes
     branches:
-    - master
+    - ^master$
     cluster: app.ci
     decorate: true
     labels:

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -65,7 +65,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: app.ci
     context: ci/build-farm/newCluster-dry
     decorate: true

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
@@ -2,7 +2,7 @@ postsubmits:
   openshift/release:
   - agent: kubernetes
     branches:
-    - master
+    - ^master$
     cluster: app.ci
     decorate: true
     labels:

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -3,7 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - master
+    - ^master$
+    - ^master-
     cluster: app.ci
     context: ci/build-farm/existingCluster-dry
     decorate: true


### PR DESCRIPTION
- Extract brancher regex utility code from prowgen
- cluster-init: generate jobs with explicit branchers

Make cluster-init jobs to generate jobs with explicit brancher stanza, to be
consistent with prowgen jobs, and to allow enforcing explicit regex stanzas
everywhere.

xref: https://github.com/openshift/release/pull/23380
