### PR TITLE
DPTP-3081 prReminder add held label

### DIFF
--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -456,8 +456,5 @@ func messageUser(user user, slackClient slackClient) error {
 
 // getLabelMessage returns a string listing te PR's labels
 func getLabelMessage(labels []string) string {
-	if len(labels) == 0 {
-		return ""
-	}
 	return fmt.Sprintf(":label: labeled: *%v*", strings.Join(labels[:], ", "))
 }


### PR DESCRIPTION
When Pr Reminder slack tool lists PRs, this adds additional information if the PR is labeled as held (do-not-merge/hold).

for https://issues.redhat.com/browse/DPTP-3081
/cc smg247