### PR TITLE
repo-init: use correct list of cluster profiles

### DIFF
--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -251,7 +251,7 @@ func (s *server) clusterProfileHandler() http.HandlerFunc {
 		s.disableCORS(w)
 		switch r.Method {
 		case http.MethodGet:
-			marshalled, err := json.Marshal(getClusterProfiles())
+			marshalled, err := json.Marshal(clusterProfileList)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -706,20 +706,4 @@ func configExists(org, repo, releaseRepo string) bool {
 	configPath := path.Join(releaseRepo, "ci-operator", "config", org, repo)
 	_, err := os.Stat(configPath)
 	return err == nil
-}
-
-// getClusterProfiles returns a limited set of cluster profiles to use for e2e testing.
-// TODO: this should be removed when we deprecate cluster profiles.
-func getClusterProfiles() []api.ClusterProfile {
-	return []api.ClusterProfile{
-		api.ClusterProfileAWS,
-		api.ClusterProfileAWSArm64,
-		api.ClusterProfileAWSOSDMSP,
-		api.ClusterProfileAzure,
-		api.ClusterProfileAzure2,
-		api.ClusterProfileAzure4,
-		api.ClusterProfileAzureStack,
-		api.ClusterProfileGCP,
-		api.ClusterProfileAlibabaCloud,
-	}
 }

--- a/cmd/repo-init/api_test.go
+++ b/cmd/repo-init/api_test.go
@@ -23,7 +23,10 @@ func TestClusterProfiles(t *testing.T) {
 	writer := &fakeWriter{}
 	s.clusterProfileHandler()(writer, r)
 
-	expected, _ := json.Marshal(getClusterProfiles())
+	expected, err := json.Marshal(clusterProfileList)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if diff := cmp.Diff(writer.body, expected); diff != "" {
 		t.Fatalf("unexpected response %v", diff)
 	}


### PR DESCRIPTION
This change addresses a number of problems:

- The PR used as an example in our documentation for adding cluster
  profiles incorrectly added a profile to `repo-init`'s list, so others
  have occasionally followed:

  https://docs.ci.openshift.org/docs/how-tos/adding-a-cluster-profile/#registering-a-new-profile

- `repo-init` and its "frontend" unfortunately do not share most of
  their code.

- As a result, they have used independent lists of profiles, which have
  advanced inconsistently.

To that end, I've unified the list of profiles used by both programs.
Since https://github.com/openshift/ci-tools/pull/1509, this list has
been a very reduced subset of all available profiles, so I've restricted
it to those three profiles and added a clarifying comment to discourage
future additions.