### PR TITLE
only provide one secret for QE cluster profiles without configmap

### DIFF
--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -318,6 +318,8 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureArc,
 		cioperatorapi.ClusterProfileAzureStack,
 		cioperatorapi.ClusterProfileAzureMag,
+		cioperatorapi.ClusterProfileAzureQE,
+		cioperatorapi.ClusterProfileAzureMagQE,
 		cioperatorapi.ClusterProfileEquinixOcpMetal,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,


### PR DESCRIPTION
After https://github.com/openshift/ci-tools/pull/2721, my prow job failed with:

```
The pod could not start because it could not mount the volume "cluster-profile": configmap "cluster-profile-azure-qe" not found
```

This PR fix that.