### PR TITLE
config-shard-validator: further break `misc` CM

### DIFF
--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -213,7 +213,7 @@ func validatePaths(pathsToCheck []pathWithConfig, pcfg *plugins.ConfigUpdater) (
 				if glob.Match(pathToCheck.path) {
 					matches = append(matches, globStr)
 					if updateConfig.Name != pathToCheck.configMap {
-						errCh <- field.Invalid(path.Child(globStr), "", fmt.Sprintf("File matches glob from unexpected ConfigMap %s instead of %s.", updateConfig.Name, pathToCheck.configMap))
+						errCh <- field.Invalid(path.Child(globStr), "", fmt.Sprintf("File %q matches glob from unexpected ConfigMap %s instead of %s.", pathToCheck.path, updateConfig.Name, pathToCheck.configMap))
 					}
 				}
 			}

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -104,18 +104,17 @@ func IsCiopConfigCM(name string) bool {
 	return ciOPConfigRegex.MatchString(name)
 }
 
-var threeXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-3\.[0-9]+$`)
+var releaseBranches = regexp.MustCompile(`^(release|enterprise|openshift)-([1-3])\.[0-9]+(?:\.[0-9]+)?$`)
 var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9]+)$`)
 
 func FlavorForBranch(branch string) string {
 	var flavor string
 	if branch == "master" || branch == "main" {
 		flavor = "master"
-	} else if threeXBranches.MatchString(branch) {
-		flavor = "3.x"
-	} else if fourXBranches.MatchString(branch) {
-		matches := fourXBranches.FindStringSubmatch(branch)
-		flavor = matches[2] // the 4.x release string
+	} else if m := fourXBranches.FindStringSubmatch(branch); m != nil {
+		flavor = m[2] // the 4.x release string
+	} else if m := releaseBranches.FindStringSubmatch(branch); m != nil {
+		flavor = m[2] + ".x"
 	} else {
 		flavor = "misc"
 	}

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -112,6 +112,11 @@ func TestMetadata_ConfigMapName(t *testing.T) {
 			expected: "ci-operator-master-configs",
 		},
 		{
+			name:     "openshift 3.6 branch goes to 3.x configmap",
+			branch:   "openshift-3.6",
+			expected: "ci-operator-3.x-configs",
+		},
+		{
 			name:     "enterprise 3.6 branch goes to 3.x configmap",
 			branch:   "enterprise-3.6",
 			expected: "ci-operator-3.x-configs",
@@ -135,6 +140,16 @@ func TestMetadata_ConfigMapName(t *testing.T) {
 			name:     "openshift 3.11 branch goes to 3.x configmap",
 			branch:   "openshift-3.11",
 			expected: "ci-operator-3.x-configs",
+		},
+		{
+			name:     "release 1.0 branch goes to 1.x configmap",
+			branch:   "release-1.0",
+			expected: "ci-operator-1.x-configs",
+		},
+		{
+			name:     "release 2.5 branch goes to 2.x configmap",
+			branch:   "release-2.5",
+			expected: "ci-operator-2.x-configs",
 		},
 		{
 			name:     "release 3.11 branch goes to 3.x configmap",


### PR DESCRIPTION
The `job-config-misc` `ConfigMap` now exceeds the 1MB capacity, so it needs to
be further divided.  The distribution of branch names has a bias for
`release-[0-9]`:

```
$ release config \
    | yq -r '.zz_generated_metadata.branch' \
    | sort | uniq -c | sort -n | tail -30
      9 backplane-1.0
      9 release-2.2
      9 release-ocm-2.4
      9 release-v1.4
     11 release-ocm-2.5
     11 release-ocm-2.6
     11 release-v1.3
     13 release-next
     19 backplane-2.0
     20 backplane-2.1
     24 release-3.11
     50 release-2.6
     55 release-2.5
     58 release-2.3
     63 release-2.4
    201 release-4.1
    252 release-4.2
    279 release-4.3
    306 release-4.4
    336 release-4.5
    347 main
    361 release-4.6
    390 release-4.7
    409 release-4.8
    436 release-4.9
    491 release-4.10
    521 release-4.13
    528 release-4.12
    529 release-4.11
    739 master
```

Take those out of `misc` by generalizing the `release-[1-3]` pattern already
used for `3.x`, roughly bifurcating the current list:

```
$ branches=$(release config | yq --raw-output '.zz_generated_metadata.branch')
$ <<< $branches wc -l
7106
$ <<< $branches grep -ce master -e main
1088
$ <<< $branches egrep -c '^(release|enterprise|openshift)-(4\.[0-9]+)$'
5094
$ <<< $branches egrep -v '^(release|enterprise|openshift)-(4\.[0-9]+)$' \
    | egrep -c '^release-([1-3])\.'
399
$ <<< $branches egrep -cv \
    -e master -e main \
    -e '^(release|enterprise|openshift)-(4\.[0-9]+)$' \
    -e '^release-([1-3])\.'
525
```