### PR TITLE
ci-operator: improve error message for invalid `.ci-operator.yaml`

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/openshift/ci-tools/pkg/validation"
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
@@ -871,6 +872,17 @@ func defaultImageFromReleaseTag(alias string, base api.ImageStreamTagReference, 
 	return base
 }
 
+// validateCIOperatorInrepoConfig validates the content of the in-repo .ci-operator.yaml file
+// These need to be validated separately because they are dynamically loaded by ci-operator at runtime and are part
+// of the tested repository, not static configuration validated by Validator.
+func validateCIOperatorInrepoConfig(inrepoConfig *api.CIOperatorInrepoConfig) error {
+	root := inrepoConfig.BuildRootImage
+	if root.Namespace == "" || root.Name == "" || root.Tag == "" {
+		return fmt.Errorf("invalid .ci-operator.yaml: all build_root_image members (namespace, name, tag) must be non-empty")
+	}
+	return nil
+}
+
 func buildRootImageStreamFromRepository(readFile readFile) (*api.ImageStreamTagReference, error) {
 	data, err := readFile(api.CIOperatorInrepoConfigFileName)
 	if err != nil {
@@ -880,7 +892,8 @@ func buildRootImageStreamFromRepository(readFile readFile) (*api.ImageStreamTagR
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s: %w", api.CIOperatorInrepoConfigFileName, err)
 	}
-	return &config.BuildRootImage, nil
+
+	return &config.BuildRootImage, validateCIOperatorInrepoConfig(&config)
 }
 
 func ensureImageStreamTag(ctx context.Context, client ctrlruntimeclient.Client, isTagRef *api.ImageStreamTagReference, second time.Duration) {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/openshift/ci-tools/pkg/validation"
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -54,7 +54,7 @@ type configContext struct {
 	pipelineImages map[api.PipelineImageStreamTagReference]string
 }
 
-// newConfigContext creates a top-level, empty context.
+// NewConfigContext creates a top-level, empty context.
 func NewConfigContext() *configContext {
 	return &configContext{
 		pipelineImages: make(map[api.PipelineImageStreamTagReference]string),
@@ -95,14 +95,14 @@ func (c *configContext) addPipelineImage(name api.PipelineImageStreamTagReferenc
 	return nil
 }
 
-// ValidateAtRuntime validates all the configuration's values without knowledge of config
+// IsValidRuntimeConfiguration validates all the configuration's values without knowledge of config
 // repo structure
 func IsValidRuntimeConfiguration(config *api.ReleaseBuildConfiguration) error {
 	v := newSingleUseValidator()
 	return v.validateConfiguration(NewConfigContext(), config, "", "", false)
 }
 
-// ValidateResolved behaves as ValidateAtRuntime and also validates that all
+// IsValidResolvedConfiguration behaves as ValidateAtRuntime and also validates that all
 // test steps are fully resolved.
 func IsValidResolvedConfiguration(config *api.ReleaseBuildConfiguration) error {
 	config.Default()
@@ -110,7 +110,7 @@ func IsValidResolvedConfiguration(config *api.ReleaseBuildConfiguration) error {
 	return v.validateConfiguration(NewConfigContext(), config, "", "", true)
 }
 
-// Validate validates all the configuration's values.
+// IsValidConfiguration validates all the configuration's values.
 func IsValidConfiguration(config *api.ReleaseBuildConfiguration, org, repo string) error {
 	config.Default()
 	v := newSingleUseValidator()


### PR DESCRIPTION
Improve (make explicit) the error message given when `.ci-operator.yaml` is present and is a valid YAML, but not the yaml we expect
