### PR TITLE
Observer Pods: read-only kubeconfig

### DIFF
--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -92,7 +92,7 @@ func TestGeneratePods(t *testing.T) {
 		Name:      "secret",
 		MountPath: "/secret",
 	}}
-	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, secretVolumes, secretVolumeMounts)
+	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, secretVolumes, secretVolumeMounts, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Environment: tc.env,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name")
-			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil)
+			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,7 +233,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name")
-	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil)
+	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -200,7 +200,6 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	}
 	var errs []error
 	observers, err := s.generateObservers(s.observers, secretVolumes, secretVolumeMounts)
-
 	if err != nil {
 		// if we can't even generate the Pods there's no reason to run the job
 		return err
@@ -208,7 +207,6 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	observerContext, cancel := context.WithCancel(ctx)
 	observerDone := make(chan struct{})
 	go s.runObservers(observerContext, ctx, observers, observerDone)
-
 	s.flags |= shortCircuit
 	if err := s.runSteps(ctx, "pre", s.pre, env, secretVolumes, secretVolumeMounts); err != nil {
 		errs = append(errs, fmt.Errorf("%q pre steps failed: %w", s.name, err))
@@ -220,7 +218,6 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	if err := s.runSteps(context.Background(), "post", s.post, env, secretVolumes, secretVolumeMounts); err != nil {
 		errs = append(errs, fmt.Errorf("%q post steps failed: %w", s.name, err))
 	}
-
 	<-observerDone // wait for the observers to finish so we get their jUnit
 	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -200,6 +200,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	}
 	var errs []error
 	observers, err := s.generateObservers(s.observers, secretVolumes, secretVolumeMounts)
+
 	if err != nil {
 		// if we can't even generate the Pods there's no reason to run the job
 		return err
@@ -207,6 +208,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	observerContext, cancel := context.WithCancel(ctx)
 	observerDone := make(chan struct{})
 	go s.runObservers(observerContext, ctx, observers, observerDone)
+
 	s.flags |= shortCircuit
 	if err := s.runSteps(ctx, "pre", s.pre, env, secretVolumes, secretVolumeMounts); err != nil {
 		errs = append(errs, fmt.Errorf("%q pre steps failed: %w", s.name, err))
@@ -218,6 +220,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	if err := s.runSteps(context.Background(), "post", s.post, env, secretVolumes, secretVolumeMounts); err != nil {
 		errs = append(errs, fmt.Errorf("%q post steps failed: %w", s.name, err))
 	}
+
 	<-observerDone // wait for the observers to finish so we get their jUnit
 	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -33,7 +33,7 @@ func (s *multiStageTestStep) runSteps(
 ) error {
 	start := time.Now()
 	logrus.Infof("Running multi-stage phase %s", phase)
-	pods, bestEffortSteps, err := s.generatePods(steps, env, secretVolumes, secretVolumeMounts)
+	pods, bestEffortSteps, err := s.generatePods(steps, env, secretVolumes, secretVolumeMounts, false)
 	if err != nil {
 		s.flags |= hasPrevErrs
 		return err


### PR DESCRIPTION
It seems that observer pods don't need to get write access to the kubeconfig.
This PR add "skip manageKubeconfig" functionality to `entrypoint-wrapper` such that observers get the read-only kubeconfig version as soon as it is ready.

There is nothing wrong with the `rw` variant of kubeconfig but this one:
1. the `entrypoint-wrapper` makes an empty temporary `rw` kubeconfig in `/tmp/kubeconfig-xxxx`, it sets `$KUBECONFIG` env variable to its child process (observer pod in such a case) and it finally waits for the real one to be uploaded by someone
2. when the observer pod starts it checks and finds the kubeconfig but it is (most likely) empty at the beginning
3. in the meanwhile someone has just uploaded a proper kubeconfig
4. `entrypoint-wrapper` detects it and updates the temporary `rw` copy
5. at this time only the observer pod gets the real content

We want to avoid step (2.) such that the observer pod gets the kubeconfig iff it's ready and non-empty.

/cc @jmguzik @bbguimaraes 