### PR TITLE
Fix github-ldap-user-group-creator

### DIFF
--- a/cmd/github-ldap-user-group-creator/main.go
+++ b/cmd/github-ldap-user-group-creator/main.go
@@ -254,8 +254,10 @@ func makeGroups(openshiftPrivAdmins sets.String, peribolosConfig string, mapping
 		kerberosIDs := sets.NewString()
 		for _, admin := range openshiftPrivAdmins.List() {
 			kerberosID, ok := mapping[admin]
-			if !ok && !githubRobotIds.Has(admin) {
-				ignoredOpenshiftPrivAdminNames.Insert(admin)
+			if !ok {
+				if !githubRobotIds.Has(admin) {
+					ignoredOpenshiftPrivAdminNames.Insert(admin)
+				}
 				continue
 			}
 			kerberosIDs.Insert(kerberosID)

--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -43,7 +43,7 @@ func TestMakeGroups(t *testing.T) {
 		{
 			name:                "basic case",
 			peribolosConfig:     "bar",
-			openshiftPrivAdmins: sets.NewString("a"),
+			openshiftPrivAdmins: sets.NewString("a", "RH-Cachito"),
 			mapping:             map[string]string{"a": "b", "c": "c"},
 			roverGroups:         map[string][]string{"old-group-name": {"b", "c"}, "x": {"y", "y"}},
 			config: &group.Config{


### PR DESCRIPTION
Introduced in https://github.com/openshift/ci-tools/pull/2841/files
It caused failures like
```
$ attempt to create invalid group openshift-priv-admins on cluster app.ci: member name in group cannot be empty
```

/cc @openshift/test-platform 