### PR TITLE
ci-operator: validate test name lengths

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -35,6 +35,12 @@ const (
 	testStagePre
 	testStageTest
 	testStagePost
+
+	// These are a bit arbitrary but they reflect what was working when I set
+	// these limits. Tests with claims must be shorter because they infer
+	// more things from the name
+	maxClaimTestNameLength = 42
+	maxTestNameLength      = 61
 )
 
 func (v *Validator) commandHasTrap(cmd string) bool {
@@ -130,6 +136,10 @@ func (v *Validator) validateTestStepConfiguration(
 		fieldRootN := fmt.Sprintf("%s[%d]", fieldRoot, num)
 		if len(test.As) == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: is required", fieldRootN))
+		} else if l := len(test.As); l > maxTestNameLength {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: %d characters long, maximum length is %d", fieldRootN, l, maxTestNameLength))
+		} else if l := len(test.As); l > maxClaimTestNameLength && test.ClusterClaim != nil {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: %d characters long, maximum length is %d for tests with claims", fieldRootN, l, maxClaimTestNameLength))
 		} else if test.As == "images" {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: should not be called 'images' because it gets confused with '[images]' target", fieldRootN))
 		} else if strings.HasPrefix(test.As, string(api.PipelineImageStreamTagReferenceIndexImage)) {

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -114,11 +114,6 @@ func (v *Validator) IsValidReference(step api.LiteralTestStep) []error {
 	return v.validateLiteralTestStep(&context{field: fieldPath(step.As)}, testStageUnknown, step, nil)
 }
 
-func IsValidReference(step api.LiteralTestStep) []error {
-	v := NewValidator()
-	return v.IsValidReference(step)
-}
-
 func (v *Validator) validateTestStepConfiguration(
 	configCtx *configContext,
 	fieldRoot string,

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -572,6 +572,32 @@ func TestValidateTests(t *testing.T) {
 			},
 			expectedError: errors.New("tests[0]: `optional` and `postsubmit` are mututally exclusive"),
 		},
+		{
+			id: "test name too long",
+			tests: []api.TestStepConfiguration{
+				{
+					As:                         "yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada-yada",
+					Commands:                   "commands",
+					ContainerTestConfiguration: &api.ContainerTestConfiguration{From: "ignored"},
+				},
+			},
+			expectedError: errors.New("tests[0].as: 89 characters long, maximum length is 61"),
+		},
+		{
+			id: "test name too long for claim tests which must be shorter",
+			tests: []api.TestStepConfiguration{
+				{
+					As: "yada-yada-yada-yada-yada-yada-yada-yada-yada-yada",
+					ClusterClaim: &api.ClusterClaim{
+						Version: "4.9",
+						Cloud:   "gcp",
+						Owner:   "ME",
+					},
+					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{},
+				},
+			},
+			expectedError: errors.New("tests[0].as: 49 characters long, maximum length is 42 for tests with claims"),
+		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()


### PR DESCRIPTION
We missed the opportunity to make these numbers sensible and we have stupidly
long names in the repo already (which apparently work), hence stupid numbers.
Claims have stricter limits because they internally infer more things from the
name.

I also took the opportunity to remove some unused code.

[DPTP-2507](https://issues.redhat.com/browse/DPTP-2507)