### PR TITLE
ci-operator multi-stage: fetch credentials once

### DIFF
--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -138,7 +138,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	if err := s.createSharedDirSecret(ctx); err != nil {
 		return fmt.Errorf("failed to create secret: %w", err)
 	}
-	if err := s.createCredentials(); err != nil {
+	if err := s.createCredentials(ctx); err != nil {
 		return fmt.Errorf("failed to create credentials: %w", err)
 	}
 	if err := s.createCommandConfigMaps(ctx); err != nil {
@@ -321,7 +321,7 @@ func (s *multiStageTestStep) createSharedDirSecret(ctx context.Context) error {
 	return s.client.Create(ctx, secret)
 }
 
-func (s *multiStageTestStep) createCredentials() error {
+func (s *multiStageTestStep) createCredentials(ctx context.Context) error {
 	logrus.Debugf("Creating multi-stage test credentials for %q", s.name)
 	toCreate := map[string]*coreapi.Secret{}
 	for _, step := range append(s.pre, append(s.test, s.post...)...) {
@@ -332,7 +332,7 @@ func (s *multiStageTestStep) createCredentials() error {
 			// small, so we can get away with this string prefixing
 			name := fmt.Sprintf("%s-%s", credential.Namespace, credential.Name)
 			raw := &coreapi.Secret{}
-			if err := s.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: credential.Namespace, Name: credential.Name}, raw); err != nil {
+			if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: credential.Namespace, Name: credential.Name}, raw); err != nil {
 				return fmt.Errorf("could not read source credential: %w", err)
 			}
 			toCreate[name] = &coreapi.Secret{
@@ -349,7 +349,7 @@ func (s *multiStageTestStep) createCredentials() error {
 	}
 
 	for name := range toCreate {
-		if err := s.client.Create(context.TODO(), toCreate[name]); err != nil && !kerrors.IsAlreadyExists(err) {
+		if err := s.client.Create(ctx, toCreate[name]); err != nil && !kerrors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not create source credential: %w", err)
 		}
 	}

--- a/pkg/steps/multi_stage.go
+++ b/pkg/steps/multi_stage.go
@@ -331,6 +331,9 @@ func (s *multiStageTestStep) createCredentials(ctx context.Context) error {
 			// chance we get a second-level collision (ns-a, name) and (ns, a-name) is
 			// small, so we can get away with this string prefixing
 			name := fmt.Sprintf("%s-%s", credential.Namespace, credential.Name)
+			if _, ok := toCreate[name]; ok {
+				continue
+			}
 			raw := &coreapi.Secret{}
 			if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: credential.Namespace, Name: credential.Name}, raw); err != nil {
 				return fmt.Errorf("could not read source credential: %w", err)


### PR DESCRIPTION
```yaml
tests:
- as: test
  literal_steps:
    test:
    - as: test0
      from: root
      commands: "true"
      credentials:
      - namespace: bbguimaraes
        name: test
        mount_path: /tmp/test
      resources: # …
    - # so on for test1 to test7
```

```console
$ ci-operator -v … &> log.txt
$ grep 'secrets/test 200 OK' log.txt
I0412 11:12:58.447473   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 115 milliseconds
I0412 11:12:58.558331   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 108 milliseconds
I0412 11:12:58.668861   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 107 milliseconds
I0412 11:12:58.777998   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 104 milliseconds
I0412 11:12:58.894395   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 113 milliseconds
I0412 11:12:59.004757   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 107 milliseconds
I0412 11:12:59.112059   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 105 milliseconds
I0412 11:12:59.221288   60218 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 105 milliseconds
```

With this change:

```console
$ ci-operator -v … &> log.txt
$ grep 'secrets/test 200 OK' log.txt
I0412 11:21:01.421711   60502 round_trippers.go:454] GET https://api.build01.ci.devcluster.openshift.com:6443/api/v1/namespaces/bbguimaraes/secrets/test 200 OK in 107 milliseconds
```