### PR TITLE
ci-secret-bootstrap: fix the secret-names flag: another nil pointer

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -84,7 +84,7 @@ func parseOptions(censor *secrets.DynamicCensor) (options, error) {
 	fs.StringVar(&o.configPath, "config", "", "Path to the config file to use for this tool.")
 	fs.StringVar(&o.generatorConfigPath, "generator-config", "", "Path to the secret-generator config file.")
 	fs.StringVar(&o.cluster, "cluster", "", "If set, only provision secrets for this cluster")
-	fs.Var(&o.secretNamesRaw, "secret-names", "If set, only provision secrets with the name and user_secrets_target_clusters in the configuration is ignored. Can be passed multiple times.")
+	fs.Var(&o.secretNamesRaw, "secret-names", "If set, only provision secrets with the given name. user_secrets_target_clusters in the configuration is ignored. Can be passed multiple times.")
 	fs.BoolVar(&o.force, "force", false, "If true, update the secrets even if existing one differs from Bitwarden items instead of existing with error. Default false.")
 	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	fs.StringVar(&o.impersonateUser, "as", "", "Username to impersonate")

--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -84,7 +84,7 @@ func parseOptions(censor *secrets.DynamicCensor) (options, error) {
 	fs.StringVar(&o.configPath, "config", "", "Path to the config file to use for this tool.")
 	fs.StringVar(&o.generatorConfigPath, "generator-config", "", "Path to the secret-generator config file.")
 	fs.StringVar(&o.cluster, "cluster", "", "If set, only provision secrets for this cluster")
-	fs.Var(&o.secretNamesRaw, "secret-names", "If set, only provision secrets with the name. Can be passed multiple times.")
+	fs.Var(&o.secretNamesRaw, "secret-names", "If set, only provision secrets with the name and user_secrets_target_clusters in the configuration is ignored. Can be passed multiple times.")
 	fs.BoolVar(&o.force, "force", false, "If true, update the secrets even if existing one differs from Bitwarden items instead of existing with error. Default false.")
 	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
 	fs.StringVar(&o.impersonateUser, "as", "", "Username to impersonate")
@@ -124,9 +124,9 @@ func (o *options) completeOptions(censor *secrets.DynamicCensor, kubeConfigs map
 
 	if vals := o.secretNamesRaw.Strings(); len(vals) > 0 {
 		secretNames := sets.NewString(vals...)
-		logrus.WithField("secretNames", secretNames.List()).Info("pruning irrelevant secrets ...")
-		pruneIrrelevantSecrets(&o.config, secretNames)
-		logrus.WithField("secretNames", secretNames.List()).WithField("o.config.Secrets", o.config.Secrets).Info("pruned irrelevant secrets")
+		logrus.WithField("secretNames", secretNames.List()).Info("pruning irrelevant configuration ...")
+		pruneIrrelevantConfiguration(&o.config, secretNames)
+		logrus.WithField("secretNames", secretNames.List()).WithField("o.config.Secrets", o.config.Secrets).Info("pruned irrelevant configuration")
 	}
 
 	if o.generatorConfigPath != "" {
@@ -183,7 +183,7 @@ func (o *options) completeOptions(censor *secrets.DynamicCensor, kubeConfigs map
 	return o.validateCompletedOptions()
 }
 
-func pruneIrrelevantSecrets(c *secretbootstrap.Config, secretNames sets.String) {
+func pruneIrrelevantConfiguration(c *secretbootstrap.Config, secretNames sets.String) {
 	var secretConfigs []secretbootstrap.SecretConfig
 	for _, secretConfig := range c.Secrets {
 		for _, secretContext := range secretConfig.To {
@@ -194,6 +194,7 @@ func pruneIrrelevantSecrets(c *secretbootstrap.Config, secretNames sets.String) 
 		}
 	}
 	c.Secrets = secretConfigs
+	c.UserSecretsTargetClusters = nil
 }
 
 func (o *options) validateCompletedOptions() error {

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -2831,7 +2831,7 @@ func TestIntegration(t *testing.T) {
 	}
 }
 
-func TestPruneIrrelevantSecrets(t *testing.T) {
+func TestPruneIrrelevantConfiguration(t *testing.T) {
 	testCases := []struct {
 		name     string
 		given    *secretbootstrap.Config
@@ -2860,6 +2860,7 @@ func TestPruneIrrelevantSecrets(t *testing.T) {
 						},
 					},
 				},
+				UserSecretsTargetClusters: []string{"b01"},
 			},
 			expected: &secretbootstrap.Config{
 				Secrets: []secretbootstrap.SecretConfig{
@@ -2879,7 +2880,7 @@ func TestPruneIrrelevantSecrets(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			pruneIrrelevantSecrets(tc.given, sets.NewString("config-updater"))
+			pruneIrrelevantConfiguration(tc.given, sets.NewString("config-updater"))
 			if diff := cmp.Diff(tc.given, tc.expected); diff != "" {
 				t.Errorf("%s: actual differs from expected: %s", tc.name, diff)
 			}


### PR DESCRIPTION
```console
{"cluster":"build03","component":"ci-secret-bootstrap","file":"/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:490","func":"main.updateSecrets","level":"debug","msg":"Syncing secrets for cluster","severity":"debug","time":"2021-11-23T22:16:23Z"}
{"cluster":"build03","component":"ci-secret-bootstrap","file":"/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:493","func":"main.updateSecrets","level":"debug","msg":"handling secret","name":"github-token","namespace":"test-credentials","severity":"debug","time":"2021-11-23T22:16:23Z","type":"Opaque"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x18b29d9]

goroutine 1 [running]:
main.updateSecrets(0x7fbf783c74b8, 0xc000854e70, 0x1, 0x6)
	/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:495 +0x539
main.reconcileSecrets({{{0x0, 0x0}, {0x7ffc77c41ded, 0x1e}, {0x7ffc77c41e1b, 0x2}, {0x0, 0x0}, {0xc00004206c, 0x1a}}, ...}, ...)
	/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:867 +0x83c
main.main()
	/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:824 +0x6b8
make: *** [Makefile:225: ci-secret-bootstrap] Error 2
```

/cc @openshift/test-platform 