### PR TITLE
github-ldap-user-group-creator: whitelist github IDs for robots

### DIFF
--- a/cmd/github-ldap-user-group-creator/main.go
+++ b/cmd/github-ldap-user-group-creator/main.go
@@ -243,6 +243,8 @@ type GroupClusters struct {
 	Group    *userv1.Group
 }
 
+var githubRobotIds = sets.NewString("RH-Cachito", "openshift-bot", "openshift-ci-robot", "openshift-merge-robot")
+
 func makeGroups(openshiftPrivAdmins sets.String, peribolosConfig string, mapping map[string]string, roverGroups map[string][]string, config *group.Config, clusters sets.String) (map[string]GroupClusters, error) {
 	groups := map[string]GroupClusters{}
 	var errs []error
@@ -252,7 +254,7 @@ func makeGroups(openshiftPrivAdmins sets.String, peribolosConfig string, mapping
 		kerberosIDs := sets.NewString()
 		for _, admin := range openshiftPrivAdmins.List() {
 			kerberosID, ok := mapping[admin]
-			if !ok {
+			if !ok && !githubRobotIds.Has(admin) {
 				ignoredOpenshiftPrivAdminNames.Insert(admin)
 				continue
 			}
@@ -268,7 +270,7 @@ func makeGroups(openshiftPrivAdmins sets.String, peribolosConfig string, mapping
 	}
 	if ignoredOpenshiftPrivAdminNames.Len() > 0 {
 		logrus.WithField("ignoredOpenshiftPrivAdminNames", ignoredOpenshiftPrivAdminNames.List()).
-			Warn("These logins are members of openshift-priv but have no mapping to RH login.")
+			Error("These logins are members of openshift-priv but have no mapping to RH login.")
 	}
 
 	clustersExceptHive := clusters.Difference(sets.NewString(string(api.HiveCluster)))


### PR DESCRIPTION
Found those (see `githubRobotIds`) in the logs.

/hold

Give DPP more time to confirm if https://github.com/RH-Cachito is a robot
https://coreos.slack.com/archives/CBUT43E94/p1653679694670849

1. Ignore those known robot accounts while logging
2. Error instead of warning if seeing more in the future

/cc @smg247 