### PR TITLE
Revert "DPTP-2760 Resolve console host url while completing options"

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -483,7 +483,6 @@ func bindOptions(flag *flag.FlagSet) *options {
 }
 
 func (o *options) Complete() error {
-	o.resolveConsoleHost()
 	jobSpec, err := api.ResolveSpecFromEnv()
 	if err != nil {
 		if len(o.gitRef) == 0 {
@@ -826,6 +825,8 @@ func (o *options) Run() []error {
 	if o.leaseServer != "" && o.leaseServerCredentialsFile != "" {
 		leaseClient = &o.leaseClient
 	}
+
+	o.resolveConsoleHost()
 
 	// load the graph from the configuration
 	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost)

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -45,10 +45,6 @@ func getUsernameAndPassword(credentials string) (string, string, error) {
 
 // Client returns an HTTP or HTTPs client, based on the options
 func (o *Options) Reporter(spec *api.JobSpec, consoleHost string) (Reporter, error) {
-	if consoleHost == "" {
-		consoleHost = "unknown"
-	}
-
 	if o.address == "" || o.credentials == "" {
 		return &noopReporter{}, nil
 	}


### PR DESCRIPTION
Reverts openshift/ci-tools#2735

Seeing `WARN[2022-03-30T09:46:19Z] Could not create client for accessing Routes. Will not resolve console URL.  error=must provide non-nil rest.Config to client.New` now, pretty sure the PR is the thing that broke this ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_osp-director-operator/551/pull-ci-openstack-k8s-operators-osp-director-operator-master-golint/1509104703160455168#1:build-log.txt%3A2))