### PR TITLE
`pj-rehearse`: don't report failure when there are no jobs to rehearse

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -133,6 +133,10 @@ func rehearseMain() error {
 	if err != nil {
 		return fmt.Errorf("error determining affected jobs: %w: %s", err, misconfigurationOutput)
 	}
+	if len(presubmits) == 0 && len(periodics) == 0 {
+		// Nothing to rehearse
+		return nil
+	}
 
 	debugLogger := logrus.New()
 	debugLogger.Level = logrus.DebugLevel


### PR DESCRIPTION
Minor bug with the refactor, we now report the job as failed if we don't find anything to rehearse. See [example log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/32927/pull-ci-openshift-release-master-pj-rehearse/1578381689887920128).

/cc @openshift/test-platform 