### PR TITLE
Change retestOrBackoff functionality: Added option enable-on-repo

### DIFF
--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -23,8 +22,6 @@ type githubClient interface {
 	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 }
 
-type arrayFlags []string
-
 type options struct {
 	config configflagutil.ConfigOptions
 	github prowflagutil.GitHubOptions
@@ -37,16 +34,7 @@ type options struct {
 	cacheFile      string
 	cacheRecordAge time.Duration
 
-	enableOnRepo arrayFlags
-}
-
-func (list *arrayFlags) Set(value string) error {
-	*list = append(*list, value)
-	return nil
-}
-
-func (list *arrayFlags) String() string {
-	return strings.Join(*list, ", ")
+	enableOnRepos prowflagutil.Strings
 }
 
 func (o *options) Validate() error {
@@ -70,7 +58,7 @@ func gatherOptions() options {
 	fs.StringVar(&intervalRaw, "interval", "1h", "Parseable duration string that specifies the sync period")
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
 	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
-	fs.Var(&o.enableOnRepo, "enable-on-repo", "Repository is saved in list. It can be used more than once, the result is a list of repositories where we start commenting instead of logging")
+	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository is saved in list. It can be used more than once, the result is a list of repositories where we start commenting instead of logging")
 
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.config} {
 		group.AddFlags(fs)
@@ -114,7 +102,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 
-	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.enableOnRepo)
+	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.enableOnRepos.Strings())
 
 	interrupts.OnInterrupt(func() {
 		if err := gitClient.Clean(); err != nil {

--- a/cmd/better-retester/main_test.go
+++ b/cmd/better-retester/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+func TestGatherOptions(t *testing.T) {
+	expected := []string{"org/repo", "other-org/other-repo"}
+	os.Args = []string{"cmd", "--enable-on-repo=org/repo", "--cache-record-age=100h", "--enable-on-repo=other-org/other-repo"}
+
+	actual := gatherOptions()
+
+	if !stringSlicesEqual(actual.enableOnRepo, expected) {
+		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.enableOnRepo)
+	}
+}

--- a/cmd/better-retester/main_test.go
+++ b/cmd/better-retester/main_test.go
@@ -3,26 +3,17 @@ package main
 import (
 	"os"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
-}
 func TestGatherOptions(t *testing.T) {
 	expected := []string{"org/repo", "other-org/other-repo"}
 	os.Args = []string{"cmd", "--enable-on-repo=org/repo", "--cache-record-age=100h", "--enable-on-repo=other-org/other-repo"}
 
 	actual := gatherOptions()
 
-	if !stringSlicesEqual(actual.enableOnRepos.Strings(), expected) {
+	if diff := cmp.Diff(expected, actual.enableOnRepos.Strings()); diff != "" {
 		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.enableOnRepos)
 	}
 }

--- a/cmd/better-retester/main_test.go
+++ b/cmd/better-retester/main_test.go
@@ -22,7 +22,7 @@ func TestGatherOptions(t *testing.T) {
 
 	actual := gatherOptions()
 
-	if !stringSlicesEqual(actual.enableOnRepo, expected) {
-		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.enableOnRepo)
+	if !stringSlicesEqual(actual.enableOnRepos.Strings(), expected) {
+		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.enableOnRepos)
 	}
 }

--- a/cmd/better-retester/retester.go
+++ b/cmd/better-retester/retester.go
@@ -107,9 +107,11 @@ type retestController struct {
 
 	usesGitHubApp bool
 	backoff       *backoffCache
+
+	commentOnRepo []string
 }
 
-func newController(ghClient githubClient, cfg config.Getter, gitClient git.ClientFactory, usesApp bool, cacheFile string, cacheRecordAge time.Duration) *retestController {
+func newController(ghClient githubClient, cfg config.Getter, gitClient git.ClientFactory, usesApp bool, cacheFile string, cacheRecordAge time.Duration, enableOnRepo []string) *retestController {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	ret := &retestController{
 		ghClient:      ghClient,
@@ -118,6 +120,7 @@ func newController(ghClient githubClient, cfg config.Getter, gitClient git.Clien
 		logger:        logger,
 		usesGitHubApp: usesApp,
 		backoff:       &backoffCache{cache: map[string]*PullRequest{}, file: cacheFile, cacheRecordAge: cacheRecordAge, logger: logger},
+		commentOnRepo: enableOnRepo,
 	}
 	if err := ret.backoff.loadFromDisk(); err != nil {
 		logger.WithError(err).Warn("Failed to load backoff cache from disk")

--- a/cmd/better-retester/retester.go
+++ b/cmd/better-retester/retester.go
@@ -108,19 +108,19 @@ type retestController struct {
 	usesGitHubApp bool
 	backoff       *backoffCache
 
-	commentOnRepo []string
+	commentOnRepos []string
 }
 
-func newController(ghClient githubClient, cfg config.Getter, gitClient git.ClientFactory, usesApp bool, cacheFile string, cacheRecordAge time.Duration, enableOnRepo []string) *retestController {
+func newController(ghClient githubClient, cfg config.Getter, gitClient git.ClientFactory, usesApp bool, cacheFile string, cacheRecordAge time.Duration, enableOnRepos []string) *retestController {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	ret := &retestController{
-		ghClient:      ghClient,
-		gitClient:     gitClient,
-		configGetter:  cfg,
-		logger:        logger,
-		usesGitHubApp: usesApp,
-		backoff:       &backoffCache{cache: map[string]*PullRequest{}, file: cacheFile, cacheRecordAge: cacheRecordAge, logger: logger},
-		commentOnRepo: enableOnRepo,
+		ghClient:       ghClient,
+		gitClient:      gitClient,
+		configGetter:   cfg,
+		logger:         logger,
+		usesGitHubApp:  usesApp,
+		backoff:        &backoffCache{cache: map[string]*PullRequest{}, file: cacheFile, cacheRecordAge: cacheRecordAge, logger: logger},
+		commentOnRepos: enableOnRepos,
 	}
 	if err := ret.backoff.loadFromDisk(); err != nil {
 		logger.WithError(err).Warn("Failed to load backoff cache from disk")


### PR DESCRIPTION
First part of changing retestOrBackoff. Option --enable-on-repo will create list of repositories. In this repos retestOrBackoff will be commenting instead of logging.
- I created option enable-on-repo, basic test for gaterOptions method.
- Edit option and retestController struct to contain the list of repositories.