### PR TITLE
retester: Adding config file to retester

### DIFF
--- a/cmd/retester/main.go
+++ b/cmd/retester/main.go
@@ -35,6 +35,8 @@ type options struct {
 	cacheFile      string
 	cacheRecordAge time.Duration
 
+	configFile string
+
 	enableOnRepos prowflagutil.Strings
 	enableOnOrgs  prowflagutil.Strings
 }
@@ -60,6 +62,7 @@ func gatherOptions() options {
 	fs.StringVar(&intervalRaw, "interval", "1h", "Parseable duration string that specifies the sync period")
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
 	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
+	fs.StringVar(&o.configFile, "config-file", "", "File to configure maxRetestsForShaAndBase and maxRetestsForSha. Default maxRetestsForShaAndBase is 3 and maxRetestsForSha is 9 if config is not not set")
 	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository that the retester is enabled on, e.g., 'openshift/ci-tools'. It can be used more than once.")
 	fs.Var(&o.enableOnOrgs, "enable-on-org", "Organization that the retester is enabled on, e.g., 'openshift'. It can be used more than once.")
 
@@ -105,7 +108,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 
-	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.enableOnRepos, o.enableOnOrgs)
+	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.configFile, o.enableOnRepos, o.enableOnOrgs)
 
 	interrupts.OnInterrupt(func() {
 		if err := gitClient.Clean(); err != nil {

--- a/cmd/retester/main.go
+++ b/cmd/retester/main.go
@@ -62,7 +62,7 @@ func gatherOptions() options {
 	fs.StringVar(&intervalRaw, "interval", "1h", "Parseable duration string that specifies the sync period")
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
 	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
-	fs.StringVar(&o.configFile, "config-file", "", "File to configure maxRetestsForShaAndBase and maxRetestsForSha. Default maxRetestsForShaAndBase is 3 and maxRetestsForSha is 9 if config is not not set")
+	fs.StringVar(&o.configFile, "config-file", "", "Path to the configure file of the retest.")
 	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository that the retester is enabled on, e.g., 'openshift/ci-tools'. It can be used more than once.")
 	fs.Var(&o.enableOnOrgs, "enable-on-org", "Organization that the retester is enabled on, e.g., 'openshift'. It can be used more than once.")
 

--- a/cmd/retester/main.go
+++ b/cmd/retester/main.go
@@ -36,9 +36,6 @@ type options struct {
 	cacheRecordAge time.Duration
 
 	configFile string
-
-	enableOnRepos prowflagutil.Strings
-	enableOnOrgs  prowflagutil.Strings
 }
 
 func (o *options) Validate() error {
@@ -63,8 +60,6 @@ func gatherOptions() options {
 	fs.StringVar(&o.cacheFile, "cache-file", "", "File to persist cache. No persistence of cache if not set")
 	fs.StringVar(&cacheRecordAgeRaw, "cache-record-age", "168h", "Parseable duration string that specifies how long a cache record lives in cache after the last time it was considered")
 	fs.StringVar(&o.configFile, "config-file", "", "Path to the configure file of the retest.")
-	fs.Var(&o.enableOnRepos, "enable-on-repo", "Repository that the retester is enabled on, e.g., 'openshift/ci-tools'. It can be used more than once.")
-	fs.Var(&o.enableOnOrgs, "enable-on-org", "Organization that the retester is enabled on, e.g., 'openshift'. It can be used more than once.")
 
 	for _, group := range []flagutil.OptionGroup{&o.github, &o.config} {
 		group.AddFlags(fs)
@@ -108,7 +103,12 @@ func main() {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 
-	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, o.configFile, o.enableOnRepos, o.enableOnOrgs)
+	config, err := loadConfig(o.configFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to load config from file")
+	}
+
+	c := newController(gc, configAgent.Config, git.ClientFactoryFrom(gitClient), o.github.AppPrivateKeyPath != "", o.cacheFile, o.cacheRecordAge, config)
 
 	interrupts.OnInterrupt(func() {
 		if err := gitClient.Clean(); err != nil {

--- a/cmd/retester/main_test.go
+++ b/cmd/retester/main_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 func TestGatherOptions(t *testing.T) {
-	expected := []string{"org/repo", "other-org/other-repo"}
-	os.Args = []string{"cmd", "--enable-on-repo=org/repo", "--cache-record-age=100h", "--config-file=config.yaml", "--enable-on-repo=other-org/other-repo"}
+	expected := "config.yaml"
+	os.Args = []string{"cmd", "--cache-record-age=100h", "--config-file=config.yaml"}
 
 	actual := gatherOptions()
 
-	if diff := cmp.Diff(expected, actual.enableOnRepos.Strings()); diff != "" {
-		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.enableOnRepos)
+	if diff := cmp.Diff(expected, actual.configFile); diff != "" {
+		t.Errorf("Test failed, expected: '%+v', got:  '%+v'", expected, actual.configFile)
 	}
 }

--- a/cmd/retester/main_test.go
+++ b/cmd/retester/main_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGatherOptions(t *testing.T) {
 	expected := []string{"org/repo", "other-org/other-repo"}
-	os.Args = []string{"cmd", "--enable-on-repo=org/repo", "--cache-record-age=100h", "--enable-on-repo=other-org/other-repo"}
+	os.Args = []string{"cmd", "--enable-on-repo=org/repo", "--cache-record-age=100h", "--config-file=config.yaml", "--enable-on-repo=other-org/other-repo"}
 
 	actual := gatherOptions()
 

--- a/cmd/retester/retester.go
+++ b/cmd/retester/retester.go
@@ -169,18 +169,24 @@ func (c *Config) GetRetesterPolicy(org, repo string) (RetesterPolicy, error) {
 		if repoStruct, ok = orgStruct.Repos[repo]; ok && repoStruct.Enabled != nil {
 			policy.Enabled = repoStruct.Enabled
 			if *repoStruct.Enabled {
-				if repoStruct.MaxRetestsForSha != 0 && repoStruct.MaxRetestsForShaAndBase != 0 {
-					// returns max retests from repo if repo is enabled and configured
-					return repoStruct.RetesterPolicy, nil
+				// set max retests repo level value
+				if repoStruct.MaxRetestsForSha != 0 {
+					policy.MaxRetestsForSha = repoStruct.MaxRetestsForSha
+				}
+				if repoStruct.MaxRetestsForShaAndBase != 0 {
+					policy.MaxRetestsForShaAndBase = repoStruct.MaxRetestsForShaAndBase
 				}
 			} else {
 				return policy, fmt.Errorf("repo is disabled")
 			}
 		}
 		if *orgStruct.Enabled {
-			if orgStruct.MaxRetestsForSha != 0 && orgStruct.MaxRetestsForShaAndBase != 0 {
-				// returns max retests from org
-				return orgStruct.RetesterPolicy, nil
+			// set max retests org level value
+			if orgStruct.MaxRetestsForSha != 0 && policy.MaxRetestsForSha == 0 {
+				policy.MaxRetestsForSha = orgStruct.MaxRetestsForSha
+			}
+			if orgStruct.MaxRetestsForShaAndBase != 0 && policy.MaxRetestsForShaAndBase == 0 {
+				policy.MaxRetestsForShaAndBase = orgStruct.MaxRetestsForShaAndBase
 			}
 		}
 		if !*policy.Enabled {
@@ -189,9 +195,13 @@ func (c *Config) GetRetesterPolicy(org, repo string) (RetesterPolicy, error) {
 	} else {
 		return policy, fmt.Errorf("not configured org")
 	}
-	// returns max retests default value
-	policy.MaxRetestsForSha = c.Retester.MaxRetestsForSha
-	policy.MaxRetestsForShaAndBase = c.Retester.MaxRetestsForShaAndBase
+	// set max retests default value
+	if policy.MaxRetestsForSha == 0 {
+		policy.MaxRetestsForSha = c.Retester.MaxRetestsForSha
+	}
+	if policy.MaxRetestsForShaAndBase == 0 {
+		policy.MaxRetestsForShaAndBase = c.Retester.MaxRetestsForShaAndBase
+	}
 	return policy, nil
 }
 

--- a/cmd/retester/retester.go
+++ b/cmd/retester/retester.go
@@ -108,7 +108,7 @@ type Config struct {
 // Policy is overridden by specific levels when they are enabled.
 type Retester struct {
 	RetesterPolicy `json:",inline"`
-	Oranizations   map[string]Oranization `json:"orgs"`
+	Oranizations   map[string]Oranization `json:"orgs,omitempty"`
 }
 
 // Oranization is org level configuration for retester configuration.
@@ -130,8 +130,8 @@ type Repo struct {
 // True/False in level org means enabled/disabled org. But repo can be disabled/enabled.
 type RetesterPolicy struct {
 	MaxRetestsForShaAndBase int   `json:"max_retests_for_sha_and_base,omitempty"`
-	MaxRetestsForSha        int   `json:"max_retests_for_sha"`
-	Enabled                 *bool `json:"enabled"`
+	MaxRetestsForSha        int   `json:"max_retests_for_sha,omitempty"`
+	Enabled                 *bool `json:"enabled,omitempty"`
 }
 
 func loadConfig(configFilePath string) (*Config, error) {

--- a/cmd/retester/retester.go
+++ b/cmd/retester/retester.go
@@ -129,7 +129,7 @@ type Repo struct {
 // False in level repo means disabled repo. Nothing can change that.
 // True/False in level org means enabled/disabled org. But repo can be disabled/enabled.
 type RetesterPolicy struct {
-	MaxRetestsForShaAndBase int   `json:"max_retests_for_sha_and_base"`
+	MaxRetestsForShaAndBase int   `json:"max_retests_for_sha_and_base,omitempty"`
 	MaxRetestsForSha        int   `json:"max_retests_for_sha"`
 	Enabled                 *bool `json:"enabled"`
 }

--- a/cmd/retester/retester.go
+++ b/cmd/retester/retester.go
@@ -224,8 +224,6 @@ func validatePolicies(policy RetesterPolicy) []error {
 		} else {
 			return nil
 		}
-	} else {
-		errs = append(errs, fmt.Errorf("policy is not enabled by default"))
 	}
 	return errs
 }
@@ -297,12 +295,6 @@ const (
 	retestBackoffPause
 	retestBackoffRetest
 )
-
-// MaxRetests contains MaxRetestsForSha and MaxRetestsForShaAndBase as in Repo in Config
-type MaxRetests struct {
-	ForSha        int
-	ForShaAndBase int
-}
 
 func (b *backoffCache) check(pr tide.PullRequest, baseSha string, config *Config, policy RetesterPolicy) (retestBackoffAction, string) {
 	key := prKey(&pr)

--- a/cmd/retester/retester_test.go
+++ b/cmd/retester/retester_test.go
@@ -86,11 +86,10 @@ func TestGetMaxRetests(t *testing.T) {
 	var nonconfiguredOrg githubv4.String = "org"
 	var num githubv4.Int = 123
 	testCases := []struct {
-		name               string
-		pr                 tide.PullRequest
-		config             *Info
-		expectedSha        int
-		expectedShaAndBase int
+		name     string
+		pr       tide.PullRequest
+		config   *Info
+		expected MaxRetests
 	}{
 		{
 			name: "configured org and non-configured repo",
@@ -103,9 +102,8 @@ func TestGetMaxRetests(t *testing.T) {
 					Owner         struct{ Login githubv4.String }
 				}{Name: nonConfiguredRepo, Owner: struct{ Login githubv4.String }{Login: configuredOrg}},
 			},
-			config:             c,
-			expectedSha:        15,
-			expectedShaAndBase: 6,
+			config:   c,
+			expected: MaxRetests{15, 6},
 		},
 		{
 			name: "configured org and configured repo",
@@ -118,9 +116,8 @@ func TestGetMaxRetests(t *testing.T) {
 					Owner         struct{ Login githubv4.String }
 				}{Name: configuredRepo, Owner: struct{ Login githubv4.String }{Login: configuredOrg}},
 			},
-			config:             c,
-			expectedSha:        8,
-			expectedShaAndBase: 3,
+			config:   c,
+			expected: MaxRetests{8, 3},
 		},
 		{
 			name: "non-configured org and non-configured repo",
@@ -133,9 +130,8 @@ func TestGetMaxRetests(t *testing.T) {
 					Owner         struct{ Login githubv4.String }
 				}{Name: nonConfiguredRepo, Owner: struct{ Login githubv4.String }{Login: nonconfiguredOrg}},
 			},
-			config:             c,
-			expectedSha:        9,
-			expectedShaAndBase: 3,
+			config:   c,
+			expected: MaxRetests{9, 3},
 		},
 		{
 			name: "non-configured org and configured repo",
@@ -148,19 +144,15 @@ func TestGetMaxRetests(t *testing.T) {
 					Owner         struct{ Login githubv4.String }
 				}{Name: configuredRepo, Owner: struct{ Login githubv4.String }{Login: nonconfiguredOrg}},
 			},
-			config:             c,
-			expectedSha:        9,
-			expectedShaAndBase: 3,
+			config:   c,
+			expected: MaxRetests{9, 3},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualSha, actualShaAndBase := tc.config.getMaxRetests(tc.pr)
-			if diff := cmp.Diff(tc.expectedSha, actualSha); diff != "" {
-				t.Errorf("%s differs from expectedSha:\n%s", tc.name, diff)
-			}
-			if diff := cmp.Diff(tc.expectedShaAndBase, actualShaAndBase); diff != "" {
-				t.Errorf("%s differs from expectedShaAndBase:\n%s", tc.name, diff)
+			actual := tc.config.getMaxRetests(tc.pr)
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
 			}
 		})
 	}

--- a/cmd/retester/retester_test.go
+++ b/cmd/retester/retester_test.go
@@ -94,6 +94,9 @@ func TestGetRetesterPolicy(t *testing.T) {
 						"ci-tools": {RetesterPolicy: RetesterPolicy{
 							MaxRetestsForSha: 3, MaxRetestsForShaAndBase: 3, Enabled: &True,
 						}},
+						"repo-max": {RetesterPolicy: RetesterPolicy{
+							MaxRetestsForSha: 6, Enabled: &True,
+						}},
 						"repo": {RetesterPolicy: RetesterPolicy{Enabled: &False}},
 					}},
 				"no-openshift": {
@@ -128,6 +131,20 @@ func TestGetRetesterPolicy(t *testing.T) {
 			},
 			config:   c,
 			expected: RetesterPolicy{3, 3, &True},
+		},
+		{
+			name: "enabled repo with one max retest value and enabled org",
+			pr: tide.PullRequest{
+				Number: num,
+				Author: struct{ Login githubv4.String }{Login: "openshift"},
+				Repository: struct {
+					Name          githubv4.String
+					NameWithOwner githubv4.String
+					Owner         struct{ Login githubv4.String }
+				}{Name: "repo-max", Owner: struct{ Login githubv4.String }{Login: "openshift"}},
+			},
+			config:   c,
+			expected: RetesterPolicy{2, 6, &True},
 		},
 		{
 			name: "enabled repo and disabled org",

--- a/cmd/retester/retester_test.go
+++ b/cmd/retester/retester_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/openshift/ci-tools/pkg/testhelper"
-	"github.com/shurcooL/githubv4"
-	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/tide"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/shurcooL/githubv4"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/tide"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 type MyFakeClient struct {

--- a/cmd/retester/testdata/testconfig/config.yaml
+++ b/cmd/retester/testdata/testconfig/config.yaml
@@ -1,24 +1,15 @@
 retester:
+  max_retests_for_sha_and_base: 1
+  max_retests_for_sha: 1
   orgs:
     openshift:
-      max_retests_for_sha_and_base: 3
-      max_retests_for_sha: 9
+      enabled: true
+      max_retests_for_sha_and_base: 2
+      max_retests_for_sha: 2
       repos:
         ci-tools:
           enabled: true
           max_retests_for_sha_and_base: 3
-          max_retests_for_sha: 8
+          max_retests_for_sha: 3
         ci-docs:
           enabled: true
-    no-openshift:
-      max_retests_for_sha_and_base: 1
-      max_retests_for_sha: 1
-      repos:
-        test:
-          enabled: true
-          max_retests_for_sha_and_base: 3
-          max_retests_for_sha: 7
-        disabled-repo:
-          enabled: false
-          max_retests_for_sha_and_base: 2
-          max_retests_for_sha: 4

--- a/cmd/retester/testdata/testconfig/config.yaml
+++ b/cmd/retester/testdata/testconfig/config.yaml
@@ -1,0 +1,16 @@
+retester:
+  orgs:
+    openshift:
+      max_retests_for_sha_and_base: 3
+      max_retests_for_sha: 9
+      repos:
+        ci-tools:
+          max_retests_for_sha_and_base: 3
+          max_retests_for_sha: 8
+    no-openshift:
+      max_retests_for_sha_and_base: 1
+      max_retests_for_sha: 1
+      repos:
+        test:
+          max_retests_for_sha_and_base: 3
+          max_retests_for_sha: 7

--- a/cmd/retester/testdata/testconfig/config.yaml
+++ b/cmd/retester/testdata/testconfig/config.yaml
@@ -5,6 +5,7 @@ retester:
       max_retests_for_sha: 9
       repos:
         ci-tools:
+          enabled: true
           max_retests_for_sha_and_base: 3
           max_retests_for_sha: 8
     no-openshift:
@@ -12,5 +13,10 @@ retester:
       max_retests_for_sha: 1
       repos:
         test:
+          enabled: true
           max_retests_for_sha_and_base: 3
           max_retests_for_sha: 7
+        disabled-repo:
+          enabled: false
+          max_retests_for_sha_and_base: 2
+          max_retests_for_sha: 4

--- a/cmd/retester/testdata/testconfig/config.yaml
+++ b/cmd/retester/testdata/testconfig/config.yaml
@@ -8,6 +8,8 @@ retester:
           enabled: true
           max_retests_for_sha_and_base: 3
           max_retests_for_sha: 8
+        ci-docs:
+          enabled: true
     no-openshift:
       max_retests_for_sha_and_base: 1
       max_retests_for_sha: 1

--- a/cmd/retester/testdata/testconfig/config.yaml
+++ b/cmd/retester/testdata/testconfig/config.yaml
@@ -1,4 +1,5 @@
 retester:
+  enabled: true
   max_retests_for_sha_and_base: 1
   max_retests_for_sha: 1
   orgs:

--- a/cmd/retester/testdata/testconfig/default.yaml
+++ b/cmd/retester/testdata/testconfig/default.yaml
@@ -1,0 +1,3 @@
+retester:
+  max_retests_for_sha_and_base: 3
+  max_retests_for_sha: 9

--- a/cmd/retester/testdata/testconfig/empty.yaml
+++ b/cmd/retester/testdata/testconfig/empty.yaml
@@ -1,0 +1,1 @@
+retester: {}

--- a/cmd/retester/testdata/testconfig/no-config.yaml
+++ b/cmd/retester/testdata/testconfig/no-config.yaml
@@ -1,0 +1,1 @@
+something: a

--- a/cmd/retester/testdata/testconfig/openshift-config.yaml
+++ b/cmd/retester/testdata/testconfig/openshift-config.yaml
@@ -1,0 +1,8 @@
+retester:
+  max_retests_for_sha_and_base: 3
+  max_retests_for_sha: 9
+  orgs:
+    openshift:
+      enabled: true
+    openshift-knative:
+      enabled: true


### PR DESCRIPTION
Option `--config-file` path to File which configure maxRetestsForShaAndBase and maxRetestsForSha. Default maxRetests values are configured in file.
Options `--enable-on-repo` and `--enable-on-org` are removed. And replaced by config file.
Test config file: [cmd/retester/testdata/testconfig/config.yaml](cmd/retester/testdata/testconfig/config.yaml)

[ci-docs PR](https://github.com/openshift/ci-docs/pull/268)
[DPTP-2828](https://issues.redhat.com/browse/DPTP-2828)