### PR TITLE
Note /validate-backports in commit validation messages

### DIFF
--- a/cmd/backport-verifier/server.go
+++ b/cmd/backport-verifier/server.go
@@ -171,6 +171,8 @@ func (s *server) handle(l *logrus.Entry, org, repo, user string, num int, reques
 			message = fmt.Sprintf("%s\n\nThe following commits %s:\n%s", message, item.qualifier, strings.Join(formatted, "\n"))
 		}
 	}
+	footer := "\n\nComment <code>/validate-backports</code> to re-evaluate validity of the upstream PRs, for example when they are merged upstream."
+	message = message + footer
 	if commentErr := s.ghc.CreateComment(org, repo, num, message); commentErr != nil {
 		logger.WithError(commentErr).Warn("couldn't respond to user")
 	}

--- a/cmd/backport-verifier/server_test.go
+++ b/cmd/backport-verifier/server_test.go
@@ -122,7 +122,9 @@ func TestHandle(t *testing.T) {
 The following commits are valid:
  - [1234567|UPSTREAM: 1: whoa](https://github.com/org/repo/commit/123456789): the upstream PR [upstream/repo#1](https://github.com/upstream/repo/pull/1) has merged
  - [456789a|UPSTREAM: 2: whoa](https://github.com/org/repo/commit/456789abc): the upstream PR [upstream/repo#2](https://github.com/upstream/repo/pull/2) has merged
- - [789abcd|UPSTREAM: 3: whoa](https://github.com/org/repo/commit/789abcdef): the upstream PR [upstream/repo#3](https://github.com/upstream/repo/pull/3) has merged`},
+ - [789abcd|UPSTREAM: 3: whoa](https://github.com/org/repo/commit/789abcdef): the upstream PR [upstream/repo#3](https://github.com/upstream/repo/pull/3) has merged
+
+Comment <code>/validate-backports</code> to re-evaluate validity of the upstream PRs, for example when they are merged upstream.`},
 		},
 		{
 			name:   "invalid upstreams",
@@ -154,7 +156,9 @@ The following commits could not be validated and must be approved by a top-level
  - [defghij|UPSTREAM: 4: whoa](https://github.com/org/repo/commit/defghijkl): the upstream PR [upstream/repo#4](https://github.com/upstream/repo/pull/4) does not exist
 
 The following commits could not be processed:
- - [789abcd|UPSTREAM: 3: whoa](https://github.com/org/repo/commit/789abcdef): failed to fetch upstream PR: injected error`},
+ - [789abcd|UPSTREAM: 3: whoa](https://github.com/org/repo/commit/789abcdef): failed to fetch upstream PR: injected error
+
+Comment <code>/validate-backports</code> to re-evaluate validity of the upstream PRs, for example when they are merged upstream.`},
 		},
 	}
 


### PR DESCRIPTION
For users to see how to re-run checks when e.g. an upstream PR merges after a failed check.
