### PR TITLE
allow correcting history without changing test name when we get criteria incorrect

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -233,7 +233,7 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if err := assignPassFail(ctx, currentAggregationJunitSuites, o.passFailCalculator); err != nil {
+	if err := assignPassFail(ctx, o.jobName, currentAggregationJunitSuites, o.passFailCalculator); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This allows a controlled relaxing on history on a test we incorrectly marked perma-passing in the past.