### PR TITLE
payload-testing-ui: check presence of status URL

### DIFF
--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -81,7 +81,11 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
     <tt>
       {{ with $status := jobStatus $i }}
         <span class="{{ jobClass $status }}">{{ jobText $job }}</span>:
-        <a href="{{ $status.Status.URL }}">{{ $status.ProwJob }}</a>
+        {{ if $status.Status.URL }}
+          <a href="{{ $status.Status.URL }}">{{ $status.ProwJob }}</a>
+        {{ else }}
+          {{ $status.ProwJob }}
+        {{ end }}
       {{ else }}
         {{ jobText $job }}
       {{ end }}


### PR DESCRIPTION
The URL in the status is filled by `plank` after the creation of the
`ProwJob`, so it may be empty while the test is scheduled.