### PR TITLE
Pod Scaler: cap memory requests at 20Gi

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/transport"
 	prowConfig "k8s.io/test-infra/prow/config"
@@ -59,6 +60,8 @@ type consumerOptions struct {
 	dataDir              string
 	certDir              string
 	mutateResourceLimits bool
+	cpuCap               int64
+	memoryCap            string
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -78,6 +81,8 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&o.dataDir, "data-dir", "", "Local directory to cache UI data into.")
 	fs.StringVar(&o.cacheBucket, "cache-bucket", "", "GCS bucket name holding cached Prometheus data.")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "File where GCS credentials are stored.")
+	fs.Int64Var(&o.cpuCap, "cpu-cap", 10, "The maximum CPU request value, ex: 10")
+	fs.StringVar(&o.memoryCap, "memory-cap", "20Gi", "The maximum memory request value, ex: '20Gi'")
 	return &o
 }
 
@@ -104,6 +109,13 @@ func (o *options) validate() error {
 		if o.certDir == "" {
 			return errors.New("--serving-cert-dir is required")
 		}
+		if cpuCap := resource.NewQuantity(o.cpuCap, resource.DecimalSI); cpuCap.Sign() <= 0 {
+			return errors.New("--cpu-cap must be greater than 0")
+		}
+		if memoryCap := resource.MustParse(o.memoryCap); memoryCap.Sign() <= 0 {
+			return errors.New("--memory-cap must be greater than 0")
+		}
+
 	default:
 		return errors.New("--mode must be either \"producer\", \"consumer.ui\", or \"consumer.admission\"")
 	}
@@ -234,7 +246,7 @@ func mainAdmission(opts *options, cache cache) {
 		logrus.WithError(err).Fatal("Failed to construct client.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, loaders(cache), opts.mutateResourceLimits)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap)
 }
 
 func loaders(cache cache) map[string][]*cacheReloader {

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
@@ -12,10 +12,10 @@
   				Resources: v1.ResourceRequirements{
   					Limits: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 16}, Format: "DecimalSI"},
-- 						s"memory": {i: resource.int64Amount{value: 40000000000}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 60000000000}, Format: "BinarySI"},
+- 						s"memory": {i: resource.int64Amount{value: 400000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 600000000}, Format: "BinarySI"},
   					},
-  					Requests: {s"cpu": {i: {value: 8}, Format: "DecimalSI"}, s"memory": {i: {value: 30000000000}, Format: "BinarySI"}},
+  					Requests: {s"cpu": {i: {value: 8}, Format: "DecimalSI"}, s"memory": {i: {value: 300000000}, Format: "BinarySI"}},
   				},
   				VolumeMounts:  nil,
   				VolumeDevices: nil,
@@ -27,11 +27,11 @@
   				Env:     nil,
   				Resources: v1.ResourceRequirements{
 - 					Limits: v1.ResourceList{},
-+ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 40000000000}, Format: "BinarySI"}},
++ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 400000000}, Format: "BinarySI"}},
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {value: 8}, Format: "DecimalSI"},
-- 						s"memory": {i: resource.int64Amount{value: 10000000000}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
+- 						s"memory": {i: resource.int64Amount{value: 100000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,
@@ -44,12 +44,12 @@
   				Env:     nil,
   				Resources: v1.ResourceRequirements{
 - 					Limits: v1.ResourceList{},
-+ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 40000000000}, Format: "BinarySI"}},
++ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 400000000}, Format: "BinarySI"}},
   					Requests: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
 + 						s"cpu":    {i: resource.int64Amount{value: 5}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,
@@ -62,11 +62,11 @@
   				Env:     nil,
   				Resources: v1.ResourceRequirements{
 - 					Limits: v1.ResourceList{},
-+ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 40000000000}, Format: "BinarySI"}},
++ 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 400000000}, Format: "BinarySI"}},
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {value: 10}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
@@ -5,7 +5,22 @@
   		Volumes:        nil,
   		InitContainers: nil,
   		Containers: []v1.Container{
-  			{Name: "large", Resources: {Limits: {s"cpu": {i: {value: 16}, Format: "DecimalSI"}, s"memory": {i: {value: 40000000000}, Format: "BinarySI"}}, Requests: {s"cpu": {i: {value: 8}, Format: "DecimalSI"}, s"memory": {i: {value: 30000000000}, Format: "BinarySI"}}}},
+  			{
+  				... // 6 identical fields
+  				EnvFrom: nil,
+  				Env:     nil,
+  				Resources: v1.ResourceRequirements{
+  					Limits: {s"cpu": {i: {value: 16}, Format: "DecimalSI"}, s"memory": {i: {value: 40000000000}, Format: "BinarySI"}},
+  					Requests: v1.ResourceList{
+  						s"cpu":    {i: {value: 8}, Format: "DecimalSI"},
+- 						s"memory": {i: resource.int64Amount{value: 30000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 21474836480}, s: "20Gi", Format: "BinarySI"},
+  					},
+  				},
+  				VolumeMounts:  nil,
+  				VolumeDevices: nil,
+  				... // 11 identical fields
+  			},
   			{
   				... // 6 identical fields
   				EnvFrom: nil,

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_associated_with_a_build_with_labels.yaml
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePods_pod_associated_with_a_build_with_labels.yaml
@@ -21,10 +21,10 @@ Patches:
   path: /spec/containers/0/resources
   value:
     limits:
-      memory: 39062500Ki
+      memory: "40000"
     requests:
       cpu: "9"
-      memory: 19531250Ki
+      memory: "20000"
 - op: add
   path: /spec/containers/1/resources
   value: {}

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -52,6 +52,8 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
 		"--metrics-port=9092",
+		"--cpu-cap=10",
+		"--memory-cap=20Gi",
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)


### PR DESCRIPTION
We need to cap the amount of memory that the `pod-scaler` requests to `20Gi`. I made this amount configurable and also made the existing `cpu-cap` configurable.

For: [DPTP-2928](https://issues.redhat.com/browse/DPTP-2928)

/cc @openshift/test-platform 