### PR TITLE
cluster-init: make -dry jobs run only on changes in manifests

### DIFF
--- a/cmd/cluster-init/update_jobs.go
+++ b/cmd/cluster-init/update_jobs.go
@@ -137,10 +137,13 @@ func generatePresubmit(clusterName string) prowconfig.Presubmit {
 				jobconfig.LabelCluster:        clusterName,
 			},
 		},
-		AlwaysRun:    true,
+		AlwaysRun:    false,
 		Optional:     optional,
 		Trigger:      prowconfig.DefaultTriggerFor(clusterName + "-dry"),
 		RerunCommand: prowconfig.DefaultRerunCommandFor(clusterName + "-dry"),
+		RegexpChangeMatcher: prowconfig.RegexpChangeMatcher{
+			RunIfChanged: "^clusters/.*",
+		},
 		Brancher: prowconfig.Brancher{
 			Branches: []string{jobconfig.ExactlyBranch("master"), jobconfig.FeatureBranch("master")},
 		},

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -63,7 +63,7 @@ presubmits:
         name: tmp
     trigger: (?m)^/test( | .* )build01-dry,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -76,6 +76,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-release-master-newCluster-dry
     rerun_command: /test newCluster-dry
+    run_if_changed: ^clusters/.*
     spec:
       containers:
       - args:

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   openshift/release:
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -14,6 +14,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-release-master-existingCluster-dry
     rerun_command: /test existingCluster-dry
+    run_if_changed: ^clusters/.*
     spec:
       containers:
       - args:


### PR DESCRIPTION
Make https://github.com/openshift/release/pull/25651 changes persistent even for newly added clusters.