### PR TITLE
pod-scaler admission: filter out workloads with 0 configured memory

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -219,7 +219,7 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, podNam
 			if our.Cmp(their) == 1 {
 				logger.Debugf("determined %s %s of %s to be larger than %s configured", field, pair.resource, our.String(), their.String())
 				(*pair.theirs)[field] = our
-				if our.Value() > (their.Value() * 10) {
+				if their.Value() > 0 && our.Value() > (their.Value()*10) {
 					reporter.ReportMemoryConfigurationWarning(podName, their.String(), our.String())
 				}
 			}

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -789,6 +789,28 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 			reporter: mockReporter{client: &http.Client{}},
 			expected: false,
 		},
+		{
+			//pod-scaler admission should not report the warning when their configured memory is 0
+			name: "ours is 10x larger, their memory is 0",
+			ours: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(3e10, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(2e10, resource.BinarySI),
+				},
+			},
+			theirs: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(3e10, resource.BinarySI),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: *resource.NewQuantity(0, resource.BinarySI),
+				},
+			},
+			reporter: mockReporter{client: &http.Client{}},
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
To reduce the number of alerts, this modifies pod-scaler admission so it doesn't report the warning when the configured memory is 0.

for https://issues.redhat.com/browse/DPTP-2929
/cc smg247