### PR TITLE
add quay.io pull credentials when generating the bootstrap secrets for build clusters

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -159,6 +159,12 @@ func generatePushPullSecretFrom(clusterName string, items []secretbootstrap.Dock
 				Item:        buildUFarm,
 				RegistryURL: registryUrlFor(clusterName),
 			},
+			{
+				AuthField:   "auth",
+				Item:        "quay.io-pull-secret",
+				RegistryURL: "quay.io",
+				EmailField:  "email",
+			},
 		},
 	}
 	itemContext.DockerConfigJSONData =

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -278,6 +278,10 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -302,6 +306,10 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -334,6 +342,10 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: auth
         email_field: email
         item: cloud.openshift.com-pull-secret

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -254,6 +254,10 @@ secret_configs:
         registry_url: registry.existingCluster.ci.openshift.org
       - auth_field: auth
         email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
+      - auth_field: auth
+        email_field: email
         item: cloud.openshift.com-pull-secret
         registry_url: cloud.openshift.com
       - auth_field: auth
@@ -292,6 +296,10 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -316,6 +324,10 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org


### PR DESCRIPTION
/cc @openshift/test-platform 

With the recent changes that have been made to privatize the repositories in quay.io, some tests are still trying to pull the release payload from quay.io and failing

needed for https://github.com/openshift/release/pull/32209

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>