### PR TITLE
Fixing prerelease support for multiarch

### DIFF
--- a/pkg/release/prerelease/client.go
+++ b/pkg/release/prerelease/client.go
@@ -16,7 +16,7 @@ import (
 
 // endpoint determines the API endpoint to use for a prerelease
 func endpoint(prerelease api.Prerelease) string {
-	return fmt.Sprintf("%s/4-stable/latest", candidate.ServiceHost(prerelease.Product, prerelease.Architecture))
+	return fmt.Sprintf("%s/4-stable%s/latest", candidate.ServiceHost(prerelease.Product, prerelease.Architecture), candidate.Architecture(prerelease.Architecture))
 }
 
 func defaultFields(prerelease api.Prerelease) api.Prerelease {

--- a/pkg/release/prerelease/client_test.go
+++ b/pkg/release/prerelease/client_test.go
@@ -34,21 +34,21 @@ func TestEndpoint(t *testing.T) {
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitecturePPC64le,
 			},
-			output: "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://ppc64le.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-ppc64le/latest",
 		},
 		{
 			input: api.Prerelease{
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitectureS390x,
 			},
-			output: "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://s390x.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-s390x/latest",
 		},
 		{
 			input: api.Prerelease{
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitectureARM64,
 			},
-			output: "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest",
+			output: "https://arm64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable-arm64/latest",
 		},
 	}
 


### PR DESCRIPTION
Requires ${arch} -> `4-stable-${arch}` instead of `4-stable` for all architectures

/assign @petr-muller 