### PR TITLE
prpqr: base tests on data fixtures instead of code

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -3,9 +3,8 @@ package prpqr_reconciler
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,15 +15,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestReconcile(t *testing.T) {
 	testCases := []struct {
-		name             string
-		prowJobs         []ctrlruntimeclient.Object
-		expectedProwjobs []prowv1.ProwJob
-		prpqr            []ctrlruntimeclient.Object
-		expected         []v1.PullRequestPayloadQualificationRun
+		name     string
+		prowJobs []ctrlruntimeclient.Object
+		prpqr    []ctrlruntimeclient.Object
 	}{
 		{
 			name: "basic case",
@@ -38,54 +36,6 @@ func TestReconcile(t *testing.T) {
 							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
 						},
 					},
-				},
-			},
-			expected: []v1.PullRequestPayloadQualificationRun{
-				{
-					TypeMeta:   metav1.TypeMeta{Kind: "PullRequestPayloadQualificationRun", APIVersion: "ci.openshift.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
-					Spec: v1.PullRequestPayloadTestSpec{PullRequest: v1.PullRequestUnderTest{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}},
-						Jobs: v1.PullRequestPayloadJobSpec{
-							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
-							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}}},
-					},
-					Status: v1.PullRequestPayloadTestStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    "AllJobsTriggered",
-								Status:  "True",
-								Reason:  "AllJobsTriggered",
-								Message: "All jobs triggered successfully",
-							},
-						},
-
-						Jobs: []v1.PullRequestPayloadJobStatus{{ReleaseJobName: "periodic-ci-test-org-test-repo-test-branch-test-name", Status: prowv1.ProwJobStatus{State: "triggered"}}},
-					},
-				},
-			},
-			expectedProwjobs: []prowv1.ProwJob{
-				{
-					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							"prow.k8s.io/context": "",
-							"prow.k8s.io/job":     "",
-							"releaseJobName":      "periodic-ci-test-org-test-repo-test-branch-test-name",
-						},
-						Labels: map[string]string{
-							"created-by-prow":           "true",
-							"prow.k8s.io/context":       "",
-							"prow.k8s.io/job":           "",
-							"prow.k8s.io/refs.base_ref": "test-branch",
-							"prow.k8s.io/refs.org":      "test-org",
-							"prow.k8s.io/refs.repo":     "test-repo",
-							"prow.k8s.io/type":          "periodic",
-							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
-							"releaseJobNameHash": "ee3858eff62263cd7266320c00d1d38b",
-						},
-					},
-					Status: prowv1.ProwJobStatus{State: "triggered"},
 				},
 			},
 		},
@@ -102,56 +52,8 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 			},
-			expected: []v1.PullRequestPayloadQualificationRun{
-				{
-					TypeMeta:   metav1.TypeMeta{Kind: "PullRequestPayloadQualificationRun", APIVersion: "ci.openshift.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
-					Spec: v1.PullRequestPayloadTestSpec{
-						PullRequest: v1.PullRequestUnderTest{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}},
-						Jobs: v1.PullRequestPayloadJobSpec{
-							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
-							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
-						},
-					},
-					Status: v1.PullRequestPayloadTestStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    "AllJobsTriggered",
-								Status:  "True",
-								Reason:  "AllJobsTriggered",
-								Message: "All jobs triggered successfully",
-							},
-						},
-					},
-				},
-			},
 			prowJobs: []ctrlruntimeclient.Object{
 				&prowv1.ProwJob{
-					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							"prow.k8s.io/context": "",
-							"prow.k8s.io/job":     "",
-							"releaseJobName":      "periodic-ci-test-org-test-repo-test-branch-test-name",
-						},
-						Labels: map[string]string{
-							"created-by-prow":           "true",
-							"prow.k8s.io/context":       "",
-							"prow.k8s.io/job":           "",
-							"prow.k8s.io/refs.base_ref": "test-branch",
-							"prow.k8s.io/refs.org":      "test-org",
-							"prow.k8s.io/refs.repo":     "test-repo",
-							"prow.k8s.io/type":          "periodic",
-							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
-							"releaseJobNameHash": "ee3858eff62263cd7266320c00d1d38b",
-						},
-					},
-					Status: prowv1.ProwJobStatus{State: "triggered"},
-				},
-			},
-			expectedProwjobs: []prowv1.ProwJob{
-				{
 					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "test-namespace",
@@ -195,36 +97,6 @@ func TestReconcile(t *testing.T) {
 						Jobs: []v1.PullRequestPayloadJobStatus{{ReleaseJobName: "periodic-ci-test-org-test-repo-test-branch-test-name", Status: prowv1.ProwJobStatus{State: "triggered"}}}},
 				},
 			},
-			expected: []v1.PullRequestPayloadQualificationRun{
-				{
-					TypeMeta:   metav1.TypeMeta{Kind: "PullRequestPayloadQualificationRun", APIVersion: "ci.openshift.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
-					Spec: v1.PullRequestPayloadTestSpec{
-						PullRequest: v1.PullRequestUnderTest{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}},
-						Jobs: v1.PullRequestPayloadJobSpec{
-							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
-							Jobs: []v1.ReleaseJobSpec{
-								{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"},
-								{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name-2"},
-							},
-						},
-					},
-					Status: v1.PullRequestPayloadTestStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:    "AllJobsTriggered",
-								Status:  "True",
-								Reason:  "AllJobsTriggered",
-								Message: "All jobs triggered successfully",
-							},
-						},
-						Jobs: []v1.PullRequestPayloadJobStatus{
-							{ReleaseJobName: "periodic-ci-test-org-test-repo-test-branch-test-name", Status: prowv1.ProwJobStatus{State: "triggered"}},
-							{ReleaseJobName: "periodic-ci-test-org-test-repo-test-branch-test-name-2", Status: prowv1.ProwJobStatus{State: "triggered"}},
-						},
-					},
-				},
-			},
 			prowJobs: []ctrlruntimeclient.Object{
 				&prowv1.ProwJob{
 					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
@@ -241,50 +113,6 @@ func TestReconcile(t *testing.T) {
 							"prow.k8s.io/type":          "periodic",
 							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
 							"releaseJobNameHash": "ee3858eff62263cd7266320c00d1d38b",
-						},
-					},
-					Status: prowv1.ProwJobStatus{State: "triggered"},
-				},
-			},
-			expectedProwjobs: []prowv1.ProwJob{
-				{
-					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   "test-namespace",
-						Annotations: map[string]string{"prow.k8s.io/context": "", "prow.k8s.io/job": ""},
-						Labels: map[string]string{
-							"created-by-prow":           "true",
-							"prow.k8s.io/context":       "",
-							"prow.k8s.io/job":           "",
-							"prow.k8s.io/refs.base_ref": "test-branch",
-							"prow.k8s.io/refs.org":      "test-org",
-							"prow.k8s.io/refs.repo":     "test-repo",
-							"prow.k8s.io/type":          "periodic",
-							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
-							"releaseJobNameHash": "ee3858eff62263cd7266320c00d1d38b",
-						},
-					},
-					Status: prowv1.ProwJobStatus{State: "triggered"},
-				},
-				{
-					TypeMeta: metav1.TypeMeta{Kind: "ProwJob", APIVersion: "prow.k8s.io/v1"},
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-namespace",
-						Annotations: map[string]string{
-							"prow.k8s.io/context": "",
-							"prow.k8s.io/job":     "",
-							"releaseJobName":      "periodic-ci-test-org-test-repo-test-branch-test-name-2",
-						},
-						Labels: map[string]string{
-							"created-by-prow":           "true",
-							"prow.k8s.io/context":       "",
-							"prow.k8s.io/job":           "",
-							"prow.k8s.io/refs.base_ref": "test-branch",
-							"prow.k8s.io/refs.org":      "test-org",
-							"prow.k8s.io/refs.repo":     "test-repo",
-							"prow.k8s.io/type":          "periodic",
-							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
-							"releaseJobNameHash": "428af2aff595f9d8074f2f6bfba1aec1",
 						},
 					},
 					Status: prowv1.ProwJobStatus{State: "triggered"},
@@ -308,22 +136,41 @@ func TestReconcile(t *testing.T) {
 			if err := r.client.List(context.Background(), &actualProwjobsList); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(actualProwjobsList.Items, tc.expectedProwjobs, cmpopts.IgnoreFields(prowv1.ProwJob{}, "Spec", "ResourceVersion", "Status.StartTime", "ObjectMeta.Name")); diff != "" {
-				t.Fatal(diff)
-			}
+
+			pruneProwjobsForTests(actualProwjobsList.Items)
+			testhelper.CompareWithFixture(t, actualProwjobsList.Items, testhelper.WithPrefix("prowjobs-"))
 
 			var actualPrpqr v1.PullRequestPayloadQualificationRunList
 			if err := r.client.List(context.Background(), &actualPrpqr); err != nil {
 				t.Fatal(err)
 			}
-			if diff := cmp.Diff(actualPrpqr.Items, tc.expected,
-				cmpopts.IgnoreFields(metav1.TypeMeta{}, "Kind", "APIVersion"),
-				cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
-				cmpopts.IgnoreFields(prowv1.ProwJobStatus{}, "StartTime"),
-				cmpopts.IgnoreFields(v1.PullRequestPayloadQualificationRun{}, "ResourceVersion"),
-				cmpopts.IgnoreFields(v1.PullRequestPayloadJobStatus{}, "ProwJob")); diff != "" {
-				t.Fatal(diff)
-			}
+
+			prunePRPQRForTests(actualPrpqr.Items)
+			testhelper.CompareWithFixture(t, actualPrpqr.Items, testhelper.WithPrefix("prpqr-"))
 		})
+	}
+}
+
+var (
+	zeroTime = metav1.NewTime(time.Unix(0, 0))
+)
+
+func prunePRPQRForTests(items []v1.PullRequestPayloadQualificationRun) {
+	for i := range items {
+		for job := range items[i].Status.Jobs {
+			items[i].Status.Jobs[job].ProwJob = "some-uuid"
+			items[i].Status.Jobs[job].Status.StartTime = zeroTime
+
+		}
+		for condition := range items[i].Status.Conditions {
+			items[i].Status.Conditions[condition].LastTransitionTime = zeroTime
+		}
+	}
+}
+
+func pruneProwjobsForTests(items []prowv1.ProwJob) {
+	for i := range items {
+		items[i].Status.StartTime = zeroTime
+		items[i].Name = "some-uuid"
 	}
 }

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -1,0 +1,41 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    extra_refs:
+    - base_ref: test-branch
+      org: test-org
+      repo: test-repo
+    pod_spec:
+      containers:
+      - args:
+        - "100"
+        command:
+        - sleep
+        image: centos:8
+        name: ""
+        resources: {}
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
@@ -1,0 +1,25 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "999"
+  spec: {}
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -1,0 +1,65 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "999"
+  spec: {}
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-2
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ""
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: 428af2aff595f9d8074f2f6bfba1aec1
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    extra_refs:
+    - base_ref: test-branch
+      org: test-org
+      repo: test-repo
+    pod_spec:
+      containers:
+      - args:
+        - "100"
+        command:
+        - sleep
+        image: centos:8
+        name: ""
+        resources: {}
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
@@ -1,0 +1,42 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
@@ -1,0 +1,36 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -1,0 +1,52 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name-2
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name-2
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered


### PR DESCRIPTION
Most of our newer tests that work with more complex structures use data
fixtures instead of code: they are easier to maintain (running with
UPDATE=true updates them when needed) and they are also really good in
inspecting changes.

The only change in the actual tests is that *fewer* members are ignored.
Previously, the `Spec` was ignored when comparing Prowjobs for no
apparent reason, and not ignoring it will improve the tests for the
future when we change how the submitted Prowjobs exactly look like.

/cc @droslean @openshift/test-platform 
