### PR TITLE
`slack-bot`: log user and bot_id fields in helpdesk-message handler

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -46,6 +46,7 @@ func Handler(client messagePoster, keywordsConfig KeywordsConfig) events.Partial
 			if !ok {
 				return false, nil
 			}
+			log = log.WithFields(logrus.Fields{"user": event.User, "bot_id": event.BotID})
 			if event.ChannelType != "channel" {
 				return false, nil
 			}


### PR DESCRIPTION
In preparation for alerting that users should use the new workflows in #forum-testplatform I need to determine the best way to tell if a user is posting a direct message or is using a workflow. Since we can't add workflows to the dptp-robot-testing slack space due to it being a free plan I need some additional logging.