### PR TITLE
pkg/config: use generic pipeline function

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -7,16 +7,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"sync"
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/util"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 	"github.com/openshift/ci-tools/pkg/validation"
 )
@@ -169,9 +166,9 @@ func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback func(*ci
 		info   *Info
 	}
 	inputCh := make(chan string)
-	errCh := make(chan error)
-	go func() {
-		if err := filepath.WalkDir(filepath.Join(configDir, subDir), func(path string, info fs.DirEntry, err error) error {
+	produce := func() error {
+		defer close(inputCh)
+		return filepath.WalkDir(filepath.Join(configDir, subDir), func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
 				logrus.WithField("source-file", path).WithError(err).Error("Failed to walk CI Operator configuration dir")
 				// file may not exist due to race condition between the reload and k8s removing deleted/moved symlinks in a confimap directory; ignore it
@@ -190,56 +187,42 @@ func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback func(*ci
 				inputCh <- path
 			}
 			return nil
-		}); err != nil {
-			errCh <- err
-		}
-		close(inputCh)
-	}()
-	nWorkers := runtime.GOMAXPROCS(0)
-	outputCh := make(chan item)
-	var wg sync.WaitGroup
-	wg.Add(nWorkers)
-	for i := 0; i < nWorkers; i++ {
-		go func() {
-			defer wg.Done()
-			for path := range inputCh {
-				info, err := InfoFromPath(path)
-				if err != nil {
-					logrus.WithField("source-file", path).WithError(err).Error("Failed to resolve info from CI Operator configuration path")
-					errCh <- err
-					continue
-				}
-				config, err := readCiOperatorConfig(path, *info)
-				if err != nil {
-					logrus.WithField("source-file", path).WithError(err).Error("Failed to load CI Operator configuration")
-					errCh <- err
-					continue
-				}
-				if err := validation.IsValidRuntimeConfiguration(config); err != nil {
-					errCh <- fmt.Errorf("invalid ci-operator config: %w", err)
-					continue
-				}
-				outputCh <- item{config, info}
-			}
-		}()
+		})
 	}
-	go func() {
-		wg.Wait()
-		close(outputCh)
-	}()
-	go func() {
+	outputCh := make(chan item)
+	errCh := make(chan error)
+	map_ := func() error {
+		for path := range inputCh {
+			info, err := InfoFromPath(path)
+			if err != nil {
+				logrus.WithField("source-file", path).WithError(err).Error("Failed to resolve info from CI Operator configuration path")
+				errCh <- err
+				continue
+			}
+			config, err := readCiOperatorConfig(path, *info)
+			if err != nil {
+				logrus.WithField("source-file", path).WithError(err).Error("Failed to load CI Operator configuration")
+				errCh <- err
+				continue
+			}
+			if err := validation.IsValidRuntimeConfiguration(config); err != nil {
+				errCh <- fmt.Errorf("invalid ci-operator config: %w", err)
+				continue
+			}
+			outputCh <- item{config, info}
+		}
+		return nil
+	}
+	reduce := func() error {
 		for i := range outputCh {
 			if err := callback(i.config, i.info); err != nil {
 				errCh <- err
 			}
 		}
-		close(errCh)
-	}()
-	var ret []error
-	for err := range errCh {
-		ret = append(ret, err)
+		return nil
 	}
-	return utilerrors.NewAggregate(ret)
+	done := func() { close(outputCh) }
+	return util.ProduceMapReduce(0, produce, map_, reduce, done, errCh)
 }
 
 func LoggerForInfo(info Info) *logrus.Entry {

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -1,0 +1,103 @@
+package util
+
+import (
+	"runtime"
+	"sync"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type WorkerFn func() error
+
+func start(
+	n int,
+	wg *sync.WaitGroup,
+	ch chan<- error,
+	produce WorkerFn,
+	map_ WorkerFn,
+) {
+	if n == 0 {
+		n = runtime.GOMAXPROCS(0)
+	}
+	go func() {
+		if err := produce(); err != nil {
+			ch <- err
+		}
+	}()
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if err := map_(); err != nil {
+				ch <- err
+			}
+		}()
+	}
+}
+
+func finish(ch <-chan error) error {
+	var ret []error
+	for err := range ch {
+		ret = append(ret, err)
+	}
+	return utilerrors.NewAggregate(ret)
+}
+
+// ProduceMap is similar to ProduceMapReduce but without a reduce step.
+func ProduceMap(
+	n int,
+	produce WorkerFn,
+	map_ WorkerFn,
+	errCh chan error,
+) error {
+	var wg sync.WaitGroup
+	start(n, &wg, errCh, produce, map_)
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+	return finish(errCh)
+}
+
+// ProduceMapReduce handles the execution of a triphasic pipeline.
+// The pipeline is constituted of a single producer, a single reducer, and `n`
+// mapper workers, i.e.:
+//
+//       producer
+//      / /   \ \
+//     m m  …  m m ---> done
+//      \ \   / /        |
+//       reducer <-------'
+//
+// All processes are executed to completion even if an error occurs in any of
+// them (as opposed to, for example, `x/sync/errorgroup`).  Errors sent to
+// `errCh` are aggregated in the return value.  A process which encounters an
+// error can either return it to stop itself or send it to `errCh` and continue
+// processing its input.
+//
+// For convenience, if `n` is zero, it is treated as `runtime.GOMAXPROCS(0)`.
+//
+// `done` is called when all mapping workers finish.  It usually closes a
+// channel used by the reduce step.
+func ProduceMapReduce(
+	n int,
+	produce WorkerFn,
+	map_ WorkerFn,
+	reduce WorkerFn,
+	done func(),
+	errCh chan error,
+) error {
+	var wg sync.WaitGroup
+	start(n, &wg, errCh, produce, map_)
+	go func() {
+		wg.Wait()
+		done()
+	}()
+	go func() {
+		if err := reduce(); err != nil {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+	return finish(errCh)
+}

--- a/pkg/util/sync_test.go
+++ b/pkg/util/sync_test.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"fmt"
+)
+
+func ExampleProduceMapReduce() {
+	input := []int{0, 1, 2, 3}
+	inputCh := make(chan int)
+	errCh := make(chan error)
+	produce := func() error {
+		defer close(inputCh)
+		for _, x := range input {
+			inputCh <- x
+		}
+		return nil
+	}
+	outputCh := make(chan int)
+	map_ := func() error {
+		for x := range inputCh {
+			if x == 2 {
+				errCh <- fmt.Errorf("%d", x)
+			} else {
+				outputCh <- x
+			}
+		}
+		return nil
+	}
+	done := func() { close(outputCh) }
+	reduce := func() error {
+		r := 0
+		for x := range outputCh {
+			r += x
+		}
+		fmt.Println(r)
+		return nil
+	}
+	if err := ProduceMapReduce(0, produce, map_, reduce, done, errCh); err != nil {
+		fmt.Println("error:", err)
+	}
+	// Output:
+	// 4
+	// error: 2
+}


### PR DESCRIPTION
This pattern is everywhere, implemented slightly differently each time.  Some
versions do not bound the maximum number of Go routines, causing file descriptor
exhaustion.

This change creates a small library that is as generic as I managed to make it
in Go and reimplements `ci-operator` configuration loading using it.  More to
come.

/hold

Based on https://github.com/openshift/ci-tools/pull/2627.

https://issues.redhat.com/browse/DPTP-2531

---

See also:

- [ ] https://github.com/openshift/ci-tools/pull/2629
- [ ] https://github.com/openshift/ci-tools/pull/2630
- [ ] https://github.com/openshift/ci-tools/pull/2631
- [ ] https://github.com/openshift/ci-tools/pull/2632