### PR TITLE
Register Cluster Profile for platform=none

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1118,6 +1118,7 @@ const (
 	ClusterProfileVSphere               ClusterProfile = "vsphere"
 	ClusterProfileVSphereDiscon         ClusterProfile = "vsphere-discon"
 	ClusterProfileVSphereClusterbot     ClusterProfile = "vsphere-clusterbot"
+	ClusterProfileVSpherePlatformNone   ClusterProfile = "vsphere-platform-none"
 	ClusterProfileVSphereMultizone      ClusterProfile = "vsphere-multizone"
 	ClusterProfileKubevirt              ClusterProfile = "kubevirt"
 	ClusterProfileAWSCPaaS              ClusterProfile = "aws-cpaas"
@@ -1170,6 +1171,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileVSphere,
 		ClusterProfileVSphereDiscon,
 		ClusterProfileVSphereClusterbot,
+		ClusterProfileVSpherePlatformNone,
 		ClusterProfileVSphereMultizone,
 		ClusterProfileKubevirt,
 		ClusterProfileAWSCPaaS,
@@ -1248,6 +1250,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileVSphere,
 		ClusterProfileVSphereDiscon,
 		ClusterProfileVSphereClusterbot,
+		ClusterProfileVSpherePlatformNone,
 		ClusterProfileVSphereMultizone:
 		return "vsphere"
 	case ClusterProfileOvirt:
@@ -1346,6 +1349,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "vsphere-discon-quota-slice"
 	case ClusterProfileVSphereClusterbot:
 		return "vsphere-clusterbot-quota-slice"
+	case ClusterProfileVSpherePlatformNone:
+		return "vsphere-platform-none-quota-slice"
 	case ClusterProfileVSphereMultizone:
 		return "vsphere-multizone-quota-slice"
 	case ClusterProfileKubevirt:

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -331,6 +331,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileVSphere,
 		cioperatorapi.ClusterProfileVSphereDiscon,
 		cioperatorapi.ClusterProfileVSphereClusterbot,
+		cioperatorapi.ClusterProfileVSpherePlatformNone,
 		cioperatorapi.ClusterProfileVSphereMultizone,
 		cioperatorapi.ClusterProfileKubevirt,
 		cioperatorapi.ClusterProfileAWSCPaaS,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -443,6 +443,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileVSphere,
 		api.ClusterProfileVSphereDiscon,
 		api.ClusterProfileVSphereClusterbot,
+		api.ClusterProfileVSpherePlatformNone,
 		api.ClusterProfileVSphereMultizone,
 		api.ClusterProfileKubevirt,
 		api.ClusterProfileAWSCPaaS,


### PR DESCRIPTION
This PR adds a new cluster profile for `platform=none` clusters in VMC. Required to map `platform=none` clusters to specific ci-segments in VMC for Windows workload' ci jobs ([WINC-607](https://issues.redhat.com/browse/WINC-607)).