### PR TITLE
ci-operator: add logging for cluster pool selection

### DIFF
--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -114,6 +114,7 @@ func (s *clusterClaimStep) acquireCluster(ctx context.Context, waitForClaim func
 	if err != nil {
 		return nil, err
 	}
+	logrus.Infof("Claiming cluster from pool %s/%s owned by %s", clusterPool.Namespace, clusterPool.Name, clusterPool.Labels["owner"])
 
 	claimName := s.jobSpec.ProwJobID
 	claimNamespace := clusterPool.Namespace


### PR DESCRIPTION
Followup for [DPTP-2633](https://issues.redhat.com/browse/DPTP-2633)

/cc @hongkailiu @dirgim @samvarankashyap @openshift/test-platform 