### PR TITLE
autoowners: stop putting fetch time into header

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -263,10 +263,10 @@ func writeOwners(orgRepo orgRepo, httpResult httpResult, cleaner ownersCleaner, 
 	return nil
 }
 
-func makeHeader(destOrg, srcOrg, srcRepo string, fetched time.Time) string {
+func makeHeader(destOrg, srcOrg, srcRepo string) string {
 	lines := []string{
 		doNotEdit,
-		fmt.Sprintf("Fetched from https://github.com/%s/%s root OWNERS on %s", srcOrg, srcRepo, fetched.UTC().Format(time.RFC3339)),
+		fmt.Sprintf("Fetched from https://github.com/%s/%s root OWNERS", srcOrg, srcRepo),
 		"If the repo had OWNERS_ALIASES then the aliases were expanded",
 		fmt.Sprintf("Logins who are not members of '%s' organization were filtered out", destOrg),
 		ownersComment,
@@ -304,7 +304,7 @@ func pullOwners(gc github.Client, configRootDir string, blocklist blocklist, con
 			continue
 		}
 
-		if err := writeOwners(orgRepo, httpResult, cleaner, makeHeader(githubOrg, orgRepo.Organization, orgRepo.Repository, time.Now())); err != nil {
+		if err := writeOwners(orgRepo, httpResult, cleaner, makeHeader(githubOrg, orgRepo.Organization, orgRepo.Repository)); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -24,9 +23,9 @@ func assertEqual(t *testing.T, actual, expected interface{}) {
 }
 
 func TestMakeHeader(t *testing.T) {
-	actual := makeHeader("destination", "source", "src-repo", time.Unix(123456789, 0))
+	actual := makeHeader("destination", "source", "src-repo")
 	expected := `# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
-# Fetched from https://github.com/source/src-repo root OWNERS on 1973-11-29T21:33:09Z
+# Fetched from https://github.com/source/src-repo root OWNERS
 # If the repo had OWNERS_ALIASES then the aliases were expanded
 # Logins who are not members of 'destination' organization were filtered out
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md


### PR DESCRIPTION
Technically a nice idea, but it results in a daily super-churn: https://github.com/openshift/release/pull/26399/files

I considered to make the tool smarter (compare the existing OWNERS files and only change the header when the content fails) but because we have two types of OWNERS files, we need to handle cases like files missing and varius errors etc, I decided it is not worth the hassle. The information about when the file was last changed will be stored in `git` so putting it to header is just convenience.

/cc @hongkailiu @openshift/test-platform 