### PR TITLE
`pj-rehearse`: do not error when all jobs have been filtered out

### DIFF
--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -2,7 +2,6 @@ package rehearse
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -223,7 +222,8 @@ func (r RehearsalConfig) SetupJobs(candidate RehearsalCandidate, candidatePath s
 	presubmitsToRehearse = append(presubmitsToRehearse, periodicPresubmits...)
 
 	if rehearsals := len(presubmitsToRehearse); rehearsals == 0 {
-		return nil, nil, nil, nil, errors.New("no jobs found to rehearse")
+		jobLogger.Info("no jobs to rehearse have been found")
+		return nil, nil, nil, nil, nil
 	} else if rehearsals > limit {
 		jobCountFields := logrus.Fields{
 			"rehearsal-threshold": limit,


### PR DESCRIPTION
I discovered another case of `pj-rehearse` behaving incorrectly post-refactor. It marks itself as failed if all the affected jobs are filtered out due to not being valid for rehearsal. The original code: https://github.com/openshift/ci-tools/blob/59dafbf35eb09ed0ba56fa06a33022f3f47bfe30/cmd/pj-rehearse/main.go#L326-L328

Example erroneous [log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/32983/pull-ci-openshift-release-master-pj-rehearse/1579448374787051520).

/cc @openshift/test-platform 