### PR TITLE
better-retester: fix the default value of cache-record-age

### DIFF
--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -55,7 +55,7 @@ func gatherOptions() options {
 	fs.BoolVar(&o.runOnce, "run-once", false, "If true, run only once then quit.")
 	fs.StringVar(&intervalRaw, "interval", "1h", "Parseable duration string that specifies the sync period")
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
-	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "7d", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
+	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
 
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.config} {
 		group.AddFlags(fs)


### PR DESCRIPTION
To fix

```console
$ oc logs -n ci better-retester-5d65875457-d2wfr
time="2022-02-17T17:00:33Z" level=fatal msg="could not parse cache record age" error="time: unknown unit \"d\" in duration \"7d\""
```

It does not support `days`.
https://github.com/golang/go/issues/17767

/cc @petr-muller 

