### PR TITLE
Update job names list for 4.12

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -28,6 +28,7 @@ func newGenerateJobNamesFlags() *generateJobNamesFlags {
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.10-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.11-periodics.yaml",
+			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.12-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/multiarch/openshift-multiarch-master-periodics.yaml",
 		},
 		releaseConfigURLs: []string{
@@ -44,6 +45,13 @@ func newGenerateJobNamesFlags() *generateJobNamesFlags {
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-ppc64le.json",
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-s390x.json",
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11.json",
+
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-arm64.json",
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ci.json",
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-multi.json",
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ppc64le.json",
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-s390x.json",
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12.json",
 		},
 	}
 }

--- a/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
+++ b/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
@@ -38,7 +38,7 @@ periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-techpreview
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-techpreview-serial
-periodic-ci-openshift-release-master-ci-4.10-e2e-azure-upgrade-single-node
+periodic-ci-openshift-release-master-ci-4.10-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-ovn
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-techpreview
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-techpreview-serial
@@ -98,7 +98,10 @@ periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-aws-arm64-single-nod
 periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-aws-arm64-techpreview
 periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-aws-arm64-techpreview-serial
 periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-aws-ovn-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-ovn-serial-aws-arm64
 periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-serial-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-upgrade-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.11-upgrade-from-stable-4.10-ocp-e2e-aws-arm64
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-arm64.json
 
 // begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-ci.json
@@ -114,6 +117,8 @@ periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-azure-
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-ci.json
 
 // begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-multi.json
+periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-aws-heterogeneous
+periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-serial-aws-heterogeneous
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-multi.json
 
 // begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11-ppc64le.json
@@ -130,11 +135,11 @@ periodic-ci-openshift-release-master-ci-4.11-e2e-azure-ovn
 periodic-ci-openshift-release-master-ci-4.11-e2e-azure-ovn-upgrade
 periodic-ci-openshift-release-master-ci-4.11-e2e-azure-techpreview
 periodic-ci-openshift-release-master-ci-4.11-e2e-azure-techpreview-serial
-periodic-ci-openshift-release-master-ci-4.11-e2e-azure-upgrade-single-node
+periodic-ci-openshift-release-master-ci-4.11-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-ci-4.11-e2e-gcp-ovn
 periodic-ci-openshift-release-master-ci-4.11-e2e-gcp-techpreview
 periodic-ci-openshift-release-master-ci-4.11-e2e-gcp-techpreview-serial
-periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-gcp-ovn-upgrade
+periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-gcp-ovn-rt-upgrade
 periodic-ci-openshift-release-master-nightly-4.11-console-aws
 periodic-ci-openshift-release-master-nightly-4.11-e2e-alibaba
 periodic-ci-openshift-release-master-nightly-4.11-e2e-aws
@@ -175,6 +180,7 @@ periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview
 periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-techpreview-serial
 periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi
 periodic-ci-openshift-release-master-nightly-4.11-e2e-vsphere-upi-serial
+periodic-ci-openshift-release-master-nightly-4.11-install-analysis-vsphere-sdn-ipi
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
@@ -186,6 +192,103 @@ release-openshift-ocp-installer-e2e-metal-serial-4.11
 release-openshift-ocp-osd-aws-nightly-4.11
 release-openshift-ocp-osd-gcp-nightly-4.11
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.11.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-arm64.json
+periodic-ci-openshift-multiarch-master-nightly-4.11-ocp-e2e-ovn-serial-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-arm64-single-node
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-arm64-techpreview
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-arm64-techpreview-serial
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-ovn-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-serial-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-upgrade-aws-arm64
+periodic-ci-openshift-multiarch-master-nightly-4.12-upgrade-from-stable-4.11-ocp-e2e-aws-arm64
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-arm64.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ci.json
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-ovn-upgrade
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-azure-upgrade
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ci.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-multi.json
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-aws-heterogeneous
+periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-serial-aws-heterogeneous
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-multi.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ppc64le.json
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ppc64le.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-s390x.json
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-s390x.json
+
+// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12.json
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-ovn
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-techpreview-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-techpreview
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn-upgrade
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-techpreview
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-techpreview-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-upgrade-ovn-single-node
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-ovn
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-techpreview
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-techpreview-serial
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-gcp-ovn-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-console-aws
+periodic-ci-openshift-release-master-nightly-4.12-e2e-alibaba
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-csi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-driver-toolkit
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-fips
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-proxy
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-e2e-azure
+periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp
+periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-csi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-rt
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-assisted
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-ovn-dualstack
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-ovn-ipv6
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ipv4
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ovn-dualstack
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ovn-ipv6
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-virtualmedia
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade-ovn-ipv6
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-virtualmedia
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-single-node-live-iso
+periodic-ci-openshift-release-master-nightly-4.12-e2e-ovirt
+periodic-ci-openshift-release-master-nightly-4.12-e2e-ovirt-csi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-csi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-techpreview
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-techpreview-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-upi
+periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-upi-serial
+periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-aws-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
+release-openshift-ocp-installer-e2e-aws-upi-4.12
+release-openshift-ocp-installer-e2e-azure-serial-4.12
+release-openshift-ocp-installer-e2e-gcp-serial-4.12
+release-openshift-ocp-installer-e2e-metal-4.12
+release-openshift-ocp-installer-e2e-metal-serial-4.12
+release-openshift-ocp-osd-aws-nightly-4.12
+release-openshift-ocp-osd-gcp-nightly-4.12
+// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12.json
 
 // begin https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/multiarch/openshift-multiarch-master-periodics.yaml
 periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-aws-arm64
@@ -220,17 +323,15 @@ periodic-ci-openshift-release-master-ci-4.10-e2e-aws
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-cgroupsv2
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-cilium
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-crun
-periodic-ci-openshift-release-master-ci-4.10-e2e-aws-network-stress
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn
-periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-network-stress
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-ovn-upgrade
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-sdn-multitenant
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-serial
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-techpreview
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-techpreview-serial
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-upgrade
+periodic-ci-openshift-release-master-ci-4.10-e2e-aws-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-ci-4.10-e2e-aws-upgrade-rollback
-periodic-ci-openshift-release-master-ci-4.10-e2e-aws-upgrade-single-node
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-cilium
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn
@@ -239,7 +340,7 @@ periodic-ci-openshift-release-master-ci-4.10-e2e-azure-serial
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-techpreview
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-techpreview-serial
 periodic-ci-openshift-release-master-ci-4.10-e2e-azure-upgrade
-periodic-ci-openshift-release-master-ci-4.10-e2e-azure-upgrade-single-node
+periodic-ci-openshift-release-master-ci-4.10-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-cilium
 periodic-ci-openshift-release-master-ci-4.10-e2e-gcp-ovn
@@ -298,6 +399,7 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node
 periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-single-node-serial
 periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade
 periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade-rollback-oldest-supported
+periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-workers-rhel8
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azure
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-csi
@@ -306,7 +408,9 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-deploy-cnv
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-fips-serial
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
+periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-csi
+periodic-ci-openshift-release-master-nightly-4.10-e2e-azurestack-upi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi-migration
@@ -314,6 +418,7 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-libvirt-cert-rotation
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
+periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-compact
@@ -342,13 +447,13 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-vsphere-upi-serial
 periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.8-e2e-aws-upgrade-paused
 periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade
-periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-single-node
-periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-azure-upgrade-single-node
+periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-aws-upgrade-ovn-single-node
+periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade
 periodic-ci-openshift-release-master-nightly-4.10-upgrade-from-stable-4.9-e2e-metal-ipi-upgrade-ovn-ipv6
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade
-periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-single-node
-periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade-single-node
+periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-aws-upgrade-ovn-single-node
+periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade
 periodic-ci-openshift-release-master-nightly-4.11-upgrade-from-stable-4.10-e2e-metal-ipi-upgrade-ovn-ipv6
 periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.10-e2e-aws-upgrade-paused
@@ -385,4 +490,8 @@ release-openshift-origin-installer-e2e-gcp-shared-vpc-4.10
 // begin https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.11-periodics.yaml
 release-openshift-origin-installer-e2e-aws-upgrade-4.8-to-4.9-to-4.10-to-4.11-ci
 // end https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.11-periodics.yaml
+
+// begin https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.12-periodics.yaml
+release-openshift-origin-installer-e2e-aws-upgrade-4.9-to-4.10-to-4.11-to-4.12-ci
+// end https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.12-periodics.yaml
 


### PR DESCRIPTION
- Updated pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go to include 4.12 URL's
- Ran: `go build ./cmd/job-run-aggregator/...`
- Ran: `./job-run-aggregator generate-job-names > pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt`