### PR TITLE
pr-reminder: add 'updated' emoji to legend

### DIFF
--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -426,10 +426,16 @@ func messageUser(user user, slackClient slackClient) error {
 						Type: slack.MarkdownType,
 						Text: fmt.Sprintf("%s: created more than a week ago", old),
 					},
+					&slack.TextBlockObject{
+						Type: slack.MarkdownType,
+						Text: fmt.Sprintf("%s: updated in the last 24 hours", newUpdate),
+					},
 				},
 			},
 		},
 	}
+
+	message = append(message, &slack.DividerBlock{Type: slack.MBTDivider})
 
 	for _, pr := range user.PrRequests {
 		prBlock := &slack.ContextBlock{


### PR DESCRIPTION
Adds explanation of the :new: emoji (signifying a PR that was updated in the last 24h) into pr-reminder's legend.

/cc smg247