### PR TITLE
sync-rover-groups: skip resolving the renamed group

### DIFF
--- a/cmd/sync-rover-groups/main.go
+++ b/cmd/sync-rover-groups/main.go
@@ -149,7 +149,11 @@ func roverGroups(manifestDirs sets.String, config *group.Config, groupCollector 
 	}
 
 	groupNames.Insert(api.CIAdminsGroupName)
-	for k := range config.Groups {
+	for k, v := range config.Groups {
+		if v.RenameTo != "" {
+			logrus.WithField("group", v.RenameTo).Info("Skip resolving the renamed group")
+			groupNames.Delete(v.RenameTo)
+		}
 		groupNames.Insert(k)
 	}
 


### PR DESCRIPTION
If a group is used in manifest, which is a renamed group of a rover group, we do not need to resolve the renamed one.
Resolving it anyway would probably lead to a not-found error which spams our log.

/cc @openshift/test-platform 