### PR TITLE
`pj-rehearse`: plugin: rebase the branch onto the current master

### DIFF
--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -89,7 +89,7 @@ func RehearsalCandidateFromJobSpec(jobSpec *pjdwapi.JobSpec) RehearsalCandidate 
 	}
 }
 
-func RehearsalCandidateFromPullRequest(pullRequest github.PullRequest, baseSHA string) RehearsalCandidate {
+func RehearsalCandidateFromPullRequest(pullRequest *github.PullRequest, baseSHA string) RehearsalCandidate {
 	repo := pullRequest.Head.Repo
 	return RehearsalCandidate{
 		org:  pullRequest.Base.Repo.Owner.Login,
@@ -121,7 +121,6 @@ func (rc RehearsalCandidate) createRefs() *pjapi.Refs {
 				Author: rc.author,
 				SHA:    rc.head.sha,
 				Title:  rc.title,
-				Ref:    rc.head.ref,
 				Link:   rc.link,
 			},
 		},


### PR DESCRIPTION
Follows up on: https://github.com/openshift/ci-tools/pull/3101.
Unfortunately, even when the correct `SHA` was used for determining the changes we still got a bunch of changes that were made in between the HEAD and the BASE.

In order to solve this we simply need to rebase the PR branch onto the current head. This will apply cleanly in the case that a manual rebase is not needed, and if that is needed we don't want to run rehearsals anyways. We don't push the rebase, so it is only present in our local git checkout.

I also needed to remove the `head` ref from the prow job `refs` in order for the rehearsal jobs to initialize. This is not something that the original `pj-rehearse` was setting, so no need to set it with the plugin.

/cc @droslean @openshift/test-platform 