### PR TITLE
[DPTP-2598] Support spawing aggregated jobs when its needed

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -42,6 +44,8 @@ const (
 
 	conditionAllJobsTriggered = "AllJobsTriggered"
 	conditionWithErrors       = "WithErrors"
+
+	aggregationIDLabel = "release.openshift.io/aggregation-id"
 )
 
 type injectingResolverClient interface {
@@ -159,7 +163,13 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 
 	baseMetadata := metadataFromPullRequestUnderTest(prpqr.Spec.PullRequest)
 	for _, jobSpec := range prpqr.Spec.Jobs.Jobs {
+		var prowjobsToCreate []*prowv1.ProwJob
 		mimickedJob := jobSpec.JobName(jobconfig.PeriodicPrefix)
+		if jobSpec.AggregatedCount > 0 {
+			// We treat the aggregator job as the mimicked job, and we assume if this job exists then
+			// all the aggregated jobs exist too.
+			mimickedJob = fmt.Sprintf("aggregator-%s", jobSpec.JobName(jobconfig.PeriodicPrefix))
+		}
 		logger = logger.WithFields(logrus.Fields{"want-job": mimickedJob})
 
 		if status, exists := statusByJobName[mimickedJob]; exists {
@@ -178,7 +188,17 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			continue
 		}
 
-		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, jobSpec)
+		inject := &api.MetadataWithTest{
+			Metadata: api.Metadata{
+				Org:     jobSpec.CIOperatorConfig.Org,
+				Repo:    jobSpec.CIOperatorConfig.Repo,
+				Branch:  jobSpec.CIOperatorConfig.Branch,
+				Variant: jobSpec.CIOperatorConfig.Variant,
+			},
+			Test: jobSpec.Test,
+		}
+
+		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, inject)
 		if err != nil {
 			logger.WithError(err).Error("Failed to resolve the ci-operator configuration")
 			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -191,57 +211,98 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			continue
 		}
 
-		prowjob, err := generateProwjob(ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &jobSpec, &prpqr.Spec.PullRequest)
-		if err != nil {
-			logger.WithError(err).Error("Failed to create a payload prowjob")
-			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
-				ReleaseJobName: mimickedJob,
-				Status: prowv1.ProwJobStatus{
-					State:       prowv1.ErrorState,
-					Description: err.Error(),
-				},
-			}
-			continue
-		}
-
-		logger.Info("Creating prowjob...")
-		if err := r.client.Create(ctx, prowjob); err != nil {
-			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
-				ReleaseJobName: mimickedJob,
-				Status: prowv1.ProwJobStatus{
-					State:       prowv1.ErrorState,
-					Description: fmt.Errorf("failed to create prowjob: %w", err).Error(),
-				},
-			}
-			continue
-		}
-
-		// There is some delay until it gets back to our cache, so block until we can retrieve
-		// it successfully.
-		key := ctrlruntimeclient.ObjectKey{Namespace: prowjob.Namespace, Name: prowjob.Name}
-		if err := wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-			if err := r.client.Get(ctx, key, &prowv1.ProwJob{}); err != nil {
-				if kerrors.IsNotFound(err) {
-					return false, nil
+		if jobSpec.AggregatedCount > 0 {
+			uid := jobNameHash(req.Name + mimickedJob)
+			aggregatedProwjobs, err := generateAggregatedProwjobs(uid, ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &jobSpec, &prpqr.Spec.PullRequest, inject)
+			if err != nil {
+				logger.WithError(err).Error("Failed to generate the aggregated prowjobs")
+				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+					ReleaseJobName: mimickedJob,
+					Status: prowv1.ProwJobStatus{
+						State:       prowv1.ErrorState,
+						Description: fmt.Errorf("failed to generate the aggregated prowjobs: %w", err).Error(),
+					},
 				}
-				return false, fmt.Errorf("getting prowJob failed: %w", err)
+				continue
 			}
-			return true, nil
-		}); err != nil {
+			prowjobsToCreate = append(prowjobsToCreate, aggregatedProwjobs...)
+
+			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest)
+			aggregatorJob, err := generateAggregatorJob(uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix), req.Name, req.Namespace, r.prowConfigGetter.Config(), time.Now(), submitted)
+			if err != nil {
+				logger.WithError(err).Error("Failed to generate an aggregator prowjob")
+				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+					ReleaseJobName: mimickedJob,
+					Status: prowv1.ProwJobStatus{
+						State:       prowv1.ErrorState,
+						Description: fmt.Errorf("failed to create an aggregator prowjob: %w", err).Error(),
+					},
+				}
+				continue
+			}
 			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
 				ReleaseJobName: mimickedJob,
-				Status: prowv1.ProwJobStatus{
-					State:       prowv1.ErrorState,
-					Description: fmt.Errorf("created job never appeared in cache: %w", err).Error(),
-				},
+				ProwJob:        aggregatorJob.Name,
+				Status:         aggregatorJob.Status,
 			}
-			continue
+			prowjobsToCreate = append(prowjobsToCreate, aggregatorJob)
+
+		} else {
+			prowjob, err := generateProwjob(ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &prpqr.Spec.PullRequest, mimickedJob, inject, nil)
+			if err != nil {
+				logger.WithError(err).Error("Failed to generate prowjob")
+				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+					ReleaseJobName: mimickedJob,
+					Status: prowv1.ProwJobStatus{
+						State:       prowv1.ErrorState,
+						Description: fmt.Errorf("failed to generate prowjob: %w", err).Error(),
+					},
+				}
+				continue
+			}
+			prowjobsToCreate = append(prowjobsToCreate, prowjob)
 		}
 
-		statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
-			ReleaseJobName: mimickedJob,
-			ProwJob:        prowjob.Name,
-			Status:         prowjob.Status,
+		for _, prowjob := range prowjobsToCreate {
+			logger.WithField("job", prowjob.Spec.Job).Info("Creating prowjob...")
+			if err := r.client.Create(ctx, prowjob); err != nil {
+				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+					ReleaseJobName: mimickedJob,
+					Status: prowv1.ProwJobStatus{
+						State:       prowv1.ErrorState,
+						Description: fmt.Errorf("failed to create prowjob: %w", err).Error(),
+					},
+				}
+				continue
+			}
+
+			// There is some delay until it gets back to our cache, so block until we can retrieve
+			// it successfully.
+			key := ctrlruntimeclient.ObjectKey{Namespace: prowjob.Namespace, Name: prowjob.Name}
+			if err := wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+				if err := r.client.Get(ctx, key, &prowv1.ProwJob{}); err != nil {
+					if kerrors.IsNotFound(err) {
+						return false, nil
+					}
+					return false, fmt.Errorf("getting prowJob failed: %w", err)
+				}
+				return true, nil
+			}); err != nil {
+				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+					ReleaseJobName: mimickedJob,
+					Status: prowv1.ProwJobStatus{
+						State:       prowv1.ErrorState,
+						Description: fmt.Errorf("created job never appeared in cache: %w", err).Error(),
+					},
+				}
+				continue
+			}
+
+			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
+				ReleaseJobName: mimickedJob,
+				ProwJob:        prowjob.Name,
+				Status:         prowjob.Status,
+			}
 		}
 	}
 
@@ -295,6 +356,10 @@ func reconcileStatus(theirs *v1.PullRequestPayloadQualificationRun, ourStatuses 
 	theirs.Status.Jobs = []v1.PullRequestPayloadJobStatus{}
 	for _, spec := range theirs.Spec.Jobs.Jobs {
 		jobName := spec.JobName(jobconfig.PeriodicPrefix)
+		if spec.AggregatedCount > 0 {
+			jobName = fmt.Sprintf("aggregator-%s", spec.JobName(jobconfig.PeriodicPrefix))
+		}
+
 		our := ourStatuses[jobName]
 		their := statusByJobName[jobName]
 		theirs.Status.Jobs = append(theirs.Status.Jobs, reconcileJobStatus(jobName, their, our))
@@ -358,17 +423,7 @@ func jobNameHash(name string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, spec v1.ReleaseJobSpec) (*api.ReleaseBuildConfiguration, error) {
-	inject := &api.MetadataWithTest{
-		Metadata: api.Metadata{
-			Org:     spec.CIOperatorConfig.Org,
-			Repo:    spec.CIOperatorConfig.Repo,
-			Branch:  spec.CIOperatorConfig.Branch,
-			Variant: spec.CIOperatorConfig.Variant,
-		},
-		Test: spec.Test,
-	}
-
+func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
 	ciopConfig, err := rc.ConfigWithTest(baseCiop, inject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config from resolver: %w", err)
@@ -377,26 +432,36 @@ func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, spec 
 	return ciopConfig, nil
 }
 
-func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, spec *v1.ReleaseJobSpec, pr *v1.PullRequestUnderTest) (*prowv1.ProwJob, error) {
+type aggregatedOptions struct {
+	labels          map[string]string
+	aggregatedIndex int
+	releaseJobName  string
+}
+
+func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, pr *v1.PullRequestUnderTest, mimickedJob string, inject *api.MetadataWithTest, aggregatedOptions *aggregatedOptions) (*prowv1.ProwJob, error) {
 	fakeProwgenInfo := &prowgen.ProwgenInfo{Metadata: *baseCiop}
 
-	mimickedJob := spec.JobName(jobconfig.PeriodicPrefix)
+	var annotations map[string]string
 	labels := map[string]string{
-		v1.PullRequestPayloadQualificationRunLabel: prpqrName,
-		releaseJobNameLabel:                        jobNameHash(mimickedJob),
-	}
-	annotations := map[string]string{
-		releaseJobNameAnnotation: mimickedJob,
+		releaseJobNameLabel: jobNameHash(mimickedJob),
 	}
 
-	inject := &api.MetadataWithTest{
-		Metadata: api.Metadata{
-			Org:     spec.CIOperatorConfig.Org,
-			Repo:    spec.CIOperatorConfig.Repo,
-			Branch:  spec.CIOperatorConfig.Branch,
-			Variant: spec.CIOperatorConfig.Variant,
-		},
-		Test: spec.Test,
+	hashInput := prowgen.CustomHashInput(prpqrName)
+	if aggregatedOptions != nil {
+		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
+		if aggregatedOptions.labels != nil {
+			for k, v := range aggregatedOptions.labels {
+				labels[k] = v
+			}
+		}
+		annotations = map[string]string{
+			releaseJobNameAnnotation: aggregatedOptions.releaseJobName,
+		}
+	} else {
+		labels[v1.PullRequestPayloadQualificationRunLabel] = prpqrName
+		annotations = map[string]string{
+			releaseJobNameAnnotation: mimickedJob,
+		}
 	}
 
 	var periodic *prowconfig.Periodic
@@ -411,16 +476,12 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		// PRPQR name should be safe to use as a discriminating input, because
 		// there should never be more than one execution of a specific job per
 		// PRPQR (until aggregated jobs, but for them we'll have a sequence index)
-		jobBaseGen.PodSpec.Add(prowgen.CustomHashInput(prpqrName))
+		jobBaseGen.PodSpec.Add(hashInput)
 
 		// TODO(muller): Solve cluster assignment
 		jobBaseGen.Cluster("build01")
 		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
-		var variant string
-		if inject.Variant != "" {
-			variant = fmt.Sprintf("-%s", inject.Variant)
-		}
-		periodic.Name = fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 		break
 	}
 	// We did not find the injected test: this is a bug
@@ -464,4 +525,100 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 
 func metadataFromPullRequestUnderTest(pr v1.PullRequestUnderTest) *api.Metadata {
 	return &api.Metadata{Org: pr.Org, Repo: pr.Repo, Branch: pr.BaseRef}
+}
+
+func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, spec *v1.ReleaseJobSpec, pr *v1.PullRequestUnderTest, inject *api.MetadataWithTest) ([]*prowv1.ProwJob, error) {
+	var ret []*prowv1.ProwJob
+
+	for i := 0; i < spec.AggregatedCount; i++ {
+		opts := &aggregatedOptions{
+			labels:          map[string]string{aggregationIDLabel: uid},
+			aggregatedIndex: i,
+			releaseJobName:  spec.JobName(jobconfig.PeriodicPrefix),
+		}
+		jobName := fmt.Sprintf("%s-%d", spec.JobName(jobconfig.PeriodicPrefix), i)
+
+		pj, err := generateProwjob(ciopConfig, defaulter, baseCiop, prpqrName, prpqrNamespace, pr, jobName, inject, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create prowjob: %w", err)
+		}
+
+		ret = append(ret, pj)
+	}
+
+	return ret, nil
+}
+
+func generateAggregatorJob(uid, aggregatorJobName, jobName, prpqrName, prpqrNamespace string, defaulter periodicDefaulter, startTime time.Time, submitted string) (*prowv1.ProwJob, error) {
+	labels := map[string]string{aggregationIDLabel: uid, v1.PullRequestPayloadQualificationRunLabel: prpqrName}
+	spec := &corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{
+				Name: "pull-secret",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "registry-pull-credentials"},
+				},
+			},
+			{
+				Name: "gcs-credentials",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "gce-sa-credentials-gcs-publisher"},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Image:           "registry.ci.openshift.org/ci/job-run-aggregator",
+				ImagePullPolicy: corev1.PullAlways,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
+				},
+				Command: []string{"job-run-aggregator"},
+				Args: []string{
+					"--analyze-job-runs",
+					"--google-service-account-credential-file=/secrets/gcs/service-account.json",
+					fmt.Sprintf("--job=%s", jobName),
+					fmt.Sprintf("--aggregation-id=%s", uid),
+					fmt.Sprintf("--explicit-gcs-prefix=logs/%s", submitted),
+					fmt.Sprintf("--job-start-time=%s", startTime.Format(time.RFC3339)),
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "pull-secret",
+						MountPath: "/etc/pull-secret",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "gcs-credentials",
+						MountPath: api.GCSUploadCredentialsSecretMountPath,
+						ReadOnly:  true,
+					},
+				},
+			},
+		},
+	}
+	annotations := map[string]string{
+		releaseJobNameAnnotation: jobNameHash(aggregatorJobName),
+	}
+
+	periodic := prowconfig.Periodic{JobBase: prowconfig.JobBase{
+		Name:      aggregatorJobName,
+		Namespace: &[]string{prpqrNamespace}[0],
+		Spec:      spec,
+	}}
+
+	if err := defaulter.DefaultPeriodic(&periodic); err != nil {
+		return nil, fmt.Errorf("failed to default the ProwJob: %w", err)
+	}
+
+	pj := pjutil.NewProwJob(pjutil.PeriodicSpec(periodic), labels, annotations)
+	return &pj, nil
+}
+
+func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest) string {
+	var variant string
+	if inject.Variant != "" {
+		variant = fmt.Sprintf("-%s", inject.Variant)
+	}
+	return fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
 }

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -1,0 +1,213 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
+      releaseJobName: e2bd00d6b219bda9ee14b9e9e3c8300e
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
+    name: some-uuid
+    resourceVersion: "1"
+  spec:
+    cluster: this-job-was-defaulted
+    job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
+    namespace: test-namespace
+    pod_spec:
+      containers:
+      - args:
+        - --analyze-job-runs
+        - --google-service-account-credential-file=/secrets/gcs/service-account.json
+        - --job=periodic-ci-test-org-test-repo-test-branch-test-name
+        - --aggregation-id=a0e1bddfc1d7a5e78e6c2e483f238b15
+        - --explicit-gcs-prefix=logs/test-org-test-repo-100-test-name
+        - --job-start-time=some-time
+        command:
+        - job-run-aggregator
+        image: registry.ci.openshift.org/ci/job-run-aggregator
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: gcs-credentials
+        secret:
+          secretName: gce-sa-credentials-gcs-publisher
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.pull: "100"
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
+      releaseJobNameHash: 3cfd4050d8c5f92e2a61b67055742651
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: this-job-was-defaulted
+    decoration_config:
+      skip_cloning: true
+    extra_refs:
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    job: test-org-test-repo-100-test-name
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test-0
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.pull: "100"
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
+      releaseJobNameHash: 283d99c0dcbd80070e6816420ac68caa
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: this-job-was-defaulted
+    decoration_config:
+      skip_cloning: true
+    extra_refs:
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    job: test-org-test-repo-100-test-name
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test-1
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case.yaml
@@ -1,0 +1,43 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - aggregatedCount: 2
+        ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2598

These changes allow the controller to check if the job is aggregated by reading the [AggregatedCount](https://github.com/openshift/ci-tools/blob/master/pkg/api/pullrequestpayloadqualification/v1/types.go#L107) field.
If that number is more than 0, then the controller spawns the same prowjob X times including the `release.openshift.io/aggregation-id` label with the same UID. Then it spawns the aggregator analysis job.



/cc @openshift/test-platform @petr-muller 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>