### PR TITLE
use the logrusutil to set the component and formatter in repo-init-apiserver

### DIFF
--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -20,6 +20,7 @@ import (
 	prowConfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/simplifypath"
@@ -77,13 +78,14 @@ type serverConfigType string
 var configTypes = []serverConfigType{GitHubClientId, GitHubClientSecret, GitHubRedirectUri}
 
 func serveAPI(port, healthPort, numRepos int, ghOptions flagutil.GitHubOptions, disableCorsVerification bool, serverConfigPath string) {
+	logrusutil.ComponentInit()
 	rm := &repoManager{
 		numRepos: numRepos,
 	}
 	rm.init()
 
 	s := server{
-		logger:        logrus.WithField("component", "repo-init-api"),
+		logger:        &logrus.Entry{},
 		githubOptions: ghOptions,
 		disableCors:   disableCorsVerification,
 		rm:            rm,

--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -85,7 +85,7 @@ func serveAPI(port, healthPort, numRepos int, ghOptions flagutil.GitHubOptions, 
 	rm.init()
 
 	s := server{
-		logger:        &logrus.Entry{},
+		logger:        logrus.WithField("component", "repo-init-apiserver"),
 		githubOptions: ghOptions,
 		disableCors:   disableCorsVerification,
 		rm:            rm,

--- a/cmd/repo-init/frontend.go
+++ b/cmd/repo-init/frontend.go
@@ -13,6 +13,7 @@ import (
 
 	prowConfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/simplifypath"
@@ -26,6 +27,7 @@ var (
 )
 
 func serveUI(port, healthPort, metricsPort int) {
+	logrusutil.ComponentInit()
 	logger := logrus.WithField("component", "repo-init-frontend")
 
 	health := pjutil.NewHealthOnPort(healthPort)


### PR DESCRIPTION
The logs aren't showing in CloudWatch. This should fix that by formatting in JSON.