### PR TITLE
Aggregated disruption

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -224,6 +224,17 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	if err := assignPassFail(ctx, currentAggregationJunitSuites, o.passFailCalculator); err != nil {
 		return err
 	}
+
+	fmt.Printf("%q for %q:  aggregating disruption tests.\n", o.jobName, o.payloadTag)
+	disruptionSuite, err := o.CalculateDisruptionTestSuite(ctx, o.jobName, finishedJobsToAggregate)
+	if err != nil {
+		return err
+	}
+	currentAggregationJunitSuites.Suites = append(currentAggregationJunitSuites.Suites, disruptionSuite)
+
+	// TODO this is the spot where we would add an alertSuite that aggregates the alerts firing in our clusters to prevent
+	//  allowing more and more failing alerts through just because one fails.
+
 	currentAggrationJunitXML, err := xml.Marshal(currentAggregationJunitSuites)
 	if err != nil {
 		return err

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -1,0 +1,159 @@
+package jobrunaggregatoranalyzer
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+	"github.com/openshift/ci-tools/pkg/junit"
+)
+
+func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx context.Context, jobName string, finishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo) (*junit.TestSuite, error) {
+	disruptionJunitSuite := &junit.TestSuite{
+		Name:      "BackendDisruption",
+		TestCases: []*junit.TestCase{},
+	}
+
+	jobRunIDToBackendNameToAvailabilityResult, err := getDisruptionByJobRunID(ctx, finishedJobsToAggregate)
+	switch {
+	case len(jobRunIDToBackendNameToAvailabilityResult) < 3 && err != nil:
+		return nil, err
+	case len(jobRunIDToBackendNameToAvailabilityResult) < 3 && err == nil:
+		return nil, fmt.Errorf("david has to fill this in to fail the aggregation but not the commmand")
+
+	default:
+		// ignore the errors if we have at least three results
+		fmt.Fprintf(os.Stderr, "Could not fetch backend disruption data for all runs %v", err)
+	}
+
+	allBackends := getAllDisruptionBackendNames(jobRunIDToBackendNameToAvailabilityResult)
+	for _, backendName := range allBackends.List() {
+		jobRunIDToAvailabilityResultForBackend := getDisruptionForBackend(jobRunIDToBackendNameToAvailabilityResult, backendName)
+		historicalStats, failed, message, err := o.passFailCalculator.CheckDisruption(ctx, jobRunIDToAvailabilityResultForBackend, backendName)
+		if err != nil {
+			return nil, err
+		}
+
+		junitTestCase := &junit.TestCase{
+			Name: fmt.Sprintf("%s should remain available", backendName),
+		}
+		disruptionJunitSuite.TestCases = append(disruptionJunitSuite.TestCases, junitTestCase)
+
+		currDetails := TestCaseDetails{
+			Name:    junitTestCase.Name,
+			Summary: message,
+		}
+		for jobRunID := range jobRunIDToAvailabilityResultForBackend {
+			currAvailabilityStat := jobRunIDToAvailabilityResultForBackend[jobRunID]
+			humanURL := jobrunaggregatorapi.GetHumanURL(jobName, jobRunID)
+			gcsArtifactURL := jobrunaggregatorapi.GetGCSArtifactURL(jobName, jobRunID)
+			overMean := float64(currAvailabilityStat.SecondsUnavailable) > historicalStats.mean
+			overP95 := float64(currAvailabilityStat.SecondsUnavailable) > historicalStats.p95
+			switch {
+			case overP95:
+				currDetails.Failures = append(currDetails.Failures, TestCaseFailure{
+					JobRunID:       jobRunID,
+					HumanURL:       humanURL,
+					GCSArtifactURL: gcsArtifactURL,
+				})
+
+			case overMean: // this will mark it as a flake in higher layers
+				currDetails.Failures = append(currDetails.Failures, TestCaseFailure{
+					JobRunID:       jobRunID,
+					HumanURL:       humanURL,
+					GCSArtifactURL: gcsArtifactURL,
+				})
+				currDetails.Passes = append(currDetails.Passes, TestCasePass{
+					JobRunID:       jobRunID,
+					HumanURL:       humanURL,
+					GCSArtifactURL: gcsArtifactURL,
+				})
+
+			default: // this will mark as success only
+				currDetails.Passes = append(currDetails.Passes, TestCasePass{
+					JobRunID:       jobRunID,
+					HumanURL:       humanURL,
+					GCSArtifactURL: gcsArtifactURL,
+				})
+			}
+		}
+
+		currDetails.Summary = message
+		detailsBytes, err := yaml.Marshal(currDetails)
+		if err != nil {
+			return nil, err
+		}
+		junitTestCase.SystemOut = string(detailsBytes)
+
+		if !failed {
+			continue
+		}
+		junitTestCase.FailureOutput = &junit.FailureOutput{
+			Message: message,
+			Output:  junitTestCase.SystemOut,
+		}
+		disruptionJunitSuite.NumFailed++
+
+	}
+
+	return disruptionJunitSuite, nil
+}
+
+// getDisruptionByJobRunID returns a map of map[jobRunID] to map[backend-name]availabilityResult
+func getDisruptionByJobRunID(ctx context.Context, finishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo) (map[string]map[string]jobrunaggregatorlib.AvailabilityResult, error) {
+	jobRunIDToBackendNameToAvailabilityResult := map[string]map[string]jobrunaggregatorlib.AvailabilityResult{}
+
+	errs := []error{}
+	for i := range finishedJobsToAggregate {
+		jobRun := finishedJobsToAggregate[i]
+		rawBackendDisruptionData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "backend-disruption")
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if len(rawBackendDisruptionData) == 0 {
+			fmt.Fprintf(os.Stderr, "Could not fetch backend disruption data for %s", jobRun.GetJobRunID())
+			continue
+		}
+
+		disruptionData := jobrunaggregatorlib.GetServerAvailabilityResultsFromDirectData(rawBackendDisruptionData)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		jobRunIDToBackendNameToAvailabilityResult[jobRun.GetJobRunID()] = disruptionData
+	}
+
+	return jobRunIDToBackendNameToAvailabilityResult, utilerrors.NewAggregate(errs)
+}
+
+// getDisruptionForBackend returns a map of jobrunid to the availabilityresult for the specified backend
+func getDisruptionForBackend(jobRunIDToBackendNameToAvailabilityResult map[string]map[string]jobrunaggregatorlib.AvailabilityResult, backend string) map[string]jobrunaggregatorlib.AvailabilityResult {
+	jobRunIDToAvailabilityResultForBackend := map[string]jobrunaggregatorlib.AvailabilityResult{}
+	for jobRunID := range jobRunIDToBackendNameToAvailabilityResult {
+		backendToAvailabilityForJobRunID := jobRunIDToBackendNameToAvailabilityResult[jobRunID]
+		availability, ok := backendToAvailabilityForJobRunID[backend]
+		if !ok {
+			continue
+		}
+		jobRunIDToAvailabilityResultForBackend[jobRunID] = availability
+	}
+	return jobRunIDToAvailabilityResultForBackend
+}
+
+func getAllDisruptionBackendNames(jobRunIDToBackendNameToAvailabilityResult map[string]map[string]jobrunaggregatorlib.AvailabilityResult) sets.String {
+	ret := sets.String{}
+	ret.Insert(jobrunaggregatorlib.RequiredDisruptionTests().List()...)
+	for _, curr := range jobRunIDToBackendNameToAvailabilityResult {
+		ret.Insert(sets.StringKeySet(curr).List()...)
+	}
+	return ret
+}

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
@@ -3,7 +3,6 @@ package jobrunaggregatoranalyzer
 import (
 	"context"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -12,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
-	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
@@ -74,20 +72,7 @@ func (a *aggregatedJobRunJunit) aggregateAllJobRuns() (*junit.TestSuites, error)
 	for _, aggregationName := range sets.StringKeySet(a.aggregationNameToJobRuns).List() {
 		jobRunJunits := a.aggregationNameToJobRuns[aggregationName]
 		for _, currJobRunJunit := range jobRunJunits {
-			rawBackendDisruptionData, err := currJobRunJunit.jobRun.GetOpenShiftTestsFilesWithPrefix(context.Background(), "backend-disruption")
-			if err != nil {
-				return nil, err
-			}
-			if len(rawBackendDisruptionData) == 0 {
-				fmt.Fprintf(os.Stderr, "Could not fetch backend disruption data for %s", currJobRunJunit.jobRun.GetJobRunID())
-				continue
-			}
-
-			disruptionData := jobrunaggregatorlib.GetServerAvailabilityResultsFromDirectData(rawBackendDisruptionData)
-			if err != nil {
-				return nil, err
-			}
-			if err := combineTestSuites(combined, disruptionData, currJobRunJunit.jobRun.GetJobName(), currJobRunJunit.jobRun.GetJobRunID(), currJobRunJunit.combinedJunit); err != nil {
+			if err := combineTestSuites(combined, currJobRunJunit.jobRun.GetJobName(), currJobRunJunit.jobRun.GetJobRunID(), currJobRunJunit.combinedJunit); err != nil {
 				return nil, err
 			}
 		}
@@ -101,27 +86,27 @@ func (a *aggregatedJobRunJunit) aggregateAllJobRuns() (*junit.TestSuites, error)
 	return a.combinedJunit, nil
 }
 
-func combineTestSuites(combined *junit.TestSuites, disruptionData map[string]jobrunaggregatorlib.AvailabilityResult, jobName, toAddJobRunID string, toAdd *junit.TestSuites) error {
+func combineTestSuites(combined *junit.TestSuites, jobName, toAddJobRunID string, toAdd *junit.TestSuites) error {
 	for _, suiteToAdd := range toAdd.Suites {
 		combinedSuite := ensureSuiteInSuites(combined, suiteToAdd.Name)
-		if err := combineTestSuite(combinedSuite, disruptionData, jobName, toAddJobRunID, suiteToAdd); err != nil {
+		if err := combineTestSuite(combinedSuite, jobName, toAddJobRunID, suiteToAdd); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func combineTestSuite(combined *junit.TestSuite, disruptionData map[string]jobrunaggregatorlib.AvailabilityResult, jobName, toAddJobRunID string, toAdd *junit.TestSuite) error {
+func combineTestSuite(combined *junit.TestSuite, jobName, toAddJobRunID string, toAdd *junit.TestSuite) error {
 	for _, testCaseToAdd := range toAdd.TestCases {
 		combinedTestCase := ensureTestCaseInSuite(combined, testCaseToAdd.Name)
-		if err := aggregateTestCase(combinedTestCase, disruptionData, jobName, toAddJobRunID, testCaseToAdd); err != nil {
+		if err := aggregateTestCase(combinedTestCase, jobName, toAddJobRunID, testCaseToAdd); err != nil {
 			return err
 		}
 	}
 
 	for _, suiteToAdd := range toAdd.Children {
 		combinedSuite := ensureSuiteInSuite(combined, suiteToAdd.Name)
-		if err := combineTestSuite(combinedSuite, disruptionData, jobName, toAddJobRunID, suiteToAdd); err != nil {
+		if err := combineTestSuite(combinedSuite, jobName, toAddJobRunID, suiteToAdd); err != nil {
 			return err
 		}
 	}
@@ -189,11 +174,10 @@ func ensureTestCaseInSuite(o *junit.TestSuite, name string) *junit.TestCase {
 	return ret
 }
 
-func aggregateTestCase(combined *junit.TestCase, disruptionData map[string]jobrunaggregatorlib.AvailabilityResult, jobName, toAddJobRunID string, toAdd *junit.TestCase) error {
+func aggregateTestCase(combined *junit.TestCase, jobName, toAddJobRunID string, toAdd *junit.TestCase) error {
 	currDetails := &TestCaseDetails{
 		Name: toAdd.Name,
 	}
-
 	if len(combined.SystemOut) > 0 {
 		if err := yaml.Unmarshal([]byte(combined.SystemOut), currDetails); err != nil {
 			return err
@@ -201,27 +185,6 @@ func aggregateTestCase(combined *junit.TestCase, disruptionData map[string]jobru
 	}
 
 	switch {
-	case jobrunaggregatorlib.IsDisruptionTest(toAdd.Name):
-		backend := jobrunaggregatorlib.GetBackendName(toAdd.Name)
-		secondsUnavailable := 0
-		if availability, ok := disruptionData[backend]; ok {
-			secondsUnavailable = availability.SecondsUnavailable
-		} else if toAdd.FailureOutput != nil {
-			// Fallback to junit disruption data
-			seconds, err := jobrunaggregatorlib.GetOutageSecondsFromMessage(toAdd.FailureOutput.Output)
-			if err != nil {
-				return err
-			}
-			secondsUnavailable = seconds
-		}
-
-		currDetails.Disruption = append(currDetails.Disruption,
-			TestCaseDisruption{
-				JobRunID:          toAddJobRunID,
-				HumanURL:          jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID),
-				GCSArtifactURL:    jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
-				DisruptionSeconds: secondsUnavailable,
-			})
 	case toAdd.FailureOutput != nil:
 		humanURL := jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID)
 		currDetails.Failures = append(
@@ -231,6 +194,7 @@ func aggregateTestCase(combined *junit.TestCase, disruptionData map[string]jobru
 				HumanURL:       humanURL,
 				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
 			})
+
 	case toAdd.SkipMessage != nil:
 		currDetails.Skips = append(
 			currDetails.Skips,
@@ -239,6 +203,7 @@ func aggregateTestCase(combined *junit.TestCase, disruptionData map[string]jobru
 				HumanURL:       jobrunaggregatorapi.GetHumanURL(jobName, toAddJobRunID),
 				GCSArtifactURL: jobrunaggregatorapi.GetGCSArtifactURL(jobName, toAddJobRunID),
 			})
+
 	default:
 		currDetails.Passes = append(
 			currDetails.Passes,
@@ -263,10 +228,9 @@ type TestCaseDetails struct {
 	// Summary is filled in during the pass/fail calculation
 	Summary string
 
-	Passes     []TestCasePass
-	Failures   []TestCaseFailure
-	Skips      []TestCaseSkip
-	Disruption []TestCaseDisruption
+	Passes   []TestCasePass
+	Failures []TestCaseFailure
+	Skips    []TestCaseSkip
 	//NeverExecuted []TestCaseNeverExecuted
 }
 
@@ -274,13 +238,6 @@ type TestCasePass struct {
 	JobRunID       string
 	HumanURL       string
 	GCSArtifactURL string
-}
-
-type TestCaseDisruption struct {
-	JobRunID          string
-	HumanURL          string
-	GCSArtifactURL    string
-	DisruptionSeconds int
 }
 
 type TestCaseFailure struct {

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -19,7 +19,7 @@ import (
 
 type baseline interface {
 	CheckFailed(ctx context.Context, suiteNames []string, testCaseDetails *TestCaseDetails) (failed bool, message string, err error)
-	CheckDisruption(ctx context.Context, details *TestCaseDetails) (failed bool, message string, err error)
+	CheckDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string) (stats *DisruptionStatistic, failed bool, message string, err error)
 }
 
 func assignPassFail(ctx context.Context, combined *junit.TestSuites, baselinePassFail baseline) error {
@@ -54,16 +54,15 @@ func assignPassFailForTestSuite(ctx context.Context, parentTestSuites []string, 
 		var failed bool
 		var message string
 		var err error
-		if jobrunaggregatorlib.IsDisruptionTest(currTestCase.Name) {
-			failed, message, err = baselinePassFail.CheckDisruption(ctx, currDetails)
-			if err != nil {
-				return err
-			}
-		} else {
-			failed, message, err = baselinePassFail.CheckFailed(ctx, currSuiteNames, currDetails)
-			if err != nil {
-				return err
-			}
+		// TODO once we are ready to stop failing on aggregating the availability tests, we write something here to ignore
+		//  the aggregated tests when they fail.  In actuality, this may never be the case, since we're likely to make the
+		//  individual tests nearly always pass.
+		//if jobrunaggregatorlib.IsDisruptionTest(currTestCase.Name) {
+		//}
+
+		failed, message, err = baselinePassFail.CheckFailed(ctx, currSuiteNames, currDetails)
+		if err != nil {
+			return err
 		}
 
 		currDetails.Summary = message
@@ -132,7 +131,7 @@ func getWorkingPercentage(testCaseDetails *TestCaseDetails) float32 {
 	return float32(len(testCaseDetails.Passes)) / float32(len(testCaseDetails.Passes)+failureCount) * 100.0
 }
 */
-type disruptionStatistic struct {
+type DisruptionStatistic struct {
 	p95  float64
 	mean float64
 }
@@ -151,7 +150,7 @@ type weeklyAverageFromTenDays struct {
 
 	queryDisruptionOnce sync.Once
 	queryDisruptionErr  error
-	disruptionByBackend map[string]disruptionStatistic
+	disruptionByBackend map[string]DisruptionStatistic
 }
 
 func newWeeklyAverageFromTenDaysAgo(jobName string, startDay time.Time, minimumNumberOfAttempts int, bigQueryClient jobrunaggregatorlib.CIDataClient) baseline {
@@ -165,7 +164,7 @@ func newWeeklyAverageFromTenDaysAgo(jobName string, startDay time.Time, minimumN
 		queryTestRunsOnce:        sync.Once{},
 		queryTestRunsErr:         nil,
 		aggregatedTestRunsByName: nil,
-		disruptionByBackend:      make(map[string]disruptionStatistic),
+		disruptionByBackend:      make(map[string]DisruptionStatistic),
 	}
 }
 
@@ -186,7 +185,7 @@ func (a *weeklyAverageFromTenDays) getAggregatedTestRuns(ctx context.Context) (m
 	return a.aggregatedTestRunsByName, a.queryTestRunsErr
 }
 
-func (a *weeklyAverageFromTenDays) getDisruptionByBackend(ctx context.Context) (map[string]disruptionStatistic, error) {
+func (a *weeklyAverageFromTenDays) getDisruptionByBackend(ctx context.Context) (map[string]DisruptionStatistic, error) {
 	a.queryDisruptionOnce.Do(func() {
 		rows, err := a.bigQueryClient.GetBackendDisruptionStatisticsByJob(ctx, a.jobName)
 		if err != nil {
@@ -194,9 +193,9 @@ func (a *weeklyAverageFromTenDays) getDisruptionByBackend(ctx context.Context) (
 			return
 		}
 
-		a.disruptionByBackend = make(map[string]disruptionStatistic)
+		a.disruptionByBackend = make(map[string]DisruptionStatistic)
 		for _, row := range rows {
-			a.disruptionByBackend[row.BackendName] = disruptionStatistic{
+			a.disruptionByBackend[row.BackendName] = DisruptionStatistic{
 				p95:  row.P95,
 				mean: row.Mean,
 			}
@@ -207,51 +206,51 @@ func (a *weeklyAverageFromTenDays) getDisruptionByBackend(ctx context.Context) (
 	return a.disruptionByBackend, a.queryDisruptionErr
 }
 
-func (a *weeklyAverageFromTenDays) CheckDisruption(ctx context.Context, details *TestCaseDetails) (bool, string, error) {
+func (a *weeklyAverageFromTenDays) CheckDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string) (*DisruptionStatistic, bool, string, error) {
 	missingAllHistoricalData := false
 	historicalDisruption, err := a.getDisruptionByBackend(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error getting past disruption data, assume 1s disruption allowed: %v\n", err)
 		missingAllHistoricalData = true
 	}
+	historicalDisruptionStatistic := historicalDisruption[backend]
 
 	// If disruption mean (excluding at most 1 outlier) is greater than 10% of the historical mean,
 	// the aggregation fails.
 	disruptionThreshold := float64(1)
-	backend := jobrunaggregatorlib.GetBackendName(details.Name)
 	if !missingAllHistoricalData {
-		disruptionThreshold = historicalDisruption[backend].mean * 1.10
+		disruptionThreshold = historicalDisruptionStatistic.mean * 1.10
 	}
 
-	totalRuns := len(details.Disruption)
+	totalRuns := len(jobRunIDToAvailabilityResultForBackend)
 	totalDisruption := 0
 	max := 0
-	for _, disruption := range details.Disruption {
-		totalDisruption += disruption.DisruptionSeconds
-		if disruption.DisruptionSeconds > max {
-			max = disruption.DisruptionSeconds
+	for _, disruption := range jobRunIDToAvailabilityResultForBackend {
+		totalDisruption += disruption.SecondsUnavailable
+		if disruption.SecondsUnavailable > max {
+			max = disruption.SecondsUnavailable
 		}
 	}
 
 	// We allow one "mulligan" by throwing away at most one outlier > our p95.
-	if float64(max) > historicalDisruption[backend].p95 {
-		fmt.Printf("%s throwing away one outlier (outlier=%ds p95=%fs)\n", backend, max, historicalDisruption[backend].p95)
+	if float64(max) > historicalDisruptionStatistic.p95 {
+		fmt.Printf("%s throwing away one outlier (outlier=%ds p95=%fs)\n", backend, max, historicalDisruptionStatistic.p95)
 		totalRuns--
 		totalDisruption -= max
 	}
 	meanDisruption := float64(totalDisruption) / float64(totalRuns)
 	fmt.Printf("%s disruption calculated for current runs (historicalMean=%.2fs failureThreshold(110%%)=%.2fs historicalP95=%.2fs runs=%d totalDisruptionSecs=%ds mean=%.2fs max=%ds)\n",
-		backend, historicalDisruption[backend].mean, disruptionThreshold, historicalDisruption[backend].p95, totalRuns, totalDisruption, meanDisruption, max)
+		backend, historicalDisruptionStatistic.mean, disruptionThreshold, historicalDisruptionStatistic.p95, totalRuns, totalDisruption, meanDisruption, max)
 
 	if meanDisruption > disruptionThreshold {
-		return true, fmt.Sprintf(
+		return &historicalDisruptionStatistic, true, fmt.Sprintf(
 			"Mean disruption of %s is %.2f seconds, which is more than 110%% of the weekly historical mean from 10 days ago of %.2f seconds, marking this as a failure",
 			backend,
 			meanDisruption,
 			disruptionThreshold), nil
 	}
 
-	return false, fmt.Sprintf(
+	return &historicalDisruptionStatistic, false, fmt.Sprintf(
 		"Mean disruption of %s is %.2f seconds, which is no more than 110%% of the weekly historical mean from 10 days ago of %.2f seconds. This is OK.",
 		backend,
 		meanDisruption,

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types.go
@@ -33,3 +33,9 @@ type BackendDisruptionRow struct {
 	JobRunName        string
 	DisruptionSeconds int
 }
+
+type BackendDisruptionStatisticsRow struct {
+	BackendName string
+	Mean        float64
+	P95         float64
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
@@ -1,0 +1,196 @@
+package jobrunaggregatorlib
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/ci-tools/pkg/junit"
+)
+
+var (
+	upgradeBackendNameToTestSubstring = map[string]string{
+		"kube-api-new-connections":                          "Kubernetes APIs remain available for new connections",
+		"kube-api-reused-connections":                       "Kubernetes APIs remain available with reused connections",
+		"openshift-api-new-connections":                     "OpenShift APIs remain available for new connections",
+		"openshift-api-reused-connections":                  "OpenShift APIs remain available with reused connections",
+		"oauth-api-new-connections":                         "OAuth APIs remain available for new connections",
+		"oauth-api-reused-connections":                      "OAuth APIs remain available with reused connections",
+		"service-load-balancer-with-pdb-reused-connections": "Application behind service load balancer with PDB is not disrupted",
+		"image-registry-reused-connections":                 "Image registry remain available",
+		"cluster-ingress-new-connections":                   "Cluster frontend ingress remain available",
+		"ingress-to-oauth-server-new-connections":           "OAuth remains available via cluster frontend ingress using new connections",
+		"ingress-to-oauth-server-used-connections":          "OAuth remains available via cluster frontend ingress using reused connections",
+		"ingress-to-console-new-connections":                "Console remains available via cluster frontend ingress using new connections",
+		"ingress-to-console-used-connections":               "Console remains available via cluster frontend ingress using reused connections",
+	}
+
+	e2eBackendNameToTestSubstring = map[string]string{
+		"kube-api-new-connections":         "kube-apiserver-new-connection",
+		"kube-api-reused-connections":      "kube-apiserver-reused-connection should be available",
+		"openshift-api-new-connections":    "openshift-apiserver-new-connection should be available",
+		"openshift-api-reused-connections": "openshift-apiserver-reused-connection should be available",
+		"oauth-api-new-connections":        "oauth-apiserver-new-connection should be available",
+		"oauth-api-reused-connections":     "oauth-apiserver-reused-connection should be available",
+	}
+
+	detectUpgradeOutage = regexp.MustCompile(` unreachable during disruption.*for at least (?P<DisruptionDuration>.*) of `)
+	detectE2EOutage     = regexp.MustCompile(` was failing for (?P<DisruptionDuration>.*) seconds `)
+)
+
+func IsDisruptionTest(testName string) bool {
+	for _, v := range upgradeBackendNameToTestSubstring {
+		if strings.Contains(testName, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func GetBackendName(testName string) string {
+	for k, v := range upgradeBackendNameToTestSubstring {
+		if strings.Contains(testName, v) {
+			return k
+		}
+	}
+
+	return ""
+}
+
+type AvailabilityResult struct {
+	ServerName         string
+	SecondsUnavailable int
+}
+
+type BackendDisruptionList struct {
+	// BackendDisruptions is keyed by name to make the consumption easier
+	BackendDisruptions map[string]*BackendDisruption
+}
+
+type BackendDisruption struct {
+	// Name ensure self-identification
+	Name string
+	// ConnectionType is New or Reused
+	ConnectionType     string
+	DisruptedDuration  v1.Duration
+	DisruptionMessages []string
+}
+
+func GetServerAvailabilityResultsFromDirectData(backendDisruptionData map[string]string) map[string]AvailabilityResult {
+	availabilityResultsByName := map[string]AvailabilityResult{}
+
+	for _, disruptionJSON := range backendDisruptionData {
+		if len(disruptionJSON) == 0 {
+			continue
+		}
+		allDisruptions := &BackendDisruptionList{}
+		if err := json.Unmarshal([]byte(disruptionJSON), allDisruptions); err != nil {
+			continue
+		}
+
+		currAvailabilityResults := map[string]AvailabilityResult{}
+		for _, disruption := range allDisruptions.BackendDisruptions {
+			currAvailabilityResults[disruption.Name] = AvailabilityResult{
+				ServerName:         disruption.Name,
+				SecondsUnavailable: int(math.Ceil(disruption.DisruptedDuration.Seconds())),
+			}
+		}
+		addUnavailability(availabilityResultsByName, currAvailabilityResults)
+	}
+
+	return availabilityResultsByName
+}
+
+func GetServerAvailabilityResultsFromJunit(suites *junit.TestSuites) map[string]AvailabilityResult {
+	availabilityResultsByName := map[string]AvailabilityResult{}
+
+	for _, curr := range suites.Suites {
+		currResults := GetServerAvailabilityResultsBySuite(curr)
+		addUnavailability(availabilityResultsByName, currResults)
+	}
+
+	return availabilityResultsByName
+}
+
+func GetServerAvailabilityResultsBySuite(suite *junit.TestSuite) map[string]AvailabilityResult {
+	availabilityResultsByName := map[string]AvailabilityResult{}
+
+	for _, curr := range suite.Children {
+		currResults := GetServerAvailabilityResultsBySuite(curr)
+		addUnavailability(availabilityResultsByName, currResults)
+	}
+
+	for _, testCase := range suite.TestCases {
+		backendName := ""
+		for currBackendName, testSubstring := range upgradeBackendNameToTestSubstring {
+			if strings.Contains(testCase.Name, testSubstring) {
+				backendName = currBackendName
+				break
+			}
+		}
+		for currBackendName, testSubstring := range e2eBackendNameToTestSubstring {
+			if strings.Contains(testCase.Name, testSubstring) {
+				backendName = currBackendName
+				break
+			}
+		}
+		if len(backendName) == 0 {
+			continue
+		}
+
+		if testCase.FailureOutput != nil {
+			addUnavailabilityForAPIServerTest(availabilityResultsByName, backendName, testCase.FailureOutput.Message)
+			continue
+		}
+
+		// if the test passed and we DO NOT have an entry already, add one
+		if _, ok := availabilityResultsByName[backendName]; !ok {
+			availabilityResultsByName[backendName] = AvailabilityResult{
+				ServerName:         backendName,
+				SecondsUnavailable: 0,
+			}
+		}
+	}
+
+	return availabilityResultsByName
+}
+
+func addUnavailabilityForAPIServerTest(runningTotals map[string]AvailabilityResult, serverName string, message string) {
+	secondsUnavailable, err := GetOutageSecondsFromMessage(message)
+	if err != nil {
+		fmt.Printf("#### err %v\n", err)
+		return
+	}
+	existing := runningTotals[serverName]
+	existing.SecondsUnavailable += secondsUnavailable
+	runningTotals[serverName] = existing
+}
+
+func addUnavailability(runningTotals, toAdd map[string]AvailabilityResult) {
+	for serverName, unavailability := range toAdd {
+		existing := runningTotals[serverName]
+		existing.SecondsUnavailable += unavailability.SecondsUnavailable
+		runningTotals[serverName] = existing
+	}
+}
+
+func GetOutageSecondsFromMessage(message string) (int, error) {
+	matches := detectUpgradeOutage.FindStringSubmatch(message)
+	if len(matches) < 2 {
+		matches = detectE2EOutage.FindStringSubmatch(message)
+	}
+	if len(matches) < 2 {
+		return 0, fmt.Errorf("not the expected format: %v", message)
+	}
+	outageDuration, err := time.ParseDuration(matches[1])
+	if err != nil {
+		return 0, err
+	}
+	return int(math.Ceil(outageDuration.Seconds())), nil
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
@@ -8,9 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/junit"
 )

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/ci-tools/pkg/junit"
 )
@@ -42,6 +44,10 @@ var (
 	detectUpgradeOutage = regexp.MustCompile(` unreachable during disruption.*for at least (?P<DisruptionDuration>.*) of `)
 	detectE2EOutage     = regexp.MustCompile(` was failing for (?P<DisruptionDuration>.*) seconds `)
 )
+
+func RequiredDisruptionTests() sets.String {
+	return sets.StringKeySet(upgradeBackendNameToTestSubstring)
+}
 
 func IsDisruptionTest(testName string) bool {
 	for _, v := range upgradeBackendNameToTestSubstring {
@@ -101,7 +107,7 @@ func GetServerAvailabilityResultsFromDirectData(backendDisruptionData map[string
 				SecondsUnavailable: int(math.Ceil(disruption.DisruptedDuration.Seconds())),
 			}
 		}
-		addUnavailability(availabilityResultsByName, currAvailabilityResults)
+		AddUnavailability(availabilityResultsByName, currAvailabilityResults)
 	}
 
 	return availabilityResultsByName
@@ -112,7 +118,7 @@ func GetServerAvailabilityResultsFromJunit(suites *junit.TestSuites) map[string]
 
 	for _, curr := range suites.Suites {
 		currResults := GetServerAvailabilityResultsBySuite(curr)
-		addUnavailability(availabilityResultsByName, currResults)
+		AddUnavailability(availabilityResultsByName, currResults)
 	}
 
 	return availabilityResultsByName
@@ -123,7 +129,7 @@ func GetServerAvailabilityResultsBySuite(suite *junit.TestSuite) map[string]Avai
 
 	for _, curr := range suite.Children {
 		currResults := GetServerAvailabilityResultsBySuite(curr)
-		addUnavailability(availabilityResultsByName, currResults)
+		AddUnavailability(availabilityResultsByName, currResults)
 	}
 
 	for _, testCase := range suite.TestCases {
@@ -172,7 +178,7 @@ func addUnavailabilityForAPIServerTest(runningTotals map[string]AvailabilityResu
 	runningTotals[serverName] = existing
 }
 
-func addUnavailability(runningTotals, toAdd map[string]AvailabilityResult) {
+func AddUnavailability(runningTotals, toAdd map[string]AvailabilityResult) {
 	for serverName, unavailability := range toAdd {
 		existing := runningTotals[serverName]
 		existing.SecondsUnavailable += unavailability.SecondsUnavailable

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locators.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locators.go
@@ -88,7 +88,7 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 	} else {
 		query.StartOffset = fmt.Sprintf("logs/%s/%s", a.jobName, startingJobRun.Name)
 	}
-	if false && endingJobRun != nil {
+	if endingJobRun != nil {
 		query.EndOffset = fmt.Sprintf("logs/%s/%s", a.jobName, endingJobRun.Name)
 	}
 	fmt.Printf("  starting from %v, ending at %q\n", query.StartOffset, query.EndOffset)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -24,6 +24,16 @@ func NewRetryingCIDataClient(delegate CIDataClient) CIDataClient {
 	}
 }
 
+func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
+	var ret []jobrunaggregatorapi.BackendDisruptionStatisticsRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetBackendDisruptionStatisticsByJob(ctx, jobName)
+		return innerErr
+	})
+	return ret, err
+}
+
 func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error) {
 	var ret []jobrunaggregatorapi.JobRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -2,14 +2,10 @@ package jobrunbigqueryloader
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"math"
-	"regexp"
 	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
@@ -17,168 +13,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
 	"github.com/openshift/ci-tools/pkg/junit"
 )
-
-type availabilityResult struct {
-	serverName         string
-	secondsUnavailable int
-}
-
-type BackendDisruptionList struct {
-	// BackendDisruptions is keyed by name to make the consumption easier
-	BackendDisruptions map[string]*BackendDisruption
-}
-
-type BackendDisruption struct {
-	// Name ensure self-identification
-	Name string
-	// ConnectionType is New or Reused
-	ConnectionType     string
-	DisruptedDuration  metav1.Duration
-	DisruptionMessages []string
-}
-
-func getServerAvailabilityResultsFromDirectData(backendDisruptionData map[string]string) map[string]availabilityResult {
-	availabilityResultsByName := map[string]availabilityResult{}
-
-	for _, disruptionJSON := range backendDisruptionData {
-		if len(disruptionJSON) == 0 {
-			continue
-		}
-		allDisruptions := &BackendDisruptionList{}
-		if err := json.Unmarshal([]byte(disruptionJSON), allDisruptions); err != nil {
-			continue
-		}
-
-		currAvailabilityResults := map[string]availabilityResult{}
-		for _, disruption := range allDisruptions.BackendDisruptions {
-			currAvailabilityResults[disruption.Name] = availabilityResult{
-				serverName:         disruption.Name,
-				secondsUnavailable: int(math.Ceil(disruption.DisruptedDuration.Seconds())),
-			}
-		}
-		addUnavailability(availabilityResultsByName, currAvailabilityResults)
-	}
-
-	return availabilityResultsByName
-}
-
-func getServerAvailabilityResultsFromJunit(suites *junit.TestSuites) map[string]availabilityResult {
-	availabilityResultsByName := map[string]availabilityResult{}
-
-	for _, curr := range suites.Suites {
-		currResults := getServerAvailabilityResultsBySuite(curr)
-		addUnavailability(availabilityResultsByName, currResults)
-	}
-
-	return availabilityResultsByName
-}
-
-var (
-	upgradeBackendNameToTestSubstring = map[string]string{
-		"kube-api-new-connections":                          "Kubernetes APIs remain available for new connections",
-		"kube-api-reused-connections":                       "Kubernetes APIs remain available with reused connections",
-		"openshift-api-new-connections":                     "OpenShift APIs remain available for new connections",
-		"openshift-api-reused-connections":                  "OpenShift APIs remain available with reused connections",
-		"oauth-api-new-connections":                         "OAuth APIs remain available for new connections",
-		"oauth-api-reused-connections":                      "OAuth APIs remain available with reused connections",
-		"service-load-balancer-with-pdb-reused-connections": "Application behind service load balancer with PDB is not disrupted",
-		"image-registry-reused-connections":                 "Image registry remain available",
-		"cluster-ingress-new-connections":                   "Cluster frontend ingress remain available",
-		"ingress-to-oauth-server-new-connections":           "OAuth remains available via cluster frontend ingress using new connections",
-		"ingress-to-oauth-server-used-connections":          "OAuth remains available via cluster frontend ingress using reused connections",
-		"ingress-to-console-new-connections":                "Console remains available via cluster frontend ingress using new connections",
-		"ingress-to-console-used-connections":               "Console remains available via cluster frontend ingress using reused connections",
-	}
-
-	e2eBackendNameToTestSubstring = map[string]string{
-		"kube-api-new-connections":         "kube-apiserver-new-connection",
-		"kube-api-reused-connections":      "kube-apiserver-reused-connection should be available",
-		"openshift-api-new-connections":    "openshift-apiserver-new-connection should be available",
-		"openshift-api-reused-connections": "openshift-apiserver-reused-connection should be available",
-		"oauth-api-new-connections":        "oauth-apiserver-new-connection should be available",
-		"oauth-api-reused-connections":     "oauth-apiserver-reused-connection should be available",
-	}
-
-	detectUpgradeOutage = regexp.MustCompile(` unreachable during disruption.*for at least (?P<DisruptionDuration>.*) of `)
-	detectE2EOutage     = regexp.MustCompile(` was failing for (?P<DisruptionDuration>.*) seconds `)
-)
-
-func getServerAvailabilityResultsBySuite(suite *junit.TestSuite) map[string]availabilityResult {
-	availabilityResultsByName := map[string]availabilityResult{}
-
-	for _, curr := range suite.Children {
-		currResults := getServerAvailabilityResultsBySuite(curr)
-		addUnavailability(availabilityResultsByName, currResults)
-	}
-
-	for _, testCase := range suite.TestCases {
-		backendName := ""
-		for currBackendName, testSubstring := range upgradeBackendNameToTestSubstring {
-			if strings.Contains(testCase.Name, testSubstring) {
-				backendName = currBackendName
-				break
-			}
-		}
-		for currBackendName, testSubstring := range e2eBackendNameToTestSubstring {
-			if strings.Contains(testCase.Name, testSubstring) {
-				backendName = currBackendName
-				break
-			}
-		}
-		if len(backendName) == 0 {
-			continue
-		}
-
-		if testCase.FailureOutput != nil {
-			addUnavailabilityForAPIServerTest(availabilityResultsByName, backendName, testCase.FailureOutput.Message)
-			continue
-		}
-
-		// if the test passed and we DO NOT have an entry already, add one
-		if _, ok := availabilityResultsByName[backendName]; !ok {
-			availabilityResultsByName[backendName] = availabilityResult{
-				serverName:         backendName,
-				secondsUnavailable: 0,
-			}
-		}
-	}
-
-	return availabilityResultsByName
-}
-
-func addUnavailabilityForAPIServerTest(runningTotals map[string]availabilityResult, serverName string, message string) {
-	secondsUnavailable, err := getOutageSecondsFromMessage(message)
-	if err != nil {
-		fmt.Printf("#### err %v\n", err)
-		return
-	}
-	existing := runningTotals[serverName]
-	existing.secondsUnavailable += secondsUnavailable
-	runningTotals[serverName] = existing
-}
-
-func addUnavailability(runningTotals, toAdd map[string]availabilityResult) {
-	for serverName, unavailability := range toAdd {
-		existing := runningTotals[serverName]
-		existing.secondsUnavailable += unavailability.secondsUnavailable
-		runningTotals[serverName] = existing
-	}
-}
-
-func getOutageSecondsFromMessage(message string) (int, error) {
-	matches := detectUpgradeOutage.FindStringSubmatch(message)
-	if len(matches) < 2 {
-		matches = detectE2EOutage.FindStringSubmatch(message)
-	}
-	if len(matches) < 2 {
-		return 0, fmt.Errorf("not the expected format: %v", message)
-	}
-	outageDuration, err := time.ParseDuration(matches[1])
-	if err != nil {
-		return 0, err
-	}
-	return int(math.Ceil(outageDuration.Seconds())), nil
-}
 
 type disruptionUploader struct {
 	backendDisruptionInserter jobrunaggregatorlib.BigQueryInserter
@@ -232,22 +66,22 @@ func (o *disruptionUploader) uploadContent(ctx context.Context, jobRun jobrunagg
 }
 
 func (o *disruptionUploader) uploadBackendDisruptionFromJunit(ctx context.Context, jobRunName string, suites *junit.TestSuites) error {
-	serverAvailabilityResults := getServerAvailabilityResultsFromJunit(suites)
+	serverAvailabilityResults := jobrunaggregatorlib.GetServerAvailabilityResultsFromJunit(suites)
 	return o.uploadBackendDisruption(ctx, jobRunName, serverAvailabilityResults)
 }
 
 func (o *disruptionUploader) uploadBackendDisruptionFromDirectData(ctx context.Context, jobRunName string, backendDisruptionData map[string]string) error {
-	serverAvailabilityResults := getServerAvailabilityResultsFromDirectData(backendDisruptionData)
+	serverAvailabilityResults := jobrunaggregatorlib.GetServerAvailabilityResultsFromDirectData(backendDisruptionData)
 	return o.uploadBackendDisruption(ctx, jobRunName, serverAvailabilityResults)
 }
-func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRunName string, serverAvailabilityResults map[string]availabilityResult) error {
+func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRunName string, serverAvailabilityResults map[string]jobrunaggregatorlib.AvailabilityResult) error {
 	rows := []*jobrunaggregatorapi.BackendDisruptionRow{}
 	for _, backendName := range sets.StringKeySet(serverAvailabilityResults).List() {
 		unavailability := serverAvailabilityResults[backendName]
 		row := &jobrunaggregatorapi.BackendDisruptionRow{
 			BackendName:       backendName,
 			JobRunName:        jobRunName,
-			DisruptionSeconds: unavailability.secondsUnavailable,
+			DisruptionSeconds: unavailability.SecondsUnavailable,
 		}
 		rows = append(rows, row)
 	}


### PR DESCRIPTION
tweak on https://github.com/openshift/ci-tools/pull/2417 to build the suite independent of junit results so we can start having the disruption tests on individual job runs only fail on passing the p95.