### PR TITLE
prowgen: do not use projected secrets unless needed

### DIFF
--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -303,17 +303,6 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 
 	ret := corev1.Volume{
 		Name: clusterProfileVolume,
-		VolumeSource: corev1.VolumeSource{
-			Projected: &corev1.ProjectedVolumeSource{
-				Sources: []corev1.VolumeProjection{{
-					Secret: &corev1.SecretProjection{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: fmt.Sprintf("cluster-secrets-%s", clusterType),
-						},
-					}},
-				},
-			},
-		},
 	}
 	switch profile {
 	case
@@ -349,14 +338,26 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfilePacket,
 		cioperatorapi.ClusterProfilePacketAssisted,
 		cioperatorapi.ClusterProfilePacketSNO:
+		ret.VolumeSource = corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: fmt.Sprintf("cluster-secrets-%s", clusterType),
+			},
+		}
 	default:
-		ret.VolumeSource.Projected.Sources = append(ret.VolumeSource.Projected.Sources, corev1.VolumeProjection{
-			ConfigMap: &corev1.ConfigMapProjection{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: fmt.Sprintf("cluster-profile-%s", profile),
+		ret.VolumeSource.Projected = &corev1.ProjectedVolumeSource{
+			Sources: []corev1.VolumeProjection{
+				{
+					Secret: &corev1.SecretProjection{
+						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("cluster-secrets-%s", clusterType)},
+					},
+				},
+				{
+					ConfigMap: &corev1.ConfigMapProjection{
+						LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("cluster-profile-%s", profile)},
+					},
 				},
 			},
-		})
+		}
 	}
 	return ret
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws.yaml
@@ -28,10 +28,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws_cpaas.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws_cpaas.yaml
@@ -28,10 +28,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws-cpaas
+  secret:
+    secretName: cluster-secrets-aws-cpaas
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_openstack.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_openstack.yaml
@@ -28,10 +28,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-openstack
+  secret:
+    secretName: cluster-secrets-openstack
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
@@ -46,10 +46,8 @@ spec:
   serviceAccountName: ci-operator
   volumes:
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - configMap:
       name: prow-job-cluster-launch-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
@@ -46,10 +46,8 @@ spec:
   serviceAccountName: ci-operator
   volumes:
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - configMap:
       name: prow-job-cluster-launch-e2e-openshift-ansible
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
@@ -54,10 +54,8 @@ spec:
         path: credentials
       secretName: boskos-credentials
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - configMap:
       name: prow-job-cluster-launch-installer-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
@@ -56,10 +56,8 @@ spec:
         path: credentials
       secretName: boskos-credentials
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - configMap:
       name: prow-job-cluster-launch-installer-custom-test-image
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
@@ -54,10 +54,8 @@ spec:
         path: credentials
       secretName: boskos-credentials
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - configMap:
       name: prow-job-cluster-launch-installer-upi-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
@@ -44,10 +44,8 @@ spec:
         path: credentials
       secretName: boskos-credentials
   - name: cluster-profile
-    projected:
-      sources:
-      - secret:
-          name: cluster-secrets-alibaba
+    secret:
+      secretName: cluster-secrets-alibaba
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_additional_envvar_generated_for_template.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_additional_envvar_generated_for_template.yaml
@@ -41,10 +41,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - configMap:
     name: prow-job-template
   name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_different_template_with_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_different_template_with_command.yaml
@@ -38,10 +38,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - configMap:
     name: prow-job-cluster-launch-installer-libvirt-e2e
   name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_a_custom_test_image.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_a_custom_test_image.yaml
@@ -41,10 +41,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_command.yaml
@@ -39,10 +39,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_different_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_different_command.yaml
@@ -39,10 +39,8 @@ containers:
 serviceAccountName: ci-operator
 volumes:
 - name: cluster-profile
-  projected:
-    sources:
-    - secret:
-        name: cluster-secrets-aws
+  secret:
+    secretName: cluster-secrets-aws
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -56,10 +56,8 @@ periodics:
     serviceAccountName: ci-operator
     volumes:
     - name: cluster-profile
-      projected:
-        sources:
-        - secret:
-            name: cluster-secrets-aws
+      secret:
+        secretName: cluster-secrets-aws
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition
@@ -126,10 +124,8 @@ periodics:
     serviceAccountName: ci-operator
     volumes:
     - name: cluster-profile
-      projected:
-        sources:
-        - secret:
-            name: cluster-secrets-aws
+      secret:
+        secretName: cluster-secrets-aws
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -337,10 +337,8 @@ presubmits:
             path: credentials
           secretName: boskos-credentials
       - name: cluster-profile
-        projected:
-          sources:
-          - secret:
-              name: cluster-secrets-aws
+        secret:
+          secretName: cluster-secrets-aws
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -451,10 +449,8 @@ presubmits:
             path: credentials
           secretName: boskos-credentials
       - name: cluster-profile
-        projected:
-          sources:
-          - secret:
-              name: cluster-secrets-aws
+        secret:
+          secretName: cluster-secrets-aws
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -112,10 +112,8 @@ presubmits:
         secret:
           secretName: ci-pull-credentials
       - name: cluster-profile
-        projected:
-          sources:
-          - secret:
-              name: cluster-secrets-aws
+        secret:
+          secretName: cluster-secrets-aws
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -186,10 +184,8 @@ presubmits:
         secret:
           secretName: ci-pull-credentials
       - name: cluster-profile
-        projected:
-          sources:
-          - secret:
-              name: cluster-secrets-aws
+        secret:
+          secretName: cluster-secrets-aws
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -65,10 +65,8 @@ presubmits:
         secret:
           secretName: ci-pull-credentials
       - name: cluster-profile
-        projected:
-          sources:
-          - secret:
-              name: cluster-secrets-aws
+        secret:
+          secretName: cluster-secrets-aws
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials


### PR DESCRIPTION
Projected secrets are useful when we need multiple sources melded into a
single volume. In most cases, our cluster profiles are just a single
secret, so using secrets directly as a volume source saves a bunch of
YAML lines (and simplifies the config).

Expected to fail breaking-changes check, needs a followup PR

/hold