### PR TITLE
Increase progress deadline for RPM repos

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -85,10 +85,12 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 	}
 	one := int64(1)
 	two := int32(2)
+	progressDeadline := int32(1200) // It can take 10 minutes for a machine to come up, so double default deadline
 	deployment := &appsapi.Deployment{
 		ObjectMeta: commonMeta,
 		Spec: appsapi.DeploymentSpec{
-			Replicas: &two,
+			ProgressDeadlineSeconds: &progressDeadline,
+			Replicas:                &two,
 			Selector: &meta.LabelSelector{
 				MatchLabels: labelSet,
 			},


### PR DESCRIPTION
Improvements in scaling down build farms mean there is less immediately
available capacity to spare. These pods will schedule, but it may require
the creation of a new machine by the cluster autoscaler. Allow time for
those machines to come up by adding 10 minutes to default deployment
progress deadline.