### PR TITLE
Update `test-infra` dependency

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -412,7 +412,7 @@ func sendNextWeeksRoleDigest(client *pagerduty.Client, slackClient *slack.Client
 
 func getIssuesNeedingApproval(jiraClient *jiraapi.Client) ([]slack.Block, error) {
 	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND status="Review"`, jira.ProjectDPTP), nil)
-	if err := jirautil.JiraError(response, err); err != nil {
+	if err := jirautil.HandleJiraError(response, err); err != nil {
 		return nil, fmt.Errorf("could not query for Jira issues: %w", err)
 	}
 
@@ -518,7 +518,7 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 
 func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, userId string) error {
 	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT (labels=ready OR labels=no-intake)) AND created >= -30d AND status = "To Do" AND issuetype != Sub-task`, jira.ProjectDPTP), nil)
-	if err := jirautil.JiraError(response, err); err != nil {
+	if err := jirautil.HandleJiraError(response, err); err != nil {
 		return fmt.Errorf("could not query for Jira issues: %w", err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	k8s.io/apiserver v0.22.2
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/klog/v2 v2.9.0
-	k8s.io/test-infra v0.0.0-20220426162453-28f5d976bee5
+	k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/boskos v0.0.0-20210730172138-093b54882439
 	sigs.k8s.io/controller-runtime v0.10.3

--- a/go.sum
+++ b/go.sum
@@ -2510,8 +2510,8 @@ k8s.io/test-infra v0.0.0-20200514184223-ba32c8aae783/go.mod h1:bW6thaPZfL2hW7ecj
 k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20200630233406-1dca6122872e/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20210730160938-8ad9b8c53bd8/go.mod h1:RXgSaKbQA0upN4GGyH38yRkotDJr3myiKWkvdfB5yP4=
-k8s.io/test-infra v0.0.0-20220426162453-28f5d976bee5 h1:aM4VI9SE5F1j0zSlWPQaAyGn3L0dJhtHmJVEnhm0l80=
-k8s.io/test-infra v0.0.0-20220426162453-28f5d976bee5/go.mod h1:vpjKxOiS0b0nItAL87ZIE8CBlEvAYDdGPPpB+5VJC7s=
+k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55 h1:j+AvG9c0Z35e3beA2uJVETpPde43nOhA11Y8oBQ6M7k=
+k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55/go.mod h1:17p/rdMZ5P5EKrQzVFQ4S8+6t265ufYlvfXVqep2iT0=
 k8s.io/utils v0.0.0-20181019225348-5e321f9a457c/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/jira/issues.go
+++ b/pkg/jira/issues.go
@@ -93,7 +93,7 @@ func (f *filer) FileIssue(issueType, title, description, reporter string, logger
 		Description: description,
 	}}
 	issue, response, err := f.jiraClient.CreateIssue(toCreate)
-	return issue, jirautil.JiraError(response, err)
+	return issue, jirautil.HandleJiraError(response, err)
 }
 
 // resolveRequester attempts to get more information about the Slack
@@ -107,7 +107,7 @@ func (f *filer) resolveRequester(reporter string, logger *logrus.Entry) (string,
 		suffix = fmt.Sprintf("[a Slack user|%s/team/%s]", slackutil.CoreOSURL, reporter)
 	} else {
 		jiraUsers, response, err := f.jiraClient.FindUser(slackUser.RealName)
-		if err := jirautil.JiraError(response, err); err != nil {
+		if err := jirautil.HandleJiraError(response, err); err != nil {
 			logger.WithError(err).Warn("could not search Jira for requester")
 		}
 		if len(jiraUsers) != 0 {
@@ -131,7 +131,7 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client) (IssueFil
 	}
 
 	project, response, err := jiraClient.Project.Get(ProjectDPTP)
-	if err := jirautil.JiraError(response, err); err != nil {
+	if err := jirautil.HandleJiraError(response, err); err != nil {
 		return nil, fmt.Errorf("could not find Jira project %s: %w", ProjectDPTP, err)
 	}
 	filer.project = *project
@@ -145,7 +145,7 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client) (IssueFil
 	}
 
 	botUser, response, err := jiraClient.User.GetSelf()
-	if err := jirautil.JiraError(response, err); err != nil {
+	if err := jirautil.HandleJiraError(response, err); err != nil {
 		return nil, fmt.Errorf("could not resolve Jira bot user: %w", err)
 	}
 	filer.botUser = botUser

--- a/vendor/k8s.io/test-infra/prow/apis/prowjobs/v1/types.go
+++ b/vendor/k8s.io/test-infra/prow/apis/prowjobs/v1/types.go
@@ -66,6 +66,17 @@ const (
 	ErrorState ProwJobState = "error"
 )
 
+// GetAllProwJobStates returns all possible job states.
+func GetAllProwJobStates() []ProwJobState {
+	return []ProwJobState{
+		TriggeredState,
+		PendingState,
+		SuccessState,
+		FailureState,
+		AbortedState,
+		ErrorState}
+}
+
 // ProwJobAgent specifies the controller (such as plank or jenkins-agent) that runs the job.
 type ProwJobAgent string
 

--- a/vendor/k8s.io/test-infra/prow/git/git.go
+++ b/vendor/k8s.io/test-infra/prow/git/git.go
@@ -381,6 +381,8 @@ func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy types.PullRequ
 		return r.mergeWithMergeStrategyMerge(commitlike)
 	case types.MergeSquash:
 		return r.mergeWithMergeStrategySquash(commitlike)
+	case types.MergeRebase:
+		return r.mergeWithMergeStrategyRebase(commitlike)
 	default:
 		return false, fmt.Errorf("merge strategy %q is not supported", mergeStrategy)
 	}
@@ -421,6 +423,41 @@ func (r *Repo) mergeWithMergeStrategySquash(commitlike string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (r *Repo) mergeWithMergeStrategyRebase(commitlike string) (bool, error) {
+	if commitlike == "" {
+		return false, errors.New("branch must be set")
+	}
+
+	headRev, err := r.revParse("HEAD")
+	if err != nil {
+		r.logger.WithError(err).Infof("Failed to parse HEAD revision")
+		return false, err
+	}
+	headRev = strings.TrimSuffix(headRev, "\n")
+
+	co := r.gitCommand("rebase", "--no-stat", headRev, commitlike)
+	b, err := co.CombinedOutput()
+	if err != nil {
+		r.logger.WithField("out", string(b)).WithError(err).Infof("Rebase failed.")
+		if b, err := r.gitCommand("rebase", "--abort").CombinedOutput(); err != nil {
+			return false, fmt.Errorf("error aborting after failed rebase for commitlike %s: %v. output: %s", commitlike, err, string(b))
+		}
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (r *Repo) revParse(args ...string) (string, error) {
+	fullArgs := append([]string{"rev-parse"}, args...)
+	co := r.gitCommand(fullArgs...)
+	b, err := co.CombinedOutput()
+	if err != nil {
+		return "", errors.New(string(b))
+	}
+	return string(b), nil
 }
 
 // MergeAndCheckout merges the provided headSHAs in order onto baseSHA using the provided strategy.

--- a/vendor/k8s.io/test-infra/prow/git/v2/interactor.go
+++ b/vendor/k8s.io/test-infra/prow/git/v2/interactor.go
@@ -207,6 +207,8 @@ func (i *interactor) MergeWithStrategy(commitlike, mergeStrategy string, opts ..
 		return i.mergeMerge(commitlike, opts...)
 	case "squash":
 		return i.squashMerge(commitlike)
+	case "rebase":
+		return i.mergeRebase(commitlike)
 	case "ifNecessary":
 		return i.mergeIfNecessary(commitlike, opts...)
 	default:
@@ -264,6 +266,38 @@ func (i *interactor) squashMerge(commitlike string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+func (i *interactor) mergeRebase(commitlike string) (bool, error) {
+	if commitlike == "" {
+		return false, errors.New("branch must be set")
+	}
+
+	headRev, err := i.revParse("HEAD")
+	if err != nil {
+		i.logger.WithError(err).Infof("Failed to parse HEAD revision")
+		return false, err
+	}
+	headRev = strings.TrimSuffix(headRev, "\n")
+
+	b, err := i.executor.Run("rebase", "--no-stat", headRev, commitlike)
+	if err != nil {
+		i.logger.WithField("out", string(b)).WithError(err).Infof("Rebase failed.")
+		if b, err := i.executor.Run("rebase", "--abort"); err != nil {
+			return false, fmt.Errorf("error aborting after failed rebase for commitlike %s: %v. output: %s", commitlike, err, string(b))
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+func (i *interactor) revParse(args ...string) (string, error) {
+	fullArgs := append([]string{"rev-parse"}, args...)
+	b, err := i.executor.Run(fullArgs...)
+	if err != nil {
+		return "", errors.New(string(b))
+	}
+	return string(b), nil
 }
 
 // Only the `merge` and `squash` strategies are supported.

--- a/vendor/k8s.io/test-infra/prow/github/types.go
+++ b/vendor/k8s.io/test-infra/prow/github/types.go
@@ -253,6 +253,7 @@ type PullRequest struct {
 	Title              string            `json:"title"`
 	Body               string            `json:"body"`
 	RequestedReviewers []User            `json:"requested_reviewers"`
+	RequestedTeams     []Team            `json:"requested_teams"`
 	Assignees          []User            `json:"assignees"`
 	State              string            `json:"state"`
 	Draft              bool              `json:"draft"`

--- a/vendor/k8s.io/test-infra/prow/plugins/jira/jira.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/jira/jira.go
@@ -310,7 +310,7 @@ func upsertGitHubLinkToIssue(log *logrus.Entry, issueID string, jc jiraclient.Cl
 		}
 		log.Info("Updated jira link")
 	} else {
-		if err := jc.AddRemoteLink(issueID, link); err != nil {
+		if _, err := jc.AddRemoteLink(issueID, link); err != nil {
 			return fmt.Errorf("failed to add remote link: %w", err)
 		}
 		log.Info("Created jira link")

--- a/vendor/k8s.io/test-infra/prow/plugins/testfreeze/checker/checker.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/testfreeze/checker/checker.go
@@ -17,15 +17,28 @@ limitations under the License.
 package checker
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/blang/semver"
 	git "github.com/go-git/go-git/v5"
 	gitconfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	gitmemory "github.com/go-git/go-git/v5/storage/memory"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+const (
+	prowjobsURL = "https://prow.k8s.io/prowjobs.js?omit=annotations,labels,decoration_config,pod_spec"
+	jobName     = "ci-fast-forward"
+	unknownTime = "unknown"
 )
 
 // Checker is the main structure of checking if we're in Test Freeze.
@@ -44,12 +57,20 @@ type Result struct {
 
 	// Tag is the latest minor release tag to be expected.
 	Tag string
+
+	// LastFastForward specifies the latest point int time when a fast forward
+	// was successful.
+	LastFastForward string
 }
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . checker
 type checker interface {
 	ListRefs(*git.Remote) ([]*plumbing.Reference, error)
+	HttpGet(string) (*http.Response, error)
+	CloseBody(*http.Response) error
+	ReadAllBody(*http.Response) ([]byte, error)
+	UnmarshalProwJobs([]byte) (*v1.ProwJobList, error)
 }
 
 type defaultChecker struct{}
@@ -74,7 +95,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 	refs, err := c.checker.ListRefs(remote)
 	if err != nil {
 		c.log.Errorf("Unable to list git remote: %v", err)
-		return nil, errors.Wrap(err, "list git remote")
+		return nil, fmt.Errorf("list git remote: %w", err)
 	}
 
 	const releaseBranchPrefix = "release-"
@@ -97,7 +118,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 
 			parsed, err := semver.Parse(version)
 			if err != nil {
-				c.log.WithField("version", version).WithError(err).Debug("Unable parse version.")
+				c.log.WithField("version", version).WithError(err).Debug("Unable to parse version.")
 				continue
 			}
 
@@ -118,7 +139,7 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 
 			parsed, err := semver.Parse(tag)
 			if err != nil {
-				c.log.WithField("tag", tag).WithError(err).Debug("Unable parse tag.")
+				c.log.WithField("tag", tag).WithError(err).Debug("Unable to parse tag.")
 				continue
 			}
 
@@ -134,15 +155,70 @@ func (c *Checker) InTestFreeze() (*Result, error) {
 		}
 	}
 
+	lastFastForward := unknownTime
+	last, err := c.lastFastForward()
+	if err != nil {
+		c.log.WithError(err).Error("Unable to get last fast forward result.")
+	} else {
+		lastFastForward = last.Format(time.UnixDate)
+	}
+
 	// Latest minor version not found in latest release branch,
 	// we're in Test Freeze.
 	return &Result{
-		InTestFreeze: true,
-		Branch:       latestBranch,
-		Tag:          "v" + latestSemver.String(),
+		InTestFreeze:    true,
+		Branch:          latestBranch,
+		Tag:             "v" + latestSemver.String(),
+		LastFastForward: lastFastForward,
 	}, nil
+}
+
+func (c *Checker) lastFastForward() (*metav1.Time, error) {
+	resp, err := c.checker.HttpGet(prowjobsURL)
+	if err != nil {
+		return nil, fmt.Errorf("get prow jobs: %w", err)
+	}
+	defer c.checker.CloseBody(resp)
+
+	body, err := c.checker.ReadAllBody(resp)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	prowJobs, err := c.checker.UnmarshalProwJobs(body)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal prow jobs: %w", err)
+	}
+
+	for _, job := range prowJobs.Items {
+		if job.Spec.Job == jobName && job.Status.State == v1.SuccessState {
+			return job.Status.CompletionTime, nil
+		}
+	}
+
+	return nil, errors.New("unable to find successful run")
 }
 
 func (*defaultChecker) ListRefs(r *git.Remote) ([]*plumbing.Reference, error) {
 	return r.List(&git.ListOptions{})
+}
+
+func (*defaultChecker) HttpGet(url string) (*http.Response, error) {
+	return http.Get(url)
+}
+
+func (*defaultChecker) CloseBody(resp *http.Response) error {
+	return resp.Body.Close()
+}
+
+func (*defaultChecker) ReadAllBody(resp *http.Response) ([]byte, error) {
+	return io.ReadAll(resp.Body)
+}
+
+func (*defaultChecker) UnmarshalProwJobs(data []byte) (*v1.ProwJobList, error) {
+	prowJobs := &v1.ProwJobList{}
+	if err := json.Unmarshal(data, prowJobs); err != nil {
+		return nil, err
+	}
+	return prowJobs, nil
 }

--- a/vendor/k8s.io/test-infra/prow/plugins/testfreeze/testfreeze.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/testfreeze/testfreeze.go
@@ -36,9 +36,10 @@ const (
 	PluginName                  = "testfreeze"
 	defaultKubernetesBranch     = "master"
 	defaultKubernetesRepoAndOrg = "kubernetes"
-	templateString              = `{{ if .InTestFreeze -}}
-Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR has to be cherry-picked into the release branch to be part of the upcoming {{ .Tag }} release.
-{{ end }}`
+	templateString              = `Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR will be automatically fast-forwarded via the periodic [ci-fast-forward](https://testgrid.k8s.io/sig-release-releng-blocking#git-repo-kubernetes-fast-forward) job to the release branch of the upcoming {{ .Tag }} release.
+
+The most recent automatic fast forward was: {{ .LastFastForward }}.
+`
 )
 
 func init() {

--- a/vendor/k8s.io/test-infra/prow/spyglass/README.md
+++ b/vendor/k8s.io/test-infra/prow/spyglass/README.md
@@ -103,8 +103,17 @@ deck:
       - ^artifacts/junit.*\.xml$
     - lens:
         name: podinfo
+        config:
+          runner_configs: # Would only work if `prowjob.json` is configured below
+            "<BUILD_CLUSTER_ALIAS>":
+              pod_link_template: "https://<YOUR_CLOUD_PROVIDER_URL>/{{ .Name }}" # Name is directly from the Pod truct.
+            # Example:
+            # "default":
+            #    pod_link_template: "https://console.cloud.google.com/kubernetes/pod/us-central1-f/prow/test-pods/{{ .Name }}/details?project=k8s-prow-builds"
       required_files:
         - ^podinfo\.json$
+      optional_files:
+        - ^prowjob\.json$ # Only if runner_configs is configured.
 ```
 
 ### Accessing custom storage buckets

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1451,7 +1451,7 @@ k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/kubernetes v1.14.7
 ## explicit
 k8s.io/kubernetes/pkg/apis/core
-# k8s.io/test-infra v0.0.0-20220426162453-28f5d976bee5
+# k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55
 ## explicit; go 1.18
 k8s.io/test-infra/ghproxy/ghcache
 k8s.io/test-infra/ghproxy/ghmetrics


### PR DESCRIPTION
We need an updated `test-infra` specifically to obtain the change in https://github.com/kubernetes/test-infra/pull/26214.

Note: the jira `JiraError` function name was changed to `HandleJiraError`.