### PR TITLE
github-ldap-user-group-creator: move concurrency onto clusters

### DIFF
--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -257,8 +258,9 @@ func TestEnsureGroups(t *testing.T) {
 					},
 				},
 			},
-			dryRun:   true,
-			expected: fmt.Errorf("attempt to create invalid group gh01-group on cluster b01: duplicate member: a"),
+			dryRun: true,
+			expected: kerrors.NewAggregate([]error{fmt.Errorf("attempt to create invalid group gh01-group on cluster b01: duplicate member: a"),
+				fmt.Errorf("attempt to create invalid group gh01-group on cluster b02: duplicate member: a")}),
 		},
 	}
 


### PR DESCRIPTION
We have in total 3387 github user-groups to sync on 7-8 clusters.

It is still too slow after https://github.com/openshift/ci-tools/pull/2620

The reason is that the concurrency there is inside one cluster and it is throttled:

```
I0125 22:36:55.445260      15 request.go:665] Waited for 11.970939214s due to client-side throttling, not priority and fairness, request: GET:https://api.build02.gcp.ci.openshift.org:6443/apis/user.openshift.io/v1/groups/REDACTED
```

/cc @openshift/test-platform 


---
This one is a run with the image built by this PR.
https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-private/logs/periodic-github-ldap-user-group-creator/1486149476094578688

Nice! Reduced to 23m from 3h.