### PR TITLE
skip disruption check on azure

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -68,6 +69,12 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 			failedJobRunIDs, successfulJobRunIDs, status, message, err := disruptionCheckFn(ctx, jobRunIDToAvailabilityResultForBackend, backendName)
 			if err != nil {
 				return nil, err
+			}
+
+			// for a reason we don't yet understand, azure is failing more than others. Long term, we prefer this to flake
+			// over an explicit skip.  Other possible outcomes include allowing more noise on Azure.
+			if strings.Contains(o.jobName, "azure") {
+				status = testCaseSkipped
 			}
 
 			testCaseName := fmt.Sprintf(testCaseNamePattern, backendName)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -350,7 +350,7 @@ func (a *weeklyAverageFromTenDays) checkPercentileDisruption(jobRunIDToAvailabil
 	workingPercentage := thresholdPercentile // the percentile is our success percentage
 	requiredNumberOfPasses := requiredPassesByPassPercentageByNumberOfAttempts[numberOfAttempts][workingPercentage]
 	// TODO try to tighten this after we can keep the test in for about a week.
-	requiredNumberOfPasses = requiredNumberOfPasses - 1 // subtracting one because our current sample missed by one
+	requiredNumberOfPasses = requiredNumberOfPasses - 2 // subtracting one because our current sample missed by one
 
 	if requiredNumberOfPasses <= 0 {
 		message := fmt.Sprintf("current percentile is so low that we cannot latch, skipping P%d=%.2fs", thresholdPercentile, threshold)


### PR DESCRIPTION
This leaves teh code that checks active, but sets the junit to skip.  This change allows future analysis 