### PR TITLE
`check-gh-automation`: don't check repos in presubmit if more than 10 have been modified

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -150,6 +150,8 @@ func checkRepos(repos []string, bots []string, ignore sets.String, client collab
 	return failing, nil
 }
 
+const maxRepos = 10
+
 func gatherModifiedRepos(releaseRepoPath string, logger *logrus.Entry) []string {
 	jobSpec, err := downwardapi.ResolveSpecFromEnv()
 	if err != nil {
@@ -165,6 +167,11 @@ func gatherModifiedRepos(releaseRepoPath string, logger *logrus.Entry) []string 
 		path := strings.TrimPrefix(c, config.CiopConfigInRepoPath+"/")
 		split := strings.Split(path, "/")
 		orgRepos.Insert(fmt.Sprintf("%s/%s", split[0], split[1]))
+	}
+
+	if orgRepos.Len() > maxRepos {
+		logger.Warnf("Found %d repos, which is more than we will check for a PR. It is likely that this PR is a config update on many repos, and doesn't need to be checked.", orgRepos.Len())
+		return []string{}
 	}
 
 	return orgRepos.List()


### PR DESCRIPTION
We need to limit the repos that we check in the presubmit version. If there are more than 10 modified repos it is likely that this is a code-freeze (or similar) PR, and there is no need to check those.

for https://issues.redhat.com/browse/DPTP-2984