### PR TITLE
Change http client to http client with retry options

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
@@ -104,8 +104,10 @@ func FromConfig(
 			return nil, nil, fmt.Errorf("could not get Hive client for Hive kube config: %w", err)
 		}
 	}
+	httpClient := retryablehttp.NewClient()
+	httpClient.Logger = nil
 
-	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, &http.Client{}, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost)
+	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient.StandardClient(), requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost)
 }
 
 func fromConfig(


### PR DESCRIPTION
Due to rare protocol errors, a standard HTTP client is exchanged with a retriable HTTP client. To keep compatibility, after creating a retriable client, it is converted to the standard client with a custom transport.

An alternative approach to this problem would be to inject a custom transport to the standard HTTP client (which is exactly what a retriable HTTP client does).
Logger is nulled similarly to pkg/github/github.go

Signed-off-by: Jakub Guzik <jguzik@redhat.com>