### PR TITLE
private-prow-configs-mirror: skipResolveConfigUpdater=true

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -89,7 +89,7 @@ func (o *options) validate() error {
 
 func loadProwPlugins(pluginsPath string) (*plugins.Configuration, error) {
 	agent := plugins.ConfigAgent{}
-	if err := agent.Load(pluginsPath, []string{filepath.Dir(config.PluginConfigFile)}, "_pluginconfig.yaml", false, false); err != nil {
+	if err := agent.Load(pluginsPath, []string{filepath.Dir(config.PluginConfigFile)}, "_pluginconfig.yaml", false, true); err != nil {
 		return nil, err
 	}
 	return agent.Config(), nil


### PR DESCRIPTION
This tool loads and dumps `plugins.yaml`.
It is also a part of `auto-config-brancher`.

It explains why the changes in https://github.com/openshift/release/pull/24007/files
got reverted by
https://github.com/openshift/release/pull/24115/commits/0b2deef72a5d95dd8fcefcbba5c408360688818c

According to https://github.com/openshift/ci-tools/tree/master/cmd/private-prow-configs-mirror#prow-plugins
This tool does not touch config_updater's config.
Hence, it is OK to skip the resolving.