### PR TITLE
Bump aggregator to 6h at least temporarily.

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -74,8 +74,9 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute
-	if durationToWait > (4*time.Hour + 15*time.Minute) {
-		durationToWait = 4*time.Hour + 15*time.Minute
+	// TODO: drop back to 4:15, this was temporary due to slow jobs on azure going over 4h timeout
+	if durationToWait > (6*time.Hour + 15*time.Minute) {
+		durationToWait = 6*time.Hour + 15*time.Minute
 	}
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)
 


### PR DESCRIPTION
We're extending the job limit to 8h in https://github.com/openshift/ci-tools/pull/3045

The aggregator's internal wait time was still 4h, thus we were still
timing out.
