### PR TITLE
job-trigger-cm: code structure refactor

### DIFF
--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
@@ -34,3 +34,9 @@
       reason: AllJobsTriggered
       status: "True"
       type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered


### PR DESCRIPTION
Previous code structure assumed `generateProwjobs` is a cheap operation
(it is not, each Prowjob is a call to ci-operator-configresolver) so it
first generated all prowjobs and then it processed them.

This PR changes the reconciliation algorithm to straightforward
iteration over all jobs that *should* exist and hence should be present
in the status. First the code checks whether there is evidence that they
already exists (or existed in the past): either by presence in the
status, or by presence in the cluster. If the job is not present, it is
created. For all jobs, we track our observation of what their status
should be in our PRPQR resource.

Finally, the status reconciling takes into account that the updated
PRPQR can have *better* information than what *we* have, and we only
update the status when ours is more precise (for example, we will not
overwrite a status for an existing job with our error status).
