### PR TITLE
add cluster profile for multizone vSphere CI pool

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1114,6 +1114,7 @@ const (
 	ClusterProfileVSphere               ClusterProfile = "vsphere"
 	ClusterProfileVSphereDiscon         ClusterProfile = "vsphere-discon"
 	ClusterProfileVSphereClusterbot     ClusterProfile = "vsphere-clusterbot"
+	ClusterProfileVSphereMultizone      ClusterProfile = "vsphere-multizone"
 	ClusterProfileKubevirt              ClusterProfile = "kubevirt"
 	ClusterProfileAWSCPaaS              ClusterProfile = "aws-cpaas"
 	ClusterProfileOSDEphemeral          ClusterProfile = "osd-ephemeral"
@@ -1164,6 +1165,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileVSphere,
 		ClusterProfileVSphereDiscon,
 		ClusterProfileVSphereClusterbot,
+		ClusterProfileVSphereMultizone,
 		ClusterProfileKubevirt,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileOSDEphemeral,
@@ -1238,9 +1240,9 @@ func (p ClusterProfile) ClusterType() string {
 	case
 		ClusterProfileVSphere,
 		ClusterProfileVSphereDiscon,
-		ClusterProfileVSphereClusterbot:
+		ClusterProfileVSphereClusterbot,
+		ClusterProfileVSphereMultizone:
 		return "vsphere"
-
 	case ClusterProfileOvirt:
 		return "ovirt"
 	case
@@ -1335,6 +1337,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "vsphere-discon-quota-slice"
 	case ClusterProfileVSphereClusterbot:
 		return "vsphere-clusterbot-quota-slice"
+	case ClusterProfileVSphereMultizone:
+		return "vsphere-multizone-quota-slice"
 	case ClusterProfileKubevirt:
 		return "kubevirt-quota-slice"
 	case ClusterProfileAWSCPaaS:

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -341,6 +341,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileVSphere,
 		cioperatorapi.ClusterProfileVSphereDiscon,
 		cioperatorapi.ClusterProfileVSphereClusterbot,
+		cioperatorapi.ClusterProfileVSphereMultizone,
 		cioperatorapi.ClusterProfileKubevirt,
 		cioperatorapi.ClusterProfileAWSCPaaS,
 		cioperatorapi.ClusterProfileOSDEphemeral,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -437,6 +437,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileVSphere,
 		api.ClusterProfileVSphereDiscon,
 		api.ClusterProfileVSphereClusterbot,
+		api.ClusterProfileVSphereMultizone,
 		api.ClusterProfileKubevirt,
 		api.ClusterProfileAWSCPaaS,
 		api.ClusterProfileAWS2,


### PR DESCRIPTION
The intention of this PR is to add a new cluster profile which will be used target specific CI jobs to a resource pool capable of running e2e tests in a multizone vSphere environment.