### PR TITLE
Use token file in secret test-credentials/ci-operator

### DIFF
--- a/cmd/cluster-init/main.go
+++ b/cmd/cluster-init/main.go
@@ -35,6 +35,8 @@ type options struct {
 
 	bumper.GitAuthorOptions
 	prcreation.PRCreationOptions
+
+	useTokenFileInKubeconfig bool
 }
 
 func (o options) String() string {
@@ -50,6 +52,7 @@ func parseOptions() (options, error) {
 	fs.BoolVar(&o.createPR, "create-pr", true, "If a PR should be created. Set to true by default")
 	fs.StringVar(&o.githubLogin, "github-login", githubLogin, "The GitHub username to use. Set to "+githubLogin+" by default")
 	fs.StringVar(&o.assign, "assign", githubTeam, "The github username or group name to assign the created pull request to. Set to Test Platform by default")
+	fs.BoolVar(&o.useTokenFileInKubeconfig, "use-token-file-in-kubeconfig", true, "Set true if the token files are used in kubeconfigs. Set to true by default")
 
 	o.GitAuthorOptions.AddFlags(fs)
 	o.PRCreationOptions.AddFlags(fs)
@@ -255,5 +258,13 @@ func buildFarmDirFor(releaseRepo, clusterName string) string {
 }
 
 func serviceAccountKubeconfigPath(serviceAccount, clusterName string) string {
-	return fmt.Sprintf("sa.%s.%s.config", serviceAccount, clusterName)
+	return serviceAccountFile(serviceAccount, clusterName, config)
+}
+
+func serviceAccountTokenFile(serviceAccount, clusterName string) string {
+	return serviceAccountFile(serviceAccount, clusterName, "token.txt")
+}
+
+func serviceAccountFile(serviceAccount, clusterName, fileType string) string {
+	return fmt.Sprintf("sa.%s.%s.%s", serviceAccount, clusterName, fileType)
 }

--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -85,13 +85,21 @@ func updateSecret(secretGenerator func(options) secretbootstrap.SecretConfig) fu
 }
 
 func generateCiOperatorSecret(o options) secretbootstrap.SecretConfig {
-	return secretbootstrap.SecretConfig{
-		From: map[string]secretbootstrap.ItemContext{
-			kubeconfig: {
-				Field: serviceAccountKubeconfigPath(ciOperator, o.clusterName),
-				Item:  buildUFarm,
-			},
+	from := map[string]secretbootstrap.ItemContext{
+		kubeconfig: {
+			Field: serviceAccountKubeconfigPath(ciOperator, o.clusterName),
+			Item:  buildUFarm,
 		},
+	}
+	if o.useTokenFileInKubeconfig {
+		tokenFile := serviceAccountTokenFile(ciOperator, o.clusterName)
+		from[tokenFile] = secretbootstrap.ItemContext{
+			Field: tokenFile,
+			Item:  buildUFarm,
+		}
+	}
+	return secretbootstrap.SecretConfig{
+		From: from,
 		To: []secretbootstrap.SecretContext{
 			{
 				Cluster:   o.clusterName,

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -280,6 +280,9 @@ secret_configs:
     kubeconfig:
       field: sa.ci-operator.newCluster.config
       item: build_farm
+    sa.ci-operator.newCluster.token.txt:
+      field: sa.ci-operator.newCluster.token.txt
+      item: build_farm
   to:
   - cluster: newCluster
     name: ci-operator

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -290,6 +290,9 @@ secret_configs:
     kubeconfig:
       field: sa.ci-operator.existingCluster.config
       item: build_farm
+    sa.ci-operator.existingCluster.token.txt:
+      field: sa.ci-operator.existingCluster.token.txt
+      item: build_farm
   to:
   - cluster: existingCluster
     name: ci-operator


### PR DESCRIPTION
The breaking will be fixed by https://github.com/openshift/release/pull/32833

As far as I can tell, the secret is used only in the tests of `ci-tools`:

https://github.com/openshift/release/blob/70499fc48ae9e4bbdc621dee9820ddd4c02d433f/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml#L765

The verification will be in two steps:
1. add the tokenFile to the secret but the config file is still with `token`.
2. use the tokenFile in the config file.

We have to do this PR first because otherwise the build-clusters job would fail in 
https://github.com/openshift/release/pull/32642


