### PR TITLE
Change retestOrBackoff functionality: Added method createComment, Edited retestOrBackoff funcionality

### DIFF
--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -103,7 +103,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 
-	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.enableOnRepos.Strings())
+	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.enableOnRepos)
 
 	interrupts.OnInterrupt(func() {
 		if err := gitClient.Clean(); err != nil {

--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -20,6 +20,7 @@ type githubClient interface {
 	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
 	GetRef(string, string, string) (string, error)
 	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
+	CreateComment(owner, repo string, number int, comment string) error
 }
 
 type options struct {

--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/interrupts"
 )
 
@@ -21,6 +23,21 @@ type githubClient interface {
 	GetRef(string, string, string) (string, error)
 	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 	CreateComment(owner, repo string, number int, comment string) error
+}
+
+type MyFakeClient struct {
+	*fakegithub.FakeClient
+}
+
+func (f *MyFakeClient) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
+	return nil
+}
+
+func (f *MyFakeClient) GetRef(owner, repo, ref string) (string, error) {
+	if owner == "failed test" {
+		return "", fmt.Errorf("failed")
+	}
+	return "abcde", nil
 }
 
 type options struct {

--- a/cmd/better-retester/main.go
+++ b/cmd/better-retester/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"time"
 
@@ -14,7 +13,6 @@ import (
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/interrupts"
 )
 
@@ -23,21 +21,6 @@ type githubClient interface {
 	GetRef(string, string, string) (string, error)
 	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 	CreateComment(owner, repo string, number int, comment string) error
-}
-
-type MyFakeClient struct {
-	*fakegithub.FakeClient
-}
-
-func (f *MyFakeClient) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
-	return nil
-}
-
-func (f *MyFakeClient) GetRef(owner, repo, ref string) (string, error) {
-	if owner == "failed test" {
-		return "", fmt.Errorf("failed")
-	}
-	return "abcde", nil
 }
 
 type options struct {

--- a/cmd/better-retester/retester_test.go
+++ b/cmd/better-retester/retester_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
@@ -13,10 +15,11 @@ import (
 )
 
 func TestRetestOrBackoff(t *testing.T) {
-	ghc := fakegithub.NewFakeClient()
+	ghc := &MyFakeClient{fakegithub.NewFakeClient()}
 	var name githubv4.String = "repo"
 	var notEnabledRepo githubv4.String = "other-repo"
 	var owner githubv4.String = "org"
+	var fail githubv4.String = "failed test"
 	var num githubv4.Int = 123
 	var num2 githubv4.Int = 321
 	pr123 := github.PullRequest{}
@@ -27,10 +30,11 @@ func TestRetestOrBackoff(t *testing.T) {
 	enableOnRepos := prowflagutil.NewStrings("org/repo")
 
 	testCases := []struct {
-		name     string
-		pr       tide.PullRequest
-		c        *retestController
-		expected string
+		name          string
+		pr            tide.PullRequest
+		c             *retestController
+		expected      string
+		expectedError error
 	}{
 		{
 			name: "basic case",
@@ -70,16 +74,41 @@ func TestRetestOrBackoff(t *testing.T) {
 			},
 			expected: "",
 		},
+		{
+			name: "failed test",
+			pr: tide.PullRequest{
+				Number: num2,
+				Author: struct{ Login githubv4.String }{Login: fail},
+				Repository: struct {
+					Name          githubv4.String
+					NameWithOwner githubv4.String
+					Owner         struct{ Login githubv4.String }
+				}{Name: notEnabledRepo, Owner: struct{ Login githubv4.String }{Login: fail}},
+			},
+			c: &retestController{
+				ghClient:       ghc,
+				logger:         logger,
+				backoff:        &backoffCache{cache: map[string]*PullRequest{}, logger: logger},
+				commentOnRepos: enableOnRepos.StringSet(),
+			},
+			expected:      "",
+			expectedError: fmt.Errorf("failed"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.c.retestOrBackoff(tc.pr)
-			actual := ""
-			if len(ghc.IssueComments[int(tc.pr.Number)]) != 0 {
-				actual = ghc.IssueComments[int(tc.pr.Number)][0].Body
+			err := tc.c.retestOrBackoff(tc.pr)
+			if diff := cmp.Diff(tc.expectedError, err, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("Error differs from expected:\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+			if tc.expectedError == nil {
+				actual := ""
+				if len(ghc.IssueComments[int(tc.pr.Number)]) != 0 {
+					actual = ghc.IssueComments[int(tc.pr.Number)][0].Body
+				}
+				if diff := cmp.Diff(tc.expected, actual); diff != "" {
+					t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+				}
 			}
 		})
 	}

--- a/cmd/better-retester/retester_test.go
+++ b/cmd/better-retester/retester_test.go
@@ -1,18 +1,36 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/openshift/ci-tools/pkg/testhelper"
 	"github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
+
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	github "k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/tide"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
+
+type MyFakeClient struct {
+	*fakegithub.FakeClient
+}
+
+func (f *MyFakeClient) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
+	return nil
+}
+
+func (f *MyFakeClient) GetRef(owner, repo, ref string) (string, error) {
+	if owner == "failed test" {
+		return "", fmt.Errorf("failed")
+	}
+	return "abcde", nil
+}
 
 func TestRetestOrBackoff(t *testing.T) {
 	ghc := &MyFakeClient{fakegithub.NewFakeClient()}

--- a/cmd/better-retester/retester_test.go
+++ b/cmd/better-retester/retester_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	github "k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/tide"
+)
+
+func TestRetestOrBackoff(t *testing.T) {
+	ghc := fakegithub.NewFakeClient()
+	var name githubv4.String = "repo"
+	var notEnabledRepo githubv4.String = "other-repo"
+	var owner githubv4.String = "org"
+	var num githubv4.Int = 123
+	var num2 githubv4.Int = 321
+	pr123 := github.PullRequest{}
+	pr321 := github.PullRequest{}
+	ghc.PullRequests = map[int]*github.PullRequest{123: &pr123, 321: &pr321}
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	enableOnRepos := prowflagutil.NewStrings("org/repo")
+
+	testCases := []struct {
+		name     string
+		pr       tide.PullRequest
+		c        *retestController
+		expected string
+	}{
+		{
+			name: "basic case",
+			pr: tide.PullRequest{
+				Number: num,
+				Author: struct{ Login githubv4.String }{Login: owner},
+				Repository: struct {
+					Name          githubv4.String
+					NameWithOwner githubv4.String
+					Owner         struct{ Login githubv4.String }
+				}{Name: name, Owner: struct{ Login githubv4.String }{Login: owner}},
+			},
+			c: &retestController{
+				ghClient:       ghc,
+				logger:         logger,
+				backoff:        &backoffCache{cache: map[string]*PullRequest{}, logger: logger},
+				commentOnRepos: enableOnRepos.StringSet(),
+			},
+			expected: "/retest-required\n\nRemaining retests: 2 against base HEAD abcde and 8 for PR HEAD  in total\n",
+		},
+		{
+			name: "no comment",
+			pr: tide.PullRequest{
+				Number: num2,
+				Author: struct{ Login githubv4.String }{Login: owner},
+				Repository: struct {
+					Name          githubv4.String
+					NameWithOwner githubv4.String
+					Owner         struct{ Login githubv4.String }
+				}{Name: notEnabledRepo, Owner: struct{ Login githubv4.String }{Login: owner}},
+			},
+			c: &retestController{
+				ghClient:       ghc,
+				logger:         logger,
+				backoff:        &backoffCache{cache: map[string]*PullRequest{}, logger: logger},
+				commentOnRepos: enableOnRepos.StringSet(),
+			},
+			expected: "",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.c.retestOrBackoff(tc.pr)
+			actual := ""
+			if len(ghc.IssueComments[int(tc.pr.Number)]) != 0 {
+				actual = ghc.IssueComments[int(tc.pr.Number)][0].Body
+			}
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/test-infra/prow/github/fakegithub/fakegithub.go
+++ b/vendor/k8s.io/test-infra/prow/github/fakegithub/fakegithub.go
@@ -1108,10 +1108,6 @@ func (f *FakeClient) ListCurrentUserOrgInvitations() ([]github.UserOrgInvitation
 	return ret, nil
 }
 
-func (f *FakeClient) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
-	return nil
-}
-
 func (f *FakeClient) MutateWithGitHubAppsSupport(ctx context.Context, m interface{}, input githubql.Input, vars map[string]interface{}, org string) error {
 	return nil
 }

--- a/vendor/k8s.io/test-infra/prow/github/fakegithub/fakegithub.go
+++ b/vendor/k8s.io/test-infra/prow/github/fakegithub/fakegithub.go
@@ -1108,6 +1108,10 @@ func (f *FakeClient) ListCurrentUserOrgInvitations() ([]github.UserOrgInvitation
 	return ret, nil
 }
 
+func (f *FakeClient) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
+	return nil
+}
+
 func (f *FakeClient) MutateWithGitHubAppsSupport(ctx context.Context, m interface{}, input githubql.Input, vars map[string]interface{}, org string) error {
 	return nil
 }


### PR DESCRIPTION
Second part of changing retestOrBackoff. Option --enable-on-repo will create list of repositories. In this repos retestOrBackoff will be commenting instead of logging.

- I created method createComment.
- Edit retestOrBackoff funcionality to start commenting instead of logging on repositories from the list

Previous PR: https://github.com/openshift/ci-tools/pull/2729