### PR TITLE
Add creation timestamps to records

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_release.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_release.go
@@ -48,6 +48,9 @@ type ReleaseRow struct {
 
 	// OSDiffURL is a link to the release page diffing the two OS versions.
 	OSDiffURL string `bigquery:"osDiffURL"`
+
+	// CreatedAt contains a timestamp for when this record was created in BigQuery.
+	CreatedAt time.Time `bigquery:"createdAt" json:"-"`
 }
 
 // ReleaseRepositoryRow represents a repository whose contents was updated in the referenced
@@ -66,6 +69,9 @@ type ReleaseRepositoryRow struct {
 	// FullChangelog contains a link that diffs the contents of this repo
 	// from the prior accepted release.
 	FullChangelog string `bigquery:"fullChangeLog"`
+
+	// CreatedAt contains a timestamp for when this record was created in BigQuery.
+	CreatedAt time.Time `bigquery:"createdAt" json:"-"`
 }
 
 // ReleasePullRequestRow represents a pull request that was included for the first time
@@ -88,6 +94,9 @@ type ReleasePullRequestRow struct {
 
 	// BugURL links to the bug, if any.
 	BugURL string `bigquery:"bugURL"`
+
+	// CreatedAt contains a timestamp for when this record was created in BigQuery.
+	CreatedAt time.Time `bigquery:"createdAt" json:"-"`
 }
 
 type ReleaseJobRunRow struct {
@@ -128,4 +137,7 @@ type ReleaseJobRunRow struct {
 
 	// Upgrade is a flag that indicates whether this job run was an upgrade or not.
 	Upgrade bool `bigquery:"upgrade"`
+
+	// CreatedAt contains a timestamp for when this record was created in BigQuery.
+	CreatedAt time.Time `bigquery:"createdAt" json:"-"`
 }

--- a/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser.go
@@ -2,6 +2,7 @@ package releasebigqueryloader
 
 import (
 	"strings"
+	"time"
 
 	"github.com/anaskhan96/soup"
 
@@ -84,6 +85,7 @@ func (c *Changelog) Repositories() []jobrunaggregatorapi.ReleaseRepositoryRow {
 			Name:       imageName,
 			ReleaseTag: c.releaseTag,
 			Head:       head,
+			CreatedAt:  time.Now(),
 		}
 		ul := section.FindNextElementSibling()
 		if ul.Error != nil {
@@ -133,6 +135,7 @@ func (c *Changelog) PullRequests() []jobrunaggregatorapi.ReleasePullRequestRow {
 				row := jobrunaggregatorapi.ReleasePullRequestRow{
 					Name:       imageName,
 					ReleaseTag: c.releaseTag,
+					CreatedAt:  time.Now(),
 				}
 				row.Description = strings.Trim(strings.TrimPrefix(item.Text(), ": "), " ")
 				anchors := item.FindAll("a")

--- a/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser_test.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/changelog_parser_test.go
@@ -1,8 +1,8 @@
 package releasebigqueryloader
 
 import (
+	"bytes"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/anaskhan96/soup"
@@ -226,16 +226,16 @@ func TestChangelog_PullRequests(t *testing.T) {
 				releaseTag: "test",
 				root:       tt.root,
 			}
-			if got := c.PullRequests(); !reflect.DeepEqual(got, tt.want) {
-				gotJSON, err := json.MarshalIndent(got, "", "    ")
-				if err != nil {
-					t.Fatal(err)
-				}
-				wantJSON, err := json.MarshalIndent(tt.want, "", "    ")
-				if err != nil {
-					t.Fatal(err)
-				}
-
+			got := c.PullRequests()
+			gotJSON, err := json.MarshalIndent(got, "", "    ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantJSON, err := json.MarshalIndent(tt.want, "", "    ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(gotJSON, wantJSON) {
 				t.Errorf("PullRequests() = %v, want %v", string(gotJSON), string(wantJSON))
 			}
 		})
@@ -267,18 +267,18 @@ func TestChangelog_Repositories(t *testing.T) {
 				releaseTag: "test",
 				root:       tt.root,
 			}
-			if got := c.Repositories(); !reflect.DeepEqual(got, tt.want) {
-				gotJSON, err := json.MarshalIndent(got, "", "    ")
-				if err != nil {
-					t.Fatal(err)
-				}
-				wantJSON, err := json.MarshalIndent(tt.want, "", "    ")
-				if err != nil {
-					t.Fatal(err)
-				}
+			got := c.Repositories()
+			gotJSON, err := json.MarshalIndent(got, "", "    ")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantJSON, err := json.MarshalIndent(tt.want, "", "    ")
+			if err != nil {
+				t.Fatal(err)
+			}
 
+			if !bytes.Equal(gotJSON, wantJSON) {
 				t.Errorf("Repositories() = %v, want %v", string(gotJSON), string(wantJSON))
-
 			}
 		})
 	}

--- a/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
+++ b/pkg/jobrunaggregator/releasebigqueryloader/release_uploader.go
@@ -203,6 +203,7 @@ func releaseDetailsToBigQuery(architecture string, tag ReleaseTag, details Relea
 		Architecture: architecture,
 		ReleaseTag:   details.Name,
 		Phase:        tag.Phase,
+		CreatedAt:    time.Now(),
 	}
 	// 4.10.0-0.nightly-2021-11-04-001635 -> 4.10
 	parts := strings.Split(details.Name, ".")
@@ -254,6 +255,7 @@ func releaseJobRunsToBigQuery(details ReleaseDetails) []*jobrunaggregatorapi.Rel
 				URL:            jobResult.URL,
 				Retries:        jobResult.Retries,
 				TransitionTime: jobResult.TransitionTime,
+				CreatedAt:      time.Now(),
 			}
 		}
 	}
@@ -270,6 +272,7 @@ func releaseJobRunsToBigQuery(details ReleaseDetails) []*jobrunaggregatorapi.Rel
 				URL:            jobResult.URL,
 				Retries:        jobResult.Retries,
 				TransitionTime: jobResult.TransitionTime,
+				CreatedAt:      time.Now(),
 			}
 		}
 	}


### PR DESCRIPTION
This adds timestamps to row in bigquery. The method of relying on generated ID's from bigquery doesn't seem reliable when exporting to postgres, so I want to base it off creation time stamps instead.