### PR TITLE
[OKD/SCOS] Adding okd-scos as a ReleaseStream for the OKD ReleaseProduct

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -332,6 +332,7 @@ const (
 	ReleaseStreamCI      ReleaseStream = "ci"
 	ReleaseStreamNightly ReleaseStream = "nightly"
 	ReleaseStreamOKD     ReleaseStream = "okd"
+	ReleaseStreamOKDScos ReleaseStream = "okd-scos"
 )
 
 // Release describes a generally available release payload

--- a/pkg/validation/release.go
+++ b/pkg/validation/release.go
@@ -91,7 +91,8 @@ func validateCandidate(fieldRoot string, candidate api.Candidate) []error {
 	}
 
 	streamsByProduct := map[api.ReleaseProduct]sets.String{
-		api.ReleaseProductOKD: sets.NewString("", string(api.ReleaseStreamOKD)), // we allow unset and will default it
+		api.ReleaseProductOKD: sets.NewString("", string(api.ReleaseStreamOKD),
+			string(api.ReleaseStreamOKDScos)), // we allow unset and will default it
 		api.ReleaseProductOCP: sets.NewString(string(api.ReleaseStreamCI), string(api.ReleaseStreamNightly)),
 	}
 	if !streamsByProduct[candidate.Product].Has(string(candidate.Stream)) {

--- a/pkg/validation/release_test.go
+++ b/pkg/validation/release_test.go
@@ -269,7 +269,7 @@ func TestValidateCandidate(t *testing.T) {
 				Version:      "4.4",
 			},
 			output: []error{
-				errors.New("root.stream: must be one of , okd"),
+				errors.New("root.stream: must be one of , okd, okd-scos"),
 			},
 		},
 		{


### PR DESCRIPTION
This PR fixes the consumers of the ReleaseProduct and ReleaseStream APIs that will try validating the new OKD's `okd-scos` ReleaseStream name. 

I tested `ci-operator-checkconfig`, `ci-operator,prowgen`, `the determinize-ci-operator` locally against the changes at [openshift/openshift-release#33320](https://github.com/openshift/release/pull/33320)

/cc @LorbusChris @vrutkovs

I'm not 100% sure this is enough for the jobs at the PR above to start passing and the rehearsals to be triggered.
