### PR TITLE
skip disrupt tests

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -65,13 +65,13 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 		allBackends := getAllDisruptionBackendNames(jobRunIDToBackendNameToAvailabilityResult)
 		for _, backendName := range allBackends.List() {
 			jobRunIDToAvailabilityResultForBackend := getDisruptionForBackend(jobRunIDToBackendNameToAvailabilityResult, backendName)
-			failedJobRunIDs, successfulJobRunIDs, status, message, err := disruptionCheckFn(ctx, jobRunIDToAvailabilityResultForBackend, backendName)
+			failedJobRunIDs, successfulJobRunIDs, _, message, err := disruptionCheckFn(ctx, jobRunIDToAvailabilityResultForBackend, backendName)
 			if err != nil {
 				return nil, err
 			}
 
 			// we are correcting our disruption numbers, so we are forcing everything to skipped until 12/15
-			status = testCaseSkipped
+			status := testCaseSkipped
 
 			testCaseName := fmt.Sprintf(testCaseNamePattern, backendName)
 			junitTestCase, err := disruptionToJUnitTestCase(testCaseName, jobGCSBucketRoot, failedJobRunIDs, successfulJobRunIDs, status, message)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -70,6 +70,9 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 				return nil, err
 			}
 
+			// we are correcting our disruption numbers, so we are forcing everything to skipped until 12/15
+			status = testCaseSkipped
+
 			testCaseName := fmt.Sprintf(testCaseNamePattern, backendName)
 			junitTestCase, err := disruptionToJUnitTestCase(testCaseName, jobGCSBucketRoot, failedJobRunIDs, successfulJobRunIDs, status, message)
 			if err != nil {


### PR DESCRIPTION
- force all disruption aggregation to skipped status while we re-gather unbugged data
- Fix lint issue.
