### PR TITLE
retester: check if a PR is enabled earlier

### DIFF
--- a/cmd/retester/main.go
+++ b/cmd/retester/main.go
@@ -60,8 +60,8 @@ func gatherOptions() options {
 	fs.StringVar(&intervalRaw, "interval", "1h", "Parseable duration string that specifies the sync period")
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
 	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
-	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository is saved in list. It can be used more than once, the result is a list of repositories where we start commenting instead of logging")
-	fs.Var(&o.enableOnOrgs, "enable-on-org", "Organization is saved in list. It can be used more than once, the result is a list of organizations (owners) where we start commenting instead of logging")
+	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository that the retester is enabled on, e.g., 'openshift/ci-tools'. It can be used more than once.")
+	fs.Var(&o.enableOnOrgs, "enable-on-org", "Organization that the retester is enabled on, e.g., 'openshift'. It can be used more than once.")
 
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.config} {
 		group.AddFlags(fs)


### PR DESCRIPTION
The logic before this PR:

`enable`-checking takes place right before issuing the command on PRs:
Yes: issue `/retest` command
No: logging (The cache will count even this case).

The miscounting led to the fact that the PRs that come from a newly enabled repo/org have no comments because it reaches the limit in cache.

To fix this, the logic after this PR:
Filter out disabled PRs before checking if it has failures from required jobs.
Remove the logging for disabled PRs because each PR is enabled at that point.

/cc @openshift/test-platform 