### PR TITLE
prowgen podspec builder: new `CustomHashInput()` method

### DIFF
--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -594,6 +594,14 @@ func Variant(variant string) PodSpecMutator {
 	}
 }
 
+func CustomHashInput(input string) PodSpecMutator {
+	return func(spec *corev1.PodSpec) error {
+		container := &spec.Containers[0]
+		addUniqueParameter(container, fmt.Sprintf("--input-hash=%s", input))
+		return nil
+	}
+}
+
 // InjectTestFrom configures ci-operator to inject the specified test from the
 // specified ci-operator config into the base config and target it
 func InjectTestFrom(source *cioperatorapi.MetadataWithTest) PodSpecMutator {

--- a/pkg/prowgen/podspec_test.go
+++ b/pkg/prowgen/podspec_test.go
@@ -140,6 +140,38 @@ func TestTargets(t *testing.T) {
 	}
 }
 
+func TestCustomHashInput(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		inputs []string
+	}{
+		{
+			name:   "custom hash input is added",
+			inputs: []string{"one"},
+		},
+		{
+			name:   "custom hash inputs are added",
+			inputs: []string{"one", "two"},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewCiOperatorPodSpecGenerator()
+			for _, input := range tc.inputs {
+				g.Add(CustomHashInput(input))
+			}
+			podspec, err := g.Build()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			testhelper.CompareWithFixture(t, podspec)
+		})
+	}
+}
+
 func TestCIPullSecret(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
@@ -1,0 +1,32 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --input-hash=one
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
@@ -1,0 +1,33 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --input-hash=one
+  - --input-hash=two
+  - --report-credentials-file=/etc/report/credentials
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator


### PR DESCRIPTION
Needed to be able to generate jobs that do not share namespaces on identical inputs
