### PR TITLE
Change minimum number of jobs to 6 instead of 3 for more accurate aggregation

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -171,7 +171,7 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 	return &JobRunAggregatorAnalyzerOptions{
 		explicitGCSPrefix:   f.ExplicitGCSPrefix,
 		jobRunLocator:       jobRunLocator,
-		passFailCalculator:  newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 3, ciDataClient),
+		passFailCalculator:  newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 6, ciDataClient),
 		jobName:             f.JobName,
 		payloadTag:          f.PayloadTag,
 		workingDir:          f.WorkingDir,


### PR DESCRIPTION
Re: [TRT-370](https://issues.redhat.com//browse/TRT-370)

The current minimum is only 3 and when there are infra problems, this seems too small because too many job runs don't get to fully run as in [this example](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-azure-sdn-upgrade-4.12-minor-release-openshift-release-analysis-aggregator/1570003912218382336).

3 seems too small of a sample for an accurate signal from aggregation; 6 seems more appropriate (allowing up to 4 jobs to fail due to infra issues).