### PR TITLE
Create QE dedicated Alibabacloud cluster profile "alibabacloud-qe"

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1090,6 +1090,7 @@ const (
 	ClusterProfileAWSGluster            ClusterProfile = "aws-gluster"
 	ClusterProfileAWSOSDMSP             ClusterProfile = "aws-osd-msp"
 	ClusterProfileAlibabaCloud          ClusterProfile = "alibabacloud"
+	ClusterProfileAlibabaCloudQE        ClusterProfile = "alibabacloud-qe"
 	ClusterProfileAzure                 ClusterProfile = "azure"
 	ClusterProfileAzure2                ClusterProfile = "azure-2"
 	ClusterProfileAzure4                ClusterProfile = "azure4"
@@ -1156,6 +1157,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSQE,
 		ClusterProfileAWSSC2SQE,
 		ClusterProfileAlibabaCloud,
+		ClusterProfileAlibabaCloudQE,
 		ClusterProfileAzure2,
 		ClusterProfileAzure4,
 		ClusterProfileAzureArc,
@@ -1215,7 +1217,9 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWS2,
 		ClusterProfileAWSQE:
 		return string(CloudAWS)
-	case ClusterProfileAlibabaCloud:
+	case
+		ClusterProfileAlibabaCloud,
+		ClusterProfileAlibabaCloudQE:
 		return "alibabacloud"
 	case ClusterProfileAWSArm64:
 		return "aws-arm64"
@@ -1332,6 +1336,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-sc2s-qe-quota-slice"
 	case ClusterProfileAlibabaCloud:
 		return "alibabacloud-quota-slice"
+	case ClusterProfileAlibabaCloudQE:
+		return "alibabacloud-qe-quota-slice"
 	case ClusterProfileAzure2:
 		return "azure-2-quota-slice"
 	case ClusterProfileAzure4:


### PR DESCRIPTION
After discuss with DPP and Installer dev team, QE should use our dedicated cluster profiles.

release https://github.com/openshift/release/pull/28013

Profile | Profile String | Cloud Type
-- | -- | --
ClusterProfileAlibabaCloudQE | alibabacloud-qe | alibabacloud
