### PR TITLE
serviceaccount_secret_refresher: stop handling SA's token secrets

### DIFF
--- a/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher.go
+++ b/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher.go
@@ -135,6 +135,11 @@ func (r *reconciler) reconcile(ctx context.Context, l *logrus.Entry, req reconci
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if secret should be kept: %w", err)
 		}
+		if secret.Type == corev1.SecretTypeServiceAccountToken {
+			// This controller does not rotate token secrets
+			tokenSecretsToKeep = append(tokenSecretsToKeep, tokenSecretRef)
+			continue
+		}
 		if deleteObjectIn := objectExpiredIn(l, secret, thirtyDays); deleteObjectIn != 0 {
 			tokenSecretsToKeep = append(tokenSecretsToKeep, tokenSecretRef)
 			if requeueAfter == 0 || deleteObjectIn < requeueAfter {
@@ -145,10 +150,10 @@ func (r *reconciler) reconcile(ctx context.Context, l *logrus.Entry, req reconci
 		l.Info("Not keeping token secret")
 	}
 
-	dockerSecretDiffCount, tokenSecretDiffCount := len(imagePullSecretsToKeep)-len(sa.ImagePullSecrets), len(tokenSecretsToKeep)-len(sa.Secrets)
+	dockerSecretDiffCount := len(imagePullSecretsToKeep) - len(sa.ImagePullSecrets)
 
-	if dockerSecretDiffCount != 0 || tokenSecretDiffCount != 0 {
-		l.WithField("docker_secret_diff_count", dockerSecretDiffCount).WithField("token_secret_diff_count", tokenSecretDiffCount).Info("Updating ServiceAccount")
+	if dockerSecretDiffCount != 0 {
+		l.WithField("docker_secret_diff_count", dockerSecretDiffCount).Info("Updating ServiceAccount")
 		sa.ImagePullSecrets = imagePullSecretsToKeep
 		sa.Secrets = tokenSecretsToKeep
 		if err := r.client.Update(ctx, sa); err != nil {
@@ -160,10 +165,10 @@ func (r *reconciler) reconcile(ctx context.Context, l *logrus.Entry, req reconci
 		if err := r.client.Get(ctx, req.NamespacedName, sa); err != nil {
 			return false, err
 		}
-		// Secrets includes the pull secret, hence the >= 2 instead of >=1
-		return len(sa.ImagePullSecrets) >= 1 && len(sa.Secrets) >= 2, nil
+		// Secrets include the pull secrets
+		return len(sa.ImagePullSecrets) >= 1 && len(sa.Secrets) >= 1, nil
 	}); err != nil {
-		return nil, fmt.Errorf("failed to wait for ServiceAccount to have a pull and a tokenSecret: %w", err)
+		return nil, fmt.Errorf("failed to wait for ServiceAccount to have a pull secret: %w", err)
 	}
 
 	if !r.removeOldSecrets {

--- a/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher_test.go
+++ b/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher_test.go
@@ -46,9 +46,9 @@ func TestReconcile(t *testing.T) {
 			},
 			removeOldSecrets:           true,
 			expectedNumImagePullSecret: 1,
-			expectedNumTokenSecret:     1,
+			expectedNumTokenSecret:     0,
 			expectedPullSecretName:     "new-pull-secret",
-			expectedTokenSecretName:    "new-token-secret",
+			expectedTokenSecretName:    "token-secret",
 		},
 		{
 			name: "secrets are rotated but not old enough to be cleaned",
@@ -65,9 +65,9 @@ func TestReconcile(t *testing.T) {
 			},
 			removeOldSecrets:           true,
 			expectedNumImagePullSecret: 2,
-			expectedNumTokenSecret:     2,
+			expectedNumTokenSecret:     1,
 			expectedPullSecretName:     "new-pull-secret",
-			expectedTokenSecretName:    "new-token-secret",
+			expectedTokenSecretName:    "token-secret",
 			expectedRequeAfterHours:    23,
 		},
 		{
@@ -79,9 +79,9 @@ func TestReconcile(t *testing.T) {
 			},
 			removeOldSecrets:           false,
 			expectedNumImagePullSecret: 2,
-			expectedNumTokenSecret:     2,
+			expectedNumTokenSecret:     1,
 			expectedPullSecretName:     "new-pull-secret",
-			expectedTokenSecretName:    "new-token-secret",
+			expectedTokenSecretName:    "token-secret",
 		},
 		{
 			name: "secrets are up to date, reconcileAfter is returned",
@@ -134,9 +134,9 @@ func TestReconcile(t *testing.T) {
 			},
 			removeOldSecrets:           true,
 			expectedNumImagePullSecret: 1,
-			expectedNumTokenSecret:     1,
+			expectedNumTokenSecret:     0,
 			expectedPullSecretName:     "new-pull-secret",
-			expectedTokenSecretName:    "new-token-secret",
+			expectedTokenSecretName:    "token-secret",
 		},
 	}
 


### PR DESCRIPTION
To follow up https://coreos.slack.com/archives/GB7NB0CUC/p1665415175612979

```
{
	"cluster": "build01",
	"component": "dptp-controller-manager",
	"controller": "serviceaccount_secret_refresher",
	"error": "failed to wait for ServiceAccount to have a pull and a tokenSecret: timed out waiting for the condition",
	"file": "/go/src/github.com/openshift/ci-tools/pkg/controller/serviceaccount_secret_refresher/serviceaccount_secret_refresher.go:87",
	"func": "github.com/openshift/ci-tools/pkg/controller/serviceaccount_secret_refresher.(*reconciler).Reconcile",
	"kubernetes": {
		"container_id": "cri-o://15a1d90a1b6f0702fbdd273f277f504b3b7b9bcab0380c6e204aef709889aa14",
		"container_image": "image-registry.openshift-image-registry.svc:5000/ci/dptp-controller-manager@sha256:e3d4861b7782ef92405195e223425953479974eaa15c7e353f4e4f8a0339feb6",
		"container_name": "dptp-controller-manager",
		"namespace_labels": {
			"ci.openshift.io/scale-pods": "true",
			"kubernetes.io/metadata.name": "ci",
			"name": "ci",
			"pod-security.kubernetes.io/audit": "privileged",
			"pod-security.kubernetes.io/audit-version": "v1.24",
			"pod-security.kubernetes.io/warn": "privileged",
			"pod-security.kubernetes.io/warn-version": "v1.24"
		},
		"pod_annotations": {
			"k8s.v1.cni.cncf.io/network-status": "[{\n \"name\": \"openshift-sdn\",\n \"interface\": \"eth0\",\n \"ips\": [\n \"10.128.45.198\"\n ],\n \"default\": true,\n \"dns\": {}\n}]",
			"k8s.v1.cni.cncf.io/networks-status": "[{\n \"name\": \"openshift-sdn\",\n \"interface\": \"eth0\",\n \"ips\": [\n \"10.128.45.198\"\n ],\n \"default\": true,\n \"dns\": {}\n}]",
			"openshift.io/scc": "restricted-v2",
			"seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
		},
		"pod_ip": "10.128.45.198",
		"pod_ips": ["10.128.45.198"],
		"pod_labels": {
			"app": "dptp-controller-manager",
			"pod-template-hash": "6d567f54d5"
		},
		"pod_name": "dptp-controller-manager-6d567f54d5-cdbfk",
		"pod_namespace": "ci",
		"pod_node_name": "ip-10-0-130-237.ec2.internal",
		"pod_owner": "ReplicaSet/dptp-controller-manager-6d567f54d5",
		"pod_uid": "7298c115-1a29-4fe7-8e1d-9c3235ec65e0"
	},
	"level": "error",
	"msg": "Reconciliation failed",
	"request": "ci/plank",
	"severity": "error",
	"source_type": "kubernetes_logs",
	"stream": "stderr",
	"time": "2022-10-10T15:18:22Z"
}
```

Starting 4.11, k8s (token controller) does not generate Token secrets for service accounts.

https://issues.redhat.com/browse/DPTP-3001

/cc @openshift/test-platform 
