### PR TITLE
Support runIfChanged and skipIfOnlyChanged for postsubmit

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -20,6 +20,7 @@ postsubmits:
             cpu: 10m
       serviceAccountName: ci-operator
   - agent: kubernetes
+    always_run: true
     branches:
     - ^branch$
     decorate: true

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -20,6 +20,7 @@ postsubmits:
             cpu: 10m
       serviceAccountName: ci-operator
   - agent: kubernetes
+    always_run: true
     branches:
     - ^branch$
     decorate: true

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -22,6 +22,7 @@ postsubmits:
             cpu: 10m
       serviceAccountName: ci-operator
   - agent: kubernetes
+    always_run: true
     branches:
     - ^branch$
     decorate: true

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   super/duper:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^branch$
     decorate: true

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -130,10 +130,12 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 func TestGeneratePostSubmitForTest(t *testing.T) {
 	testname := "postsubmit"
 	tests := []struct {
-		name       string
-		repoInfo   *ProwgenInfo
-		jobRelease string
-		clone      bool
+		name              string
+		repoInfo          *ProwgenInfo
+		jobRelease        string
+		runIfChanged      string
+		skipIfOnlyChanged string
+		clone             bool
 	}{
 		{
 			name: "Lowercase org repo and branch",
@@ -151,12 +153,30 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Branch: "Branch",
 			}},
 		},
+		{
+			name: "postsubmit with run_if_changed",
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+			runIfChanged: "^README.md$",
+		},
+		{
+			name: "postsubmit with skip_if_only_changed",
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+			skipIfOnlyChanged: "^README.md$",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			test := ciop.TestStepConfiguration{As: testname}
 			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
-			testhelper.CompareWithFixture(t, generatePostsubmitForTest(jobBaseGen, tc.repoInfo))
+			testhelper.CompareWithFixture(t, generatePostsubmitForTest(jobBaseGen, tc.repoInfo, tc.runIfChanged, tc.skipIfOnlyChanged))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   organization/repository:
-  - labels:
+  - always_run: true
+    labels:
       ci-operator.openshift.io/is-promotion: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   organization/repository:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^branch$
     decorate: true

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_postsubmit.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   organization/repository:
-  - labels:
+  - always_run: true
+    labels:
       ci-operator.openshift.io/cluster: build01
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   organization/repository:
-  - max_concurrency: 1
+  - always_run: true
+    max_concurrency: 1
     name: branch-ci-organization-repository-branch-leTest
 presubmits:
   organization/repository:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   organization/repository:
-  - labels:
+  - always_run: true
+    labels:
       ci-operator.openshift.io/is-promotion: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
@@ -1,4 +1,5 @@
 agent: kubernetes
+always_run: true
 branches:
 - ^Branch$
 decorate: true

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_run_if_changed.yaml
@@ -1,8 +1,9 @@
 agent: kubernetes
-always_run: true
+always_run: false
 branches:
 - ^branch$
 decorate: true
 decoration_config:
   skip_cloning: true
 name: branch-ci-organization-repository-branch-postsubmit
+run_if_changed: ^README.md$

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_skip_if_only_changed.yaml
@@ -1,8 +1,9 @@
 agent: kubernetes
-always_run: true
+always_run: false
 branches:
 - ^branch$
 decorate: true
 decoration_config:
   skip_cloning: true
 name: branch-ci-organization-repository-branch-postsubmit
+skip_if_only_changed: ^README.md$

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   private/duper:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     decorate: true

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   super/duper:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     decorate: true
@@ -60,6 +61,7 @@ postsubmits:
       master: ci.openshift.redhat.com
     name: branch-ci-super-duper-master-legacy
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     decorate: true
@@ -103,6 +105,7 @@ postsubmits:
         secret:
           secretName: result-aggregator
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     decorate: true

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   super/duper:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^release-3\.11$
     decorate: true

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   openshift/ci-tools:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     cluster: api.ci

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -1,6 +1,7 @@
 postsubmits:
   openshift/origin:
   - agent: kubernetes
+    always_run: true
     branches:
     - ^master$
     cluster: api.ci


### PR DESCRIPTION
We have a case to define a publish the image job with `skip_if_only_changed` or `run_if_changed`. we want to configure it in ci config, but ci-operator cannot generate `skip_if_only_changed` or `run_if_changed` in jobs.

Signed-off-by: clyang82 <chuyang@redhat.com>