### PR TITLE
fix prow-config-sharding of welcome plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	k8s.io/apiserver v0.22.2
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible
 	k8s.io/klog/v2 v2.9.0
-	k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55
+	k8s.io/test-infra v0.0.0-20220519160727-e2358f85de1e
 	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/boskos v0.0.0-20210730172138-093b54882439
 	sigs.k8s.io/controller-runtime v0.10.3

--- a/go.sum
+++ b/go.sum
@@ -2510,8 +2510,8 @@ k8s.io/test-infra v0.0.0-20200514184223-ba32c8aae783/go.mod h1:bW6thaPZfL2hW7ecj
 k8s.io/test-infra v0.0.0-20200617221206-ea73eaeab7ff/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20200630233406-1dca6122872e/go.mod h1:L3+cRvwftUq8IW1TrHji5m3msnc4uck/7LsE/GR/aZk=
 k8s.io/test-infra v0.0.0-20210730160938-8ad9b8c53bd8/go.mod h1:RXgSaKbQA0upN4GGyH38yRkotDJr3myiKWkvdfB5yP4=
-k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55 h1:j+AvG9c0Z35e3beA2uJVETpPde43nOhA11Y8oBQ6M7k=
-k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55/go.mod h1:17p/rdMZ5P5EKrQzVFQ4S8+6t265ufYlvfXVqep2iT0=
+k8s.io/test-infra v0.0.0-20220519160727-e2358f85de1e h1:xp40QBWdveHhPuy4nwyBWSPy4VkxpYQ23wgHU4AgBos=
+k8s.io/test-infra v0.0.0-20220519160727-e2358f85de1e/go.mod h1:17p/rdMZ5P5EKrQzVFQ4S8+6t265ufYlvfXVqep2iT0=
 k8s.io/utils v0.0.0-20181019225348-5e321f9a457c/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=

--- a/pkg/prowconfigsharding/prowconfigsharding.go
+++ b/pkg/prowconfigsharding/prowconfigsharding.go
@@ -18,6 +18,7 @@ type pluginsConfigWithPointers struct {
 	Approve         []*plugins.Approve                  `json:"approve,omitempty"`
 	Lgtm            []plugins.Lgtm                      `json:"lgtm,omitempty"`
 	Triggers        []plugins.Trigger                   `json:"triggers,omitempty"`
+	Welcome         []plugins.Welcome                   `json:"welcome,omitempty"`
 	ExternalPlugins map[string][]plugins.ExternalPlugin `json:"external_plugins,omitempty"`
 	Label           *plugins.Label                      `json:"label,omitempty"`
 }
@@ -128,6 +129,19 @@ func WriteShardedPluginConfig(pc *plugins.Configuration, target afero.Fs) (*plug
 		}
 	}
 	pc.Triggers = nil
+
+	for _, welcome := range pc.Welcome {
+		for _, orgOrRepo := range welcome.Repos {
+			path := filepath.Join(orgOrRepo, config.SupplementalPluginConfigFileName)
+			if _, ok := fileList[path]; !ok {
+				fileList[path] = &pluginsConfigWithPointers{}
+			}
+			welcomeCopy := welcome
+			welcomeCopy.Repos = []string{orgOrRepo}
+			fileList[path].Welcome = []plugins.Welcome{welcomeCopy}
+		}
+	}
+	pc.Welcome = nil
 
 	for orgOrRepo, externalPlugins := range pc.ExternalPlugins {
 		path := filepath.Join(orgOrRepo, config.SupplementalPluginConfigFileName)

--- a/vendor/k8s.io/test-infra/prow/flagutil/github.go
+++ b/vendor/k8s.io/test-infra/prow/flagutil/github.go
@@ -256,8 +256,12 @@ func (o *GitHubOptions) githubClient(dryRun bool) (github.Client, error) {
 	fields := logrus.Fields{}
 	options := o.baseClientOptions()
 	options.DryRun = dryRun
-	if o.TokenPath == "" {
+
+	if o.TokenPath == "" && o.AppPrivateKeyPath == "" {
 		logrus.Warn("empty -github-token-path, will use anonymous github client")
+	}
+
+	if o.TokenPath == "" {
 		options.GetToken = func() []byte {
 			return []byte{}
 		}

--- a/vendor/k8s.io/test-infra/prow/github/client.go
+++ b/vendor/k8s.io/test-infra/prow/github/client.go
@@ -3593,6 +3593,8 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 	if c.fake {
 		return nil, nil
 	} else if c.dry {
+		// When in dry mode we need a believable slug to call corresponding methods for this team
+		team.Slug = strings.ToLower(strings.ReplaceAll(team.Name, " ", "-"))
 		return &team, nil
 	}
 	path := fmt.Sprintf("/orgs/%s/teams", org)

--- a/vendor/k8s.io/test-infra/prow/plugins/plugin-config-documented.yaml
+++ b/vendor/k8s.io/test-infra/prow/plugins/plugin-config-documented.yaml
@@ -698,7 +698,11 @@ triggers:
     # January 2020.
     trusted_org: ' '
 welcome:
-  - # MessageTemplate is the welcome message template to post on new-contributor PRs
+  - # Post welcome message in all cases, even if PR author is not an existing
+    # contributor or part of the organization
+    always_post: true
+
+    # MessageTemplate is the welcome message template to post on new-contributor PRs
     # For the info struct see prow/plugins/welcome/welcome.go's PRInfo
     message_template: ' '
 

--- a/vendor/k8s.io/test-infra/prow/plugins/testfreeze/testfreeze.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/testfreeze/testfreeze.go
@@ -38,7 +38,7 @@ const (
 	defaultKubernetesRepoAndOrg = "kubernetes"
 	templateString              = `Please note that we're already in [Test Freeze](https://github.com/kubernetes/sig-release/blob/master/releases/release_phases.md#test-freeze) for the ` + "`{{ .Branch }}`" + ` branch. This means every merged PR will be automatically fast-forwarded via the periodic [ci-fast-forward](https://testgrid.k8s.io/sig-release-releng-blocking#git-repo-kubernetes-fast-forward) job to the release branch of the upcoming {{ .Tag }} release.
 
-The most recent automatic fast forward was: {{ .LastFastForward }}.
+Fast forwards are scheduled to happen every 6 hours, whereas the most recent run was: {{ .LastFastForward }}.
 `
 )
 

--- a/vendor/k8s.io/test-infra/prow/plugins/welcome/welcome.go
+++ b/vendor/k8s.io/test-infra/prow/plugins/welcome/welcome.go
@@ -52,7 +52,7 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	welcomeConfig := map[string]string{}
 	for _, repo := range enabledRepos {
-		messageTemplate := welcomeMessageForRepo(config, repo.Org, repo.Repo)
+		messageTemplate := welcomeMessageForRepo(optionsForRepo(config, repo.Org, repo.Repo))
 		welcomeConfig[repo.String()] = fmt.Sprintf("The welcome plugin is configured to post using following welcome template: %s.", messageTemplate)
 	}
 
@@ -65,6 +65,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 					"org/repo2",
 				},
 				MessageTemplate: "Welcome @{{.AuthorLogin}}!",
+				AlwaysPost:      false,
 			},
 		},
 	})
@@ -72,7 +73,7 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		logrus.WithError(err).Warnf("cannot generate comments for %s plugin", pluginName)
 	}
 	return &pluginhelp.PluginHelp{
-			Description: "The welcome plugin posts a welcoming message when it detects a user's first contribution to a repo.",
+			Description: "The welcome plugin greets incoming PRs with a welcoming message.",
 			Config:      welcomeConfig,
 			Snippet:     yamlSnippet,
 		},
@@ -101,10 +102,11 @@ func getClient(pc plugins.Agent) client {
 
 func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	t := pc.PluginConfig.TriggerFor(pre.PullRequest.Base.Repo.Owner.Login, pre.PullRequest.Base.Repo.Name)
-	return handlePR(getClient(pc), t, pre, welcomeMessageForRepo(pc.PluginConfig, pre.Repo.Owner.Login, pre.Repo.Name))
+	options := optionsForRepo(pc.PluginConfig, pre.Repo.Owner.Login, pre.Repo.Name)
+	return handlePR(getClient(pc), t, pre, welcomeMessageForRepo(options), options.AlwaysPost)
 }
 
-func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeTemplate string) error {
+func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeTemplate string, alwaysPost bool) error {
 	// Only consider newly opened PRs
 	if pre.Action != github.PullRequestActionOpened {
 		return nil
@@ -134,8 +136,8 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 		return err
 	}
 
-	// if there are no results, this is the first! post the welcome comment
-	if len(issues) == 0 || len(issues) == 1 && issues[0].Number == pre.Number {
+	// if there are no results, or if configured to greet any PR - post the welcome comment
+	if alwaysPost || len(issues) == 0 || len(issues) == 1 && issues[0].Number == pre.Number {
 		// load the template, and run it over the PR info
 		parsedTemplate, err := template.New("welcome").Parse(welcomeTemplate)
 		if err != nil {
@@ -159,10 +161,9 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 	return nil
 }
 
-func welcomeMessageForRepo(config *plugins.Configuration, org, repo string) string {
-	opts := optionsForRepo(config, org, repo)
-	if opts.MessageTemplate != "" {
-		return opts.MessageTemplate
+func welcomeMessageForRepo(options *plugins.Welcome) string {
+	if options.MessageTemplate != "" {
+		return options.MessageTemplate
 	}
 	return defaultWelcomeMessage
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1451,7 +1451,7 @@ k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/kubernetes v1.14.7
 ## explicit
 k8s.io/kubernetes/pkg/apis/core
-# k8s.io/test-infra v0.0.0-20220505233241-5dbfbf033d55
+# k8s.io/test-infra v0.0.0-20220519160727-e2358f85de1e
 ## explicit; go 1.18
 k8s.io/test-infra/ghproxy/ghcache
 k8s.io/test-infra/ghproxy/ghmetrics


### PR DESCRIPTION
Continuing work in kubernetes/test-infra#26343 with enabling all welcome plugin configuration to be sharded by organizations / repositories / etc. instead of only being defined globally.

Without this fix, one will get failure similar to this:
```
time="2022-05-19T17:26:20Z" level=fatal msg="could not update Prow
plugin configuration" error="could not load Prow plugin configuration:
failed to merge config from
/config/openshift-assisted/_pluginconfig.yaml into main config:
supplemental plugin configuration has config that doesn't support
merging:   &plugins.Configuration{\n  \t... // 26 identical fields\n
\tSize:     {},\n  \tTriggers: nil,\n- \tWelcome:
[]plugins.Welcome{{Repos: []string{\"openshift-assisted\"}}},\n+
\tWelcome:  nil,\n  \tOverride: {},\n  \tHelp:     {},\n  }\n"
```

In addition, updating kubernetes/test-infra to its latest available version.