### PR TITLE
add disruption P95 cap

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
@@ -24,7 +24,6 @@ var (
 		"oauth-api-reused-connections":                      "OAuth APIs remain available with reused connections",
 		"service-load-balancer-with-pdb-reused-connections": "Application behind service load balancer with PDB is not disrupted",
 		"image-registry-reused-connections":                 "Image registry remain available",
-		"cluster-ingress-new-connections":                   "Cluster frontend ingress remain available",
 		"ingress-to-oauth-server-new-connections":           "OAuth remains available via cluster frontend ingress using new connections",
 		"ingress-to-oauth-server-used-connections":          "OAuth remains available via cluster frontend ingress using reused connections",
 		"ingress-to-console-new-connections":                "Console remains available via cluster frontend ingress using new connections",


### PR DESCRIPTION
```
CGO_ENABLED=0 go build github.com/openshift/ci-tools/cmd/job-run-aggregator && ./job-run-aggregator analyze-job-runs --google-service-account-credential-file=/home/deads/openshift-ci-bigquery-credentials.json --job=periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade --payload-tag=4.10.0-0.nightly-2021-12-01-120924 --job-start-time=2021-12-01T12:11:54Z
```