### PR TITLE
ci-operator: retry infra-failed builds immediately

### DIFF
--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -75,7 +75,7 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 	)
-	return handleBuild(ctx, s.client, build)
+	return handleBuild(ctx, s.client, *build)
 }
 
 func replaceCommand(pullSpec, with string) string {

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -42,7 +42,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 			secretName = s.cloneAuthConfig.Secret.Name
 		}
 
-		return handleBuild(ctx, s.buildClient, buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
+		return handleBuild(ctx, s.buildClient, *buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
 			Type:         buildapi.BuildSourceGit,
 			Dockerfile:   s.config.DockerfileLiteral,
 			ContextDir:   s.config.ContextDir,

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -79,7 +79,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 	)
-	err = handleBuild(ctx, s.client, build)
+	err = handleBuild(ctx, s.client, *build)
 	if err != nil && strings.Contains(err.Error(), "error checking provided apis") {
 		return results.ForReason("generating_index").WithError(err).Errorf("failed to generate operator index due to invalid bundle info: %v", err)
 	}

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -44,7 +44,7 @@ func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return handleBuild(ctx, s.client, buildFromSource(
+	return handleBuild(ctx, s.client, *buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -61,7 +61,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.pullSecret,
 		s.config.BuildArgs,
 	)
-	return handleBuild(ctx, s.client, build)
+	return handleBuild(ctx, s.client, *build)
 }
 
 type workingDir func(tag string) (string, error)

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -48,7 +48,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return handleBuild(ctx, s.client, buildFromSource(
+	return handleBuild(ctx, s.client, *buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -369,46 +369,57 @@ func isBuildPhaseTerminated(phase buildapi.BuildPhase) bool {
 }
 
 func handleBuild(ctx context.Context, buildClient BuildClient, build *buildapi.Build) error {
-	if err := buildClient.Create(ctx, build); err != nil {
-		if !kerrors.IsAlreadyExists(err) {
-			return fmt.Errorf("could not create build %s: %w", build.Name, err)
+	var buildErr error
+	attempts := 5
+	if boErr := wait.ExponentialBackoff(wait.Backoff{Duration: time.Minute, Factor: 1.5, Steps: attempts}, func() (bool, error) {
+		if err := buildClient.Create(ctx, build); err != nil && !kerrors.IsAlreadyExists(err) {
+			return false, fmt.Errorf("could not create build %s: %w", build.Name, err)
 		}
+
+		buildErr = waitForBuildOrTimeout(ctx, buildClient, build.Namespace, build.Name)
+		if buildErr == nil {
+			if err := gatherSuccessfulBuildLog(buildClient, build.Namespace, build.Name); err != nil {
+				// log error but do not fail successful build
+				logrus.WithError(err).Warnf("Failed gathering successful build %s logs into artifacts.", build.Name)
+			}
+			return true, nil
+		}
+
 		b := &buildapi.Build{}
 		if err := buildClient.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: build.Namespace, Name: build.Name}, b); err != nil {
-			return fmt.Errorf("could not get build %s: %w", build.Name, err)
+			return false, fmt.Errorf("could not get build %s: %w", build.Name, err)
 		}
 
-		if isBuildPhaseTerminated(b.Status.Phase) &&
-			(isInfraReason(b.Status.Reason) || hintsAtInfraReason(b.Status.LogSnippet)) {
-			logrus.Infof("Build %s previously failed from an infrastructure error (%s), retrying...", b.Name, b.Status.Reason)
-			zero := int64(0)
-			foreground := metav1.DeletePropagationForeground
-			opts := metav1.DeleteOptions{
-				GracePeriodSeconds: &zero,
-				Preconditions:      &metav1.Preconditions{UID: &b.UID},
-				PropagationPolicy:  &foreground,
-			}
-			if err := buildClient.Delete(ctx, build, &ctrlruntimeclient.DeleteOptions{Raw: &opts}); err != nil && !kerrors.IsNotFound(err) && !kerrors.IsConflict(err) {
-				return fmt.Errorf("could not delete build %s: %w", build.Name, err)
-			}
-			if err := waitForBuildDeletion(ctx, buildClient, build.Namespace, build.Name); err != nil {
-				return fmt.Errorf("could not wait for build %s to be deleted: %w", build.Name, err)
-			}
-			if err := buildClient.Create(ctx, build); err != nil && !kerrors.IsAlreadyExists(err) {
-				return fmt.Errorf("could not recreate build %s: %w", build.Name, err)
-			}
+		if !isBuildPhaseTerminated(b.Status.Phase) {
+			return false, buildErr
 		}
-	}
-	err := waitForBuildOrTimeout(ctx, buildClient, build.Namespace, build.Name)
-	if err == nil {
-		if err := gatherSuccessfulBuildLog(buildClient, build.Namespace, build.Name); err != nil {
-			// log error but do not fail successful build
-			logrus.WithError(err).Warnf("Failed gathering successful build %s logs into artifacts.", build.Name)
-		}
-	}
-	// this will still be the err from waitForBuild
-	return err
 
+		if !(isInfraReason(b.Status.Reason) || hintsAtInfraReason(b.Status.LogSnippet)) {
+			return false, buildErr
+		}
+
+		logrus.Infof("Build %s previously failed from an infrastructure error (%s), retrying...", b.Name, b.Status.Reason)
+		zero := int64(0)
+		foreground := metav1.DeletePropagationForeground
+		opts := metav1.DeleteOptions{
+			GracePeriodSeconds: &zero,
+			Preconditions:      &metav1.Preconditions{UID: &b.UID},
+			PropagationPolicy:  &foreground,
+		}
+		if err := buildClient.Delete(ctx, build, &ctrlruntimeclient.DeleteOptions{Raw: &opts}); err != nil && !kerrors.IsNotFound(err) && !kerrors.IsConflict(err) {
+			return false, fmt.Errorf("could not delete build %s: %w", build.Name, err)
+		}
+		if err := waitForBuildDeletion(ctx, buildClient, build.Namespace, build.Name); err != nil {
+			return false, fmt.Errorf("could not wait for build %s to be deleted: %w", build.Name, err)
+		}
+		return false, nil
+	}); boErr != nil {
+		if boErr == wait.ErrWaitTimeout {
+			return fmt.Errorf("build not successful after %d attempts, last error: %w", attempts, buildErr)
+		}
+		return boErr
+	}
+	return nil
 }
 
 func waitForBuildDeletion(ctx context.Context, client ctrlruntimeclient.Client, ns, name string) error {


### PR DESCRIPTION
Previous version caused `resourceVersion should not be set on objects to be created ` errors and needed to be reverted. This PR addresses that bug in a new commit. I also included the error handling change from https://github.com/openshift/ci-tools/pull/2655.

ci-operator was already able to recognize infrastructure-failed builds
from previous runs and retry them. This is an attempt to reuse that code
to retry such failed builds immediately, with two attempts in an
exponential backoff. The backoff has an intentionally long starting
delay of 1 minute to give the infrastructure problem a chance to go
away. The way the code is structured makes it less optimal for the case
where we are retrying infra failures from the previous executions: it
will eat one of the backoff iterations, but such cases should be rare
because ci-op runs should not result in failures caused by
infrastructure failures anymore (because they are retried immediately).

/cc @openshift/test-platform @bbguimaraes @jupierce 
/label tide/merge-method-squash