### PR TITLE
pkg/registry: correct `retryablehttp` logger

### DIFF
--- a/pkg/registry/server/client.go
+++ b/pkg/registry/server/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/sirupsen/logrus"
@@ -96,20 +97,30 @@ func (r *resolverClient) Resolve(raw []byte) (*api.ReleaseBuildConfiguration, er
 
 type adapter struct{}
 
+func (a adapter) format(s string, i ...interface{}) string {
+	builder := strings.Builder{}
+	builder.WriteString(s)
+	for _, x := range i {
+		builder.WriteString(" ")
+		builder.WriteString(fmt.Sprintf("%v", x))
+	}
+	return builder.String()
+}
+
 func (a adapter) Error(s string, i ...interface{}) {
-	logrus.Errorf(s, i...)
+	logrus.Error(a.format(s, i...))
 }
 
 func (a adapter) Info(s string, i ...interface{}) {
-	logrus.Infof(s, i...)
+	logrus.Info(a.format(s, i...))
 }
 
 func (a adapter) Debug(s string, i ...interface{}) {
-	logrus.Debugf(s, i...)
+	logrus.Debug(a.format(s, i...))
 }
 
 func (a adapter) Warn(s string, i ...interface{}) {
-	logrus.Warnf(s, i...)
+	logrus.Warn(a.format(s, i...))
 }
 
 var _ retryablehttp.LeveledLogger = adapter{}


### PR DESCRIPTION
The first argument to the logging functions is a regular string, not a
formatting directive:

https://github.com/hashicorp/go-retryablehttp/blob/493aa4cf372e47ec00228558d9d91a9517b045a5/client.go#L315-L325
https://github.com/hashicorp/go-retryablehttp/blob/493aa4cf372e47ec00228558d9d91a9517b045a5/client.go#L587

This results in an incorrect message, e.g.:

```
{"level":"debug","msg":"performing request%!(EXTRA string=method, string=GET, string=url, *url.URL=https://config.ci.openshift.org/config?branch=master\u0026org=openshift\u0026repo=ci-tools)","time":"2022-07-11T17:03:22Z"}
```

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_ci-tools/2883/pull-ci-openshift-ci-tools-master-unit/1546540394894856192/artifacts/ci-operator.log

Now:

```
{"level":"debug","msg":"performing request method GET url https://config.ci.openshift.org/config?branch=master\u0026org=openshift\u0026repo=ci-tools","time":"2022-07-11T19:12:27Z"}
```