### PR TITLE
Support promoting images based on their architecture and resolve build cache

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -131,7 +131,7 @@ func (o *options) validateConfiguration(
 		return err
 	}
 	for _, tag := range release.PromotedTags(configuration) {
-		seenCh <- promotedTag{tag, repoInfo}
+		seenCh <- promotedTag{tag.ImageStreamTagReference, repoInfo}
 	}
 	if configuration.PromotionConfiguration != nil && configuration.PromotionConfiguration.RegistryOverride != "" {
 		return errors.New("setting promotion.registry_override is not allowed")

--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -425,9 +425,9 @@ func main() {
 	var promotedTags []api.ImageStreamTagReference
 	if err := config.OperateOnCIOperatorConfigDir(abs, func(cfg *api.ReleaseBuildConfiguration, metadata *config.Info) error {
 		for _, isTagRef := range release.PromotedTags(cfg) {
-			promotedTags = append(promotedTags, isTagRef)
-			if _, ok := opts.explains[isTagRef]; ok {
-				opts.explains[isTagRef] = cfg.Metadata.AsString()
+			promotedTags = append(promotedTags, isTagRef.ImageStreamTagReference)
+			if _, ok := opts.explains[isTagRef.ImageStreamTagReference]; ok {
+				opts.explains[isTagRef.ImageStreamTagReference] = cfg.Metadata.AsString()
 			}
 		}
 		return nil

--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -833,7 +833,7 @@ func updateDockerfilesToMatchOCPBuildData(
 		if promotedTag.Namespace != "ocp" || promotedTag.Name != majorMinorVersion {
 			continue
 		}
-		promotedTags[promotedTag.Tag] = promotedTag
+		promotedTags[promotedTag.Tag] = promotedTag.ImageStreamTagReference
 	}
 	if len(promotedTags) == 0 {
 		return

--- a/pkg/api/helper/imageextraction.go
+++ b/pkg/api/helper/imageextraction.go
@@ -69,7 +69,7 @@ func TestInputImageStreamTagsFromResolvedConfig(cfg api.ReleaseBuildConfiguratio
 			insert(*cfg.BuildRootImage.ImageStreamTagReference, result)
 		}
 		if cfg.BuildRootImage.UseBuildCache {
-			insert(api.BuildCacheFor(cfg.Metadata), result)
+			insert(api.BuildCacheFor(cfg.Metadata).ImageStreamTagReference, result)
 		}
 	}
 

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -130,15 +130,17 @@ func LogFieldsFor(metadata Metadata) logrus.Fields {
 	}
 }
 
-func BuildCacheFor(metadata Metadata) ImageStreamTagReference {
+func BuildCacheFor(metadata Metadata) MultiArchImageStreamTagReference {
 	tag := metadata.Branch
 	if metadata.Variant != "" {
 		tag = fmt.Sprintf("%s-%s", tag, metadata.Variant)
 	}
-	return ImageStreamTagReference{
-		Namespace: "build-cache",
-		Name:      fmt.Sprintf("%s-%s", metadata.Org, metadata.Repo),
-		Tag:       tag,
+	return MultiArchImageStreamTagReference{
+		ImageStreamTagReference: ImageStreamTagReference{
+			Namespace: "build-cache",
+			Name:      fmt.Sprintf("%s-%s", metadata.Org, metadata.Repo),
+			Tag:       tag,
+		},
 	}
 }
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -49,7 +49,7 @@ func addCloneRefs(cfg *api.SourceStepConfiguration) *api.SourceStepConfiguration
 }
 
 func TestStepConfigsForBuild(t *testing.T) {
-	noopResolver := func(root, cache *api.ImageStreamTagReference) (*api.ImageStreamTagReference, error) {
+	noopResolver := func(root, cache *api.MultiArchImageStreamTagReference) (*api.MultiArchImageStreamTagReference, error) {
 		return root, nil
 	}
 	var testCases = []struct {
@@ -129,7 +129,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 			},
-			resolver: func(root, cache *api.ImageStreamTagReference) (*api.ImageStreamTagReference, error) {
+			resolver: func(root, cache *api.MultiArchImageStreamTagReference) (*api.MultiArchImageStreamTagReference, error) {
 				return cache, nil
 			},
 			output: []api.StepConfiguration{{
@@ -238,7 +238,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 			},
-			resolver: func(root, cache *api.ImageStreamTagReference) (*api.ImageStreamTagReference, error) {
+			resolver: func(root, cache *api.MultiArchImageStreamTagReference) (*api.MultiArchImageStreamTagReference, error) {
 				return cache, nil
 			},
 			output: []api.StepConfiguration{{

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -147,7 +147,7 @@ func TestPromotedTags(t *testing.T) {
 	var testCases = []struct {
 		name     string
 		input    *api.ReleaseBuildConfiguration
-		expected []api.ImageStreamTagReference
+		expected []api.MultiArchImageStreamTagReference
 	}{
 		{
 			name:     "no promotion, no output",
@@ -165,11 +165,9 @@ func TestPromotedTags(t *testing.T) {
 					Name:      "fred",
 				},
 			},
-			expected: []api.ImageStreamTagReference{{
-				Namespace: "roger",
-				Name:      "fred",
-				Tag:       "foo",
-			}},
+			expected: []api.MultiArchImageStreamTagReference{
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "fred", Tag: "foo"}},
+			},
 		},
 		{
 			name: "promoted image but disabled promotion means no output tags",
@@ -196,11 +194,9 @@ func TestPromotedTags(t *testing.T) {
 					Tag:       "fred",
 				},
 			},
-			expected: []api.ImageStreamTagReference{{
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "fred",
-			}},
+			expected: []api.MultiArchImageStreamTagReference{
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "fred"}},
+			},
 		},
 		{
 			name: "promoted additional image with rename",
@@ -216,15 +212,10 @@ func TestPromotedTags(t *testing.T) {
 					},
 				},
 			},
-			expected: []api.ImageStreamTagReference{{
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "fred",
-			}, {
-				Namespace: "roger",
-				Name:      "output",
-				Tag:       "fred",
-			}},
+			expected: []api.MultiArchImageStreamTagReference{
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "fred"}},
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "output", Tag: "fred"}},
+			},
 		},
 		{
 			name: "disabled image",
@@ -255,11 +246,9 @@ func TestPromotedTags(t *testing.T) {
 					Branch: "branch",
 				},
 			},
-			expected: []api.ImageStreamTagReference{{
-				Namespace: "build-cache",
-				Name:      "org-repo",
-				Tag:       "branch",
-			}},
+			expected: []api.MultiArchImageStreamTagReference{
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "build-cache", Name: "org-repo", Tag: "branch"}},
+			},
 		},
 		{
 			name: "promotion with AdditionalImages: many to one",
@@ -279,7 +268,11 @@ func TestPromotedTags(t *testing.T) {
 					Branch: "release-4.6",
 				},
 			},
-			expected: []api.ImageStreamTagReference{{Namespace: "ocp", Name: "4.6", Tag: "base"}, {Namespace: "ocp", Name: "4.6", Tag: "base-7"}, {Namespace: "ocp", Name: "4.6", Tag: "base-8"}},
+			expected: []api.MultiArchImageStreamTagReference{
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base"}},
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base-7"}},
+				{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base-8"}},
+			},
 		},
 	}
 
@@ -297,7 +290,7 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 		name     string
 		input    *api.ReleaseBuildConfiguration
 		options  []PromotedTagsOption
-		expected map[string][]api.ImageStreamTagReference
+		expected map[string][]api.MultiArchImageStreamTagReference
 		names    sets.String
 	}{
 		{
@@ -315,11 +308,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Name:      "fred",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "fred",
-				Tag:       "foo",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "fred", Tag: "foo"}},
+				},
+			},
 		},
 		{
 			name: "optional image is ignored means output tags",
@@ -333,11 +326,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Name:      "fred",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "fred",
-				Tag:       "foo",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "fred", Tag: "foo"}},
+				},
+			},
 		},
 		{
 			name: "optional image that's required means output tags",
@@ -351,11 +344,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 				},
 			},
 			options: []PromotedTagsOption{WithRequiredImages(sets.NewString("foo"))},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "fred",
-				Tag:       "foo",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "fred", Tag: "foo"}},
+				},
+			},
 		},
 		{
 			name: "promoted image but disabled promotion means no output tags",
@@ -382,11 +375,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Tag:       "fred",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "fred",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "fred"}},
+				},
+			},
 		},
 		{
 			name: "promoted image tagged by commit means an additional tag",
@@ -401,15 +394,12 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 				},
 			},
 			options: []PromotedTagsOption{WithCommitSha("sha")},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "fred",
-			}, {
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "sha",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "fred"}},
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "sha"}},
+				},
+			},
 		},
 		{
 			name: "promoted additional image with rename",
@@ -425,15 +415,14 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"foo": {{
-				Namespace: "roger",
-				Name:      "foo",
-				Tag:       "fred",
-			}}, "src": {{
-				Namespace: "roger",
-				Name:      "output",
-				Tag:       "fred",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"foo": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "foo", Tag: "fred"}},
+				},
+				"src": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "roger", Name: "output", Tag: "fred"}},
+				},
+			},
 		},
 		{
 			name: "disabled image",
@@ -447,7 +436,7 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					ExcludedImages: []string{"foo"},
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{},
+			expected: map[string][]api.MultiArchImageStreamTagReference{},
 		},
 		{
 			name: "promotion set and binaries built, means binaries promoted",
@@ -464,11 +453,9 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Branch: "branch",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"bin": {{
-				Namespace: "build-cache",
-				Name:      "org-repo",
-				Tag:       "branch",
-			}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"bin": {{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "build-cache", Name: "org-repo", Tag: "branch"}}},
+			},
 		},
 		{
 			name: "promotion set and binaries built, build cache disabled means no binaries promoted",
@@ -486,7 +473,7 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Branch: "branch",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{},
+			expected: map[string][]api.MultiArchImageStreamTagReference{},
 		},
 		{
 			name: "promotion with AdditionalImages: many to one",
@@ -506,8 +493,15 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Branch: "release-4.6",
 				},
 			},
-			expected: map[string][]api.ImageStreamTagReference{"base-7": {{Namespace: "ocp", Name: "4.6", Tag: "base-7"}},
-				"base-8": {{Namespace: "ocp", Name: "4.6", Tag: "base"}, {Namespace: "ocp", Name: "4.6", Tag: "base-8"}}},
+			expected: map[string][]api.MultiArchImageStreamTagReference{
+				"base-7": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base-7"}},
+				},
+				"base-8": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base"}},
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ocp", Name: "4.6", Tag: "base-8"}},
+				},
+			},
 		},
 	}
 
@@ -524,7 +518,7 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 func TestBuildCacheFor(t *testing.T) {
 	var testCases = []struct {
 		input  api.Metadata
-		output api.ImageStreamTagReference
+		output api.MultiArchImageStreamTagReference
 	}{
 		{
 			input: api.Metadata{
@@ -532,10 +526,12 @@ func TestBuildCacheFor(t *testing.T) {
 				Repo:   "repo",
 				Branch: "branch",
 			},
-			output: api.ImageStreamTagReference{
-				Namespace: "build-cache",
-				Name:      "org-repo",
-				Tag:       "branch",
+			output: api.MultiArchImageStreamTagReference{
+				ImageStreamTagReference: api.ImageStreamTagReference{
+					Namespace: "build-cache",
+					Name:      "org-repo",
+					Tag:       "branch",
+				},
 			},
 		},
 		{
@@ -545,10 +541,12 @@ func TestBuildCacheFor(t *testing.T) {
 				Branch:  "branch",
 				Variant: "variant",
 			},
-			output: api.ImageStreamTagReference{
-				Namespace: "build-cache",
-				Name:      "org-repo",
-				Tag:       "branch-variant",
+			output: api.MultiArchImageStreamTagReference{
+				ImageStreamTagReference: api.ImageStreamTagReference{
+					Namespace: "build-cache",
+					Name:      "org-repo",
+					Tag:       "branch-variant",
+				},
 			},
 		},
 	}
@@ -586,7 +584,7 @@ func TestGetPromotionPod(t *testing.T) {
 func TestGetImageMirror(t *testing.T) {
 	var testCases = []struct {
 		name     string
-		tags     map[string][]api.ImageStreamTagReference
+		tags     map[string][]api.MultiArchImageStreamTagReference
 		pipeline *imageapi.ImageStream
 		expected map[string]string
 	}{
@@ -599,18 +597,12 @@ func TestGetImageMirror(t *testing.T) {
 		},
 		{
 			name: "basic case",
-			tags: map[string][]api.ImageStreamTagReference{
-				"b": {{
-					Namespace: "ci",
-					Name:      "a",
-					Tag:       "latest",
+			tags: map[string][]api.MultiArchImageStreamTagReference{
+				"b": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ci", Name: "a", Tag: "latest"}},
 				},
-				},
-				"d": {{
-					Namespace: "ci",
-					Name:      "c",
-					Tag:       "latest",
-				},
+				"d": {
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ci", Name: "c", Tag: "latest"}},
 				},
 			},
 			pipeline: &imageapi.ImageStream{
@@ -642,13 +634,13 @@ func TestGetImageMirror(t *testing.T) {
 		},
 		{
 			name: "image promoted to multiple names",
-			tags: map[string][]api.ImageStreamTagReference{
+			tags: map[string][]api.MultiArchImageStreamTagReference{
 				"b": {
-					{Namespace: "ci", Name: "a", Tag: "promoted"},
-					{Namespace: "ci", Name: "a", Tag: "also-promoted"},
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ci", Name: "a", Tag: "promoted"}},
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ci", Name: "a", Tag: "also-promoted"}},
 				},
 				"d": {
-					{Namespace: "ci", Name: "c", Tag: "latest"},
+					{ImageStreamTagReference: api.ImageStreamTagReference{Namespace: "ci", Name: "c", Tag: "latest"}},
 				},
 			},
 			pipeline: &imageapi.ImageStream{


### PR DESCRIPTION
/cc @openshift/test-platform 

These changes allow image promotions to resolve the namespace based on the os architecture that the promotion pod is running.
For example, If the job is running on arm64 architecture, all images will be promoted to the `$NAMESPACE-arm64` namespace in apps.ci registry.   

In addition, the build cache for the images was refactored to resolve the namespace too, which means the non-amd64 architecture images will generate a new cache.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>