### PR TITLE
Post ephemeral reply to the messaging user in forum-tesplatform channel

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
 
 	"github.com/openshift/ci-tools/pkg/slack/events"
@@ -14,9 +15,13 @@ const (
 	dptpHelpdeskId = "<@STSR51Q76>"
 )
 
+type ephemeralMessagePoster interface {
+	PostEphemeral(channelID, userID string, options ...slack.MsgOption) (string, error)
+}
+
 // Handler returns a handler that knows how to respond to new messages
 // in forum-testplatform channel that mention @dptp-helpdesk.
-func Handler() events.PartialHandler {
+func Handler(client ephemeralMessagePoster) events.PartialHandler {
 	return events.PartialHandlerFunc("helpdesk",
 		func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
 
@@ -39,6 +44,40 @@ func Handler() events.PartialHandler {
 			}
 			logger.Info("Handling response in forum-testplatform channel...")
 
+			timestamp := event.TimeStamp
+			if event.ThreadTimeStamp != "" {
+				timestamp = event.ThreadTimeStamp
+			}
+
+			responseTimestamp, err := client.PostEphemeral(event.Channel, event.User, slack.MsgOptionBlocks(getResponse()...), slack.MsgOptionTS(timestamp))
+			if err != nil {
+				logger.WithError(err).Warn("Failed to post ephemeral response")
+			} else {
+				logger.Infof("Posted ephemeral message in channel %s to user %s at %s", event.Channel, event.User, responseTimestamp)
+			}
+
 			return true, err
 		})
+}
+
+func getResponse() []slack.Block {
+	sections := []string{
+		":wave: You have reached the Test Platform Help Desk. An assigned engineer will respond in several hours during their working hours.",
+		"Please see if our documentation can be of use: https://docs.ci.openshift.org/docs/",
+		"If this is an urgent CI outage, please ping `(@)dptp-triage`",
+	}
+
+	var blocks []slack.Block
+
+	for _, section := range sections {
+		blocks = append(blocks, &slack.SectionBlock{
+			Type: slack.MBTSection,
+			Text: &slack.TextBlockObject{
+				Type: slack.MarkdownType,
+				Text: section,
+			},
+		})
+	}
+
+	return blocks
 }

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -16,7 +16,7 @@ import (
 // event callbacks for the handlers we know about
 func ForEvents(client *slack.Client, config config.Getter, gcsClient *storage.Client) events.Handler {
 	return events.MultiHandler(
-		helpdesk.Handler(),
+		helpdesk.Handler(client),
 		mention.Handler(client),
 		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),
 	)


### PR DESCRIPTION
Currently, after a user posts a message in forum-tesplatform slack channel, a public auto-response is generated. This PR adds an ephemeral message that is sent to the user.

[DPTP-2748](https://issues.redhat.com/browse/DPTP-2748)
