### PR TITLE
sanitize-prow-jobs: operate on subdirectories

### DIFF
--- a/cmd/sanitize-prow-jobs/main.go
+++ b/cmd/sanitize-prow-jobs/main.go
@@ -165,7 +165,14 @@ func main() {
 	if err := config.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Failed to validate the config")
 	}
-	if err := determinizeJobs(opt.prowJobConfigDir, config); err != nil {
-		logrus.WithError(err).Fatal("Failed to determinize")
+	args := flagSet.Args()
+	if len(args) == 0 {
+		args = append(args, "")
+	}
+	for _, subDir := range args {
+		subDir = filepath.Join(opt.prowJobConfigDir, subDir)
+		if err := determinizeJobs(subDir, config); err != nil {
+			logrus.WithError(err).Fatal("Failed to determinize")
+		}
 	}
 }


### PR DESCRIPTION
Do as other programs which support arguments, such as `prowgen`.

```console
$ time sanitize-prow-jobs \
>     --prow-jobs-dir ci-operator/jobs \
>     --config-path core-services/sanitize-prow-jobs/_config.yaml

real    0m10.515s
user    1m11.742s
sys     0m2.853s
```

vs.

```console
$ time sanitize-prow-jobs \
>     --prow-jobs-dir ci-operator/jobs \
>     --config-path core-services/sanitize-prow-jobs/_config.yaml \
>     openshift/ci-tools

real    0m0.091s
user    0m0.106s
sys     0m0.020s
```