### PR TITLE
sprint-automation: add a role digest for the following week

### DIFF
--- a/cmd/sprint-automation/README.md
+++ b/cmd/sprint-automation/README.md
@@ -1,0 +1,14 @@
+# Sprint-automation
+
+Test Platform's daily helper. Utilizes slack and pager duty to do things such as:
+- Remind `team-dp-testplatform` of our rotating positions, and cards awaiting acceptance
+- Send the daily intake digest to the intake role
+- Send reminders about next week's roles
+- Ensure that our aliases are staffed
+- Remind triage of necessary upgrades
+
+# Local testing
+You can test out `sprint-automation` utilizing the `dptp-robot-testing` and the `hack/local-sprint-automation.sh` script:
+- Make sure to join the `dptp-robot-testing` slack space.
+- Run the `hack/local-sprint-automation.sh` script like so: `bash local-sprint-automation.sh`
+- Now you can go into `dptp-robot-testing` and watch the output of your local `sprint-automation` run.

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -327,6 +327,13 @@ func sendNextWeeksRoleDigest(client *pagerduty.Client, slackClient *slack.Client
 	userIdsByRole, errs := usersOnCallAtTime(client, slackClient, nextWeek)
 	if len(errs) > 0 {
 		errors = append(errors, errs...)
+		msg := "Could not get rotating roles from PagerDuty."
+		err := kerrors.NewAggregate(errors)
+		if len(userIdsByRole) == 0 {
+			logrus.WithError(err).Fatal(msg)
+		} else {
+			logrus.WithError(err).Error(msg)
+		}
 	}
 
 	// Invert to group all roles for each userId as a user can be in multiple roles

--- a/hack/local-sprint-automation.sh
+++ b/hack/local-sprint-automation.sh
@@ -29,4 +29,4 @@ OC extract secret/jira-token-dptp-bot --keys token --to "${data}/jira"
 OC extract secret/pagerduty --keys token --to "${data}/pd"
 
 os::log::info "Running sprint-automation"
-sprint-automation --week-start=true --slack-token-path "${data}/oauth_token" --pager-duty-token-file="${data}/pd/token" --jira-bearer-token-file="${data}/jira/token" --jira-endpoint=https://issues.redhat.com --log-level=trace
+go run ./cmd/sprint-automation --week-start=true --slack-token-path "${data}/oauth_token" --pager-duty-token-file="${data}/pd/token" --jira-bearer-token-file="${data}/jira/token" --jira-endpoint=https://issues.redhat.com --log-level=trace

--- a/hack/local-sprint-automation.sh
+++ b/hack/local-sprint-automation.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+function cleanup() {
+  return_code=$?
+  os::cleanup::all
+  os::util::describe_return_code "${return_code}"
+  exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+if [[ -z "${RELEASE_REPO_DIR:-}" ]]; then
+  os::log::fatal "\$RELEASE_REPO_DIR is required"
+fi
+
+data="${BASETMPDIR}/data"
+mkdir -p "${data}"
+mkdir -p "${data}/jira"
+mkdir -p "${data}/pd"
+
+function OC() {
+	oc --context app.ci --namespace ci --as system:admin "$@"
+}
+
+os::log::info "Extracting production data we need to run sprint-automation..."
+OC extract secret/slack-credentials-dptp-bot-alpha --keys oauth_token --to "${data}"
+OC extract secret/jira-token-dptp-bot --keys token --to "${data}/jira"
+OC extract secret/pagerduty --keys token --to "${data}/pd"
+
+os::log::info "Running sprint-automation"
+sprint-automation --week-start=true --slack-token-path "${data}/oauth_token" --pager-duty-token-file="${data}/pd/token" --jira-bearer-token-file="${data}/jira/token" --jira-endpoint=https://issues.redhat.com --log-level=trace


### PR DESCRIPTION
This adds the role digest mentioned in [DPTP-2432](https://issues.redhat.com/browse/DPTP-2432).
It also adds an easy way to test using our testing slack, and a README describing `sprint-automation`.
I still want to follow up with an "on demand" view of upcoming on call role's, but that will use the `slack-bot` and be more complex.

Next up:
add a new job to `infra-periodics.yaml` that runs weekly on mondays using the new `week-start` flag. Also, will need to stop the current `periodic-sprint-automation` from running on mondays. I think the work I've done here will make it easier to fix [DPTP-2403](https://issues.redhat.com/browse/DPTP-2403) as well, by allowing us to query for active roles as of noon UTC on mondays.