### PR TITLE
promotion: treat promoting to `origin` as promoting official images

### DIFF
--- a/cmd/autopublicizeconfig/main.go
+++ b/cmd/autopublicizeconfig/main.go
@@ -152,6 +152,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if o.dryRun {
+		logrus.Info("Running in dry-run mode, not preparing a Pull Request")
+		os.Exit(0)
+	}
+
 	logrus.Info("Preparing pull request")
 	title := fmt.Sprintf("%s %s", matchTitle, time.Now().Format(time.RFC1123))
 	if err := bumper.GitCommitAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin, string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {

--- a/cmd/autopublicizeconfig/main.go
+++ b/cmd/autopublicizeconfig/main.go
@@ -184,7 +184,7 @@ func getReposForPrivateOrg(releaseRepoPath string, allowlist map[string][]string
 	}
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
-		if !promotion.BuildsOfficialImages(c) {
+		if !promotion.BuildsOfficialImages(c, promotion.WithoutOKD) {
 			return nil
 		}
 

--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -83,7 +83,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to throttle")
 	}
 
-	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, promotion.WithoutOKD, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := config.LoggerForInfo(*repoInfo)
 
 		branches := sets.NewString()
@@ -106,7 +106,7 @@ func main() {
 			failed = true
 		}
 
-		//sleep to respect Github's API 30 requests per minute limit, absolute minimum is above 2 seconds
+		// sleep to respect Github's API 30 requests per minute limit, absolute minimum is above 2 seconds
 		time.Sleep(5 * time.Second)
 		return nil
 	}); err != nil || failed {

--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -123,7 +123,7 @@ func main() {
 			return nil
 		}
 
-		if !promotion.BuildsOfficialImages(rbc) && !o.WhitelistConfig.IsWhitelisted(repoInfo) {
+		if !promotion.BuildsOfficialImages(rbc, promotion.WithoutOKD) && !o.WhitelistConfig.IsWhitelisted(repoInfo) {
 			logger.Warn("Skipping...")
 			return nil
 		}
@@ -159,7 +159,7 @@ func main() {
 		}
 
 		if rbc.PromotionConfiguration != nil {
-			if !promotion.BuildsOfficialImages(rbc) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
+			if !promotion.BuildsOfficialImages(rbc, promotion.WithoutOKD) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
 				logger.Warn("Repo is whitelisted. Disable promotion...")
 				rbc.PromotionConfiguration.Disabled = true
 			}

--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	var toCommit []config.DataWithInfo
-	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, promotion.WithOKD, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
 		for _, output := range generateBranchedConfigs(o.CurrentRelease, o.BumpRelease, o.FutureReleases.Strings(), config.DataWithInfo{Configuration: *configuration, Info: *info}) {
 			if !o.Confirm {
 				output.Logger().Info("Would commit new file.")
@@ -169,7 +169,7 @@ func updateRelease(config *api.ReleaseBuildConfiguration, futureRelease string) 
 func updateImages(config *api.ReleaseBuildConfiguration, currentRelease, futureRelease string) {
 	for name := range config.InputConfiguration.BaseImages {
 		image := config.InputConfiguration.BaseImages[name]
-		if promotion.RefersToOfficialImage(image.Name, image.Namespace) && image.Name == currentRelease {
+		if promotion.RefersToOfficialImage(image.Namespace, promotion.WithOKD) && image.Name == currentRelease {
 			image.Name = futureRelease
 		}
 		config.InputConfiguration.BaseImages[name] = image
@@ -177,7 +177,7 @@ func updateImages(config *api.ReleaseBuildConfiguration, currentRelease, futureR
 
 	for i := range config.InputConfiguration.BaseRPMImages {
 		image := config.InputConfiguration.BaseRPMImages[i]
-		if promotion.RefersToOfficialImage(image.Name, image.Namespace) && image.Name == currentRelease {
+		if promotion.RefersToOfficialImage(image.Namespace, promotion.WithOKD) && image.Name == currentRelease {
 			image.Name = futureRelease
 		}
 		config.InputConfiguration.BaseRPMImages[i] = image
@@ -185,7 +185,7 @@ func updateImages(config *api.ReleaseBuildConfiguration, currentRelease, futureR
 
 	if config.InputConfiguration.BuildRootImage != nil {
 		image := config.InputConfiguration.BuildRootImage.ImageStreamTagReference
-		if image != nil && promotion.RefersToOfficialImage(image.Name, image.Namespace) && image.Name == currentRelease {
+		if image != nil && promotion.RefersToOfficialImage(image.Namespace, promotion.WithOKD) && image.Name == currentRelease {
 			image.Name = futureRelease
 		}
 		config.InputConfiguration.BuildRootImage.ImageStreamTagReference = image

--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -175,7 +175,7 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) string {
 		logger.WithError(err).Error("could not resolve ci-operator's config")
 		return formatError(fmt.Errorf("could not resolve ci-operator's config for %s/%s/%s: %w", org, repo, pr.Base.Ref, err))
 	}
-	if !promotion.PromotesOfficialImages(ciOpConfig) {
+	if !promotion.PromotesOfficialImages(ciOpConfig, promotion.WithOKD) {
 		logger.Info("the repo does not contribute to the OpenShift official images")
 		return fmt.Sprintf("the repo %s/%s does not contribute to the OpenShift official images", org, repo)
 	}

--- a/cmd/private-org-peribolos-sync/main.go
+++ b/cmd/private-org-peribolos-sync/main.go
@@ -182,7 +182,7 @@ func getReposForPrivateOrg(releaseRepoPath string, whitelist map[string][]string
 	}
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
-		if !promotion.BuildsOfficialImages(c) {
+		if !promotion.BuildsOfficialImages(c, promotion.WithoutOKD) {
 			return nil
 		}
 

--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -526,7 +526,7 @@ func (o *options) makeFilter(callback func(*api.ReleaseBuildConfiguration, *conf
 		if o.repo != "" && o.repo != fmt.Sprintf("%s/%s", i.Org, i.Repo) {
 			return nil
 		}
-		if !promotion.BuildsOfficialImages(c) {
+		if !promotion.BuildsOfficialImages(c, promotion.WithoutOKD) {
 			return nil
 		}
 		return callback(c, i)

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -104,10 +104,10 @@ func TestOptionsMakeFilter(t *testing.T) {
 		},
 	}
 	// Check that our assumptions about what is an official image still holds
-	if !promotion.BuildsOfficialImages(official) {
+	if !promotion.BuildsOfficialImages(official, promotion.WithoutOKD) {
 		t.Fatal("Test data assumed to be official images are not official images")
 	}
-	if promotion.BuildsOfficialImages(notOfficial) {
+	if promotion.BuildsOfficialImages(notOfficial, promotion.WithoutOKD) {
 		t.Fatal("Test data assumed to be non-official images are official images")
 	}
 	testcases := []struct {

--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -136,7 +136,7 @@ func getOrgReposWithOfficialImages(configDir string, whitelist map[string][]stri
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
 
-		if !promotion.BuildsOfficialImages(c) {
+		if !promotion.BuildsOfficialImages(c, promotion.WithoutOKD) {
 			return nil
 		}
 

--- a/cmd/repo-brancher/main.go
+++ b/cmd/repo-brancher/main.go
@@ -109,7 +109,7 @@ func main() {
 	}
 
 	failed := false
-	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, promotion.WithoutOKD, func(configuration *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := config.LoggerForInfo(*repoInfo)
 
 		repoDir := path.Join(gitDir, repoInfo.Org, repoInfo.Repo)

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -12,10 +12,14 @@ import (
 	"github.com/openshift/ci-tools/pkg/config"
 )
 
+type okdInclusion bool
+
 const (
-	okdPromotionNamespace = "openshift"
-	okd40Imagestream      = "origin-v4.0"
+	okdPromotionNamespace = "origin"
 	ocpPromotionNamespace = "ocp"
+
+	WithOKD    okdInclusion = true
+	WithoutOKD okdInclusion = false
 )
 
 // PromotesImagesInto determines if a configuration will result in images being promoted.
@@ -55,25 +59,24 @@ func AllPromotionImageStreamTags(configSpec *cioperatorapi.ReleaseBuildConfigura
 // PromotesOfficialImages determines if a configuration will result in official images
 // being promoted. This is a proxy for determining if a configuration contributes to
 // the release payload.
-func PromotesOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
-	return !isDisabled(configSpec) && BuildsOfficialImages(configSpec)
+func PromotesOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration, includeOKD okdInclusion) bool {
+	return !isDisabled(configSpec) && BuildsOfficialImages(configSpec, includeOKD)
 }
 
 func isDisabled(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
 	return configSpec.PromotionConfiguration != nil && configSpec.PromotionConfiguration.Disabled
 }
 
-// buildOfficialImages determines if a configuration will result in official images
+// BuildsOfficialImages determines if a configuration will result in official images
 // being built.
-func BuildsOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
+func BuildsOfficialImages(configSpec *cioperatorapi.ReleaseBuildConfiguration, includeOKD okdInclusion) bool {
 	promotionNamespace := extractPromotionNamespace(configSpec)
-	promotionName := extractPromotionName(configSpec)
-	return RefersToOfficialImage(promotionName, promotionNamespace)
+	return RefersToOfficialImage(promotionNamespace, includeOKD)
 }
 
 // RefersToOfficialImage determines if an image is official
-func RefersToOfficialImage(name, namespace string) bool {
-	return (namespace == okdPromotionNamespace && name == okd40Imagestream) || namespace == ocpPromotionNamespace
+func RefersToOfficialImage(namespace string, includeOKD okdInclusion) bool {
+	return (bool(includeOKD) && namespace == okdPromotionNamespace) || namespace == ocpPromotionNamespace
 }
 
 func extractPromotionNamespace(configSpec *cioperatorapi.ReleaseBuildConfiguration) string {
@@ -112,7 +115,7 @@ func DetermineReleaseBranch(currentRelease, futureRelease, currentBranch string)
 	}
 }
 
-// Options holds options to load CI Operator configuration and
+// FutureOptions holds options to load CI Operator configuration and
 // operate on a subset of them to update for future releases.
 type FutureOptions struct {
 	Options
@@ -164,10 +167,10 @@ func (o *Options) Bind(fs *flag.FlagSet) {
 	o.ConfirmableOptions.Bind(fs)
 }
 
-func (o *Options) matches(configuration *cioperatorapi.ReleaseBuildConfiguration) bool {
+func (o *Options) matches(configuration *cioperatorapi.ReleaseBuildConfiguration, includeOKD okdInclusion) bool {
 	var imagesMatch bool
 	if o.CurrentPromotionNamespace == "" {
-		imagesMatch = PromotesOfficialImages(configuration)
+		imagesMatch = PromotesOfficialImages(configuration, includeOKD)
 	} else {
 		imagesMatch = PromotesImagesInto(configuration, o.CurrentPromotionNamespace)
 	}
@@ -176,9 +179,9 @@ func (o *Options) matches(configuration *cioperatorapi.ReleaseBuildConfiguration
 
 // OperateOnCIOperatorConfigDir filters the full set of configurations
 // down to those that were selected by the user with promotion options
-func (o *Options) OperateOnCIOperatorConfigDir(configDir string, callback func(*cioperatorapi.ReleaseBuildConfiguration, *config.Info) error) error {
+func (o *Options) OperateOnCIOperatorConfigDir(configDir string, includeOKD okdInclusion, callback func(*cioperatorapi.ReleaseBuildConfiguration, *config.Info) error) error {
 	return o.Options.OperateOnCIOperatorConfigDir(configDir, func(configuration *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
-		if !o.matches(configuration) {
+		if !o.matches(configuration, includeOKD) {
 			return nil
 		}
 		return callback(configuration, info)

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -47,29 +47,18 @@ func TestPromotesOfficialImages(t *testing.T) {
 			expected: false,
 		},
 		{
-			name: "config explicitly promoting to okd release imagestream in okd namespace produces official images",
+			name: "config explicitly promoting to okd namespace produces official images",
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace: "openshift",
-					Name:      "origin-v4.0",
+					Namespace: "origin",
 				},
 			},
 			expected: true,
 		},
-		{
-			name: "config explicitly promoting to random imagestream in okd namespace does not produce official images",
-			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
-				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace: "openshift",
-					Name:      "random",
-				},
-			},
-			expected: false,
-		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := PromotesOfficialImages(testCase.configSpec), testCase.expected; actual != expected {
+			if actual, expected := PromotesOfficialImages(testCase.configSpec, WithOKD), testCase.expected; actual != expected {
 				t.Errorf("%s: did not identify official promotion correctly, expected %v got %v", testCase.name, expected, actual)
 			}
 		})
@@ -412,12 +401,12 @@ func TestOptionsMatche(t *testing.T) {
 		{
 			name: "for okd4.0",
 			input: []string{
-				"--current-release=origin-v4.0",
+				"--current-release=4.8",
 			},
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Name:      "origin-v4.0",
-					Namespace: "openshift",
+					Name:      "4.8",
+					Namespace: "origin",
 				},
 			},
 			expected: true,
@@ -444,7 +433,7 @@ func TestOptionsMatche(t *testing.T) {
 		if err := fs.Parse(testCase.input); err != nil {
 			t.Fatalf("%s: cannot parse args: %v", testCase.name, err)
 		}
-		if actual, expected := o.matches(testCase.configSpec), testCase.expected; actual != expected {
+		if actual, expected := o.matches(testCase.configSpec, WithOKD), testCase.expected; actual != expected {
 			t.Errorf("expected matches, but failed, input_args=%v, promation_config=%v.", testCase.input, testCase.configSpec)
 		}
 	}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -91,7 +91,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	if len(imageTargets) > 0 {
 		// Identify which jobs need to have a release payload explicitly requested
 		var presubmitTargets = imageTargets.List()
-		if promotion.PromotesOfficialImages(configSpec) {
+		if promotion.PromotesOfficialImages(configSpec, promotion.WithOKD) {
 			presubmitTargets = append(presubmitTargets, "[release:latest]")
 		}
 		jobBaseGen := newJobBaseBuilder().TestName("images")


### PR DESCRIPTION
The motivation for this change is to include OKD in various release automation. From how the code looked like in the past, it seems that it was always the intent, but the code was not maintained and kept updated with how OKD configuration is structured: previously, the OKD check was `namespace == okdPromotionNamespace && name == okd40Imagestream`, but none of the existing ci-operator configs use these names.

Because the usage of `*OfficialImages` proliferated over time, some of the callsites expect the check to include OKD, and some callsites do not (notably, the `openshift-priv` tools are not needed to handle OKD and things actually break if they do). Therefore, I have added an explicit parameter to all these methods to control whether the caller wants to work also with OKD or not.

We also need to evaluate the impact on all code that uses this check, because most of the callsites are probably not aware of OKD at all.

- `RefersToOfficialImages` callsites: `config-brancher`, `BuildsOfficialImages`
- `BuildsOfficialImages` callsites: `autopublicizeconfig`, `ci-operator-config-mirror`, `private-org-peribolos-sync`, `private-org-sync`, `private-prow-configs-mirror`, `PromotesOfficialImages`
- `PromotesOfficialImages` callsites: `payload-testing-prow-plugin`, `Prowgen`, `blocking-issue-creator`, `repo-brancher`

---

- [x] config-brancher: looks good in https://github.com/openshift/release/pull/26703: creates and carries modifications to branches' OKD config
- [x] `autopublicizeconfig`: should exclude OKD, otherwise includes OKD-only repositories in openshift-priv machinery
- [x] `ci-operator-config-mirror`: should exclude OKD, otherwise includes OKD-only repositories in openshift-priv machinery
- [x] `private-org-peribolos-config`: should exclude OKD, otherwise includes OKD-only repositories in openshift-priv machinery
- [x] `private-org-sync`: should exclude OKD, otherwise includes OKD-only repositories in openshift-priv machinery
- [x] `private-prow-configs-mirror`: should exclude OKD, otherwise includes OKD-only repositories in openshift-priv machinery
- [x] `payload-testing-prow-plugin`: does not matter too much, can include OKD
- [x] `blocking-issues-creator`: should exclude OKD - branches on OKD repositories are not fast forwarded, so no need to block merges
- [x] `repo-brancher`: should exclude OKD - branches on OKD were never fast-forwarded and nobody ever asked them to be
- [x] `prowgen`: should include OKD, will make OKD-promoting image jobs check the feasibility of building a release, this is desirable