### PR TITLE
autoconfigbrancher: explicitly choose merge method

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -271,7 +271,9 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to push changes.")
 	}
 
-	var labelsToAdd []string
+	labelsToAdd := []string{
+		"tide/merge-method-merge",
+	}
 	if o.selfApprove {
 		logrus.Infof("Self-approving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)


### PR DESCRIPTION
https://github.com/openshift/release/pull/30862 changed the merge method for all
pull requests in `openshift/release` to `squash`.  This destroys the discrete
commits intentionally created by `autoconfigbrancher`, resulting in a single
commit with all changes, e.g.: https://github.com/openshift/release/pull/31473.

This change makes the program always explicitly set the merge method so it is
not affected by repository configuration.