### PR TITLE
Result-aggregator: handle pod-scaler admission requests

### DIFF
--- a/cmd/result-aggregator/main.go
+++ b/cmd/result-aggregator/main.go
@@ -37,7 +37,7 @@ var (
 			Name: "pod_scaler_admission_error_rate",
 			Help: "number of errors, sorted by label/type",
 		},
-		[]string{"test_name", "configured_memory", "actual_memory"},
+		[]string{"workload_name", "configured_memory", "determined_memory"},
 	)
 )
 
@@ -53,9 +53,9 @@ type options struct {
 }
 
 type podScalerRequest struct {
-	testName         string
+	workloadName     string
 	configuredMemory string
-	actualMemory     string
+	determinedMemory string
 }
 
 func gatherOptions() (options, error) {
@@ -102,14 +102,14 @@ func validateRequest(request *results.Request) error {
 }
 
 func validatePodScalerRequest(request *podScalerRequest) error {
-	if request.testName == "" {
-		return fmt.Errorf("test_name field in request is empty")
+	if request.workloadName == "" {
+		return fmt.Errorf("workload_name field in request is empty")
 	}
 	if request.configuredMemory == "" {
 		return fmt.Errorf("configured_memory field in request is empty")
 	}
-	if request.actualMemory == "" {
-		return fmt.Errorf("actual_memory field in request is empty")
+	if request.determinedMemory == "" {
+		return fmt.Errorf("determined_memory field in request is empty")
 	}
 	return nil
 }
@@ -132,9 +132,9 @@ func withErrorRate(request *results.Request) {
 
 func recordPodScalerError(request *podScalerRequest) {
 	labels := prometheus.Labels{
-		"test_name":         request.testName,
+		"workload_name":     request.workloadName,
 		"configured_memory": request.configuredMemory,
-		"actual_memory":     request.actualMemory,
+		"determined_memory": request.determinedMemory,
 	}
 	podScalerErrorRate.With(labels).Inc()
 }

--- a/cmd/result-aggregator/main.go
+++ b/cmd/result-aggregator/main.go
@@ -32,6 +32,13 @@ var (
 		},
 		[]string{"job_name", "type", "state", "reason", "cluster"},
 	)
+	podScalerErrorRate = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pod_scaler_admission_error_rate",
+			Help: "number of errors, sorted by label/type",
+		},
+		[]string{"test_name", "configured_memory", "actual_memory"},
+	)
 )
 
 func init() {
@@ -43,6 +50,12 @@ type options struct {
 	address     string
 	gracePeriod time.Duration
 	passwdFile  string
+}
+
+type podScalerRequest struct {
+	testName         string
+	configuredMemory string
+	actualMemory     string
 }
 
 func gatherOptions() (options, error) {
@@ -88,6 +101,19 @@ func validateRequest(request *results.Request) error {
 	return nil
 }
 
+func validatePodScalerRequest(request *podScalerRequest) error {
+	if request.testName == "" {
+		return fmt.Errorf("test_name field in request is empty")
+	}
+	if request.configuredMemory == "" {
+		return fmt.Errorf("configured_memory field in request is empty")
+	}
+	if request.actualMemory == "" {
+		return fmt.Errorf("actual_memory field in request is empty")
+	}
+	return nil
+}
+
 func handleError(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusBadRequest)
 	fmt.Fprint(w, err)
@@ -102,6 +128,15 @@ func withErrorRate(request *results.Request) {
 		"cluster":  request.Cluster,
 	}
 	errorRate.With(labels).Inc()
+}
+
+func recordPodScalerError(request *podScalerRequest) {
+	labels := prometheus.Labels{
+		"test_name":         request.testName,
+		"configured_memory": request.configuredMemory,
+		"actual_memory":     request.actualMemory,
+	}
+	podScalerErrorRate.With(labels).Inc()
 }
 
 type validator interface {
@@ -148,6 +183,32 @@ func handleCIOperatorResult() http.HandlerFunc {
 	}
 }
 
+func handlePodScalerResult() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		bytes, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			handleError(w, fmt.Errorf("unable to read pod-scaler request body: %w", err))
+			return
+		}
+
+		request := &podScalerRequest{}
+		if err = json.Unmarshal(bytes, request); err != nil {
+			handleError(w, fmt.Errorf("unable to decode pod-scaler request body: %w", err))
+			return
+		}
+
+		if err := validatePodScalerRequest(request); err != nil {
+			handleError(w, err)
+			return
+		}
+
+		recordPodScalerError(request)
+		w.WriteHeader(http.StatusOK)
+		log.WithFields(log.Fields{"request": request, "duration": time.Since(start).String()}).Info("Pod-scaler request processed")
+	}
+}
+
 func main() {
 	o, err := gatherOptions()
 	if err != nil {
@@ -167,6 +228,8 @@ func main() {
 	validator := &multi{delegates: []validator{&passwdFile{file: o.passwdFile}}}
 
 	http.Handle("/result", loginHandler(validator, handleCIOperatorResult()))
+	http.Handle("/pod-scaler", loginHandler(validator, handlePodScalerResult()))
+
 	metrics.ExposeMetrics("result-aggregator", prowConfig.PushGateway{}, flagutil.DefaultMetricsPort)
 
 	interrupts.ListenAndServe(&http.Server{Addr: o.address}, o.gracePeriod)

--- a/cmd/result-aggregator/main_test.go
+++ b/cmd/result-aggregator/main_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestValidator(t *testing.T) {
@@ -206,14 +208,8 @@ func TestValidatePodScalerRequest(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			actual := validatePodScalerRequest(testCase.request)
-			if actual == nil {
-				if testCase.expected != nil {
-					t.Fatalf("got error when test case was ok, error: %v", actual.Error())
-				}
-			} else {
-				if actual.Error() != testCase.expected.Error() {
-					t.Fatalf("error: %v doesn't match expected error: %v", actual.Error(), testCase.expected.Error())
-				}
+			if diff := cmp.Diff(testCase.expected, actual, testhelper.EquateErrorMessage); diff != "" {
+				t.Fatalf("actual error doesn't match expected error, diff: %v", diff)
 			}
 		})
 	}

--- a/cmd/result-aggregator/main_test.go
+++ b/cmd/result-aggregator/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -146,5 +147,74 @@ func TestLoginHandler(t *testing.T) {
 		if diff := cmp.Diff(tc.expectedBody, responseRecorder.Body.String()); diff != "" {
 			t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 		}
+	}
+}
+
+func TestValidatePodScalerRequest(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		request  *podScalerRequest
+		expected error
+	}{
+		{
+			name: "everything ok",
+			request: &podScalerRequest{
+				workloadName:     "name",
+				configuredMemory: "100",
+				determinedMemory: "400",
+			},
+			expected: nil,
+		},
+		{
+			name: "empty workload name",
+			request: &podScalerRequest{
+				workloadName:     "",
+				configuredMemory: "100",
+				determinedMemory: "400",
+			},
+			expected: fmt.Errorf("workload_name field in request is empty"),
+		},
+		{
+			name: "empty configured memory",
+			request: &podScalerRequest{
+				workloadName:     "name",
+				configuredMemory: "",
+				determinedMemory: "400",
+			},
+			expected: fmt.Errorf("configured_memory field in request is empty"),
+		},
+		{
+			name: "empty determined memory",
+			request: &podScalerRequest{
+				workloadName:     "name",
+				configuredMemory: "100",
+				determinedMemory: "",
+			},
+			expected: fmt.Errorf("determined_memory field in request is empty"),
+		},
+		{
+			name: "empty determined memory",
+			request: &podScalerRequest{
+				workloadName:     "name",
+				configuredMemory: "100",
+				determinedMemory: "",
+			},
+			expected: fmt.Errorf("determined_memory field in request is empty"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := validatePodScalerRequest(testCase.request)
+			if actual == nil {
+				if testCase.expected != nil {
+					t.Fatalf("got error when test case was ok, error: %v", actual.Error())
+				}
+			} else {
+				if actual.Error() != testCase.expected.Error() {
+					t.Fatalf("error: %v doesn't match expected error: %v", actual.Error(), testCase.expected.Error())
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Adds functionality to result-aggregator to handle requests from pod-scaler admission service and record them to Prometheus.

for https://issues.redhat.com/browse/DPTP-3106
/cc smg247