### PR TITLE
dptp-cm: fix forbidden registry handling

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -391,7 +391,7 @@ func main() {
 			registriesExceptAppCI.Insert(domain)
 		}
 		logrus.WithField("registriesExceptAppCI", registriesExceptAppCI.List()).Info("forbidden registries from build-farm clusters")
-		opts.testImagesDistributorOptions.forbiddenRegistries.Union(registriesExceptAppCI)
+		opts.testImagesDistributorOptions.forbiddenRegistries = opts.testImagesDistributorOptions.forbiddenRegistries.Union(registriesExceptAppCI)
 
 		if err := testimagesdistributor.AddToManager(
 			mgr,


### PR DESCRIPTION
`Union` returns a new set, it does not change the input sets. Therefore
the `registriesExceptAppCI` did not really propagate anywhere.

Noticed while looking into [DPTP-2626](https://issues.redhat.com/browse/DPTP-2626)
@hongkailiu , it looks like we were running *without* the forbidden registries for few days. What is the impact?

/cc @hongkailiu @openshift/test-platform 