### PR TITLE
`prowgen`: expose option to disable rehearsals for specific tests

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -27,13 +27,13 @@ func IsPromotionJob(jobLabels map[string]string) bool {
 // ReleaseBuildConfiguration describes how release
 // artifacts are built from a repository of source
 // code. The configuration is made up of two parts:
-//  - minimal fields that allow the user to buy into
-//    our normal conventions without worrying about
-//    how the pipeline flows. Use these preferentially
-//    for new projects with simple/conventional build
-//    configurations.
-//  - raw steps that can be used to create custom and
-//    fine-grained build flows
+//   - minimal fields that allow the user to buy into
+//     our normal conventions without worrying about
+//     how the pipeline flows. Use these preferentially
+//     for new projects with simple/conventional build
+//     configurations.
+//   - raw steps that can be used to create custom and
+//     fine-grained build flows
 type ReleaseBuildConfiguration struct {
 	Metadata Metadata `json:"zz_generated_metadata"`
 
@@ -688,6 +688,10 @@ type TestStepConfiguration struct {
 
 	// Timeout overrides maximum prowjob duration
 	Timeout *prowv1.Duration `json:"timeout,omitempty"`
+
+	// DisableRehearsal will exclude the "can-be-rehearsed" label from the pj spec.
+	// Which will mean the test will not be picked up for rehearsals. Not valid on postsubmits.
+	DisableRehearsal bool `json:"disable_rehearsal,omitempty"`
 
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -488,7 +488,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			jobBaseGen.Cluster("build01")
 		}
 
-		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
+		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 		break
 	}
@@ -595,7 +595,7 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 
 	jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &prowgen.ProwgenInfo{}, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0])
 
-	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
+	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
 	periodic.Name = aggregatorJobName
 
 	// Aggregator jobs need more time to finish than the jobs they are aggregating. The default job timeout in CI is set to 4h

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals.yaml
@@ -1,0 +1,97 @@
+periodics:
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  name: periodic-ci-organization-repository-branch-periodic-unit
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=periodic-unit
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-organization-repository-branch-periodic-lint
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=periodic-lint
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+presubmits:
+  organization/repository:
+  - always_run: false
+    name: pull-ci-organization-repository-branch-unit
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-lint

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
@@ -1,0 +1,10 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/validation/graph.go
+++ b/pkg/validation/graph.go
@@ -88,5 +88,9 @@ func validateTestStepConfiguration(
 	if _, ok := pipelineImages[c.From]; !ok {
 		ret = append(ret, fmt.Errorf("tests[%s].from: unknown image %q", s.As, c.From))
 	}
+
+	if s.Postsubmit && s.DisableRehearsal {
+		ret = append(ret, fmt.Errorf("tests[%s] is a postsubmit, but disable_rehearsal has been set, this is not a valid configuration for postsubmits", s.As))
+	}
 	return
 }

--- a/pkg/validation/graph_test.go
+++ b/pkg/validation/graph_test.go
@@ -285,6 +285,21 @@ func TestIsValidGraph_ContainerTestFrom(t *testing.T) {
 			},
 			Tests: tests("root"),
 		},
+	}, {
+		name: "disable_rehearsal set on postsubmit invalid",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				BaseImages: map[string]api.ImageStreamTagReference{"from": {}},
+			},
+			Tests: []api.TestStepConfiguration{{
+				As: "test-invalid-postsubmit-config",
+				ContainerTestConfiguration: &api.ContainerTestConfiguration{
+					From: api.PipelineImageStreamTagReference("from"),
+				},
+				Postsubmit:       true,
+				DisableRehearsal: true,
+			}}},
+		expected: errs(`tests[test-invalid-postsubmit-config] is a postsubmit, but disable_rehearsal has been set, this is not a valid configuration for postsubmits`),
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			graphConf := defaults.FromConfigStatic(&tc.config)

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -450,6 +450,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        # of pull request workflows. Setting this field will\n" +
 	"        # create a periodic job instead of a presubmit\n" +
 	"        cron: \"\"\n" +
+	"        # DisableRehearsal will exclude the \"can-be-rehearsed\" label from the pj spec.\n" +
+	"        # Which will mean the test will not be picked up for rehearsals. Not valid on postsubmits.\n" +
+	"        disable_rehearsal: true\n" +
 	"        # Interval is how frequently the test should be run based\n" +
 	"        # on the last time the test ran. Setting this field will\n" +
 	"        # create a periodic job instead of a presubmit\n" +
@@ -1216,6 +1219,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"      # of pull request workflows. Setting this field will\n" +
 	"      # create a periodic job instead of a presubmit\n" +
 	"      cron: \"\"\n" +
+	"      # DisableRehearsal will exclude the \"can-be-rehearsed\" label from the pj spec.\n" +
+	"      # Which will mean the test will not be picked up for rehearsals. Not valid on postsubmits.\n" +
+	"      disable_rehearsal: true\n" +
 	"      # Interval is how frequently the test should be run based\n" +
 	"      # on the last time the test ran. Setting this field will\n" +
 	"      # create a periodic job instead of a presubmit\n" +

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -35,6 +35,7 @@ tests:
   commands: make test-unit
   container:
     from: src
+  disable_rehearsal: true
 - as: upload-results
   commands: make upload-results
   container:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -521,7 +521,6 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-super-duper-master-unit
     rerun_command: /test unit
     spec:


### PR DESCRIPTION
We need an option for test maintainers to not have rehearsals for specific tests when using `prowgen`.

Coming next: An option in the repo's `.ci-operator.prowgen` config to disable rehearsals for **all** tests.

For: https://issues.redhat.com/browse/DPTP-3091