### PR TITLE
Create a dedicated aws cluster profile for cspi qe

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1417,7 +1417,6 @@ func (p ClusterProfile) LeaseType() string {
 		ClusterProfileAWSAtomic,
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
-		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSGluster:
 		return "aws-quota-slice"
 	case ClusterProfileAWSArm64:
@@ -1430,6 +1429,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-c2s-qe-quota-slice"
 	case ClusterProfileAWSChinaQE:
 		return "aws-china-qe-quota-slice"
+	case ClusterProfileAWSCSPIQE:
+		return "aws-cspi-qe-quota-slice"
 	case ClusterProfileAWSGovCloudQE:
 		return "aws-usgov-qe-quota-slice"
 	case ClusterProfileAWSSC2SQE:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1136,6 +1136,7 @@ const (
 	ClusterProfileAWSAtomic             ClusterProfile = "aws-atomic"
 	ClusterProfileAWSCentos             ClusterProfile = "aws-centos"
 	ClusterProfileAWSCentos40           ClusterProfile = "aws-centos-40"
+	ClusterProfileAWSCSPIQE             ClusterProfile = "aws-cspi-qe"
 	ClusterProfileAWSQE                 ClusterProfile = "aws-qe"
 	ClusterProfileAWSC2SQE              ClusterProfile = "aws-c2s-qe"
 	ClusterProfileAWSChinaQE            ClusterProfile = "aws-china-qe"
@@ -1216,6 +1217,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
+		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSChinaQE,
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSGovCloudQE,
@@ -1288,6 +1290,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSAtomic,
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
+		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWS2,
@@ -1414,6 +1417,7 @@ func (p ClusterProfile) LeaseType() string {
 		ClusterProfileAWSAtomic,
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
+		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSGluster:
 		return "aws-quota-slice"
 	case ClusterProfileAWSArm64:


### PR DESCRIPTION
The cloud services and platform integration team requires a dedicated cluster profile for spinning up openshift clusters using our aws account. Profile will be used for interoperability testing of products on openshift.