### PR TITLE
github-ldap-user-group-creator: add concurrency

### DIFF
--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -265,7 +265,7 @@ func TestEnsureGroups(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.TODO()
-			actual := ensureGroups(ctx, tc.clients, tc.groups, tc.dryRun)
+			actual := ensureGroups(ctx, tc.clients, tc.groups, 60, tc.dryRun)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}


### PR DESCRIPTION
It takes `2h` to sync user groups.
Now we start to sync rover groups.

Adding concurrency on group handling should help reduce the time on each run.

/cc @openshift/test-platform 