### PR TITLE
override job_url_prefix for rehearsals

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -37,6 +38,7 @@ import (
 	apihelper "github.com/openshift/ci-tools/pkg/api/helper"
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	"github.com/openshift/ci-tools/pkg/config"
+	ciopconfig "github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/diffs"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
@@ -117,6 +119,16 @@ func loadConfigUpdaterCfg(releaseRepoPath string) (ret prowplugins.ConfigUpdater
 		ret = agent.Config().ConfigUpdater
 	}
 	return
+}
+
+func loadProwConfig(releaseRepoPath string) (*prowconfig.Config, error) {
+	configPath := path.Join(releaseRepoPath, ciopconfig.ConfigInRepoPath)
+	agent := prowconfig.Agent{}
+	if err := agent.Start(configPath, "", nil, ""); err != nil {
+		return nil, fmt.Errorf("could not load Prow configuration: %w", err)
+	}
+
+	return agent.Config(), nil
 }
 
 func rehearseMain() error {
@@ -306,7 +318,11 @@ func rehearseMain() error {
 
 	resolver := registry.NewResolver(refs, chains, workflows, observers)
 	jobConfigurer := rehearse.NewJobConfigurer(prConfig.CiOperator, resolver, prNumber, loggers, rehearsalTemplates.Names, rehearsalClusterProfiles.Names, jobSpec.Refs)
-	imagestreamtags, presubmitsToRehearse, err := jobConfigurer.ConfigurePresubmitRehearsals(toRehearse)
+	pc, err := loadProwConfig(o.releaseRepoPath)
+	if err != nil {
+		return err
+	}
+	imagestreamtags, presubmitsToRehearse, err := jobConfigurer.ConfigurePresubmitRehearsals(toRehearse, pc)
 	if err != nil {
 		return err
 	}

--- a/test/integration/pj-rehearse/candidate/core-services/prow/02_config/_config.yaml
+++ b/test/integration/pj-rehearse/candidate/core-services/prow/02_config/_config.yaml
@@ -1,6 +1,8 @@
 plank:
   allow_cancellations: true
-  job_url_prefix: 'https://openshift-gce-devel.appspot.com/build/'
+  job_url_prefix_config:
+    '*': https://openshift-gce-devel.appspot.com/build/
+    super/duper: https://super-duper.appspot.com/build/
   job_url_template: 'https://openshift-gce-devel.appspot.com/build/origin-ci-test/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if ne .Spec.Refs.Repo "origin"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://openshift-gce-devel.appspot.com/pr/{{if ne .Spec.Refs.Repo "origin"}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://openshift-gce-devel.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   default_decoration_configs:

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -732,6 +732,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://super-duper.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -822,6 +823,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://super-duper.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -924,6 +926,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://super-duper.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1032,6 +1035,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://super-duper.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1117,6 +1121,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://super-duper.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1225,6 +1230,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://openshift-gce-devel.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1334,6 +1340,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://openshift-gce-devel.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1437,6 +1444,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://openshift-gce-devel.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
@@ -1540,6 +1548,7 @@
         bucket: origin-ci-test
         default_org: openshift
         default_repo: origin
+        job_url_prefix: https://openshift-gce-devel.appspot.com/build/
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s

--- a/test/integration/pj-rehearse/master/core-services/prow/02_config/_config.yaml
+++ b/test/integration/pj-rehearse/master/core-services/prow/02_config/_config.yaml
@@ -1,6 +1,8 @@
 plank:
   allow_cancellations: true
-  job_url_prefix: 'https://openshift-gce-devel.appspot.com/build/'
+  job_url_prefix_config:
+    '*': https://openshift-gce-devel.appspot.com/build/
+    super/duper: https://super-duper.appspot.com/build/
   job_url_template: 'https://openshift-gce-devel.appspot.com/build/origin-ci-test/{{if eq .Spec.Type "presubmit"}}pr-logs/pull{{else if eq .Spec.Type "batch"}}pr-logs/pull{{else}}logs{{end}}{{if ne .Spec.Refs.Repo "origin"}}/{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}{{end}}{{if eq .Spec.Type "presubmit"}}/{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}{{else if eq .Spec.Type "batch"}}/batch{{end}}/{{.Spec.Job}}/{{.Status.BuildID}}/'
   report_template: '[Full PR test history](https://openshift-gce-devel.appspot.com/pr/{{if ne .Spec.Refs.Repo "origin"}}{{.Spec.Refs.Org}}_{{.Spec.Refs.Repo}}/{{end}}{{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://openshift-gce-devel.appspot.com/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   default_decoration_configs:


### PR DESCRIPTION
In order to allow for the correct Details link to be shared on the gh status for rehearsals for qe-private-deck repos (https://issues.redhat.com/browse/DPTP-2742) we can utilize the `DecorationConfig` where an existing override is in place: https://github.com/kubernetes/test-infra/blob/b800243aebae95801cec2b9f16950623c6a42497/prow/config/config.go#L820