### PR TITLE
pkg/load: use correct registry metric

### DIFF
--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -149,7 +149,7 @@ func (a *registryAgent) loadRegistry() error {
 	if err != nil {
 		return err
 	}
-	configReloadTimeMetric.Observe(duration.Seconds())
+	registryReloadTimeMetric.Observe(duration.Seconds())
 	logrus.WithField("duration", duration).Info("Registry reloaded")
 	return nil
 }


### PR DESCRIPTION
Experience suggests metrics are more useful when you populate them.

https://prometheus-prow-monitoring.apps.ci.l2s4.p1.openshiftapps.com/graph?g0.range_input=4w&g0.expr=configresolver_registry_reload_duration_seconds_bucket&g0.tab=1
https://prometheus-prow-monitoring.apps.ci.l2s4.p1.openshiftapps.com/graph?g0.range_input=4w&g0.expr=configresolver_registry_reload_duration_seconds_count&g0.tab=1
https://prometheus-prow-monitoring.apps.ci.l2s4.p1.openshiftapps.com/graph?g0.range_input=4w&g0.expr=configresolver_registry_reload_duration_seconds_sum&g0.tab=1