### PR TITLE
add 'make' to repo-init image

### DIFF
--- a/images/repo-init/Dockerfile
+++ b/images/repo-init/Dockerfile
@@ -5,6 +5,7 @@ ADD repo-init /usr/bin/repo-init
 
 RUN yum install -y git && \
     yum install -y podman && \
+    yum install -y make && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
Error from repo-init-apiserver:
`{"component":"repo-init-apiserver","error":"exec: \"make\": executable file not found in $PATH","file":"/go/src/github.com/openshift/ci-tools/cmd/repo-init/api.go:636","func":"main.server.generateConfig","level":"error","msg":"failed to make jobs","severity":"error","time":"2022-02-22T14:12:46Z"}`