### PR TITLE
determinize-prow-config: use strict mode to fail when there is an unknown key

### DIFF
--- a/cmd/determinize-prow-config/main.go
+++ b/cmd/determinize-prow-config/main.go
@@ -68,16 +68,14 @@ func main() {
 
 func updateProwConfig(configDir, shardingBaseDir string) error {
 	configPath := path.Join(configDir, config.ProwConfigFile)
-	agent := prowconfig.Agent{}
 	var additionalConfigs []string
 	if shardingBaseDir != "" {
 		additionalConfigs = append(additionalConfigs, shardingBaseDir)
 	}
-	if err := agent.Start(configPath, "", additionalConfigs, "_prowconfig.yaml"); err != nil {
-		return fmt.Errorf("could not load Prow configuration: %w", err)
+	config, err := prowconfig.LoadStrict(configPath, "", additionalConfigs, "_prowconfig.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to load Prow config in strict mode: %w", err)
 	}
-
-	config := agent.Config()
 
 	if shardingBaseDir != "" {
 		pc, err := shardProwConfig(&config.ProwConfig, afero.NewBasePathFs(afero.NewOsFs(), shardingBaseDir))


### PR DESCRIPTION
In order to not have a situation where running `make prow-config` causes us to silently lose configuration due to improper indentation or misnaming a key we should load the config in strict mode.

There is an existing function in test-infra to do this, but `agent.Start` doesn't utilize it. I considered adding a flag to that method to trigger that behavior, but we don't need to be using `agent.Start` here anyways. We can just load the config once, in strict mode, and then let the rest of the functionality follow as normal.