### PR TITLE
add the capability to aggregate per-pr payload promotion jobs

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -187,7 +187,12 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 		)
 	}
 
-	currentAggregationJunit := &aggregatedJobRunJunit{}
+	currentAggregationJunit := &aggregatedJobRunJunit{
+		jobGCSBucketRoot: filepath.Join("logs", o.jobName),
+	}
+	if len(o.explicitGCSPrefix) > 0 {
+		currentAggregationJunit.jobGCSBucketRoot = o.explicitGCSPrefix
+	}
 	for i := range finishedJobsToAggregate {
 		jobRun := finishedJobsToAggregate[i]
 		currJunit, err := newJobRunJunit(ctx, jobRun)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -28,9 +28,10 @@ type JobRunAggregatorAnalyzerOptions struct {
 	jobRunLocator      jobrunaggregatorlib.JobRunLocator
 	passFailCalculator baseline
 
-	jobName    string
-	payloadTag string
-	workingDir string
+	explicitGCSPrefix string
+	jobName           string
+	payloadTag        string
+	workingDir        string
 
 	// jobRunStartEstimate is the time that we think the job runs we're aggregating started.
 	// it should be within an hour, plus or minus.
@@ -170,13 +171,17 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 
 	aggregationConfiguration := &AggregationConfiguration{}
 	for _, jobRunName := range unfinishedJobNames {
+		jobRunGCSBucketRoot := filepath.Join("logs", o.jobName, jobRunName)
+		if len(o.explicitGCSPrefix) > 0 {
+			jobRunGCSBucketRoot = filepath.Join(o.explicitGCSPrefix, jobRunName)
+		}
 		aggregationConfiguration.FinishedJobs = append(
 			aggregationConfiguration.FinishedJobs,
 			JobRunInfo{
 				JobName:      o.jobName,
 				JobRunID:     jobRunName,
-				HumanURL:     jobrunaggregatorapi.GetHumanURL(o.jobName, jobRunName),
-				GCSBucketURL: jobrunaggregatorapi.GetGCSArtifactURL(o.jobName, jobRunName),
+				HumanURL:     jobrunaggregatorapi.GetHumanURLForLocation(jobRunGCSBucketRoot),
+				GCSBucketURL: jobrunaggregatorapi.GetGCSArtifactURLForLocation(jobRunGCSBucketRoot),
 				Status:       "unknown",
 			},
 		)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -28,6 +28,8 @@ type JobRunAggregatorAnalyzerOptions struct {
 	jobRunLocator      jobrunaggregatorlib.JobRunLocator
 	passFailCalculator baseline
 
+	// explicitGCSPrefix is set to control the base path we search in GCSBuckets. If not set, the jobName will be used
+	// to set a default value that usually works.
 	explicitGCSPrefix string
 	jobName           string
 	payloadTag        string
@@ -236,7 +238,7 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	}
 
 	fmt.Printf("%q for %q:  aggregating disruption tests.\n", o.jobName, o.payloadTag)
-	disruptionSuite, err := o.CalculateDisruptionTestSuite(ctx, o.jobName, finishedJobsToAggregate)
+	disruptionSuite, err := o.CalculateDisruptionTestSuite(ctx, currentAggregationJunit.jobGCSBucketRoot, finishedJobsToAggregate)
 	if err != nil {
 		return err
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 
 	"gopkg.in/yaml.v2"
 
@@ -15,7 +16,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
-func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx context.Context, jobName string, finishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo) (*junit.TestSuite, error) {
+func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx context.Context, jobGCSBucketRoot string, finishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo) (*junit.TestSuite, error) {
 	disruptionJunitSuite := &junit.TestSuite{
 		Name:      "BackendDisruption",
 		TestCases: []*junit.TestCase{},
@@ -67,8 +68,8 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 		}
 		for jobRunID := range jobRunIDToAvailabilityResultForBackend {
 			currAvailabilityStat := jobRunIDToAvailabilityResultForBackend[jobRunID]
-			humanURL := jobrunaggregatorapi.GetHumanURL(jobName, jobRunID)
-			gcsArtifactURL := jobrunaggregatorapi.GetGCSArtifactURL(jobName, jobRunID)
+			humanURL := jobrunaggregatorapi.GetHumanURLForLocation(path.Join(jobGCSBucketRoot, jobRunID))
+			gcsArtifactURL := jobrunaggregatorapi.GetGCSArtifactURLForLocation(path.Join(jobGCSBucketRoot, jobRunID))
 			overMean := float64(currAvailabilityStat.SecondsUnavailable) > historicalStats.mean
 			overP95 := float64(currAvailabilityStat.SecondsUnavailable) > historicalStats.p95
 			switch {

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -47,8 +47,8 @@ func (f *JobRunsAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobName, "job", f.JobName, "The name of the job to inspect, like periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade")
 	fs.StringVar(&f.WorkingDir, "working-dir", f.WorkingDir, "The directory to store caches, output, and the like.")
 	fs.StringVar(&f.PayloadTag, "payload-tag", f.PayloadTag, "The payload tag to aggregate, like 4.9.0-0.ci-2021-07-19-185802")
-	fs.StringVar(&f.AggregationID, "aggregation-id", f.AggregationID, "mutually exclusive to --payload-tag.  Matches the .label[release.openshift.io/aggregation-id], which is a UID")
-	fs.StringVar(&f.ExplicitGCSPrefix, "explicit-gcs-prefix", f.ExplicitGCSPrefix, "only used by per PR payload promotion jobs.  This overrides the well-known mapping and scopes the GCS query")
+	fs.StringVar(&f.AggregationID, "aggregation-id", f.AggregationID, "mutually exclusive to --payload-tag.  Matches the .label[release.openshift.io/aggregation-id] on the prowjob, which is a UID")
+	fs.StringVar(&f.ExplicitGCSPrefix, "explicit-gcs-prefix", f.ExplicitGCSPrefix, "only used by per PR payload promotion jobs.  This overrides the well-known mapping and becomes the required prefix for the GCS query")
 	fs.DurationVar(&f.Timeout, "timeout", f.Timeout, "Time to wait for aggregation to complete.")
 	fs.StringVar(&f.EstimatedJobStartTimeString, "job-start-time", f.EstimatedJobStartTimeString, fmt.Sprintf("Start time in RFC822Z: %s", kubeTimeSerializationLayout))
 }

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -21,6 +21,8 @@ type JobRunsAnalyzerFlags struct {
 	JobName                     string
 	WorkingDir                  string
 	PayloadTag                  string
+	AggregationID               string
+	ExplicitGCSPrefix           string
 	Timeout                     time.Duration
 	EstimatedJobStartTimeString string
 }
@@ -45,6 +47,8 @@ func (f *JobRunsAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobName, "job", f.JobName, "The name of the job to inspect, like periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade")
 	fs.StringVar(&f.WorkingDir, "working-dir", f.WorkingDir, "The directory to store caches, output, and the like.")
 	fs.StringVar(&f.PayloadTag, "payload-tag", f.PayloadTag, "The payload tag to aggregate, like 4.9.0-0.ci-2021-07-19-185802")
+	fs.StringVar(&f.AggregationID, "aggregation-id", f.AggregationID, "mutually exclusive to --payload-tag.  Matches the .label[release.openshift.io/aggregation-id], which is a UID")
+	fs.StringVar(&f.ExplicitGCSPrefix, "explicit-gcs-prefix", f.ExplicitGCSPrefix, "only used by per PR payload promotion jobs.  This overrides the well-known mapping and scopes the GCS query")
 	fs.DurationVar(&f.Timeout, "timeout", f.Timeout, "Time to wait for aggregation to complete.")
 	fs.StringVar(&f.EstimatedJobStartTimeString, "job-start-time", f.EstimatedJobStartTimeString, fmt.Sprintf("Start time in RFC822Z: %s", kubeTimeSerializationLayout))
 }
@@ -91,9 +95,6 @@ func (f *JobRunsAnalyzerFlags) Validate() error {
 	if len(f.JobName) == 0 {
 		return fmt.Errorf("missing --job: like periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade")
 	}
-	if len(f.PayloadTag) == 0 {
-		return fmt.Errorf("missing --job: like 4.9.0-0.ci-2021-07-19-185802")
-	}
 	if _, err := time.Parse(kubeTimeSerializationLayout, f.EstimatedJobStartTimeString); err != nil {
 		return err
 	}
@@ -102,6 +103,15 @@ func (f *JobRunsAnalyzerFlags) Validate() error {
 	}
 	if err := f.Authentication.Validate(); err != nil {
 		return err
+	}
+	if len(f.PayloadTag) > 0 && len(f.AggregationID) > 0 {
+		return fmt.Errorf("cannot specify both --payload-tag and --aggregation-id")
+	}
+	if len(f.PayloadTag) == 0 && len(f.AggregationID) == 0 {
+		return fmt.Errorf("exactly one of --payload-tag or --aggregation-id must be specified")
+	}
+	if len(f.AggregationID) > 0 && len(f.ExplicitGCSPrefix) == 0 {
+		return fmt.Errorf("if --aggregation-id is specified, you must specify --explicit-gcs-prefix")
 	}
 
 	return nil
@@ -132,16 +142,30 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 		return nil, err
 	}
 
-	// TODO will need different flags for finding payload promotion jobs from CI
-	jobRunLocator := jobrunaggregatorlib.NewPayloadAnalysisJobLocator(
-		f.JobName,
-		f.PayloadTag,
-		estimatedStartTime,
-		ciDataClient,
-		ciGCSClient,
-		gcsClient,
-		"origin-ci-test",
-	)
+	var jobRunLocator jobrunaggregatorlib.JobRunLocator
+	if len(f.PayloadTag) > 0 {
+		jobRunLocator = jobrunaggregatorlib.NewPayloadAnalysisJobLocatorForReleaseController(
+			f.JobName,
+			f.PayloadTag,
+			estimatedStartTime,
+			ciDataClient,
+			ciGCSClient,
+			gcsClient,
+			"origin-ci-test",
+		)
+	}
+	if len(f.AggregationID) > 0 {
+		jobRunLocator = jobrunaggregatorlib.NewPayloadAnalysisJobLocatorForPR(
+			f.JobName,
+			f.AggregationID,
+			estimatedStartTime,
+			ciDataClient,
+			ciGCSClient,
+			gcsClient,
+			"origin-ci-test",
+			f.ExplicitGCSPrefix,
+		)
+	}
 
 	return &JobRunAggregatorAnalyzerOptions{
 		jobRunLocator:       jobRunLocator,

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -168,6 +168,7 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 	}
 
 	return &JobRunAggregatorAnalyzerOptions{
+		explicitGCSPrefix:   f.ExplicitGCSPrefix,
 		jobRunLocator:       jobRunLocator,
 		passFailCalculator:  newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 3, ciDataClient),
 		jobName:             f.JobName,

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
@@ -186,13 +186,13 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 
 	switch {
 	case toAdd.FailureOutput != nil:
-		humanURL := jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID)
+		humanURL := jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID)
 		currDetails.Failures = append(
 			currDetails.Failures,
 			TestCaseFailure{
 				JobRunID:       toAddJobRunID,
 				HumanURL:       humanURL,
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
 			})
 
 	case toAdd.SkipMessage != nil:
@@ -200,8 +200,8 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 			currDetails.Skips,
 			TestCaseSkip{
 				JobRunID:       toAddJobRunID,
-				HumanURL:       jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID),
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
+				HumanURL:       jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
 			})
 
 	default:
@@ -209,8 +209,8 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 			currDetails.Passes,
 			TestCasePass{
 				JobRunID:       toAddJobRunID,
-				HumanURL:       jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID),
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
+				HumanURL:       jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
 			})
 
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
@@ -3,6 +3,7 @@ package jobrunaggregatoranalyzer
 import (
 	"context"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 
@@ -40,6 +41,7 @@ func newJobRunJunit(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo) 
 }
 
 type aggregatedJobRunJunit struct {
+	jobGCSBucketRoot         string
 	aggregationNameToJobRuns map[string][]*jobRunJunit
 
 	combinedJunit *junit.TestSuites
@@ -72,7 +74,7 @@ func (a *aggregatedJobRunJunit) aggregateAllJobRuns() (*junit.TestSuites, error)
 	for _, aggregationName := range sets.StringKeySet(a.aggregationNameToJobRuns).List() {
 		jobRunJunits := a.aggregationNameToJobRuns[aggregationName]
 		for _, currJobRunJunit := range jobRunJunits {
-			if err := combineTestSuites(combined, currJobRunJunit.jobRun.GetJobName(), currJobRunJunit.jobRun.GetJobRunID(), currJobRunJunit.combinedJunit); err != nil {
+			if err := combineTestSuites(combined, a.jobGCSBucketRoot, currJobRunJunit.jobRun.GetJobRunID(), currJobRunJunit.combinedJunit); err != nil {
 				return nil, err
 			}
 		}
@@ -86,27 +88,27 @@ func (a *aggregatedJobRunJunit) aggregateAllJobRuns() (*junit.TestSuites, error)
 	return a.combinedJunit, nil
 }
 
-func combineTestSuites(combined *junit.TestSuites, jobName, toAddJobRunID string, toAdd *junit.TestSuites) error {
+func combineTestSuites(combined *junit.TestSuites, jobGCSBucketRoot, toAddJobRunID string, toAdd *junit.TestSuites) error {
 	for _, suiteToAdd := range toAdd.Suites {
 		combinedSuite := ensureSuiteInSuites(combined, suiteToAdd.Name)
-		if err := combineTestSuite(combinedSuite, jobName, toAddJobRunID, suiteToAdd); err != nil {
+		if err := combineTestSuite(combinedSuite, jobGCSBucketRoot, toAddJobRunID, suiteToAdd); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func combineTestSuite(combined *junit.TestSuite, jobName, toAddJobRunID string, toAdd *junit.TestSuite) error {
+func combineTestSuite(combined *junit.TestSuite, jobGCSBucketRoot, toAddJobRunID string, toAdd *junit.TestSuite) error {
 	for _, testCaseToAdd := range toAdd.TestCases {
 		combinedTestCase := ensureTestCaseInSuite(combined, testCaseToAdd.Name)
-		if err := aggregateTestCase(combinedTestCase, jobName, toAddJobRunID, testCaseToAdd); err != nil {
+		if err := aggregateTestCase(combinedTestCase, jobGCSBucketRoot, toAddJobRunID, testCaseToAdd); err != nil {
 			return err
 		}
 	}
 
 	for _, suiteToAdd := range toAdd.Children {
 		combinedSuite := ensureSuiteInSuite(combined, suiteToAdd.Name)
-		if err := combineTestSuite(combinedSuite, jobName, toAddJobRunID, suiteToAdd); err != nil {
+		if err := combineTestSuite(combinedSuite, jobGCSBucketRoot, toAddJobRunID, suiteToAdd); err != nil {
 			return err
 		}
 	}
@@ -174,7 +176,7 @@ func ensureTestCaseInSuite(o *junit.TestSuite, name string) *junit.TestCase {
 	return ret
 }
 
-func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, toAdd *junit.TestCase) error {
+func aggregateTestCase(combined *junit.TestCase, jobGCSBucketRoot, toAddJobRunID string, toAdd *junit.TestCase) error {
 	currDetails := &TestCaseDetails{
 		Name: toAdd.Name,
 	}
@@ -186,13 +188,13 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 
 	switch {
 	case toAdd.FailureOutput != nil:
-		humanURL := jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID)
+		humanURL := jobrunaggregatorapi.GetHumanURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID))
 		currDetails.Failures = append(
 			currDetails.Failures,
 			TestCaseFailure{
 				JobRunID:       toAddJobRunID,
 				HumanURL:       humanURL,
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID)),
 			})
 
 	case toAdd.SkipMessage != nil:
@@ -200,8 +202,8 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 			currDetails.Skips,
 			TestCaseSkip{
 				JobRunID:       toAddJobRunID,
-				HumanURL:       jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID),
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
+				HumanURL:       jobrunaggregatorapi.GetHumanURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID)),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID)),
 			})
 
 	default:
@@ -209,8 +211,8 @@ func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, 
 			currDetails.Passes,
 			TestCasePass{
 				JobRunID:       toAddJobRunID,
-				HumanURL:       jobrunaggregatorapi.GetHumanURLForReleaseJob(jobName, toAddJobRunID),
-				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForReleaseJob(jobName, toAddJobRunID),
+				HumanURL:       jobrunaggregatorapi.GetHumanURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID)),
+				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURLForLocation(path.Join(jobGCSBucketRoot, toAddJobRunID)),
 			})
 
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -318,7 +318,7 @@ func (j *gcsJobRun) GetGCSArtifactURL() string {
 }
 
 func (j *gcsJobRun) IsFinished(ctx context.Context) bool {
-	content, err := j.GetContent(ctx, fmt.Sprintf("logs/%v/%v/finished.json", j.GetJobName(), j.GetJobRunID()))
+	content, err := j.GetContent(ctx, fmt.Sprintf("%s/finished.json", j.jobRunGCSBucketRoot))
 	if err != nil {
 		return false
 	}
@@ -327,16 +327,6 @@ func (j *gcsJobRun) IsFinished(ctx context.Context) bool {
 	}
 
 	return true
-}
-
-func GetHumanURLForReleaseJob(jobName, jobRunName string) string {
-	// https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.8-e2e-gcp-upgrade/1429691282619371520
-	return fmt.Sprintf("https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/%s/%s", jobName, jobRunName)
-}
-
-func GetGCSArtifactURLForReleaseJob(jobName, jobRunName string) string {
-	// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.9-e2e-gcp-upgrade/1420676206029705216/artifacts/e2e-gcp-upgrade/
-	return fmt.Sprintf("https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/%s/%s/artifacts", jobName, jobRunName)
 }
 
 func GetHumanURLForLocation(jobRunGCSBucketRoot string) string {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -167,12 +167,12 @@ func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 
 		currTestSuite := &junit.TestSuite{}
 		if testSuiteErr := xml.Unmarshal(junitContent, currTestSuite); testSuiteErr != nil {
-			if isParseFloatError(testSuitesErr) {
+			if isParseFloatError(testSuiteErr) {
 				// this was a testsuite, but we cannot read the file.  There is no choice to ignore errors so we suppress here
-				fmt.Fprintf(os.Stderr, "error parsing testsuite: %v", testSuitesErr)
+				fmt.Fprintf(os.Stderr, "error parsing testsuite: %v", testSuiteErr)
 				continue
 			}
-			return nil, fmt.Errorf("error parsing junit for jobrun/%v/%v %q: testsuiteError=%w  testsuitesError=%v", j.GetJobName(), j.GetJobRunID(), junitFile, testSuiteErr, testSuitesErr)
+			return nil, fmt.Errorf("error parsing junit for jobrun/%v/%v %q: testsuiteError=%w  testsuitesError=%v", j.GetJobName(), j.GetJobRunID(), junitFile, testSuiteErr, testSuitesErr.Error() /*tricking invalid/wrong linter*/)
 		}
 		testSuites.Suites = append(testSuites.Suites, currTestSuite)
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
+
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -114,7 +114,7 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 		switch {
 		case strings.HasSuffix(attrs.Name, "prowjob.json"):
 			jobRunId := filepath.Base(filepath.Dir(attrs.Name))
-			jobRunInfo, err := a.ciGCSClient.ReadJobRunFromGCS(ctx, a.jobName, jobRunId)
+			jobRunInfo, err := a.ciGCSClient.ReadJobRunFromGCS(ctx, a.gcsPrefix, a.jobName, jobRunId)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_per_pr_jobs.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_per_pr_jobs.go
@@ -1,0 +1,56 @@
+package jobrunaggregatorlib
+
+import (
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func GetAggregationIDFromProwJob(prowJob *prowjobv1.ProwJob) string {
+	return prowJob.Labels["release.openshift.io/aggregation-id"]
+}
+
+func NewPayloadAnalysisJobLocatorForPR(
+	jobName, aggregationID string,
+	startTime time.Time,
+	ciDataClient AggregationJobClient,
+	ciGCSClient CIGCSClient,
+	gcsClient *storage.Client,
+	gcsBucketName string,
+	gcsPrefix string) JobRunLocator {
+
+	return NewPayloadAnalysisJobLocator(
+		jobName,
+		perPRProwJobMatcher{
+			aggregationID: aggregationID,
+		}.shouldAggregateReleaseControllerJob,
+		startTime,
+		ciDataClient,
+		ciGCSClient,
+		gcsClient,
+		gcsBucketName,
+		gcsPrefix,
+	)
+}
+
+type perPRProwJobMatcher struct {
+	// aggregationID is how we recognize repeated per-PR jobs
+	aggregationID string
+}
+
+func (a perPRProwJobMatcher) shouldAggregateReleaseControllerJob(prowJob *prowjobv1.ProwJob) bool {
+	payloadTag := GetPayloadTagFromProwJob(prowJob)
+	aggregationID := GetAggregationIDFromProwJob(prowJob)
+	jobName := prowJob.Labels["prow.k8s.io/job"]
+	jobRunId := prowJob.Labels["prow.k8s.io/build-id"]
+	fmt.Printf("  checking %v/%v for aggregationID match: looking for %q found %q.\n", jobName, jobRunId, a.aggregationID, payloadTag)
+	aggregationIDMatches := len(a.aggregationID) > 0 && aggregationID == a.aggregationID
+	if aggregationIDMatches {
+		return true
+	}
+
+	return false
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_per_pr_jobs.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_per_pr_jobs.go
@@ -37,7 +37,8 @@ func NewPayloadAnalysisJobLocatorForPR(
 }
 
 type perPRProwJobMatcher struct {
-	// aggregationID is how we recognize repeated per-PR jobs
+	// aggregationID is how we recognize repeated per-PR jobs.  It is set when invoking the aggregator based on the value
+	// that the per-PR payload controller sets in the prowjobs it creates.
 	aggregationID string
 }
 
@@ -48,9 +49,6 @@ func (a perPRProwJobMatcher) shouldAggregateReleaseControllerJob(prowJob *prowjo
 	jobRunId := prowJob.Labels["prow.k8s.io/build-id"]
 	fmt.Printf("  checking %v/%v for aggregationID match: looking for %q found %q.\n", jobName, jobRunId, a.aggregationID, payloadTag)
 	aggregationIDMatches := len(a.aggregationID) > 0 && aggregationID == a.aggregationID
-	if aggregationIDMatches {
-		return true
-	}
 
-	return false
+	return aggregationIDMatches
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_release_jobs.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_release_jobs.go
@@ -1,0 +1,53 @@
+package jobrunaggregatorlib
+
+import (
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/storage"
+
+	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func GetPayloadTagFromProwJob(prowJob *prowjobv1.ProwJob) string {
+	return prowJob.Labels["release.openshift.io/analysis"]
+}
+
+func NewPayloadAnalysisJobLocatorForReleaseController(
+	jobName, payloadTag string,
+	startTime time.Time,
+	ciDataClient AggregationJobClient,
+	ciGCSClient CIGCSClient,
+	gcsClient *storage.Client,
+	gcsBucketName string) JobRunLocator {
+
+	return NewPayloadAnalysisJobLocator(
+		jobName,
+		releaseControllerProwJobMatcher{
+			payloadTag: payloadTag,
+		}.shouldAggregateReleaseControllerJob,
+		startTime,
+		ciDataClient,
+		ciGCSClient,
+		gcsClient,
+		gcsBucketName,
+		"logs/"+jobName,
+	)
+}
+
+type releaseControllerProwJobMatcher struct {
+	payloadTag string
+}
+
+func (a releaseControllerProwJobMatcher) shouldAggregateReleaseControllerJob(prowJob *prowjobv1.ProwJob) bool {
+	payloadTag := GetPayloadTagFromProwJob(prowJob)
+	jobName := prowJob.Labels["prow.k8s.io/job"]
+	jobRunId := prowJob.Labels["prow.k8s.io/build-id"]
+	fmt.Printf("  checking %v/%v for payloadtag match: looking for %q found %q.\n", jobName, jobRunId, a.payloadTag, payloadTag)
+	payloadTagMatches := len(a.payloadTag) > 0 && payloadTag == a.payloadTag
+	if payloadTagMatches {
+		return true
+	}
+
+	return false
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_release_jobs.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator_release_jobs.go
@@ -45,9 +45,6 @@ func (a releaseControllerProwJobMatcher) shouldAggregateReleaseControllerJob(pro
 	jobRunId := prowJob.Labels["prow.k8s.io/build-id"]
 	fmt.Printf("  checking %v/%v for payloadtag match: looking for %q found %q.\n", jobName, jobRunId, a.payloadTag, payloadTag)
 	payloadTagMatches := len(a.payloadTag) > 0 && payloadTag == a.payloadTag
-	if payloadTagMatches {
-		return true
-	}
 
-	return false
+	return payloadTagMatches
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -121,7 +121,7 @@ func (o *jobLoaderOptions) Run(ctx context.Context) error {
 		startingJobRunID = jobrunaggregatorlib.NextJobRunID(lastJobRun.Name)
 	}
 
-	jobRunProcessingCh, errorCh, err := o.gcsClient.ListJobRunNames(ctx, o.jobName, startingJobRunID)
+	jobRunProcessingCh, errorCh, err := o.gcsClient.ListJobRunNamesOlderThanFourHours(ctx, o.jobName, startingJobRunID)
 	if err != nil {
 		return err
 	}
@@ -261,7 +261,7 @@ func (o *jobRunLoaderOptions) uploadJobRun(ctx context.Context, jobRun jobrunagg
 
 // associateJobRuns returns allJobRuns and currentAggregationTargetJobRuns
 func (o *jobRunLoaderOptions) readJobRunFromGCS(ctx context.Context) (jobrunaggregatorapi.JobRunInfo, error) {
-	jobRunInfo, err := o.gcsClient.ReadJobRunFromGCS(ctx, o.jobName, o.hobRunID)
+	jobRunInfo, err := o.gcsClient.ReadJobRunFromGCS(ctx, "logs/"+o.jobName, o.jobName, o.hobRunID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`./job-run-aggregator analyze-job-runs --google-service-account-credential-file='/home/deads/openshift-ci-bigquery-credentials.json' --job=periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade --aggregation-id=3796f19a-4860-11ec-9fdb-74d435fb2dc0 --explicit-gcs-prefix=logs/ovn-kubernetes-834-ci-4.10-e2e-azure-ovn-upgrade --job-start-time=2021-11-18T11:11:43Z`

this is a command to run the aggregator on the the PR jobs