### PR TITLE
pkg/source: retry on `GenericBuildFailed`

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -436,19 +436,19 @@ func waitForBuildDeletion(ctx context.Context, client ctrlruntimeclient.Client, 
 
 func isInfraReason(reason buildapi.StatusReason) bool {
 	infraReasons := []buildapi.StatusReason{
-		buildapi.StatusReasonCannotCreateBuildPod,
-		buildapi.StatusReasonBuildPodDeleted,
-		buildapi.StatusReasonExceededRetryTimeout,
-		buildapi.StatusReasonPushImageToRegistryFailed,
-		buildapi.StatusReasonPullBuilderImageFailed,
-		buildapi.StatusReasonFetchSourceFailed,
-		buildapi.StatusReasonBuildPodExists,
-		buildapi.StatusReasonNoBuildContainerStatus,
-		buildapi.StatusReasonFailedContainer,
-		buildapi.StatusReasonOutOfMemoryKilled,
-		buildapi.StatusReasonCannotRetrieveServiceAccount,
-		buildapi.StatusReasonFetchImageContentFailed,
 		buildapi.StatusReason("BuildPodEvicted"), // vendoring to get this is so hard
+		buildapi.StatusReasonBuildPodDeleted,
+		buildapi.StatusReasonBuildPodExists,
+		buildapi.StatusReasonCannotCreateBuildPod,
+		buildapi.StatusReasonCannotRetrieveServiceAccount,
+		buildapi.StatusReasonExceededRetryTimeout,
+		buildapi.StatusReasonFailedContainer,
+		buildapi.StatusReasonFetchImageContentFailed,
+		buildapi.StatusReasonFetchSourceFailed,
+		buildapi.StatusReasonNoBuildContainerStatus,
+		buildapi.StatusReasonOutOfMemoryKilled,
+		buildapi.StatusReasonPullBuilderImageFailed,
+		buildapi.StatusReasonPushImageToRegistryFailed,
 	}
 	for _, option := range infraReasons {
 		if reason == option {

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -445,6 +445,7 @@ func isInfraReason(reason buildapi.StatusReason) bool {
 		buildapi.StatusReasonFailedContainer,
 		buildapi.StatusReasonFetchImageContentFailed,
 		buildapi.StatusReasonFetchSourceFailed,
+		buildapi.StatusReasonGenericBuildFailed,
 		buildapi.StatusReasonNoBuildContainerStatus,
 		buildapi.StatusReasonOutOfMemoryKilled,
 		buildapi.StatusReasonPullBuilderImageFailed,


### PR DESCRIPTION
Seen in failures due to the current autoscaler issue:

```
* could not run steps: step csi-livenessprobe failed: the build csi-livenessprobe failed with reason GenericBuildFailed: Generic Build failure - check logs for details.
```
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-csi-livenessprobe-release-4.11-images/1490635717557096448

Seems to be distinct enough from legitimate build failures:

```
* could not run steps: step crc failed: the build crc failed after 2m5s with reason DockerBuildFailed: Dockerfile build strategy has failed.
```
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/code-ready_crc/2984/pull-ci-code-ready-crc-dev-images/1490627156324126720