### PR TITLE
`check-gh-automation`: allow repo to be passed in and create local dev script

### DIFF
--- a/cmd/check-gh-automation/README.md
+++ b/cmd/check-gh-automation/README.md
@@ -1,5 +1,6 @@
 # Check GH Automation
 A tool to check that our bots (`openshift-merge-robot` and `openshift-ci-robot`) have access to repositories that have CI configured.
+It also checks that the app used to run it is installed in the repositories.
 This can be run in multiple modes:
 
 ## Pass Prow Config Options
@@ -26,3 +27,14 @@ check-gh-automation
 --github-app-id={APP_ID} \
 --github-app-private-key-path={CERT_PATH}
 ```
+
+## Pass specific Repo(s) to check
+The `--repo` parameter can be used to pass one or more repos in to be checked.
+When using this mode do not supply the prow config options or the `candidate-path`
+
+## Local Development
+A `hack/local-check-gh-automation.sh` script exists to test out the tool locally. Usage is simple:
+```bash
+hack/local-check-gh-automation.sh some-org/repo
+```
+The script will pull the necessary secrets from the `app.ci` cluster and run the tool locally, checking the provided repo.

--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -80,19 +79,22 @@ func TestCheckRepos(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name:  "org has bots as members",
-			repos: []string{"org-1/repo-a"},
-			bots:  []string{"d-bot", "e-bot"},
+			name:     "org has bots as members",
+			repos:    []string{"org-1/repo-a"},
+			bots:     []string{"d-bot", "e-bot"},
+			expected: []string{},
 		},
 		{
-			name:  "org has one bot as member, and one as collaborator",
-			repos: []string{"org-1/repo-a"},
-			bots:  []string{"a-bot", "e-bot"},
+			name:     "org has one bot as member, and one as collaborator",
+			repos:    []string{"org-1/repo-a"},
+			bots:     []string{"a-bot", "e-bot"},
+			expected: []string{},
 		},
 		{
-			name:  "repo has bots as collaborators",
-			repos: []string{"org-1/repo-a"},
-			bots:  []string{"a-bot", "b-bot"},
+			name:     "repo has bots as collaborators",
+			repos:    []string{"org-1/repo-a"},
+			bots:     []string{"a-bot", "b-bot"},
+			expected: []string{},
 		},
 		{
 			name:     "org doesn't have bots as members, and repo doesn't have bots as collaborators",
@@ -107,8 +109,9 @@ func TestCheckRepos(t *testing.T) {
 			expected: []string{"org-2/repo-z"},
 		},
 		{
-			name:  "app installed, no bots",
-			repos: []string{"org-1/repo-a"},
+			name:     "app installed, no bots",
+			repos:    []string{"org-1/repo-a"},
+			expected: []string{},
 		},
 		{
 			name:     "app not installed",
@@ -117,16 +120,18 @@ func TestCheckRepos(t *testing.T) {
 			expected: []string{"org-3/repo-y"},
 		},
 		{
-			name:   "ignored repo",
-			repos:  []string{"org-2/repo-z"},
-			bots:   []string{"a-bot", "b-bot"},
-			ignore: sets.NewString("org-2/repo-z"),
+			name:     "ignored repo",
+			repos:    []string{"org-2/repo-z"},
+			bots:     []string{"a-bot", "b-bot"},
+			ignore:   sets.NewString("org-2/repo-z"),
+			expected: []string{},
 		},
 		{
-			name:   "ignored org",
-			repos:  []string{"org-2/repo-z"},
-			bots:   []string{"a-bot", "b-bot"},
-			ignore: sets.NewString("org-2"),
+			name:     "ignored org",
+			repos:    []string{"org-2/repo-z"},
+			bots:     []string{"a-bot", "b-bot"},
+			ignore:   sets.NewString("org-2"),
+			expected: []string{},
 		},
 		{
 			name:        "org member check returns error",
@@ -153,7 +158,7 @@ func TestCheckRepos(t *testing.T) {
 			if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("error doesn't match expected, diff: %s", diff)
 			}
-			if diff := cmp.Diff(tc.expected, failing, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.expected, failing); diff != "" {
 				t.Fatalf("returned failing repos did not match expected, diff: %s", diff)
 			}
 		})

--- a/hack/local-check-gh-automation.sh
+++ b/hack/local-check-gh-automation.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+function cleanup() {
+  return_code=$?
+  os::cleanup::all
+  os::util::describe_return_code "${return_code}"
+  exit "${return_code}"
+}
+trap "cleanup" EXIT
+
+data="${BASETMPDIR}/data"
+mkdir -p "${data}"
+
+function OC() {
+	oc --context app.ci --namespace ci --as system:admin "$@"
+}
+
+os::log::info "Extracting production data we need to run check-gh-automation..."
+OC extract secret/openshift-prow-github-app --keys appid,cert --to "${data}"
+
+app_id=$(cat "${data}/appid")
+
+os::log::info "Running check-gh-automation"
+go run ./cmd/check-gh-automation --repo="$1" --bot=openshift-merge-robot --bot=openshift-ci-robot --github-app-id="$app_id" --github-app-private-key-path="${data}/cert"

--- a/hack/local-check-gh-automation.sh
+++ b/hack/local-check-gh-automation.sh
@@ -14,7 +14,7 @@ data="${BASETMPDIR}/data"
 mkdir -p "${data}"
 
 function OC() {
-	oc --context app.ci --namespace ci --as system:admin "$@"
+	oc --context app.ci --namespace ci "$@"
 }
 
 os::log::info "Extracting production data we need to run check-gh-automation..."


### PR DESCRIPTION
Now that this tool is getting more complicated, it is nice to have an easy way to run it locally. By adding a new option to supply the repo(s) to be checked we can achieve that.

As a follow up, I want to create a make target in `openshift/release` that allows us to simply check a repo on command. This is useful when we think some changes to the automation access may be causing problems.