### PR TITLE
Increase progress deadline for rpm server

### DIFF
--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -83,14 +83,14 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 		SuccessThreshold:    1,
 		TimeoutSeconds:      1,
 	}
-	one := int64(1)
-	two := int32(2)
-	progressDeadline := int32(1200) // It can take 10 minutes for a machine to come up, so double default deadline
+	oneI64 := int64(1)
+	oneI32 := int32(2)
+	progressDeadline := int32(3600) // If a build farm is scaling up, provide plenty of time for pods to schedule
 	deployment := &appsapi.Deployment{
 		ObjectMeta: commonMeta,
 		Spec: appsapi.DeploymentSpec{
 			ProgressDeadlineSeconds: &progressDeadline,
-			Replicas:                &two,
+			Replicas:                &oneI32,
 			Selector: &meta.LabelSelector{
 				MatchLabels: labelSet,
 			},
@@ -187,7 +187,7 @@ fi
 							},
 						},
 					}},
-					TerminationGracePeriodSeconds: &one,
+					TerminationGracePeriodSeconds: &oneI64,
 				},
 			},
 		},


### PR DESCRIPTION
During extreme scale up events on build farms, particularly when clouds are low on capacity, it may take a long time for pods to be scheduled. It's normally counter productive for jobs to fail because of an rpm server timeout, so increase this timeout significantly.