### PR TITLE
Only include disruption NURPs if we have 100 rows.

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -10,6 +10,7 @@ type HistoricalData interface {
 	GetP99() string
 	GetP95() string
 	GetKey() string
+	GetJobRuns() int
 }
 
 type HistoricalJobData struct {
@@ -26,8 +27,9 @@ type HistoricalJobData struct {
 type AlertHistoricalDataRow struct {
 	AlertName string
 	HistoricalJobData
-	P95 string
-	P99 string
+	P95     string
+	P99     string
+	JobRuns int
 }
 
 func (a *AlertHistoricalDataRow) GetJobData() HistoricalJobData {
@@ -41,6 +43,9 @@ func (a *AlertHistoricalDataRow) GetP99() string {
 }
 func (a *AlertHistoricalDataRow) GetP95() string {
 	return a.P95
+}
+func (a *AlertHistoricalDataRow) GetJobRuns() int {
+	return a.JobRuns
 }
 func (a *AlertHistoricalDataRow) GetKey() string {
 	return fmt.Sprintf("%s_%s_%s_%s_%s_%s_%s",
@@ -72,6 +77,9 @@ func (a *DisruptionHistoricalDataRow) GetP99() string {
 }
 func (a *DisruptionHistoricalDataRow) GetP95() string {
 	return a.P95
+}
+func (a *DisruptionHistoricalDataRow) GetJobRuns() int {
+	return a.JobRuns
 }
 func (a *DisruptionHistoricalDataRow) GetKey() string {
 	return fmt.Sprintf("%s_%s_%s_%s_%s_%s_%s",

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -19,6 +19,8 @@ type HistoricalJobData struct {
 	Architecture string
 	Network      string
 	Topology     string
+	// JobRuns is the number of job runs that were included when we queried the historical data.
+	JobRuns int
 }
 
 type AlertHistoricalDataRow struct {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -92,39 +92,47 @@ func NewCIDataClient(dataCoordinates BigQueryDataCoordinates, client *bigquery.C
 }
 
 func (c *ciDataClient) ListDisruptionHistoricalData(ctx context.Context) ([]jobrunaggregatorapi.HistoricalData, error) {
+	// We attempt to only fail tests when results are worse than a P99, thus only consider NURPs where
+	// we have at least 100 runs. Sort for consistent ordering to help us see changes in diffs in the pr
+	// which updates the static files in origin.
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(`
-    SELECT
-    BackendName,
-    Release,
-    FromRelease,
-    Platform,
-    Architecture,
-    Network,
-    Topology,
-    IFNULL(SAFE_CAST(ANY_VALUE(P95) AS STRING), "0.0") AS P95,
-    IFNULL(SAFE_CAST(ANY_VALUE(P99) AS STRING), "0.0") AS P99,
-    FROM (
-        SELECT
-            Jobs.Release,
-            Jobs.FromRelease,
-            Jobs.Platform,
-            Jobs.Architecture,
-            Jobs.Network,
-            Jobs.Topology,
-            BackendName,
-            PERCENTILE_CONT(BackendDisruption.DisruptionSeconds, 0.95) OVER(PARTITION BY BackendDisruption.BackendName, Jobs.Network, Jobs.Platform, Jobs.Release, Jobs.FromRelease, Jobs.Topology) AS P95,
-            PERCENTILE_CONT(BackendDisruption.DisruptionSeconds, 0.99) OVER(PARTITION BY BackendDisruption.BackendName, Jobs.Network, Jobs.Platform, Jobs.Release, Jobs.FromRelease, Jobs.Topology) AS P99,
-        FROM
-            DATA_SET_LOCATION.BackendDisruption as BackendDisruption
-        INNER JOIN
-            DATA_SET_LOCATION.BackendDisruption_JobRuns as JobRuns on JobRuns.Name = BackendDisruption.JobRunName
-        INNER JOIN
-            DATA_SET_LOCATION.Jobs as Jobs on Jobs.JobName = JobRuns.JobName
-        WHERE
-            JobRuns.StartTime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 21 DAY)
-    )
-    GROUP BY
-        BackendName, Release, FromRelease, Platform, Architecture, Network, Topology
+	SELECT * FROM (
+		SELECT
+		COUNT(*) AS JobRuns,
+		BackendName,
+		Release,
+		FromRelease,
+		Platform,
+		Architecture,
+		Network,
+		Topology,
+		IFNULL(SAFE_CAST(ANY_VALUE(P95) AS STRING), "0.0") AS P95,
+		IFNULL(SAFE_CAST(ANY_VALUE(P99) AS STRING), "0.0") AS P99
+		FROM (
+			SELECT
+				Jobs.Release,
+				Jobs.FromRelease,
+				Jobs.Platform,
+				Jobs.Architecture,
+				Jobs.Network,
+				Jobs.Topology,
+				BackendName,
+				PERCENTILE_CONT(BackendDisruption.DisruptionSeconds, 0.95) OVER(PARTITION BY BackendDisruption.BackendName, Jobs.Network, Jobs.Platform, Jobs.Release, Jobs.FromRelease, Jobs.Topology) AS P95,
+				PERCENTILE_CONT(BackendDisruption.DisruptionSeconds, 0.99) OVER(PARTITION BY BackendDisruption.BackendName, Jobs.Network, Jobs.Platform, Jobs.Release, Jobs.FromRelease, Jobs.Topology) AS P99,
+			FROM
+				DATA_SET_LOCATION.BackendDisruption as BackendDisruption
+			INNER JOIN
+				DATA_SET_LOCATION.BackendDisruption_JobRuns as JobRuns on JobRuns.Name = BackendDisruption.JobRunName
+			INNER JOIN
+				DATA_SET_LOCATION.Jobs as Jobs on Jobs.JobName = JobRuns.JobName
+			WHERE
+				JobRuns.StartTime > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 21 DAY)
+		)
+		GROUP BY
+			BackendName, Release, FromRelease, Platform, Architecture, Network, Topology
+	)
+	WHERE JobRuns >= 100
+	ORDER BY Release, FromRelease, Platform, Architecture, Network, Topology, BackendName
     `)
 	query := c.client.Query(queryString)
 	disruptionRow, err := query.Read(ctx)

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
@@ -121,6 +121,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) compareAndUpdate(newData, currentD
 			d.HistoricalData = new
 			d.DurationP99 = newP99
 			d.DurationP95 = newP95
+			d.JobResults = new.GetJobRuns()
 
 			timeDiff := newP99 - oldP99
 			percentDiff := 0.0

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
@@ -16,6 +16,7 @@ type parsedJobData struct {
 	PrevP99                            time.Duration `json:"-"`
 	DurationP95                        time.Duration `json:"-"`
 	DurationP99                        time.Duration `json:"-"`
+	JobResults                         int           `json:"-"`
 	jobrunaggregatorapi.HistoricalData `json:",inline"`
 }
 

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
@@ -128,14 +128,14 @@ func formatTableOutput(data []parsedJobData, filter bool) string {
 		return data[i].TimeDiff > data[j].TimeDiff
 	})
 	var buffer bytes.Buffer
-	buffer.WriteString("| Name | Release | From | Arch | Network | Platform | Topology | Prev P99 | P99 | Time Increase | Percent Increase |\n")
-	buffer.WriteString("| ---- | ------- | ---- | ---- | ------- | -------- |--------- | -------- | --- | ------------- | ---------------- |\n")
+	buffer.WriteString("| Name | Release | From | Arch | Network | Platform | Topology | Prev P99 | P99 | Job Results | Time Increase | Percent Increase |\n")
+	buffer.WriteString("| ---- | ------- | ---- | ---- | ------- | -------- |--------- | -------- | --- | ----------- | ------------- | ---------------- |\n")
 	for _, d := range data {
 		if d.TimeDiff == 0 && filter {
 			continue
 		}
 		buffer.WriteString(
-			fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %.2f%% |\n",
+			fmt.Sprintf("| %s | %s | %s | %s | %s | %s | %s | %s | %s | %d| %s | %.2f%% |\n",
 				d.GetName(),
 				d.GetJobData().Release,
 				d.GetJobData().FromRelease,
@@ -145,6 +145,7 @@ func formatTableOutput(data []parsedJobData, filter bool) string {
 				d.GetJobData().Topology,
 				d.PrevP99,
 				d.DurationP99,
+				d.JobResults,
 				d.TimeDiff,
 				d.PercentTimeDiff,
 			),


### PR DESCRIPTION
We fail tests if you're over the P99 value, but it turns out the
majority of our platforms we were enforcing on do not have 100 results
per 3 weeks, so we weren't really getting P99s and thus could fail quite
often for some.

Update the query to include the count of JobRuns, and exclude if there's less
than 100.

Also added sorting so the file stays in a consistent order, which will
help us decipher diffs when they land in origin.

[TRT-583](https://issues.redhat.com//browse/TRT-583)
