### PR TITLE
Introduce a watcher for a symlink release repo path

### DIFF
--- a/pkg/load/agents/utils.go
+++ b/pkg/load/agents/utils.go
@@ -3,62 +3,145 @@ package agents
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/fsnotify.v1"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/interrupts"
 )
 
-func startWatchers(path string, callback func() error, recordError func(string)) error {
-	cms, dirs, err := config.ListCMsAndDirs(path)
-	if err != nil {
-		return err
-	}
-	errFunc := func(err error, msg string) {
-		recordError(msg)
-		log.WithError(err).Error(msg)
-	}
+func startWatchers(path string, callback func() error, metric *prometheus.CounterVec, universalSymlinkWatcher *UniversalSymlinkWatcher) error {
 	var watchers []func(context.Context)
-	for cm := range cms {
-		watcher, err := config.GetCMMountWatcher(callback, errFunc, cm)
+
+	if universalSymlinkWatcher != nil {
+		watcher := func(ctx context.Context) {
+			errFunc := func(err error, msg string) {
+				recordErrorForMetric(metric, msg)
+				logrus.WithError(err).Error(msg)
+			}
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case event := <-universalSymlinkWatcher.EventCh:
+					logrus.Infof("Received event: %s", event.String())
+					if err := universalSymlinkWatcher.ConfigEventFn(); err != nil {
+						errFunc(err, "failed to load config")
+					}
+					if err := universalSymlinkWatcher.RegistryEventFn(); err != nil {
+						errFunc(err, "failed to load registry")
+					}
+
+				case err := <-universalSymlinkWatcher.ErrCh:
+					errFunc(err, "received error")
+				}
+			}
+		}
+		watchers = append(watchers, watcher)
+	} else {
+		cms, dirs, err := config.ListCMsAndDirs(path)
 		if err != nil {
 			return err
 		}
-		watchers = append(watchers, watcher)
-	}
-	if len(dirs) != 0 {
-		eventFunc := func(w *fsnotify.Watcher) error {
-			go func() {
-				err := callback()
-				if err != nil {
-					logrus.WithError(err).Errorf("Coalescer function failed")
-				}
-			}()
-			// add new files to be watched; if a watch already exists on a file, the
-			// watch is simply updated
-			_, dirs, err := config.ListCMsAndDirs(path)
+		errFunc := func(err error, msg string) {
+			recordErrorForMetric(metric, msg)
+			logrus.WithError(err).Error(msg)
+		}
+
+		for cm := range cms {
+			watcher, err := config.GetCMMountWatcher(callback, errFunc, cm)
 			if err != nil {
 				return err
 			}
-			for dir := range dirs {
-				// Adding a file or directory that already exists in fsnotify is a no-op, so it is safe to always run Add
-				if err := w.Add(dir); err != nil {
-					return fmt.Errorf("Failed to update watcher: %w", err)
+			watchers = append(watchers, watcher)
+		}
+		if len(dirs) != 0 {
+			eventFunc := func(w *fsnotify.Watcher) error {
+				go func() {
+					err := callback()
+					if err != nil {
+						logrus.WithError(err).Errorf("Coalescer function failed")
+					}
+				}()
+				// add new files to be watched; if a watch already exists on a file, the
+				// watch is simply updated
+				_, dirs, err := config.ListCMsAndDirs(path)
+				if err != nil {
+					return err
 				}
+				for dir := range dirs {
+					// Adding a file or directory that already exists in fsnotify is a no-op, so it is safe to always run Add
+					if err := w.Add(dir); err != nil {
+						return fmt.Errorf("failed to update watcher: %w", err)
+					}
+				}
+				return nil
 			}
-			return nil
+			watcher, err := config.GetFileWatcher(eventFunc, errFunc, dirs.UnsortedList()...)
+			if err != nil {
+				return err
+			}
+			watchers = append(watchers, watcher)
 		}
-		watcher, err := config.GetFileWatcher(eventFunc, errFunc, dirs.UnsortedList()...)
-		if err != nil {
-			return err
-		}
-		watchers = append(watchers, watcher)
 	}
+
 	for _, watcher := range watchers {
 		interrupts.Run(watcher)
 	}
 	return nil
+}
+
+type UniversalSymlinkWatcher struct {
+	WatchPath       string
+	EventCh         chan fsnotify.Event
+	ErrCh           chan error
+	ConfigEventFn   func() error
+	RegistryEventFn func() error
+}
+
+func recordErrorForMetric(metric *prometheus.CounterVec, label string) {
+	labels := prometheus.Labels{"error": label}
+	metric.With(labels).Inc()
+}
+
+func (u *UniversalSymlinkWatcher) GetWatcher() (func(ctx context.Context), error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new watcher: %w", err)
+	}
+
+	if err = w.Add(filepath.Dir(u.WatchPath)); err != nil {
+		w.Close()
+		return nil, fmt.Errorf("failed to add %s to watcher: %w", u.WatchPath, err)
+	}
+	return func(ctx context.Context) {
+		for {
+			select {
+			case <-ctx.Done():
+				if err := w.Close(); err != nil {
+					u.ErrCh <- fmt.Errorf("failed to close fsnotify watcher for directory %s: %w", u.WatchPath, err)
+				}
+				return
+			case event := <-w.Events:
+				if event.Name != u.WatchPath {
+					continue
+				}
+				newDestination, err := os.Readlink(event.Name)
+				if err != nil {
+					logrus.WithError(err).Errorf("couldn't read the destination link of %s", event.Name)
+				} else {
+					logrus.Infof("Loading configs from %s", newDestination)
+					logrus.Info("Sending event to channel")
+					u.EventCh <- event
+				}
+			case err := <-w.Errors:
+				u.ErrCh <- fmt.Errorf("received fsnotify error %w", err)
+			}
+		}
+	}, nil
 }


### PR DESCRIPTION
/cc @bbguimaraes @openshift/test-platform 


- Adds a `--release-repo-path` flag
- Start watcher for the release repo folder symlink destination

If the symlink of the release repo path will change, then the watcher starts watching the new destination and reload the configs once.

https://issues.redhat.com/browse/DPTP-2531

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>