### PR TITLE
Revert "ci-operator: always set security context"

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -288,10 +288,8 @@ func setSecurityContexts(
 	f := func(l []coreapi.Container) {
 		for i := range l {
 			if l[i].Name == root {
-				nonRoot := false
 				var uid int64
 				l[i].SecurityContext = &coreapi.SecurityContext{
-					RunAsNonRoot:   &nonRoot,
 					RunAsUser:      &uid,
 					Capabilities:   capabilities,
 					SELinuxOptions: seLinuxOpts,

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -132,8 +132,6 @@
         name: entrypoint-wrapper
     nodeName: node-name
     restartPolicy: Never
-    securityContext:
-      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -291,8 +289,6 @@
         name: entrypoint-wrapper
     nodeName: node-name
     restartPolicy: Never
-    securityContext:
-      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -446,8 +442,6 @@
         name: entrypoint-wrapper
     nodeName: node-name
     restartPolicy: Never
-    securityContext:
-      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:
@@ -613,8 +607,6 @@
         name: entrypoint-wrapper
     nodeName: node-name
     restartPolicy: Never
-    securityContext:
-      runAsNonRoot: true
     serviceAccountName: test
     terminationGracePeriodSeconds: 18
     volumes:

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestSetSecurityContexts_match.yaml
@@ -11,7 +11,6 @@ spec:
     resources: {}
     securityContext:
       capabilities: {}
-      runAsNonRoot: false
       runAsUser: 0
       seLinuxOptions: {}
   initContainers:

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -207,7 +207,6 @@ func GenerateBasePod(
 	if err != nil {
 		return nil, err
 	}
-	nonRoot := true
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
@@ -221,9 +220,6 @@ func GenerateBasePod(
 		Spec: coreapi.PodSpec{
 			NodeName:      nodeName,
 			RestartPolicy: coreapi.RestartPolicyNever,
-			SecurityContext: &coreapi.PodSecurityContext{
-				RunAsNonRoot: &nonRoot,
-			},
 			Containers: []coreapi.Container{
 				{
 					Image:                    image,

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -85,8 +85,6 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  securityContext:
-    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -85,8 +85,6 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  securityContext:
-    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
@@ -112,8 +112,6 @@ spec:
     - mountPath: /tools
       name: tools
   restartPolicy: Never
-  securityContext:
-    runAsNonRoot: true
   volumes:
   - emptyDir: {}
     name: logs


### PR DESCRIPTION
This reverts commit c2bc9d7135f4ac622541f42ad1f579cb32ff9412.

This ended up interacting badly with the temporary container injection
we have in the builds clusters:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/27092/rehearse-27092-pull-ci-openshift-installer-master-e2e-nutanix/1529090805015252992#1:build-log.txt%3A56

Reverting for now as it's just a bonus and not strictly necessary.