### PR TITLE
retry on query quota rate exceeded

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -119,7 +119,9 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 	if err != nil {
 		return nil, err
 	}
-	ciDataClient := jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, bigQueryClient)
+	ciDataClient := jobrunaggregatorlib.NewRetryingCIDataClient(
+		jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, bigQueryClient),
+	)
 
 	gcsClient, err := f.Authentication.NewGCSClient(ctx)
 	if err != nil {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -1,0 +1,133 @@
+package jobrunaggregatorlib
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
+)
+
+type retryingCIDataClient struct {
+	delegate CIDataClient
+}
+
+var _ CIDataClient = &retryingCIDataClient{}
+
+func NewRetryingCIDataClient(delegate CIDataClient) CIDataClient {
+	return &retryingCIDataClient{
+		delegate: delegate,
+	}
+}
+
+func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error) {
+	var ret []jobrunaggregatorapi.JobRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListAllJobs(ctx)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastJobRunWithTestRunDataForJobName(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastJobRunWithTestRunDataForJobName(ctx, jobName)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastJobRunWithDisruptionDataForJobName(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastJobRunWithDisruptionDataForJobName(ctx, jobName)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastAggregationForJob(ctx context.Context, frequency, jobName string) (*jobrunaggregatorapi.AggregatedTestRunRow, error) {
+	var ret *jobrunaggregatorapi.AggregatedTestRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastAggregationForJob(ctx, frequency, jobName)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) ListUnifiedTestRunsForJobAfterDay(ctx context.Context, jobName string, startDay time.Time) (*UnifiedTestRunRowIterator, error) {
+	var ret *UnifiedTestRunRowIterator
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListUnifiedTestRunsForJobAfterDay(ctx, jobName, startDay)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) ListReleaseTags(ctx context.Context) (sets.String, error) {
+	var ret sets.String
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListReleaseTags(ctx)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetJobRunForJobNameBeforeTime(ctx, jobName, targetTime)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetJobRunForJobNameAfterTime(ctx, jobName, targetTime)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) ListAggregatedTestRunsForJob(ctx context.Context, frequency, jobName string, startDay time.Time) ([]jobrunaggregatorapi.AggregatedTestRunRow, error) {
+	var ret []jobrunaggregatorapi.AggregatedTestRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListAggregatedTestRunsForJob(ctx, frequency, jobName, startDay)
+		return innerErr
+	})
+	return ret, err
+}
+
+var slowBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Cap:      200 * time.Second,
+}
+
+func isReadQuotaError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "exceeded quota for concurrent queries") {
+		return true
+	}
+	return false
+}

--- a/pkg/jobrunaggregator/releasebigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/cmd.go
@@ -82,13 +82,15 @@ func (f *BigQueryReleaseUploadFlags) Validate() error {
 // ToOptions goes from the user input to the runtime values need to run the command.
 // Expect to see unit tests on the options, but not on the flags which are simply value mappings.
 func (f *BigQueryReleaseUploadFlags) ToOptions(ctx context.Context) (*allReleaseUploaderOptions, error) {
-	client, err := f.Authentication.NewBigQueryClient(ctx, f.DataCoordinates.ProjectID)
+	bigQueryClient, err := f.Authentication.NewBigQueryClient(ctx, f.DataCoordinates.ProjectID)
 	if err != nil {
 		return nil, err
 	}
-	ciDataClient := jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, client)
+	ciDataClient := jobrunaggregatorlib.NewRetryingCIDataClient(
+		jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, bigQueryClient),
+	)
 	httpClient := &http.Client{Timeout: 60 * time.Second}
-	ciDataSet := client.Dataset(f.DataCoordinates.DataSetID)
+	ciDataSet := bigQueryClient.Dataset(f.DataCoordinates.DataSetID)
 
 	return &allReleaseUploaderOptions{
 		ciDataClient:  ciDataClient,
@@ -165,12 +167,14 @@ func (f *BigQueryReleaseTableCreateFlags) Validate() error {
 // ToOptions goes from the user input to the runtime values need to run the command.
 // Expect to see unit tests on the options, but not on the flags which are simply value mappings.
 func (f *BigQueryReleaseTableCreateFlags) ToOptions(ctx context.Context) (*allReleaseTableCreatorOptions, error) {
-	client, err := f.Authentication.NewBigQueryClient(ctx, f.DataCoordinates.ProjectID)
+	bigQueryClient, err := f.Authentication.NewBigQueryClient(ctx, f.DataCoordinates.ProjectID)
 	if err != nil {
 		return nil, err
 	}
-	ciDataClient := jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, client)
-	ciDataSet := client.Dataset(f.DataCoordinates.DataSetID)
+	ciDataClient := jobrunaggregatorlib.NewRetryingCIDataClient(
+		jobrunaggregatorlib.NewCIDataClient(*f.DataCoordinates, bigQueryClient),
+	)
+	ciDataSet := bigQueryClient.Dataset(f.DataCoordinates.DataSetID)
 
 	return &allReleaseTableCreatorOptions{
 		ciDataClient: ciDataClient,


### PR DESCRIPTION
we see errors like
 
> time="2021-11-16T04:00:44Z" level=fatal msg="Command failed" error="failed to query aggregation table with \"\\nSELECT *\\nFROM openshift-ci-data-analysis.ci_data.BackendDisruption_JobRuns as JobRuns\\nWHERE JobRuns.JobName = @JobName\\nORDER BY JobRuns.Name DESC\\nLIMIT 1\\n\": googleapi: Error 400: Job exceeded rate limits: Your project_and_region exceeded quota for concurrent queries. For more information, see https://cloud.google.com/bigquery/docs/troubleshoot-quotas, jobRateLimitExceeded"


in our log, which cause retries.  This wraps our client to retry on a backoff.