### PR TITLE
Deprecate Incident and Request issue jira types from slack-bot integration

### DIFF
--- a/pkg/jira/issues.go
+++ b/pkg/jira/issues.go
@@ -16,11 +16,9 @@ import (
 const (
 	ProjectDPTP = "DPTP"
 
-	IssueTypeBug      = "Bug"
-	IssueTypeIncident = "Incident"
-	IssueTypeRequest  = "Request"
-	IssueTypeStory    = "Story"
-	IssueTypeTask     = "Task"
+	IssueTypeBug   = "Bug"
+	IssueTypeStory = "Story"
+	IssueTypeTask  = "Task"
 )
 
 // IssueFiler knows how to file an issue in Jira
@@ -140,7 +138,7 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client) (IssueFil
 	for _, t := range project.IssueTypes {
 		filer.issueTypesByName[t.Name] = t
 	}
-	for _, name := range []string{IssueTypeRequest, IssueTypeStory, IssueTypeBug, IssueTypeIncident, IssueTypeTask} {
+	for _, name := range []string{IssueTypeStory, IssueTypeBug, IssueTypeTask} {
 		if _, found := filer.issueTypesByName[name]; !found {
 			return nil, fmt.Errorf("could not find issue type %s in Jira for project %s", name, ProjectDPTP)
 		}

--- a/pkg/slack/modals/consultation/view.go
+++ b/pkg/slack/modals/consultation/view.go
@@ -99,7 +99,7 @@ func helpdeskButtonHandler(updater modals.ViewUpdater) interactions.Handler {
 func issueParameters() modals.JiraIssueParameters {
 	return modals.JiraIssueParameters{
 		Id:        Identifier,
-		IssueType: jira.IssueTypeRequest,
+		IssueType: jira.IssueTypeStory,
 		Template: template.Must(template.New(string(Identifier)).Funcs(modals.BulletListFunc()).Parse(`h3. Requirement
 {{ .` + blockIdRequirement + ` }}
 

--- a/pkg/slack/modals/consultation/view_test.go
+++ b/pkg/slack/modals/consultation/view_test.go
@@ -16,7 +16,7 @@ func TestProcessSubmissionHandler(t *testing.T) {
 		Name: "happy path with additional details",
 		Filer: jira.NewFake(map[jira.IssueRequest]jira.IssueResponse{
 			{
-				IssueType: "Request",
+				IssueType: "Story",
 				Title:     "Please Help Me",
 				Description: `h3. Requirement
 I would like to do something really simple.

--- a/pkg/slack/modals/incident/view.go
+++ b/pkg/slack/modals/incident/view.go
@@ -123,7 +123,7 @@ type slackClient interface {
 func issueParameters(client infoGetter) modals.JiraIssueParameters {
 	return modals.JiraIssueParameters{
 		Id:        Identifier,
-		IssueType: jira.IssueTypeIncident,
+		IssueType: jira.IssueTypeStory,
 		Template: template.Must(template.New(string(Identifier)).Funcs(slackEntityFormatFuncs(client)).Parse(`h3. Summary
 {{ .` + blockIdSummary + ` }}
 

--- a/pkg/slack/modals/incident/view_test.go
+++ b/pkg/slack/modals/incident/view_test.go
@@ -95,7 +95,7 @@ func TestProcessSubmissionHandler(t *testing.T) {
 		Name: "happy path with additional details",
 		Filer: jira.NewFake(map[jira.IssueRequest]jira.IssueResponse{
 			{
-				IssueType: "Incident",
+				IssueType: "Story",
 				Title:     "api.ci Is Broken Again",
 				Description: `h3. Summary
 The bootstrap node auto-approver is down for the fiftieth time.


### PR DESCRIPTION
`Incident` and `Request` Jira issue types will be deprecated. This PR just only changes those issue types into the `Story` type.


/cc @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>