### PR TITLE
Generate cloud label on Prow jobs

### DIFF
--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -90,11 +90,11 @@ func TestValidate(t *testing.T) {
 var (
 	c = dispatcher.Config{
 		Default: "api.ci",
-		BuildFarm: map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames{
-			dispatcher.CloudAWS: {
+		BuildFarm: map[api.Cloud]map[api.Cluster]dispatcher.Filenames{
+			api.CloudAWS: {
 				api.ClusterBuild01: {},
 			},
-			dispatcher.CloudGCP: {
+			api.CloudGCP: {
 				api.ClusterBuild02: {},
 			},
 		},
@@ -143,7 +143,7 @@ func TestDispatchJobs(t *testing.T) {
 		config            *dispatcher.Config
 		jobVolumes        map[string]float64
 		expected          error
-		expectedBuildFarm map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames
+		expectedBuildFarm map[api.Cloud]map[api.Cluster]dispatcher.Filenames
 	}{
 		{
 			name:     "nil config",
@@ -159,7 +159,7 @@ func TestDispatchJobs(t *testing.T) {
 				"pull-ci-openshift-ci-tools-master-e2e":               12,
 				"pull-ci-openshift-cluster-etcd-operator-master-unit": 6,
 			},
-			expectedBuildFarm: map[dispatcher.CloudProvider]map[api.Cluster]dispatcher.Filenames{
+			expectedBuildFarm: map[api.Cloud]map[api.Cluster]dispatcher.Filenames{
 				"aws": {"build01": {FilenamesRaw: []string{"ci-tools-presubmits.yaml"}}},
 				"gcp": {"build02": {FilenamesRaw: []string{"cluster-api-provider-gcp-presubmits.yaml", "cluster-etcd-operator-master-presubmits.yaml", "wildfly-operator-presubmits.yaml"}}},
 			},

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -18,8 +18,10 @@ const (
 	// DPTPRequesterLabel is the label on a Kubernates CR whose value indicates the automated tool that requests the CR
 	DPTPRequesterLabel = "dptp.openshift.io/requester"
 
-	KVMDeviceLabel = "devices.kubevirt.io/kvm"
-	ClusterLabel   = "ci-operator.openshift.io/cluster"
+	KVMDeviceLabel           = "devices.kubevirt.io/kvm"
+	ClusterLabel             = "ci-operator.openshift.io/cluster"
+	CloudLabel               = "ci-operator.openshift.io/cloud"
+	CloudClusterProfileLabel = "ci-operator.openshift.io/cloud-cluster-profile"
 
 	NoBuildsLabel = "ci.openshift.io/no-builds"
 	NoBuildsValue = "true"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -683,6 +683,7 @@ type Cloud string
 
 const (
 	CloudAWS Cloud = "aws"
+	CloudGCP Cloud = "gcp"
 )
 
 // ClusterClaim claims an OpenShift cluster for the job.
@@ -1184,7 +1185,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWS2:
-		return "aws"
+		return string(CloudAWS)
 	case ClusterProfileAlibaba:
 		return "alibaba"
 	case ClusterProfileAWSArm64:
@@ -1212,7 +1213,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileGCPLoggingJSONFile,
 		ClusterProfileGCPLoggingCRIO,
 		ClusterProfileGCP2:
-		return "gcp"
+		return string(CloudGCP)
 	case ClusterProfileIBMCloud:
 		return "ibmcloud"
 	case ClusterProfileLibvirtPpc64le:

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -18,16 +18,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
-// CloudProvider define cloud providers
-type CloudProvider string
-
-const (
-	// CloudAWS is the cloud provider AWS
-	CloudAWS CloudProvider = "aws"
-	// CloudGCP is the cloud provider GCP
-	CloudGCP CloudProvider = "gcp"
-)
-
 // Config is the configuration file of this tools, which defines the cluster parameter for each Prow job, i.e., where it runs
 type Config struct {
 	// the cluster cluster name if no other condition matches
@@ -41,7 +31,7 @@ type Config struct {
 	// Groups maps a group of jobs to a cluster
 	Groups JobGroups `json:"groups"`
 	// BuildFarm maps groups of jobs to a cloud provider, like GCP
-	BuildFarm map[CloudProvider]map[api.Cluster]Filenames `json:"buildFarm,omitempty"`
+	BuildFarm map[api.Cloud]map[api.Cluster]Filenames `json:"buildFarm,omitempty"`
 }
 
 type Filenames struct {
@@ -159,7 +149,7 @@ func isSSHBastionJob(base prowconfig.JobBase) bool {
 }
 
 // IsInBuildFarm returns the cloudProvider if the cluster is in the build farm; empty string otherwise.
-func (config *Config) IsInBuildFarm(clusterName api.Cluster) CloudProvider {
+func (config *Config) IsInBuildFarm(clusterName api.Cluster) api.Cloud {
 	for cloudProvider, v := range config.BuildFarm {
 		for cluster := range v {
 			if cluster == clusterName {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -60,11 +60,11 @@ var (
 
 	configWithBuildFarm = Config{
 		Default: "api.ci",
-		BuildFarm: map[CloudProvider]map[api.Cluster]Filenames{
-			CloudAWS: {
+		BuildFarm: map[api.Cloud]map[api.Cluster]Filenames{
+			api.CloudAWS: {
 				api.ClusterBuild01: {},
 			},
-			CloudGCP: {
+			api.CloudGCP: {
 				api.ClusterBuild02: {},
 			},
 		},
@@ -108,8 +108,8 @@ var (
 		Default:  "api.ci",
 		KVM:      []api.Cluster{api.ClusterBuild02},
 		NoBuilds: []api.Cluster{api.ClusterBuild03},
-		BuildFarm: map[CloudProvider]map[api.Cluster]Filenames{
-			CloudAWS: {
+		BuildFarm: map[api.Cloud]map[api.Cluster]Filenames{
+			api.CloudAWS: {
 				api.ClusterBuild01: {
 					FilenamesRaw: []string{
 						"some-build-farm-presubmits.yaml",
@@ -117,7 +117,7 @@ var (
 					Filenames: sets.NewString("some-build-farm-presubmits.yaml"),
 				},
 			},
-			CloudGCP: {
+			api.CloudGCP: {
 				api.ClusterBuild02: {},
 			},
 		},
@@ -444,7 +444,7 @@ func TestIsInBuildFarm(t *testing.T) {
 		name        string
 		config      *Config
 		clusterName api.Cluster
-		expected    CloudProvider
+		expected    api.Cloud
 	}{
 		{
 			name:        "build01",

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -125,15 +125,19 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 
 	switch {
 	case test.MultiStageTestConfigurationLiteral != nil:
-		if test.MultiStageTestConfigurationLiteral.ClusterProfile != "" {
-			p.PodSpec.Add(ClusterProfile(test.MultiStageTestConfigurationLiteral.ClusterProfile, test.As), LeaseClient())
+		if clusterProfile := test.MultiStageTestConfigurationLiteral.ClusterProfile; clusterProfile != "" {
+			p.PodSpec.Add(ClusterProfile(clusterProfile, test.As), LeaseClient())
+			p.WithLabel(cioperatorapi.CloudClusterProfileLabel, string(clusterProfile))
+			p.WithLabel(cioperatorapi.CloudLabel, clusterProfile.ClusterType())
 		}
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
 		}
 	case test.MultiStageTestConfiguration != nil:
-		if test.MultiStageTestConfiguration.ClusterProfile != "" {
-			p.PodSpec.Add(ClusterProfile(test.MultiStageTestConfiguration.ClusterProfile, test.As), LeaseClient())
+		if clusterProfile := test.MultiStageTestConfiguration.ClusterProfile; clusterProfile != "" {
+			p.PodSpec.Add(ClusterProfile(clusterProfile, test.As), LeaseClient())
+			p.WithLabel(cioperatorapi.CloudClusterProfileLabel, string(clusterProfile))
+			p.WithLabel(cioperatorapi.CloudLabel, clusterProfile.ClusterType())
 		}
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
@@ -2,6 +2,9 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  ci-operator.openshift.io/cloud: alibaba
+  ci-operator.openshift.io/cloud-cluster-profile: alibaba
 name: prefix-ci-o-r-b-simple
 spec:
   containers:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -291,6 +291,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-optional-job
@@ -404,6 +406,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-registry-with-profile

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -60,6 +60,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-org-repo-master-e2e
@@ -132,6 +134,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-org-repo-master-e2e-aws

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -11,6 +11,8 @@ presubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       job-release: "4.4"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/GB7NB0CUC/p1637862410018500?thread_ts=1637860578.014800&cid=GB7NB0CUC

1. ProwGen generates the label for multistage test according to `cluster_profile`
2. This is going to be used by sanitizer to determine the cluster where the job runs.

/cc @petr-muller 

[DPTP-2651](https://issues.redhat.com/browse/DPTP-2651)