### PR TITLE
use git-sync in pr-deploy-configresolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,6 @@ pr-deploy-configresolver:
 	$(eval USER=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.user.login))
 	$(eval BRANCH=$(shell curl --fail -Ss https://api.github.com/repos/openshift/ci-tools/pulls/$(PULL_REQUEST)|jq -r .head.ref))
 	oc --context app.ci --as system:admin process -p USER=$(USER) -p BRANCH=$(BRANCH) -p PULL_REQUEST=$(PULL_REQUEST) -f hack/pr-deploy.yaml | oc  --context app.ci --as system:admin apply -f -
-	for cm in ci-operator-master-configs step-registry config; do oc  --context app.ci --as system:admin get configmap $${cm} -n ci -o json | eval $(kubeExport)|oc  --context app.ci --as system:admin create -f - -n ci-tools-$(PULL_REQUEST); done
 	echo "server is at https://$$( oc  --context app.ci --as system:admin get route server -n ci-tools-$(PULL_REQUEST) -o jsonpath={.spec.host} )"
 .PHONY: pr-deploy
 

--- a/hack/pr-deploy.yaml
+++ b/hack/pr-deploy.yaml
@@ -27,9 +27,9 @@ objects:
     name: admin
     namespace: ci-tools-${PULL_REQUEST}
   subjects:
-    - kind: User
-      name: ${USER}
-      apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: ${USER}
+    apiGroup: rbac.authorization.k8s.io
 - kind: ImageStream
   apiVersion: image.openshift.io/v1
   metadata:
@@ -148,16 +148,44 @@ objects:
         labels:
           app: server
       spec:
+        initContainers:
+        - name: git-sync-init
+          command:
+          - /git-sync
+          args:
+          - --repo=https://github.com/openshift/release.git
+          - --branch=master
+          - --root=/tmp/git-sync
+          - --one-time=true
+          env:
+          - name: GIT_SYNC_DEST
+            value: release
+          image: gcr.io/google_containers/git-sync:v3.1.6
+          volumeMounts:
+          - name: release
+            mountPath: /tmp/git-sync
         containers:
+        - name: git-sync
+          command:
+          - /git-sync
+          args:
+          - --repo=https://github.com/openshift/release.git
+          - --branch=master
+          - --wait=30
+          - --root=/tmp/git-sync
+          env:
+          - name: GIT_SYNC_DEST
+            value: release
+          image: gcr.io/google_containers/git-sync:v3.1.6
+          volumeMounts:
+          - name: release
+            mountPath: /tmp/git-sync
         - name: ci-operator-configresolver
           image: "output:server"
           imagePullPolicy: Always
           args:
-          - -config=/etc/configs
-          - -registry=/etc/registry
-          - -flat-registry
+          - -release-repo-git-sync-path=/var/repo/release
           - -log-level=debug
-          - -cycle=2m
           ports:
           - name: ui
             containerPort: 8082
@@ -175,20 +203,13 @@ objects:
             periodSeconds: 3
             timeoutSeconds: 600
           volumeMounts:
-          - name: registry
-            mountPath: /etc/registry
-            readOnly: true
-          - name: configs
-            mountPath: /etc/configs
+          - name: release
+            mountPath: /var/repo
             readOnly: true
           resources:
             requests:
               memory: "2Gi"
               cpu: "200m"
         volumes:
-        - name: registry
-          configMap:
-            name: step-registry
-        - name: configs
-          configMap:
-            name: ci-operator-master-configs
+        - name: release
+          emptyDir: {}


### PR DESCRIPTION
step-registry CM is removed in https://github.com/openshift/release/pull/30298. We can now use the standard git-sync for the configs like the deployed `configresolver` does.