### PR TITLE
Add option to ignore repos in `check-gh-automation`

### DIFF
--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )

--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -40,6 +41,7 @@ func TestCheckRepos(t *testing.T) {
 		name        string
 		repos       []string
 		bots        []string
+		ignoreRepos sets.String
 		expected    []string
 		expectedErr error
 	}{
@@ -61,6 +63,12 @@ func TestCheckRepos(t *testing.T) {
 			expected: []string{"org-2/repo-z"},
 		},
 		{
+			name:        "ignored repo",
+			repos:       []string{"org-2/repo-z"},
+			bots:        []string{"a-bot", "b-bot"},
+			ignoreRepos: sets.NewString("org-2/repo-z"),
+		},
+		{
 			name:        "collaborator check returns error",
 			repos:       []string{"org-1/fake"},
 			bots:        []string{"a-bot"},
@@ -69,7 +77,7 @@ func TestCheckRepos(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			failing, err := checkRepos(tc.repos, tc.bots, client, logrus.NewEntry(logrus.New()))
+			failing, err := checkRepos(tc.repos, tc.bots, tc.ignoreRepos, client, logrus.NewEntry(logrus.New()))
 			if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("error doesn't match expected, diff: %s", diff)
 			}


### PR DESCRIPTION
From testing out the periodic in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/29112/rehearse-29112-periodic-check-gh-automation/1532421549770936320 it appears there will be some repos that we need to ignore in this check. I am reaching out to owners to confirm that they have valid reasons for not adding the automation, but in the meantime I want to add the ability to ignore some repos.

/cc @openshift/test-platform 