### PR TITLE
Allow setting always_run in the ci-operator config

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -687,6 +687,9 @@ type TestStepConfiguration struct {
 	// ClusterClaim claims an OpenShift cluster and exposes environment variable ${KUBECONFIG} to the test container
 	ClusterClaim *ClusterClaim `json:"cluster_claim,omitempty"`
 
+	// AlwaysRun can be set to false to disable running the job on every PR
+	AlwaysRun *bool `json:"always_run,omitempty"`
+
 	// RunIfChanged is a regex that will result in the test only running if something that matches it was changed.
 	RunIfChanged string `json:"run_if_changed,omitempty"`
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -1847,6 +1847,11 @@ func (in *TestStepConfiguration) DeepCopyInto(out *TestStepConfiguration) {
 		*out = new(ClusterClaim)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AlwaysRun != nil {
+		in, out := &in.AlwaysRun, &out.AlwaysRun
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Timeout != nil {
 		in, out := &in.Timeout, &out.Timeout
 		*out = new(v1.Duration)

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -60,6 +60,14 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch", Variant: "also"}},
 		},
 		{
+			description: "presubmit with always_run false",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			generateOption: func(options *generatePresubmitOptions) {
+				options.defaultDisable = true
+			},
+		},
+		{
 			description: "presubmit with run_if_changed",
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false.yaml
@@ -1,0 +1,14 @@
+agent: kubernetes
+always_run: false
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -402,6 +402,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        from: ' '\n" +
 	"        to: ' '\n" +
 	"      test_step:\n" +
+	"        # AlwaysRun can be set to false to disable running the job on every PR\n" +
+	"        always_run: false\n" +
 	"        # As is the name of the test.\n" +
 	"        as: ' '\n" +
 	"        # Cluster specifies the name of the cluster where the test runs.\n" +
@@ -1173,7 +1175,9 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"# The images launched as pods but have no explicit access to\n" +
 	"# the cluster they are running on.\n" +
 	"tests:\n" +
-	"    - # As is the name of the test.\n" +
+	"    - # AlwaysRun can be set to false to disable running the job on every PR\n" +
+	"      always_run: false\n" +
+	"      # As is the name of the test.\n" +
 	"      as: ' '\n" +
 	"      # Cluster specifies the name of the cluster where the test runs.\n" +
 	"      cluster: ' '\n" +


### PR DESCRIPTION
If there is an existing job definition then the prow job generation preserves the value of the always_run setting. However, when generating a new job it is always set to true unless forced to false by a run_if_changed or skip_if_always_changed directive in the config.

The result of this is that when copying or renaming job configs, jobs that were intended to only ever be run manually always get enabled on every PR and nobody ever notices before merging the configuration change.

Allow setting "always_run: false" in the config so that we at least have the option to set it in the config and thus have it preserved when jobs are renamed or duplicated.