### PR TITLE
[DO NOT MERGE] [WIP] never merge this, disruption calculation comparison

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -154,7 +154,7 @@ SELECT *
 FROM DATA_SET_LOCATION.` + jobrunaggregatorapi.DisruptionJobRunTableName + ` as JobRuns
 WHERE JobRuns.JobName = @JobName
 ORDER BY JobRuns.Name DESC
-LIMIT 1
+LIMIT 500
 `)
 
 	query := c.client.Query(queryString)
@@ -166,12 +166,15 @@ LIMIT 1
 		return nil, fmt.Errorf("failed to query aggregation table with %q: %w", queryString, err)
 	}
 	lastJobRun := &jobrunaggregatorapi.JobRunRow{}
-	err = lastJobRunRow.Next(lastJobRun)
-	if err == iterator.Done {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
+
+	for {
+		err = lastJobRunRow.Next(lastJobRun)
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 	return lastJobRun, nil
 }


### PR DESCRIPTION
compare the output of disruption from junit output and direct file output from openshift-tests.

> panic: periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-upgrade/1460417551287717888 has a diff on ingress-to-console-used-connections junit=10 direct=0

> panic: periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-upgrade/1457862929142517760 has a diff on ingress-to-console-new-connections junit=0 direct=1881

***ONLY RUN THIS WITH --dry-run***