### PR TITLE
Add title for test analyzer variant to enhance readability

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -92,7 +92,7 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	finishedJobsToAggregate, _, finishedJobRunNames, unfinishedJobNames, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, o.workingDir)
+	finishedJobsToAggregate, _, finishedJobRunNames, unfinishedJobNames, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, o.workingDir, "aggregated")
 	if err != nil {
 		return err
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/spyglass_summary.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/spyglass_summary.go
@@ -8,10 +8,13 @@ import (
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 )
 
-func htmlForJobRuns(ctx context.Context, finishedJobsToAggregate, unfinishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo) string {
-	html := `<!DOCTYPE html>
+func htmlForJobRuns(ctx context.Context, finishedJobsToAggregate, unfinishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo, jobSummaryInfo string) string {
+	html := fmt.Sprintf(`<!DOCTYPE html>
 <html>
 <head>
+<title>
+job-run-summary for %s
+</title>
 <style>
 a {
 	color: #ff8caa;
@@ -28,13 +31,13 @@ body {
 }
 </style>
 </head>
-<body>`
+<body>`, jobSummaryInfo)
 
 	if len(unfinishedJobsToAggregate) > 0 {
-		html += `
-<h2>Unfinished Jobs</h2>
+		html += fmt.Sprintf(`
+<h2>Unfinished Jobs %s</h2>
 <ol>
-`
+`, jobSummaryInfo)
 		for _, job := range unfinishedJobsToAggregate {
 			html += `<li>`
 			html += fmt.Sprintf(`<a target="_blank" href="%s">%s/%s</a>`, job.GetHumanURL(), job.GetJobName(), job.GetJobRunID())
@@ -54,10 +57,10 @@ body {
 	}
 
 	if len(finishedJobsToAggregate) > 0 {
-		html += `
-<h2>Finished Jobs</h2>
+		html += fmt.Sprintf(`
+<h2>Finished Jobs %s</h2>
 <ol>
-`
+`, jobSummaryInfo)
 		for _, job := range finishedJobsToAggregate {
 			html += `<li>`
 			html += fmt.Sprintf(`<a target="_blank" href="%s">%s/%s</a>`, job.GetHumanURL(), job.GetJobName(), job.GetJobRunID())

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -41,7 +41,8 @@ func WaitUntilTime(ctx context.Context, readyAt time.Time) error {
 func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	timeToStopWaiting time.Time,
 	jobRunGetter JobRunGetter,
-	outputDir string) ([]jobrunaggregatorapi.JobRunInfo, []jobrunaggregatorapi.JobRunInfo, []string, []string, error) {
+	outputDir string,
+	variantInfo string) ([]jobrunaggregatorapi.JobRunInfo, []jobrunaggregatorapi.JobRunInfo, []string, []string, error) {
 	clock := clock.RealClock{}
 
 	var finishedJobRuns []jobrunaggregatorapi.JobRunInfo
@@ -93,7 +94,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 			finishedJobRunNames = append(finishedJobRunNames, jobRun.GetJobName()+jobRun.GetJobRunID())
 		}
 
-		summaryHTML := htmlForJobRuns(ctx, finishedJobRuns, unfinishedJobRuns)
+		summaryHTML := htmlForJobRuns(ctx, finishedJobRuns, unfinishedJobRuns, variantInfo)
 		if err := ioutil.WriteFile(filepath.Join(outputDir, "job-run-summary.html"), []byte(summaryHTML), 0644); err != nil {
 			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 		}

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -464,7 +464,13 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	finishedJobRuns, unfinishedJobRuns, _, _, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, outputDir)
+
+	platform := o.jobGetter.(*testCaseAnalyzerJobGetter).platform
+	network := o.jobGetter.(*testCaseAnalyzerJobGetter).network
+	infrastructure := o.jobGetter.(*testCaseAnalyzerJobGetter).infrastructure
+	testVariantName := fmt.Sprintf("%s-%s-%s", platform, network, infrastructure)
+
+	finishedJobRuns, unfinishedJobRuns, _, _, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, outputDir, testVariantName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Regarding [TRT-562](https://issues.redhat.com//browse/TRT-562)

Apparently, the name of the `job-run-summary.html` file is used as the title for the accordion menu in aggregated jobs.

For test analyzer aggregated jobs, there are several variants and so the title is always the same; this makes it hard to find results for a specific variant.

This PR names the `job-run-summary.html` with more text that is indicative of the variant to make it easier to look at the job results.  There will be no difference for the origin aggregated jobs.