### PR TITLE
ClusterPools: Log claim & cluster name

### DIFF
--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -146,14 +146,14 @@ func (s *clusterClaimStep) acquireCluster(ctx context.Context, waitForClaim func
 	if err := s.hiveClient.Create(ctx, claim); err != nil {
 		return nil, fmt.Errorf("failed to created cluster claim %s in namespace %s: %w", claimName, claimNamespace, err)
 	}
-	logrus.Info("Waiting for the claimed cluster to be ready.")
+	logrus.Infof("Waiting for cluster claim %s/%s to be fulfilled.", claimNamespace, claimName)
 	claimStart := time.Now()
 	into := &hivev1.ClusterClaim{}
 	if err := waitForClaim(s.hiveClient, claimNamespace, claimName, into, s.clusterClaim.Timeout.Duration); err != nil {
 		return claim, fmt.Errorf("failed to wait for the created cluster claim to become ready: %w", err)
 	}
 	claim = into
-	logrus.Infof("The claimed cluster is ready after %s.", time.Since(claimStart).Truncate(time.Second))
+	logrus.Infof("The claimed cluster %s is ready after %s.", claim.Spec.Namespace, time.Since(claimStart).Truncate(time.Second))
 	clusterDeployment := &hivev1.ClusterDeployment{}
 	if err := s.hiveClient.Get(ctx, ctrlruntimeclient.ObjectKey{Name: claim.Spec.Namespace, Namespace: claim.Spec.Namespace}, clusterDeployment); err != nil {
 		return claim, fmt.Errorf("failed to get cluster deployment %s in namespace %s: %w", claim.Spec.Namespace, claim.Spec.Namespace, err)


### PR DESCRIPTION
Include the namespaced name of the ClusterClaim and the name of the
claimed cluster in the info log of a job. Example before:

```
INFO[2022-01-25T17:22:44Z] Waiting for the claimed cluster to be ready.
INFO[2022-01-25T18:11:30Z] The claimed cluster is ready after 48m46s.
```

Example after:

```
INFO[2022-01-25T17:22:44Z] Waiting for the cluster claim the-namespace/the-claim to be fulfilled.
INFO[2022-01-25T18:11:30Z] The claimed cluster my-pool-abc123 is ready after 48m46s.
```