### PR TITLE
[cluster-init] add the quay.io secret when generating the registry-pull-credentials secret

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -156,6 +156,12 @@ func generatePushPullSecretFrom(clusterName string, items []secretbootstrap.Dock
 				Item:        buildUFarm,
 				RegistryURL: registryUrlFor(clusterName),
 			},
+			{
+				AuthField:   "auth",
+				EmailField:  "email",
+				Item:        "quay.io-pull-secret",
+				RegistryURL: "quay.io",
+			},
 		},
 	}
 	itemContext.DockerConfigJSONData =

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -232,6 +232,10 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -256,6 +260,10 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -242,6 +242,10 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -266,6 +270,10 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
+      - auth_field: auth
+        email_field: email
+        item: quay.io-pull-secret
+        registry_url: quay.io
       - auth_field: token_image-puller_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org


### PR DESCRIPTION
/cc @openshift/test-platform @hongkailiu 


This is now safe and possible after https://github.com/openshift/ci-tools/pull/3008 and https://github.com/openshift/release/pull/32289


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>