### PR TITLE
Give warning when no jobs found for testcase analyzer

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -2,6 +2,7 @@ package jobrunaggregatorlib
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -13,6 +14,9 @@ import (
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/junit"
 )
+
+var ErrorNoRelatedJobs = errors.New("found no related jobRuns")
+var ErrorTestCheckerFailed = errors.New("some test checker failed,  see above for details")
 
 type JobRunGetter interface {
 	// GetRelatedJobRuns gets all related job runs for analysis
@@ -63,7 +67,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		}
 
 		if len(relatedJobRuns) == 0 {
-			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, fmt.Errorf("found no related jobRuns")
+			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, ErrorNoRelatedJobs
 		}
 
 		for i := range relatedJobRuns {

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -481,7 +481,7 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 		return err
 	}
 	if testSuite.NumFailed > 0 {
-		return fmt.Errorf("some test checker failed,  see above for details")
+		return jobrunaggregatorlib.ErrorTestCheckerFailed
 	}
 	return nil
 }

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -218,7 +218,12 @@ payload 4.11.0-0.nightly-2022-04-28-102605, run this command:
 			}
 
 			if err := o.Run(ctx); err != nil {
-				logrus.WithError(err).Fatal("Command failed")
+				switch err {
+				case jobrunaggregatorlib.ErrorNoRelatedJobs, jobrunaggregatorlib.ErrorTestCheckerFailed:
+					logrus.WithError(err).Warning("Unable to perform test analysis")
+				default:
+					logrus.WithError(err).Fatal("Command failed")
+				}
 			}
 
 			return nil


### PR DESCRIPTION
Re: [TRT-407](https://issues.redhat.com//browse/TRT-407)

This PR makes it so that if there is no related job data, we don't fatally abort; this makes it so that we can still analyze subsequent tests.

The "some test checker failed,  see above for details" condition occurs when the minimum number of jobs is not met like this:

```
Message: required minimum successful count 2, got 1
name: 'install should succeed: overall'
testsuitename: cluster install
summary: 'Total job runs: 1, passes: 1, failures: 0, skips 0'
passes:
- jobrunid: "1569348024021291008"
  humanurl: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn/1569348024021291008
  gcsartifacturl: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.12-e2e-vsphere-sdn/1569348024021291008/artifacts
failures: []
skips: []

WARN[0007] Unable to perform test analysis               error="some test checker failed,  see above for details"
```

This PR also makes it so that condition is no longer a fatal error.

I also removed jobs that lack job data in [release/PR32225](https://github.com/openshift/release/pull/32225) to avoid errors in the log.