### PR TITLE
Fix snyk-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -441,3 +441,7 @@ $(TMPDIR)/.cluster-display-kubeconfig-dir:
 cluster-display: $(TMPDIR)/.cluster-display-kubeconfig-dir
 	@go run  ./cmd/cluster-display --kubeconfig-dir=$(TMPDIR)/.cluster-display-kubeconfig-dir
 .PHONY: cluster-display
+
+analyse-deps: cmd/vault-secret-collection-manager/index.js
+	@snyk test --project-name=ci-tools --org=red-hat-org
+.PHONY: analyse-deps


### PR DESCRIPTION
Execute `cmd/vault-secret-collection-manager/index.js` before calling `snyk test` to workaround the following error

` 'go list -json -deps ./...' command failed with error: cmd/vault-secret-collection-manager/frontend.go:12:13: pattern index.js: no matching files found`