### PR TITLE
feat: update render output to account for new release data

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -27,9 +27,8 @@ type HistoricalJobData struct {
 type AlertHistoricalDataRow struct {
 	AlertName string
 	HistoricalJobData
-	P95     string
-	P99     string
-	JobRuns int
+	P95 string
+	P99 string
 }
 
 func (a *AlertHistoricalDataRow) GetJobData() HistoricalJobData {

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
@@ -64,7 +64,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
 	// We then write to a `require_review` file to record why a review would be required.
 	newReleaseUpdate := currentDataContainsPreviousRelease(previousRelease, currentHistoricalData)
 	if newReleaseUpdate {
-		if err := requireReviewFile("The current data contains previous release version"); err != nil {
+		if err := requireReviewFile("The current data contains previous release version\n"); err != nil {
 			return err
 		}
 	}
@@ -163,11 +163,12 @@ func (o *JobRunHistoricalDataAnalyzerOptions) compareAndUpdate(newData, currentD
 	}
 
 	return compareResults{
-		increaseCount: increaseCount,
-		decreaseCount: decreaseCount,
-		addedJobs:     added,
-		jobs:          results,
-		missingJobs:   missingJobs,
+		increaseCount:   increaseCount,
+		decreaseCount:   decreaseCount,
+		addedJobs:       added,
+		jobs:            results,
+		missingJobs:     missingJobs,
+		newReleaseEvent: newReleaseEvent,
 	}
 }
 
@@ -183,6 +184,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) renderResultFiles(result compareRe
 	args := struct {
 		DataType       string
 		Leeway         string
+		NewReleaseData bool
 		IncreasedCount int
 		DecreasedCount int
 		AddedJobs      []string
@@ -191,6 +193,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) renderResultFiles(result compareRe
 	}{
 		DataType:       o.dataType,
 		Leeway:         fmt.Sprintf("%.2f%%", o.leeway),
+		NewReleaseData: result.newReleaseEvent,
 		IncreasedCount: result.increaseCount,
 		DecreasedCount: result.decreaseCount,
 		AddedJobs:      result.addedJobs,

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/pr_message_template.md
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/pr_message_template.md
@@ -2,6 +2,12 @@
 
 There were (`{{len .AddedJobs}}`) added jobs and (`{{len .MissingJobs}}`) were removed.
 
+{{- if .NewReleaseData }}
+
+> :warning: {{ .DataType }} data has been updated to latest release. {{ if eq (len .AddedJobs) 0}}No Jobs were added, please check data set. ([query docs](https://docs.ci.openshift.org/docs/release-oversight/disruption-testing/data-architecture/#query)){{ end}}
+
+{{ end }}
+
 {{- if gt .IncreasedCount 0 }}
 
 ### Comparisons were above allowed leeway of `{{.Leeway}}`
@@ -14,9 +20,9 @@ Note: {{.DataType}} had `{{.IncreasedCount}}` jobs increased and `{{.DecreasedCo
 {{formatTableOutput .Jobs true}}
 
 </details>
-{{- end -}}
+{{ end }}
 
-{{ if .MissingJobs }}
+{{- if .MissingJobs }}
 
 ### Missing Data
 

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
@@ -21,9 +21,10 @@ type parsedJobData struct {
 }
 
 type compareResults struct {
-	increaseCount int
-	decreaseCount int
-	addedJobs     []string
-	jobs          []parsedJobData
-	missingJobs   []parsedJobData
+	newReleaseEvent bool
+	increaseCount   int
+	decreaseCount   int
+	addedJobs       []string
+	jobs            []parsedJobData
+	missingJobs     []parsedJobData
 }


### PR DESCRIPTION
/assign @dgoodwin 

Changed:

- Updated template
- Removed redundant `JobRuns` from `AlertHistoricalDataRow` which is being inlined by `HistoricalJobData`

Signed-off-by: eggfoobar <eggfoobar@users.noreply.github.com>