### PR TITLE
Pod Scaler Producer: use less memory at one time

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -129,10 +129,10 @@ func produce(clients map[string]prometheusapi.API, dataCache cache, ignoreLatest
 				if err := q.execute(interrupts.Context(), metadata, until); err != nil {
 					metadata.logger.WithError(err).Error("Failed to query Prometheus.")
 				}
-
-			}
-			if err := storeCache(dataCache, name, cache, logger); err != nil {
-				logger.WithError(err).Error("Failed to write cached data.")
+				if err := storeCache(dataCache, name, cache, logger); err != nil {
+					logger.WithError(err).Error("Failed to write cached data.")
+				}
+				cache.Clear()
 			}
 		}
 	})

--- a/pkg/pod-scaler/types.go
+++ b/pkg/pod-scaler/types.go
@@ -334,6 +334,12 @@ func (q *CachedQuery) Prune() {
 	}
 }
 
+// Clear clears out the Data and DataByMetaData this is utilized to conserve memory ones the data has been stored
+func (q *CachedQuery) Clear() {
+	q.Data = map[model.Fingerprint]*circonusllhist.HistogramWithoutLookups{}
+	q.DataByMetaData = map[FullMetadata][]model.Fingerprint{}
+}
+
 // TimeRange describes a range of time, inclusive.
 type TimeRange struct {
 	Start time.Time `json:"start"`


### PR DESCRIPTION
`pod-scaler-producer` is using a ton of memory creating histograms. I recently increased the memory limit to `6Gi`, and it still is not enough. A `pprof` showed that this memory is largely being consumed in the binning of the histograms. I believe that simply querying one cluster's prometheus at a time, storing the cached data and then clearing it when done, will significantly reduce memory consumption.