### PR TITLE
entrypoint-wrapper: correct kubeconfig test

### DIFF
--- a/test/integration/entrypoint-wrapper.sh
+++ b/test/integration/entrypoint-wrapper.sh
@@ -117,7 +117,8 @@ test_copy_kubeconfig() {
     diff <(echo "$v") <(echo "yes")
 
     echo '[INFO] Verifying KUBECONFIG is populated when possible'
-    ( sleep 1 && echo "test" > "/tmp/.kubeconfig" ) &
+    echo "test" > "${dir}/kubeconfig.new"
+    ( sleep 1 && mv "${dir}/kubeconfig.new" "${dir}/kubeconfig" ) &
     if ! v=$( \
         KUBECONFIG="${dir}/kubeconfig" \
         entrypoint-wrapper --dry-run \


### PR DESCRIPTION
Replace `echo … > …` with an `mv` of a preexisting file, which is an
atomic operation:

```
$ > a; strace mv a b |& grep renameat
renameat2(AT_FDCWD, "a", AT_FDCWD, "b", RENAME_NOREPLACE) = 0
```

There is a race in this test due to the way `>` works in `bash`:

```
$ strace bash -c 'printf a > a' |& sed -n '144p;149p;152p'
openat(AT_FDCWD, "a", O_WRONLY|O_CREAT|O_TRUNC, 0666) = 3
dup2(3, 1)                              = 1
write(1, "a", 1)                        = 1
```

I.e. the shell (`echo` is a `bash` built-in command) opens/truncates the
file, then writes the content.  There is a window where the file exists
but is empty, which can cause the test to fail:

```
[INFO] Verifying KUBECONFIG is populated when possible
1c1
<
---
> test
[ERROR] test command failed, output:
```

Even though I haven't seen this one in CI, I've reliably found it while
trying to reproduce other failures.