### PR TITLE
Correction in the aggregator job arguments

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -582,7 +582,7 @@ func generateAggregatorJob(uid, aggregatorJobName, jobName, prpqrName, prpqrName
 				},
 				Command: []string{"job-run-aggregator"},
 				Args: []string{
-					"--analyze-job-runs",
+					"analyze-job-runs",
 					"--google-service-account-credential-file=/secrets/gcs/service-account.json",
 					fmt.Sprintf("--job=%s", jobName),
 					fmt.Sprintf("--aggregation-id=%s", uid),

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -179,7 +179,7 @@
     pod_spec:
       containers:
       - args:
-        - --analyze-job-runs
+        - analyze-job-runs
         - --google-service-account-credential-file=/secrets/gcs/service-account.json
         - --job=periodic-ci-test-org-test-repo-test-branch-test-name
         - --aggregation-id=a0e1bddfc1d7a5e78e6c2e483f238b15


### PR DESCRIPTION
/cc @openshift/test-platform

It turns out that the [analyze-job-runs](https://github.com/openshift/ci-tools/blob/master/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go#L60) is a param instead of a flag.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>