### PR TITLE
secret-bootstrap: create ns with a requester label

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -499,7 +499,10 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 					errs = append(errs, fmt.Errorf("failed to check if namespace %s exists: %w", secret.Namespace, err))
 					continue
 				}
-				if _, err := nsClient.Create(context.TODO(), &coreapi.Namespace{ObjectMeta: metav1.ObjectMeta{Name: secret.Namespace}}, metav1.CreateOptions{DryRun: dryRunOptions}); err != nil && !kerrors.IsAlreadyExists(err) {
+				if _, err := nsClient.Create(context.TODO(), &coreapi.Namespace{ObjectMeta: metav1.ObjectMeta{
+					Name:   secret.Namespace,
+					Labels: map[string]string{api.DPTPRequesterLabel: "ci-secret-bootstrap"},
+				}}, metav1.CreateOptions{DryRun: dryRunOptions}); err != nil && !kerrors.IsAlreadyExists(err) {
 					errs = append(errs, fmt.Errorf("failed to create namespace %s: %w", secret.Namespace, err))
 					continue
 				}


### PR DESCRIPTION
When the tool creates a namespace for a secret, label the namespace to indicate the requester.
We did the same to the secret already.

https://github.com/openshift/ci-tools/blob/606a8617c28c4e4a912a2b7bba05dd7e2207581a/cmd/ci-secret-bootstrap/main.go#L374

It won't label the existing namespaces.

/cc @openshift/test-platform 