### PR TITLE
pkg/steps: add RPM repositories for all `refs`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/api v0.83.0

--- a/go.sum
+++ b/go.sum
@@ -1811,6 +1811,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/steps/rpm_server_test.go
+++ b/pkg/steps/rpm_server_test.go
@@ -1,0 +1,83 @@
+package steps
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	routev1 "github.com/openshift/api/route/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	"github.com/openshift/ci-tools/pkg/testhelper"
+	"github.com/openshift/ci-tools/pkg/util"
+)
+
+func TestRPMServerStepProvides(t *testing.T) {
+	ns := "ns"
+	if err := routev1.AddToScheme(scheme.Scheme); err != nil {
+		t.Error(err)
+	}
+	client := loggingclient.New(fakectrlruntimeclient.NewFakeClient(
+		&routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "rpm-repo"},
+			Status: routev1.RouteStatus{
+				Ingress: []routev1.RouteIngress{{
+					Host: "host",
+					Conditions: []routev1.RouteIngressCondition{{
+						Type:   routev1.RouteAdmitted,
+						Status: corev1.ConditionTrue,
+					}},
+				}},
+			},
+		},
+	))
+	for _, tc := range []struct {
+		name     string
+		jobSpec  api.JobSpec
+		expected [][2]string
+	}{{
+		name: "no refs",
+	}, {
+		name: "ref",
+		jobSpec: api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{Org: "org", Repo: "repo"},
+			},
+		},
+		expected: [][2]string{{"RPM_REPO_ORG_REPO", "http://host"}},
+	}, {
+		name: "extra refs",
+		jobSpec: api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				ExtraRefs: []prowapi.Refs{
+					{Org: "org0", Repo: "repo0"},
+					{Org: "org1", Repo: "repo1"},
+				},
+			},
+		},
+		expected: [][2]string{
+			{"RPM_REPO_ORG0_REPO0", "http://host"},
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.jobSpec.SetNamespace(ns)
+			step := RPMServerStep(api.RPMServeStepConfiguration{}, client, &tc.jobSpec)
+			providesMap := step.Provides()
+			var provides [][2]string
+			for _, k := range util.SortedKeys(providesMap) {
+				s, err := providesMap[k]()
+				if err != nil {
+					t.Fatal(err)
+				}
+				provides = append(provides, [2]string{k, s})
+			}
+			testhelper.Diff(t, "parameter map", provides, tc.expected)
+		})
+	}
+}

--- a/pkg/steps/rpm_server_test.go
+++ b/pkg/steps/rpm_server_test.go
@@ -63,6 +63,23 @@ func TestRPMServerStepProvides(t *testing.T) {
 		},
 		expected: [][2]string{
 			{"RPM_REPO_ORG0_REPO0", "http://host"},
+			{"RPM_REPO_ORG1_REPO1", "http://host"},
+		},
+	}, {
+		name: "refs + extra refs",
+		jobSpec: api.JobSpec{
+			JobSpec: downwardapi.JobSpec{
+				Refs: &prowapi.Refs{Org: "org", Repo: "repo"},
+				ExtraRefs: []prowapi.Refs{
+					{Org: "org0", Repo: "repo0"},
+					{Org: "org1", Repo: "repo1"},
+				},
+			},
+		},
+		expected: [][2]string{
+			{"RPM_REPO_ORG0_REPO0", "http://host"},
+			{"RPM_REPO_ORG1_REPO1", "http://host"},
+			{"RPM_REPO_ORG_REPO", "http://host"},
 		},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"sort"
+
+	"golang.org/x/exp/constraints"
+)
+
+// SortSlice is a generic version of sort.Slice
+func SortSlice[T constraints.Ordered](s []T) {
+	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
+}
+
+// Keys returns a slice with the keys in `m` in unspecified order
+func Keys[K comparable, V any](m map[K]V) (ret []K) {
+	ret = make([]K, 0, len(m))
+	for k := range m {
+		ret = append(ret, k)
+	}
+	return
+}
+
+// SortedKeys returns a slice with the keys in `m` in sorted order
+func SortedKeys[K constraints.Ordered, V any](m map[K]V) (ret []K) {
+	ret = Keys(m)
+	SortSlice(ret)
+	return
+}

--- a/vendor/golang.org/x/exp/LICENSE
+++ b/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/exp/PATENTS
+++ b/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/exp/constraints/constraints.go
+++ b/vendor/golang.org/x/exp/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -842,6 +842,9 @@ golang.org/x/crypto/ssh
 golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
+# golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
+## explicit; go 1.18
+golang.org/x/exp/constraints
 # golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 ## explicit; go 1.11
 golang.org/x/lint


### PR DESCRIPTION
The `RPM_REPO_*` variables are currently exposed based on either the
`refs` _or_ `extra_refs` field of the Prow _job spec_.  This works for
(all examples abbreviated):

- Pre-/post-submit jobs, where the repository is in `refs`, e.g.:
  https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/27320/pull-ci-openshift-origin-release-3.11-e2e-gcp/1551900345024647168

    "spec": {"refs": {"org": "openshift", "repo": "origin"}}

- Periodic jobs, where the repository is in `extra_refs`, e.g.:
  https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-origin-release-3.11-e2e-gcp/1552572811980050432

    "spec": {"extra_refs": [{"org": "openshift", "repo": "origin"}]}

However, it does not work for rehearsals, where `refs` is
`openshift/release` and the target is in `extra_refs`, e.g.:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/26155/rehearse-26155-pull-ci-openshift-origin-release-3.11-e2e-aws/1552262021293019136

    "spec": {
        "refs": {"org": "openshift", "repo": "release"},
        "extra_refs": [{"org": "openshift", "repo": "origin"}]
    }

---

With this change, `refs` and all `extra_refs` are added as aliases to
the same repository, so that all cases are satisfied.  Extra entries in
the parameter map should be harmless, as they are only used to match
template parameters.  Unused entries should have no effect.

---

/hold

To be tested elsewhere.