### PR TITLE
jobrunaggregator: add more reviewers

### DIFF
--- a/cmd/job-run-aggregator/OWNERS
+++ b/cmd/job-run-aggregator/OWNERS
@@ -1,4 +1,6 @@
 reviewers:
 - deads2k
+- dgoodwin
+- stbenjam
 approvers:
 - deads2k

--- a/pkg/jobrunaggregator/OWNERS
+++ b/pkg/jobrunaggregator/OWNERS
@@ -1,4 +1,6 @@
 reviewers:
 - deads2k
+- dgoodwin
+- stbenjam
 approvers:
 - deads2k


### PR DESCRIPTION
Prow wants to assign two reviewers but one David is not enough, root reviewers (TP) get assigned, and TP pretend they do not see these PRs. Adding reviewers does not change permissions, just makes the pool of auto-assigned reviewers larger - David still needs to `/approve`

/cc @deads2k 