### PR TITLE
prow-job-dispatcher: add options for enabling/disabling clusters

### DIFF
--- a/cmd/prow-job-dispatcher/main_test.go
+++ b/cmd/prow-job-dispatcher/main_test.go
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 var (
 	c = dispatcher.Config{
 		Default: "api.ci",
-		BuildFarm: map[api.Cloud]map[api.Cluster]dispatcher.Filenames{
+		BuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
 			api.CloudAWS: {
 				api.ClusterBuild01: {},
 			},
@@ -143,7 +143,7 @@ func TestDispatchJobs(t *testing.T) {
 		config            *dispatcher.Config
 		jobVolumes        map[string]float64
 		expected          error
-		expectedBuildFarm map[api.Cloud]map[api.Cluster]dispatcher.Filenames
+		expectedBuildFarm map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig
 	}{
 		{
 			name:     "nil config",
@@ -159,7 +159,7 @@ func TestDispatchJobs(t *testing.T) {
 				"pull-ci-openshift-ci-tools-master-e2e":               12,
 				"pull-ci-openshift-cluster-etcd-operator-master-unit": 6,
 			},
-			expectedBuildFarm: map[api.Cloud]map[api.Cluster]dispatcher.Filenames{
+			expectedBuildFarm: map[api.Cloud]map[api.Cluster]*dispatcher.BuildFarmConfig{
 				"aws": {"build01": {FilenamesRaw: []string{"ci-tools-presubmits.yaml"}}},
 				"gcp": {"build02": {FilenamesRaw: []string{"cluster-api-provider-gcp-presubmits.yaml", "cluster-etcd-operator-master-presubmits.yaml", "wildfly-operator-presubmits.yaml"}}},
 			},

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -33,20 +33,22 @@ type Config struct {
 	// Groups maps a group of jobs to a cluster
 	Groups JobGroups `json:"groups"`
 	// BuildFarm maps groups of jobs to a cloud provider, like GCP
-	BuildFarm map[api.Cloud]map[api.Cluster]Filenames `json:"buildFarm,omitempty"`
+	BuildFarm map[api.Cloud]map[api.Cluster]*BuildFarmConfig `json:"buildFarm,omitempty"`
 	// BuildFarmCloud maps sets of clusters to a cloud provider, like GCP
 	BuildFarmCloud map[api.Cloud][]string `json:"-"`
 }
 
-type Filenames struct {
+type BuildFarmConfig struct {
 	FilenamesRaw []string    `json:"filenames,omitempty"`
 	Filenames    sets.String `json:"-"`
+
+	Disabled bool `json:"disabled,omitempty"`
 }
 
 // JobGroups maps a group of jobs to a cluster
 type JobGroups = map[api.Cluster]Group
 
-//Group is a group of jobs
+// Group is a group of jobs
 type Group struct {
 	// a list of job names
 	Jobs []string `json:"jobs,omitempty"`
@@ -172,7 +174,7 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 			}
 		}
 	}
-	//sort for tests
+	// sort for tests
 	sort.Strings(matches)
 	if len(matches) > 1 {
 		return "", false, fmt.Errorf("path %s matches more than 1 regex: %s", path, matches)
@@ -284,7 +286,7 @@ func (config *Config) Validate() error {
 			matches = append(matches, k)
 		}
 	}
-	//sort for tests
+	// sort for tests
 	sort.Strings(matches)
 	if len(matches) > 1 {
 		return fmt.Errorf("there are job names occurring more than once: %s", matches)

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -60,7 +60,7 @@ var (
 
 	configWithBuildFarm = Config{
 		Default: "api.ci",
-		BuildFarm: map[api.Cloud]map[api.Cluster]Filenames{
+		BuildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{
 			api.CloudAWS: {
 				api.ClusterBuild01: {},
 			},
@@ -109,7 +109,7 @@ var (
 		Default:  "api.ci",
 		KVM:      []api.Cluster{api.ClusterBuild02},
 		NoBuilds: []api.Cluster{api.ClusterBuild03},
-		BuildFarm: map[api.Cloud]map[api.Cluster]Filenames{
+		BuildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{
 			api.CloudAWS: {
 				api.ClusterBuild01: {
 					FilenamesRaw: []string{
@@ -162,7 +162,7 @@ var (
 		KVM:               []api.Cluster{api.ClusterBuild02},
 		NoBuilds:          []api.Cluster{api.ClusterBuild03},
 		DetermineE2EByJob: true,
-		BuildFarm: map[api.Cloud]map[api.Cluster]Filenames{
+		BuildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{
 			api.CloudAWS: {
 				api.ClusterBuild01: {
 					FilenamesRaw: []string{
@@ -300,7 +300,7 @@ func TestGetClusterForJob(t *testing.T) {
 			path:    "ci-operator/jobs/openshift-s2i/s2i-wildfly/openshift-s2i-s2i-wildfly-master-postsubmits.yaml",
 		},
 		{
-			//https://github.com/openshift/release/pull/15918
+			// https://github.com/openshift/release/pull/15918
 			name: "error: PR 15918",
 			config: &Config{
 				Default: "api.ci",
@@ -322,7 +322,7 @@ func TestGetClusterForJob(t *testing.T) {
 			expectedErr: fmt.Errorf("path ci-operator/jobs/openshift/openshift-azure/openshift-openshift-azure-infra-periodics.yaml matches more than 1 regex: [.*/openshift-openshift-azure-infra-periodics.yaml$ .*infra-periodics.yaml$]"),
 		},
 		{
-			//https://github.com/openshift/ci-tools/pull/1722
+			// https://github.com/openshift/ci-tools/pull/1722
 			name: "error: PR 1722",
 			config: &Config{
 				Default: "api.ci",
@@ -340,7 +340,7 @@ func TestGetClusterForJob(t *testing.T) {
 			expectedErr: fmt.Errorf("path ci-operator/jobs/kubevirt/kubevirt-ssp-operator/kubevirt-kubevirt-ssp-operator-master-presubmits.yaml matches more than 1 regex: [.*kubevirt-kubevirt-ssp-operator-master-presubmits.yaml$ .*kubevirt-ssp-operator-master-presubmits.yaml$]"),
 		},
 		{
-			//https://github.com/openshift/ci-tools/pull/1722
+			// https://github.com/openshift/ci-tools/pull/1722
 			name: "fix: PR 1722",
 			config: &Config{
 				Default: "api.ci",


### PR DESCRIPTION
Add:
- `--enable-cluster`
- `--disable-cluster`
- `--default-cluster`
    
These options should be helpful for failovers etc. The implementation of
`prow-job-dispatcher` is a little messy, so I ended up removing the
disabled clusters from the structure before the dispatching, and then I
return them back.

Part of: [DPTP-2064](https://issues.redhat.com/browse/DPTP-2064)

/cc @hongkailiu @jmguzik @openshift/test-platform 
