### PR TITLE
add equinix-ocp-metal cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1091,6 +1091,7 @@ const (
 	ClusterProfileAzureArc              ClusterProfile = "azure-arc"
 	ClusterProfileAzureStack            ClusterProfile = "azurestack"
 	ClusterProfileAzureMag              ClusterProfile = "azuremag"
+	ClusterProfileEquinixOcpMetal       ClusterProfile = "equinix-ocp-metal"
 	ClusterProfileGCP                   ClusterProfile = "gcp"
 	ClusterProfileGCP40                 ClusterProfile = "gcp-40"
 	ClusterProfileGCPHA                 ClusterProfile = "gcp-ha"
@@ -1145,6 +1146,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureArc,
 		ClusterProfileAzureStack,
 		ClusterProfileAzureMag,
+		ClusterProfileEquinixOcpMetal,
 		ClusterProfileGCP,
 		ClusterProfileGCP40,
 		ClusterProfileGCPHA,
@@ -1213,6 +1215,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "azurestack"
 	case ClusterProfileAzureMag:
 		return "azuremag"
+	case ClusterProfileEquinixOcpMetal:
+		return "equinix-ocp-metal"
 	case
 		ClusterProfileGCP,
 		ClusterProfileGCP40,
@@ -1301,6 +1305,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "azurestack-quota-slice"
 	case ClusterProfileAzureMag:
 		return "azuremag-quota-slice"
+	case ClusterProfileEquinixOcpMetal:
+		return "equinix-ocp-metal-quota-slice"
 	case
 		ClusterProfileGCP,
 		ClusterProfileGCP40,
@@ -1371,7 +1377,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas", "osd-ephemeral":
+	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas", "osd-ephemeral":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -317,6 +317,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureArc,
 		cioperatorapi.ClusterProfileAzureStack,
 		cioperatorapi.ClusterProfileAzureMag,
+		cioperatorapi.ClusterProfileEquinixOcpMetal,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -416,6 +416,7 @@ func validateClusterProfile(fieldRoot string, p api.ClusterProfile) []error {
 		api.ClusterProfileAzureArc,
 		api.ClusterProfileAzureStack,
 		api.ClusterProfileAzureMag,
+		api.ClusterProfileEquinixOcpMetal,
 		api.ClusterProfileGCP,
 		api.ClusterProfileGCP2,
 		api.ClusterProfileGCP40,


### PR DESCRIPTION
As part of the reorganization of the Equinix accounts per team, this new cluster profile will be used by the Metal team for their CI jobs, instead of the `packet` cluster profile.
Once all the jobs will have been migrated to the new profile, the `packet` profile could be safely deleted

cc @derekhiggins @ardaguclu 