### PR TITLE
Also skip okd jobs for gathering disruption/alert data.

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -223,6 +223,11 @@ func (o *GenerateJobNamesOptions) Run(ctx context.Context) error {
 				continue
 			}
 
+			// OKD jobs are not something we monitor and keep slipping into our disruption data skewing results quite badly.
+			if strings.Contains(curr.Name, "okd") {
+				continue
+			}
+
 			localLines = append(localLines, curr.Name)
 		}
 		sort.Strings(localLines)


### PR DESCRIPTION
[TRT-646](https://issues.redhat.com//browse/TRT-646)