### PR TITLE
[autoowners] trim body when it exceeds more than 65536 characters

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -386,7 +386,14 @@ func getBody(directories []string, assign string) string {
 		lines = append(lines, fmt.Sprintf("* %s", d))
 	}
 	lines = append(lines, []string{"", fmt.Sprintf("/cc @%s", assign), ""}...)
-	return strings.Join(lines, "\n")
+
+	body := strings.Join(lines, "\n")
+
+	if len(body) >= 65536 {
+		body = body[:65530] + "..."
+	}
+
+	return body
 }
 
 func getTitle(matchTitle, datetime string) string {


### PR DESCRIPTION
fixes: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-owners/1494248760073523200#1:build-log.txt%3A2155

`body is too long (maximum is 65536 characters)`

/cc @openshift/test-platform 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>