### PR TITLE
autoowners: include source and date feched in header comment

### DIFF
--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -19,6 +20,21 @@ func assertEqual(t *testing.T, actual, expected interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("actual differs from expected:\n%s", cmp.Diff(expected, actual, cmp.AllowUnexported(httpResult{})))
+	}
+}
+
+func TestMakeHeader(t *testing.T) {
+	actual := makeHeader("destination", "source", "src-repo", time.Unix(123456789, 0))
+	expected := `# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/source/src-repo root OWNERS on 1973-11-29T21:33:09Z
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'destination' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+`
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("Actual differs from expected:\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Currently we put a [header like this](https://github.com/openshift/release/blob/08e400216f5d0fd121a517bc97512d7928f44c8f/ci-operator/config/openshift/ci-tools/OWNERS#L1-L2) to OWNERS files:

```
# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
```

We can provide more information in there:

```
# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
# Fetched from https://github.com/openshift/ci-tools root OWNERS on 2022-02-04T17:14:58Z
# If the repo had OWNERS_ALIASES then the aliases were expanded
# Logins who are not members of 'openshift' organization were filtered out
# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
```