### PR TITLE
DPTP-2760 Resolve console host url while completing options

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -483,6 +483,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 }
 
 func (o *options) Complete() error {
+	o.resolveConsoleHost()
 	jobSpec, err := api.ResolveSpecFromEnv()
 	if err != nil {
 		if len(o.gitRef) == 0 {
@@ -825,8 +826,6 @@ func (o *options) Run() []error {
 	if o.leaseServer != "" && o.leaseServerCredentialsFile != "" {
 		leaseClient = &o.leaseClient
 	}
-
-	o.resolveConsoleHost()
 
 	// load the graph from the configuration
 	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost)

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -45,6 +45,10 @@ func getUsernameAndPassword(credentials string) (string, string, error) {
 
 // Client returns an HTTP or HTTPs client, based on the options
 func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, error) {
+	if consoleHost == "" {
+		consoleHost = "unknown"
+	}
+
 	if o.address == "" || o.credentials == "" {
 		return &noopReporter{}, nil
 	}


### PR DESCRIPTION
/cc @openshift/test-platform 

Description of the problem:
If ci-operator fails to resolve the config from the config resolver, it tries to report the error and exit (see [ci-operator/main.go#L541-L543](https://github.com/openshift/ci-tools/blob/master/cmd/ci-operator/main.go#L541-L543)). This will generate another error while reporting the results to the results server: `response for the report was not 200: cluster field in request is empty` which is expected since by that time the cluster field is empty because it's being resolved later in the code.

This PR changes the resolving method while completing the options instead.


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>