### PR TITLE
Fix test data

### DIFF
--- a/cmd/ci-operator-prowgen/main_test.go
+++ b/cmd/ci-operator-prowgen/main_test.go
@@ -50,7 +50,6 @@ resources:
 tag_specification:
   name: origin-v3.11
   namespace: openshift
-  tag: ''
 promotion:
   namespace: ci
   name: other
@@ -89,7 +88,6 @@ resources:
 tag_specification:
   name: origin-v3.11
   namespace: openshift
-  tag: ''
 promotion:
   name: test
   namespace: ci
@@ -145,7 +143,6 @@ resources:
 tag_specification:
   name: origin-v3.11
   namespace: openshift
-  tag: ''
 promotion:
   name: test
   namespace: ci
@@ -205,7 +202,6 @@ resources:
 tag_specification:
   name: origin-v3.11
   namespace: openshift
-  tag: ''
 promotion:
   name: test
   namespace: ci

--- a/test/integration/repo-init/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/integration/repo-init/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -23,8 +23,7 @@ resources:
       cpu: 100m
       memory: 200Mi
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: ARTIFACT_DIR=/tmp/artifacts make test
   container:
     from: src

--- a/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -30,8 +30,7 @@ tag_specification:
   name: "4.3"
   namespace: ocp
 tests:
-- artifact_dir: /tmp/artifacts
-  as: unit
+- as: unit
   commands: TMPDIR=/tmp/volume GOTEST_FLAGS='-p 8' ARTIFACT_DIR=/tmp/artifacts TIMEOUT=180s
     JUNIT_REPORT=1 TEST_KUBE=true KUBERNETES_SERVICE_HOST= hack/test-go.sh
   container:


### PR DESCRIPTION
These fields are ancient and have long been removed, but were still
unintentionally allowed due to the loading duplication we had, cf.:

https://github.com/openshift/ci-tools/pull/2627/files#diff-9d074e6d02129dc16ea4fb5dd423cfb7120791f74e477efa77e9424861a78960L169
https://github.com/openshift/ci-tools/blob/3c2360c044e5efa70394e6abcdc8be2c491c9f8f/pkg/config/load.go#L46

Required so `UnmarshalStrict` can be enabled for all tools which load
`ci-operator` configuration files.