### PR TITLE
github-id-group contains only kerberos_id

### DIFF
--- a/cmd/github-ldap-user-group-creator/main.go
+++ b/cmd/github-ldap-user-group-creator/main.go
@@ -207,7 +207,7 @@ func makeGroups(mapping map[string]string, roverGroups map[string][]string, conf
 			Clusters: clustersExceptHive,
 			Group: &userv1.Group{
 				ObjectMeta: metav1.ObjectMeta{Name: groupName, Labels: map[string]string{api.DPTPRequesterLabel: toolName}},
-				Users:      sets.NewString(githubLogin, kerberosId).Delete("").List(),
+				Users:      []string{kerberosId},
 			},
 		}
 	}

--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -60,7 +60,7 @@ func TestMakeGroups(t *testing.T) {
 							Name:   "a-group",
 							Labels: map[string]string{api.DPTPRequesterLabel: toolName},
 						},
-						Users: userv1.OptionalNames{"a", "b"},
+						Users: userv1.OptionalNames{"b"},
 					},
 				},
 				"c-group": {


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2659

The GitHub IDP has been removed on the clusters and thus the github users cannot login into the clusters any more.
We do not need the github user in the group.

