### PR TITLE
pkg/steps/multi_stage: Log phase result

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -437,17 +437,21 @@ func (s *multiStageTestStep) runSteps(
 
 	err = utilerrors.NewAggregate(errs)
 	finished := time.Now()
+	duration := finished.Sub(start)
 	testCase := &junit.TestCase{
 		Name:      fmt.Sprintf("Run multi-stage test %s phase", phase),
-		Duration:  finished.Sub(start).Seconds(),
+		Duration:  duration.Seconds(),
 		SystemOut: fmt.Sprintf("The collected steps of multi-stage phase %s.", phase),
 	}
+	verb := "succeeded"
 	if err != nil {
+		verb = "failed"
 		testCase.FailureOutput = &junit.FailureOutput{
 			Output: err.Error(),
 		}
 	}
 	s.subTests = append(s.subTests, testCase)
+	logrus.Infof("Step phase %s %s after %s.", phase, verb, duration.Truncate(time.Second))
 
 	return err
 }


### PR DESCRIPTION
d5ac60199f (#2697) added JUnit output for whether the phase passed or failed.  It also added logging to the start of the phase.  But it did not add logging around phase completion.  This commit adds that phase-completion logging.  Besides making the phase boundaries clearer to folks reading the logs, it also allows for CI-search queries like:

```console
$ curl -s 'https://search.ci.openshift.org/search?maxAge=24h&type=build log&search=test+pre+phase&search=test+test+phase&search=Using+namespace+https'
```

to combine information about the build cluster (currently only 'Using namespace https...' in the build log with no JUnit exposure) and the phase status (in JUnit since d5ac60199f, but going into the build log too with this commit).