### PR TITLE
Don't fetch release tag again if it's already in bigquery

### DIFF
--- a/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
@@ -70,14 +70,17 @@ func (r *allReleaseUploaderOptions) Run(ctx context.Context) error {
 
 		for _, tags := range allTags {
 			for _, tag := range tags.Tags {
+				// Skip release tags that are already in BigQuery
+				if _, ok := releaseTagSet[tag.Name]; ok {
+					fmt.Fprintf(os.Stderr, "%s is already present, skipping...\n", tag.Name)
+					continue
+				}
+
 				fmt.Fprintf(os.Stderr, "Fetching tag %s from release controller...\n", tag.Name)
 				releaseDetails := r.fetchReleaseDetails(tags.Architecture, release, tag)
 				releaseTag, repositories, pullRequests := releaseDetailsToBigQuery(tags.Architecture, tag, releaseDetails)
-				// We skip releases that aren't fully baked, or already in the big query tables:
+				// We skip releases that aren't fully baked (i.e. all jobs run and changelog calculated)
 				if releaseTag.Phase == "Ready" || repositories == nil {
-					continue
-				}
-				if _, ok := releaseTagSet[releaseTag.ReleaseTag]; ok {
 					continue
 				}
 

--- a/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
@@ -80,7 +80,7 @@ func (r *allReleaseUploaderOptions) Run(ctx context.Context) error {
 				releaseDetails := r.fetchReleaseDetails(tags.Architecture, release, tag)
 				releaseTag, repositories, pullRequests := releaseDetailsToBigQuery(tags.Architecture, tag, releaseDetails)
 				// We skip releases that aren't fully baked (i.e. all jobs run and changelog calculated)
-				if releaseTag.Phase == "Ready" || repositories == nil {
+				if (releaseTag.Phase != "Accepted" && releaseTag.Phase != "Rejected") || repositories == nil {
 					continue
 				}
 


### PR DESCRIPTION
There's no reason to fetch the tag again if it's in bigquery, this makes
it much faster to run this.

The code also previously assumed the only incomplete state was "Ready," but a
release can be pending as well. We are ONLY interested in releases that
are Accepted or Rejected (which indicates all jobs have been run), so we
explicitly check that instead.
