### PR TITLE
Omit disruptive jobs from the biquery disruption db.

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -209,6 +209,11 @@ func (o *GenerateJobNamesOptions) Run(ctx context.Context) error {
 				!strings.Contains(curr.Name, "-4.20") {
 				continue
 			}
+
+			// Disruptive jobs can dramatically alter our data for certain NURP combos:
+			if strings.Contains(curr.Name, "-disruptive") {
+				continue
+			}
 			localLines = append(localLines, curr.Name)
 		}
 		sort.Strings(localLines)

--- a/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
+++ b/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
@@ -762,7 +762,6 @@ release-openshift-ocp-installer-e2e-azure-serial-4.10
 release-openshift-ocp-installer-e2e-gcp-serial-4.10
 release-openshift-ocp-osd-aws-nightly-4.10
 release-openshift-ocp-osd-gcp-nightly-4.10
-release-openshift-origin-installer-e2e-aws-disruptive-4.10
 release-openshift-origin-installer-e2e-aws-shared-vpc-4.10
 release-openshift-origin-installer-e2e-aws-upgrade-4.7-to-4.8-to-4.9-to-4.10-ci
 release-openshift-origin-installer-e2e-azure-shared-vpc-4.10
@@ -780,7 +779,6 @@ release-openshift-ocp-installer-e2e-azure-serial-4.11
 release-openshift-ocp-installer-e2e-gcp-serial-4.11
 release-openshift-ocp-osd-aws-nightly-4.11
 release-openshift-ocp-osd-gcp-nightly-4.11
-release-openshift-origin-installer-e2e-aws-disruptive-4.11
 release-openshift-origin-installer-e2e-aws-shared-vpc-4.11
 release-openshift-origin-installer-e2e-aws-upgrade-4.8-to-4.9-to-4.10-to-4.11-ci
 release-openshift-origin-installer-e2e-azure-shared-vpc-4.11
@@ -798,7 +796,6 @@ release-openshift-ocp-installer-e2e-azure-serial-4.12
 release-openshift-ocp-installer-e2e-gcp-serial-4.12
 release-openshift-ocp-osd-aws-nightly-4.12
 release-openshift-ocp-osd-gcp-nightly-4.12
-release-openshift-origin-installer-e2e-aws-disruptive-4.12
 release-openshift-origin-installer-e2e-aws-shared-vpc-4.12
 release-openshift-origin-installer-e2e-aws-upgrade-4.9-to-4.10-to-4.11-to-4.12-ci
 release-openshift-origin-installer-e2e-azure-shared-vpc-4.12


### PR DESCRIPTION
Keeping them out of the job names list means they will not be imported
into bigquery, however the jobs themselves continue to run disruption
monitoring, output data files, and show disruption in the spyglass
intervals chart.

[TRT-573](https://issues.redhat.com//browse/TRT-573)