### PR TITLE
DPTP-3106 add reporter to admission

### DIFF
--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -31,11 +31,11 @@ import (
 
 type mockReporter struct {
 	client *http.Client
-	state  string
+	called bool
 }
 
 func (r *mockReporter) ReportMemoryConfigurationWarning(string, string, string) {
-	r.state = "ReportMemoryConfigurationWarning was called"
+	r.called = true
 }
 
 var defaultReporter = mockReporter{client: &http.Client{}}
@@ -745,7 +745,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 		name         string
 		ours, theirs corev1.ResourceRequirements
 		reporter     mockReporter
-		expected     string
+		expected     bool
 	}{
 		{
 			name: "ours is 10 times larger than theirs",
@@ -766,7 +766,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 				},
 			},
 			reporter: mockReporter{client: &http.Client{}},
-			expected: "ReportMemoryConfigurationWarning was called",
+			expected: true,
 		},
 		{
 			name: "ours is not 10 times larger than theirs",
@@ -787,7 +787,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 				},
 			},
 			reporter: mockReporter{client: &http.Client{}},
-			expected: "",
+			expected: false,
 		},
 	}
 
@@ -795,7 +795,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			useOursIfLarger(&tc.ours, &tc.theirs, "test", &tc.reporter, logrus.WithField("test", tc.name))
 
-			if diff := cmp.Diff(tc.reporter.state, tc.expected); diff != "" {
+			if diff := cmp.Diff(tc.reporter.called, tc.expected); diff != "" {
 				t.Errorf("actual and expected reporter states don't match, : %v", diff)
 			}
 		})

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -3,6 +3,7 @@ package results
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -30,6 +31,17 @@ type Options struct {
 func (o *Options) Bind(flag *flag.FlagSet) {
 	flag.StringVar(&o.address, "report-address", reportAddress, "Address of the aggregate reporting server.")
 	flag.StringVar(&o.credentials, "report-credentials-file", "", "File holding the <username>:<password> for the aggregate reporting server.")
+}
+
+// Validate checks if the Options elements are empty
+func (o *Options) Validate() error {
+	if o.address == "" {
+		return errors.New("report-address is required")
+	}
+	if o.credentials == "" {
+		return errors.New("report-credentials-file is required")
+	}
+	return nil
 }
 
 func getUsernameAndPassword(credentials string) (string, string, error) {

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -236,7 +236,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 			}))
 			defer testServer.Close()
 
-			podScalerReporter := PodScalerReporter{
+			podScalerReporter := podScalerReporter{
 				client: &http.Client{
 					Transport: &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -248,3 +248,35 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 		})
 	}
 }
+
+func TestOptions_Validate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		options  *Options
+		expected error
+	}{
+		{
+			name:     "valid options",
+			options:  &Options{address: "foo.com", credentials: "<username>:<password>"},
+			expected: nil,
+		},
+		{
+			name:     "empty address",
+			options:  &Options{address: "", credentials: "<username>:<password>"},
+			expected: errors.New("report-address is required"),
+		},
+		{
+			name:     "empty credentials",
+			options:  &Options{address: "foo.com", credentials: ""},
+			expected: errors.New("report-credentials-file is required"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(tc.options.Validate(), tc.expected, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("actual and expected result don't match, diff: %v", diff)
+			}
+		})
+	}
+}

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -47,7 +47,8 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 
 	// create mock report credentials
 	credFile := path.Join(t.TempDir(), "credentials")
-	err = ioutil.WriteFile(credFile, []byte{"<username>:<password>"}, filemode.Regular)
+	var content string = "<username>:<password>"
+	err = ioutil.WriteFile(credFile, []byte(content), 0400)
 	if err != nil {
 		t.Fatalf("Failed to create a mock file for report-credentials: %v", err)
 	}

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io/ioutil"
 	"net/http"
 	"path"
 
@@ -44,6 +45,13 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		t.Fatalf("Failed to ensure client cert and key for admission: %v", err)
 	}
 
+	// create mock report credentials
+	credFile := path.Join(t.TempDir(), "credentials")
+	err = ioutil.WriteFile(credFile, []byte{"<username>:<password>"}, filemode.Regular)
+	if err != nil {
+		t.Fatalf("Failed to create a mock file for report-credentials: %v", err)
+	}
+
 	podScalerFlags := []string{
 		"--loglevel=trace",
 		"--log-style=text",
@@ -52,6 +60,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 		"--mutate-resource-limits",
 		"--serving-cert-dir=" + authDir,
 		"--metrics-port=9092",
+		"--report-credentials-file=" + credFile,
 	}
 	podScaler := testhelper.NewAccessory("pod-scaler", podScalerFlags, func(port, healthPort string) []string {
 		t.Logf("pod-scaler admission starting on port %s", port)


### PR DESCRIPTION
Adds the ability to work with report credentials ([this PR](https://github.com/openshift/release/pull/32403)), and pod-scaler-admission can now send requests to result-aggregator using PodScalerReporter.

for https://issues.redhat.com/browse/DPTP-3106
/cc smg247