### PR TITLE
ci-operator: always set security context

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -288,8 +288,10 @@ func setSecurityContexts(
 	f := func(l []coreapi.Container) {
 		for i := range l {
 			if l[i].Name == root {
+				nonRoot := false
 				var uid int64
 				l[i].SecurityContext = &coreapi.SecurityContext{
+					RunAsNonRoot:   &nonRoot,
 					RunAsUser:      &uid,
 					Capabilities:   capabilities,
 					SELinuxOptions: seLinuxOpts,

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -131,6 +131,8 @@
       - mountPath: /tmp/entrypoint-wrapper
         name: entrypoint-wrapper
     restartPolicy: Never
+    securityContext:
+      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -287,6 +289,8 @@
       - mountPath: /tmp/entrypoint-wrapper
         name: entrypoint-wrapper
     restartPolicy: Never
+    securityContext:
+      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -439,6 +443,8 @@
       - mountPath: /tmp/entrypoint-wrapper
         name: entrypoint-wrapper
     restartPolicy: Never
+    securityContext:
+      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -603,6 +609,8 @@
       - mountPath: /tmp/entrypoint-wrapper
         name: entrypoint-wrapper
     restartPolicy: Never
+    securityContext:
+      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
@@ -11,6 +11,7 @@ spec:
     resources: {}
     securityContext:
       capabilities: {}
+      runAsNonRoot: false
       runAsUser: 0
       seLinuxOptions: {}
   initContainers:

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -204,6 +204,7 @@ func GenerateBasePod(
 	if err != nil {
 		return nil, err
 	}
+	nonRoot := true
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
@@ -216,6 +217,9 @@ func GenerateBasePod(
 		},
 		Spec: coreapi.PodSpec{
 			RestartPolicy: coreapi.RestartPolicyNever,
+			SecurityContext: &coreapi.PodSecurityContext{
+				RunAsNonRoot: &nonRoot,
+			},
 			Containers: []coreapi.Container{
 				{
 					Image:                    image,

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -85,6 +85,8 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -85,6 +85,8 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
@@ -112,6 +112,8 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs


### PR DESCRIPTION
d31d564f0 started adding security contexts to multi-stage tests which
use VPN connections, but there is never a reason to execute containers
as UID 0 outside of that case.

Set a security context for all pods created during the execution of a
test.  This includes those that import releases etc. but not builds —
which are `privileged` anyway.

The settings in the `PodSecurityContext` propagate and are overridden by
those in the container's `SecurityContext`, so small changes are
required to the existing ones:

https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container

This will also make me less nervous when making changes to the VPN
implementation.

---

/hold

Let's not deploy things right before a holiday =)