### PR TITLE
Create QE dedicated GCP cluster profile "gcp-qe" (using "SecretVolumeSource")

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -175,8 +175,6 @@ const (
 	primaryOnCallQuery     = "DPTP Primary On-Call"
 	secondaryUSOnCallQuery = "DPTP Secondary On-Call (US)"
 	secondaryEUOnCallQuery = "DPTP Secondary On-Call (EU)"
-	helpdeskQuery          = "DPTP Help Desk"
-	intakeQuery            = "DPTP Intake"
 	roleTriagePrimary      = "@dptp-triage Primary"
 	roleTriageSecondaryUS  = "@dptp-triage Secondary (US)"
 	roleTriageSecondaryEU  = "@dptp-triage Secondary (EU)"
@@ -248,36 +246,46 @@ func users(client *pagerduty.Client, slackClient *slack.Client) (map[string]stri
 func usersOnCallAtTime(client *pagerduty.Client, slackClient *slack.Client, year int, month time.Month, day int) (map[string]string, []error) {
 	var errors []error
 	userIdsByRole := map[string]string{}
-
+	// 7 am UTC is when our PD day begins, and US on-call ends at 10pm UTC. Query 8 am - 9 pm for safe results
+	dayStart := time.Date(year, month, day, 8, 0, 1, 0, time.UTC)
+	dayEnd := dayStart.Add(13 * time.Hour).Add(-2 * time.Second)
 	for _, item := range []struct {
-		role  string
-		query string
+		role         string
+		query        string
+		since, until time.Time
 	}{
 		{
 			role:  roleTriagePrimary,
 			query: primaryOnCallQuery,
+			since: dayStart,
+			until: dayEnd,
 		},
 		{
 			role:  roleTriageSecondaryUS,
 			query: secondaryUSOnCallQuery,
+			since: dayStart,
+			until: dayEnd,
 		},
 		{
 			role:  roleTriageSecondaryEU,
 			query: secondaryEUOnCallQuery,
+			since: dayStart,
+			until: dayEnd,
 		},
 		{
 			role:  roleHelpdesk,
-			query: helpdeskQuery,
+			query: primaryOnCallQuery,
+			since: dayStart.Add(-7 * 24 * time.Hour),
+			until: dayEnd.Add(-7 * 24 * time.Hour),
 		},
 		{
 			role:  roleIntake,
-			query: intakeQuery,
+			query: primaryOnCallQuery,
+			since: dayStart.Add(-2 * 7 * 24 * time.Hour),
+			until: dayEnd.Add(-2 * 7 * 24 * time.Hour),
 		},
 	} {
-		// 7 am UTC is when our PD day begins, and US on-call ends at 10pm UTC. Query 8 am - 9 pm for safe results
-		dayStart := time.Date(year, month, day, 8, 0, 1, 0, time.UTC)
-		dayEnd := dayStart.Add(13 * time.Hour).Add(-2 * time.Second)
-		pagerDutyUser, err := userOnCallDuring(client, item.query, dayStart, dayEnd)
+		pagerDutyUser, err := userOnCallDuring(client, item.query, item.since, item.until)
 		if err != nil {
 			errors = append(errors, fmt.Errorf("could not get PagerDuty user for %s: %w", item.role, err))
 			continue
@@ -298,41 +306,20 @@ func userOnCallDuring(client *pagerduty.Client, query string, since, until time.
 		return nil, fmt.Errorf("could not query PagerDuty for the %s on-call schedule: %w", query, err)
 	}
 	if len(scheduleResponse.Schedules) != 1 {
-		return nil, fmt.Errorf("did not get exactly one schedule when querying PagerDuty for the '%s' on-call schedule: %v", query, scheduleResponse.Schedules)
+		return nil, fmt.Errorf("did not get exactly one schedule when querying PagerDuty for the %s on-call schedule: %v", query, scheduleResponse.Schedules)
 	}
-	schedule := scheduleResponse.Schedules[0]
 
-	users, err := client.ListOnCallUsers(schedule.ID, pagerduty.ListOnCallUsersOptions{
+	users, err := client.ListOnCallUsers(scheduleResponse.Schedules[0].ID, pagerduty.ListOnCallUsersOptions{
 		Since: since.String(),
 		Until: until.String(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not query PagerDuty for the %s on-call: %w", query, err)
 	}
-	if len(users) == 0 {
-		return nil, fmt.Errorf("did not get any users when querying PagerDuty for the '%s' on-call: %v", query, users)
-	} else if len(users) == 1 {
-		return &users[0], nil
+	if len(users) != 1 {
+		return nil, fmt.Errorf("did not get exactly one user when querying PagerDuty for the %s on-call: %v", query, users)
 	}
-
-	// more than 1 user means there must be an override, determine who the override is associated with
-	overrides, err := client.ListOverrides(schedule.ID, pagerduty.ListOverridesOptions{
-		Since: since.String(),
-		Until: until.String(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("could not query PagerDuty for the '%s' overrides: %w", query, err)
-	}
-	if len(overrides.Overrides) != 1 {
-		return nil, fmt.Errorf("did not get exactly one override when querying PagerDuty for the '%s' overrides: %v", query, overrides)
-	}
-	override := overrides.Overrides[0]
-
-	user, err := client.GetUser(override.User.ID, pagerduty.GetUserOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("could not get User: %s associated with the override: %v", override.User.ID, override)
-	}
-	return user, nil
+	return &users[0], nil
 }
 
 func sendNextWeeksRoleDigest(client *pagerduty.Client, slackClient *slack.Client) error {

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -329,6 +329,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureQE,
 		cioperatorapi.ClusterProfileAzureMagQE,
 		cioperatorapi.ClusterProfileEquinixOcpMetal,
+		cioperatorapi.ClusterProfileGCPQE,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -329,7 +329,6 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureQE,
 		cioperatorapi.ClusterProfileAzureMagQE,
 		cioperatorapi.ClusterProfileEquinixOcpMetal,
-		cioperatorapi.ClusterProfileGCPQE,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,


### PR DESCRIPTION
Cont. to https://github.com/openshift/ci-tools/pull/2727.

1. With the last PR, "ProjectedVolumeSource" is expected for the new cluster profile, but jobs using the profile would fail due to lack of the config-map "gcp-qe".
2. On considering that, the secrets data structures defined on [Vault](https://vault.ci.openshift.org/ui/vault/auth?with=oidc%2F) of different cloud providers are similar, I'd like to try "SecretVolumeSource" for the GCP profile and see if it can work. Or any suggestion? Thanks in advance! 

