### PR TITLE
entrypoint-wrapper: separate cmd. `Start`/`Wait`

### DIFF
--- a/cmd/entrypoint-wrapper/main.go
+++ b/cmd/entrypoint-wrapper/main.go
@@ -187,6 +187,9 @@ func execCmd(argv []string) error {
 	}
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	if err := proc.Start(); err != nil {
+		return fmt.Errorf("failed to start main process: %w", err)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go func() {
@@ -202,7 +205,7 @@ func execCmd(argv []string) error {
 			}
 		}
 	}()
-	return proc.Run()
+	return proc.Wait()
 }
 
 // manageCLI configures the PATH to include a CLI_DIR if one was provided


### PR DESCRIPTION
entrypoint-wrapper: improve integration tests

At some point tests started interfering with each other such that it is
no longer possible to execute them individually.  Make each use its own
environment.

---

entrypoint-wrapper: improve test output

Better identify failures, cf.:

<details>

```
--- /tmp/openshift/test-integration/out.log     2021-10-03 00:03:37.531198260 +0000
+++ /tmp/openshift/test-integration/secret.yaml 2021-10-03 00:03:31.456150623 +0000
@@ -0,0 +1 @@
+{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test","creationTimestamp":null,"labels":{"ci.openshift.io/skip-censoring":"true"}},"data":{"test0.txt":"dGVzdDAK"},"type":"Opaque"}
```
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/2414/pull-ci-openshift-ci-tools-master-integration/1444448555258351616#1:build-log.txt%3A2282

vs.

```
--- /tmp/int_15252/openshift/test-integration/out.log   2022-02-11 19:22:32.041099722 +0000
+++ /tmp/int_15252/openshift/test-integration/secret.yaml       2022-02-11 19:22:31.909098208 +0000
@@ -1,15 +1 @@
-[ERROR] output:
-[ERROR] error output:
-received signal 15, forwarding
-panic: runtime error: invalid memory address or nil pointer dereference
-[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d9919]
-
-goroutine 59 [running]:
-os.(*Process).signal(0x1d7afc0, {0x1d94e30, 0x2b70af8})
-       /home/bbguimaraes/go-1.17/src/os/exec_unix.go:64 +0x39
-os.(*Process).Signal(...)
-       /home/bbguimaraes/go-1.17/src/os/exec.go:138
-main.execCmd.func1()
-       /home/bbguimaraes/src/ci-tools/cmd/entrypoint-wrapper/main.go:199 +0x15a
-created by main.execCmd
-       /home/bbguimaraes/src/ci-tools/cmd/entrypoint-wrapper/main.go:192 +0x236
+{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test","creationTimestamp":null,"labels":{"ci.openshift.io/skip-censoring":"true"}},"data":{"test0.txt":"dGVzdDAK"},"type":"Opaque"}
```

</details>

---

entrypoint-wrapper: separate cmd. `Start`/`Wait`

This is a tight race (I need to throw 32 parallel processes at it for
minutes to reproduce), but it's kind of miraculous it has never been
seen in production with our volume of tests.

`proc.Process` is `nil` before the process is started:

> // Process is the underlying process, once started.
> Process *os.Process

https://pkg.go.dev/os/exec#Cmd

This means dereferencing it for the `Signal` call is invalid until then.
Use separate `Start` (which populates `Process`) and `Wait` calls
instead of `Run` to guarantee sending a signal is always safe.

```
$ JOB_NAME_SAFE=a NAMESPACE=a SHARED_DIR=a \
    strace -o /dev/null --inject clone:when=5:delay_exit=1s:signal=TERM \
    entrypoint-wrapper --dry-run true
received signal 15, forwarding
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4d9919]

goroutine 84 [running]:
os.(*Process).signal(0x1d7afc0, {0x1d94e30, 0x2b70af8})
        /home/bbguimaraes/go-1.17/src/os/exec_unix.go:64 +0x39
os.(*Process).Signal(...)
        /home/bbguimaraes/go-1.17/src/os/exec.go:138
main.execCmd.func1()
        /home/bbguimaraes/src/ci-tools/cmd/entrypoint-wrapper/main.go:199 +0x15a
created by main.execCmd
        /home/bbguimaraes/src/ci-tools/cmd/entrypoint-wrapper/main.go:192 +0x236
```

Note that the integration tests try to prevent this situation (among
others), but there is a(nother) tight race where the child process could
have been started and externally observable but not have been registered
by the parent yet by the time the signal is received.