### PR TITLE
Share ReleaseController's config

### DIFF
--- a/cmd/promoted-image-governor/main_test.go
+++ b/cmd/promoted-image-governor/main_test.go
@@ -19,6 +19,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	releaseconfig "github.com/openshift/ci-tools/pkg/release/config"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -76,7 +77,7 @@ func TestTagsToDelete(t *testing.T) {
 		client                               ctrlruntimeclient.Client
 		promotedTags                         []api.ImageStreamTagReference
 		toIgnore                             []*regexp.Regexp
-		imageStreamRefs                      []ImageStreamRef
+		imageStreamRefs                      []releaseconfig.ImageStreamRef
 		expectedTagsToDelete                 map[api.ImageStreamTagReference]interface{}
 		expectedImageStreamsWithPromotedTags map[ctrlruntimeclient.ObjectKey]interface{}
 		expectedError                        error
@@ -104,7 +105,7 @@ func TestTagsToDelete(t *testing.T) {
 			toIgnore: []*regexp.Regexp{
 				regexp.MustCompile(`^ocp/\S+:machine-os-content$`),
 			},
-			imageStreamRefs: []ImageStreamRef{
+			imageStreamRefs: []releaseconfig.ImageStreamRef{
 				{
 					Namespace:   "origin",
 					Name:        "4.8",
@@ -157,7 +158,7 @@ func TestGenerateMappings(t *testing.T) {
 		name            string
 		promotedTags    []api.ImageStreamTagReference
 		mappingConfig   *OpenshiftMappingConfig
-		imageStreamRefs []ImageStreamRef
+		imageStreamRefs []releaseconfig.ImageStreamRef
 		expected        map[string]map[string]sets.String
 		expectedErr     error
 	}{
@@ -210,7 +211,7 @@ func TestGenerateMappings(t *testing.T) {
 					"4.9": {"4.9", "4.9.0", "latest"},
 				},
 			},
-			imageStreamRefs: []ImageStreamRef{
+			imageStreamRefs: []releaseconfig.ImageStreamRef{
 				{
 					Namespace:   "origin",
 					Name:        "4.8",
@@ -263,7 +264,7 @@ func TestGenerateMappings(t *testing.T) {
 					"4.6": {"4.6", "4.6.0"},
 				},
 			},
-			imageStreamRefs: []ImageStreamRef{
+			imageStreamRefs: []releaseconfig.ImageStreamRef{
 				{
 					Namespace: "origin",
 					Name:      "4.6",
@@ -297,7 +298,7 @@ func TestGenerateMappings(t *testing.T) {
 					"4.6": {"4.6", "4.6.0"},
 				},
 			},
-			imageStreamRefs: []ImageStreamRef{
+			imageStreamRefs: []releaseconfig.ImageStreamRef{
 				{
 					Namespace:   "origin",
 					Name:        "4.6",

--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	jc "github.com/openshift/ci-tools/pkg/jobconfig"
+	releaseconfig "github.com/openshift/ci-tools/pkg/release/config"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
@@ -177,19 +178,6 @@ func getAllowList(data []byte) (map[string]string, error) {
 	return allowList, utilerrors.NewAggregate(errs)
 }
 
-// release is a subset of fields from the release controller's config
-type release struct {
-	Name   string
-	Verify map[string]struct {
-		Optional bool `json:"optional"`
-		Upgrade  bool `json:"upgrade"`
-		ProwJob  struct {
-			Name        string            `json:"name"`
-			Annotations map[string]string `json:"annotations"`
-		} `json:"prowJob"`
-	} `json:"verify"`
-}
-
 var reVersion = regexp.MustCompile(`-(\d+\.\d+)(-|$)`)
 
 // This tool is intended to make the process of maintaining TestGrid dashboards for
@@ -221,7 +209,7 @@ func main() {
 			return fmt.Errorf("could not read release controller config at %s: %w", path, err)
 		}
 
-		var releaseConfig release
+		var releaseConfig releaseconfig.Config
 		if err := json.Unmarshal(data, &releaseConfig); err != nil {
 			return fmt.Errorf("could not unmarshal release controller config at %s: %w", path, err)
 		}

--- a/pkg/release/config/client.go
+++ b/pkg/release/config/client.go
@@ -19,24 +19,6 @@ func endpoint(c api.Candidate) string {
 	return fmt.Sprintf("%s/%s.0-0.%s%s/config", candidate.ServiceHost(c.Product, c.Architecture), c.Version, c.Stream, candidate.Architecture(c.Architecture))
 }
 
-type Job struct {
-	Name                 string `json:"name"`
-	api.MetadataWithTest `json:",inline"`
-
-	AggregatedCount int `json:"-"`
-}
-
-type AggregatedJob struct {
-	AnalysisJobCount int `json:"analysisJobCount"`
-}
-
-type Verify map[string]VerifyItem
-
-type VerifyItem struct {
-	ProwJob           Job           `json:"prowJob"`
-	AggregatedProwJob AggregatedJob `json:"aggregatedProwJob"`
-}
-
 type JobType string
 
 const (
@@ -76,7 +58,7 @@ func resolveJobs(client release.HTTPClient, endpoint string, jobType JobType) ([
 	if readErr != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", readErr)
 	}
-	verify := Verify{}
+	verify := map[string]VerifyItem{}
 	err = json.Unmarshal(data, &verify)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal release controll's jobs in config: %w (%s)", err, data)

--- a/pkg/release/config/config.go
+++ b/pkg/release/config/config.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+// Config is a subset of fields from the release controller's config
+type Config struct {
+	Name    string                `json:"name,omitempty"`
+	Publish Publish               `json:"publish"`
+	Verify  map[string]VerifyItem `json:"verify,omitempty"`
+}
+
+type Publish struct {
+	MirrorToOrigin MirrorToOrigin `json:"mirror-to-origin"`
+}
+
+type MirrorToOrigin struct {
+	ImageStreamRef ImageStreamRef `json:"imageStreamRef"`
+}
+
+type ImageStreamRef struct {
+	Namespace   string   `json:"namespace"`
+	Name        string   `json:"name"`
+	ExcludeTags []string `json:"excludeTags,omitempty"`
+}
+
+type Job struct {
+	Name                 string            `json:"name"`
+	Annotations          map[string]string `json:"annotations"`
+	api.MetadataWithTest `json:",inline"`
+
+	AggregatedCount int `json:"-"`
+}
+
+type AggregatedJob struct {
+	AnalysisJobCount int `json:"analysisJobCount"`
+}
+
+type VerifyItem struct {
+	Optional          bool          `json:"optional"`
+	Upgrade           bool          `json:"upgrade"`
+	ProwJob           Job           `json:"prowJob"`
+	AggregatedProwJob AggregatedJob `json:"aggregatedProwJob"`
+}


### PR DESCRIPTION
Found 3 tools use ReleaseControllers configuration.
This PR starts to use the configuration struct from one place instead of three.

/cc @openshift/test-platform 