### PR TITLE
modify to allow ignoring entire orgs in `check-gh-automation`

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -21,7 +21,7 @@ import (
 type options struct {
 	config          configflagutil.ConfigOptions
 	bots            flagutil.Strings
-	ignoreRepos     flagutil.Strings
+	ignore          flagutil.Strings
 	releaseRepoPath string
 	flagutil.GitHubOptions
 }
@@ -31,7 +31,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	fs.Var(&o.bots, "bot", "Check if this bot is a collaborator. Can be passed multiple times.")
-	fs.Var(&o.ignoreRepos, "ignore-repo", "Ignore a repo. Formatted org/repo. Can be passed multiple times.")
+	fs.Var(&o.ignore, "ignore", "Ignore a repo or entire org. Formatted org or org/repo. Can be passed multiple times.")
 	fs.StringVar(&o.releaseRepoPath, "candidate-path", "", "Path to a openshift/release working copy with a revision to be tested")
 
 	o.GitHubOptions.AddFlags(fs)
@@ -90,7 +90,7 @@ func main() {
 	} else {
 		repos = gatherModifiedRepos(o.releaseRepoPath, logger)
 	}
-	failing, err := checkRepos(repos, o.bots.Strings(), o.ignoreRepos.StringSet(), client, logger)
+	failing, err := checkRepos(repos, o.bots.Strings(), o.ignore.StringSet(), client, logger)
 	if err != nil {
 		logger.Fatalf("error checking repos: %v", err)
 	}
@@ -102,7 +102,7 @@ func main() {
 	logger.Infof("All repos have github automation configured.")
 }
 
-func checkRepos(repos []string, bots []string, ignoreRepos sets.String, client collaboratorClient, logger *logrus.Entry) ([]string, error) {
+func checkRepos(repos []string, bots []string, ignore sets.String, client collaboratorClient, logger *logrus.Entry) ([]string, error) {
 	var failing []string
 	for _, orgRepo := range repos {
 		split := strings.Split(orgRepo, "/")
@@ -112,7 +112,7 @@ func checkRepos(repos []string, bots []string, ignoreRepos sets.String, client c
 			"repo": repo,
 		})
 
-		if ignoreRepos.Has(orgRepo) {
+		if ignore.Has(org) || ignore.Has(orgRepo) {
 			repoLogger.Infof("skipping ignored repo")
 			continue
 		}

--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -42,7 +42,7 @@ func TestCheckRepos(t *testing.T) {
 		name        string
 		repos       []string
 		bots        []string
-		ignoreRepos sets.String
+		ignore      sets.String
 		expected    []string
 		expectedErr error
 	}{
@@ -64,16 +64,16 @@ func TestCheckRepos(t *testing.T) {
 			expected: []string{"org-2/repo-z"},
 		},
 		{
-			name:        "ignored repo",
-			repos:       []string{"org-2/repo-z"},
-			bots:        []string{"a-bot", "b-bot"},
-			ignoreRepos: sets.NewString("org-2/repo-z"),
+			name:   "ignored repo",
+			repos:  []string{"org-2/repo-z"},
+			bots:   []string{"a-bot", "b-bot"},
+			ignore: sets.NewString("org-2/repo-z"),
 		},
 		{
-			name:        "ignored org",
-			repos:       []string{"org-2/repo-z"},
-			bots:        []string{"a-bot", "b-bot"},
-			ignoreRepos: sets.NewString("org-2"),
+			name:   "ignored org",
+			repos:  []string{"org-2/repo-z"},
+			bots:   []string{"a-bot", "b-bot"},
+			ignore: sets.NewString("org-2"),
 		},
 		{
 			name:        "collaborator check returns error",
@@ -84,7 +84,7 @@ func TestCheckRepos(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			failing, err := checkRepos(tc.repos, tc.bots, tc.ignoreRepos, client, logrus.NewEntry(logrus.New()))
+			failing, err := checkRepos(tc.repos, tc.bots, tc.ignore, client, logrus.NewEntry(logrus.New()))
 			if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("error doesn't match expected, diff: %s", diff)
 			}

--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -70,6 +70,12 @@ func TestCheckRepos(t *testing.T) {
 			ignoreRepos: sets.NewString("org-2/repo-z"),
 		},
 		{
+			name:        "ignored org",
+			repos:       []string{"org-2/repo-z"},
+			bots:        []string{"a-bot", "b-bot"},
+			ignoreRepos: sets.NewString("org-2"),
+		},
+		{
 			name:        "collaborator check returns error",
 			repos:       []string{"org-1/fake"},
 			bots:        []string{"a-bot"},


### PR DESCRIPTION
The periodic is getting rate limited due to having to check too many repos. We can entirely ignore the checks for `openshift` and `openshift-priv` as part of the process for setting up repos there include adding the bots team to the repo. I have also verified (by running the periodic rehearsal) that everything there is set up correctly.

/cc @openshift/test-platform 