### PR TITLE
ci-operator: wait loooonger for `cli` operator to appear

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -511,7 +511,7 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 	}
 
 	startedWaiting := time.Now()
-	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 6, Duration: 1 * time.Second, Factor: 2}, func() (bool, error) {
+	if err := wait.ExponentialBackoff(wait.Backoff{Steps: 9, Duration: time.Second, Factor: 2}, func() (bool, error) {
 		if err := s.client.Get(ctx, key, streamTag); err != nil {
 			if kerrors.IsNotFound(err) {
 				return false, nil


### PR DESCRIPTION
In https://github.com/openshift/ci-tools/pull/2634 we made this timeout after ~30s but this apparently still happens and @deads2k hates it. Let's try 8m timeout, there's no reason to not do that. When it succeeds, nobody cares about few minutes. When it fails, the failure is still sufficiently fast.

https://search.ci.openshift.org/chart?search=unable+to+wait+for+the+.*+image+in+the+stable+stream+to+populate&maxAge=48h&context=1&type=bug%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Slack thread: https://coreos.slack.com/archives/C01CQA76KMX/p1649352789006809

