### PR TITLE
ci-operator-configresolver: remove defunct URLs

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -153,12 +153,6 @@ func main() {
 
 	uisimplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root
 		l(""),
-		l("help",
-			l("adding-components"),
-			l("examples"),
-			l("ci-operator"),
-			l("leases"),
-		),
 		l("search"),
 		l("job"),
 		l("reference"),


### PR DESCRIPTION
These pages have long been moved to https://docs.ci.openshift.org and
are no longer served.