### PR TITLE
read backend disruption for aggregator from the raw data instead of the junit

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/interfaces.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/interfaces.go
@@ -28,6 +28,9 @@ type JobRunInfo interface {
 
 	GetProwJob(ctx context.Context) (*prowjobv1.ProwJob, error)
 	GetCombinedJUnitTestSuites(ctx context.Context) (*junit.TestSuites, error)
+	// GetOpenShiftTestsFilesWithPrefix checks the datasource for "openshift-e2e-test/artifacts/junit/<prefix>*"
+	// and returns that content indexed by local filename.  This is useful for things like back-disruption and alerts.
+	GetOpenShiftTestsFilesWithPrefix(ctx context.Context, prefix string) (map[string]string, error)
 	GetContent(ctx context.Context, path string) ([]byte, error)
 	GetAllContent(ctx context.Context) (map[string][]byte, error)
 	ClearAllContent()

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -2,12 +2,14 @@ package jobrunbigqueryloader
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math"
 	"regexp"
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
@@ -21,7 +23,46 @@ type availabilityResult struct {
 	secondsUnavailable int
 }
 
-func getServerAvailabilityResults(suites *junit.TestSuites) map[string]availabilityResult {
+type BackendDisruptionList struct {
+	// BackendDisruptions is keyed by name to make the consumption easier
+	BackendDisruptions map[string]*BackendDisruption
+}
+
+type BackendDisruption struct {
+	// Name ensure self-identification
+	Name string
+	// ConnectionType is New or Reused
+	ConnectionType     string
+	DisruptedDuration  metav1.Duration
+	DisruptionMessages []string
+}
+
+func getServerAvailabilityResultsFromDirectData(backendDisruptionData map[string]string) map[string]availabilityResult {
+	availabilityResultsByName := map[string]availabilityResult{}
+
+	for _, disruptionJSON := range backendDisruptionData {
+		if len(disruptionJSON) == 0 {
+			continue
+		}
+		allDisruptions := &BackendDisruptionList{}
+		if err := json.Unmarshal([]byte(disruptionJSON), allDisruptions); err != nil {
+			continue
+		}
+
+		currAvailabilityResults := map[string]availabilityResult{}
+		for _, disruption := range allDisruptions.BackendDisruptions {
+			currAvailabilityResults[disruption.Name] = availabilityResult{
+				serverName:         disruption.Name,
+				secondsUnavailable: int(math.Ceil(disruption.DisruptedDuration.Seconds())),
+			}
+		}
+		addUnavailability(availabilityResultsByName, currAvailabilityResults)
+	}
+
+	return availabilityResultsByName
+}
+
+func getServerAvailabilityResultsFromJunit(suites *junit.TestSuites) map[string]availabilityResult {
 	availabilityResultsByName := map[string]availabilityResult{}
 
 	for _, curr := range suites.Suites {
@@ -151,17 +192,56 @@ func newDisruptionUploader(backendDisruptionInserter jobrunaggregatorlib.BigQuer
 
 func (o *disruptionUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob) error {
 	fmt.Printf("  uploading backend disruption results: %q/%q\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+	backendDisruptionData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "backend-disruption")
+	if err != nil {
+		return err
+	}
+	if len(backendDisruptionData) > 0 {
+		return o.uploadBackendDisruptionFromDirectData(ctx, jobRun.GetJobRunID(), backendDisruptionData)
+	}
+
+	dateWeStartedTrackingDirectDisruptionData, err := time.Parse(time.RFC3339, "2021-11-08T00:00:00Z")
+	if err != nil {
+		return err
+	}
+	// TODO fix better before we hit 4.20
+	releaseHasDisruptionData := strings.Contains(jobRun.GetJobName(), "4.10") ||
+		strings.Contains(jobRun.GetJobName(), "4.11") ||
+		strings.Contains(jobRun.GetJobName(), "4.12") ||
+		strings.Contains(jobRun.GetJobName(), "4.13") ||
+		strings.Contains(jobRun.GetJobName(), "4.14") ||
+		strings.Contains(jobRun.GetJobName(), "4.15") ||
+		strings.Contains(jobRun.GetJobName(), "4.16") ||
+		strings.Contains(jobRun.GetJobName(), "4.17") ||
+		strings.Contains(jobRun.GetJobName(), "4.17") ||
+		strings.Contains(jobRun.GetJobName(), "4.19")
+	if releaseHasDisruptionData && prowJob.CreationTimestamp.After(dateWeStartedTrackingDirectDisruptionData) {
+		fmt.Printf("  No disruption data found, returning: %v/%v\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+		// we  have no data, just return
+		return nil
+	}
+
+	fmt.Printf("  missing direct backend disruption results, trying to read from junit: %v/%v\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+	// if we don't have
 	combinedJunitContent, err := jobRun.GetCombinedJUnitTestSuites(ctx)
 	if err != nil {
 		return err
 	}
 
-	return o.uploadBackendDisruption(ctx, jobRun.GetJobRunID(), combinedJunitContent)
+	return o.uploadBackendDisruptionFromJunit(ctx, jobRun.GetJobRunID(), combinedJunitContent)
 }
 
-func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRunName string, suites *junit.TestSuites) error {
+func (o *disruptionUploader) uploadBackendDisruptionFromJunit(ctx context.Context, jobRunName string, suites *junit.TestSuites) error {
+	serverAvailabilityResults := getServerAvailabilityResultsFromJunit(suites)
+	return o.uploadBackendDisruption(ctx, jobRunName, serverAvailabilityResults)
+}
+
+func (o *disruptionUploader) uploadBackendDisruptionFromDirectData(ctx context.Context, jobRunName string, backendDisruptionData map[string]string) error {
+	serverAvailabilityResults := getServerAvailabilityResultsFromDirectData(backendDisruptionData)
+	return o.uploadBackendDisruption(ctx, jobRunName, serverAvailabilityResults)
+}
+func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRunName string, serverAvailabilityResults map[string]availabilityResult) error {
 	rows := []*jobrunaggregatorapi.BackendDisruptionRow{}
-	serverAvailabilityResults := getServerAvailabilityResults(suites)
 	for _, backendName := range sets.StringKeySet(serverAvailabilityResults).List() {
 		unavailability := serverAvailabilityResults[backendName]
 		row := &jobrunaggregatorapi.BackendDisruptionRow{


### PR DESCRIPTION
This lets us add disruption tests in origin and have them reported without change the code in the aggregator.

I left the old code in to gather data from pre-4.10 releases until we ship 4.10.  Then we can probably remove them