### PR TITLE
`pr-reminder`: include PRs where user is assigned

### DIFF
--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -179,6 +179,12 @@ func (u *user) requestedToReview(pr github.PullRequest) bool {
 				return true
 			}
 		}
+
+		for _, assignee := range pr.Assignees {
+			if u.GithubId == assignee.Login {
+				return true
+			}
+		}
 	}
 
 	return false

--- a/cmd/pr-reminder/main_test.go
+++ b/cmd/pr-reminder/main_test.go
@@ -35,6 +35,18 @@ func Test_user_requestedToReview(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "user assigned",
+			user: user{GithubId: "some-id"},
+			pr: github.PullRequest{
+				Assignees: []github.User{
+					{
+						Login: "some-id",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name: "team requested",
 			user: user{GithubId: "some-id", TeamNames: sets.NewString("some-team")},
 			pr: github.PullRequest{


### PR DESCRIPTION
PRs that have been assigned should also be included in the digest. Sometimes people assign a user without `cc`ing them, and we still need to be aware of those.

For: https://issues.redhat.com/browse/DPTP-3009