### PR TITLE
repo init ui: run 'make jobs' prior to commit

### DIFF
--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -422,7 +422,6 @@ func unmarshalValidationRequest(data []byte) (validationType, interface{}, error
 func (s server) validateConfig(w http.ResponseWriter, r *http.Request) {
 	logger := s.logger.WithField("handler", "configValidationHandler")
 	body, err := ioutil.ReadAll(r.Body)
-
 	if err != nil {
 		logger.WithError(err).Error("Error while reading request body")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -436,6 +435,7 @@ func (s server) validateConfig(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("Invalid validation request"))
 		return
 	}
+	logger.WithField("validationType", validationType).Debug("validating the config")
 
 	var validationErrors []error
 
@@ -458,8 +458,32 @@ func (s server) validateConfig(w http.ResponseWriter, r *http.Request) {
 		case OperatorBundle:
 			validationErrors = append(validationErrors, validation.ValidateOperator(context.AddField("operator_bundle"), generated)...)
 		case Tests:
-			v := validation.NewValidator()
-			validationErrors = append(validationErrors, v.ValidateTestStepConfiguration(context.AddField("tests"), generated, false)...)
+			// Build up a graph configuration with the relevant parts in order to validate the tests
+			var rawSteps []api.StepConfiguration
+			for _, t := range generated.Tests {
+				test := t
+				rawSteps = append(rawSteps, api.StepConfiguration{
+					TestStepConfiguration: &test,
+				})
+			}
+			for _, i := range generated.InputConfiguration.BaseImages {
+				image := i
+				rawSteps = append(rawSteps, api.StepConfiguration{
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						InputImage: api.InputImage{
+							BaseImage: image,
+							To:        api.PipelineImageStreamTagReference(image.Name),
+						}}})
+			}
+			for _, i := range generated.Images {
+				image := i
+				rawSteps = append(rawSteps, api.StepConfiguration{
+					ProjectDirectoryImageBuildStepConfiguration: &image,
+				})
+			}
+			if err = validation.IsValidGraphConfiguration(rawSteps); err != nil {
+				validationErrors = append(validationErrors, err)
+			}
 		default:
 			logger.WithError(err).Error("Invalid validation type specified")
 			w.WriteHeader(http.StatusBadRequest)
@@ -607,9 +631,10 @@ func (s server) generateConfig(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Debug("running 'make jobs' prior to commit")
 	makeJobs := exec.Command("make", "jobs")
-	err = makeJobs.Run()
-	if err != nil {
+	if err = makeJobs.Run(); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
 		s.logger.WithError(err).Error("failed to make jobs")
+		return
 	}
 
 	createPR, _ := strconv.ParseBool(r.URL.Query().Get("generatePR"))

--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -602,6 +603,13 @@ func (s server) generateConfig(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		s.logger.WithError(err).Error("could not generate new CI Operator configuration")
 		return
+	}
+
+	s.logger.Debug("running 'make jobs' prior to commit")
+	makeJobs := exec.Command("make", "jobs")
+	err = makeJobs.Run()
+	if err != nil {
+		s.logger.WithError(err).Error("failed to make jobs")
 	}
 
 	createPR, _ := strconv.ParseBool(r.URL.Query().Get("generatePR"))

--- a/cmd/repo-init/frontend/src/app/Common/Messaging.tsx
+++ b/cmd/repo-init/frontend/src/app/Common/Messaging.tsx
@@ -39,3 +39,20 @@ export const SuccessMessage: (props: MessageProps) => (JSX.Element) = (props: Me
   }
   return <div/>
 }
+
+export const InfoMessage: (props: MessageProps) => (JSX.Element) = (props: MessageProps) => {
+  if (props.messages && props.messages.length > 0) {
+    return (
+      <AlertGroup>
+        {props.messages.map((message, i) => {
+          return <Alert key={"info_" + i} variant="info" title={message}/>
+        })}
+      </AlertGroup>
+    );
+  } else if (props.message && props.message.trim()) {
+    return (
+      <Alert variant="info" title={props.message}/>
+    )
+  }
+  return <div/>
+}

--- a/cmd/repo-init/frontend/src/app/Generate/Generate.tsx
+++ b/cmd/repo-init/frontend/src/app/Generate/Generate.tsx
@@ -3,7 +3,7 @@ import {Button} from '@patternfly/react-core';
 import {AuthContext, ConfigContext, WizardContext} from "@app/types";
 import {fetchWithTimeout, marshallConfig} from "@app/utils/utils";
 import {ConfigEditor} from "@app/ConfigEditor/ConfigEditor";
-import {ErrorMessage, SuccessMessage} from "@app/Common/Messaging";
+import {ErrorMessage, SuccessMessage, InfoMessage} from "@app/Common/Messaging";
 
 const Generate: React.FunctionComponent = () => {
   const authContext = useContext(AuthContext);
@@ -11,9 +11,11 @@ const Generate: React.FunctionComponent = () => {
   const configContext = useContext(ConfigContext);
   const [isLoading, setIsLoading] = useState(false);
   const [successMessage, setSuccessMessage] = useState("");
+  const [infoMessage, setInfoMessage] = useState("");
 
   function submit(generatePR: boolean) {
     setIsLoading(true);
+    setInfoMessage("Generating the config, this could take a minute...");
     setSuccessMessage("");
     context.setStep({
       ...context.step,
@@ -21,6 +23,7 @@ const Generate: React.FunctionComponent = () => {
       stepIsComplete: false
     });
     fetchWithTimeout(process.env.REACT_APP_API_URI + '/configs?generatePR=' + generatePR, {
+      timeout: 120000,
       method: 'POST',
       headers: {
         'Accept': 'application/json',
@@ -35,6 +38,7 @@ const Generate: React.FunctionComponent = () => {
           context.setStep({...context.step, errorMessage: "", stepIsComplete: true});
           r.text()
             .then(text => {
+              setInfoMessage("");
               if (generatePR) {
                 setSuccessMessage("Config and Pull Request created!")
               } else {
@@ -63,6 +67,7 @@ const Generate: React.FunctionComponent = () => {
   }
 
   function generateError() {
+    setInfoMessage("");
     context.setStep({
       ...context.step,
       errorMessages: ["An error was caught while generating the config."],
@@ -75,6 +80,7 @@ const Generate: React.FunctionComponent = () => {
     <ConfigEditor readOnly={true}/>
     <ErrorMessage messages={context.step.errorMessages}/>
     <SuccessMessage message={successMessage}/>
+    <InfoMessage message={infoMessage}/>
     <Button
       variant="primary"
       isLoading={isLoading}

--- a/images/repo-init/Dockerfile
+++ b/images/repo-init/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="eberglin@redhat.com"
 ADD repo-init /usr/bin/repo-init
 
 RUN yum install -y git && \
+    yum install -y podman && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
We need to generate the jobs prior to the commit/pr creation. I also thought of utilizing the the tools that `make jobs` runs inside the repo-init binary itself, but it is doing a lot and most of it would need to be refactored to be accessible here. Ultimately, I decided that the `make jobs` target is better to use as it will remain up to date and is the way that we currently onboard a new repo.

We also need to validate that the tests execute in an image that we have specified so that context needs to be built up for the validation.

Since `make jobs` takes some time I added an info message to make it more user friendly.