### PR TITLE
Add an empty dir as a working directory for the aggregator job

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -572,6 +572,12 @@ func generateAggregatorJob(uid, aggregatorJobName, jobName, prpqrName, prpqrName
 					Secret: &corev1.SecretVolumeSource{SecretName: "gce-sa-credentials-gcs-publisher"},
 				},
 			},
+			{
+				Name: "temp",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
 		},
 		Containers: []corev1.Container{
 			{
@@ -588,8 +594,13 @@ func generateAggregatorJob(uid, aggregatorJobName, jobName, prpqrName, prpqrName
 					fmt.Sprintf("--aggregation-id=%s", uid),
 					fmt.Sprintf("--explicit-gcs-prefix=logs/%s", submitted),
 					fmt.Sprintf("--job-start-time=%s", startTime.Format(time.RFC3339)),
+					"--working-dir=/tmp",
 				},
 				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "temp",
+						MountPath: "/tmp",
+					},
 					{
 						Name:      "pull-secret",
 						MountPath: "/etc/pull-secret",

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -185,6 +185,7 @@
         - --aggregation-id=a0e1bddfc1d7a5e78e6c2e483f238b15
         - --explicit-gcs-prefix=logs/test-org-test-repo-100-test-name
         - --job-start-time=some-time
+        - --working-dir=/tmp
         command:
         - job-run-aggregator
         image: registry.ci.openshift.org/ci/job-run-aggregator
@@ -194,6 +195,8 @@
           requests:
             cpu: 10m
         volumeMounts:
+        - mountPath: /tmp
+          name: temp
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -207,6 +210,8 @@
       - name: gcs-credentials
         secret:
           secretName: gce-sa-credentials-gcs-publisher
+      - emptyDir: {}
+        name: temp
     report: true
     type: periodic
   status:


### PR DESCRIPTION
The `job-run-aggregator` defaults to a working directory (see: [here](https://github.com/openshift/ci-tools/blob/master/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go#L48)) which makes the job fail since it doesn't have permission to create the working directory in the root folder.

With this change we allow the job to mount an emptyDir and adds the `--working-dir` argument to point to that path.

Related error:
```console
time="2022-01-24T19:02:02Z" level=fatal msg="Command failed" error="error creating destination directory \"job-aggregator-working-dir/periodic-ci-openshift-release-master-ci-4.10-upgrade-from-stable-4.9-e2e-azure-upgrade\": mkdir job-aggregator-working-dir: permission denied"
```

/cc @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>