### PR TITLE
Remove Petr and Emil from OWNERS reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,14 +7,11 @@ approvers:
 - stevekuznetsov
 - AlexNPavel
 - alvaroaleman
-- emilvberglind
 - smg247
 - jmguzik
 reviewers:
 - bbguimaraes
 - droslean
 - hongkailiu
-- petr-muller
-- emilvberglind
 - smg247
 - jmguzik


### PR DESCRIPTION
Blunderbuss keeps selecting Petr as a reviewer for my PRs. This is annoying as I end up with only one "active" reviewer and must `/cc` someone else manually.
I went ahead and removed Emil from approvers and reviewers as he has been gone from Red Hat for awhile now.