### PR TITLE
[prowgen] override the ci-operator image for the arm01 cluster

### DIFF
--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -428,6 +428,15 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
 			},
 		},
+		{
+			name: "simple container-based test with arm01 cluster",
+			test: ciop.TestStepConfiguration{
+				As:                         "simple",
+				Commands:                   "make",
+				Cluster:                    "arm01",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
@@ -1,0 +1,40 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  ci-operator.openshift.io/cluster: arm01
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    image: registry.arm-build01.arm-build.devcluster.openshift.com/ci-arm64/ci-operator:latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator


### PR DESCRIPTION
The `ci-operator` in `arm01` cluster is being mirrored from apps.ci by the image distributor controller. The prowjob needs to pull from the `ci-arm64` namespace where the `ci-operator` image for arm64 architecture is being built.

/cc @danilo-gemoli @deepsm007 @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>