### PR TITLE
dptp-cm: use git-sync

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -22,15 +22,11 @@ import (
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/simplifypath"
 
+	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/html"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	registryserver "github.com/openshift/ci-tools/pkg/registry/server"
 	"github.com/openshift/ci-tools/pkg/webreg"
-)
-
-const (
-	releaseRepoConfigsPath  = "ci-operator/config"
-	releaseRepoRegistryPath = "ci-operator/step-registry"
 )
 
 type options struct {
@@ -114,8 +110,8 @@ func validateOptions(o *options) error {
 			return fmt.Errorf("error getting stat info for --release-repo-path directory: %w", err)
 		}
 
-		o.configPath = filepath.Join(o.releaseRepoGitSyncPath, releaseRepoConfigsPath)
-		o.registryPath = filepath.Join(o.releaseRepoGitSyncPath, releaseRepoRegistryPath)
+		o.configPath = filepath.Join(o.releaseRepoGitSyncPath, config.CiopConfigInRepoPath)
+		o.registryPath = filepath.Join(o.releaseRepoGitSyncPath, config.RegistryPath)
 	}
 
 	if o.validateOnly && o.flatRegistry {

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -129,7 +129,7 @@ func newOpts() (*options, error) {
 	var errs []error
 	if opts.releaseRepoGitSyncPath != "" {
 		if opts.ciOperatorconfigPath != "" || opts.stepConfigPath != "" || opts.prowconfig.JobConfigPath != "" || opts.prowconfig.SupplementalProwConfigDirs.String() != "" {
-			errs = append(errs, fmt.Errorf("--release-repo-path is mutually exclusive with --ci-operator-config-path and --step-config-path and --%s and --%s", opts.prowconfig.JobConfigPathFlagName, "supplemental-prow-config-dir"))
+			errs = append(errs, fmt.Errorf("--release-repo-path is mutually exclusive with --ci-operator-config-path and --step-config-path and --%s and --supplemental-prow-config-dir", opts.prowconfig.JobConfigPathFlagName))
 		} else {
 			if _, err := os.Stat(opts.releaseRepoGitSyncPath); err != nil {
 				if os.IsNotExist(err) {


### PR DESCRIPTION
Follow up https://coreos.slack.com/archives/CHY2E1BL4/p1657280723675739

```
{"component":"config-bootstrapper","configmap":{"cluster":"app.ci","name":"step-registry","namespace":"ci"},"error":"update config map err: ConfigMap \"step-registry\" is invalid: []: Too long: must have at most 1048576 bytes","file":"k8s.io/test-infra/prow/cmd/config-bootstrapper/main.go:155","func":"main.run","level":"error","msg":"failed to update config on cluster","severity":"error","time":"2022-07-08T11:43:11Z"}
```

`CM/step-registry` is too big.

After https://github.com/openshift/ci-tools/pull/2805, `dptp-cm` is the only component using it.

This PR enables the feature on it.

/cc @openshift/test-platform 