### PR TITLE
`pj-rehearse` plugin: day 1 fixes

### DIFF
--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -9,7 +9,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 spec:
   containers:
   - args:

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 spec:
   containers:
   - args:

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
@@ -19,7 +19,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 skip_fetch_head: true
 spec:
   containers:

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 spec:
   containers:
   - args:

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -8,7 +8,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 spec:
   containers:
   - args:

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /test pj-rehearse
+rerun_command: /pj-rehearse
 spec:
   containers:
   - args:

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -247,7 +247,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -327,7 +327,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -410,7 +410,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -492,7 +492,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -596,7 +596,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -700,7 +700,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -790,7 +790,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -894,7 +894,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1003,7 +1003,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1089,7 +1089,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1198,7 +1198,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1307,7 +1307,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1411,7 +1411,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1515,7 +1515,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1619,7 +1619,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /test pj-rehearse
+    rerun_command: /pj-rehearse
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z


### PR DESCRIPTION
A few tweaks to the plugin are needed after seeing results and hearing comments from real users:

- Clean up the failure comments
- Fix the rerun command output for rehearsal jobs
- Move the label filtering logic to determineAffectedJobs so that we don’t list jobs that will eventually be filtered out
- When a user asks to rehearse and there are no affected jobs comment as such
- Refs should not be created using the repo name from the fork. See [thread](https://coreos.slack.com/archives/CBN38N3MW/p1667507527620019).

There are some more incoming, but wanted to get these out since they are ready.

/cc @droslean @openshift/test-platform 
/hold so I can watch the rollout