### PR TITLE
Update cluster type to packet-edge for Assisted and SNO profiles

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1260,10 +1260,12 @@ func (p ClusterProfile) ClusterType() string {
 	case ClusterProfileOvirt:
 		return "ovirt"
 	case
-		ClusterProfilePacket,
+		ClusterProfilePacket:
+		return "packet"
+	case
 		ClusterProfilePacketAssisted,
 		ClusterProfilePacketSNO:
-		return "packet"
+		return "packet-edge"
 	case ClusterProfileKubevirt:
 		return "kubevirt"
 	case ClusterProfileOSDEphemeral:
@@ -1377,7 +1379,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "kubevirt", "aws-cpaas", "osd-ephemeral":
+	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "kubevirt", "aws-cpaas", "osd-ephemeral":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
Originally all the cluster profiles associated with Equinix were expecting a cluster type to be `packet`. We are now deprecating the old `packet` cluster profile and cluster type. There was a requirement for the two cluster_profiles `packet-assisted` and `packet-sno` to use the same qouta. This updates the cluster type for those profiles to be `packet-edge`

See: https://github.com/openshift/release/pull/25952 where the jobs under `packet-assisted` and `packet-sno` are now being blocked from running.