### PR TITLE
Adding cluster override unit tests

### DIFF
--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -22,7 +22,7 @@
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: this-job-was-defaulted
+    cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
     extra_refs:
@@ -100,7 +100,7 @@
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: this-job-was-defaulted
+    cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
     extra_refs:
@@ -174,7 +174,7 @@
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: this-job-was-defaulted
+    cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
       timeout: 6h0m0s

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -22,7 +22,7 @@
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: this-job-was-defaulted
+    cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
     extra_refs:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_cluster_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_cluster_override.yaml
@@ -3,52 +3,29 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name-metal
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-metal
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
-      prow.k8s.io/refs.base_ref: test-branch
-      prow.k8s.io/refs.org: test-org
-      prow.k8s.io/refs.repo: test-repo
-      prow.k8s.io/type: periodic
-      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
-    name: some-uuid
-    namespace: test-namespace
-    resourceVersion: "999"
-  spec: {}
-  status:
-    startTime: "1970-01-01T00:00:00Z"
-    state: triggered
-- apiVersion: prow.k8s.io/v1
-  kind: ProwJob
-  metadata:
-    annotations:
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-2
-    creationTimestamp: null
-    labels:
-      created-by-prow: "true"
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
+      prow.k8s.io/job: test-org-test-repo-100-test-name-metal
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 428af2aff595f9d8074f2f6bfba1aec1
+      releaseJobNameHash: baecd8bd25b4096accbafec934e6383f
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: cluster-name-defaulted
+    cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"
@@ -59,7 +36,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name-2
+    job: test-org-test-repo-100-test-name-metal
     pod_spec:
       containers:
       - args:
@@ -67,8 +44,8 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
-        - --target=test-name-2
-        - --with-test-from=test-org/test-repo@test-branch:test-name-2
+        - --target=test-name-metal
+        - --with-test-from=test-org/test-repo@test-branch:test-name-metal
         command:
         - ci-operator
         image: ci-operator:latest

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -25,7 +25,6 @@
     cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -3,52 +3,29 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name-metal
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-metal
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
-      prow.k8s.io/refs.base_ref: test-branch
-      prow.k8s.io/refs.org: test-org
-      prow.k8s.io/refs.repo: test-repo
-      prow.k8s.io/type: periodic
-      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
-    name: some-uuid
-    namespace: test-namespace
-    resourceVersion: "999"
-  spec: {}
-  status:
-    startTime: "1970-01-01T00:00:00Z"
-    state: triggered
-- apiVersion: prow.k8s.io/v1
-  kind: ProwJob
-  metadata:
-    annotations:
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-2
-    creationTimestamp: null
-    labels:
-      created-by-prow: "true"
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
+      prow.k8s.io/job: test-org-test-repo-100-test-name-metal
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 428af2aff595f9d8074f2f6bfba1aec1
+      releaseJobNameHash: baecd8bd25b4096accbafec934e6383f
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: cluster-name-defaulted
+    cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"
@@ -59,7 +36,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name-2
+    job: test-org-test-repo-100-test-name-metal
     pod_spec:
       containers:
       - args:
@@ -67,8 +44,8 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
-        - --target=test-name-2
-        - --with-test-from=test-org/test-repo@test-branch:test-name-2
+        - --target=test-name-metal
+        - --with-test-from=test-org/test-repo@test-branch:test-name-metal
         command:
         - ci-operator
         image: ci-operator:latest

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -22,7 +22,7 @@
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: this-job-was-defaulted
+    cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
     extra_refs:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -25,7 +25,6 @@
     cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -3,52 +3,29 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name-vsphere
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-vsphere
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: ""
-      prow.k8s.io/refs.base_ref: test-branch
-      prow.k8s.io/refs.org: test-org
-      prow.k8s.io/refs.repo: test-repo
-      prow.k8s.io/type: periodic
-      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
-    name: some-uuid
-    namespace: test-namespace
-    resourceVersion: "999"
-  spec: {}
-  status:
-    startTime: "1970-01-01T00:00:00Z"
-    state: triggered
-- apiVersion: prow.k8s.io/v1
-  kind: ProwJob
-  metadata:
-    annotations:
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-2
-    creationTimestamp: null
-    labels:
-      created-by-prow: "true"
-      prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name-2
+      prow.k8s.io/job: test-org-test-repo-100-test-name-vsphere
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 428af2aff595f9d8074f2f6bfba1aec1
+      releaseJobNameHash: 94766f73b98ce654ac263e1f733f5c0f
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
   spec:
     agent: kubernetes
-    cluster: cluster-name-defaulted
+    cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"
@@ -59,7 +36,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name-2
+    job: test-org-test-repo-100-test-name-vsphere
     pod_spec:
       containers:
       - args:
@@ -67,8 +44,8 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
-        - --target=test-name-2
-        - --with-test-from=test-org/test-repo@test-branch:test-name-2
+        - --target=test-name-vsphere
+        - --with-test-from=test-org/test-repo@test-branch:test-name-vsphere
         command:
         - ci-operator
         image: ci-operator:latest

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_cluster_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_cluster_override.yaml
@@ -1,0 +1,42 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name-metal
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name-metal
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_metal_override.yaml
@@ -1,0 +1,42 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name-metal
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name-metal
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -1,0 +1,42 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name-vsphere
+    pullRequest:
+      baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name-vsphere
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered


### PR DESCRIPTION
This PR updates the unit tests to more clearly test the logic that selects the `Cluster` where to run the `/payload` jobs.  