### PR TITLE
provide different secrets for QE dedicated cluster profiles

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1390,7 +1390,7 @@ func (p ClusterProfile) LeaseType() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "azure-qe", "azuremag-qe", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "kubevirt", "aws-cpaas", "osd-ephemeral":
+	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "alibaba", "azure-2", "azure4", "azure-arc", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "kubevirt", "aws-cpaas", "osd-ephemeral":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -290,13 +290,14 @@ const (
 )
 
 func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterType string) corev1.Volume {
-	// AWS-2 and CPaaS and GCP2 PacketAssisted and PacketSNO need a different secret that should be provided to jobs
-	// AWS-2 and CPaaS and GCP2 need a different secret that should be provided to jobs
+	// AWS-2 and CPaaS and GCP2 PacketAssisted and PacketSNO and AzureQE and AzureMagQE need a different secret that should be provided to jobs
 	if profile == cioperatorapi.ClusterProfileAWSCPaaS ||
 		profile == cioperatorapi.ClusterProfileAWS2 ||
 		profile == cioperatorapi.ClusterProfileGCP2 ||
 		profile == cioperatorapi.ClusterProfilePacketAssisted ||
 		profile == cioperatorapi.ClusterProfilePacketSNO ||
+		profile == cioperatorapi.ClusterProfileAzureQE ||
+		profile == cioperatorapi.ClusterProfileAzureMagQE ||
 		profile == cioperatorapi.ClusterProfileAzure2 {
 		clusterType = string(profile)
 	}
@@ -317,8 +318,6 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureArc,
 		cioperatorapi.ClusterProfileAzureStack,
 		cioperatorapi.ClusterProfileAzureMag,
-		cioperatorapi.ClusterProfileAzureQE,
-		cioperatorapi.ClusterProfileAzureMagQE,
 		cioperatorapi.ClusterProfileEquinixOcpMetal,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,


### PR DESCRIPTION
Follow up https://github.com/openshift/ci-tools/pull/2720, after testing, my prow job is still using the `azure4` secrets, the installation did not land into QE dedicated cluster profiles.
