### PR TITLE
e2e: mitigate observer pods tests flakiness

### DIFF
--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -23,6 +23,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
+const (
+	TerminateObserversLog string = "Signalling observers to terminate..."
+)
+
 func (s *multiStageTestStep) runSteps(
 	ctx context.Context,
 	phase string,
@@ -123,7 +127,7 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 	for _, pod := range pods {
 		go func(p coreapi.Pod) {
 			<-ctx.Done()
-			logrus.Info("Signalling observers to terminate...")
+			logrus.Info(TerminateObserversLog)
 			if err := s.client.Delete(context.Background(), &p); err != nil {
 				logrus.WithError(err).Warn("failed to trigger observer to stop")
 			}


### PR DESCRIPTION
The reason of being of this PR is explained here: [DPTP-3140](https://issues.redhat.com/browse/DPTP-3140)

TL;DR: 
observers run concurrently alongside the regular tests but from time to time it happens tests complete before observers have even the chance to be scheduled. In order to keep things simple I have decided to skip e2e tests when that behavior emerges.

/cc @jmguzik @bbguimaraes 

FYI: @smg247 