### PR TITLE
Create QE dedicated Alibabacloud cluster profile "alibabacloud-cn-qe"

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1091,6 +1091,7 @@ const (
 	ClusterProfileAWSOSDMSP             ClusterProfile = "aws-osd-msp"
 	ClusterProfileAlibabaCloud          ClusterProfile = "alibabacloud"
 	ClusterProfileAlibabaCloudQE        ClusterProfile = "alibabacloud-qe"
+	ClusterProfileAlibabaCloudCNQE      ClusterProfile = "alibabacloud-cn-qe"
 	ClusterProfileAzure                 ClusterProfile = "azure"
 	ClusterProfileAzure2                ClusterProfile = "azure-2"
 	ClusterProfileAzure4                ClusterProfile = "azure4"
@@ -1158,6 +1159,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSSC2SQE,
 		ClusterProfileAlibabaCloud,
 		ClusterProfileAlibabaCloudQE,
+		ClusterProfileAlibabaCloudCNQE,
 		ClusterProfileAzure2,
 		ClusterProfileAzure4,
 		ClusterProfileAzureArc,
@@ -1219,7 +1221,8 @@ func (p ClusterProfile) ClusterType() string {
 		return string(CloudAWS)
 	case
 		ClusterProfileAlibabaCloud,
-		ClusterProfileAlibabaCloudQE:
+		ClusterProfileAlibabaCloudQE,
+		ClusterProfileAlibabaCloudCNQE:
 		return "alibabacloud"
 	case ClusterProfileAWSArm64:
 		return "aws-arm64"
@@ -1338,6 +1341,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "alibabacloud-quota-slice"
 	case ClusterProfileAlibabaCloudQE:
 		return "alibabacloud-qe-quota-slice"
+	case ClusterProfileAlibabaCloudCNQE:
+		return "alibabacloud-cn-qe-quota-slice"
 	case ClusterProfileAzure2:
 		return "azure-2-quota-slice"
 	case ClusterProfileAzure4:


### PR DESCRIPTION
After discuss with DPP and Installer dev team, QE should use our dedicated cluster profiles.

_FYI Similar to https://github.com/openshift/ci-tools/pull/2781, but for another cluster profile (owned by QE) which is for Alibabacloud China-site accounts testing._

release https://github.com/openshift/release/pull/28090

Profile | Profile String | Cloud Type
-- | -- | --
ClusterProfileAlibabaCloudCNQE | alibabacloud-cn-qe | alibabacloud
