### PR TITLE
Change the gcs secret in the aggregator job

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -569,7 +569,7 @@ func generateAggregatorJob(uid, aggregatorJobName, jobName, prpqrName, prpqrName
 			{
 				Name: "gcs-credentials",
 				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{SecretName: "gce-sa-credentials-gcs-publisher"},
+					Secret: &corev1.SecretVolumeSource{SecretName: "release-controller-signature-publisher"},
 				},
 			},
 			{

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -209,7 +209,7 @@
           secretName: registry-pull-credentials
       - name: gcs-credentials
         secret:
-          secretName: gce-sa-credentials-gcs-publisher
+          secretName: release-controller-signature-publisher
       - emptyDir: {}
         name: temp
     report: true


### PR DESCRIPTION
/cc @openshift/test-platform 

This secret is already being used by the release controller. We assume that the service account has the required permissions.
see: https://github.com/openshift/release/blob/master/clusters/app.ci/release-controller/deploy-ci-signer.yaml#L57-L60

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>