### PR TITLE
relax disruption aggregation to five standard deviations

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -51,7 +51,7 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 	}
 
 	testCaseNamePatternToDisruptionCheckFn := map[string]disruptionJunitCheckFunc{
-		"%s mean disruption should be less than historical plus two standard deviations": o.passFailCalculator.CheckDisruptionMeanWithinTwoStandardDeviations,
+		"%s mean disruption should be less than historical plus five standard deviations": o.passFailCalculator.CheckDisruptionMeanWithinFiveStandardDeviations,
 		// TODO add a SKIP mechanism to disruptionJunitCheckFunc instead of the fail bool
 		//"%s mean disruption should be less than historical plus one standard deviation":  o.passFailCalculator.CheckDisruptionMeanWithinOneStandardDeviation,
 		"%s disruption P70 should not be worse":  checkPercentileDisruption(o.passFailCalculator, 70), // for 7 attempts, this  gives us a latch on getting worse


### PR DESCRIPTION
This appears to catch the failures we've found in https://search.ci.openshift.org/?search=which+is+more+than+the+failureThreshold+of+the+weekly+historical+mean+from&maxAge=48h&context=1&type=junit&name=aggregator.*4.11&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

We still want to see failures when we hit significant regressions.