### PR TITLE
prowgen: stop tolerating changes to `optional` fields

### DIFF
--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -487,7 +487,6 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 	merged.AlwaysRun = old.AlwaysRun
 	merged.RunIfChanged = old.RunIfChanged
 	merged.SkipIfOnlyChanged = old.SkipIfOnlyChanged
-	merged.Optional = old.Optional
 	merged.MaxConcurrency = old.MaxConcurrency
 	merged.SkipReport = old.SkipReport
 	if old.Cluster != "" {
@@ -498,8 +497,15 @@ func mergePresubmits(old, new *prowconfig.Presubmit) prowconfig.Presubmit {
 		merged.SkipIfOnlyChanged = new.SkipIfOnlyChanged
 		merged.AlwaysRun = new.AlwaysRun
 	}
-	if new.Optional {
-		merged.Optional = new.Optional
+
+	// TODO(muller): Special case images jobs for now. Some repos are marking
+	// images jobs as optional for which we do not have syntax in ci-operator (should we?).
+	// Tolerate manual changes for these jobs for now
+	if strings.HasSuffix(merged.Name, "-images") {
+		merged.Optional = old.Optional
+		if new.Optional {
+			merged.Optional = new.Optional
+		}
 	}
 
 	return merged

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -411,7 +411,7 @@ func TestMergePresubmits(t *testing.T) {
 					SkipReport: true,
 				},
 				RegexpChangeMatcher: prowconfig.RegexpChangeMatcher{RunIfChanged: "whatever"},
-				Optional:            true,
+				Optional:            false,
 				Trigger:             "whatever",
 				RerunCommand:        "something",
 			},


### PR DESCRIPTION
...except for images jobs for which do not have syntax in ci-operator config

Once we pull all manual changes to ci-operator configs, we can stop tolerating these changes. One step closer to fully generated Prowjob configuration.

Needs https://github.com/openshift/release/pull/24629 for breaking changes to pass (we only want to merge this once breaking changes passes)

/hold
/cc @droslean @openshift/test-platform 