### PR TITLE
blocking-issue-creator: direct users to docs

### DIFF
--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -121,7 +121,7 @@ func manageIssues(client githubClient, githubLogin string, repoInfo *config.Info
 		body += fmt.Sprintf(" - `%s`\n", branch)
 		branchTokens = append(branchTokens, fmt.Sprintf("branch:%s", branch))
 	}
-	body += "\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information."
+	body += "\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/)."
 	title := fmt.Sprintf("Future Release Branches Frozen For Merging | %s", strings.Join(branchTokens, " "))
 
 	query := fmt.Sprintf("is:issue state:open label:\"tide/merge-blocker\" repo:%s/%s author:%s", repoInfo.Org, repoInfo.Repo, githubLogin)

--- a/cmd/blocking-issue-creator/main_test.go
+++ b/cmd/blocking-issue-creator/main_test.go
@@ -50,7 +50,7 @@ func TestManageIssues(t *testing.T) {
 				1: {
 					ID:     1,
 					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
-					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/).",
 					Labels: []github.Label{{Name: "tide/merge-blocker"}},
 				},
 			},
@@ -58,7 +58,7 @@ func TestManageIssues(t *testing.T) {
 				{
 					ID:     1,
 					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
-					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/).",
 					Labels: []github.Label{{Name: "tide/merge-blocker"}},
 				},
 			},
@@ -78,7 +78,7 @@ func TestManageIssues(t *testing.T) {
 				{
 					ID:     1,
 					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
-					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/).",
 					Labels: []github.Label{{Name: "tide/merge-blocker"}},
 				},
 			},
@@ -104,7 +104,7 @@ func TestManageIssues(t *testing.T) {
 				{
 					Number: 1,
 					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
-					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/).",
 					Labels: []github.Label{{Name: "tide/merge-blocker"}},
 				},
 			},
@@ -146,7 +146,7 @@ func TestManageIssues(t *testing.T) {
 					ID:     1,
 					Number: 1,
 					Title:  "Future Release Branches Frozen For Merging | branch:release-4.9",
-					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nContact the [Test Platform](https://coreos.slack.com/messages/CBN38N3MW) or [Automated Release](https://coreos.slack.com/messages/CB95J6R4N) teams for more information.",
+					Body:   "The following branches are being fast-forwarded from the current development branch (testBranch) as placeholders for future releases. No merging is allowed into these release branches until they are unfrozen for production release.\n\n - `release-4.9`\n\nFor more information, see the [branching documentation](https://docs.ci.openshift.org/docs/architecture/branching/).",
 					Labels: []github.Label{{Name: "tide/merge-blocker"}},
 				},
 				{


### PR DESCRIPTION
"Contact the Test Platform team" should never be the suggested first
step for more information.