### PR TITLE
ci-operator multi-stage: log observer errors

### DIFF
--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -134,6 +134,8 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 				// when the observer is cancelled, we get an error here that we need to ignore, as it's not an error
 				// for the Pod to be deleted when it's cancelled, it's just expected
 				errs <- err
+			} else {
+				logrus.Debugf("ignoring observer error after cancellation: %v", err)
 			}
 			wg.Done()
 		}(pod)


### PR DESCRIPTION
This part of the code is already difficult to follow as it is.

`ci-operator` is generally not happy about pods it is following being deleted,
which does not happen frequently due to the PDB used for builds and tests.  Put
the error in the debug log so it can be used to understand how the monitoring
code responds to the deletion.

---

The notifier (which generates JUnit information) is only triggered by terminated
pods:

https://github.com/openshift/ci-tools/blob/68249882ebce83a5f9b093b313adad88d67f67dd/pkg/util/pods.go#L378

which explains results seen in some of the E2E test failures (the test itself is
a very contrived — but possible — scenario).  This should help identify the sort
of information coming from the API server in those situations.