### PR TITLE
ci-operator: do not hide reporting log line

### DIFF
--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -140,7 +140,7 @@ func (r *reporter) report(request Request) {
 		reportMsg = fmt.Sprintf("Reporting job state '%s' with reason '%s'", request.State, request.Reason)
 	}
 
-	logrus.Debugf(reportMsg)
+	logrus.Infof(reportMsg)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/result", r.address), bytes.NewReader(data))
 	if err != nil {
 		logrus.Tracef("could not create report request: %v", err)


### PR DESCRIPTION
Partially reverts b00a10669f79c36c8f6bd4d4e87eb3a905c6ede7.

While not generally of interest to the regular user, hiding this line
makes it impossible to find instances of a particular error reason using
https://search.ci.openshift.org.

The original messages were in the following format:

```
Reporting job state 'succeeded'
```

```
Reporting job state 'failed' with reason 'the:reason'
```

which is not terrible for a user-facing message, so I'm just reverting
the level back to `Info`.

In the future, we may finally work on presenting results in a better
format.  In the meantime, simply removing the message achieves very
little.

https://issues.redhat.com/browse/DPTP-2632