### PR TITLE
pr-reminder: modify to not include un-actionable PRs

### DIFF
--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/logrusutil"
 )
 
@@ -72,16 +73,16 @@ type config struct {
 
 // getInterestedLabels returns a set of those labels we are interested in when using the PR reminder
 func getInterestedLabels() sets.String {
-	var labels = sets.String{}
-	labels.Insert("do-not-merge/hold")
-	return labels
+	var prLabels = sets.String{}
+	prLabels.Insert("do-not-merge/hold")
+	return prLabels
 }
 
 // getUnactionablePrLabels returns a set of those labels that mark a PR which can't be reviewed in its current state
 func getUnactionablePrLabels() sets.String {
-	var labels = sets.String{}
-	labels.Insert("do-not-merge/work-in-progress", "needs-rebase")
-	return labels
+	var prLabels = sets.String{}
+	prLabels.Insert(labels.WorkInProgress, labels.NeedsRebase)
+	return prLabels
 }
 
 var orgRepoFormat = regexp.MustCompile(`\w+/\w+`)

--- a/cmd/pr-reminder/main_test.go
+++ b/cmd/pr-reminder/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/labels"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
@@ -600,10 +601,10 @@ func Test_filterLabels(t *testing.T) {
 }
 
 func Test_hasUnactionableLabels(t *testing.T) {
-	holdLabel := github.Label{Name: "do-not-merge/hold"}
-	acceptedLabel := github.Label{Name: "accepted"}
-	wipLabel := github.Label{Name: "do-not-merge/work-in-progress"}
-	needsRebaseLabel := github.Label{Name: "needs-rebase"}
+	holdLabel := github.Label{Name: labels.Hold}
+	approvedLabel := github.Label{Name: labels.Approved}
+	wipLabel := github.Label{Name: labels.WorkInProgress}
+	needsRebaseLabel := github.Label{Name: labels.NeedsRebase}
 
 	var testCases = []struct {
 		name     string
@@ -617,7 +618,7 @@ func Test_hasUnactionableLabels(t *testing.T) {
 		},
 		{
 			name:     "no unwanted labels",
-			labels:   []github.Label{acceptedLabel},
+			labels:   []github.Label{approvedLabel},
 			expected: false,
 		},
 		{
@@ -627,7 +628,7 @@ func Test_hasUnactionableLabels(t *testing.T) {
 		},
 		{
 			name:     "one unwanted label among ok labels",
-			labels:   []github.Label{acceptedLabel, needsRebaseLabel, holdLabel},
+			labels:   []github.Label{approvedLabel, needsRebaseLabel, holdLabel},
 			expected: true,
 		},
 		{


### PR DESCRIPTION
Modifies the pr-reminder tool so that the slack message that gets sent every morning doesn't include those PRs that have un-actionable labels (`needs-rebase` or `do-not-merge/work-in-progress`).

for https://issues.redhat.com/browse/DPTP-3037

/cc @openshift/test-platform