### PR TITLE
Add '--aggr-data-start-time' parameter to target specific aggregation data

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -24,11 +24,11 @@ func NewRetryingCIDataClient(delegate CIDataClient) CIDataClient {
 	}
 }
 
-func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
+func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string, aggrDataTime time.Time) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
 	var ret []jobrunaggregatorapi.BackendDisruptionStatisticsRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
-		ret, innerErr = c.delegate.GetBackendDisruptionStatisticsByJob(ctx, jobName)
+		ret, innerErr = c.delegate.GetBackendDisruptionStatisticsByJob(ctx, jobName, aggrDataTime)
 		return innerErr
 	})
 	return ret, err


### PR DESCRIPTION
This is for TRT-132.

Today, aggregation data from BigQuery is taken by starting at roughly the time when the aggregation job was run, going back 10 days, and then using 7 days worth of data.

This change allows us to choose an arbitrary time instead of the time when the aggregation job was run.  This allows us to target data at a specific point in time.  For example, if there was some problem that resulted in gaps in the data, we can move to a different day and avoid the gap.

The value of the `--aggr-data-start-time` will be used as the day where we backoff by 10 days and use 7 days worth of aggregation data; example:

```
./job-run-aggregator analyze-job-runs \
    --job periodic-ci-openshift-release-master-ci-4.11-e2e-azure-ovn-upgrade \
    --payload-tag 4.11.0-0.nightly-2022-04-13-115124 \
    --explicit-gcs-prefix https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/ \
    --job-start-time 2022-04-13T12:03:59Z \
    --working-dir dp-debug1 \
    --aggr-data-start-time 2022-04-07T12:03:59Z \
    --timeout 4h40m \
    --google-service-account-credential-file openshift-ci-data-read-only.json
```