### PR TITLE
resolver: base images only conflict when different

### DIFF
--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -122,7 +122,7 @@ func (config *ReleaseBuildConfiguration) WithPresubmitFrom(source *ReleaseBuildC
 
 	for name, isTagRef := range source.BaseImages {
 		// TODO: handle conflicts better
-		if _, ok := result.BaseImages[name]; ok {
+		if destIsTagRef, ok := result.BaseImages[name]; ok && isTagRef != destIsTagRef {
 			return nil, fmt.Errorf("conflicting base_images: %s", name)
 		}
 		result.BaseImages[name] = isTagRef

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -111,11 +111,31 @@ func TestWithPresubmitFrom(t *testing.T) {
 			defaultTests: true,
 		},
 		{
-			name: "errors when base_images conflict",
+			name: "base_images do not conflict when both configs have a same base image",
 			base: &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{BaseImages: baseBaseImages}},
 			source: &ReleaseBuildConfiguration{
 				InputConfiguration: InputConfiguration{BaseImages: baseBaseImages},
 				Tests:              []TestStepConfiguration{sourceTest},
+			},
+			expected: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{
+					BaseImages: map[string]ImageStreamTagReference{
+						"base-image": {Namespace: "base-namespace", Name: "base-image", Tag: "base-tag"},
+					}},
+			},
+			defaultTests: true,
+		},
+		{
+			name: "errors when base_images conflict",
+			base: &ReleaseBuildConfiguration{InputConfiguration: InputConfiguration{BaseImages: baseBaseImages}},
+			source: &ReleaseBuildConfiguration{
+				InputConfiguration: InputConfiguration{BaseImages: map[string]ImageStreamTagReference{"base-image": {
+					Namespace: "another-namespace",
+					Name:      "base-image",
+					Tag:       "base-tag",
+				}},
+				},
+				Tests: []TestStepConfiguration{sourceTest},
 			},
 			expectedError: errors.New("conflicting base_images: base-image"),
 		},


### PR DESCRIPTION
Previously we errored out on the sole presence of a base image name in both files. We can easily tolerate that unless the imagestream references are actually different.

/cc @openshift/test-platform @deads2k 