### PR TITLE
Increase timeout while waiting the secret creation of the service account

### DIFF
--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -108,14 +108,7 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 	labels := map[string]string{MultiStageTestLabel: s.name}
 	ns := s.jobSpec.Namespace()
 	m := meta.ObjectMeta{Namespace: ns, Name: s.name, Labels: labels}
-	sa := &coreapi.ServiceAccount{
-		ObjectMeta: m,
-		ImagePullSecrets: []coreapi.LocalObjectReference{
-			{
-				Name: api.RegistryPullCredentialsSecret,
-			},
-		},
-	}
+	sa := &coreapi.ServiceAccount{ObjectMeta: m}
 	role := &rbacapi.Role{
 		ObjectMeta: m,
 		Rules: []rbacapi.PolicyRule{{

--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -149,7 +149,7 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 			Subjects: subj,
 		})
 	}
-	if err := util.CreateRBACs(ctx, sa, role, bindings, s.client, 1*time.Second, 1*time.Minute); err != nil {
+	if err := util.CreateRBACs(ctx, sa, role, bindings, s.client, 1*time.Second, 10*time.Minute); err != nil {
 		return err
 	}
 

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -71,11 +71,6 @@ func setupReleaseImageStream(ctx context.Context, namespace string, client ctrlr
 			Name:      "ci-operator",
 			Namespace: namespace,
 		},
-		ImagePullSecrets: []coreapi.LocalObjectReference{
-			{
-				Name: api.RegistryPullCredentialsSecret,
-			},
-		},
 	}
 
 	role := &rbacapi.Role{

--- a/pkg/util/rbacs.go
+++ b/pkg/util/rbacs.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	coreapi "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
 )
 
@@ -45,15 +42,6 @@ func CreateRBACs(ctx context.Context, sa *coreapi.ServiceAccount, role *rbacapi.
 		return nil
 	}
 
-	hasDockerCfgImagePullSecretSet := func(imagePullSecrets []coreapi.LocalObjectReference) bool {
-		for _, secret := range imagePullSecrets {
-			if api.RegistryPullCredentialsSecret != secret.Name {
-				return true
-			}
-		}
-		return false
-	}
-
 	if err := wait.PollImmediate(retryDuration, timeout, func() (bool, error) {
 		actualSA := &coreapi.ServiceAccount{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{
@@ -63,14 +51,15 @@ func CreateRBACs(ctx context.Context, sa *coreapi.ServiceAccount, role *rbacapi.
 			return false, fmt.Errorf("couldn't get service account %s: %w", sa.Name, err)
 		}
 
-		if !hasDockerCfgImagePullSecretSet(actualSA.ImagePullSecrets) {
+		if len(actualSA.ImagePullSecrets) == 0 {
 			return false, nil
 		}
 
 		return true, nil
-	}); err != nil {
-		_ = results.ForReason("create_dockercfg_secrets").WithError(err).Errorf("timeout while waiting for dockercfg secret creation for service account %q: %v", sa.Name, err)
-		logrus.WithError(err).Debugf("timeout while waiting for dockercfg secret creation for service account %q", sa.Name)
+	},
+	); err != nil {
+		return results.ForReason("create_dockercfg_secrets").WithError(err).Errorf("timeout while waiting for dockercfg secret creation for service account %q: %v", sa.Name, err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
/cc @danilo-gemoli @hongkailiu /cc @jupierce @openshift/test-platform  


In theory, there is no way that we create the pod before the actual secret is created. If this is the case, then Kubernetes or Openshift has a core bug in etcd. 

The only case where we stop polling is if we time out. This can happen if the dockercfgcontroller will rollout or the cluster is stressed-up or we are upgrading the cluster.

The fix just increases the timeout from 1 minute to 10 minutes.

It also reverts https://github.com/openshift/ci-tools/pull/3019 and adds one more commit with the timeout change

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
