### PR TITLE
`pj-rehearse`: fix incorrect ref issues with plugin

### DIFF
--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -89,13 +89,13 @@ func RehearsalCandidateFromJobSpec(jobSpec *pjdwapi.JobSpec) RehearsalCandidate 
 	}
 }
 
-func RehearsalCandidateFromPullRequest(pullRequest github.PullRequest) RehearsalCandidate {
+func RehearsalCandidateFromPullRequest(pullRequest github.PullRequest, baseSHA string) RehearsalCandidate {
 	repo := pullRequest.Head.Repo
 	return RehearsalCandidate{
-		org:  repo.Owner.Login,
+		org:  pullRequest.Base.Repo.Owner.Login,
 		repo: repo.Name,
 		base: ref{
-			sha: pullRequest.Base.SHA,
+			sha: baseSHA,
 			ref: pullRequest.Base.Ref,
 		},
 		head: ref{


### PR DESCRIPTION
I found a couple of issues related to the refs when testing out the new plugin:

1. Many modified jobs are found that weren't actually present in the PR. This is due to simply using the base SHA from the `PullRequest` rather than determining the SHA for the current head. See [example comment on test PR](https://github.com/openshift/release/pull/33262#issuecomment-1284368180).
2. Triggered rehearsal jobs don't contain the proper org in the `refs`. They currently have the `org` set to that of the fork. I didn't notice this with initial testing as I was testing it in my fork. We need to use the Base org instead.