### PR TITLE
Add aggregating job results to testgrid

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -21,6 +21,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	prowConfig "k8s.io/test-infra/prow/config"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -36,6 +37,8 @@ type options struct {
 	validationOnlyRun bool
 	jobsAllowListFile string
 }
+
+const defaultAggregateProwJobName = "release-openshift-release-analysis-aggregator"
 
 func (o *options) Validate() error {
 	if o.prowJobConfigDir == "" && !o.validationOnlyRun {
@@ -177,20 +180,139 @@ func getAllowList(data []byte) (map[string]string, error) {
 	return allowList, utilerrors.NewAggregate(errs)
 }
 
+type prowJob struct {
+	Name        string            `json:"name"`
+	Annotations map[string]string `json:"annotations"`
+}
+
 // release is a subset of fields from the release controller's config
 type release struct {
 	Name   string
 	Verify map[string]struct {
-		Optional bool `json:"optional"`
-		Upgrade  bool `json:"upgrade"`
-		ProwJob  struct {
-			Name        string            `json:"name"`
-			Annotations map[string]string `json:"annotations"`
-		} `json:"prowJob"`
+		Optional          bool    `json:"optional"`
+		Upgrade           bool    `json:"upgrade"`
+		ProwJob           prowJob `json:"prowJob"`
+		AggregatedProwJob *struct {
+			ProwJob          *prowJob `json:"prowJob,omitempty"`
+			AnalysisJobCount int      `json:"analysisJobCount"`
+		} `json:"aggregatedProwJob,omitempty"`
 	} `json:"verify"`
 }
 
 var reVersion = regexp.MustCompile(`-(\d+\.\d+)(-|$)`)
+
+func addDashboardTab(p prowConfig.Periodic,
+	dashboards map[string]*dashboard,
+	configuredJobs map[string]string,
+	allowList map[string]string,
+	aggregateJobName *string) {
+	name := p.Name
+	var dashboardType string
+
+	label, ok := allowList[name]
+	if len(label) == 0 && ok {
+		// if the allow list has an empty label for the type, exclude it from dashboards
+		return
+	}
+
+	switch label {
+	case "informing", "blocking", "broken", "generic-informing":
+		dashboardType = label
+		if label == "informing" && (configuredJobs[p.Name] == "blocking" || aggregateJobName != nil) {
+			dashboardType = "blocking"
+		}
+	default:
+		if aggregateJobName != nil {
+			dashboardType = "blocking"
+			break
+		} else if label, ok := configuredJobs[name]; ok {
+			dashboardType = label
+			break
+		}
+		switch {
+		case strings.HasPrefix(name, "release-openshift-"),
+			strings.HasPrefix(name, "promote-release-openshift-"),
+			strings.HasPrefix(name, "periodic-ci-openshift-multiarch"),
+			strings.HasPrefix(name, "periodic-ci-openshift-release-master-ci-"),
+			strings.HasPrefix(name, "periodic-ci-openshift-release-master-okd-"),
+			strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"):
+			// the standard release periodics should always appear in testgrid
+			dashboardType = "informing"
+		default:
+			// unknown labels or non standard jobs do not appear in testgrid
+			return
+		}
+	}
+
+	var current *dashboard
+	switch dashboardType {
+	case "generic-informing":
+		current = genericDashboardFor("informing")
+	default:
+		var stream string
+		switch {
+		case
+			// these will be removable once most / all jobs are generated periodics and are for legacy release-* only
+			strings.Contains(name, "-ocp-"),
+			strings.Contains(name, "-origin-"),
+			// these prefixes control whether a job is ocp or okd going forward
+			strings.HasPrefix(name, "periodic-ci-openshift-multiarch"),
+			strings.HasPrefix(name, "periodic-ci-openshift-release-master-ci-"),
+			strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"),
+			strings.HasPrefix(name, "periodic-ci-openshift-verification-tests-master-"):
+			stream = "ocp"
+		case strings.Contains(name, "-okd-"):
+			stream = "okd"
+		case strings.HasPrefix(name, "promote-release-openshift-"):
+			// TODO fix these jobs to have a consistent name
+			stream = "ocp"
+		default:
+			logrus.Warningf("unrecognized release type in job: %s", name)
+			return
+		}
+
+		version := p.Labels["job-release"]
+		if len(version) == 0 {
+			m := reVersion.FindStringSubmatch(name)
+			if len(m) == 0 {
+				logrus.Warningf("release is not in -X.Y- form and will go into the generic informing dashboard: %s", name)
+				current = genericDashboardFor("informing")
+				break
+			}
+			version = m[1]
+		}
+		current = dashboardFor(stream, version, dashboardType)
+	}
+
+	if existing, ok := dashboards[current.Name]; ok {
+		current = existing
+	} else {
+		dashboards[current.Name] = current
+	}
+
+	daysOfResults := int32(0)
+	// for infrequently run jobs (at 12h or 24h intervals) we'd prefer to have more history than just the default
+	// 7-10 days (specified by the default testgrid config), so try to set number of days of results so that we
+	// see at least 100 entries, capping out at 2 months (60 days).
+	desiredResults := 100
+	if len(p.Interval) > 0 {
+		if interval, err := time.ParseDuration(p.Interval); err == nil && interval > 0 && interval < (14*24*time.Hour) {
+			daysOfResults = int32(math.Round(float64(time.Duration(desiredResults)*interval) / float64(24*time.Hour)))
+			if daysOfResults < 7 {
+				daysOfResults = 0
+			}
+			if daysOfResults > 60 {
+				daysOfResults = 60
+			}
+		}
+	}
+
+	if aggregateJobName != nil {
+		current.add(*aggregateJobName, p.Annotations["description"], daysOfResults)
+	} else {
+		current.add(name, p.Annotations["description"], daysOfResults)
+	}
+}
 
 // This tool is intended to make the process of maintaining TestGrid dashboards for
 // release-gating and release-informing tests simple.
@@ -209,6 +331,7 @@ func main() {
 
 	// find the default type for jobs referenced by the release controllers
 	configuredJobs := make(map[string]string)
+	aggregateJobsMap := make(map[string][]string)
 	if err := filepath.WalkDir(o.releaseConfigDir, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -226,7 +349,7 @@ func main() {
 			return fmt.Errorf("could not unmarshal release controller config at %s: %w", path, err)
 		}
 
-		for _, job := range releaseConfig.Verify {
+		for name, job := range releaseConfig.Verify {
 			existing := configuredJobs[job.ProwJob.Name]
 			var dashboardType string
 			switch {
@@ -242,6 +365,18 @@ func main() {
 					continue
 				}
 				dashboardType = "blocking"
+			}
+			if job.AggregatedProwJob != nil {
+				jobName := defaultAggregateProwJobName
+				if job.AggregatedProwJob.ProwJob != nil && len(job.AggregatedProwJob.ProwJob.Name) > 0 {
+					jobName = job.AggregatedProwJob.ProwJob.Name
+				}
+				aggregateJobName := fmt.Sprintf("%s-%s", name, jobName)
+				if _, ok := aggregateJobsMap[job.ProwJob.Name]; !ok {
+					aggregateJobsMap[job.ProwJob.Name] = []string{aggregateJobName}
+				} else {
+					aggregateJobsMap[job.ProwJob.Name] = append(aggregateJobsMap[job.ProwJob.Name], aggregateJobName)
+				}
 			}
 			configuredJobs[job.ProwJob.Name] = dashboardType
 		}
@@ -283,103 +418,12 @@ func main() {
 	}
 
 	for _, p := range jobConfig.Periodics {
-		name := p.Name
-		var dashboardType string
-
-		label, ok := allowList[name]
-		if len(label) == 0 && ok {
-			// if the allow list has an empty label for the type, exclude it from dashboards
-			continue
-		}
-		switch label {
-		case "informing", "blocking", "broken", "generic-informing":
-			dashboardType = label
-			if label == "informing" && configuredJobs[p.Name] == "blocking" {
-				dashboardType = "blocking"
-			}
-		default:
-			if label, ok := configuredJobs[name]; ok {
-				dashboardType = label
-				break
-			}
-			switch {
-			case strings.HasPrefix(name, "release-openshift-"),
-				strings.HasPrefix(name, "promote-release-openshift-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-multiarch"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-ci-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-okd-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"):
-				// the standard release periodics should always appear in testgrid
-				dashboardType = "informing"
-			default:
-				// unknown labels or non standard jobs do not appear in testgrid
-				continue
+		addDashboardTab(p, dashboards, configuredJobs, allowList, nil)
+		if aggregateJobs, ok := aggregateJobsMap[p.Name]; ok {
+			for _, aggregateJob := range aggregateJobs {
+				addDashboardTab(p, dashboards, configuredJobs, allowList, &aggregateJob)
 			}
 		}
-
-		var current *dashboard
-		switch dashboardType {
-		case "generic-informing":
-			current = genericDashboardFor("informing")
-		default:
-			var stream string
-			switch {
-			case
-				// these will be removable once most / all jobs are generated periodics and are for legacy release-* only
-				strings.Contains(name, "-ocp-"),
-				strings.Contains(name, "-origin-"),
-				// these prefixes control whether a job is ocp or okd going forward
-				strings.HasPrefix(name, "periodic-ci-openshift-multiarch"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-ci-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-release-master-nightly-"),
-				strings.HasPrefix(name, "periodic-ci-openshift-verification-tests-master-"):
-				stream = "ocp"
-			case strings.Contains(name, "-okd-"):
-				stream = "okd"
-			case strings.HasPrefix(name, "promote-release-openshift-"):
-				// TODO fix these jobs to have a consistent name
-				stream = "ocp"
-			default:
-				logrus.Warningf("unrecognized release type in job: %s", name)
-				continue
-			}
-
-			version := p.Labels["job-release"]
-			if len(version) == 0 {
-				m := reVersion.FindStringSubmatch(name)
-				if len(m) == 0 {
-					logrus.Warningf("release is not in -X.Y- form and will go into the generic informing dashboard: %s", name)
-					current = genericDashboardFor("informing")
-					break
-				}
-				version = m[1]
-			}
-			current = dashboardFor(stream, version, dashboardType)
-		}
-
-		if existing, ok := dashboards[current.Name]; ok {
-			current = existing
-		} else {
-			dashboards[current.Name] = current
-		}
-
-		daysOfResults := int32(0)
-		// for infrequently run jobs (at 12h or 24h intervals) we'd prefer to have more history than just the default
-		// 7-10 days (specified by the default testgrid config), so try to set number of days of results so that we
-		// see at least 100 entries, capping out at 2 months (60 days).
-		desiredResults := 100
-		if len(p.Interval) > 0 {
-			if interval, err := time.ParseDuration(p.Interval); err == nil && interval > 0 && interval < (14*24*time.Hour) {
-				daysOfResults = int32(math.Round(float64(time.Duration(desiredResults)*interval) / float64(24*time.Hour)))
-				if daysOfResults < 7 {
-					daysOfResults = 0
-				}
-				if daysOfResults > 60 {
-					daysOfResults = 60
-				}
-			}
-		}
-		current.add(p.Name, p.Annotations["description"], daysOfResults)
 	}
 
 	// first, update the overall list of dashboards that exist for the redhat group

--- a/pkg/release/config/client.go
+++ b/pkg/release/config/client.go
@@ -71,7 +71,9 @@ func resolveJobs(client release.HTTPClient, endpoint string, jobType JobType) ([
 	var jobs []Job
 	for _, k := range keys {
 		j := verify[k].ProwJob
-		j.AggregatedCount = verify[k].AggregatedProwJob.AnalysisJobCount
+		if verify[k].AggregatedProwJob != nil {
+			j.AggregatedCount = verify[k].AggregatedProwJob.AnalysisJobCount
+		}
 		jobs = append(jobs, j)
 	}
 	return jobs, nil

--- a/test/integration/testgrid-config-generator/config/_allow-list.yaml
+++ b/test/integration/testgrid-config-generator/config/_allow-list.yaml
@@ -2,3 +2,4 @@ release-openshift-origin-job-from-allow-list: informing
 release-openshift-origin-job: informing
 release-openshift-origin-job-without-release-label-broken: broken
 release-openshift-ocp-job: informing
+aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator: informing

--- a/test/integration/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
+++ b/test/integration/testgrid-config-generator/config/jobs/org/repo/org-repo-master-periodics.yaml
@@ -72,3 +72,15 @@ periodics:
   labels:
     job-release: "4.2"
   name: release-openshift-origin-job-from-allow-list
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    job-release: "4.10"
+  name: periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
+- agent: kubernetes
+  decorate: true
+  interval: 12h
+  labels:
+    job-release: "4.10"
+  name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade

--- a/test/integration/testgrid-config-generator/config/release/ocp-4.10.json
+++ b/test/integration/testgrid-config-generator/config/release/ocp-4.10.json
@@ -1,0 +1,34 @@
+{
+  "name":"4.10.0-0.nightly",
+  "to": "release",
+  "message": "Builds releases from OSBS images that are on quay.io",
+  "mirrorPrefix": "4.10-art-latest",
+  "expires":"168h",
+  "referenceMode": "source",
+  "pullSecretName": "source",
+  "check":{
+    "OCP and Origin images should match": {
+      "consistentImages":{"parent":"4.10.0-0.ci"}
+    }
+  },
+  "publish":{
+    "tag":{"tagRef":{"name":"4.10"}}
+  },
+  "verify":{
+    "aggregated-aws-ovn-upgrade-4.10-micro":{
+      "upgrade":true,
+      "prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade"},
+      "aggregatedProwJob": {
+        "analysisJobCount": 10
+      }
+    },
+    "aggregated-aws-ovn-upgrade-4.10-minor":{
+      "upgrade":true,
+      "upgradeFrom": "PreviousMinor",
+      "prowJob":{"name":"periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade"},
+      "aggregatedProwJob": {
+        "analysisJobCount": 10
+      }
+    }
+  }
+}

--- a/test/integration/testgrid-config-generator/expected/groups.yaml
+++ b/test/integration/testgrid-config-generator/expected/groups.yaml
@@ -4,6 +4,8 @@ dashboard_groups:
   - redhat-openshift-informing
   - redhat-openshift-ocp-release-4.1-blocking
   - redhat-openshift-ocp-release-4.1-informing
+  - redhat-openshift-ocp-release-4.10-blocking
+  - redhat-openshift-ocp-release-4.10-informing
   - redhat-openshift-ocp-release-4.2-blocking
   - redhat-openshift-ocp-release-4.2-informing
   - redhat-openshift-ocp-release-4.3-broken

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.10-blocking.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.10-blocking.yaml
@@ -1,0 +1,64 @@
+dashboards:
+- dashboard_tab:
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: aggregated-aws-ovn-upgrade-4.10-micro-release-openshift-release-analysis-aggregator
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: aggregated-aws-ovn-upgrade-4.10-micro-release-openshift-release-analysis-aggregator
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator
+  name: redhat-openshift-ocp-release-4.10-blocking
+test_groups:
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/aggregated-aws-ovn-upgrade-4.10-micro-release-openshift-release-analysis-aggregator
+  name: aggregated-aws-ovn-upgrade-4.10-micro-release-openshift-release-analysis-aggregator
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator
+  name: aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator

--- a/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.10-informing.yaml
+++ b/test/integration/testgrid-config-generator/expected/redhat-openshift-ocp-release-4.10-informing.yaml
@@ -1,0 +1,64 @@
+dashboards:
+- dashboard_tab:
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade
+  name: redhat-openshift-ocp-release-4.10-informing
+test_groups:
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
+  name: periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade
+  name: periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-aws-ovn-upgrade


### PR DESCRIPTION
Aggregating jobs are added to blocking dashboard of the corresponding release.
Release is determined by the aggregated job prow config.