### PR TITLE
`pj-rehearse`: don't validate or rehearse when all jobs have been filtered out

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -156,16 +156,18 @@ func rehearseMain() error {
 		return fmt.Errorf("error setting up jobs: %w: %s", err, failedSetupOutput)
 	}
 
-	if err := prConfig.Prow.ValidateJobConfig(); err != nil {
-		return fmt.Errorf("%s: %w", jobValidationOutput, err)
-	}
+	if len(presubmitsToRehearse) > 0 {
+		if err := prConfig.Prow.ValidateJobConfig(); err != nil {
+			return fmt.Errorf("%s: %w", jobValidationOutput, err)
+		}
 
-	jobsTriggered, err := rc.RehearseJobs(candidate, o.releaseRepoPath, prConfig, prRefs, imageStreamTags, presubmitsToRehearse, changedTemplates, changedClusterProfiles, loggers)
-	if err != nil {
-		if jobsTriggered {
-			return fmt.Errorf(jobsFailureOutput)
-		} else {
-			return fmt.Errorf(rehearseFailureOutput)
+		jobsTriggered, err := rc.RehearseJobs(candidate, o.releaseRepoPath, prConfig, prRefs, imageStreamTags, presubmitsToRehearse, changedTemplates, changedClusterProfiles, loggers)
+		if err != nil {
+			if jobsTriggered {
+				return fmt.Errorf(jobsFailureOutput)
+			} else {
+				return fmt.Errorf(rehearseFailureOutput)
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow up to: https://github.com/openshift/ci-tools/pull/3074. We exited from the `setupJobs` function, but the whole process needs to end in this case. See example [log](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/33169/pull-ci-openshift-release-master-pj-rehearse/1582007145447034880) where it still fails.