### PR TITLE
bugzilla-config-manager: do not resolve cluster groups

### DIFF
--- a/cmd/branchingconfigmanagers/bugzilla-config-manager/main.go
+++ b/cmd/branchingconfigmanagers/bugzilla-config-manager/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	configPath := path.Join(opts.pluginConfigDir, config.PluginConfigFile)
 	agent := plugins.ConfigAgent{}
-	if err := agent.Load(configPath, []string{opts.pluginConfigDir}, "_pluginconfig.yaml", false, false); err != nil {
+	if err := agent.Load(configPath, []string{opts.pluginConfigDir}, "_pluginconfig.yaml", false, true); err != nil {
 		logrus.WithError(err).Fatal("failed to load Prow plugin configuration")
 	}
 


### PR DESCRIPTION
`bugzilla-config-manager` was suffering from a similar problem to [DPTP-2721](https://issues.redhat.com//browse/DPTP-2721) which was fixed in https://github.com/openshift/ci-tools/pull/2647: it expanded the clustergroup on save.