### PR TITLE
pod-scaler: ignore pods with the `ci-workload-autoscaler.openshift.io/scale`=false annotation

### DIFF
--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -141,6 +141,17 @@ func TestMutatePods(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pod marked with ignore annotation",
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					UID:      "705ab4f5-6393-11e8-b7cc-42010a800002",
+					Kind:     metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+					Resource: metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+					Object:   runtime.RawExtension{Raw: []byte(`{"apiVersion": "v1","kind": "Pod","metadata": {"creationTimestamp": null, "name": "somethingelse","namespace": "namespace", "labels": {"openshift.io/build.name": "withlabels"}, "annotations": {"openshift.io/build.name": "withlabels", "ci-workload-autoscaler.openshift.io/scale": "false"}}, "spec":{"containers":[{"name":"test"},{"name":"other"}]}, "status":{}}`)},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_marked_with_ignore_annotation.yaml
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_marked_with_ignore_annotation.yaml
@@ -1,0 +1,7 @@
+Patches: null
+allowed: true
+status:
+  code: 200
+  metadata: {}
+  reason: ignoring pod due to presence of annotation
+uid: ""


### PR DESCRIPTION
ci cost savings requires the ability to specify that a pod should be excluded from pod-scaler mutating its resources. This will be done using a new `ci-workload-autoscaler.openshift.io/scale` annotation. If the value of this is `false` or it is missing the pod-scaler will behave as normal. Otherwise, it will allow the admission without mutating anything.