### PR TITLE
bugzilla-config-manager: fix 4.9/4.10 sorting issue

### DIFF
--- a/cmd/branchingconfigmanagers/bugzilla-config-manager/main.go
+++ b/cmd/branchingconfigmanagers/bugzilla-config-manager/main.go
@@ -217,7 +217,7 @@ func reconcileConfig(cfg *plugins.Bugzilla, developmentVersion *ocplifecycle.Maj
 	// * if not latestGA: add $Version+1.z to DependentBugTargetReleases
 	// * TargetRelease: $VERSION.z
 	// * ValidateByDefault: true
-	sort.Slice(gaVersions, func(i, j int) bool { return gaVersions[i].String() < gaVersions[j].String() })
+	sort.Slice(gaVersions, func(i, j int) bool { return gaVersions[i].Less(gaVersions[j]) })
 	for idx, gaVersion := range gaVersions {
 		isLatestGA := idx == len(gaVersions)-1
 

--- a/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/lifecycle_multiple_ga_410_bigger_49.yaml
+++ b/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/lifecycle_multiple_ga_410_bigger_49.yaml
@@ -1,0 +1,7 @@
+ocp:
+  "4.9":
+  - event: "generally-available"
+    when: "2020-04-17T14:47:58Z"
+  "4.10":
+  - event: "generally-available"
+    when: "2020-04-17T14:47:58Z"

--- a/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/zz_fixture_TestRun_lifecycle_multiple_ga_410_bigger_49.yaml.yaml
+++ b/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/zz_fixture_TestRun_lifecycle_multiple_ga_410_bigger_49.yaml.yaml
@@ -1,0 +1,23 @@
+default:
+  openshift-4.9:
+    dependent_bug_target_releases:
+    - 4.10.0
+    target_release: 4.9.z
+    validate_by_default: true
+  openshift-4.10:
+    dependent_bug_target_releases:
+    - 4.11.0
+    - 4.11.z
+    target_release: 4.10.z
+    validate_by_default: true
+  release-4.9:
+    dependent_bug_target_releases:
+    - 4.10.0
+    target_release: 4.9.z
+    validate_by_default: true
+  release-4.10:
+    dependent_bug_target_releases:
+    - 4.11.0
+    - 4.11.z
+    target_release: 4.10.z
+    validate_by_default: true

--- a/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/zz_fixture_TestRun_lifecycle_multiple_ga_410_bigger_49.yaml.yaml
+++ b/cmd/branchingconfigmanagers/bugzilla-config-manager/testdata/zz_fixture_TestRun_lifecycle_multiple_ga_410_bigger_49.yaml.yaml
@@ -2,22 +2,22 @@ default:
   openshift-4.9:
     dependent_bug_target_releases:
     - 4.10.0
+    - 4.10.z
     target_release: 4.9.z
     validate_by_default: true
   openshift-4.10:
     dependent_bug_target_releases:
     - 4.11.0
-    - 4.11.z
     target_release: 4.10.z
     validate_by_default: true
   release-4.9:
     dependent_bug_target_releases:
     - 4.10.0
+    - 4.10.z
     target_release: 4.9.z
     validate_by_default: true
   release-4.10:
     dependent_bug_target_releases:
     - 4.11.0
-    - 4.11.z
     target_release: 4.10.z
     validate_by_default: true

--- a/pkg/api/ocplifecycle/ocplifecycle.go
+++ b/pkg/api/ocplifecycle/ocplifecycle.go
@@ -67,6 +67,15 @@ type MajorMinor struct {
 	Minor int `json:"minor"`
 }
 
+func (m MajorMinor) Less(other MajorMinor) bool {
+	if m.Major < other.Major {
+		return true
+	} else if m.Major > other.Major {
+		return false
+	}
+	return m.Minor < other.Minor
+}
+
 func (m MajorMinor) WithIncrementedMinor(increment int) MajorMinor {
 	return MajorMinor{Major: m.Major, Minor: m.Minor + increment}
 }


### PR DESCRIPTION
- bugzilla-config-manager: add test for wrong 4.9/4.10 sort
- bugzilla-config-manager: fix wrong 4.9/4.10 sort

The config manager was sorting versions using `String()` which resulted in a wrong sort of `4.9` and `4.10`, resulting in generating wrong configuration.