### PR TITLE
config-shard-validator: compile globs once

### DIFF
--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -173,35 +173,40 @@ func checkSpec(spec *v1.PodSpec, relPath, name string, configInfos map[string]*c
 }
 
 func validatePaths(pathsToCheck []pathWithConfig, pcfg *plugins.ConfigUpdater) utilerrors.Aggregate {
+	var globs []interface{ Match(string) bool }
+	var globStrings []string
+	var configs []plugins.ConfigMapSpec
+	for s, c := range pcfg.Maps {
+		g, err := zglob.New(s)
+		if err != nil {
+			logrus.WithField("glob", s).WithError(err).Warn("Failed to compile glob matcher.")
+			continue
+		}
+		globs = append(globs, g)
+		globStrings = append(globStrings, s)
+		configs = append(configs, c)
+	}
 	var errs []error
 
 	for _, pathToCheck := range pathsToCheck {
 		var matchesAny bool
 		var matchedMap string
-		logger := logrus.WithField("source-file", pathToCheck.path)
 		path := field.NewPath(pathToCheck.path, "config_updater", "maps")
-		for glob, updateConfig := range pcfg.Maps {
-			path := path.Child(glob)
+		for i, glob := range globs {
+			globStr, updateConfig := globStrings[i], configs[i]
+			path := path.Child(globStr)
 			if _, hasDefaultCluster := updateConfig.Clusters[prowv1.DefaultClusterAlias]; hasDefaultCluster {
 				errs = append(errs, field.Invalid(path.Child("clusters"), prowv1.DefaultClusterAlias, "`default` cluster name is not allowed, a clustername must be explicitly specified"))
 			}
-
-			globLogger := logger.WithField("glob", glob)
-			matches, matchErr := zglob.Match(glob, pathToCheck.path)
-			if matchErr != nil {
-				globLogger.WithError(matchErr).Warn("Failed to check glob match.")
-			}
-			if jobConfigMatch, err := zglob.Match(glob, "ci-operator/jobs"); err != nil {
-				errs = append(errs, field.Invalid(path, glob, fmt.Sprintf("value can not be parsed as glob: %v", err)))
-			} else if jobConfigMatch && (updateConfig.GZIP == nil || !*updateConfig.GZIP) {
+			if glob.Match("ci-operator/jobs") && (updateConfig.GZIP == nil || !*updateConfig.GZIP) {
 				errs = append(errs, field.Invalid(path.Child("gzip"), updateConfig.GZIP, "field must be set to `true` for jobconfigs"))
 			}
-			if matches {
+			if glob.Match(pathToCheck.path) {
 				if matchesAny {
-					errs = append(errs, field.Invalid(path, glob, fmt.Sprintf("File matches glob from more than one ConfigMap: %s, %s.", matchedMap, pathToCheck.configMap)))
+					errs = append(errs, field.Invalid(path, globStr, fmt.Sprintf("File matches glob from more than one ConfigMap: %s, %s.", matchedMap, pathToCheck.configMap)))
 				}
 				if updateConfig.Name != pathToCheck.configMap {
-					errs = append(errs, field.Invalid(path, glob, fmt.Sprintf("File matches glob from unexpected ConfigMap %s instead of %s.", updateConfig.Name, pathToCheck.configMap)))
+					errs = append(errs, field.Invalid(path, globStr, fmt.Sprintf("File matches glob from unexpected ConfigMap %s instead of %s.", updateConfig.Name, pathToCheck.configMap)))
 				}
 				matchesAny = true
 				matchedMap = pathToCheck.configMap


### PR DESCRIPTION
We currently check 272 globs against 17642 paths.  This compiles 4798624 glob
matchers, 99.994% of which are unnecessary.  This PR eliminates that and other
inneficiencies, parallelizes the verification (configuration loading is already
implicitly done in parallel), and improves some errors messages while it's at
it.

```
        master      c1481a757    ci-operator job
-----------------------------------------------------
real    4m1.932s    0m4.997s     0m3.145s    0m0.974s
user    7m35.714s   0m34.346s    0m20.285s   0m5.193s
sys     0m8.350s    0m0.763s     0m0.701s    0m0.244s
```

These are timings for the complete execution of builds from `master` and this
PR, and the time to load the `ci-operator` and job configuration exclusively.
This new version executes in 2.065% of the original time, 62.938% and 19.491% of
which are spent loading `ci-operator`/job configuration files, and 17.570%
performing the validations (3.691% of the time taken by the `master` version to
perform the same validation).

This should allow `openshift/release` PRs to be merged in much less time, since
it's by far the longest job there:

```
pull-ci-openshift-release-master-ordered-prow-config          1m39s
pull-ci-openshift-release-master-owners                       1m37s
pull-ci-openshift-release-master-prow-config-filenames        1m32s
pull-ci-openshift-release-openshift-image-mirror-mappings     1m27s
pull-ci-openshift-release-yamllint                            1m54s
pull-ci-openshift-release-master-build-clusters               1m30s
pull-ci-openshift-release-master-ci-operator-config           1m26s
pull-ci-openshift-release-master-ci-operator-config-metadata  1m36s
pull-ci-openshift-release-master-ci-operator-registry         1m47s
pull-ci-openshift-release-master-core-valid                   3m28s
pull-ci-openshift-release-master-correctly-sharded-config     8m27s
pull-ci-openshift-release-master-deprecate-templates          1m42s
pull-ci-openshift-release-master-generated-config             1m30s
```