### PR TITLE
pkg/config: use newer `diff-filter` syntax

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -236,7 +236,7 @@ func GetChangedClusterProfiles(path, baseRev string) ([]string, error) {
 func getRevChanges(root, path, base string) ([]string, error) {
 	// Sample output (with abbreviated hashes) from git-diff-tree(1):
 	// :100644 100644 bcd1234 0123456 M file0
-	cmd := []string{"diff-tree", "-r", "--diff-filter=ABCMRTUX", base + ":" + path, "HEAD:" + path}
+	cmd := []string{"diff-tree", "-r", "--diff-filter=d", base + ":" + path, "HEAD:" + path}
 	diff, err := git(root, cmd...)
 	if err != nil || diff == "" {
 		return nil, err


### PR DESCRIPTION
In the Paleolithic era, our images used CentOS 7 and `git` 1.8:

https://github.com/openshift/ci-operator-prowgen/pull/118#issuecomment-475582854

(note the repository URL for extra nostalgia)

We are no longer using stone tools, so change the `diff-filter` to
something more reasonable.  See:

https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203