### PR TITLE
sync-rover-group: cannot use the group name openshift-priv-admins

### DIFF
--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -30,24 +30,22 @@ func init() {
 
 func TestMakeGroups(t *testing.T) {
 	testCases := []struct {
-		name                     string
-		openshiftPrivAdmins      sets.String
-		peribolosConfig          string
-		openshiftPrivAdminsGroup string
-		mapping                  map[string]string
-		roverGroups              map[string][]string
-		config                   *group.Config
-		clusters                 sets.String
-		expected                 map[string]GroupClusters
-		expectedErr              error
+		name                string
+		openshiftPrivAdmins sets.String
+		peribolosConfig     string
+		mapping             map[string]string
+		roverGroups         map[string][]string
+		config              *group.Config
+		clusters            sets.String
+		expected            map[string]GroupClusters
+		expectedErr         error
 	}{
 		{
-			name:                     "basic case",
-			peribolosConfig:          "bar",
-			openshiftPrivAdmins:      sets.NewString("a"),
-			openshiftPrivAdminsGroup: "openshift-priv-admins",
-			mapping:                  map[string]string{"a": "b", "c": "c"},
-			roverGroups:              map[string][]string{"old-group-name": {"b", "c"}, "x": {"y", "y"}},
+			name:                "basic case",
+			peribolosConfig:     "bar",
+			openshiftPrivAdmins: sets.NewString("a"),
+			mapping:             map[string]string{"a": "b", "c": "c"},
+			roverGroups:         map[string][]string{"old-group-name": {"b", "c"}, "x": {"y", "y"}},
 			config: &group.Config{
 				ClusterGroups: map[string][]string{"cluster-group-1": {"build01", "build02"}},
 				Groups: map[string]group.Target{
@@ -115,7 +113,7 @@ func TestMakeGroups(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, actualErr := makeGroups(tc.openshiftPrivAdmins, tc.peribolosConfig, tc.openshiftPrivAdminsGroup,
+			actual, actualErr := makeGroups(tc.openshiftPrivAdmins, tc.peribolosConfig,
 				tc.mapping, tc.roverGroups, tc.config, tc.clusters)
 			if diff := cmp.Diff(tc.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)

--- a/pkg/group/config_test.go
+++ b/pkg/group/config_test.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -26,6 +27,11 @@ func TestLoadConfig(t *testing.T) {
 					"some-group":     {},
 				},
 			},
+		},
+		{
+			name:        "cannot use the group name openshift-priv-admins",
+			file:        filepath.Join("testdata", "TestLoadConfig", "openshift_priv_admins.yaml"),
+			expectedErr: fmt.Errorf("failed to validate config file: cannot use the group name openshift-priv-admins in the configuration file"),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/group/testdata/TestLoadConfig/openshift_priv_admins.yaml
+++ b/pkg/group/testdata/TestLoadConfig/openshift_priv_admins.yaml
@@ -1,0 +1,16 @@
+cluster_groups:
+  dp-managed:
+    - build01
+    - build02
+groups:
+  some-group: {}
+  old-group-name:
+    rename_to: new-group-name
+    cluster_groups:
+      - dp-managed
+    clusters:
+      - arm01
+  openshift-private-release-admins:
+    clusters:
+      - app.ci
+    rename_to: openshift-priv-admins


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2811

Prevent https://github.com/openshift/release/pull/27455/files from happening in the future.

