### PR TITLE
`prowgen`: disable rehearsals via the .config.prowgen file

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -136,7 +136,7 @@ func (o *options) generateJobsToDir(subDir string, prowConfig map[string]*config
 func generateJobs(resolver registry.Resolver, cache map[string]*config.Prowgen, output map[string]*prowconfig.JobConfig) func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 	return func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
-		pInfo := &prowgen.ProwgenInfo{Metadata: info.Metadata, Config: config.Prowgen{Private: false, Expose: false}}
+		pInfo := &prowgen.ProwgenInfo{Metadata: info.Metadata, Config: config.Prowgen{Private: false, Expose: false, DisableAllRehearsals: false}}
 		var ok bool
 		var err error
 		var orgConfig, repoConfig *config.Prowgen

--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -136,7 +136,7 @@ func (o *options) generateJobsToDir(subDir string, prowConfig map[string]*config
 func generateJobs(resolver registry.Resolver, cache map[string]*config.Prowgen, output map[string]*prowconfig.JobConfig) func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 	return func(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
 		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
-		pInfo := &prowgen.ProwgenInfo{Metadata: info.Metadata, Config: config.Prowgen{Private: false, Expose: false, DisableAllRehearsals: false}}
+		pInfo := &prowgen.ProwgenInfo{Metadata: info.Metadata, Config: config.Prowgen{Private: false, Expose: false}}
 		var ok bool
 		var err error
 		var orgConfig, repoConfig *config.Prowgen

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -27,13 +27,13 @@ func IsPromotionJob(jobLabels map[string]string) bool {
 // ReleaseBuildConfiguration describes how release
 // artifacts are built from a repository of source
 // code. The configuration is made up of two parts:
-//  - minimal fields that allow the user to buy into
-//    our normal conventions without worrying about
-//    how the pipeline flows. Use these preferentially
-//    for new projects with simple/conventional build
-//    configurations.
-//  - raw steps that can be used to create custom and
-//    fine-grained build flows
+//   - minimal fields that allow the user to buy into
+//     our normal conventions without worrying about
+//     how the pipeline flows. Use these preferentially
+//     for new projects with simple/conventional build
+//     configurations.
+//   - raw steps that can be used to create custom and
+//     fine-grained build flows
 type ReleaseBuildConfiguration struct {
 	Metadata Metadata `json:"zz_generated_metadata"`
 

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -31,9 +31,14 @@ type Prowgen struct {
 	// are private.
 	// This field has no effect if private is not set.
 	Expose bool `json:"expose,omitempty"`
-	// DisableAllRehearsals indicates that all jobs will not have their "can-be-rehearsed" label set
+	// Rehearsals declares any disabled rehearsals for jobs
+	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
+}
+
+type Rehearsals struct {
+	// DisableAll indicates that all jobs will not have their "can-be-rehearsed" label set
 	// and therefore will not be picked up for rehearsals.
-	DisableAllRehearsals bool `json:"disable_all_rehearsals,omitempty"`
+	DisableAll bool `json:"disable_all,omitempty"`
 	// DisabledRehearsals contains a list of jobs that will not have their "can-be-rehearsed" label set
 	// and therefore will not be picked up for rehearsals.
 	DisabledRehearsals []string `json:"disabled_rehearsals,omitempty"`

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -31,6 +31,12 @@ type Prowgen struct {
 	// are private.
 	// This field has no effect if private is not set.
 	Expose bool `json:"expose,omitempty"`
+	// DisableAllRehearsals indicates that all jobs will not have their "can-be-rehearsed" label set
+	// and therefore will not be picked up for rehearsals.
+	DisableAllRehearsals bool `json:"disable_all_rehearsals,omitempty"`
+	// DisabledRehearsals contains a list of jobs that will not have their "can-be-rehearsed" label set
+	// and therefore will not be picked up for rehearsals.
+	DisabledRehearsals []string `json:"disabled_rehearsals,omitempty"`
 }
 
 func readCiOperatorConfig(configFilePath string, info Info) (*cioperatorapi.ReleaseBuildConfiguration, error) {
@@ -120,13 +126,13 @@ func isConfigFile(info fs.DirEntry) bool {
 // isMountSpecialFile identifies special files in Kubernetes mounts
 // The general structure of a mount is:
 //
-//     config
-//     ├── ..2019_11_15_19_57_20.547184898
-//     │   ├── foo-bar-master.yaml
-//     │   └── super-duper-master.yaml
-//     ├── ..data -> ..2019_11_15_19_57_20.547184898
-//     ├── foo-bar-master.yaml -> ..data/foo-bar-master.yaml
-//     └── super-duper-master.yaml -> ..data/super-duper-master.yaml
+//	config
+//	├── ..2019_11_15_19_57_20.547184898
+//	│   ├── foo-bar-master.yaml
+//	│   └── super-duper-master.yaml
+//	├── ..data -> ..2019_11_15_19_57_20.547184898
+//	├── foo-bar-master.yaml -> ..data/foo-bar-master.yaml
+//	└── super-duper-master.yaml -> ..data/super-duper-master.yaml
 //
 // In a recursive directory traversal, paths starting with `..` are skipped so
 // files are not processed twice.

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -488,7 +488,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			jobBaseGen.Cluster("build01")
 		}
 
-		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
+		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 		break
 	}
@@ -595,7 +595,7 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 
 	jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &prowgen.ProwgenInfo{}, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0])
 
-	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", false, ciopConfig.CanonicalGoRepository)
+	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
 	periodic.Name = aggregatorJobName
 
 	// Aggregator jobs need more time to finish than the jobs they are aggregating. The default job timeout in CI is set to 4h

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -488,7 +488,9 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			jobBaseGen.Cluster("build01")
 		}
 
-		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", prowgen.FromConfigSpec(ciopConfig))
+		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
+			options.Cron = "@yearly"
+		})
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 		break
 	}
@@ -595,7 +597,9 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 
 	jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &prowgen.ProwgenInfo{}, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0])
 
-	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", prowgen.FromConfigSpec(ciopConfig))
+	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
+		options.Cron = "@yearly"
+	})
 	periodic.Name = aggregatorJobName
 
 	// Aggregator jobs need more time to finish than the jobs they are aggregating. The default job timeout in CI is set to 4h

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -488,7 +488,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			jobBaseGen.Cluster("build01")
 		}
 
-		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
+		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, "@yearly", "", prowgen.FromConfigSpec(ciopConfig))
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 		break
 	}
@@ -595,7 +595,7 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 
 	jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, &prowgen.ProwgenInfo{}, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[0])
 
-	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", false, ciopConfig.CanonicalGoRepository, false)
+	periodic := prowgen.GeneratePeriodicForTest(jobBaseGen, &prowgen.ProwgenInfo{}, "@yearly", "", prowgen.FromConfigSpec(ciopConfig))
 	periodic.Name = aggregatorJobName
 
 	// Aggregator jobs need more time to finish than the jobs they are aggregating. The default job timeout in CI is set to 4h

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -29,13 +29,13 @@ type ProwgenInfo struct {
 // Given a ci-operator configuration file and basic information about what
 // should be tested, generate a following JobConfig:
 //
-// - one presubmit for each test defined in config file
-// - if the config file has non-empty `images` section, generate an additional
-//   presubmit and postsubmit that has `--target=[images]`. This postsubmit
-//   will additionally pass `--promote` to ci-operator
+//   - one presubmit for each test defined in config file
+//   - if the config file has non-empty `images` section, generate an additional
+//     presubmit and postsubmit that has `--target=[images]`. This postsubmit
+//     will additionally pass `--promote` to ci-operator
 //
 // All these generated jobs will be labeled as "newly generated". After all
-// new jobs are generated with GenerateJobs, the callsite should also use
+// new jobs are generated with GenerateJobs, the call site should also use
 // Prune() function to remove all stale jobs and label the jobs as simply
 // "generated".
 func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *ProwgenInfo) *prowconfig.JobConfig {
@@ -43,9 +43,11 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	presubmits := map[string][]prowconfig.Presubmit{}
 	postsubmits := map[string][]prowconfig.Postsubmit{}
 	var periodics []prowconfig.Periodic
+	disabledRehearsals := sets.NewString(info.Config.DisabledRehearsals...)
 
 	for _, element := range configSpec.Tests {
 		g := NewProwJobBaseBuilderForTest(configSpec, info, NewCiOperatorPodSpecGenerator(), element)
+		disableRehearsal := info.Config.DisableAllRehearsals || disabledRehearsals.Has(element.As)
 
 		if element.Cron != nil || element.Interval != nil || element.ReleaseController {
 			cron := ""
@@ -56,14 +58,14 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 			if element.Interval != nil {
 				interval = *element.Interval
 			}
-			periodic := GeneratePeriodicForTest(g, info, cron, interval, element.ReleaseController, configSpec.CanonicalGoRepository)
+			periodic := GeneratePeriodicForTest(g, info, cron, interval, element.ReleaseController, configSpec.CanonicalGoRepository, disableRehearsal)
 			periodics = append(periodics, *periodic)
 		} else if element.Postsubmit {
 			postsubmit := generatePostsubmitForTest(g, info, element.RunIfChanged, element.SkipIfOnlyChanged)
 			postsubmit.MaxConcurrency = 1
 			postsubmits[orgrepo] = append(postsubmits[orgrepo], *postsubmit)
 		} else {
-			presubmit := generatePresubmitForTest(g, element.As, info, element.RunIfChanged, element.SkipIfOnlyChanged, element.Optional)
+			presubmit := generatePresubmitForTest(g, element.As, info, element.RunIfChanged, element.SkipIfOnlyChanged, element.Optional, disableRehearsal)
 			v, requestingKVM := configSpec.Resources.RequirementsForStep(element.As).Requests[cioperatorapi.KVMDeviceLabel]
 			if requestingKVM {
 				presubmit.Labels[cioperatorapi.KVMDeviceLabel] = v
@@ -86,7 +88,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 		}
 		jobBaseGen := newJobBaseBuilder().TestName("images")
 		jobBaseGen.PodSpec.Add(Targets(presubmitTargets...))
-		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, "images", info, "", "", false))
+		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, "images", info, "", "", false, false))
 
 		if configSpec.PromotionConfiguration != nil {
 			jobBaseGen = newJobBaseBuilder().TestName("images")
@@ -111,13 +113,13 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 			indexName := api.IndexName(bundle.As)
 			jobBaseGen := newJobBaseBuilder().TestName(indexName)
 			jobBaseGen.PodSpec.Add(Targets(indexName))
-			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, indexName, info, "", "", false))
+			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, indexName, info, "", "", false, false))
 		}
 		if containsUnnamedBundle {
 			name := string(api.PipelineImageStreamTagReferenceIndexImage)
 			jobBaseGen := newJobBaseBuilder().TestName(name)
 			jobBaseGen.PodSpec.Add(Targets(name))
-			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, name, info, "", "", false))
+			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, name, info, "", "", false, false))
 		}
 	}
 
@@ -137,9 +139,9 @@ func testContainsLease(test *cioperatorapi.TestStepConfiguration) bool {
 	return len(api.LeasesForTest(test.MultiStageTestConfigurationLiteral)) > 0
 }
 
-func generatePresubmitForTest(jobBaseBuilder *prowJobBaseBuilder, name string, info *ProwgenInfo, runIfChanged, skipIfOnlyChanged string, optional bool) *prowconfig.Presubmit {
+func generatePresubmitForTest(jobBaseBuilder *prowJobBaseBuilder, name string, info *ProwgenInfo, runIfChanged, skipIfOnlyChanged string, optional, disableRehearsal bool) *prowconfig.Presubmit {
 	shortName := info.TestName(name)
-	base := jobBaseBuilder.Rehearsable(true).Build(jc.PresubmitPrefix)
+	base := jobBaseBuilder.Rehearsable(!disableRehearsal).Build(jc.PresubmitPrefix)
 	return &prowconfig.Presubmit{
 		JobBase:   base,
 		AlwaysRun: runIfChanged == "" && skipIfOnlyChanged == "",
@@ -183,10 +185,10 @@ func hashDailyCron(job string) string {
 	return fmt.Sprintf("%d %d * * *", minute, hour)
 }
 
-func GeneratePeriodicForTest(jobBaseBuilder *prowJobBaseBuilder, info *ProwgenInfo, cron string, interval string, releaseController bool, pathAlias *string) *prowconfig.Periodic {
+func GeneratePeriodicForTest(jobBaseBuilder *prowJobBaseBuilder, info *ProwgenInfo, cron string, interval string, releaseController bool, pathAlias *string, disableRehearsal bool) *prowconfig.Periodic {
 	// Periodics are rehearsable
 	// We are resetting PathAlias because it will be set on the `ExtraRefs` item
-	base := jobBaseBuilder.Rehearsable(true).PathAlias("").Build(jc.PeriodicPrefix)
+	base := jobBaseBuilder.Rehearsable(!disableRehearsal).PathAlias("").Build(jc.PeriodicPrefix)
 
 	if cron == "@daily" {
 		cron = hashDailyCron(base.Name)

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -43,11 +43,12 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	presubmits := map[string][]prowconfig.Presubmit{}
 	postsubmits := map[string][]prowconfig.Postsubmit{}
 	var periodics []prowconfig.Periodic
-	disabledRehearsals := sets.NewString(info.Config.DisabledRehearsals...)
+	rehearsals := info.Config.Rehearsals
+	disabledRehearsals := sets.NewString(rehearsals.DisabledRehearsals...)
 
 	for _, element := range configSpec.Tests {
 		g := NewProwJobBaseBuilderForTest(configSpec, info, NewCiOperatorPodSpecGenerator(), element)
-		disableRehearsal := info.Config.DisableAllRehearsals || disabledRehearsals.Has(element.As)
+		disableRehearsal := rehearsals.DisableAll || disabledRehearsals.Has(element.As)
 
 		if element.Cron != nil || element.Interval != nil || element.ReleaseController {
 			cron := ""

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -408,7 +408,7 @@ func TestGenerateJobs(t *testing.T) {
 				},
 			},
 			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{DisabledRehearsals: []string{"unit", "periodic-unit"}},
+				Config: config.Prowgen{Rehearsals: config.Rehearsals{DisabledRehearsals: []string{"unit", "periodic-unit"}}},
 				Metadata: ciop.Metadata{
 					Org:    "organization",
 					Repo:   "repository",
@@ -424,7 +424,7 @@ func TestGenerateJobs(t *testing.T) {
 				},
 			},
 			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{DisableAllRehearsals: true},
+				Config: config.Prowgen{Rehearsals: config.Rehearsals{DisableAll: true}},
 				Metadata: ciop.Metadata{
 					Org:    "organization",
 					Repo:   "repository",

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -164,12 +164,10 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 func TestGeneratePostSubmitForTest(t *testing.T) {
 	testname := "postsubmit"
 	tests := []struct {
-		name              string
-		repoInfo          *ProwgenInfo
-		jobRelease        string
-		runIfChanged      string
-		skipIfOnlyChanged string
-		clone             bool
+		name           string
+		repoInfo       *ProwgenInfo
+		jobRelease     string
+		generateOption generatePostsubmitOption
 	}{
 		{
 			name: "Lowercase org repo and branch",
@@ -194,7 +192,9 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			runIfChanged: "^README.md$",
+			generateOption: func(options *generatePostsubmitOptions) {
+				options.runIfChanged = "^README.md$"
+			},
 		},
 		{
 			name: "postsubmit with skip_if_only_changed",
@@ -203,14 +203,20 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Repo:   "repository",
 				Branch: "branch",
 			}},
-			skipIfOnlyChanged: "^README.md$",
+			generateOption: func(options *generatePostsubmitOptions) {
+				options.skipIfOnlyChanged = "^README.md$"
+			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			generateOption := tc.generateOption
+			if generateOption == nil {
+				generateOption = func(options *generatePostsubmitOptions) {}
+			}
 			test := ciop.TestStepConfiguration{As: testname}
 			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
-			testhelper.CompareWithFixture(t, generatePostsubmitForTest(jobBaseGen, tc.repoInfo, tc.runIfChanged, tc.skipIfOnlyChanged))
+			testhelper.CompareWithFixture(t, generatePostsubmitForTest(jobBaseGen, tc.repoInfo, generateOption))
 		})
 	}
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -112,35 +112,39 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 		repoInfo       *ProwgenInfo
 		jobRelease     string
 		clone          bool
-		cron           string
-		interval       string
 		generateOption GeneratePeriodicOption
 	}{
 		{
 			description: "periodic for standard test",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			cron:        "@yearly",
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+			},
 		},
 		{
 			description: "periodic for a test in a variant config",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
-			cron:        "@yearly",
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+			},
 		},
 		{
 			description: "periodic using interval",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			interval:    "6h",
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Interval = "6h"
+			},
 		},
 		{
 			description: "periodic with disabled rehearsal",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
-			cron:        "@yearly",
 			generateOption: func(options *GeneratePeriodicOptions) {
-				options.disableRehearsal = true
+				options.DisableRehearsal = true
+				options.Cron = "@yearly"
 			},
 		},
 	}
@@ -152,7 +156,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			}
 			test := ciop.TestStepConfiguration{As: tc.test}
 			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
-			testhelper.CompareWithFixture(t, GeneratePeriodicForTest(jobBaseGen, tc.repoInfo, tc.cron, tc.interval, generateOption))
+			testhelper.CompareWithFixture(t, GeneratePeriodicForTest(jobBaseGen, tc.repoInfo, generateOption))
 		})
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
@@ -1,0 +1,97 @@
+periodics:
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  name: periodic-ci-organization-repository-branch-periodic-unit
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=periodic-unit
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-organization-repository-branch-periodic-lint
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=periodic-lint
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+presubmits:
+  organization/repository:
+  - always_run: false
+    name: pull-ci-organization-repository-branch-unit
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-lint

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
@@ -1,0 +1,48 @@
+periodics:
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  name: periodic-ci-organization-repository-branch-periodic-unit
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=periodic-unit
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+presubmits:
+  organization/repository:
+  - always_run: false
+    name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
@@ -1,0 +1,10 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
@@ -1,0 +1,12 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/.config.prowgen
@@ -1,0 +1,1 @@
+disable_all_rehearsals: true

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/.config.prowgen
@@ -1,1 +1,2 @@
-disable_all_rehearsals: true
+rehearsals:
+    disable_all: true

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/norehearsals-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/duper/norehearsals-duper-master.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+  disable_rehearsal: true
+- as: upload-results
+  commands: make upload-results
+  container:
+    from: src
+  postsubmit: true
+- as: lint
+  commands: make test-lint
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/.config.prowgen
@@ -1,2 +1,3 @@
-disabled_rehearsals:
-- unit
+rehearsals:
+    disabled_rehearsals:
+    - unit

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/.config.prowgen
@@ -1,0 +1,2 @@
+disabled_rehearsals:
+- unit

--- a/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/norehearsals-stuper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/norehearsals/stuper/norehearsals-stuper-master.yaml
@@ -1,0 +1,38 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+  disable_rehearsal: true
+- as: upload-results
+  commands: make upload-results
+  container:
+    from: src
+  postsubmit: true
+- as: lint
+  commands: make test-lint
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: duper

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
@@ -1,0 +1,46 @@
+postsubmits:
+  norehearsals/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-norehearsals-duper-master-upload-results
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upload-results
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
@@ -1,0 +1,97 @@
+presubmits:
+  norehearsals/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/lint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-norehearsals-duper-master-lint
+    rerun_command: /test lint
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    name: pull-ci-norehearsals-duper-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
@@ -11,7 +11,6 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-norehearsals-duper-master-lint
     rerun_command: /test lint
     spec:

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
@@ -1,0 +1,46 @@
+postsubmits:
+  norehearsals/stuper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-norehearsals-stuper-master-upload-results
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upload-results
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
@@ -1,0 +1,97 @@
+presubmits:
+  norehearsals/stuper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/lint
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-norehearsals-stuper-master-lint
+    rerun_command: /test lint
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=lint
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )lint,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    name: pull-ci-norehearsals-stuper-master-unit
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
This will allow job maintainers to disable rehearsals on **all** jobs for an org or repo by using the `.config.prowgen` file. It also allows for individual tests rehearsals to be disabled via a list of `disabled_rehearsals`.

I considered adding validation that each of the tests in the disabled rehearsals list actually matched a test name, but doing so would be fairly complex and difficult to put in place. Since the job maintainers will clearly be able to see that the label has still been applied if they were to make a typo in the entry in the list, I think it is okay to forgo this validation.

Coming up next: Information about using these new configs will be added to `ci-docs`

For: https://issues.redhat.com/browse/DPTP-3091