### PR TITLE
template.JSEscapeString(callbackName)

### DIFF
--- a/cmd/cluster-display/main.go
+++ b/cmd/cluster-display/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"html/template"
 	"net/http"
 	"os"
 	"sort"
@@ -224,7 +225,8 @@ func getRouter(ctx context.Context, hiveClient ctrlruntimeclient.Client, clients
 			}
 			w.Header().Set("Content-Type", "application/javascript")
 			content := string(bytes)
-			if n, err := fmt.Fprintf(w, "%s(%s);", callbackName, content); err != nil {
+			template.JSEscape(w, []byte(callbackName))
+			if n, err := fmt.Fprintf(w, "(%s);", content); err != nil {
 				logrus.WithError(err).WithField("n", n).WithField("content", content).Error("failed to write content")
 			}
 			return

--- a/cmd/cluster-display/main.go
+++ b/cmd/cluster-display/main.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -181,10 +180,6 @@ func resolveProduct(ctx context.Context, client ctrlruntimeclient.Client, versio
 	return "OSD", nil
 }
 
-var (
-	callbackTemplate = template.Must(template.New("callback").Parse(`{{.callbackName}}({{.content}});`))
-)
-
 func getRouter(ctx context.Context, hiveClient ctrlruntimeclient.Client, clients map[string]ctrlruntimeclient.Client) *http.ServeMux {
 	handler := http.NewServeMux()
 
@@ -229,9 +224,8 @@ func getRouter(ctx context.Context, hiveClient ctrlruntimeclient.Client, clients
 			}
 			w.Header().Set("Content-Type", "application/javascript")
 			content := string(bytes)
-
-			if err := callbackTemplate.Execute(w, map[string]string{"callbackName": callbackName, "content": content}); err != nil {
-				logrus.WithError(err).WithField("content", content).Error("failed to execute the callback template")
+			if n, err := fmt.Fprintf(w, "%s(%s);", callbackName, content); err != nil {
+				logrus.WithError(err).WithField("n", n).WithField("content", content).Error("failed to write content")
 			}
 			return
 		} else {


### PR DESCRIPTION
This reverts commit 7ae33072cab074a236eb260a1cf92debaf94b56f.

Ref. the implementation https://github.com/gin-gonic/gin/blob/f2182de38c8d19d35d4b4191749216f12512f59c/render/json.go#L119

/cc @openshift/test-platform 