### PR TITLE
`pr-reminder`: extend to the org

### DIFF
--- a/cmd/pr-reminder/README.md
+++ b/cmd/pr-reminder/README.md
@@ -4,13 +4,15 @@ The tool utilizes the following configuration:
 - `config-path`: The location of the tool's config file; containing: `teamMembers`, `teamName`, and `repos`
 - `github-mapping-config-path` The location of the github mapping config file. This file contains a map of github ids to kerberos ids.
 - `slack-token-path`: The location of a file containing the slack token.
+- `validate-only`: Run in `validate` mode. This simply validates that the config is correct, and will not send any messages or check for PR review requests.
 
 ## Overview
-Each of the `teamMembers` in the config will have their `slack id` and `github id` resolved utilizing their inferred email (`{kerberosId}@redhat.com`), and the mapping config respectively.
-PRs will then be gathered via the github API for each of the `repos` in the config, and added to users based on the `requested_reviewers` and `requested_teams` attributes.
+Each of the `teams` in the config will have all of their `teamMember's` `slack id` and `github id` resolved utilizing their inferred email (`{kerberosId}@redhat.com`), and the mapping config respectively.
+PRs will then be gathered via the github API for each of the `repos` in that `team's` config, and added to users based on the `requested_reviewers` and `requested_teams` attributes.
 Finally, a slack message will be sent to each of the `teamMember's` containing information about each PR review request.
 
 ## Local Development
 A script, `hack/local-pr-reminder.sh`, exists for running the tool locally. This script takes no arguments, but the user must be logged into the `app.ci` cluster.
-The cluster is utilized to obtain the production `config` and `github-mapping` files, and the `slack-token` for the alpha slack instance.
+You will want to modify the `hack/pr-reminder-config.yaml` file to include your own kerberos ID to receive the message in the testing space.
+The cluster is utilized to obtain the production  `github-mapping` file and the `slack-token` for the alpha slack instance.
 The script will run the tool, and message corresponding slack users in the `dptp-robot-testing` space.

--- a/cmd/pr-reminder/main_test.go
+++ b/cmd/pr-reminder/main_test.go
@@ -329,10 +329,12 @@ func Test_config_CreateUsers(t *testing.T) {
 					{
 						TeamMembers: []string{"user1", "user2"},
 						TeamNames:   []string{"some-team", "other-team"},
+						Repos:       []string{"org/repo"},
 					},
 					{
 						TeamMembers: []string{"user3"},
 						TeamNames:   []string{"some-team"},
+						Repos:       []string{"other-org/repo"},
 					},
 				},
 			},
@@ -343,18 +345,48 @@ func Test_config_CreateUsers(t *testing.T) {
 					GithubId:   "user-1",
 					SlackId:    "U1000000",
 					TeamNames:  sets.NewString("some-team", "other-team"),
+					Repos:      sets.NewString("org/repo"),
 				},
 				"user2": {
 					KerberosId: "user2",
 					GithubId:   "user-2",
 					SlackId:    "U222222",
 					TeamNames:  sets.NewString("some-team", "other-team"),
+					Repos:      sets.NewString("org/repo"),
 				},
 				"user3": {
 					KerberosId: "user3",
 					GithubId:   "user-3",
 					SlackId:    "U333333",
 					TeamNames:  sets.NewString("some-team"),
+					Repos:      sets.NewString("other-org/repo"),
+				},
+			},
+		},
+		{
+			name: "user on multiple teams",
+			config: config{
+				Teams: []team{
+					{
+						TeamMembers: []string{"user1"},
+						TeamNames:   []string{"some-team", "other-team"},
+						Repos:       []string{"org/repo"},
+					},
+					{
+						TeamMembers: []string{"user1"},
+						TeamNames:   []string{"some-team", "additional-team"},
+						Repos:       []string{"other-org/repo"},
+					},
+				},
+			},
+			gtk: githubToKerberos{"user-1": "user1"},
+			expected: map[string]user{
+				"user1": {
+					KerberosId: "user1",
+					GithubId:   "user-1",
+					SlackId:    "U1000000",
+					TeamNames:  sets.NewString("some-team", "other-team", "additional-team"),
+					Repos:      sets.NewString("org/repo", "other-org/repo"),
 				},
 			},
 		},

--- a/hack/local-pr-reminder.sh
+++ b/hack/local-pr-reminder.sh
@@ -19,8 +19,7 @@ function OC() {
 
 os::log::info "Extracting production data we need to run pr-reminder..."
 OC extract secret/slack-credentials-dptp-bot-alpha --keys oauth_token --to "${data}"
-OC extract configmap/pr-reminder-config --keys config.yaml --to "${data}"
 OC extract configmap/sync-rover-groups --keys mapping.yaml --to "${data}"
 
 os::log::info "Running pr-reminder"
-go run ./cmd/pr-reminder --config-path="${data}/config.yaml" --github-mapping-config-path="${data}/mapping.yaml" --slack-token-path="${data}/oauth_token"
+go run ./cmd/pr-reminder --validate-only=false --config-path="./hack/pr-reminder-config.yaml" --github-mapping-config-path="${data}/mapping.yaml" --slack-token-path="${data}/oauth_token"

--- a/hack/pr-reminder-config.yaml
+++ b/hack/pr-reminder-config.yaml
@@ -1,0 +1,10 @@
+teams:
+- teamMembers:
+  - sgoeddel
+  teamNames:
+  - test-platform
+  repos:
+  - openshift/ci-tools
+  - openshift/ci-docs
+  - openshift/release
+  - kubernetes/test-infra


### PR DESCRIPTION
This requires:

- configuration updates to allow for multiple teams
- additional validation, and a `validate-only` mode to be used in a presubmit check when the config is modified
- performance improvements to be able to run at scale

I also updated the `local-pr-reminder.sh` script to not use the production config file for simpler manual testing.

For: https://issues.redhat.com/browse/DPTP-3016