### PR TITLE
Rename the cluster label on applyconfig jobs

### DIFF
--- a/cmd/cluster-init/update_jobs.go
+++ b/cmd/cluster-init/update_jobs.go
@@ -41,7 +41,7 @@ func updateJobs(o options) error {
 		metadata.Repo,
 		&config,
 		generator,
-		map[string]string{jobconfig.LabelCluster: o.clusterName})
+		map[string]string{jobconfig.LabelBuildFarm: o.clusterName})
 }
 
 func generatePeriodic(clusterName string) prowconfig.Periodic {
@@ -69,8 +69,8 @@ func generatePeriodic(clusterName string) prowconfig.Periodic {
 				}},
 			},
 			Labels: map[string]string{
-				labelRole:              jobRoleInfra,
-				jobconfig.LabelCluster: clusterName,
+				labelRole:                jobRoleInfra,
+				jobconfig.LabelBuildFarm: clusterName,
 			},
 		},
 		Interval: "12h",
@@ -95,8 +95,8 @@ func generatePostsubmit(clusterName string) prowconfig.Postsubmit {
 			},
 			MaxConcurrency: 1,
 			Labels: map[string]string{
-				labelRole:              jobRoleInfra,
-				jobconfig.LabelCluster: clusterName,
+				labelRole:                jobRoleInfra,
+				jobconfig.LabelBuildFarm: clusterName,
 			},
 		},
 		Brancher: prowconfig.Brancher{
@@ -134,7 +134,7 @@ func generatePresubmit(clusterName string) prowconfig.Presubmit {
 			UtilityConfig: prowconfig.UtilityConfig{Decorate: utilpointer.BoolPtr(true)},
 			Labels: map[string]string{
 				jobconfig.CanBeRehearsedLabel: "true",
-				jobconfig.LabelCluster:        clusterName,
+				jobconfig.LabelBuildFarm:      clusterName,
 			},
 		},
 		AlwaysRun:    false,

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -33,7 +33,7 @@ const (
 	SSHBastionLabel              = "dptp.openshift.io/ssh-bastion"
 	ProwJobLabelVariant          = "ci-operator.openshift.io/variant"
 	ReleaseControllerLabel       = "ci-operator.openshift.io/release-controller"
-	LabelCluster                 = "ci.openshift.io/cluster"
+	LabelBuildFarm               = "ci.openshift.io/build-farm"
 	LabelGenerator               = "ci.openshift.io/generator"
 	ReleaseControllerValue       = "true"
 	JobReleaseKey                = "job-release"

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -941,10 +941,10 @@ func TestPrune(t *testing.T) {
 			jobconfig: &prowconfig.JobConfig{
 				Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{
 					Name:   "job",
-					Labels: map[string]string{LabelCluster: "existingCluster", LabelGenerator: "cluster-init"}}}},
+					Labels: map[string]string{LabelBuildFarm: "existingCluster", LabelGenerator: "cluster-init"}}}},
 			},
 			Generator:      "cluster-init",
-			pruneLabels:    map[string]string{LabelCluster: "existingCluster"},
+			pruneLabels:    map[string]string{LabelBuildFarm: "existingCluster"},
 			expectedConfig: &prowconfig.JobConfig{},
 		},
 		{
@@ -952,14 +952,14 @@ func TestPrune(t *testing.T) {
 			jobconfig: &prowconfig.JobConfig{
 				Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{
 					Name:   "job",
-					Labels: map[string]string{LabelCluster: "existingCluster", LabelGenerator: "cluster-init"}}}},
+					Labels: map[string]string{LabelBuildFarm: "existingCluster", LabelGenerator: "cluster-init"}}}},
 			},
 			Generator:   "cluster-init",
-			pruneLabels: map[string]string{LabelCluster: "newCluster"},
+			pruneLabels: map[string]string{LabelBuildFarm: "newCluster"},
 			expectedConfig: &prowconfig.JobConfig{
 				Periodics: []prowconfig.Periodic{{JobBase: prowconfig.JobBase{
 					Name:   "job",
-					Labels: map[string]string{LabelCluster: "existingCluster", LabelGenerator: "cluster-init"}}}},
+					Labels: map[string]string{LabelBuildFarm: "existingCluster", LabelGenerator: "cluster-init"}}}},
 			},
 		},
 	}
@@ -1049,16 +1049,16 @@ func TestStaleSelectorFor(t *testing.T) {
 		},
 		{
 			description: "job with existing cluster label is not stale",
-			labels:      map[string]string{LabelGenerator: "cluster-init", LabelCluster: "existingCluster"},
+			labels:      map[string]string{LabelGenerator: "cluster-init", LabelBuildFarm: "existingCluster"},
 			generator:   "cluster-init",
-			pruneLabels: map[string]string{LabelCluster: "newCluster"},
+			pruneLabels: map[string]string{LabelBuildFarm: "newCluster"},
 			expected:    false,
 		},
 		{
 			description: "job with passed in cluster label is stale",
-			labels:      map[string]string{LabelGenerator: "cluster-init", LabelCluster: "newCluster"},
+			labels:      map[string]string{LabelGenerator: "cluster-init", LabelBuildFarm: "newCluster"},
 			generator:   "cluster-init",
-			pruneLabels: map[string]string{LabelCluster: "newCluster"},
+			pruneLabels: map[string]string{LabelBuildFarm: "newCluster"},
 			expected:    true,
 		},
 	}

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
@@ -47,7 +47,7 @@ periodics:
     repo: release
   interval: 12h
   labels:
-    ci.openshift.io/cluster: newCluster
+    ci.openshift.io/build-farm: newCluster
     ci.openshift.io/generator: cluster-init
     ci.openshift.io/role: infra
   name: periodic-openshift-release-master-newCluster-apply

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
@@ -42,7 +42,7 @@ postsubmits:
     cluster: app.ci
     decorate: true
     labels:
-      ci.openshift.io/cluster: newCluster
+      ci.openshift.io/build-farm: newCluster
       ci.openshift.io/generator: cluster-init
       ci.openshift.io/role: infra
     max_concurrency: 1

--- a/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/create/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -71,7 +71,7 @@ presubmits:
     context: ci/build-farm/newCluster-dry
     decorate: true
     labels:
-      ci.openshift.io/cluster: newCluster
+      ci.openshift.io/build-farm: newCluster
       ci.openshift.io/generator: cluster-init
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-release-master-newCluster-dry

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
@@ -47,7 +47,7 @@ periodics:
     repo: release
   interval: 12h
   labels:
-    ci.openshift.io/cluster: existingCluster
+    ci.openshift.io/build-farm: existingCluster
     ci.openshift.io/generator: cluster-init
     ci.openshift.io/role: infra
   name: periodic-openshift-release-master-existingCluster-apply

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
     cluster: app.ci
     decorate: true
     labels:
-      ci.openshift.io/cluster: existingCluster
+      ci.openshift.io/build-farm: existingCluster
       ci.openshift.io/generator: cluster-init
       ci.openshift.io/role: infra
     max_concurrency: 1

--- a/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/update/expected/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     context: ci/build-farm/existingCluster-dry
     decorate: true
     labels:
-      ci.openshift.io/cluster: existingCluster
+      ci.openshift.io/build-farm: existingCluster
       ci.openshift.io/generator: cluster-init
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-openshift-release-master-existingCluster-dry

--- a/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
+++ b/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml
@@ -47,7 +47,7 @@ periodics:
       repo: release
   interval: 12h
   labels:
-    ci.openshift.io/cluster: existingCluster
+    ci.openshift.io/build-farm: existingCluster
     ci.openshift.io/generator: cluster-init
     ci.openshift.io/role: infra
   name: periodic-openshift-release-master-existing-cluster-apply

--- a/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
+++ b/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-postsubmits.yaml
@@ -6,7 +6,7 @@ postsubmits:
       cluster: app.ci
       decorate: true
       labels:
-        ci.openshift.io/cluster: existingCluster
+        ci.openshift.io/build-farm: existingCluster
         ci.openshift.io/generator: cluster-init
         ci.openshift.io/role: infra
       max_concurrency: 1

--- a/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
+++ b/test/integration/cluster-init/update/input/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
       context: ci/build-farm/existingCluster-dry
       decorate: true
       labels:
-        ci.openshift.io/cluster: existingCluster
+        ci.openshift.io/build-farm: existingCluster
         ci.openshift.io/generator: cluster-init
         pj-rehearse.openshift.io/can-be-rehearsed: "true"
       name: pull-ci-openshift-release-master-existingCluster-dry


### PR DESCRIPTION
This PR will rename the label such as `ci.openshift.io/cluster: build01` on the `applyconfig` jobs.
E.g., https://github.com/openshift/release/blob/3ac02be7013dee4f368683dc1cd61763df9efef3/ci-operator/jobs/openshift/release/openshift-release-master-presubmits.yaml#L278

`ci.openshift.io/generator: cluster-init` should be enough to show the job is managed/generated.

`ci.openshift.io/cluster: build01` could be easily interpreted as the job runs on `build01` but it actually on `app.ci`.
The label `ci-operator.openshift.io/cluster: build01` is for that purpose.
We rename the former for reducing the confusion.

/hold

Need to fix the breaking.