### PR TITLE
Slow down blocking-issue-creator to respect API limits

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -103,9 +104,10 @@ func main() {
 
 		if err := manageIssues(client, botUser.Login, repoInfo, branches, logger); err != nil {
 			failed = true
-			return nil
 		}
 
+		//sleep to respect Github's API 30 requests per minute limit, absolute minimum is above 2 seconds
+		time.Sleep(5 * time.Second)
 		return nil
 	}); err != nil || failed {
 		logrus.WithError(err).Fatal("Could not publish merge blocking issues.")


### PR DESCRIPTION
Small change, long description.

There is a need to slow down blocking-issue-creator as it is not respecting GitHub API limits. The calls are run without any sleep so after firing up around 30 calls blocking-issue-creator waits 1 minute to regain the possibility to ask GitHub. It is visible in the logs:

`
time="2021-11-30T18:01:58Z" level=info msg="FindIssues(is:issue state:open label:\"tide/merge-blocker\" .....
time="2021-11-30T18:02:54Z" level=info msg="Current merge-blocker issue is up to date, no update.....`

The time difference is around 1 minute. Currently, there are around 240 calls fired by the tool. The minimal sleep time set not to abuse the limit is something above 2 seconds (as several additional calls can be fired when there is a need to create or delete the issue). The current safe value would be around 3,5-4 seconds.

This commit sets the sleep time to 5 seconds to back:

- Additional calls may come when more issues to be created, edited, closed
- Additional repos handled in the future
- Github API tweaks or wrongly reported abuse limits

As a consequence current run assuming around 230-250 calls would go up from around 7m30s to around 19-22mins. As currently, job runs periodically every 1h, it's safe to prolong the running time.

Signed-off-by: Jakub Guzik <jguzik@redhat.com>