### PR TITLE
Observer Pods: fix null pointer dereference

### DIFF
--- a/pkg/api/helper/imageextraction.go
+++ b/pkg/api/helper/imageextraction.go
@@ -120,7 +120,9 @@ func insertTagReferencesFromSteps(config api.MultiStageTestConfigurationLiteral,
 		}
 	}
 	for _, observer := range config.Observers {
-		insert(*observer.FromImage, m)
+		if observer.FromImage != nil {
+			insert(*observer.FromImage, m)
+		}
 	}
 }
 


### PR DESCRIPTION
Found a null pointer dereference while debugging some code.