### PR TITLE
DPTP-3106 Create PodScalerReporter

### DIFF
--- a/cmd/result-aggregator/main.go
+++ b/cmd/result-aggregator/main.go
@@ -52,12 +52,6 @@ type options struct {
 	passwdFile  string
 }
 
-type podScalerRequest struct {
-	workloadName     string
-	configuredMemory string
-	determinedMemory string
-}
-
 func gatherOptions() (options, error) {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -101,14 +95,14 @@ func validateRequest(request *results.Request) error {
 	return nil
 }
 
-func validatePodScalerRequest(request *podScalerRequest) error {
-	if request.workloadName == "" {
+func validatePodScalerRequest(request *results.PodScalerRequest) error {
+	if request.WorkloadName == "" {
 		return fmt.Errorf("workload_name field in request is empty")
 	}
-	if request.configuredMemory == "" {
+	if request.ConfiguredMemory == "" {
 		return fmt.Errorf("configured_memory field in request is empty")
 	}
-	if request.determinedMemory == "" {
+	if request.DeterminedMemory == "" {
 		return fmt.Errorf("determined_memory field in request is empty")
 	}
 	return nil
@@ -130,11 +124,11 @@ func withErrorRate(request *results.Request) {
 	errorRate.With(labels).Inc()
 }
 
-func recordPodScalerError(request *podScalerRequest) {
+func recordPodScalerError(request *results.PodScalerRequest) {
 	labels := prometheus.Labels{
-		"workload_name":     request.workloadName,
-		"configured_memory": request.configuredMemory,
-		"determined_memory": request.determinedMemory,
+		"workload_name":     request.WorkloadName,
+		"configured_memory": request.ConfiguredMemory,
+		"determined_memory": request.DeterminedMemory,
 	}
 	podScalerErrorRate.With(labels).Inc()
 }
@@ -192,7 +186,7 @@ func handlePodScalerResult() http.HandlerFunc {
 			return
 		}
 
-		request := &podScalerRequest{}
+		request := &results.PodScalerRequest{}
 		if err = json.Unmarshal(bytes, request); err != nil {
 			handleError(w, fmt.Errorf("unable to decode pod-scaler request body: %w", err))
 			return

--- a/cmd/result-aggregator/main_test.go
+++ b/cmd/result-aggregator/main_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -155,51 +156,51 @@ func TestLoginHandler(t *testing.T) {
 func TestValidatePodScalerRequest(t *testing.T) {
 	var testCases = []struct {
 		name     string
-		request  *podScalerRequest
+		request  *results.PodScalerRequest
 		expected error
 	}{
 		{
 			name: "everything ok",
-			request: &podScalerRequest{
-				workloadName:     "name",
-				configuredMemory: "100",
-				determinedMemory: "400",
+			request: &results.PodScalerRequest{
+				WorkloadName:     "name",
+				ConfiguredMemory: "100",
+				DeterminedMemory: "400",
 			},
 			expected: nil,
 		},
 		{
 			name: "empty workload name",
-			request: &podScalerRequest{
-				workloadName:     "",
-				configuredMemory: "100",
-				determinedMemory: "400",
+			request: &results.PodScalerRequest{
+				WorkloadName:     "",
+				ConfiguredMemory: "100",
+				DeterminedMemory: "400",
 			},
 			expected: fmt.Errorf("workload_name field in request is empty"),
 		},
 		{
 			name: "empty configured memory",
-			request: &podScalerRequest{
-				workloadName:     "name",
-				configuredMemory: "",
-				determinedMemory: "400",
+			request: &results.PodScalerRequest{
+				WorkloadName:     "name",
+				ConfiguredMemory: "",
+				DeterminedMemory: "400",
 			},
 			expected: fmt.Errorf("configured_memory field in request is empty"),
 		},
 		{
 			name: "empty determined memory",
-			request: &podScalerRequest{
-				workloadName:     "name",
-				configuredMemory: "100",
-				determinedMemory: "",
+			request: &results.PodScalerRequest{
+				WorkloadName:     "name",
+				ConfiguredMemory: "100",
+				DeterminedMemory: "",
 			},
 			expected: fmt.Errorf("determined_memory field in request is empty"),
 		},
 		{
 			name: "empty determined memory",
-			request: &podScalerRequest{
-				workloadName:     "name",
-				configuredMemory: "100",
-				determinedMemory: "",
+			request: &results.PodScalerRequest{
+				WorkloadName:     "name",
+				ConfiguredMemory: "100",
+				DeterminedMemory: "",
 			},
 			expected: fmt.Errorf("determined_memory field in request is empty"),
 		},

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -149,10 +149,11 @@ func (r *reporter) report(request Request) {
 	sendRequest(req, r.client, r.username, r.password)
 }
 
+// PodScalerRequest holds the data from pod-scaler used to report a result to an aggregation server
 type PodScalerRequest struct {
-	workloadName     string
-	configuredMemory string
-	determinedMemory string
+	WorkloadName     string
+	ConfiguredMemory string
+	DeterminedMemory string
 }
 
 type PodScalerReporter struct {
@@ -177,11 +178,11 @@ func (o *Options) PodScalerReporter() (*PodScalerReporter, error) {
 
 // ReportMemoryConfigurationWarning is used to send the information about memory configuration
 // from pod-scaler-admission to result-aggregator.
-func (r *PodScalerReporter) ReportMemoryConfigurationWarning(workflowName, configuredMemory, determinedMemory string) {
+func (r *PodScalerReporter) ReportMemoryConfigurationWarning(workloadName, configuredMemory, determinedMemory string) {
 	request := PodScalerRequest{
-		workloadName:     workflowName,
-		configuredMemory: configuredMemory,
-		determinedMemory: determinedMemory,
+		WorkloadName:     workloadName,
+		ConfiguredMemory: configuredMemory,
+		DeterminedMemory: determinedMemory,
 	}
 
 	data, err := json.Marshal(request)

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -146,9 +146,63 @@ func (r *reporter) report(request Request) {
 		logrus.Tracef("could not create report request: %v", err)
 		return
 	}
+	sendRequest(req, r.client, r.username, r.password)
+}
+
+type PodScalerRequest struct {
+	workloadName     string
+	configuredMemory string
+	determinedMemory string
+}
+
+type PodScalerReporter struct {
+	client             *http.Client
+	username, password string
+	address            string
+}
+
+func (o *Options) PodScalerReporter() (*PodScalerReporter, error) {
+	username, password, err := getUsernameAndPassword(o.credentials)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get username and password: %w", err)
+	}
+
+	return &PodScalerReporter{
+		client:   &http.Client{},
+		username: username,
+		password: password,
+		address:  o.address,
+	}, nil
+}
+
+// ReportMemoryConfigurationWarning is used to send the information about memory configuration
+// from pod-scaler-admission to result-aggregator.
+func (r *PodScalerReporter) ReportMemoryConfigurationWarning(workflowName, configuredMemory, determinedMemory string) {
+	request := PodScalerRequest{
+		workloadName:     workflowName,
+		configuredMemory: configuredMemory,
+		determinedMemory: determinedMemory,
+	}
+
+	data, err := json.Marshal(request)
+	if err != nil {
+		logrus.Tracef("could not marshal pod-scaler request: %v", err)
+		return
+	}
+
+	httpRequest, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/pod-scaler", r.address), bytes.NewReader(data))
+	if err != nil {
+		logrus.Tracef("could not create pod-scaler request: %v", err)
+		return
+	}
+
+	sendRequest(httpRequest, r.client, r.username, r.password)
+}
+
+func sendRequest(req *http.Request, client *http.Client, username, password string) {
 	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(r.username, r.password)
-	resp, err := r.client.Do(req)
+	req.SetBasicAuth(username, password)
+	resp, err := client.Do(req)
 	if err != nil {
 		logrus.Tracef("could not send report request: %v", err)
 		return

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -182,3 +182,69 @@ func TestGetUsernameAndPassword(t *testing.T) {
 		}
 	}
 }
+
+func TestReportMemoryConfigurationWarning(t *testing.T) {
+	testCases := []struct {
+		name             string
+		workloadName     string
+		configuredMemory string
+		determinedMemory string
+		expected         string
+	}{
+		{
+			name:             "valid request",
+			workloadName:     "name",
+			configuredMemory: "100",
+			determinedMemory: "200",
+			expected:         `{"WorkloadName":"name","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
+		},
+		{
+			name:             "empty workload name",
+			workloadName:     "",
+			configuredMemory: "100",
+			determinedMemory: "200",
+			expected:         `{"WorkloadName":"","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testServer := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Header.Get("Content-Type") != "application/json" {
+					t.Errorf("incorrectly sent content-type header for JSON")
+					return
+				}
+
+				if request.Method != http.MethodPost {
+					t.Errorf("incorrect method: %s", request.Method)
+					return
+				}
+
+				if !strings.HasSuffix(request.URL.Path, "/pod-scaler") {
+					t.Errorf("incorrect path: %s", request.URL.Path)
+					return
+				}
+
+				data, err := ioutil.ReadAll(request.Body)
+				if err != nil {
+					t.Errorf("failed to read request body: %v", err)
+				}
+
+				if actual := string(data); actual != tc.expected {
+					t.Errorf("expected %v, got %v", tc.expected, actual)
+				}
+			}))
+			defer testServer.Close()
+
+			podScalerReporter := PodScalerReporter{
+				client: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				},
+				address: testServer.URL,
+			}
+			podScalerReporter.ReportMemoryConfigurationWarning(tc.workloadName, tc.configuredMemory, tc.determinedMemory)
+		})
+	}
+}

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -225,13 +225,13 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 					return
 				}
 
-				data, err := ioutil.ReadAll(request.Body)
+				requestBody, err := ioutil.ReadAll(request.Body)
 				if err != nil {
 					t.Errorf("failed to read request body: %v", err)
 				}
 
-				if actual := string(data); actual != tc.expected {
-					t.Errorf("expected %v, got %v", tc.expected, actual)
+				if diff := cmp.Diff(tc.expected, string(requestBody)); diff != "" {
+					t.Errorf("actual and expected response don't match, diff: %v", diff)
 				}
 			}))
 			defer testServer.Close()


### PR DESCRIPTION
This adds a PodScalerReporter as a way for sending http requests from pod-scaler-admission to result-aggregator.

for https://issues.redhat.com/browse/DPTP-3106
/cc smg247