### PR TITLE
`slack-bot`: post job links for storage.googleapis.com links

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -16,6 +16,7 @@ const (
 	// routed for the current service cluster.
 	ServiceDomainCI    = "ci.openshift.org"
 	ServiceDomainAPPCI = "apps.ci.l2s4.p1.openshiftapps.com"
+	ServiceDomainGCS   = "googleapis.com"
 
 	ServiceDomainAPPCIRegistry   = "registry.ci.openshift.org"
 	ServiceDomainVSphereRegistry = "registry.apps.build01-us-west-2.vmc.ci.openshift.org"
@@ -25,12 +26,13 @@ const (
 type Service string
 
 const (
-	ServiceBoskos   Service = "boskos-ci"
-	ServiceRegistry Service = "registry"
-	ServiceRPMs     Service = "artifacts-rpms-openshift-origin-ci-rpms"
-	ServiceProw     Service = "prow"
-	ServiceConfig   Service = "config"
-	ServiceGCSWeb   Service = "gcsweb-ci"
+	ServiceBoskos     Service = "boskos-ci"
+	ServiceRegistry   Service = "registry"
+	ServiceRPMs       Service = "artifacts-rpms-openshift-origin-ci-rpms"
+	ServiceProw       Service = "prow"
+	ServiceConfig     Service = "config"
+	ServiceGCSWeb     Service = "gcsweb-ci"
+	ServiceGCSStorage Service = "storage"
 )
 
 // URLForService returns the URL for the service including scheme
@@ -46,6 +48,8 @@ func DomainForService(service Service) string {
 		serviceDomain = ServiceDomainAPPCI
 	case ServiceRPMs:
 		serviceDomain = ServiceDomainAPPCI
+	case ServiceGCSStorage:
+		serviceDomain = ServiceDomainGCS
 	default:
 		serviceDomain = ServiceDomainCI
 	}

--- a/pkg/api/domain_test.go
+++ b/pkg/api/domain_test.go
@@ -35,6 +35,10 @@ func TestDomainForService(t *testing.T) {
 			service:  ServiceConfig,
 			expected: "config.ci.openshift.org",
 		},
+		{
+			service:  ServiceGCSStorage,
+			expected: "storage.googleapis.com",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/slack/events/joblink/link.go
+++ b/pkg/slack/events/joblink/link.go
@@ -359,7 +359,7 @@ func infoFromUrl(url *url.URL) *jobInfo {
 		case "view":
 			return infoForJobView(url)
 		}
-	case api.DomainForService(api.ServiceGCSWeb):
+	case api.DomainForService(api.ServiceGCSWeb), api.DomainForService(api.ServiceGCSStorage):
 		return infoForArtifact(url)
 	}
 	return nil
@@ -409,6 +409,7 @@ func infoForJobView(url *url.URL) *jobInfo {
 
 // infoForArtifact handles URLs like:
 // https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt
+// https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/836/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-operator/1583384716713660416/build-log.txt
 func infoForArtifact(url *url.URL) *jobInfo {
 	parts := strings.Split(url.Path, "/")
 	// the last fully numeric path part before user-provided

--- a/pkg/slack/events/joblink/link_test.go
+++ b/pkg/slack/events/joblink/link_test.go
@@ -56,6 +56,14 @@ func TestExtractInfo(t *testing.T) {
 			link:     "https://github.com/openshift/release/pull/13221",
 			expected: nil,
 		},
+		{
+			link:     "https://storage.googleapis.com/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/build-log.txt",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
+		},
+		{
+			link:     "https://storage.googleapis.com/origin-ci-test/pr-logs/pull/25585/pull-ci-openshift-origin-master-e2e-aws-disruptive/1319310480841379840/artifacts/123/123123/123/12/312/3/1",
+			expected: &jobInfo{Name: "pull-ci-openshift-origin-master-e2e-aws-disruptive", Id: "1319310480841379840"},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
We should be able to post the job info from links like https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-ingress-operator/836/pull-ci-openshift-cluster-ingress-operator-master-e2e-aws-operator/1583384716713660416/build-log.txt rather than just the GCS viewer links.

Brought on by this [slack thread](https://coreos.slack.com/archives/CBN38N3MW/p1666378352080869).