### PR TITLE
use tool binaries directly to mimic 'make jobs'

### DIFF
--- a/images/repo-init/Dockerfile
+++ b/images/repo-init/Dockerfile
@@ -1,11 +1,9 @@
 FROM quay.io/centos/centos:stream8
-LABEL maintainer="eberglin@redhat.com"
+LABEL maintainer="sgoeddel@redhat.com"
 
 ADD repo-init /usr/bin/repo-init
 
 RUN yum install -y git && \
-    yum install -y podman && \
-    yum install -y make && \
     yum clean all && \
     rm -rf /var/cache/yum
 


### PR DESCRIPTION
Utilizing the tools that comprise `make jobs` directly following @petr-muller's comment here: https://github.com/openshift/ci-tools/pull/2688#discussion_r811449206.
I wasn't able to get this to work by just doing `make jobs` even when including `podman` and `make` in the image.