### PR TITLE
pod-scaler admission: add workload type

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -299,8 +299,5 @@ func determineWorkloadType(annotations, labels map[string]string) string {
 	if _, isProwjob := labels["prow.k8s.io/job"]; isProwjob {
 		return "prowjob"
 	}
-	if _, isRehearsal := labels[rehearse.Label]; isRehearsal {
-		return "rehearsal"
-	}
 	return "undefined"
 }

--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -291,7 +291,7 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 	mutateResources(pod.Spec.Containers)
 }
 
-// determineWorkloadType returns the workflow type
+// determineWorkloadType returns the workload type to be used in metrics
 func determineWorkloadType(annotations, labels map[string]string) string {
 	if _, isBuildPod := annotations[buildv1.BuildLabel]; isBuildPod {
 		return "build"

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -1028,11 +1028,6 @@ func TestDetermineWorkloadType(t *testing.T) {
 			labels:   map[string]string{"prow.k8s.io/job": "jobName"},
 			expected: "prowjob",
 		},
-		{
-			name:     "rehearsal",
-			labels:   map[string]string{rehearse.Label: "rehearsalName"},
-			expected: "rehearsal",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -34,7 +34,7 @@ type mockReporter struct {
 	called bool
 }
 
-func (r *mockReporter) ReportMemoryConfigurationWarning(string, string, string) {
+func (r *mockReporter) ReportMemoryConfigurationWarning(string, string, string, string) {
 	r.called = true
 }
 
@@ -730,7 +730,7 @@ func TestUseOursIfLarger(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", &defaultReporter, logrus.WithField("test", testCase.name))
+			useOursIfLarger(&testCase.ours, &testCase.theirs, "test", "build", &defaultReporter, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.theirs, testCase.expected); diff != "" {
 				t.Errorf("%s: got incorrect resources after mutation: %v", testCase.name, diff)
 			}
@@ -815,7 +815,7 @@ func TestUseOursIsLarger_ReporterReports(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			useOursIfLarger(&tc.ours, &tc.theirs, "test", &tc.reporter, logrus.WithField("test", tc.name))
+			useOursIfLarger(&tc.ours, &tc.theirs, "test", "build", &tc.reporter, logrus.WithField("test", tc.name))
 
 			if diff := cmp.Diff(tc.reporter.called, tc.expected); diff != "" {
 				t.Errorf("actual and expected reporter states don't match, : %v", diff)
@@ -1005,35 +1005,39 @@ func TestPreventUnschedulable(t *testing.T) {
 	}
 }
 
-func TestDetermineName(t *testing.T) {
+func TestDetermineWorkloadType(t *testing.T) {
 	testCases := []struct {
-		name          string
-		containerName string
-		podName       string
-		labels        map[string]string
-		expected      string
+		name        string
+		annotations map[string]string
+		labels      map[string]string
+		expected    string
 	}{
 		{
-			name:          "prowjob",
-			containerName: "container",
-			podName:       "pod",
-			labels: map[string]string{
-				"prow.k8s.io/job": "prowJob",
-			},
-			expected: "prowJob",
+			name:        "no labels or annotations",
+			annotations: map[string]string{},
+			labels:      map[string]string{},
+			expected:    "undefined",
 		},
 		{
-			name:          "not a prowjob",
-			containerName: "container",
-			podName:       "pod",
-			labels:        nil,
-			expected:      "pod-container",
+			name:        "build pod",
+			annotations: map[string]string{buildv1.BuildLabel: "buildName"},
+			expected:    "build",
+		},
+		{
+			name:     "prowjob",
+			labels:   map[string]string{"prow.k8s.io/job": "jobName"},
+			expected: "prowjob",
+		},
+		{
+			name:     "rehearsal",
+			labels:   map[string]string{rehearse.Label: "rehearsalName"},
+			expected: "rehearsal",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if diff := cmp.Diff(determineName(tc.labels, tc.podName, tc.containerName), tc.expected); diff != "" {
+			if diff := cmp.Diff(determineWorkloadType(tc.annotations, tc.labels), tc.expected); diff != "" {
 				t.Errorf("result differs from expected output, diff:\n%s", diff)
 			}
 		})

--- a/cmd/result-aggregator/main.go
+++ b/cmd/result-aggregator/main.go
@@ -37,7 +37,7 @@ var (
 			Name: "pod_scaler_admission_high_determined_memory",
 			Help: "number of times pod-scaler determined higher memory than configured, sorted by label/type",
 		},
-		[]string{"workload_name", "configured_memory", "determined_memory"},
+		[]string{"workload_name", "workload_type", "configured_memory", "determined_memory"},
 	)
 )
 
@@ -99,6 +99,9 @@ func validatePodScalerRequest(request *results.PodScalerRequest) error {
 	if request.WorkloadName == "" {
 		return fmt.Errorf("workload_name field in request is empty")
 	}
+	if request.WorkloadType == "" {
+		return fmt.Errorf("workload_type field in request is empty")
+	}
 	if request.ConfiguredMemory == "" {
 		return fmt.Errorf("configured_memory field in request is empty")
 	}
@@ -127,6 +130,7 @@ func withErrorRate(request *results.Request) {
 func recordHighMemory(request *results.PodScalerRequest) {
 	labels := prometheus.Labels{
 		"workload_name":     request.WorkloadName,
+		"workload_type":     request.WorkloadType,
 		"configured_memory": request.ConfiguredMemory,
 		"determined_memory": request.DeterminedMemory,
 	}

--- a/cmd/result-aggregator/main_test.go
+++ b/cmd/result-aggregator/main_test.go
@@ -196,13 +196,14 @@ func TestValidatePodScalerRequest(t *testing.T) {
 			expected: fmt.Errorf("determined_memory field in request is empty"),
 		},
 		{
-			name: "empty determined memory",
+			name: "empty workload type",
 			request: &results.PodScalerRequest{
 				WorkloadName:     "name",
+				WorkloadType:     "",
 				ConfiguredMemory: "100",
-				DeterminedMemory: "",
+				DeterminedMemory: "200",
 			},
-			expected: fmt.Errorf("determined_memory field in request is empty"),
+			expected: fmt.Errorf("workload_type field in request is empty"),
 		},
 	}
 

--- a/cmd/result-aggregator/main_test.go
+++ b/cmd/result-aggregator/main_test.go
@@ -163,6 +163,7 @@ func TestValidatePodScalerRequest(t *testing.T) {
 			name: "everything ok",
 			request: &results.PodScalerRequest{
 				WorkloadName:     "name",
+				WorkloadType:     "build",
 				ConfiguredMemory: "100",
 				DeterminedMemory: "400",
 			},
@@ -181,6 +182,7 @@ func TestValidatePodScalerRequest(t *testing.T) {
 			name: "empty configured memory",
 			request: &results.PodScalerRequest{
 				WorkloadName:     "name",
+				WorkloadType:     "build",
 				ConfiguredMemory: "",
 				DeterminedMemory: "400",
 			},
@@ -190,6 +192,7 @@ func TestValidatePodScalerRequest(t *testing.T) {
 			name: "empty determined memory",
 			request: &results.PodScalerRequest{
 				WorkloadName:     "name",
+				WorkloadType:     "build",
 				ConfiguredMemory: "100",
 				DeterminedMemory: "",
 			},

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -98,6 +98,7 @@ type Request struct {
 // PodScalerRequest holds the data from pod-scaler used to report a result to an aggregation server
 type PodScalerRequest struct {
 	WorkloadName     string
+	WorkloadType     string
 	ConfiguredMemory string
 	DeterminedMemory string
 }
@@ -169,7 +170,7 @@ func (r *reporter) report(request Request) {
 }
 
 type PodScalerReporter interface {
-	ReportMemoryConfigurationWarning(workloadName, configuredMemory, determinedMemory string)
+	ReportMemoryConfigurationWarning(workloadName, workloadType, configuredMemory, determinedMemory string)
 }
 
 type podScalerReporter struct {
@@ -194,9 +195,10 @@ func (o *Options) PodScalerReporter() (PodScalerReporter, error) {
 
 // ReportMemoryConfigurationWarning is used to send the information about memory configuration
 // from pod-scaler-admission to result-aggregator.
-func (r *podScalerReporter) ReportMemoryConfigurationWarning(workloadName, configuredMemory, determinedMemory string) {
+func (r *podScalerReporter) ReportMemoryConfigurationWarning(workloadName, workloadType, configuredMemory, determinedMemory string) {
 	request := PodScalerRequest{
 		WorkloadName:     workloadName,
+		WorkloadType:     workloadType,
 		ConfiguredMemory: configuredMemory,
 		DeterminedMemory: determinedMemory,
 	}

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -198,7 +198,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 			workloadType:     "build",
 			configuredMemory: "100",
 			determinedMemory: "200",
-			expected:         `{"WorkloadName":"name","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
+			expected:         `{"WorkloadName":"name","WorkloadType":"build","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
 		},
 		{
 			name:             "empty workload name",
@@ -206,7 +206,15 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 			workloadType:     "build",
 			configuredMemory: "100",
 			determinedMemory: "200",
-			expected:         `{"WorkloadName":"","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
+			expected:         `{"WorkloadName":"","WorkloadType":"build","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
+		},
+		{
+			name:             "empty workload type",
+			workloadName:     "name",
+			workloadType:     "",
+			configuredMemory: "100",
+			determinedMemory: "200",
+			expected:         `{"WorkloadName":"name","WorkloadType":"","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
 		},
 	}
 

--- a/pkg/results/report_test.go
+++ b/pkg/results/report_test.go
@@ -187,6 +187,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 	testCases := []struct {
 		name             string
 		workloadName     string
+		workloadType     string
 		configuredMemory string
 		determinedMemory string
 		expected         string
@@ -194,6 +195,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 		{
 			name:             "valid request",
 			workloadName:     "name",
+			workloadType:     "build",
 			configuredMemory: "100",
 			determinedMemory: "200",
 			expected:         `{"WorkloadName":"name","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
@@ -201,6 +203,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 		{
 			name:             "empty workload name",
 			workloadName:     "",
+			workloadType:     "build",
 			configuredMemory: "100",
 			determinedMemory: "200",
 			expected:         `{"WorkloadName":"","ConfiguredMemory":"100","DeterminedMemory":"200"}`,
@@ -244,7 +247,7 @@ func TestReportMemoryConfigurationWarning(t *testing.T) {
 				},
 				address: testServer.URL,
 			}
-			podScalerReporter.ReportMemoryConfigurationWarning(tc.workloadName, tc.configuredMemory, tc.determinedMemory)
+			podScalerReporter.ReportMemoryConfigurationWarning(tc.workloadName, tc.workloadType, tc.configuredMemory, tc.determinedMemory)
 		})
 	}
 }


### PR DESCRIPTION
This adds workload type for the Prometheus metric (`pod_scaler_admission_high_determined_memory`) to make determining the origin of workloads easier.

for https://issues.redhat.com/browse/DPTP-2929
/cc smg247