### PR TITLE
Renaming cluster_profile for Alibaba to alibabacloud

### DIFF
--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -625,6 +625,6 @@ func getClusterProfiles() []api.ClusterProfile {
 		api.ClusterProfileAzure4,
 		api.ClusterProfileAzureStack,
 		api.ClusterProfileGCP,
-		api.ClusterProfileAlibaba,
+		api.ClusterProfileAlibabaCloud,
 	}
 }

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -803,8 +803,8 @@ func determineWorkflow(workflow string, clusterProfile api.ClusterProfile) *stri
 			ret = "ipi-azurestack"
 		case api.ClusterProfileGCP:
 			ret = "ipi-gcp"
-		case api.ClusterProfileAlibaba:
-			ret = "ipi-alibaba"
+		case api.ClusterProfileAlibabaCloud:
+			ret = "ipi-alibabacloud"
 		}
 	}
 	return &ret

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1084,7 +1084,7 @@ const (
 	ClusterProfileAWSChina              ClusterProfile = "aws-china"
 	ClusterProfileAWSGovCloud           ClusterProfile = "aws-usgov"
 	ClusterProfileAWSGluster            ClusterProfile = "aws-gluster"
-	ClusterProfileAlibaba               ClusterProfile = "alibaba"
+	ClusterProfileAlibabaCloud          ClusterProfile = "alibabacloud"
 	ClusterProfileAzure                 ClusterProfile = "azure"
 	ClusterProfileAzure2                ClusterProfile = "azure-2"
 	ClusterProfileAzure4                ClusterProfile = "azure4"
@@ -1137,7 +1137,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSChina,
 		ClusterProfileAWSGovCloud,
 		ClusterProfileAWSGluster,
-		ClusterProfileAlibaba,
+		ClusterProfileAlibabaCloud,
 		ClusterProfileAzure2,
 		ClusterProfileAzure4,
 		ClusterProfileAzureArc,
@@ -1190,8 +1190,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWS2:
 		return string(CloudAWS)
-	case ClusterProfileAlibaba:
-		return "alibaba"
+	case ClusterProfileAlibabaCloud:
+		return "alibabacloud"
 	case ClusterProfileAWSArm64:
 		return "aws-arm64"
 	case ClusterProfileAWSC2S:
@@ -1282,8 +1282,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-china-quota-slice"
 	case ClusterProfileAWSGovCloud:
 		return "aws-usgov-quota-slice"
-	case ClusterProfileAlibaba:
-		return "alibaba-quota-slice"
+	case ClusterProfileAlibabaCloud:
+		return "alibabacloud-quota-slice"
 	case ClusterProfileAzure2:
 		return "azure-2-quota-slice"
 	case ClusterProfileAzure4:

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -320,7 +320,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "simple",
 				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
-					ClusterProfile: ciop.ClusterProfileAlibaba,
+					ClusterProfile: ciop.ClusterProfileAlibabaCloud,
 					Workflow:       pointer.StringPtr("workflow"),
 				},
 			},
@@ -357,7 +357,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "template1",
 				OpenshiftAnsibleClusterTestConfiguration: &ciop.OpenshiftAnsibleClusterTestConfiguration{
-					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibaba},
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibabaCloud},
 				},
 			},
 		},
@@ -371,7 +371,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "template1",
 				OpenshiftAnsibleCustomClusterTestConfiguration: &ciop.OpenshiftAnsibleCustomClusterTestConfiguration{
-					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibaba},
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibabaCloud},
 				},
 			},
 		},
@@ -380,7 +380,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "template1",
 				OpenshiftInstallerClusterTestConfiguration: &ciop.OpenshiftInstallerClusterTestConfiguration{
-					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibaba},
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibabaCloud},
 				},
 			},
 		},
@@ -389,7 +389,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "template1",
 				OpenshiftInstallerUPIClusterTestConfiguration: &ciop.OpenshiftInstallerUPIClusterTestConfiguration{
-					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibaba},
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibabaCloud},
 				},
 			},
 		},
@@ -398,7 +398,7 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			test: ciop.TestStepConfiguration{
 				As: "template1",
 				OpenshiftInstallerCustomTestImageClusterTestConfiguration: &ciop.OpenshiftInstallerCustomTestImageClusterTestConfiguration{
-					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibaba},
+					ClusterTestConfiguration: ciop.ClusterTestConfiguration{ClusterProfile: ciop.ClusterProfileAlibabaCloud},
 					From:                     "yada",
 				},
 			},

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -311,7 +311,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAWSC2S,
 		cioperatorapi.ClusterProfileAWSChina,
 		cioperatorapi.ClusterProfileAWSGovCloud,
-		cioperatorapi.ClusterProfileAlibaba,
+		cioperatorapi.ClusterProfileAlibabaCloud,
 		cioperatorapi.ClusterProfileAzure4,
 		cioperatorapi.ClusterProfileAzure2,
 		cioperatorapi.ClusterProfileAzureArc,

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
@@ -16,7 +16,7 @@ spec:
     - ci-operator
     env:
     - name: CLUSTER_TYPE
-      value: alibaba
+      value: alibabacloud
     - name: JOB_NAME_SAFE
       value: template1
     - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -47,7 +47,7 @@ spec:
   volumes:
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - configMap:
       name: prow-job-cluster-launch-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
@@ -16,7 +16,7 @@ spec:
     - ci-operator
     env:
     - name: CLUSTER_TYPE
-      value: alibaba
+      value: alibabacloud
     - name: JOB_NAME_SAFE
       value: template1
     - name: RPM_REPO_OPENSHIFT_ORIGIN
@@ -47,7 +47,7 @@ spec:
   volumes:
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - configMap:
       name: prow-job-cluster-launch-e2e-openshift-ansible
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
@@ -17,7 +17,7 @@ spec:
     - ci-operator
     env:
     - name: CLUSTER_TYPE
-      value: alibaba
+      value: alibabacloud
     - name: JOB_NAME_SAFE
       value: template1
     - name: TEST_COMMAND
@@ -55,7 +55,7 @@ spec:
       secretName: boskos-credentials
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - configMap:
       name: prow-job-cluster-launch-installer-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
@@ -17,7 +17,7 @@ spec:
     - ci-operator
     env:
     - name: CLUSTER_TYPE
-      value: alibaba
+      value: alibabacloud
     - name: JOB_NAME_SAFE
       value: template1
     - name: TEST_COMMAND
@@ -57,7 +57,7 @@ spec:
       secretName: boskos-credentials
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - configMap:
       name: prow-job-cluster-launch-installer-custom-test-image
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
@@ -17,7 +17,7 @@ spec:
     - ci-operator
     env:
     - name: CLUSTER_TYPE
-      value: alibaba
+      value: alibabacloud
     - name: JOB_NAME_SAFE
       value: template1
     - name: TEST_COMMAND
@@ -55,7 +55,7 @@ spec:
       secretName: boskos-credentials
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - configMap:
       name: prow-job-cluster-launch-installer-upi-e2e
     name: job-definition

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
@@ -3,8 +3,8 @@ decorate: true
 decoration_config:
   skip_cloning: true
 labels:
-  ci-operator.openshift.io/cloud: alibaba
-  ci-operator.openshift.io/cloud-cluster-profile: alibaba
+  ci-operator.openshift.io/cloud: alibabacloud
+  ci-operator.openshift.io/cloud-cluster-profile: alibabacloud
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -48,7 +48,7 @@ spec:
       secretName: boskos-credentials
   - name: cluster-profile
     secret:
-      secretName: cluster-secrets-alibaba
+      secretName: cluster-secrets-alibabacloud
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -410,7 +410,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileAWSChina,
 		api.ClusterProfileAWSGovCloud,
 		api.ClusterProfileAWSGluster,
-		api.ClusterProfileAlibaba,
+		api.ClusterProfileAlibabaCloud,
 		api.ClusterProfileAzure2,
 		api.ClusterProfileAzure4,
 		api.ClusterProfileAzureArc,


### PR DESCRIPTION
To be consistent with naming I would like to rename the cluster_profile field to `alibabacloud`. This matches the installer and other OpenShift components.

Corresponding rename: https://github.com/openshift/release/pull/24347