### PR TITLE
Revert timeouts needed to land k8s bump

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -46,10 +46,8 @@ const (
 	conditionAllJobsTriggered = "AllJobsTriggered"
 	conditionWithErrors       = "WithErrors"
 
-	aggregationIDLabel = "release.openshift.io/aggregation-id"
-
-	// TODO: Bumping this to 8 hours to hopefully allow more time for the k8s bump.  Will revert once the bump is complete.
-	defaultAggregatorJobTimeout = 8 * time.Hour
+	aggregationIDLabel          = "release.openshift.io/aggregation-id"
+	defaultAggregatorJobTimeout = 6 * time.Hour
 )
 
 type injectingResolverClient interface {

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -497,9 +497,6 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
 
 		// TODO: Temporarily bumping the timeout to 6 hours to allow extra time for the Kube rebase.  We'll remove this once the rebase lands...
-		if periodic.DecorationConfig == nil {
-			periodic.DecorationConfig = &prowv1.DecorationConfig{}
-		}
 		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
 
 		break

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -502,9 +502,6 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		return nil, fmt.Errorf("BUG: test '%s' not found in injected config", inject.Test)
 	}
 
-	// TODO: Temporarily bumping the timeout to 6 hours to allow extra time for the Kube rebase.  We'll remove this once the rebase lands...
-	periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
-
 	extraRefs := prowv1.Refs{
 		Org:  baseCiop.Org,
 		Repo: baseCiop.Repo,

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -495,16 +495,15 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			options.Cron = "@yearly"
 		})
 		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
-
-		// TODO: Temporarily bumping the timeout to 6 hours to allow extra time for the Kube rebase.  We'll remove this once the rebase lands...
-		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
-
 		break
 	}
 	// We did not find the injected test: this is a bug
 	if periodic == nil {
 		return nil, fmt.Errorf("BUG: test '%s' not found in injected config", inject.Test)
 	}
+
+	// TODO: Temporarily bumping the timeout to 6 hours to allow extra time for the Kube rebase.  We'll remove this once the rebase lands...
+	periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
 
 	extraRefs := prowv1.Refs{
 		Org:  baseCiop.Org,

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -179,7 +179,7 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 8h0m0s
+      timeout: 6h0m0s
     job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
     pod_spec:
       containers:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -25,7 +25,6 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"
@@ -104,7 +103,6 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -25,7 +25,6 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -25,7 +25,6 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -49,7 +49,6 @@
     cluster: this-job-was-defaulted
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -74,9 +74,8 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute
-	// TODO: drop back to 4:15, this was temporary due to slow jobs on azure going over 4h timeout
-	if durationToWait > (6*time.Hour + 15*time.Minute) {
-		durationToWait = 6*time.Hour + 15*time.Minute
+	if durationToWait > (4*time.Hour + 15*time.Minute) {
+		durationToWait = 4*time.Hour + 15*time.Minute
 	}
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)
 


### PR DESCRIPTION
This reverts changes from the following PRs:
- https://github.com/openshift/ci-tools/pull/3045
- https://github.com/openshift/ci-tools/pull/3042
- https://github.com/openshift/ci-tools/pull/3041
- https://github.com/openshift/ci-tools/pull/3034 (partially)

also:
- https://github.com/openshift/ci-tools/pull/3046

/assign @bradmwilliams @dgoodwin 