### PR TITLE
e2e: properly wait for Prometheus

### DIFF
--- a/test/e2e/pod-scaler/prometheus/prometheus.go
+++ b/test/e2e/pod-scaler/prometheus/prometheus.go
@@ -79,12 +79,14 @@ func Initialize(t testhelper.TestingTInterface, tmpDir string, r *rand.Rand, str
 		},
 	)
 	prometheus.RunFromFrameworkRunner(t, interrupts.Context(), stream)
-	// TODO: wait more intelligently
-	time.Sleep(1 * time.Second)
 	prometheusConnectionFlags := prometheus.ClientFlags()
 	// this is a hack, but whatever
 	prometheusAddr := prometheusConnectionFlags[1]
 	prometheusHost := "http://" + prometheusAddr
+	prometheus.Ready(t, func(o *testhelper.ReadyOptions) {
+		o.ReadyURL = prometheusHost + "/-/ready"
+		o.WaitFor = 5
+	})
 	t.Logf("Prometheus is running at %s", prometheusHost)
 	return prometheusAddr, info
 }

--- a/test/e2e/pod-scaler/prometheus/prometheus.go
+++ b/test/e2e/pod-scaler/prometheus/prometheus.go
@@ -87,6 +87,8 @@ func Initialize(t testhelper.TestingTInterface, tmpDir string, r *rand.Rand, str
 		o.ReadyURL = prometheusHost + "/-/ready"
 		o.WaitFor = 5
 	})
+	// TODO: for some reason the above is not sufficient, leave this for now
+	time.Sleep(5 * time.Second)
 	t.Logf("Prometheus is running at %s", prometheusHost)
 	return prometheusAddr, info
 }


### PR DESCRIPTION
e2e: properly wait for Prometheus

https://github.com/openshift/ci-tools/pull/2632#issuecomment-1038948252
https://github.com/openshift/ci-tools/pull/2632#issuecomment-1039252732

---

e2e: reintroduce sleep

For some reason the readiness probe is not sufficient, I still see failures
even with this in the logs:

```
accessory.go:66: `prometheus` readiness probe error: Get "http://0.0.0.0:40275/-/ready": dial tcp 0.0.0.0:40275: connect: connection refused:
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: `prometheus` readiness probe: 503
accessory.go:66: Prometheus is running at http://0.0.0.0:40275
```

Pushing a partial fix and increasing the sleep interval since the failure
has become more symptomatic in CI.