### PR TITLE
junit: fix xml.Name for testsuite properties

### DIFF
--- a/pkg/junit/types.go
+++ b/pkg/junit/types.go
@@ -38,7 +38,7 @@ type TestSuite struct {
 	Duration float64 `xml:"time,attr"`
 
 	// Properties holds other properties of the test suite as a mapping of name to value
-	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
 
 	// TestCases are the test cases contained in the test suite
 	TestCases []*TestCase `xml:"testcase"`

--- a/pkg/junit/types_test.go
+++ b/pkg/junit/types_test.go
@@ -1,0 +1,22 @@
+package junit
+
+import (
+	"encoding/xml"
+	"testing"
+)
+
+const junitXML = `<testsuites>
+<testsuite tests="1" failures="0" time="1983" name="">
+<properties>
+<property name="go.version" value="go1.17.5 linux/amd64"/>
+</properties>
+<testcase classname="" name="TestUpgradeControlPlane" time="1983"/>
+</testsuite>
+</testsuites>`
+
+func Test_CanUnmarshalTestSuites(t *testing.T) {
+	suites := &TestSuites{}
+	if err := xml.Unmarshal([]byte(junitXML), suites); err != nil {
+		t.Fatalf("could not unmarshal: %s", err.Error())
+	}
+}

--- a/test/e2e/observer/artifacts/failing-observer-junit_operator.xml
+++ b/test/e2e/observer/artifacts/failing-observer-junit_operator.xml
@@ -1,5 +1,6 @@
 <testsuites>
   <testsuite name="step graph" tests="6" skipped="0" failures="1" time="whatever">
+    <properties></properties>
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever"></testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">
       <system-out>The collected steps of multi-stage phase post.</system-out>

--- a/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
+++ b/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
@@ -1,5 +1,6 @@
 <testsuites>
   <testsuite name="step graph" tests="9" skipped="0" failures="1" time="whatever">
+    <properties></properties>
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever"></testcase>
     <testcase name="Run multi-stage test multi-observers - multi-observers-check-shared-dir container test" time="whatever"></testcase>
     <testcase name="Run multi-stage test multi-observers - multi-observers-create-kubeconfig container test" time="whatever"></testcase>

--- a/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
+++ b/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
@@ -1,5 +1,6 @@
 <testsuites>
   <testsuite name="step graph" tests="7" skipped="0" failures="0" time="whatever">
+    <properties></properties>
     <testcase name="Find the input image os and tag it into the pipeline" time="whatever"></testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">
       <system-out>The collected steps of multi-stage phase post.</system-out>

--- a/test/e2e/simple/artifacts/junit_operator.xml
+++ b/test/e2e/simple/artifacts/junit_operator.xml
@@ -1,5 +1,6 @@
 <testsuites>
   <testsuite name="step graph" tests="8" skipped="0" failures="0" time="whatever">
+    <properties></properties>
     <testcase name="All images are built and tagged into stable" time="whatever"></testcase>
     <testcase name="Clone the correct source code into an image and tag it as src" time="whatever"></testcase>
     <testcase name="Create the release image &#34;latest&#34; containing all images built by this job" time="whatever"></testcase>


### PR DESCRIPTION
[TRT-789](https://issues.redhat.com//browse/TRT-789)

TestSuite properties should be `properties` not `property`, we can't
unmarshal some junits in the job run uploader currently, it errors out
like this:

```
time="2022-07-06T08:01:16Z" level=fatal msg="Command failed"
error="[jobrun/release-openshift-ocp-osd-aws-nightly-4.11/1544457393197289472
failed to upload to bigquery: error parsing junit for
jobrun/release-openshift-ocp-osd-aws-nightly-4.11/1544457393197289472
\"logs/release-openshift-ocp-osd-aws-nightly-4.11/1544457393197289472/artifacts/install/junit_0zg9j.xml\":
testsuiteError=expected element type <testsuite> but have <testsuites>
testsuitesError=expected element type <property> but have <properties>,
jobrun/release-openshift-ocp-osd-aws-nightly-4.10/1544448209282142208
failed to upload to bigquery: error parsing junit for
jobrun/release-openshift-ocp-osd-aws-nightly-4.10/1544448209282142208
\"logs/release-openshift-ocp-osd-aws-nightly-4.10/1544448209282142208/artifacts/install/junit_a75tc.xml\":
testsuiteError=expected element type <testsuite> but have <testsuites>
testsuitesError=expected element type <property> but have <properties>,
jobrun/release-openshift-ocp-osd-gcp-nightly-4.10/154444821514...
```

Per the confusing xml docs[1], we can use the `>` operator to indicate
sub-elements:

```
If the XML element contains a sub-element whose name matches the prefix
of a tag formatted as "a" or "a>b>c", unmarshal will descend into the
XML structure looking for elements with the given names, and will map
the innermost elements to that struct field. A tag starting with ">" is
equivalent to one starting with the field name followed by ">".
```

[1] https://pkg.go.dev/encoding/xml