### PR TITLE
[WIP] pkg/util: add `openat(2)`-based walk function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
-	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
+	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -22,7 +22,7 @@ import (
 	utilgzip "github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
-const rawConfig = `tag_specification:
+const rawTestConfig = `tag_specification:
   name: '4.0'
   namespace: ocp
 promotion:
@@ -525,14 +525,14 @@ func TestConfig(t *testing.T) {
 	}{
 		{
 			name:          "loading config from file works",
-			config:        rawConfig,
+			config:        rawTestConfig,
 			asFile:        true,
 			expected:      parsedConfig,
 			expectedError: false,
 		},
 		{
 			name:          "loading config from gzipped file works",
-			config:        rawConfig,
+			config:        rawTestConfig,
 			asFile:        true,
 			expected:      parsedConfig,
 			isGzipped:     true,
@@ -540,14 +540,14 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			name:          "loading config from env works",
-			config:        rawConfig,
+			config:        rawTestConfig,
 			asEnv:         true,
 			expected:      parsedConfig,
 			expectedError: false,
 		},
 		{
 			name:          "loading config from compressed env works",
-			config:        rawConfig,
+			config:        rawTestConfig,
 			asEnv:         true,
 			compressEnv:   true,
 			expected:      parsedConfig,
@@ -555,7 +555,7 @@ func TestConfig(t *testing.T) {
 		},
 		{
 			name:          "no file or env fails to load config",
-			config:        rawConfig,
+			config:        rawTestConfig,
 			asEnv:         true,
 			expected:      parsedConfig,
 			expectedError: false,

--- a/pkg/util/walk.go
+++ b/pkg/util/walk.go
@@ -1,0 +1,111 @@
+package util
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"golang.org/x/sys/unix"
+)
+
+// Silly hack from the stdlib.
+// https://go.googlesource.com/go.git/+/refs/tags/go1.17.6/src/io/fs/walk.go#120
+type statDirEntry struct {
+	info fs.FileInfo
+}
+
+func (d *statDirEntry) Name() string               { return d.info.Name() }
+func (d *statDirEntry) IsDir() bool                { return d.info.IsDir() }
+func (d *statDirEntry) Type() fs.FileMode          { return d.info.Mode().Type() }
+func (d *statDirEntry) Info() (fs.FileInfo, error) { return d.info, nil }
+
+type WalkFDFn func(f *os.File, info fs.DirEntry, err error) error
+
+func walkFD(f *os.File, d fs.DirEntry, flags int, mode uint32, err error, fn WalkFDFn) error {
+	if !d.IsDir() {
+		return fn(f, d, err)
+	}
+	var dup *os.File
+	if err == nil {
+		var fd int
+		if fd, err = unix.Dup(int(f.Fd())); err == nil {
+			dup = os.NewFile(uintptr(fd), f.Name())
+			defer dup.Close()
+		}
+	}
+	if errFn := fn(f, d, err); err != nil || errFn != nil {
+		if errFn == fs.SkipDir {
+			errFn = nil
+		}
+		return errFn
+	}
+	dirs, err := dup.ReadDir(-1)
+	if err != nil {
+		err = fn(f, d, err)
+		if err != nil {
+			return err
+		}
+	}
+	sort.Slice(dirs, func(i, j int) bool {
+		return dirs[i].Name() < dirs[j].Name()
+	})
+	for _, d1 := range dirs {
+		fd, err := unix.Openat(int(dup.Fd()), d1.Name(), flags, mode)
+		if err == nil {
+			f := os.NewFile(uintptr(fd), filepath.Join(dup.Name(), d1.Name()))
+			err = walkFD(f, d1, flags, mode, err, fn)
+		} else {
+			err = walkFD(nil, d1, flags, mode, err, fn)
+		}
+		if err != nil {
+			if err == fs.SkipDir {
+				break
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+// WalkFD uses `openat(2)` to reimplement `filepath.WalkDir`.
+// This is so that `root` or any of its parents can be moved at any point
+// without disturbing the traversal, such as what happens when a Kubernetes
+// mount is updated.  The sequence of operations in that case is:
+//
+//     CREATE ..2021_11_29_14_58_13.225465548
+//     CHMOD  ..2021_11_29_14_58_13.225465548
+//     RENAME ..data_tmp
+//     CREATE ..data
+//     REMOVE ..2021_11_29_14_56_57.996917784
+//
+// i.e. the root is atomically moved via `rename(2)` but the contents of the old
+// directory are not changed.  This function, contrary to the one in the stdlib,
+// uses POSIX `openat(2)` to maintain file descriptor references to the
+// directory stack being traversed so that files are always opened relative to
+// their parent, without doing a full path traversal.  Otherwise, the semantics
+// are largely equivalent to the original, except for:
+//
+// - `fn` is given the already-opened files, which are effectively opened as
+//   if `OpenFile(…, flags, mode)` had been called.
+// - `fn` owns all file descriptors it receives via its first argument (so it
+//   can use them asynchronously independently of `WalkFD`).  Directories are
+//   `dup(2)`ed internally as needed.
+// - Iteration cannot proceed if a directory cannot be `Open`ed, as there is no
+//   way then to perform the `ReadDir`.  In this case, `fn` is called as usual
+//   and can replace the error, but even returning `nil` will end the iteration
+//   (and cause `WalkFD` to return no error).
+// - The `Name()` of each file is the full path starting from `root.Name()`.
+//   The `d` parameter contains the relative path as provided by `ReadDir`.
+func WalkFD(root *os.File, flags int, mode os.FileMode, fn WalkFDFn) error {
+	s, err := root.Stat()
+	if err != nil {
+		err = fn(root, nil, err)
+	} else {
+		err = walkFD(root, &statDirEntry{s}, flags, uint32(mode.Perm()), nil, fn)
+	}
+	if err == fs.SkipDir {
+		return nil
+	}
+	return err
+}

--- a/pkg/util/walk_test.go
+++ b/pkg/util/walk_test.go
@@ -1,0 +1,207 @@
+package util
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func createDir(t *testing.T, dirs ...string) string {
+	ret := t.TempDir()
+	for _, x := range dirs {
+		if err := os.MkdirAll(filepath.Join(ret, x), 0777); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ret
+}
+
+func TestWalkFD(t *testing.T) {
+	check := func(d, f string, err error, names, notFound *[]string) {
+		if r, err := filepath.Rel(d, f); err == nil {
+			f = r
+		} else {
+			t.Fatal(err)
+		}
+		if err != nil {
+			if os.IsNotExist(err) {
+				*notFound = append(*notFound, f)
+			}
+			return
+		}
+		*names = append(*names, f)
+		if filepath.Base(f) == "0" {
+			if err := os.Rename(d, d+".old"); err != nil {
+				t.Error(err)
+			}
+		}
+	}
+	d0 := createDir(t, "0", "1", "2")
+	var names, notFound []string
+	err := filepath.WalkDir(d0, func(f string, _ fs.DirEntry, err error) error {
+		check(d0, f, err, &names, &notFound)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	testhelper.Diff(t, "names", names, []string{".", "0", "1", "2"})
+	testhelper.Diff(t, "not found", notFound, []string{"0", "1", "2"})
+	d1 := createDir(t, "0", "1", "2")
+	f, err := os.Open(d1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+	names, notFound = nil, nil
+	err = WalkFD(f, os.O_RDONLY, 0777, func(f *os.File, _ fs.DirEntry, err error) error {
+		check(d1, f.Name(), err, &names, &notFound)
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	testhelper.Diff(t, "names", names, []string{".", "0", "1", "2"})
+	testhelper.Diff(t, "not found", notFound, []string(nil))
+}
+
+// TestWalkFDErrors verifies correct behavior and propagation when errors occur.
+func TestWalkFDErrors(t *testing.T) {
+	defaultStart := func(dir string) *os.File {
+		ret, err := os.Open(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ret
+	}
+	removeRoot := func(dir string) *os.File {
+		ret := defaultStart(dir)
+		if err := os.Remove(dir); err != nil {
+			t.Fatal(err)
+		}
+		return ret
+	}
+	for _, tc := range []struct {
+		name    string
+		dirs    []string
+		start   func(string) *os.File
+		fn      func(string, *os.File, fs.DirEntry, error) error
+		visited func(string) []string
+		errs    func(string) []string
+	}{{
+		name:  "root not found",
+		start: removeRoot,
+		visited: func(dir string) []string {
+			return []string{
+				dir, // `stat(2)` never fails on an open FD in Linux
+				dir, // subsequent error reported for `readdir(2)`
+			}
+		},
+		errs: func(dir string) []string { return []string{filepath.Base(dir)} },
+	}, {
+		name: "child directory removed",
+		dirs: []string{"child0", "child1"},
+		fn: func(dir string, f *os.File, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.Name() == "child0" {
+				if err := os.Remove(filepath.Join(dir, "child1")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		},
+		visited: func(dir string) []string {
+			return []string{dir, "child0", "child1"}
+		},
+		errs: func(string) []string { return []string{"child1"} },
+	}, {
+		name: "error propagated",
+		fn: func(dir string, f *os.File, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			return errors.New("injected error")
+		},
+		visited: func(dir string) []string { return []string{dir} },
+		errs:    func(string) []string { return nil },
+	}, {
+		name:  "error ignored",
+		start: removeRoot,
+		fn: func(_ string, _ *os.File, _ fs.DirEntry, err error) error {
+			return nil
+		},
+		visited: func(dir string) []string { return []string{dir, dir} },
+	}, {
+		name: "child error ignored",
+		dirs: []string{"child0", "child1"},
+		fn: func(dir string, f *os.File, d fs.DirEntry, err error) error {
+			if err != nil {
+				if os.IsNotExist(err) {
+					err = nil
+				}
+				return err
+			}
+			if d.Name() == "child0" {
+				if err := os.Remove(filepath.Join(dir, "child1")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return nil
+		},
+		visited: func(dir string) []string {
+			return []string{dir, "child0", "child1"}
+		},
+	}, {
+		name: "SkipDir",
+		dirs: []string{"child0/child00", "child0/child01"},
+		fn: func(dir string, f *os.File, d fs.DirEntry, err error) error {
+			if err == nil && d.Name() == "child0" {
+				return fs.SkipDir
+			}
+			return err
+		},
+		visited: func(dir string) []string { return []string{dir, "child0"} },
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := createDir(t, tc.dirs...)
+			var f *os.File
+			if tc.start == nil {
+				f = defaultStart(dir)
+			} else {
+				f = tc.start(dir)
+			}
+			var visited []string
+			var notFound []string
+			if err := WalkFD(f, 0, 0, func(f *os.File, d fs.DirEntry, err error) error {
+				visited = append(visited, d.Name())
+				if err != nil && os.IsNotExist(err) {
+					notFound = append(notFound, d.Name())
+				}
+				if tc.fn != nil {
+					return tc.fn(dir, f, d, err)
+				} else {
+					return err
+				}
+			}); tc.errs == nil {
+				if err != nil {
+					t.Errorf("expected no error, got %q", err)
+				}
+			} else if err == nil {
+				t.Error("expected error, got none")
+			} else {
+				testhelper.Diff(t, `"not found" errors`, notFound, tc.errs(dir))
+			}
+			testhelper.Diff(t, "visited files", visited, tc.visited(filepath.Base(dir)))
+		})
+	}
+}


### PR DESCRIPTION
Replace `filepath.WalkDir` in the configuration and step registry loading
functions with a reimplementation that always opens files relative to their
parent directory.

This should make sure the traversal is consistent even if the root
directory is moved, e.g. when it is a Kubernetes mount that is updated
while the directory tree is being traversed.

The implementation strives to stay as close to the stdlib version as
possible:

https://go.googlesource.com/go.git/+/refs/tags/go1.17.6/src/io/fs/walk.go

---

Outstanding work still required:

- [x] Merge the subset in https://github.com/openshift/ci-tools/pull/2604 before this PR.
- [x] This has bumped the open file descriptor count at startup beyond my machine's limit (1024).  The [unbounded parallelism in our configuration loading](https://github.com/openshift/ci-tools/blob/c0bdd517188f9592a6677296894a1ee48292f9f5/pkg/load/load.go#L96) is probably counterproductive anyway, it'll need to be synchronized.
  - [ ] https://github.com/openshift/ci-tools/pull/2627
  - [ ] https://github.com/openshift/ci-tools/pull/2628
- [ ] Extensive testing with Kubernetes mounts in a pod.