### PR TITLE
verify user is non-nil before posting reply

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -51,7 +51,7 @@ func Handler(client messagePoster, keywordsConfig KeywordsConfig, helpdeskAlias,
 			}
 
 			var response []slack.Block
-			notifyToUseWorkflow := requireWorkflowsInForum && event.ThreadTimeStamp == "" && event.BotID == ""
+			notifyToUseWorkflow := requireWorkflowsInForum && event.ThreadTimeStamp == "" && event.BotID == "" && event.User != ""
 			if notifyToUseWorkflow {
 				log.Debug("Top level message not from a workflow, notifying user")
 				response = getTopLevelDirectMessageResponse(event.User)


### PR DESCRIPTION
I am not completely sure how it is happening, but it appears that the bot will post a top-level message that looks like
<img width="665" alt="Screen Shot 2022-07-05 at 4 43 16 PM" src="https://user-images.githubusercontent.com/1794300/177413026-40b0ba79-2334-40f0-aea1-2a0bf94b594b.png">
when a workflow is used.

From looking through the logs it was referencing a message with no `bot-id` **and** no `user`. We only need to do this auto-reply when the user is non-nil.

/cc @openshift/test-platform 