### PR TITLE
WIP: Manual trigger tool for release jobs on PR

### DIFF
--- a/.fish-helpers
+++ b/.fish-helpers
@@ -1,0 +1,19 @@
+function forDavid
+    set --local aggid (uuid)
+    set --local org $argv[1]
+    set --local repo $argv[2]
+    set --local pr $argv[3]
+    set --local variant $argv[4]
+    set --local test $argv[5]
+    set --local iterations $argv[6]
+    set --local jobname $repo-$pr-$variant-$test
+    set --local confirm $argv[7]
+    for i in (seq $iterations)
+        go run ./cmd/payload-testing/manual-trigger/main.go --pull-request $org/$repo#$pr --test openshift/release@master__$variant:$test --github-token-path /home/afri/Temporary/muller-pat-2022-10-25 --prow-config-path=../release/core-services/prow/02_config/_config.yaml --confirm=$confirm --aggregation-id=$aggid
+    end
+
+    echo ""
+    echo "== Triggered $iterations `$variant:$test` iterations"
+    echo "URL:             https://prow.ci.openshift.org/?job=$jobname"
+    echo "Aggregation ID: `$aggid`"
+end

--- a/cmd/payload-testing/manual-trigger/main.go
+++ b/cmd/payload-testing/manual-trigger/main.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	pjclientset "k8s.io/test-infra/prow/client/clientset/versioned"
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/secret"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pjutil"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	ciopconfig "github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/prowgen"
+	"github.com/openshift/ci-tools/pkg/registry/server"
+	"github.com/openshift/ci-tools/pkg/util"
+)
+
+var (
+	configResolverAddress = api.URLForService(api.ServiceConfig)
+)
+
+func makeProwjob(configuration *api.ReleaseBuildConfiguration, pr *github.PullRequest, base *api.Metadata, inject *api.MetadataWithTest, prowConfig *prowconfig.Config) *prowconfig.Periodic {
+	fakeProwgenInfo := &prowgen.ProwgenInfo{
+		Metadata: *base,
+		Config:   ciopconfig.Prowgen{},
+	}
+
+	var periodic *prowconfig.Periodic
+	for i := range configuration.Tests {
+		if configuration.Tests[i].As == inject.Test {
+			jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(configuration, fakeProwgenInfo, prowgen.NewCiOperatorPodSpecGenerator(), configuration.Tests[i])
+			jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(inject))
+			jobBaseGen.PodSpec.Add(prowgen.CustomHashInput(time.Now().String()))
+
+			// TODO(muller): Solve cluster assignment
+			jobBaseGen.Cluster("build01")
+
+			periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, configuration.CanonicalGoRepository)
+			periodic.Name = fmt.Sprintf("%s-%s-%d-%s-%s", base.Org, base.Repo, pr.Number, inject.Variant, inject.Test)
+			break
+		}
+	}
+
+	// TODO(muller): Name the job something better
+	periodic.Name = fmt.Sprintf("%s-%d-%s-%s", base.Repo, pr.Number, inject.Variant, inject.Test)
+	// TODO(muller): Solve cluster assignment
+	periodic.Cluster = "build01"
+
+	// This is a copy of createRefs() from pjutil.go
+	// TODO(muller): DRY
+	periodic.ExtraRefs[0] = v1.Refs{
+		Org:      pr.Base.Repo.Owner.Login,
+		Repo:     pr.Base.Repo.Name,
+		RepoLink: pr.Base.Repo.HTMLURL,
+		BaseRef:  pr.Base.Ref,
+		BaseSHA:  pr.Base.SHA,
+		BaseLink: fmt.Sprintf("%s/commit/%s", pr.Base.Repo.HTMLURL, pr.Base.SHA),
+		Pulls: []v1.Pull{
+			{
+				Number:     pr.Number,
+				Author:     pr.User.Login,
+				SHA:        pr.Head.SHA,
+				Title:      pr.Title,
+				Link:       pr.HTMLURL,
+				AuthorLink: pr.User.HTMLURL,
+				CommitLink: fmt.Sprintf("%s/pull/%d/commits/%s", pr.Base.Repo.HTMLURL, pr.Number, pr.Head.SHA),
+			},
+		},
+	}
+	err := prowConfig.DefaultPeriodic(periodic)
+	if err != nil {
+		panic("Failed to roundtrip Prow config: read")
+	}
+
+	return periodic
+}
+
+type options struct {
+	pullRequest    string
+	test           string
+	prowConfigPath string
+
+	confirm bool
+
+	github prowflagutil.GitHubOptions
+}
+
+func gatherOptions() options {
+	o := options{}
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	fs.StringVar(&o.pullRequest, "pull-request", "", "Pull Request to test (org/repo#number)")
+	fs.StringVar(&o.test, "test", "", "Coordinates of the test to execute (org/repo@branch__variant:test)")
+	fs.BoolVar(&o.confirm, "confirm", false, "Set to true to actually submit the create ProwJob")
+	fs.StringVar(&o.prowConfigPath, "prow-config-path", "", "Path to Prow configuration file")
+
+	o.github.AddFlags(fs)
+
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		logrus.WithError(err).Fatalf("cannot parse args: '%s'", os.Args[1:])
+	}
+	return o
+}
+
+func (o *options) Validate() error {
+	if o.pullRequest == "" {
+		return errors.New("--pull-request must not be empty")
+	}
+	if o.test == "" {
+		return errors.New("--test must not be empty")
+	}
+	if o.prowConfigPath == "" {
+		return errors.New("--prow-config-path must not be empty")
+	}
+	return o.github.Validate(false)
+}
+
+type githubClient interface {
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+}
+
+func getPullRequest(ghc githubClient, pr string) (*github.PullRequest, error) {
+	parts := strings.Split(pr, "#")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("pull request not in org/repo#number format: %s", pr)
+	}
+	prNumber, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("pull request not in org/repo#number format: %s", pr)
+	}
+	orgRepo := strings.Split(parts[0], "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("pull request not in org/repo#number format: %s", pr)
+	}
+	org, repo := orgRepo[0], orgRepo[1]
+	return ghc.GetPullRequest(org, repo, prNumber)
+}
+
+func main() {
+	o := gatherOptions()
+	if err := o.Validate(); err != nil {
+		logrus.WithError(err).Fatal("Invalid options")
+	}
+
+	var token string
+	if o.github.TokenPath != "" {
+		token = o.github.TokenPath
+	}
+	if o.github.AppPrivateKeyPath != "" {
+		token = o.github.AppPrivateKeyPath
+	}
+	if token != "" {
+		if err := secret.Add(token); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
+	}
+
+	githubClient, err := o.github.GitHubClient(!o.confirm)
+	if err != nil {
+		logrus.WithError(err).Fatal("Error getting GitHub client.")
+	}
+
+	pr, err := getPullRequest(githubClient, o.pullRequest)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to get information about tested PR")
+	}
+	base := &api.Metadata{
+		Org:    pr.Base.Repo.Owner.Login,
+		Repo:   pr.Base.Repo.Name,
+		Branch: pr.Base.Ref,
+	}
+
+	inject, err := api.MetadataTestFromString(o.test)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to parse --test")
+	}
+
+	rc := server.NewResolverClient(configResolverAddress)
+	config, err := rc.ConfigWithTest(base, inject)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to load ci-operator configuration")
+	}
+
+	prowConfig, err := prowconfig.Load(o.prowConfigPath, "", nil, "")
+	prowjobConfig := makeProwjob(config, pr, base, inject, prowConfig)
+	if err != nil {
+		logrus.Fatal("Failed to make a Prowjob")
+	}
+	prowjob := pjutil.NewProwJob(pjutil.PeriodicSpec(*prowjobConfig), nil, nil)
+
+	if !o.confirm {
+		jobAsYAML, err := yaml.Marshal(prowjob)
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to marshal the prowjob to YAML")
+		}
+		fmt.Println(string(jobAsYAML))
+		os.Exit(0)
+	}
+
+	logrus.Info("getting cluster config")
+	clusterConfig, err := util.LoadClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to load cluster configuration")
+	}
+
+	pjcset, err := pjclientset.NewForConfig(clusterConfig)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create prowjob clientset")
+	}
+
+	pjclient := pjcset.ProwV1().ProwJobs("ci")
+
+	logrus.WithFields(pjutil.ProwJobFields(&prowjob)).Info("submitting a new prowjob")
+	_, err = pjclient.Create(context.TODO(), &prowjob, metav1.CreateOptions{})
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to submit the prowjob")
+	}
+}

--- a/cmd/payload-testing/manual-trigger/main.go
+++ b/cmd/payload-testing/manual-trigger/main.go
@@ -47,7 +47,7 @@ func makeProwjob(configuration *api.ReleaseBuildConfiguration, pr *github.PullRe
 			jobBaseGen.PodSpec.Add(prowgen.CustomHashInput(time.Now().String()))
 
 			// TODO(muller): Solve cluster assignment
-			jobBaseGen.Cluster("build01")
+			jobBaseGen.Cluster("build02")
 
 			periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, configuration.CanonicalGoRepository)
 			break
@@ -58,7 +58,7 @@ func makeProwjob(configuration *api.ReleaseBuildConfiguration, pr *github.PullRe
 	// TODO(muller): Name the job something better
 	periodic.Name = fmt.Sprintf("%s-%d-%s-%s", base.Repo, pr.Number, inject.Variant, inject.Test)
 	// TODO(muller): Solve cluster assignment
-	periodic.Cluster = "build01"
+	periodic.Cluster = "build02"
 
 	// This is a copy of createRefs() from pjutil.go
 	// TODO(muller): DRY

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -18,7 +17,6 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/pjutil"
-	utilpointer "k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -28,10 +26,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
 	"github.com/openshift/ci-tools/pkg/controller/prpqr_reconciler/pjstatussyncer"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/prowgen"
 )
 
 const (
@@ -43,7 +43,27 @@ const (
 	conditionWithErrors       = "WithErrors"
 )
 
-func AddToManager(mgr manager.Manager, ns string) error {
+type injectingResolverClient interface {
+	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error)
+}
+
+type prowConfigGetter interface {
+	Config() periodicDefaulter
+}
+
+type wrappedProwConfigAgent struct {
+	pc *prowconfig.Agent
+}
+
+func (w *wrappedProwConfigAgent) Config() periodicDefaulter {
+	return w.pc.Config()
+}
+
+type periodicDefaulter interface {
+	DefaultPeriodic(periodic *prowconfig.Periodic) error
+}
+
+func AddToManager(mgr manager.Manager, ns string, rc injectingResolverClient, prowConfigAgent *prowconfig.Agent) error {
 	if err := pjstatussyncer.AddToManager(mgr, ns); err != nil {
 		return fmt.Errorf("failed to construct pjstatussyncer: %w", err)
 	}
@@ -51,8 +71,10 @@ func AddToManager(mgr manager.Manager, ns string) error {
 	c, err := controller.New(controllerName, mgr, controller.Options{
 		MaxConcurrentReconciles: 1,
 		Reconciler: &reconciler{
-			logger: logrus.WithField("controller", controllerName),
-			client: mgr.GetClient(),
+			logger:               logrus.WithField("controller", controllerName),
+			client:               mgr.GetClient(),
+			configResolverClient: rc,
+			prowConfigGetter:     &wrappedProwConfigAgent{pc: prowConfigAgent},
 		},
 	})
 	if err != nil {
@@ -92,6 +114,9 @@ func prpqrHandler() handler.EventHandler {
 type reconciler struct {
 	logger *logrus.Entry
 	client ctrlruntimeclient.Client
+
+	configResolverClient injectingResolverClient
+	prowConfigGetter     prowConfigGetter
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -117,7 +142,14 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 		return fmt.Errorf("failed to get the PullRequestPayloadQualificationRun: %s in namespace %s: %w", req.Name, req.Namespace, err)
 	}
 
-	prowjobs := generateProwjobs(prpqr.Spec.PullRequest.Org, prpqr.Spec.PullRequest.Repo, prpqr.Spec.PullRequest.BaseRef, req.Name, req.Namespace, prpqr.Spec.Jobs.Jobs)
+	baseMetadata := metadataFromPullRequestUnderTest(prpqr.Spec.PullRequest)
+	prowjobs, errs := generateProwjobs(r.configResolverClient, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, prpqr.Spec.Jobs.Jobs, &prpqr.Spec.PullRequest)
+	for job, err := range errs {
+		createdJobs[job] = v1.PullRequestPayloadJobStatus{ReleaseJobName: job, Status: prowv1.ProwJobStatus{
+			State:       prowv1.ErrorState,
+			Description: err.Error(),
+		}}
+	}
 	for releaseJobName, pj := range prowjobs {
 		logger = logger.WithFields(logrus.Fields{"name": pj.Name, "namespace": req.Namespace})
 
@@ -223,47 +255,101 @@ func jobNameHash(name string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-// TODO: Currently we create a single dummy prowjob just for testing. The actual implementation
-// will be introduced in https://issues.redhat.com/browse/DPTP-2577
-func generateProwjobs(org, repo, branch, prpqrName, prpqrNamespace string, releaseJobSpec []v1.ReleaseJobSpec) map[string]prowv1.ProwJob {
-	ret := make(map[string]prowv1.ProwJob)
+func generateProwjobs(rc injectingResolverClient, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, releaseJobSpec []v1.ReleaseJobSpec, pr *v1.PullRequestUnderTest) (map[string]prowv1.ProwJob, map[string]error) {
+	fakeProwgenInfo := &prowgen.ProwgenInfo{Metadata: *baseCiop}
+
+	prowjobs := map[string]prowv1.ProwJob{}
+	errs := map[string]error{}
+
 	for _, spec := range releaseJobSpec {
-		releaseJobName := spec.JobName(jobconfig.PeriodicPrefix)
+		mimickedJob := spec.JobName(jobconfig.PeriodicPrefix)
 		labels := map[string]string{
 			v1.PullRequestPayloadQualificationRunLabel: prpqrName,
-			releaseJobNameLabel:                        jobNameHash(releaseJobName),
+			releaseJobNameLabel:                        jobNameHash(mimickedJob),
 		}
 		annotations := map[string]string{
-			releaseJobNameAnnotation: releaseJobName,
+			releaseJobNameAnnotation: mimickedJob,
 		}
 
-		base := prowconfig.JobBase{
-			Agent: string(prowv1.KubernetesAgent),
-			Spec: &corev1.PodSpec{
-				Containers: []corev1.Container{{Image: "centos:8", Command: []string{"sleep"}, Args: []string{"100"}}},
+		inject := &api.MetadataWithTest{
+			Metadata: api.Metadata{
+				Org:     spec.CIOperatorConfig.Org,
+				Repo:    spec.CIOperatorConfig.Repo,
+				Branch:  spec.CIOperatorConfig.Branch,
+				Variant: spec.CIOperatorConfig.Variant,
 			},
+			Test: spec.Test,
+		}
 
-			UtilityConfig: prowconfig.UtilityConfig{
-				Decorate: utilpointer.BoolPtr(true),
-			},
+		ciopConfig, err := rc.ConfigWithTest(baseCiop, inject)
+		if err != nil {
+			errs[mimickedJob] = fmt.Errorf("failed to get config from resolver: %w", err)
+			continue
+		}
+
+		var periodic *prowconfig.Periodic
+		for i := range ciopConfig.Tests {
+			if ciopConfig.Tests[i].As == inject.Test {
+				jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, fakeProwgenInfo, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[i])
+				jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(inject))
+
+				// Avoid sharing when we run the same job multiple times.
+				jobBaseGen.PodSpec.Add(prowgen.CustomHashInput(time.Now().String()))
+
+				// TODO(muller): Solve cluster assignment
+				jobBaseGen.Cluster("build01")
+				periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
+				var variant string
+				if inject.Variant != "" {
+					variant = fmt.Sprintf("-%s", variant)
+				}
+				periodic.Name = fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+				break
+			}
+		}
+		// We did not find the injected test: this is a bug
+		if periodic == nil {
+			errs[mimickedJob] = fmt.Errorf("BUG: test '%s' not found in injected config", inject.Test)
+			continue
 		}
 
 		extraRefs := prowv1.Refs{
-			Org:     org,
-			Repo:    repo,
-			BaseRef: branch,
+			Org:  baseCiop.Org,
+			Repo: baseCiop.Repo,
+			// TODO(muller): All these commented-out fields need to be propagated via the PRPQR spec
+			// We do not need them now but we should eventually wire them through
+			// RepoLink:  pr.Base.Repo.HTMLURL,
+			BaseRef: pr.BaseRef,
+			BaseSHA: pr.BaseSHA,
+			// BaseLink:  fmt.Sprintf("%s/commit/%s", pr.Base.Repo.HTMLURL, pr.BaseSHA),
+			PathAlias: periodic.ExtraRefs[0].PathAlias,
+			Pulls: []prowv1.Pull{
+				{
+					Number: pr.PullRequest.Number,
+					Author: pr.PullRequest.Author,
+					SHA:    pr.PullRequest.SHA,
+					Title:  pr.PullRequest.Title,
+					// Link:       pr.HTMLURL,
+					// AuthorLink: pr.User.HTMLURL,
+					// CommitLink: fmt.Sprintf("%s/pull/%d/commits/%s", pr.Base.Repo.HTMLURL, pr.Number, pr.Head.SHA),
+				},
+			},
 		}
-		base.ExtraRefs = []prowv1.Refs{extraRefs}
+		periodic.ExtraRefs = []prowv1.Refs{extraRefs}
 
-		periodicJob := prowconfig.Periodic{
-			JobBase: base,
-			Cron:    "@yearly",
+		if err = defaulter.DefaultPeriodic(periodic); err != nil {
+			errs[mimickedJob] = fmt.Errorf("failed to default the ProwJob: %w", err)
+			continue
 		}
 
-		pj := pjutil.NewProwJob(pjutil.PeriodicSpec(periodicJob), labels, annotations)
+		pj := pjutil.NewProwJob(pjutil.PeriodicSpec(*periodic), labels, annotations)
 		pj.Namespace = prpqrNamespace
 
-		ret[releaseJobName] = pj
+		prowjobs[mimickedJob] = pj
 	}
-	return ret
+	return prowjobs, errs
+}
+
+func metadataFromPullRequestUnderTest(pr v1.PullRequestUnderTest) *api.Metadata {
+	return &api.Metadata{Org: pr.Org, Repo: pr.Repo, Branch: pr.BaseRef}
 }


### PR DESCRIPTION
- prowgen: refactor code for reusability
- manual-trigger for payload-testing
- Bump test-infra (stand-in for https://github.com/openshift/ci-tools/pull/2489)
- WIP: Integrate dynamic payload tests with job-trigger-cm

[DPTP-2577](https://issues.redhat.com/browse/DPTP-2577)

Just the last commit is important: I will likely want to split smaller PRs from this.