### PR TITLE
fix logging when promoting images for different architectures

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -41,9 +41,9 @@ type promotionStep struct {
 
 func targetName(config api.PromotionConfiguration) string {
 	if len(config.Name) > 0 {
-		return fmt.Sprintf("%s/%s:${component}", config.Namespace, config.Name)
+		return fmt.Sprintf("%s/%s:${component}", api.ResolveMultiArchNamespaceFor(config.Namespace), config.Name)
 	}
-	return fmt.Sprintf("%s/${component}:%s", config.Namespace, config.Tag)
+	return fmt.Sprintf("%s/${component}:%s", api.ResolveMultiArchNamespaceFor(config.Namespace), config.Tag)
 }
 
 func (s *promotionStep) Inputs() (api.InputDefinition, error) {


### PR DESCRIPTION
This PR fixes the logging only when promoting the tags built for a different architecture.
Example: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-images-arm64/1582469276256702464#1:build-log.txt%3A243


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>