### PR TITLE
Prevent log to interpret bash meta-chars

### DIFF
--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -97,7 +97,7 @@ function os::log::internal::prefix_lines() {
 
 	local old_ifs="${IFS}"
 	IFS=$'\n'
-	for line in ${content}; do
+	for line in "${content}"; do
 		echo "${prefix} ${line}"
 	done
 	IFS="${old_ifs}"


### PR DESCRIPTION
When someone tries to log something like `os::log::info "*"` the result it is not as expected.
The script interprets that meta-character and it loops over the content of the current working directory.

This PR tries to fix it by converting data into a string explicitly.