### PR TITLE
Allow add tests from openshift-tests & openshift-tests-private to testgrid

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -244,6 +244,7 @@ func addDashboardTab(p prowConfig.Periodic,
 			strings.Contains(prowName, "-origin-"),
 			// these prefixes control whether a job is ocp or okd going forward
 			strings.HasPrefix(prowName, "periodic-ci-openshift-multiarch"),
+			strings.HasPrefix(prowName, "periodic-ci-openshift-openshift-tests-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-release-master-ci-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-release-master-nightly-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-verification-tests-master-"),


### PR DESCRIPTION
QE would like to add several tests from openshift-tests and openshift-tests-private (both are under openshift/) to testgrid