### PR TITLE
Pod Scaler e2e: reload cache after initial subscribe

### DIFF
--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -541,7 +541,7 @@ func TestMutatePodResources(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			original := testCase.pod.DeepCopy()
-			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi")
+			mutatePodResources(testCase.pod, testCase.server, testCase.mutateResourceLimits, 10, "20Gi", logrus.WithField("test", testCase.name))
 			diff := cmp.Diff(original, testCase.pod)
 			// In some cases, cmp.Diff decides to use non-breaking spaces, and it's not
 			// particularly deterministic about this. We don't care.
@@ -716,7 +716,7 @@ func TestUseOursIfLarger(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs)
+			useOursIfLarger(&testCase.ours, &testCase.theirs, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}
@@ -897,7 +897,7 @@ func TestPreventUnschedulable(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			preventUnschedulable(tc.resources, cpuCap, memoryCap)
+			preventUnschedulable(tc.resources, cpuCap, memoryCap, logrus.WithField("test", tc.name))
 			if diff := cmp.Diff(tc.expected, tc.resources); diff != "" {
 				t.Fatalf("result doesn't match expected, diff: %s", diff)
 			}

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add.diff
@@ -31,7 +31,7 @@
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {value: 8}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100000000}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, s: "200000000", Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,
@@ -47,9 +47,9 @@
 + 					Limits: v1.ResourceList{s"memory": {i: resource.int64Amount{value: 400000000}, Format: "BinarySI"}},
   					Requests: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
-+ 						s"cpu":    {i: resource.int64Amount{value: 5}, Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 5}, s: "5", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, s: "200000000", Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,
@@ -66,7 +66,7 @@
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {value: 10}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 200000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 200000000}, s: "200000000", Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,

--- a/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
+++ b/cmd/pod-scaler/testdata/zz_fixture_TestMutatePodResources_resources_to_add__limits_disabled.diff
@@ -30,7 +30,7 @@
   					Requests: v1.ResourceList{
   						s"cpu":    {i: {value: 8}, Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 10000000000}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 20000000000}, s: "19531250Ki", Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,
@@ -45,9 +45,9 @@
   					Limits: {},
   					Requests: v1.ResourceList{
 - 						s"cpu":    {i: resource.int64Amount{value: 2}, Format: "DecimalSI"},
-+ 						s"cpu":    {i: resource.int64Amount{value: 5}, Format: "DecimalSI"},
++ 						s"cpu":    {i: resource.int64Amount{value: 5}, s: "5", Format: "DecimalSI"},
 - 						s"memory": {i: resource.int64Amount{value: 100}, Format: "BinarySI"},
-+ 						s"memory": {i: resource.int64Amount{value: 20000000000}, Format: "BinarySI"},
++ 						s"memory": {i: resource.int64Amount{value: 20000000000}, s: "19531250Ki", Format: "BinarySI"},
   					},
   				},
   				VolumeMounts:  nil,

--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -221,7 +221,9 @@ type TestingTInterface interface {
 // WaitForHTTP200 waits waitFor seconds for the provided addr to return a http/200. If that doesn't
 // happen, it will call t.Fatalf
 func WaitForHTTP200(addr, command string, waitFor int64, t TestingTInterface) {
+	start := time.Now()
 	if waitErr := wait.PollImmediate(1*time.Second, time.Duration(waitFor)*time.Second, func() (done bool, err error) {
+		elapsed := time.Since(start)
 		resp, getErr := http.Get(addr)
 		defer func() {
 			if resp == nil || resp.Body == nil {
@@ -232,7 +234,7 @@ func WaitForHTTP200(addr, command string, waitFor int64, t TestingTInterface) {
 			}
 		}()
 		if resp != nil {
-			t.Logf("`%s` readiness probe: %v", command, resp.StatusCode)
+			t.Logf("`%s` readiness probe: %v after %s", command, resp.StatusCode, elapsed)
 		}
 		if getErr != nil {
 			t.Logf("`%s` readiness probe error: %v:", command, getErr)

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -45,15 +45,13 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 	}
 
 	podScalerFlags := []string{
-		"--loglevel=info",
+		"--loglevel=trace",
 		"--log-style=text",
 		"--cache-dir", dataDir,
 		"--mode=consumer.admission",
 		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
 		"--metrics-port=9092",
-		"--cpu-cap=10",
-		"--memory-cap=20Gi",
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)
@@ -64,7 +62,9 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 	podScaler.RunFromFrameworkRunner(t, parent, stream)
 	podScalerHost := "https://" + serverHostname + ":" + podScaler.ClientFlags()[0]
 	t.Logf("pod-scaler admission is running at %s", podScalerHost)
-	podScaler.Ready(t)
+	podScaler.Ready(t, func(options *testhelper.ReadyOptions) {
+		options.WaitFor = 300
+	})
 
 	var certs []tls.Certificate
 	for _, cert := range clientTLSConfig.Certs {


### PR DESCRIPTION
My previous attempt at fixing the flakiness in the `pod-scaler` e2e TestAdmission didn't work. I cannot get this to fail locally so I added a bunch of extra logging to diagnose the problem. This logging is at the `debug` and `trace` levels and I think is useful to triage future issues.

This ended up being a very time consuming race condition to debug. It turns out that some of the time the subscription for the `memory` metrics was not in place upon the initial loading of the cache. Since the subscription wasn't in place, and we only produce the data once for this test the admission server never became `ready`. This lead to a timeout waiting for the condition, and an eventual failure to find any data for the `memory` metric.

The solution is to make sure that we don't mark the data as seen (by updating the `lastUpdated` field) if there are no subscribers **and** reload after our initial subscription.

The effect of this issue outside of our `e2e` test is not as substantial as the cache gets update by the producer every 2 hours in that setting. At most the data wouldn't be found for 2 hours, and then would be available.

All of the changes to the test expectations are just due to the additional logging.