### PR TITLE
pkg/registry: ignore errors for overridden chains

### DIFF
--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -970,36 +970,18 @@ func TestResolveParameters(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ret, err := NewResolver(refs, chains, workflows, observers).Resolve("test", tc.test)
-			if tc.err != nil {
-				if err == nil {
-					t.Fatal("unexpected success")
-				}
-				if diff := cmp.Diff(err.Error(), tc.err.Error()); diff != "" {
-					t.Fatal(diff)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				var params [][]api.StepParameter
-				for _, s := range append(ret.Pre, append(ret.Test, ret.Post...)...) {
+			var params [][]api.StepParameter
+			var deps [][]api.StepDependency
+			for _, l := range [][]api.LiteralTestStep{ret.Pre, ret.Test, ret.Post} {
+				for _, s := range l {
 					params = append(params, s.Environment)
-				}
-				if diff := cmp.Diff(params, tc.expectedParams); diff != "" {
-					t.Error(diff)
-				}
-				var deps [][]api.StepDependency
-				for _, s := range append(ret.Pre, append(ret.Test, ret.Post...)...) {
 					deps = append(deps, s.Dependencies)
 				}
-				if diff := cmp.Diff(deps, tc.expectedDeps); diff != "" {
-					t.Error(diff)
-				}
-				depOverrides := ret.DependencyOverrides
-				if diff := cmp.Diff(depOverrides, tc.expectedDepOverrides); diff != "" {
-					t.Error(diff)
-				}
 			}
+			testhelper.Diff(t, "error", err, tc.err, testhelper.EquateErrorMessage)
+			testhelper.Diff(t, "parameters", params, tc.expectedParams)
+			testhelper.Diff(t, "dependencies", deps, tc.expectedDeps)
+			testhelper.Diff(t, "dependency overrides", ret.DependencyOverrides, tc.expectedDepOverrides)
 		})
 	}
 }

--- a/pkg/registry/resolver_test.go
+++ b/pkg/registry/resolver_test.go
@@ -967,6 +967,16 @@ func TestResolveParameters(t *testing.T) {
 			}},
 		},
 		err: errors.New("test/test: step/step: unresolved parameter: UNRESOLVED"),
+	}, {
+		name: "unresolved workflow override is not an error",
+		test: api.MultiStageTestConfiguration{
+			Workflow: &workflow,
+			Test: []api.TestStep{{
+				LiteralTestStep: &api.LiteralTestStep{As: "step"},
+			}},
+		},
+		expectedParams: [][]api.StepParameter{nil},
+		expectedDeps:   [][]api.StepDependency{nil},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			ret, err := NewResolver(refs, chains, workflows, observers).Resolve("test", tc.test)


### PR DESCRIPTION
This change makes validation accept a tricky corner case with workflows:

- a step declares a parameter (e.g. the `openshift-e2e-test` step
  declares `TEST_SKIP`)
- a workflow sets a value for that parameter (e.g. the
  `openshift-e2e-vsphere` workflow uses `TEST_SKIP` to always skip a
  suite in vSphere tests)
- a test uses the workflow, but replaces the chain that contains the
  step (e.g. the `e2e-vsphere-operator` uses `openshift-e2e-vsphere`
  with its own `test` chain)

Currently, this results in a validation error since the resulting
configuration's `env` section, inherited from the workflow, contains a
parameter that is not declared in any step.  It cannot be cleared in the
test's `env` section since mapping fields are merged, not overridden,
during resolution.  The only solution is to superfluously declare the
parameter in one of the tests' steps.

This change makes the resolution process keep track of the overridden
steps so that this type of error can be ignored.  This works since:

1. this situation can only occur in test/workflow combinations: in no
   other place where parameters are declared/overridden can a chain be
   replaced
2. parameter resolution is done bottom-up: ignored parameters are not
   included in the final configuration anyway

Ignoring errors instead of preemptively removing the parameter
declarations that target the overridden steps has the nice benefit that
only the error path is taxed.

https://issues.redhat.com/browse/DPTP-2602