### PR TITLE
Revert "add quay.io pull credentials when generating the bootstrap secrets for build clusters"

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -159,12 +159,6 @@ func generatePushPullSecretFrom(clusterName string, items []secretbootstrap.Dock
 				Item:        buildUFarm,
 				RegistryURL: registryUrlFor(clusterName),
 			},
-			{
-				AuthField:   "auth",
-				Item:        "quay.io-pull-secret",
-				RegistryURL: "quay.io",
-				EmailField:  "email",
-			},
 		},
 	}
 	itemContext.DockerConfigJSONData =

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -278,10 +278,6 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -306,10 +302,6 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -342,10 +334,6 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: auth
         email_field: email
         item: cloud.openshift.com-pull-secret

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -254,10 +254,6 @@ secret_configs:
         registry_url: registry.existingCluster.ci.openshift.org
       - auth_field: auth
         email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
-      - auth_field: auth
-        email_field: email
         item: cloud.openshift.com-pull-secret
         registry_url: cloud.openshift.com
       - auth_field: auth
@@ -296,10 +292,6 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -324,10 +316,6 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org


### PR DESCRIPTION
It seems that we have a small bug in the tool that ends-up having duplicated key for quay-io. Let's revert this one and I will open a follow-up with the fix included.

Reverts openshift/ci-tools#2998