### PR TITLE
`pj-rehearse`: create external plugin server

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -1,16 +1,25 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/flagutil"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	prowgithub "k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/githubeventserver"
+	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/logrusutil"
+	"k8s.io/test-infra/prow/pjutil"
 	pjdwapi "k8s.io/test-infra/prow/pod-utils/downwardapi"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -19,6 +28,9 @@ import (
 )
 
 type options struct {
+	logLevel string
+
+	serverMode        bool
 	dryRun            bool
 	debugLogPath      string
 	prowjobKubeconfig string
@@ -27,14 +39,29 @@ type options struct {
 	noRegistry        bool
 	noClusterProfiles bool
 
-	releaseRepoPath string
-	rehearsalLimit  int
+	preCheck            bool
+	commentOnPrCreation bool //TODO: this is useful for a soft rollout of the plugin. remove once that is complete
+
+	normalLimit int
+	moreLimit   int
+	maxLimit    int
+
+	releaseRepoPath string //TODO: this will be removed when the old pj-rehearse job is gone
+	rehearsalLimit  int    //TODO: this will be removed when the old pj-rehearse job is gone
+
+	webhookSecretFile        string
+	githubEventServerOptions githubeventserver.Options
+	github                   prowflagutil.GitHubOptions
+	git                      prowflagutil.GitOptions
 }
 
 func gatherOptions() (options, error) {
 	o := options{kubernetesOptions: flagutil.KubernetesOptions{NOInClusterConfigDefault: true}}
 	fs := flag.CommandLine
 
+	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
+
+	fs.BoolVar(&o.serverMode, "server", false, "Run as a github event server, external prow plugin rather than as a job")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to actually submit rehearsal jobs to Prow")
 
 	fs.StringVar(&o.debugLogPath, "debug-log", "", "Alternate file for debug output, defaults to stderr")
@@ -45,7 +72,19 @@ func gatherOptions() (options, error) {
 	fs.BoolVar(&o.noRegistry, "no-registry", false, "If true, do not attempt to compare step registry content")
 	fs.BoolVar(&o.noClusterProfiles, "no-cluster-profiles", false, "If true, do not attempt to compare cluster profiles")
 
+	fs.BoolVar(&o.preCheck, "pre-check", false, "If true, check for rehearsable jobs and provide the list upon PR creation")
+	fs.BoolVar(&o.preCheck, "comment-on-pr-creation", true, "If true, provide an explanatory comment when a new PR is opened in a repo with the plugin configured.")
+
+	fs.IntVar(&o.normalLimit, "normal-limit", 10, "Upper limit of jobs attempted to rehearse with normal command (if more jobs are being touched, only this many will be rehearsed)")
+	fs.IntVar(&o.moreLimit, "more-limit", 20, "Upper limit of jobs attempted to rehearse with more command (if more jobs are being touched, only this many will be rehearsed)")
+	fs.IntVar(&o.maxLimit, "max-limit", 35, "Upper limit of jobs attempted to rehearse with max command (if more jobs are being touched, only this many will be rehearsed)")
+
+	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+
 	fs.IntVar(&o.rehearsalLimit, "rehearsal-limit", 35, "Upper limit of jobs attempted to rehearse (if more jobs are being touched, only this many will be rehearsed)")
+
+	o.github.AddFlags(fs)
+	o.githubEventServerOptions.Bind(fs)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return o, fmt.Errorf("failed to parse flags: %w", err)
@@ -53,11 +92,26 @@ func gatherOptions() (options, error) {
 	return o, nil
 }
 
-func validateOptions(o options) error {
-	if len(o.releaseRepoPath) == 0 {
-		return fmt.Errorf("--candidate-path was not provided")
+func (o *options) validate() error {
+	var errs []error
+	level, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("invalid log level specified: %w", err))
 	}
-	return o.kubernetesOptions.Validate(o.dryRun)
+	logrus.SetLevel(level)
+
+	errs = append(errs, o.kubernetesOptions.Validate(o.dryRun))
+
+	if o.serverMode {
+		errs = append(errs, o.githubEventServerOptions.DefaultAndValidate())
+		errs = append(errs, o.github.Validate(o.dryRun))
+	} else {
+		if len(o.releaseRepoPath) == 0 {
+			errs = append(errs, errors.New("--candidate-path was not provided"))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
 }
 
 func rehearsalConfigFromOptions(o options) rehearse.RehearsalConfig {
@@ -68,6 +122,9 @@ func rehearsalConfigFromOptions(o options) rehearse.RehearsalConfig {
 		NoRegistry:        o.noRegistry,
 		NoClusterProfiles: o.noClusterProfiles,
 		DryRun:            o.dryRun,
+		NormalLimit:       o.normalLimit,
+		MoreLimit:         o.moreLimit,
+		MaxLimit:          o.maxLimit,
 	}
 }
 
@@ -95,20 +152,9 @@ pj-rehearse created invalid rehearsal jobs.This is either a pj-rehearse bug, or
 the rehearsed jobs themselves are invalid.`
 )
 
-func rehearseMain() error {
-	o, err := gatherOptions()
+func rehearseAsJob(o options) error {
+	jobSpec, err := pjdwapi.ResolveSpecFromEnv()
 	if err != nil {
-		logrus.WithError(err).Fatal("failed to gather options")
-	}
-	if err := validateOptions(o); err != nil {
-		logrus.WithError(err).Fatal("invalid options")
-	}
-	if err := imagev1.Install(scheme.Scheme); err != nil {
-		logrus.WithError(err).Fatal("failed to register imagev1 scheme")
-	}
-
-	var jobSpec *pjdwapi.JobSpec
-	if jobSpec, err = pjdwapi.ResolveSpecFromEnv(); err != nil {
 		logrus.WithError(err).Error("could not read JOB_SPEC")
 		return fmt.Errorf(misconfigurationOutput)
 	}
@@ -172,9 +218,57 @@ func rehearseMain() error {
 	return nil
 }
 
+func rehearsalServer(o options) {
+	logrusutil.ComponentInit()
+	logger := logrus.WithField("plugin", "pj-rehearse")
+
+	if err := secret.Add(o.github.TokenPath, o.webhookSecretFile); err != nil {
+		logger.WithError(err).Fatal("Error starting secrets agent.")
+	}
+	webhookTokenGenerator := secret.GetTokenGenerator(o.webhookSecretFile)
+
+	s, err := serverFromOptions(o)
+	if err != nil {
+		logger.WithError(err).Fatal("couldn't create server")
+	}
+
+	logger.Debug("starting eventServer")
+	eventServer := githubeventserver.New(o.githubEventServerOptions, webhookTokenGenerator, logger)
+	if o.commentOnPrCreation {
+		eventServer.RegisterHandlePullRequestEvent(s.handlePullRequestCreation)
+	}
+	eventServer.RegisterHandleIssueCommentEvent(s.handleIssueComment)
+	eventServer.RegisterHelpProvider(s.helpProvider, logger)
+
+	interrupts.OnInterrupt(func() {
+		eventServer.GracefulShutdown()
+	})
+
+	health := pjutil.NewHealth()
+	health.ServeReady()
+
+	interrupts.ListenAndServe(eventServer, time.Second*30)
+	interrupts.WaitForGracefulShutdown()
+}
+
 func main() {
-	if err := rehearseMain(); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
+	o, err := gatherOptions()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to gather options")
+	}
+	if err := o.validate(); err != nil {
+		logrus.WithError(err).Fatal("invalid options")
+	}
+	if err := imagev1.Install(scheme.Scheme); err != nil {
+		logrus.WithError(err).Fatal("failed to register imagev1 scheme")
+	}
+
+	if o.serverMode {
+		rehearsalServer(o)
+	} else {
+		if err := rehearseAsJob(o); err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -84,12 +84,12 @@ func serverFromOptions(o options) (*server, error) {
 	githubTokenGenerator := secret.GetTokenGenerator(o.github.TokenPath)
 	ghc, err := o.github.GitHubClient(o.dryRun)
 	if err != nil {
-		return nil, fmt.Errorf("error creating GitHub client: %v", err)
+		return nil, fmt.Errorf("error creating GitHub client: %w", err)
 	}
 
 	gc, err := o.git.GitClient(ghc, githubTokenGenerator, secret.Censor, o.dryRun)
 	if err != nil {
-		return nil, fmt.Errorf("error creating git client: %v", err)
+		return nil, fmt.Errorf("error creating git client: %w", err)
 	}
 
 	return &server{

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+
+	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/rehearse"
+)
+
+const (
+	rehearsalsAckLabel = "rehearsals-ack"
+	needsOkToTestLabel = "needs-ok-to-test"
+	rehearseNormal     = "/pj-rehearse"
+	rehearseMore       = "/pj-rehearse more"
+	rehearseMax        = "/pj-rehearse max"
+	rehearseSkip       = "/pj-rehearse skip"
+	rehearseAck        = "/pj-rehearse ack"
+)
+
+var commentRegex = regexp.MustCompile(`(?m)^/pj-rehearse\s*(.*)$`)
+
+type githubClient interface {
+	CreateComment(owner, repo string, number int, comment string) error
+	AddLabel(org, repo string, number int, label string) error
+	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
+}
+
+type server struct {
+	ghc githubClient
+	gc  git.ClientFactory
+
+	preCheck        bool
+	rehearsalConfig rehearse.RehearsalConfig
+}
+
+func (s *server) helpProvider(_ []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	pluginHelp := &pluginhelp.PluginHelp{
+		Description: `The pj-rehearse plugin is used to rehearse changes to affected job configurations.`,
+	}
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       rehearseNormal,
+		Description: fmt.Sprintf("Run up to %d affected job rehearsals for the change in the PR.", s.rehearsalConfig.NormalLimit),
+		WhoCanUse:   "Anyone can use on trusted PRs",
+		Examples:    []string{rehearseNormal},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       rehearseAck,
+		Description: fmt.Sprintf("Acknowledge the rehearsal result (either passing, failing, or skipped), and add the '%s' label allowing merge once other requirements are met.", rehearsalsAckLabel),
+		WhoCanUse:   "Anyone can use on trusted PRs",
+		Examples:    []string{rehearseAck},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       rehearseMore,
+		Description: fmt.Sprintf("Run up to %d affected job rehearsals for the change in the PR.", s.rehearsalConfig.MoreLimit),
+		WhoCanUse:   "Anyone can use on trusted PRs",
+		Examples:    []string{rehearseMore},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       rehearseMax,
+		Description: fmt.Sprintf("Run up to %d affected job rehearsals for the change in the PR.", s.rehearsalConfig.MaxLimit),
+		WhoCanUse:   "Anyone can use on trusted PRs",
+		Examples:    []string{rehearseMax},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       rehearseSkip,
+		Description: fmt.Sprintf("Opt-out of rehearsals for this PR, and add the '%s' label allowing merge once other requirements are met.", rehearsalsAckLabel),
+		WhoCanUse:   "Anyone can use on trusted PRs",
+		Examples:    []string{rehearseSkip},
+	})
+	return pluginHelp, nil
+}
+
+func serverFromOptions(o options) (*server, error) {
+	githubTokenGenerator := secret.GetTokenGenerator(o.github.TokenPath)
+	ghc, err := o.github.GitHubClient(o.dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GitHub client: %v", err)
+	}
+
+	gc, err := o.git.GitClient(ghc, githubTokenGenerator, secret.Censor, o.dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("error creating git client: %v", err)
+	}
+
+	return &server{
+		ghc:             ghc,
+		gc:              gc,
+		preCheck:        o.preCheck,
+		rehearsalConfig: rehearsalConfigFromOptions(o),
+	}, nil
+}
+
+func (s *server) handlePullRequestCreation(l *logrus.Entry, event github.PullRequestEvent) {
+	if github.PullRequestActionOpened == event.Action {
+		org := event.Repo.Owner.Login
+		repo := event.Repo.Name
+		number := event.Number
+		logger := l.WithFields(logrus.Fields{
+			"org":  org,
+			"repo": repo,
+			"pr":   number,
+		})
+		logger.Debug("handling pull request creation")
+
+		var comment string
+		if s.preCheck {
+			repoClient, err := s.gc.ClientFor(org, repo)
+			if err != nil {
+				logger.WithError(err).Error("couldn't get git client")
+			}
+
+			defer func() {
+				if err := repoClient.Clean(); err != nil {
+					logrus.WithError(err).Error("couldn't clean temporary repo folder")
+				}
+			}()
+
+			if err := repoClient.CheckoutPullRequest(number); err != nil {
+				logger.WithError(err).Error("couldn't checkout pull request")
+			}
+
+			candidate := rehearse.RehearsalCandidateFromPullRequest(event.PullRequest)
+			presubmits, periodics, _, _, err := s.rehearsalConfig.DetermineAffectedJobs(candidate, repoClient.Directory(), logger)
+			if err != nil {
+				logger.WithError(err).Error("couldn't determine affected jobs")
+			}
+			if len(presubmits) > 0 || len(periodics) > 0 {
+				lines := s.getJobsTableLines(presubmits, periodics, event.PullRequest.User.Login)
+				lines = append(lines, []string{
+					"Prior to this PR being merged, you will need to either run and acknowledge or opt to skip these rehearsals.",
+					"",
+				}...)
+				lines = append(lines, s.getUsageDetailsLines()...)
+				comment = strings.Join(lines, "\n")
+			} else {
+				comment = fmt.Sprintf("@%s: no rehearsable tests are affected by this change", event.PullRequest.User.Login)
+				if err := s.ghc.AddLabel(org, repo, event.Number, rehearsalsAckLabel); err != nil {
+					logger.WithError(err).Error("failed to add rehearsals-ack label")
+				}
+			}
+		} else {
+			lines := []string{
+				fmt.Sprintf("@%s: changes from this PR may affect rehearsable jobs. The `pj-rehearse` plugin is available to rehearse these jobs.", event.PullRequest.User.Login),
+				"", // For formatting
+			}
+			lines = append(lines, s.getUsageDetailsLines()...)
+			comment = strings.Join(lines, "\n")
+		}
+
+		if err := s.ghc.CreateComment(org, repo, event.Number, comment); err != nil {
+			logger.WithError(err).Error("failed to create comment")
+		}
+	}
+}
+
+func (s *server) handleIssueComment(l *logrus.Entry, event github.IssueCommentEvent) {
+	if !event.Issue.IsPullRequest() || github.IssueCommentActionCreated != event.Action {
+		return
+	}
+
+	comment := event.Comment.Body
+	pjRehearseComments := commentRegex.FindAllString(comment, -1)
+	if len(pjRehearseComments) > 0 {
+		org := event.Repo.Owner.Login
+		repo := event.Repo.Name
+		number := event.Issue.Number
+		logger := l.WithFields(logrus.Fields{
+			"org":  org,
+			"repo": repo,
+			"pr":   number,
+		})
+		logger.Debugf("handling issue comment: %s", comment)
+
+		pullRequest, err := s.ghc.GetPullRequest(org, repo, number)
+		if err != nil {
+			logger.WithError(err).Error("failed to get PR for issue comment event")
+			// We shouldn't continue here
+			return
+		}
+		// We shouldn't allow rehearsals to run (or be ack'd) on untrusted PRs
+		for _, label := range pullRequest.Labels {
+			if needsOkToTestLabel == label.Name {
+				logger.Infof("%s label found, no rehearsals will be ran", needsOkToTestLabel)
+				return
+			}
+		}
+
+		repoClient, err := s.gc.ClientFor(org, repo)
+		if err != nil {
+			logger.WithError(err).Error("couldn't get git client")
+		}
+		defer func() {
+			if err := repoClient.Clean(); err != nil {
+				logrus.WithError(err).Error("couldn't clean temporary repo folder")
+			}
+		}()
+
+		rehearsalsTriggered := false
+		for _, command := range pjRehearseComments {
+			switch command {
+			case rehearseAck, rehearseSkip:
+				if err := s.ghc.AddLabel(org, repo, number, rehearsalsAckLabel); err != nil {
+					logger.WithError(err).Error("failed to add rehearsals-ack label")
+				}
+			case rehearseNormal, rehearseMore, rehearseMax:
+				if rehearsalsTriggered {
+					// We don't want to trigger rehearsals more than once per comment
+					continue
+				}
+				rc := s.rehearsalConfig
+				if err := repoClient.CheckoutPullRequest(pullRequest.Number); err != nil {
+					logger.WithError(err).Error("couldn't checkout pull request")
+				}
+
+				candidatePath := repoClient.Directory()
+				candidate := rehearse.RehearsalCandidateFromPullRequest(*pullRequest)
+				presubmits, periodics, changedTemplates, changedClusterProfiles, err := rc.DetermineAffectedJobs(candidate, candidatePath, logger)
+				if err != nil {
+					logger.WithError(err).Error("couldn't determine affected jobs")
+				}
+				if !s.preCheck {
+					// Since we didn't provide a comment about the rehearsable jobs prior to the user selecting to run, list them now
+					jobListComment := strings.Join(s.getJobsTableLines(presubmits, periodics, pullRequest.User.Login), "\n")
+					if err := s.ghc.CreateComment(org, repo, number, jobListComment); err != nil {
+						logger.WithError(err).Error("failed to create comment")
+					}
+				}
+
+				if len(presubmits) > 0 || len(periodics) > 0 {
+					limit := rc.NormalLimit
+					if command == rehearseMore {
+						limit = rc.MoreLimit
+					} else if command == rehearseMax {
+						limit = rc.MaxLimit
+					}
+
+					loggers := rehearse.Loggers{Job: logger, Debug: logger} // TODO: for now use the same logger, the dual logger concept will go away when orignal pj-rehearse does
+					prConfig, prRefs, imageStreamTags, presubmitsToRehearse, err := rc.SetupJobs(candidate, candidatePath, presubmits, periodics, changedTemplates, changedClusterProfiles, limit, loggers)
+					if err != nil {
+						logger.WithError(err).Error("couldn't set up jobs")
+						if err = s.ghc.CreateComment(org, repo, number, "`pj-rehearse` was unable to set up jobs"); err != nil {
+							logger.WithError(err).Error("failed to create comment")
+						}
+					}
+
+					if err := prConfig.Prow.ValidateJobConfig(); err != nil {
+						logger.WithError(err).Error("validation of job config failed")
+						if err = s.ghc.CreateComment(org, repo, number, "`pj-rehearse` validation of job config failed"); err != nil {
+							logger.WithError(err).Error("failed to create comment")
+						}
+					}
+
+					_, err = rc.RehearseJobs(candidate, candidatePath, prConfig, prRefs, imageStreamTags, presubmitsToRehearse, changedTemplates, changedClusterProfiles, loggers)
+					if err != nil {
+						logger.WithError(err).Error("couldn't rehearse jobs")
+						if err := s.ghc.CreateComment(org, repo, number, "Failed to create rehearsal jobs"); err != nil {
+							logger.WithError(err).Error("couldn't create comment")
+						}
+					}
+				}
+				rehearsalsTriggered = true
+			}
+		}
+	}
+}
+
+func (s *server) getJobsTableLines(presubmits config.Presubmits, periodics config.Periodics, user string) []string {
+	lines := []string{
+		fmt.Sprintf("@%s: the following rehearsable tests have been affected by this change:", user),
+		"",
+		"Test name | Repo | Type | Reason",
+		"--- | --- | --- | ---",
+	}
+
+	limitToList := s.rehearsalConfig.MaxLimit
+	jobCount := 0
+	for repoName, jobs := range presubmits {
+		for _, presubmit := range jobs {
+			jobCount++
+			if jobCount < limitToList {
+				lines = append(lines, fmt.Sprintf("%s | %s | %s | %s", presubmit.Name, repoName, "presubmit", config.GetSourceType(presubmit.Labels).GetDisplayText()))
+			}
+		}
+	}
+	for jobName, periodic := range periodics {
+		jobCount++
+		if jobCount < limitToList {
+			lines = append(lines, fmt.Sprintf("%s | N/A | %s | %s", jobName, "periodic", config.GetSourceType(periodic.Labels).GetDisplayText()))
+		}
+	}
+
+	if jobCount > limitToList {
+		lines = append(lines, "") // For formatting
+		lines = append(lines, fmt.Sprintf("A total of %d jobs were affected by this change. The above listing is non-exhaustive and limited to %d jobs", jobCount, limitToList))
+	}
+
+	return append(lines, "") // For formatting
+}
+
+func (s *server) getUsageDetailsLines() []string {
+	rc := s.rehearsalConfig
+	return []string{
+		"<details>",
+		"<summary>Interacting with pj-rehearse</summary>",
+		"",
+		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals", rehearseNormal, rc.NormalLimit),
+		fmt.Sprintf("Comment: `%s` to opt-out of rehearsals", rehearseSkip),
+		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals", rehearseMore, rc.MoreLimit),
+		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals", rehearseMax, rc.MaxLimit),
+		"",
+		fmt.Sprintf("Once you are satisfied with the results of the rehearsals, comment: `%s` to unblock merge. When the `%s` label is present on your PR, merge will no longer be blocked by rehearsals", rehearseAck, rehearsalsAckLabel),
+		"</details>",
+	}
+}

--- a/pkg/config/jobs.go
+++ b/pkg/config/jobs.go
@@ -42,6 +42,25 @@ func GetSourceType(labels map[string]string) SourceType {
 	}
 }
 
+func (sourceType SourceType) GetDisplayText() string {
+	switch sourceType {
+	case ChangedPresubmit:
+		return "Presubmit changed"
+	case ChangedPeriodic:
+		return "Periodic changed"
+	case ChangedCiopConfig:
+		return "Ci-operator config changed"
+	case ChangedClusterProfile:
+		return "Cluster Profile changed"
+	case ChangedTemplate:
+		return "Template changed"
+	case ChangedRegistryContent:
+		return "Registry content changed"
+	default:
+		return "Unknown change occurred"
+	}
+}
+
 type Presubmits map[string][]prowconfig.Presubmit
 
 // AddAll adds all jobs from a different instance.


### PR DESCRIPTION
This adds a server to `pj-rehearse` to act as an external prow plugin. Initially, we will have `preCheck` and `commentOnPrCreation` turned off to do a soft-rollout of this change. Eventually, these will both be turned on.

When a PR is created in configured repos, the plugin determines the affected jobs and comments like:
![Screen Shot 2022-10-10 at 3 29 15 PM](https://user-images.githubusercontent.com/1794300/194940063-52957978-bf99-4c83-b112-f0acfd72aec8.png)

When a user adds a comment like `/pj-rehearse` or any of the similar commands, the jobs are triggered.

When a user comments `/pj-rehearse ack` or `/pj-rehearse skip` the `rehearsals-ack` label is added.

For: https://issues.redhat.com/browse/DPTP-3092

/cc @openshift/test-platform @droslean 
