### PR TITLE
force all disruption aggregation to skipped status while we re-gather…

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -70,6 +70,9 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 				return nil, err
 			}
 
+			// we are correcting our disruption numbers, so we are forcing everything to skipped until 12/15
+			status = testCaseSkipped
+
 			testCaseName := fmt.Sprintf(testCaseNamePattern, backendName)
 			junitTestCase, err := disruptionToJUnitTestCase(testCaseName, jobGCSBucketRoot, failedJobRunIDs, successfulJobRunIDs, status, message)
 			if err != nil {


### PR DESCRIPTION
… unbugged data

/hold

holding until we're ready.