### PR TITLE
Update job names list for 4.12 after SDN job rename

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
+++ b/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
@@ -62,7 +62,6 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-azure-upgrade-cnv
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-csi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
-periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-ipv6
@@ -159,7 +158,6 @@ periodic-ci-openshift-release-master-nightly-4.11-e2e-azure-upgrade-cnv
 periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp
 periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-csi
 periodic-ci-openshift-release-master-nightly-4.11-e2e-gcp-rt
-periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-assisted
 periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi
 periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-dualstack
 periodic-ci-openshift-release-master-nightly-4.11-e2e-metal-ipi-ovn-ipv6
@@ -207,12 +205,12 @@ periodic-ci-openshift-multiarch-master-nightly-4.12-upgrade-from-stable-4.11-ocp
 
 // begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ci.json
 periodic-ci-openshift-release-master-ci-4.12-e2e-aws-ovn-upgrade
-periodic-ci-openshift-release-master-ci-4.12-e2e-aws-serial
-periodic-ci-openshift-release-master-ci-4.12-e2e-gcp
-periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-upgrade
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-sdn
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-sdn-upgrade
 periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade
 periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-ovn-upgrade
-periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-aws-sdn-upgrade
 periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-azure-upgrade
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ci.json
 
@@ -228,37 +226,37 @@ periodic-ci-openshift-multiarch-master-nightly-4.12-ocp-e2e-serial-aws-heterogen
 // end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-s390x.json
 
 // begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12.json
+periodic-ci-openshift-hypershift-main-periodics-aws-conformance
 periodic-ci-openshift-release-master-ci-4.12-e2e-aws-ovn
+periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-techpreview
 periodic-ci-openshift-release-master-ci-4.12-e2e-aws-sdn-techpreview-serial
-periodic-ci-openshift-release-master-ci-4.12-e2e-aws-techpreview
 periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn
 periodic-ci-openshift-release-master-ci-4.12-e2e-azure-ovn-upgrade
-periodic-ci-openshift-release-master-ci-4.12-e2e-azure-techpreview
-periodic-ci-openshift-release-master-ci-4.12-e2e-azure-techpreview-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-sdn-techpreview
+periodic-ci-openshift-release-master-ci-4.12-e2e-azure-sdn-techpreview-serial
 periodic-ci-openshift-release-master-ci-4.12-e2e-azure-upgrade-ovn-single-node
 periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-ovn
-periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-techpreview
-periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-techpreview-serial
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-sdn-techpreview
+periodic-ci-openshift-release-master-ci-4.12-e2e-gcp-sdn-techpreview-serial
 periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-e2e-gcp-ovn-upgrade
 periodic-ci-openshift-release-master-nightly-4.12-console-aws
 periodic-ci-openshift-release-master-nightly-4.12-e2e-alibaba
-periodic-ci-openshift-release-master-nightly-4.12-e2e-aws
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-csi
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-driver-toolkit
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-fips
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-proxy
-periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-serial
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-sdn-upgrade
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node
 periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-single-node-serial
-periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-upgrade
-periodic-ci-openshift-release-master-nightly-4.12-e2e-aws-upgrade
-periodic-ci-openshift-release-master-nightly-4.12-e2e-azure
 periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-csi
-periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp
+periodic-ci-openshift-release-master-nightly-4.12-e2e-azure-sdn
 periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-csi
 periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-rt
+periodic-ci-openshift-release-master-nightly-4.12-e2e-gcp-sdn
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-assisted
-periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-ovn-dualstack
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-ovn-ipv6
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ipv4
@@ -268,6 +266,7 @@ periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-virtualme
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-upgrade-ovn-ipv6
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-virtualmedia
+periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-sdn-ipi
 periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-single-node-live-iso
 periodic-ci-openshift-release-master-nightly-4.12-e2e-ovirt
 periodic-ci-openshift-release-master-nightly-4.12-e2e-ovirt-csi
@@ -278,7 +277,7 @@ periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-techpreview
 periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-techpreview-serial
 periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-upi
 periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-upi-serial
-periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-aws-upgrade
+periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-aws-sdn-upgrade
 periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade
 periodic-ci-openshift-release-master-nightly-4.12-upgrade-from-stable-4.11-e2e-metal-ipi-upgrade-ovn-ipv6
 release-openshift-ocp-installer-e2e-aws-upi-4.12
@@ -378,7 +377,7 @@ periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-gcp-up
 periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-ovirt-upgrade
 periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-e2e-vsphere-upgrade
 periodic-ci-openshift-release-master-ci-4.11-upgrade-from-stable-4.10-from-stable-4.9-e2e-aws-upgrade
-periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-from-stable-4.10-e2e-aws-upgrade
+periodic-ci-openshift-release-master-ci-4.12-upgrade-from-stable-4.11-from-stable-4.10-e2e-aws-sdn-upgrade
 periodic-ci-openshift-release-master-nightly-4.10-console-aws
 periodic-ci-openshift-release-master-nightly-4.10-credentials-request-freeze
 periodic-ci-openshift-release-master-nightly-4.10-e2e-alibaba
@@ -419,7 +418,6 @@ periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-fips-serial
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-libvirt-cert-rotation
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-rt
 periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp-upi
-periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-compact
 periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi-ovn-dualstack


### PR DESCRIPTION
We've renamed a number of jobs to include `sdn` in their name, this
regenerates the job lists for the aggregator. Commands run:

- go build ./cmd/job-run-aggregator/...
- ./job-run-aggregator generate-job-names > pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt

Will prime the job table again after this merges.
