### PR TITLE
Fix DPTP-2823 Add .snyk file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+exclude:
+  global:
+    - "vendor/**"
+    - "**/*_test.go"
+


### PR DESCRIPTION
[DPTP-2823](https://issues.redhat.com//browse/DPTP-2823) We are adding this file to exclude `vendor/` and tests.