### PR TITLE
ci-operator multi-stage: add initial VPN support

### DIFF
--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -3,6 +3,8 @@ package multi_stage
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -14,7 +16,15 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/kubernetes"
 	"github.com/openshift/ci-tools/pkg/util"
+)
+
+var (
+	// uidRangeRegexp parses the base UID from a `${base}/${size}` UID range.
+	// This is the format of the `openshift.io/sa.scc.uid-range` annotation in
+	// OpenShift namespaces.
+	uidRangeRegexp = regexp.MustCompile(`^(\d+)/\d+`)
 )
 
 func (s *multiStageTestStep) createSharedDirSecret(ctx context.Context) error {
@@ -96,7 +106,8 @@ func (s *multiStageTestStep) createCommandConfigMaps(ctx context.Context) error 
 
 func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 	labels := map[string]string{MultiStageTestLabel: s.name}
-	m := meta.ObjectMeta{Namespace: s.jobSpec.Namespace(), Name: s.name, Labels: labels}
+	ns := s.jobSpec.Namespace()
+	m := meta.ObjectMeta{Namespace: ns, Name: s.name, Labels: labels}
 	sa := &coreapi.ServiceAccount{ObjectMeta: m}
 	role := &rbacapi.Role{
 		ObjectMeta: m,
@@ -123,15 +134,61 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 			Subjects:   subj,
 		},
 		{
-			ObjectMeta: meta.ObjectMeta{Namespace: s.jobSpec.Namespace(), Name: "test-runner-view-binding", Labels: labels},
+			ObjectMeta: meta.ObjectMeta{Namespace: ns, Name: "test-runner-view-binding", Labels: labels},
 			RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "view"},
 			Subjects:   subj,
 		},
 	}
-
+	if s.vpnConf != nil {
+		bindings = append(bindings, rbacapi.RoleBinding{
+			ObjectMeta: meta.ObjectMeta{Namespace: ns, Name: s.name + "-vpn"},
+			RoleRef: rbacapi.RoleRef{
+				Kind: "ClusterRole",
+				Name: "ci-operator-vpn",
+			},
+			Subjects: subj,
+		})
+	}
 	if err := util.CreateRBACs(ctx, sa, role, bindings, s.client, 1*time.Second, 1*time.Minute); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// getNamespaceUID retrieves the base UID configured for the test namespace.
+// This is required to restrict unprivileged containers to use that UID when an
+// SCC with the `RunAsUser` field set to RunAsAny` is used, as that applies to
+// every container in the pod.  There does not seem to be a mechanism in
+// OpenShift to do this automatically.
+func getNamespaceUID(
+	ctx context.Context,
+	name string,
+	client kubernetes.PodClient,
+) (int64, error) {
+	var ns coreapi.Namespace
+	key := ctrlruntimeclient.ObjectKey{Name: name}
+	if err := client.Get(ctx, key, &ns); err != nil {
+		return 0, fmt.Errorf("failed to get test namespace: %w", err)
+	}
+	var uidRange string
+	if ns.ObjectMeta.Annotations != nil {
+		uidRange = ns.ObjectMeta.Annotations["openshift.io/sa.scc.uid-range"]
+	}
+	return parseNamespaceUID(uidRange)
+}
+
+// parseNamespaceUID extracts the base UID from a `${base}/${size}` range.
+func parseNamespaceUID(uidRange string) (int64, error) {
+	matches := uidRangeRegexp.FindStringSubmatch(uidRange)
+	if matches == nil {
+		return 0, fmt.Errorf("invalid namespace UID range: %s", uidRange)
+	}
+	ret, err := strconv.ParseInt(matches[1], 10, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse UID range %q: %w", uidRange, err)
+	} else if ret == 0 {
+		return 0, fmt.Errorf("invalid namespace UID range: %s", uidRange)
+	}
+	return ret, nil
 }

--- a/pkg/steps/multi_stage/init_test.go
+++ b/pkg/steps/multi_stage/init_test.go
@@ -1,0 +1,39 @@
+package multi_stage
+
+import (
+	"testing"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestParseNamespaceUID(t *testing.T) {
+	for _, tc := range []struct {
+		name, uidRange, err string
+		uid                 int64
+	}{{
+		name:     "valid",
+		uidRange: "1007160000/10000",
+		uid:      1007160000,
+	}, {
+		name: "empty",
+		err:  "invalid namespace UID range: ",
+	}, {
+		name:     "invalid format",
+		uidRange: "invalid format",
+		err:      "invalid namespace UID range: invalid format",
+	}, {
+		name:     "missing UID",
+		uidRange: "/10000",
+		err:      "invalid namespace UID range: /10000",
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			uid, err := parseNamespaceUID(tc.uidRange)
+			var errStr string
+			if err != nil {
+				errStr = err.Error()
+			}
+			testhelper.Diff(t, "uid", uid, tc.uid)
+			testhelper.Diff(t, "error", errStr, tc.err, testhelper.EquateErrorMessage)
+		})
+	}
+}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_empty.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_empty.yaml
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec:
+  containers: null
+status: {}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
@@ -1,0 +1,27 @@
+metadata:
+  creationTimestamp: null
+spec:
+  containers:
+  - name: c0
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+  - name: c1
+    resources: {}
+    securityContext:
+      capabilities: {}
+      runAsUser: 0
+      seLinuxOptions: {}
+  initContainers:
+  - name: i0
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+  - name: i1
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+status: {}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_no_match.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_no_match.yaml
@@ -1,0 +1,26 @@
+metadata:
+  creationTimestamp: null
+spec:
+  containers:
+  - name: c0
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+  - name: c1
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+  initContainers:
+  - name: i0
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+  - name: i1
+    resources: {}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1007160000
+status: {}


### PR DESCRIPTION
Initial implementation of VPN support as described in the
[design document](https://docs.google.com/document/d/1mPjrHVS1EvmLdq4kGhRazTpGu6xVZDyGpVAphVZhX4w/).

User documentation PR: https://github.com/openshift/ci-docs/pull/249.

Based on:

- https://github.com/openshift/ci-tools/pull/2790
- https://github.com/openshift/ci-tools/pull/2795