### PR TITLE
PDB Client: v1beta1 to v1

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -31,7 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authapi "k8s.io/api/authorization/v1"
 	coreapi "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1315,8 +1315,8 @@ func generateAuthorAccessRoleBinding(namespace string, authors []string) *rbacap
 	}
 }
 
-func pdb(labelKey, namespace string) (*policyv1beta1.PodDisruptionBudget, crcontrollerutil.MutateFn) {
-	pdb := &policyv1beta1.PodDisruptionBudget{
+func pdb(labelKey, namespace string) (*policyv1.PodDisruptionBudget, crcontrollerutil.MutateFn) {
+	pdb := &policyv1.PodDisruptionBudget{
 		ObjectMeta: meta.ObjectMeta{
 			Name:      fmt.Sprintf("ci-operator-%s", strings.ReplaceAll(labelKey, "/", "-")),
 			Namespace: namespace,


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2989

<img width="915" alt="Screen Shot 2022-07-26 at 2 58 42 PM" src="https://user-images.githubusercontent.com/4013349/181090069-cc82c214-c8a7-4dde-96b2-a9a8450b1b5e.png">

The oldest version is vsphere:

```console
oc --kubeconfig /tmp/sa.config-updater.vsphere.config version
Client Version: 4.11.0-rc.3
Kustomize Version: v4.5.4
Server Version: 4.9.31
Kubernetes Version: v1.22.8+c02bd9d
```

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125

> policy/v1 API version, available since v1.21