### PR TITLE
ci-operator multi-stage: simplify best-effort test

### DIFF
--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -232,7 +232,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil)
-	_, isBestEffort, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil)
+	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 		"test-step1": true,
 		"test-step2": false,
 	} {
-		if actual, expected := isBestEffort(pod), bestEffort; actual != expected {
+		if actual, expected := bestEffortSteps.Has(pod), bestEffort; actual != expected {
 			t.Errorf("didn't check best-effort status of Pod %s correctly, expected %v", pod, bestEffort)
 		}
 	}


### PR DESCRIPTION
Return the set directly instead of a closure.

The set bound to the closure is only ever populated based on the input
configuration, there is no need to have dynamic behavior after
construction.

/hold

~Includes https://github.com/openshift/ci-tools/pull/2790 to use the new `flags` member.~