### PR TITLE
Satisfy new linter warnings

### DIFF
--- a/cmd/entrypoint-wrapper/main.go
+++ b/cmd/entrypoint-wrapper/main.go
@@ -59,7 +59,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to parse flag set")
 	}
 	opt.cmd = flagSet.Args()
-	if err := opt.complete(flagSet); err != nil {
+	if err := opt.complete(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)
 	}
@@ -94,7 +94,7 @@ func bindOptions(flag *flag.FlagSet) *options {
 	return opt
 }
 
-func (o *options) complete(flagSet *flag.FlagSet) error {
+func (o *options) complete() error {
 	if len(o.cmd) == 0 {
 		return fmt.Errorf("a command is required")
 	}

--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -372,7 +372,7 @@ func filterLabels(labels []github.Label, interestedLabels sets.String) []string 
 			result = append(result, label.Name)
 		}
 	}
-	sort.Sort(sort.StringSlice(result))
+	sort.Strings(result)
 	return result
 }
 

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -173,7 +173,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 			return err
 		}
 	}
-	env, err := s.environment(ctx)
+	env, err := s.environment()
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (s *multiStageTestStep) readVPNData(secret *coreapi.Secret) error {
 	return nil
 }
 
-func (s *multiStageTestStep) environment(ctx context.Context) ([]coreapi.EnvVar, error) {
+func (s *multiStageTestStep) environment() ([]coreapi.EnvVar, error) {
 	var ret []coreapi.EnvVar
 	for _, l := range s.leases {
 		val, err := s.params.Get(l.Env)

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -236,7 +236,7 @@ func TestEnvironment(t *testing.T) {
 				params: tc.params,
 				leases: tc.leases,
 			}
-			got, err := s.environment(context.TODO())
+			got, err := s.environment()
 			if (err != nil) != tc.expectErr {
 				t.Errorf("environment() error = %v, wantErr %v", err, tc.expectErr)
 				return


### PR DESCRIPTION
I finally managed to get `golangci-lint` working on my machine again
(apparently, it's very sensitive about the Go version on the system, building
from source made it work again).

Fix a few new issues identified by this new version (`v1.48.0`).