### PR TITLE
cmd/ci-operator: Trust suite names in writeJUnit

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1548,6 +1548,7 @@ func (o *options) writeFailingJUnit(errs []error) {
 	suites := &junit.TestSuites{
 		Suites: []*junit.TestSuite{
 			{
+				Name:      "job",
 				NumTests:  uint(len(errs)),
 				NumFailed: uint(len(errs)),
 				TestCases: testCases,
@@ -1563,7 +1564,6 @@ func (o *options) writeJUnit(suites *junit.TestSuites, name string) error {
 	if suites == nil {
 		return nil
 	}
-	suites.Suites[0].Name = name
 	sort.Slice(suites.Suites, func(i, j int) bool {
 		return suites.Suites[i].Name < suites.Suites[j].Name
 	})

--- a/pkg/steps/run.go
+++ b/pkg/steps/run.go
@@ -39,7 +39,9 @@ func Run(ctx context.Context, graph api.StepGraph) (*junit.TestSuites, []api.CIO
 
 	suites := &junit.TestSuites{
 		Suites: []*junit.TestSuite{
-			{},
+			{
+				Name: "step graph",
+			},
 		},
 	}
 	suite := suites.Suites[0]

--- a/test/e2e/simple/artifacts/junit_operator.xml
+++ b/test/e2e/simple/artifacts/junit_operator.xml
@@ -1,5 +1,5 @@
 <testsuites>
-  <testsuite name="operator" tests="8" skipped="0" failures="0" time="whatever">
+  <testsuite name="step graph" tests="8" skipped="0" failures="0" time="whatever">
     <testcase name="All images are built and tagged into stable" time="whatever"></testcase>
     <testcase name="Clone the correct source code into an image and tag it as src" time="whatever"></testcase>
     <testcase name="Create the release image &#34;latest&#34; containing all images built by this job" time="whatever"></testcase>


### PR DESCRIPTION
Way back in 12c1a0d704, it seemed like there might be a single suite, so clobbering the name with the writeJUnit argument was reasonable.  But 26ebc68367 (#1007) added sorting code that only makes sense if some JUnit may contain multiple suites.  Only clobbering the name on whichever suite happened to be first (before sorting!) doesn't seem like an internally-consistent approach.

With this commit, I'm pivoting to consistently trust the suite data to contain names, and I've updated any suites I've found in the code to declare those names as well.