### PR TITLE
prpqr plugin: downgrade several log events to `Trace`

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -137,14 +137,14 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) string {
 
 	// only reacts on comments on PRs
 	if !ic.Issue.IsPullRequest() {
-		logger.Debug("not a pull request")
+		logger.Trace("not a pull request")
 		return ""
 	}
 
-	logger.WithField("ic.Comment.Body", ic.Comment.Body).Debug("received a comment")
+	logger.WithField("ic.Comment.Body", ic.Comment.Body).Trace("received a comment")
 	specs := specsFromComment(ic.Comment.Body)
 	if len(specs) == 0 {
-		logger.Debug("found no specs from comments")
+		logger.Trace("found no specs from comments")
 		return ""
 	}
 


### PR DESCRIPTION
We bumped logging to debug, and now we log every comment on everything. Downgrade logs that say 'this event is not interesting for this plugin' to `Trace`
