### PR TITLE
prpqr: downgrade log message to `Info`

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -176,7 +176,7 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) string {
 		return formatError(fmt.Errorf("could not resolve ci-operator's config for %s/%s/%s: %w", org, repo, pr.Base.Ref, err))
 	}
 	if !promotion.PromotesOfficialImages(ciOpConfig) {
-		logger.Error("the repo does not contribute to the OpenShift official images")
+		logger.Info("the repo does not contribute to the OpenShift official images")
 		return fmt.Sprintf("the repo %s/%s does not contribute to the OpenShift official images", org, repo)
 	}
 


### PR DESCRIPTION
Someone doing `/payload` on a non-OCP repository is not an error state for our tools, it is a user-triggered action that we handle properly (by refusing). No reason to log an error or even a warning.

/cc @hongkailiu @openshift/test-platform 