### PR TITLE
Create QE dedicated GCP cluster profile "gcp-qe" (using "SecretVolumeSource")

### DIFF
--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -329,6 +329,7 @@ func generateClusterProfileVolume(profile cioperatorapi.ClusterProfile, clusterT
 		cioperatorapi.ClusterProfileAzureQE,
 		cioperatorapi.ClusterProfileAzureMagQE,
 		cioperatorapi.ClusterProfileEquinixOcpMetal,
+		cioperatorapi.ClusterProfileGCPQE,
 		cioperatorapi.ClusterProfileIBMCloud,
 		cioperatorapi.ClusterProfileLibvirtS390x,
 		cioperatorapi.ClusterProfileLibvirtPpc64le,


### PR DESCRIPTION
Cont. to https://github.com/openshift/ci-tools/pull/2727.

1. With the last PR, "ProjectedVolumeSource" is expected for the new cluster profile, but jobs using the profile would fail due to lack of the config-map "gcp-qe".
2. On considering that, the secrets data structures defined on [Vault](https://vault.ci.openshift.org/ui/vault/auth?with=oidc%2F) of different cloud providers are similar, I'd like to try "SecretVolumeSource" for the GCP profile and see if it can work. Or any suggestion? Thanks in advance!