### PR TITLE
During aggregation test, do not consider 'initialize' test as a failure

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -554,6 +554,13 @@ func testShouldAlwaysPass(jobName, testName, testSuiteName string) string {
 		// this is only for gathering artifacts.
 		return "used only to collect artifacts"
 	}
+
+	if testName == "initialize" {
+		// initialize test appears only when job run fails so job run will fail anyway
+		//
+		return "ignore initialize"
+	}
+
 	return ""
 }
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/TRT-176

This test always fails on a failure in an aggregation test so no point in reporting it too.