### PR TITLE
Observer Pods: pod timeout increased to 24h

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -40,6 +41,7 @@ func (s *multiStageTestStep) generateObservers(
 			FromImage: observer.FromImage,
 			Commands:  observer.Commands,
 			Resources: observer.Resources,
+			Timeout:   &prowapi.Duration{Duration: 24 * time.Hour},
 		})
 	}
 	pods, _, err := s.generatePods(adapted, nil, secretVolumes, secretVolumeMounts, genPodOpts)


### PR DESCRIPTION
Observer pods timeout is set to `2h` by default but some of our users just need an higher value.
The observer lifecycle is already well established as it gets killed right after the last test step of the `post:` chain completes.
This lead us to the conclusion not to let the users specify a `timeout` configuration like it is for tests, but instead we are going to increase it to a "reasonably high enough" value after which, we hope, no test will ever reach.

/cc @jmguzik @bbguimaraes 