### PR TITLE
`pj-rehearse`: plugin: don't comment empty job table and streamline acknowledgement

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -314,8 +315,8 @@ func (s *server) prepareCandidate(repoClient git.RepoClient, pullRequest *github
 
 	// In order to determine *only* the affected jobs from the changes in the PR, we need to rebase onto master
 	baseRef := pullRequest.Base.Ref
-	if _, err := repoClient.MergeWithStrategy(baseRef, "rebase"); err != nil {
-		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rebase repo client: %w", err)
+	if rebased, _ := repoClient.MergeWithStrategy(baseRef, "rebase"); !rebased {
+		return rehearse.RehearsalCandidate{}, errors.New("couldn't rebase repo client")
 	}
 
 	return candidate, nil

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -530,6 +530,7 @@ func sendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, use
 	}
 
 	if len(issues) == 0 {
+		logrus.Debug("No issues have been found for intake")
 		return nil
 	}
 


### PR DESCRIPTION
We don't want to ever comment an empty job table, if no rehearsable jobs are found we should just say that and immediately ack the rehearsals. I also refactored the code to de-duplicate the acknowledgement.

We also need to fail when the rebase fails. This utilizes the returned `bool` of `MergeWithStrategy` which will be false if the rebase failed.

/cc @droslean @openshift/test-platform 