### PR TITLE
prpqr_reconciler: replace md5 with sha2

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -2,7 +2,7 @@ package prpqr_reconciler
 
 import (
 	"context"
-	"crypto/md5"
+	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
 	"reflect"
@@ -419,10 +419,11 @@ func constructCondition(statuses map[string]*v1.PullRequestPayloadJobStatus) met
 }
 
 func jobNameHash(name string) string {
-	hasher := md5.New()
-	// MD5 Write never returns error
-	_, _ = hasher.Write([]byte(name))
-	return hex.EncodeToString(hasher.Sum(nil))
+	h := sha1.New()
+	if n, err := h.Write([]byte(name)); err != nil {
+		logrus.WithField("n", n).WithError(err).Error("failed to write")
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -91,7 +91,7 @@ func TestReconcile(t *testing.T) {
 							"prow.k8s.io/refs.repo":     "test-repo",
 							"prow.k8s.io/type":          "periodic",
 							"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test",
-							"releaseJobNameHash": "ee3858eff62263cd7266320c00d1d38b",
+							"releaseJobNameHash": "71f7d67f86fd15a22b0957b068cf2dba9433c628",
 						},
 					},
 					Status: prowv1.ProwJobStatus{State: "triggered"},

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -15,8 +15,8 @@
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
-      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
-      releaseJobNameHash: 3cfd4050d8c5f92e2a61b67055742651
+      release.openshift.io/aggregation-id: ba10bb8398ca6a8023d32d52b10282b851622c22
+      releaseJobNameHash: 2ca90b0590522c9c9db49f9953c2e5d63ac2d6c2
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
@@ -93,8 +93,8 @@
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
-      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
-      releaseJobNameHash: 283d99c0dcbd80070e6816420ac68caa
+      release.openshift.io/aggregation-id: ba10bb8398ca6a8023d32d52b10282b851622c22
+      releaseJobNameHash: 3f0af5d66fb219d461a94c835edf6ff4a23ed5a7
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
@@ -160,7 +160,7 @@
     annotations:
       prow.k8s.io/context: ""
       prow.k8s.io/job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
-      releaseJobName: e2bd00d6b219bda9ee14b9e9e3c8300e
+      releaseJobName: 4ead5eccc876bb18a1d582ff779ad545a2b5e043
     creationTimestamp: null
     labels:
       created-by-prow: "true"
@@ -168,7 +168,7 @@
       prow.k8s.io/job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      release.openshift.io/aggregation-id: a0e1bddfc1d7a5e78e6c2e483f238b15
+      release.openshift.io/aggregation-id: ba10bb8398ca6a8023d32d52b10282b851622c22
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
@@ -202,7 +202,7 @@
             - as: release-analysis-prpqr-aggregator
               steps:
                 env:
-                  AGGREGATION_ID: a0e1bddfc1d7a5e78e6c2e483f238b15
+                  AGGREGATION_ID: ba10bb8398ca6a8023d32d52b10282b851622c22
                   EXPLICIT_GCS_PREFIX: logs/test-org-test-repo-100-test-name
                   GOOGLE_SA_CREDENTIAL_FILE: /var/run/secrets/google-serviceaccount-credentials.json
                   JOB_START_TIME: "1970-01-01T01:00:00+01:00"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -16,7 +16,7 @@
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+      releaseJobNameHash: 71f7d67f86fd15a22b0957b068cf2dba9433c628
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case__prowjob_already_exists__no_updates.yaml
@@ -15,7 +15,7 @@
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+      releaseJobNameHash: 71f7d67f86fd15a22b0957b068cf2dba9433c628
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "999"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -16,7 +16,7 @@
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 96fc864a2c83534793cb2d421fbf394a
+      releaseJobNameHash: 784e479043a3a7d6564cfdf5dfbcbf5606288704
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -40,7 +40,7 @@
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 428af2aff595f9d8074f2f6bfba1aec1
+      releaseJobNameHash: 610797216135a099b94136c28abe12ab3d8bfae5
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/2852/pull-ci-openshift-release-snyk-code/1534274654162653184#1:build-log.txt%3A72

```
 ✗ [Medium] Use of Password Hash With Insufficient Computational Effort
     Path: pkg/controller/prpqr_reconciler/prpqr_reconciler.go, line 422
     Info: The MD5 hash (used in crypto.md5.New) is insecure. Consider changing it to a secure hash algorithm
```

https://issues.redhat.com/browse/DPTP-2899

/hold

