### PR TITLE
Update formatting to prep for golang version 1.19

### DIFF
--- a/cmd/cluster-init/update_secret_generator.go
+++ b/cmd/cluster-init/update_secret_generator.go
@@ -19,9 +19,9 @@ const (
 	clusterWildcard        = "$(cluster)"
 )
 
-//SecretGenConfig is used here as using secretgenerator.Config results in 'special' unmarshalling
-//where '$(*)' wildcards from the yaml are expanded in the output. Doing so for this purpose results in
-//incorrect re-serialization
+// SecretGenConfig is used here as using secretgenerator.Config results in 'special' unmarshalling
+// where '$(*)' wildcards from the yaml are expanded in the output. Doing so for this purpose results in
+// incorrect re-serialization
 type SecretGenConfig []secretgenerator.SecretItem
 
 func updateSecretGenerator(o options) error {

--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -53,15 +53,15 @@ func gatherOptions() options {
 // repos that actively promote to this release are considered to be our dev branches.
 //
 // Once we've chosen a set of configurations to operate on, we can do one of two actions:
-//  - mirror configuration out, copying the development branch config to all branches for
-//    the provided `--future-release` values, not changing the configuration for the dev
-//    branch and making sure that the release branch for the version that matches that in
-//    the dev branch has a disabled promotion stanza to ensure only one branch feeds a
-//    release ImageStream
-//  - bump configuration files, moving the development branch to promote to the version in
-//    the `--bump` flag, enabling the promotion in the release branch that used to match
-//    the dev branch version and disabling promotion in the release branch that now matches
-//    the dev branch version.
+//   - mirror configuration out, copying the development branch config to all branches for
+//     the provided `--future-release` values, not changing the configuration for the dev
+//     branch and making sure that the release branch for the version that matches that in
+//     the dev branch has a disabled promotion stanza to ensure only one branch feeds a
+//     release ImageStream
+//   - bump configuration files, moving the development branch to promote to the version in
+//     the `--bump` flag, enabling the promotion in the release branch that used to match
+//     the dev branch version and disabling promotion in the release branch that now matches
+//     the dev branch version.
 func main() {
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -253,9 +253,9 @@ type configResult struct {
 // dispatchJobs loads the Prow jobs and chooses a cluster in the build farm if possible.
 // The current implementation walks through the Prow Job config files.
 // For each file, it tries to assign all jobs in it to a cluster in the build farm.
-//  - When all the e2e tests are targeting the same cloud provider, we run the test pod on the that cloud provider too.
-//  - When the e2e tests are targeting different cloud providers, or there is no e2e tests at all, we can run the tests
-//    on any cluster in the build farm. Those jobs are used to load balance the workload of clusters in the build farm.
+//   - When all the e2e tests are targeting the same cloud provider, we run the test pod on the that cloud provider too.
+//   - When the e2e tests are targeting different cloud providers, or there is no e2e tests at all, we can run the tests
+//     on any cluster in the build farm. Those jobs are used to load balance the workload of clusters in the build farm.
 func dispatchJobs(ctx context.Context, prowJobConfigDir string, maxConcurrency int, config *dispatcher.Config, jobVolumes map[string]float64) error {
 	if config == nil {
 		return fmt.Errorf("config is nil")

--- a/pkg/backporter/httpcache_test.go
+++ b/pkg/backporter/httpcache_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-//bugzillaCache tests
+// bugzillaCache tests
 func TestBugzillaCacheSet(t *testing.T) {
 	testcases := []struct {
 		name         string

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_job.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_job.go
@@ -1,7 +1,6 @@
 package jobrunaggregatorapi
 
 // The jobSchema below is used to build the "Jobs" table.
-//
 const (
 	JobsTableName = "Jobs"
 	JobSchema     = `

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -42,7 +42,6 @@ const (
 )
 
 // Move here from jobrunbigqueryloader/types.go
-//
 type TestRunRow struct {
 	Name       string
 	JobRunName string

--- a/pkg/kubernetes/pkg/credentialprovider/config.go
+++ b/pkg/kubernetes/pkg/credentialprovider/config.go
@@ -1,7 +1,7 @@
 /*
- package credentialprovider copies the DockerConfigJSON-related parts from
- https://github.com/kubernetes/kubernetes/tree/b259c92dda81e18822b790501445d98d7c0ed339/pkg/credentialprovider in order to avoid
- depending on k8s.io/kubernetes directly, which is unsupported.
+package credentialprovider copies the DockerConfigJSON-related parts from
+https://github.com/kubernetes/kubernetes/tree/b259c92dda81e18822b790501445d98d7c0ed339/pkg/credentialprovider in order to avoid
+depending on k8s.io/kubernetes directly, which is unsupported.
 */
 package credentialprovider
 

--- a/pkg/release/official/client.go
+++ b/pkg/release/official/client.go
@@ -102,10 +102,10 @@ func latestPullSpecAndVersion(options []Release) (string, string) {
 // processVersionChannel takes the configured version and channel and
 // returns:
 //
-// * Whether the version is explicit (e.g. 4.7.0) or just a
-//   major.minor (e.g. 4.7).
-// * The appropriate channel for a Cincinnati request, e.g. stable-4.7.
-// * Any errors that turn up while processing.
+//   - Whether the version is explicit (e.g. 4.7.0) or just a
+//     major.minor (e.g. 4.7).
+//   - The appropriate channel for a Cincinnati request, e.g. stable-4.7.
+//   - Any errors that turn up while processing.
 func processVersionChannel(version string, channel api.ReleaseChannel) (explicitVersion bool, cincinnatiChannel string, err error) {
 	explicitVersion, majorMinor, err := extractMajorMinor(version)
 	if err != nil {

--- a/pkg/results/error.go
+++ b/pkg/results/error.go
@@ -8,9 +8,9 @@ import (
 // Error holds a message and a child, allowing for an error
 // The common use-case here will be to wrap errors from callsites:
 //
-// if err := doSomething(data); err != nil {
-//     return results.ForReason(results.ReasonFoo).WithError(err).Errorf("could not do something for data: %v", data)
-// }
+//	if err := doSomething(data); err != nil {
+//	    return results.ForReason(results.ReasonFoo).WithError(err).Errorf("could not do something for data: %v", data)
+//	}
 type Error struct {
 	reason  Reason
 	message string
@@ -106,7 +106,7 @@ func (e *BuilderWithReasonAndError) Errorf(format string, args ...interface{}) e
 // a child but instead wants a simple error. For instance, wrapping
 // the outcome of a function that doesn't return an Error itself:
 //
-//  err := results.ForReason(results.ReasonLoadingArgs).ForError(doSomething())
+//	err := results.ForReason(results.ReasonLoadingArgs).ForError(doSomething())
 func (e *BuilderWithReason) ForError(err error) error {
 	if err == nil {
 		return nil

--- a/pkg/util/sync.go
+++ b/pkg/util/sync.go
@@ -63,11 +63,11 @@ func ProduceMap(
 // The pipeline is constituted of a single producer, a single reducer, and `n`
 // mapper workers, i.e.:
 //
-//       producer
-//      / /   \ \
-//     m m  …  m m ---> done
-//      \ \   / /        |
-//       reducer <-------'
+//	  producer
+//	 / /   \ \
+//	m m  …  m m ---> done
+//	 \ \   / /        |
+//	  reducer <-------'
 //
 // All processes are executed to completion even if an error occurs in any of
 // them (as opposed to, for example, `x/sync/errorgroup`).  Errors sent to

--- a/pkg/webreg/webreg.go
+++ b/pkg/webreg/webreg.go
@@ -866,7 +866,8 @@ type dependencyLine struct {
 type dependencyVars map[string]dependencyLine
 
 // release:latest --> ENV_VAR_1 -> { override=false steps=step1,step2 }
-//                \-> ENV_VAR_2 -> { override=true steps=step3 }
+//
+//	\-> ENV_VAR_2 -> { override=true steps=step3 }
 type dependencyData struct {
 	Items map[string]dependencyVars
 	Type  string

--- a/test/e2e/framework/ci-operator.go
+++ b/test/e2e/framework/ci-operator.go
@@ -24,11 +24,11 @@ func init() {
 
 // CiOperatorCommand exposes a ci-operator invocation to a test and
 // ensures the following semantics:
-//  - the command will get SIGINT 1 minutes before the test deadline
-//  - the command will get SIGKILL 10 seconds before the test deadline
-//  - unique hashes ensure unique test namespaces for concurrent runs
-//  - artifacts will be persisted and jUnit will be mangled to not
-//    pollute the owning test's jUnit output
+//   - the command will get SIGINT 1 minutes before the test deadline
+//   - the command will get SIGKILL 10 seconds before the test deadline
+//   - unique hashes ensure unique test namespaces for concurrent runs
+//   - artifacts will be persisted and jUnit will be mangled to not
+//     pollute the owning test's jUnit output
 type CiOperatorCommand struct {
 	cmd         *exec.Cmd
 	artifactDir string

--- a/test/e2e/framework/test.go
+++ b/test/e2e/framework/test.go
@@ -25,15 +25,16 @@ type TestFunc func(t *T, cmd *CiOperatorCommand)
 
 // Run mimics the testing.T.Run function while providing a nice set of concurrency
 // guarantees for the processes that we create and manage for test cases. We ensure:
-// - the ci-operator process is interrupted (SIGINT) before the test times out, so
-//   that it has time to clean up and create artifacts before the test exits
-// - any accessory processes that are started will only be exposed to the ci-operator
-//   command once they have signalled that they are healthy and ready
-// - any accessory processes will have their lifetime bound to the lifetime of the
-//   individual test case - they will be killed (SIGKILL) when the test finishes
-// - any errors in running an accessory process (other than it being killed by the
-//   above mechanism) will be fatal to the test execution and will preempt the other
-//   test routines
+//   - the ci-operator process is interrupted (SIGINT) before the test times out, so
+//     that it has time to clean up and create artifacts before the test exits
+//   - any accessory processes that are started will only be exposed to the ci-operator
+//     command once they have signalled that they are healthy and ready
+//   - any accessory processes will have their lifetime bound to the lifetime of the
+//     individual test case - they will be killed (SIGKILL) when the test finishes
+//   - any errors in running an accessory process (other than it being killed by the
+//     above mechanism) will be fatal to the test execution and will preempt the other
+//     test routines
+//
 // This is a generally non-standard use of the testing.T construct; the two largest
 // reasons we built this abstraction are that we need to manage a fairly complex and
 // fragile set of concurrency and lifetime guarantees for the processes that are


### PR DESCRIPTION
I know that we aren't using `go` version `1.19` yet, but I started using it locally and it seems `gofmt` likes to format comments differently now. This change should be backwards compatible and will just be one less thing we have to do when we bump versions.

/cc @openshift/test-platform 