### PR TITLE
Pod Scaler: decrease the interval for querying

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -78,7 +78,7 @@ func produce(clients map[string]prometheusapi.API, dataCache cache, ignoreLatest
 		}
 	} else {
 		execute = func(f func()) {
-			interrupts.TickLiteral(f, 3*time.Hour)
+			interrupts.TickLiteral(f, 2*time.Hour)
 		}
 	}
 	execute(func() {


### PR DESCRIPTION
I was finally able to get `pod-scaler` to get through _all_ of the data by increasing the memory limit to `15Gi` manually (this has since been reverted). Now, the normal limit of `6Gi` is more than enough for it to get through everything with each run. This is due to how much less memory intensive it is to use the data from the bucket cache than to query Prometheus for it. To make sure that we don't run into this in the future we should decrease the interval in which we query Prometheus from `3` hours to `2`. This will result in 1/3rd less data being handled each time.

In a forthcoming PR I am also going to add an alert for `pod-scaler-producer` so that this is noticed more quickly if it occurs again.

For [DPTP-2804](https://issues.redhat.com/browse/DPTP-2804)