### PR TITLE
Add metrics to pod-scaler-admission

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/prometheus/client_golang/prometheus"
 	"net/http"
 	"sort"
 	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
@@ -224,13 +224,13 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, contai
 			if our.Cmp(their) == 1 {
 				logger.Debugf("determined %s %s of %s to be larger than %s configured", field, pair.resource, our.String(), their.String())
 				(*pair.theirs)[field] = our
-				recordPodAdmitted(containerName, admittedPodsMetric)
 				if our.Value() > (their.Value() * 10) {
 					metrics.RecordError(fmt.Sprintf("actual memory 10x more than configured amount for: %s", containerName), promMetrics.ErrorRate)
 				}
 			}
 		}
 	}
+	recordPodAdmitted(containerName, admittedPodsMetric)
 }
 
 func initPodCounterMetric() *prometheus.CounterVec {

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -716,7 +716,7 @@ func TestUseOursIfLarger(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs, logrus.WithField("test", testCase.name))
+			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}


### PR DESCRIPTION
This adds metrics for pod-scaler admission to record an error to prometheus, in case pod-scaler determines that a job needs more than 10 times the memory configured in the spec.

for the first 2 subtasks of https://issues.redhat.com/browse/DPTP-2929

/cc smg247