### PR TITLE
pkg/config: add test for registry change detection

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -186,25 +186,31 @@ func GetChangedTemplates(path, baseRev string) ([]string, error) {
 
 func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node, error) {
 	// if a commands script changed, mark reference as changed
+	var type_, name string
 	var node registry.Node
 	var ok bool
 	switch {
 	case strings.HasSuffix(filename, load.RefSuffix):
-		node, ok = graph.References[strings.TrimSuffix(filename, load.RefSuffix)]
+		type_, name = "ref", strings.TrimSuffix(filename, load.RefSuffix)
+		node, ok = graph.References[name]
 	case strings.HasSuffix(filename, load.ObserverSuffix):
-		node, ok = graph.References[strings.TrimSuffix(filename, load.ObserverSuffix)]
+		type_, name = "observer", strings.TrimSuffix(filename, load.ObserverSuffix)
+		node, ok = graph.References[name]
 	case strings.HasSuffix(filename, load.ChainSuffix):
-		node, ok = graph.Chains[strings.TrimSuffix(filename, load.ChainSuffix)]
+		type_, name = "chain", strings.TrimSuffix(filename, load.ChainSuffix)
+		node, ok = graph.Chains[name]
 	case strings.HasSuffix(filename, load.WorkflowSuffix):
-		node, ok = graph.Workflows[strings.TrimSuffix(filename, load.WorkflowSuffix)]
+		type_, name = "workflow", strings.TrimSuffix(filename, load.WorkflowSuffix)
+		node, ok = graph.Workflows[name]
 	case strings.Contains(filename, load.CommandsSuffix):
 		extension := filepath.Ext(filename)
-		node, ok = graph.References[strings.TrimSuffix(filename[0:len(filename)-len(extension)], load.CommandsSuffix)]
+		type_, name = "ref", strings.TrimSuffix(filename[0:len(filename)-len(extension)], load.CommandsSuffix)
+		node, ok = graph.References[name]
 	default:
-		return nil, fmt.Errorf("invalid step filename: %s", filename)
+		return nil, fmt.Errorf("invalid step registry filename: %s", filename)
 	}
 	if !ok {
-		return nil, fmt.Errorf("could not find registry component in registry graph: %s", filename)
+		return nil, fmt.Errorf("could not find registry component in registry graph: %s/%s", type_, name)
 	}
 	return node, nil
 }

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -14,6 +14,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/test-infra/prow/plugins"
+
+	"github.com/openshift/ci-tools/pkg/registry"
 )
 
 func compareChanges(
@@ -107,6 +109,76 @@ git mv renameme/file renamed/file
 		filepath.Join(ClusterProfilesPath, "renamed", "file"),
 	}
 	compareChanges(t, ClusterProfilesPath, files, cmd, GetChangedClusterProfiles, expected)
+}
+
+type testNode struct {
+	string
+}
+
+func (t testNode) Name() string {
+	return t.string
+}
+
+func (t testNode) Type() registry.Type          { return 0 }
+func (t testNode) Ancestors() []registry.Node   { return nil }
+func (t testNode) Descendants() []registry.Node { return nil }
+func (t testNode) Parents() []registry.Node     { return nil }
+func (t testNode) Children() []registry.Node    { return nil }
+
+var _ registry.Node = &testNode{}
+
+func TestGetChangedRegistrySteps(t *testing.T) {
+	files := []string{
+		"ipi/conf/aws/ipi-conf-aws-chain.yaml",
+		"ipi/conf/aws/ipi-conf-aws-ref.yaml",
+		"ipi/conf/aws/ipi-conf-aws-commands.sh",
+		"ipi/conf/aws/ipi-conf-gcp-chain.yaml",
+		"ipi/conf/aws/ipi-conf-gcp-ref.yaml",
+		"ipi/conf/aws/ipi-conf-gcp-commands.sh",
+		"openshift/e2e/test/openshift-e2e-test-ref.yaml",
+		"openshift/e2e/test/openshift-e2e-test-commands.sh",
+		"upi/aws/upi-aws-workflow.yaml",
+		"upi/gcp/upi-gcp-workflow.yaml",
+	}
+	cmd := `
+> ipi/conf/aws/ipi-conf-aws-chain.yaml
+> openshift/e2e/test/openshift-e2e-test-ref.yaml
+> openshift/e2e/test/openshift-e2e-test-commands.sh
+> upi/aws/upi-aws-workflow.yaml
+git add \
+    ipi/conf/aws/ipi-conf-aws-chain.yaml \
+    openshift/e2e/test/openshift-e2e-test-ref.yaml \
+    openshift/e2e/test/openshift-e2e-test-commands.sh \
+    upi/aws/upi-aws-workflow.yaml
+`
+	graph := registry.NodeByName{
+		Chains: map[string]registry.Node{
+			"ipi-conf-aws": &testNode{"chain/ipi-conf-aws"},
+			"ipi-conf-gcp": &testNode{"chain/ipi-conf-gcp"},
+		},
+		References: map[string]registry.Node{
+			"ipi-conf-aws":       &testNode{"ref/ipi-conf-aws"},
+			"ipi-conf-gcp":       &testNode{"ref/ipi-conf-gcp"},
+			"openshift-e2e-test": &testNode{"ref/openshift-e2e-test"},
+		},
+		Workflows: map[string]registry.Node{
+			"upi-aws": &testNode{"workflow/upi-aws"},
+			"upi-gcp": &testNode{"workflow/upi-gcp"},
+		},
+	}
+	f := func(path string, baseRev string) (ret []string, _ error) {
+		nodes, err := GetChangedRegistrySteps(path, baseRev, graph)
+		for _, x := range nodes {
+			ret = append(ret, x.Name())
+		}
+		return ret, err
+	}
+	compareChanges(t, RegistryPath, files, cmd, f, []string{
+		"chain/ipi-conf-aws",
+		"ref/openshift-e2e-test",
+		"ref/openshift-e2e-test",
+		"workflow/upi-aws",
+	})
 }
 
 func TestGetAddedConfigs(t *testing.T) {

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -135,6 +135,8 @@ func TestGetChangedRegistrySteps(t *testing.T) {
 		"ipi/conf/aws/ipi-conf-gcp-chain.yaml",
 		"ipi/conf/aws/ipi-conf-gcp-ref.yaml",
 		"ipi/conf/aws/ipi-conf-gcp-commands.sh",
+		"observer/test/observer-test-observer.yaml",
+		"observer/test/observer-test-commands.sh",
 		"openshift/e2e/test/openshift-e2e-test-ref.yaml",
 		"openshift/e2e/test/openshift-e2e-test-commands.sh",
 		"upi/aws/upi-aws-workflow.yaml",
@@ -142,11 +144,15 @@ func TestGetChangedRegistrySteps(t *testing.T) {
 	}
 	cmd := `
 > ipi/conf/aws/ipi-conf-aws-chain.yaml
+> observer/test/observer-test-observer.yaml
+> observer/test/observer-test-commands.sh
 > openshift/e2e/test/openshift-e2e-test-ref.yaml
 > openshift/e2e/test/openshift-e2e-test-commands.sh
 > upi/aws/upi-aws-workflow.yaml
 git add \
     ipi/conf/aws/ipi-conf-aws-chain.yaml \
+    observer/test/observer-test-observer.yaml \
+    observer/test/observer-test-commands.sh \
     openshift/e2e/test/openshift-e2e-test-ref.yaml \
     openshift/e2e/test/openshift-e2e-test-commands.sh \
     upi/aws/upi-aws-workflow.yaml
@@ -156,9 +162,15 @@ git add \
 			"ipi-conf-aws": &testNode{"chain/ipi-conf-aws"},
 			"ipi-conf-gcp": &testNode{"chain/ipi-conf-gcp"},
 		},
+		// TODO create observer field
+		// Observers: map[string]registry.Node{
+		// 	"observer-test": &testNode{"observer/test"},
+		// },
 		References: map[string]registry.Node{
-			"ipi-conf-aws":       &testNode{"ref/ipi-conf-aws"},
-			"ipi-conf-gcp":       &testNode{"ref/ipi-conf-gcp"},
+			"ipi-conf-aws": &testNode{"ref/ipi-conf-aws"},
+			"ipi-conf-gcp": &testNode{"ref/ipi-conf-gcp"},
+			// TODO create observer field
+			"observer-test":      &testNode{"observer/test"},
 			"openshift-e2e-test": &testNode{"ref/openshift-e2e-test"},
 		},
 		Workflows: map[string]registry.Node{
@@ -175,6 +187,8 @@ git add \
 	}
 	compareChanges(t, RegistryPath, files, cmd, f, []string{
 		"chain/ipi-conf-aws",
+		"observer/test",
+		"observer/test",
 		"ref/openshift-e2e-test",
 		"ref/openshift-e2e-test",
 		"workflow/upi-aws",

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -232,12 +232,12 @@ func hasCycles(node *chainNode, ancestors sets.String, traversedPath []string) e
 // NewGraph returns a NodeByType map representing the provided step references, chains, and workflows as a directed graph.
 func NewGraph(stepsByName ReferenceByName, chainsByName ChainByName, workflowsByName WorkflowByName, observersByName ObserverByName) (NodeByName, error) {
 	nodesByName := NodeByName{
-		References: make(map[string]Node),
-		Chains:     make(map[string]Node),
-		Workflows:  make(map[string]Node),
+		References: make(map[string]Node, len(stepsByName)),
+		Chains:     make(map[string]Node, len(chainsByName)),
+		Workflows:  make(map[string]Node, len(workflowsByName)),
 	}
 	// References can only be children; load them so they can be added as children by workflows and chains
-	referenceNodes := make(referenceNodeByName)
+	referenceNodes := make(referenceNodeByName, len(stepsByName))
 	for name := range stepsByName {
 		node := &referenceNode{
 			nodeWithName:    newNodeWithName(name),
@@ -259,7 +259,7 @@ func NewGraph(stepsByName ReferenceByName, chainsByName ChainByName, workflowsBy
 
 	// since we may load the parent chain before a child chain, we need to make the parent->child links after loading all chains
 	parentChildChain := make(map[*chainNode][]string)
-	chainNodes := make(chainNodeByName)
+	chainNodes := make(chainNodeByName, len(chainsByName))
 	for name, chain := range chainsByName {
 		node := &chainNode{
 			nodeWithName:     newNodeWithName(name),
@@ -294,7 +294,7 @@ func NewGraph(stepsByName ReferenceByName, chainsByName ChainByName, workflowsBy
 			return nodesByName, err
 		}
 	}
-	workflowNodes := make(workflowNodeByName)
+	workflowNodes := make(workflowNodeByName, len(workflowsByName))
 	for name, workflow := range workflowsByName {
 		node := &workflowNode{
 			nodeWithName:     newNodeWithName(name),

--- a/pkg/registry/graph.go
+++ b/pkg/registry/graph.go
@@ -126,7 +126,7 @@ func (n *nodeWithParents) Parents() []Node {
 	return parents
 }
 
-func (*workflowNode) Parents() []Node { return []Node{} }
+func (*workflowNode) Parents() []Node { return nil }
 
 func (n *nodeWithChildren) Children() []Node {
 	var children []Node
@@ -139,7 +139,7 @@ func (n *nodeWithChildren) Children() []Node {
 	return children
 }
 
-func (*referenceNode) Children() []Node { return []Node{} }
+func (*referenceNode) Children() []Node { return nil }
 
 func (n *nodeWithParents) Ancestors() []Node {
 	ancestors := n.Parents()
@@ -149,7 +149,7 @@ func (n *nodeWithParents) Ancestors() []Node {
 	return ancestors
 }
 
-func (*workflowNode) Ancestors() []Node { return []Node{} }
+func (*workflowNode) Ancestors() []Node { return nil }
 
 func (n *nodeWithChildren) Descendants() []Node {
 	descendants := n.Children()
@@ -159,7 +159,7 @@ func (n *nodeWithChildren) Descendants() []Node {
 	return descendants
 }
 
-func (*referenceNode) Descendants() []Node { return []Node{} }
+func (*referenceNode) Descendants() []Node { return nil }
 
 func (n *workflowNode) addChainChild(child *chainNode) {
 	n.chainChildren.insert(child)


### PR DESCRIPTION
This pull request adds tests for the existing implementation of change detection
for registry components.  Perfectly valid infrastructure was already in place
for profile/template/etc. tests (from before that implementation existed), so
this new test is fairly trivial.

37c63e53f tests the old code which detects reference/chain/workflow changes.
Some minor implementation improvements follow, then 3953052d9 extends the test
to also cover the temporary implementation for observer pod introduced in
https://github.com/openshift/ci-tools/pull/3061.

I have a proper graph node type with the correct edges for observers
implemented, but have been wrestling with our `pj-rehearse` integration tests,
so I'm separating this work into its own PR.