### PR TITLE
[cluster-init] maintain the registry-pull-credentials only

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	credentials         = "credentials"
-	regPullCredsAll     = "registry-pull-credentials-all"
+	regPullCredsAll     = "registry-pull-credentials"
 	dotDockerConfigJson = ".dockerconfigjson"
 	testCredentials     = "test-credentials"
 	kubeconfig          = "kubeconfig"

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -259,11 +259,11 @@ secret_configs:
         registry_url: registry.newCluster.ci.openshift.org
   to:
   - cluster: app.ci
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
   - cluster: app.ci
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
 - from:
@@ -290,38 +290,6 @@ secret_configs:
     name: registry-push-credentials-ci-central
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
-- from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
-      - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc:5000
-      - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.newCluster.ci.openshift.org
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-  to:
-  - cluster: newCluster
-    name: registry-pull-credentials
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-  - cluster: newCluster
-    name: registry-pull-credentials
-    namespace: test-credentials
-    type: kubernetes.io/dockerconfigjson
-- from:
-    kubeconfig:
-      field: sa.ci-operator.newCluster.config
-      item: build_farm
-  to:
-  - cluster: newCluster
-    name: ci-operator
-    namespace: test-credentials
 - from:
     .dockerconfigjson:
       dockerconfigJSON:
@@ -361,13 +329,21 @@ secret_configs:
         registry_url: registry.build01.ci.openshift.org
   to:
   - cluster: newCluster
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
   - cluster: newCluster
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
+- from:
+    kubeconfig:
+      field: sa.ci-operator.newCluster.config
+      item: build_farm
+  to:
+  - cluster: newCluster
+    name: ci-operator
+    namespace: test-credentials
 user_secrets_target_clusters:
 - app.ci
 - arm01

--- a/test/integration/cluster-init/create/input/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/input/core-services/ci-secret-bootstrap/_config.yaml
@@ -215,11 +215,11 @@ secret_configs:
             registry_url: registry.build01.ci.openshift.org
     to:
       - cluster: app.ci
-        name: registry-pull-credentials-all
+        name: registry-pull-credentials
         namespace: ci
         type: kubernetes.io/dockerconfigjson
       - cluster: app.ci
-        name: registry-pull-credentials-all
+        name: registry-pull-credentials
         namespace: test-credentials
         type: kubernetes.io/dockerconfigjson
 user_secrets_target_clusters:

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -223,20 +223,10 @@ secret_configs:
 - from: null
   to:
   - cluster: app.ci
-    name: registry-pull-credentials-all
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-  - cluster: app.ci
-    name: registry-pull-credentials-all
-    namespace: test-credentials
-    type: kubernetes.io/dockerconfigjson
-- from: null
-  to:
-  - cluster: newCluster
     name: registry-pull-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
-  - cluster: newCluster
+  - cluster: app.ci
     name: registry-pull-credentials
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
@@ -273,11 +263,11 @@ secret_configs:
         registry_url: registry.arm-build01.arm-build.devcluster.openshift.com
   to:
   - cluster: existingCluster
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: ci
     type: kubernetes.io/dockerconfigjson
   - cluster: existingCluster
-    name: registry-pull-credentials-all
+    name: registry-pull-credentials
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
 - from:
@@ -302,30 +292,6 @@ secret_configs:
     type: kubernetes.io/dockerconfigjson
   - cluster: existingCluster
     name: registry-push-credentials-ci-central
-    namespace: test-credentials
-    type: kubernetes.io/dockerconfigjson
-- from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-      - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
-      - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: image-registry.openshift-image-registry.svc:5000
-      - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.existingCluster.ci.openshift.org
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
-  to:
-  - cluster: existingCluster
-    name: registry-pull-credentials
-    namespace: ci
-    type: kubernetes.io/dockerconfigjson
-  - cluster: existingCluster
-    name: registry-pull-credentials
     namespace: test-credentials
     type: kubernetes.io/dockerconfigjson
 - from:

--- a/test/integration/cluster-init/update/input/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/input/core-services/ci-secret-bootstrap/_config.yaml
@@ -222,45 +222,13 @@ secret_configs:
           registry_url: registry.build01.ci.openshift.org
     to:
       - cluster: app.ci
-        name: registry-pull-credentials-all
+        name: registry-pull-credentials
         namespace: ci
         type: kubernetes.io/dockerconfigjson
       - cluster: app.ci
-        name: registry-pull-credentials-all
-        namespace: test-credentials
-        type: kubernetes.io/dockerconfigjson
-  - from:
-    .dockerconfigjson:
-      dockerconfigJSON:
-        - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-          item: build_farm
-          registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
-        - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-          item: build_farm
-          registry_url: image-registry.openshift-image-registry.svc:5000
-        - auth_field: token_image-puller_newCluster_reg_auth_value.txt
-          item: build_farm
-          registry_url: registry.newCluster.ci.openshift.org
-        - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-          item: build_farm
-          registry_url: registry.ci.openshift.org
-    to:
-      - cluster: newCluster
-        name: registry-pull-credentials
-        namespace: ci
-        type: kubernetes.io/dockerconfigjson
-      - cluster: newCluster
         name: registry-pull-credentials
         namespace: test-credentials
         type: kubernetes.io/dockerconfigjson
-      - from:
-          kubeconfig:
-            field: sa.ci-operator.newCluster.config
-            item: build_farm
-        to:
-          - cluster: existingCluster
-            name: ci-operator
-            namespace: test-credentials
   - from:
     .dockerconfigjson:
       dockerconfigJSON:
@@ -303,11 +271,11 @@ secret_configs:
           registry_url: registry.newCluster.ci.openshift.org
     to:
       - cluster: existingCluster
-        name: registry-pull-credentials-all
+        name: registry-pull-credentials
         namespace: ci
         type: kubernetes.io/dockerconfigjson
       - cluster: existingCluster
-        name: registry-pull-credentials-all
+        name: registry-pull-credentials
         namespace: test-credentials
         type: kubernetes.io/dockerconfigjson
 user_secrets_target_clusters:


### PR DESCRIPTION
/hold

There was an effort of maintaining the credentials secret that contains all required credentials in https://issues.redhat.com/browse/DPTP-1845 

However, there is nothing that creates/updates the `registry-pull-credentials` secret currently. This PR introduces changes in the tool to directly start maintaining that secret. Once the follow-up PR in the release repo will change the ci-secret-bootstrap configuration, the secret will be updated and all jobs will automatically start using it.


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>