### PR TITLE
Add metrics to produce and admission consumer

### DIFF
--- a/cmd/pod-scaler/frontend.go
+++ b/cmd/pod-scaler/frontend.go
@@ -22,8 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	prowConfig "k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
@@ -223,7 +221,6 @@ func serveUI(port, healthPort int, dataDir string, loaders map[string][]*cacheRe
 		nodes = append(nodes, l(name))
 	}
 
-	metrics.ExposeMetrics("pod-scaler", prowConfig.PushGateway{}, flagutil.DefaultMetricsPort)
 	simplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root
 		l(""), // actual UI
 		l("api",

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -16,9 +16,11 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/transport"
+	prowConfig "k8s.io/test-infra/prow/config"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/metrics"
 	pprofutil "k8s.io/test-infra/prow/pjutil/pprof"
 	"k8s.io/test-infra/prow/version"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -148,6 +150,7 @@ func main() {
 	logrus.Infof("%s version %s", version.Name, version.Version)
 
 	pprofutil.Instrument(opts.instrumentationOptions)
+	metrics.ExposeMetrics("pod-scaler", prowConfig.PushGateway{}, opts.instrumentationOptions.MetricsPort)
 
 	var cache cache
 	if opts.cacheDir != "" {

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -51,6 +51,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--mode=consumer.admission",
 		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
+		"--metrics-port=9092",
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)
@@ -92,6 +93,7 @@ func UI(t testhelper.TestingTInterface, dataDir string, parent context.Context, 
 		"--cache-dir", dataDir,
 		"--mode=consumer.ui",
 		"--data-dir", t.TempDir(),
+		"--metrics-port=9093",
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)

--- a/test/e2e/pod-scaler/run/producer.go
+++ b/test/e2e/pod-scaler/run/producer.go
@@ -21,6 +21,7 @@ func Producer(t testhelper.TestingTInterface, dataDir, kubeconfigFile string, ig
 		"--kubeconfig", kubeconfigFile,
 		"--mode=producer",
 		"--produce-once=true",
+		"--metrics-port=9091",
 		fmt.Sprintf("--ignore-latest=%s", ignoreUntil.String()),
 	}
 	start := time.Now()


### PR DESCRIPTION
`pod-scaler-producer` needs an alert so we can tell if it is down and it doesn't `CrashLoopBackOff` endlessly without being noticed. In order to do that, we need to expose metrics first. They were already exposed for the `pod-scaler-ui` so we just need to move them up to be exposed in the producer and the admission consumer as well.

I also had to supply the metrics port in the test files as the default (`9090`) cannot be used for all.