### PR TITLE
FIX: prevent log to interpret bash meta-chars

### DIFF
--- a/hack/lib/log/output.sh
+++ b/hack/lib/log/output.sh
@@ -97,8 +97,8 @@ function os::log::internal::prefix_lines() {
 
 	local old_ifs="${IFS}"
 	IFS=$'\n'
-	for line in "${content}"; do
+	while read -r line; do
 		echo "${prefix} ${line}"
-	done
+	done <<< "${content}"
 	IFS="${old_ifs}"
 }


### PR DESCRIPTION
A better version of [#2851](https://github.com/openshift/ci-tools/pull/2851)

/cc @bbguimaraes 