### PR TITLE
Unify approvers/reviewers in root OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,11 +2,6 @@ approvers:
 - bbguimaraes
 - droslean
 - hongkailiu
-- petr-muller
-- smarterclayton
-- stevekuznetsov
-- AlexNPavel
-- alvaroaleman
 - smg247
 - jmguzik
 reviewers:


### PR DESCRIPTION
So we avoid nonsensical approval attributions such as:

https://github.com/openshift/ci-tools/pull/3070#issuecomment-1271668611