### PR TITLE
job-trigger-cm: fix options

### DIFF
--- a/cmd/job-trigger-controller-manager/main.go
+++ b/cmd/job-trigger-controller-manager/main.go
@@ -36,6 +36,7 @@ func gatherOptions() (*options, error) {
 	o := &options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
+	o.ConfigOptions.AddFlags(fs)
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
 	fs.StringVar(&o.namespace, "namespace", "ci", "In which namespace the operation will take place")
 


### PR DESCRIPTION
:facepalm: 

```
flag provided but not defined: -config-path
Usage of job-trigger-controller-manager:
  -dry-run
    	Whether to run the controller-manager with dry-run (default true)
  -namespace string
    	In which namespace the operation will take place (default "ci")
```