### PR TITLE
Observer pods: manage kubeconfig and shared_dir features on entrypoint-wrapper

### DIFF
--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -92,7 +92,7 @@ func TestGeneratePods(t *testing.T) {
 		Name:      "secret",
 		MountPath: "/secret",
 	}}
-	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, secretVolumes, secretVolumeMounts)
+	ret, _, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Test, env, secretVolumes, secretVolumeMounts, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Environment: tc.env,
 				},
 			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name")
-			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil)
+			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,7 +233,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 	}
 	jobSpec.SetNamespace("namespace")
 	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name")
-	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil)
+	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -199,7 +199,9 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 		return err
 	}
 	var errs []error
-	observers, err := s.generateObservers(s.observers, secretVolumes, secretVolumeMounts)
+	generateObserverOpt := defaultGeneratePodOptions()
+	generateObserverOpt.IsObserver = true
+	observers, err := s.generateObservers(s.observers, secretVolumes, secretVolumeMounts, generateObserverOpt)
 	if err != nil {
 		// if we can't even generate the Pods there's no reason to run the job
 		return err

--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -33,7 +33,7 @@ func (s *multiStageTestStep) runSteps(
 ) error {
 	start := time.Now()
 	logrus.Infof("Running multi-stage phase %s", phase)
-	pods, bestEffortSteps, err := s.generatePods(steps, env, secretVolumes, secretVolumeMounts)
+	pods, bestEffortSteps, err := s.generatePods(steps, env, secretVolumes, secretVolumeMounts, nil)
 	if err != nil {
 		s.flags |= hasPrevErrs
 		return err
@@ -141,7 +141,7 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 	wg.Wait()
 	close(errs)
 	for err := range errs {
-		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 			logrus.WithError(err).Warn("observer failed")
 		}
 	}


### PR DESCRIPTION
This work is preparatory for a future e2e test (an additional PR will follow).

`entrypoint-wrapper` has been modified to opt-out the following features:
- make a `rw` copy of `$KUBECONFIG`
- synchronize `$SHARED_DIR` back to the shared secret
- upload a kubeconfig

`ci-operator` has been modified to configure observer-pods such that:
- they are not allowed to update the shared secret
- no kubeconfig will ever be uploaded
- a kubeconfig will exist in `$KUBECONFIG` as soon as possible

/cc @jmguzik @bbguimaraes 
/hold
