### PR TITLE
Add command to create "TestRuns" table with TestSuite; insert TestSuite as new column

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -1,0 +1,52 @@
+package jobrunaggregatorapi
+
+const (
+	TestRunTableName = "TestRuns"
+
+	// The TestRunsSchema below is used to build the "TestRuns" table.
+	//
+	TestRunsSchema = `
+[
+  {
+    "mode": "REQUIRED",
+    "name": "Name",
+    "description" : "Name of the test run",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "JobRunName",
+    "description" : "Name of the JobRun (big number) that ran this test (e.g., 1389486541524439040)",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "JobName",
+    "description" : "Name of the Job that as this test in it",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "Status",
+    "description" : "Status of the test (e.g., pass, fail)",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "TestSuite",
+    "description" : "Testsuite that this test belongs to",
+    "type": "STRING"
+  }
+]
+`
+)
+
+// Move here from jobrunbigqueryloader/types.go
+//
+type TestRunRow struct {
+	Name       string
+	JobRunName string
+	JobName    string
+	Status     string
+	TestSuite  string
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 )
 
 const (
@@ -92,8 +94,25 @@ func (d dryRunInserter) Put(ctx context.Context, src interface{}) (err error) {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "BULK INSERT into %v\n", d.table)
 	for i := 0; i < srcVal.Len(); i++ {
-		s := srcVal.Index(i).Interface()
-		fmt.Fprintf(buf, "\tINSERT into %v: %v\n", d.table, s)
+
+		switch s := srcVal.Index(i).Interface().(type) {
+		case *jobrunaggregatorapi.TestRunRow:
+			fmt.Fprintf(buf, "\tINSERT into %v: %#v\n", d.table, s)
+
+		case *jobrunaggregatorapi.JobRunRow:
+			fmt.Fprintf(buf, "\tINSERT into %v: name=%v, jobname=%v, status=%v\n", d.table, s.Name, s.JobName, s.Status)
+
+		case *jobrunaggregatorapi.BackendDisruptionRow:
+			fmt.Fprintf(buf, "\tINSERT into %v: %#v\n", d.table, s)
+
+		case jobrunaggregatorapi.JobRow:
+			fmt.Fprintf(buf, "\tINSERT into %v: JobName=%v\n", d.table, s.JobName)
+
+		default:
+
+			// If we don't know the type, output something generic.
+			fmt.Fprintf(buf, "\tINSERT into %v: %#v\n", d.table, s)
+		}
 	}
 	fmt.Fprint(d.out, buf.String())
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -87,6 +87,9 @@ func NewCIDataClient(dataCoordinates BigQueryDataCoordinates, client *bigquery.C
 }
 
 func (c *ciDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error) {
+	// For Debugging, you can set "LIMIT X" where X is small
+	// so that you can process only a small subset of jobs while
+	// you debug.
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
 		`SELECT *  
 FROM DATA_SET_LOCATION.Jobs

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
@@ -42,6 +42,9 @@ func (o *ciGCSClient) ListJobRunNamesOlderThanFourHours(ctx context.Context, job
 	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
 		return nil, nil, err
 	}
+
+	// When debugging, you can set the starting ID to a number such that you
+	// will process a relatively small number of jobsRuns.
 	query.StartOffset = fmt.Sprintf("logs/%s/%s", jobName, startingID)
 	fmt.Printf("  starting from %v\n", query.StartOffset)
 

--- a/pkg/jobrunaggregator/jobtableprimer/cmd.go
+++ b/pkg/jobrunaggregator/jobtableprimer/cmd.go
@@ -92,7 +92,7 @@ func (f *primeJobTableFlags) ToOptions(ctx context.Context) (*CreateJobsOptions,
 		jobTable := ciDataSet.Table(jobrunaggregatorapi.JobsTableName)
 		jobTableInserter = jobTable.Inserter()
 	} else {
-		jobTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.LegacyJobRunTableName)
+		jobTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.JobsTableName)
 	}
 
 	return &CreateJobsOptions{

--- a/pkg/jobrunaggregator/tablescreator/table_creator.go
+++ b/pkg/jobrunaggregator/tablescreator/table_creator.go
@@ -18,35 +18,28 @@ type allJobsTableCreatorOptions struct {
 
 func (r *allJobsTableCreatorOptions) Run(ctx context.Context) error {
 
-	// Create JobsTable
-	jobsTable := r.ciDataSet.Table(jobrunaggregatorlib.JobsTableName)
-	_, err := jobsTable.Metadata(ctx)
-	if err != nil {
-		schema, err := bigquery.SchemaFromJSON([]byte(jobrunaggregatorapi.JobSchema))
-		if err != nil {
-			return err
-		}
-		if err := jobsTable.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
-			return err
-		}
-	} else {
-		fmt.Fprintf(os.Stdout, "table already exists: %s\n", jobrunaggregatorlib.JobsTableName)
+	tableNamesToSchemas := map[string]string{
+		jobrunaggregatorlib.JobsTableName:    jobrunaggregatorapi.JobSchema,
+		jobrunaggregatorlib.TestRunTableName: jobrunaggregatorapi.TestRunsSchema,
+		jobrunaggregatorlib.JobRunTableName:  jobrunaggregatorapi.JobRunSchema,
 	}
 
-	// Create JobRunTable
-	jobRunsTable := r.ciDataSet.Table(jobrunaggregatorlib.JobRunTableName)
-	_, err = jobRunsTable.Metadata(ctx)
-	if err != nil {
-		schema, err := bigquery.SchemaFromJSON([]byte(jobrunaggregatorapi.JobRunSchema))
-		if err != nil {
-			return err
-		}
-		if err := jobRunsTable.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
-			return err
-		}
-	} else {
-		fmt.Fprintf(os.Stdout, "table already exists: %s\n", jobrunaggregatorlib.JobRunTableName)
-	}
+	for tableName, tableSchema := range tableNamesToSchemas {
 
+		// Create the table
+		bqTable := r.ciDataSet.Table(tableName)
+		_, err := bqTable.Metadata(ctx)
+		if err != nil {
+			schema, err := bigquery.SchemaFromJSON([]byte(tableSchema))
+			if err != nil {
+				return err
+			}
+			if err := bqTable.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(os.Stdout, "table already exists: %s\n", tableName)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
Before merging this PR, we need to manually add a new column to "TestRuns" (or there will be a lot of errors due to missing field).

We need the TestSuite field to help distinguish test cases that have identical names.  For now, we'll collect the TestSuite name.  There should only be 1 TestSuite name but if there are more, we'll concatenate them to make a unique TestSuite.

I added some hints for debugging to facilitate testing of the code (on a smaller scale).  I confirmed there is an error (as expected) if we try to run this with a TestRuns table with no TestSuite column.  I also confirmed that if you manually add the column, and rerun, the error will go away and the TestSuite value will be populated.