### PR TITLE
fix empty platforms

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -214,6 +214,14 @@ func (o *GenerateJobNamesOptions) Run(ctx context.Context) error {
 			if strings.Contains(curr.Name, "-disruptive") {
 				continue
 			}
+
+			// Microshift is not yet stable, jobs are not clearly named, and we're unsure what platform/topology
+			// they should be lumped in with.
+			// Today they run using a single UPI GCP vm, HA may be coming later.
+			if strings.Contains(curr.Name, "microshift") {
+				continue
+			}
+
 			localLines = append(localLines, curr.Name)
 		}
 		sort.Strings(localLines)

--- a/pkg/jobrunaggregator/jobtableprimer/job_typer.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_typer.go
@@ -29,6 +29,10 @@ func newJob(name string) *jobRowBuilder {
 		platform = openstack
 	case strings.Contains(name, "libvirt"):
 		platform = libvirt
+	case strings.Contains(name, "alibaba"):
+		platform = alibaba
+	case strings.Contains(name, "ibmcloud"):
+		platform = ibmcloud
 	}
 
 	architecture := ""

--- a/pkg/jobrunaggregator/jobtableprimer/jobs.go
+++ b/pkg/jobrunaggregator/jobtableprimer/jobs.go
@@ -16,6 +16,8 @@ const (
 	ovirt     = "ovirt"
 	openstack = "openstack"
 	libvirt   = "libvirt"
+	alibaba   = "alibaba"
+	ibmcloud  = "ibmcloud"
 
 	amd64   = "amd64"
 	arm64   = "arm64"


### PR DESCRIPTION
We recently noticed data in bigquery with no platform. Traced down to a couple key issues missing alibaba and ibmcloud as platforms.

I've also disabled microshift jobs for the time being, today they're using a single GCP UPI vm, but the jobs are not consistently named, stable, and I don't feel safe lumping it in with standard GCP IPI, nor single node.

[TRT-624](https://issues.redhat.com//browse/TRT-624)
