### PR TITLE
sprint-automation: Use mark-down when pinging triage

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -540,7 +540,7 @@ func sendTriageBuild02Upgrade(slackClient *slack.Client, version, stableDuration
 		&slack.SectionBlock{
 			Type: slack.MBTSection,
 			Text: &slack.TextBlockObject{
-				Type: slack.PlainTextType,
+				Type: slack.MarkdownType,
 				// Ideally, we could just run the upgrade command and notify triage via slack
 				// In reality we still need some manual checks before upgrading build02
 				Text: fmt.Sprintf("@%s Version %s is stable on `build01` for %s. Please upgrade `build02` if `build02` is healthy: `oc --as system:admin --context build02 adm upgrade --to=%s`",


### PR DESCRIPTION
Follow up
https://coreos.slack.com/archives/CHY2E1BL4/p1638180894165800?thread_ts=1638172838.165200&cid=CHY2E1BL4

/cc @openshift/test-platform 