### PR TITLE
`check-gh-automation`: don't check repos where the config was simply modified

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -144,7 +144,7 @@ func gatherModifiedRepos(releaseRepoPath string, logger *logrus.Entry) []string 
 	if err != nil {
 		logger.Fatalf("error resolving JobSpec: %v", err)
 	}
-	configs, err := config.GetChangedConfigs(releaseRepoPath, jobSpec.Refs.BaseSHA)
+	configs, err := config.GetAddedConfigs(releaseRepoPath, jobSpec.Refs.BaseSHA)
 	if err != nil {
 		logger.Fatalf("error determining changed configs: %v", err)
 	}

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -109,6 +109,29 @@ git mv renameme/file renamed/file
 	compareChanges(t, ClusterProfilesPath, files, cmd, GetChangedClusterProfiles, expected)
 }
 
+func TestGetAddedConfigs(t *testing.T) {
+	files := []string{
+		"nochanges/file", "changeme/file", "removeme/file", "moveme/file",
+		"renameme/file", "dir/dir/file",
+	}
+	cmd := `
+> changeme/file
+git rm --quiet removeme/file
+mkdir new/ renamed/
+> new/file
+git add new/file
+git mv moveme/file moveme/moved
+git mv renameme/file renamed/file
+> dir/dir/file
+`
+	expected := []string{
+		filepath.Join(CiopConfigInRepoPath, "moveme", "moved"),
+		filepath.Join(CiopConfigInRepoPath, "new", "file"),
+		filepath.Join(CiopConfigInRepoPath, "renamed", "file"),
+	}
+	compareChanges(t, CiopConfigInRepoPath, files, cmd, GetAddedConfigs, expected)
+}
+
 func TestConfigMapName(t *testing.T) {
 	path := "path/to/a-file.yaml"
 	dnfError := fmt.Errorf("path not covered by any config-updater pattern: path/to/a-file.yaml")


### PR DESCRIPTION
We are running this check a lot, and since we now have a periodic to consistently verify that repos that are already a part of the CI are accessible by our automation we don't need the presubmit to check repos for which the configs have merely been modified.

I used https://git-scm.com/docs/git-diff-tree#Documentation/git-diff-tree.txt---diff-filterACDMRTUXB82308203 to only flag repos for which the configs were: added, moved, or renamed.