### PR TITLE
ci-operator: remove useless check

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1257,14 +1257,12 @@ func (o *options) initializeNamespace() error {
 			return fmt.Errorf("failed to get pipeline imagestream: %w", err)
 		}
 	}
-	if is != nil {
-		o.jobSpec.SetOwner(&meta.OwnerReference{
-			APIVersion: "image.openshift.io/v1",
-			Kind:       "ImageStream",
-			Name:       api.PipelineImageStream,
-			UID:        is.UID,
-		})
-	}
+	o.jobSpec.SetOwner(&meta.OwnerReference{
+		APIVersion: "image.openshift.io/v1",
+		Kind:       "ImageStream",
+		Name:       api.PipelineImageStream,
+		UID:        is.UID,
+	})
 
 	if o.cloneAuthConfig != nil && o.cloneAuthConfig.Secret != nil {
 		o.cloneAuthConfig.Secret.Immutable = utilpointer.BoolPtr(true)


### PR DESCRIPTION
This test has been redundant since the transition to the controller
runtime client in 41a6a7910267041b357177f47bf0c4810588a368.

Identified by `golangci-lint` v1.46:

```
cmd/ci-operator/main.go:1260:5: SA4031: this nil check is always true (staticcheck)
        if is != nil {
           ^
cmd/ci-operator/main.go:1242:9: SA4031(related information): this is the value of is (staticcheck)
        is := &imageapi.ImageStream{
               ^
```