### PR TITLE
pkgs/steps/lease: log resources before acquiring

### DIFF
--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -106,7 +106,11 @@ func (s *leaseStep) Run(ctx context.Context) error {
 }
 
 func (s *leaseStep) run(ctx context.Context) error {
-	logrus.Infof("Acquiring leases for test %s", s.Name())
+	var types []string
+	for i := range s.leases {
+		types = append(types, s.leases[i].ResourceType)
+	}
+	logrus.Infof("Acquiring leases for test %s: %v", s.Name(), types)
 	client := *s.client
 	ctx, cancel := context.WithCancel(ctx)
 	if err := acquireLeases(client, ctx, cancel, s.leases); err != nil {


### PR DESCRIPTION
Before:

```
INFO[2022-04-27T13:28:52Z] Acquiring leases for test test
<pause>
INFO[2022-04-27T13:28:52Z] Acquired 1 lease(s) for nutanix-quota-slice: [nutanix-segment-01]
```

After:

```
INFO[2022-04-27T18:25:12Z] Acquiring leases for test test: [nutanix-quota-slice]
<pause>
INFO[2022-04-27T18:25:12Z] Acquired 1 lease(s) for nutanix-quota-slice: [nutanix-segment-01]
```

---

Had to debug this today and missed this information.