### PR TITLE
private-org-sync: document merge conflict policy

### DIFF
--- a/cmd/private-org-sync/README.md
+++ b/cmd/private-org-sync/README.md
@@ -18,6 +18,13 @@ When a threshold is hit, the shallow branch tip is fully fetched with
 Currently the tool does not fail when the destination repository does not exist
 at all: this should allow running against full openshift/release while
 repository mirrors are created in the private org.
+
+Errors resulting from merge conflicts are also ignored (see [DPTP-1426][]) so
+they do not cause the job to fail and an alert to be fired when there is a
+divergence between the repositories during the process of handling a CVE.  Note
+that this causes repositories to silently diverge in other cases, such as when
+there is a force-push to the source repository.
+
 ## Example
 
 ```console
@@ -98,3 +105,5 @@ INFO[0000] Pushing to destination (dry-run)              branch=master destinati
 INFO[0000] Trying to fetch source and destination full history and perform a merge  branch=master destination=dst/repo@master local-repo=tmp/src/repo org=src repo=repo source=src/repo@master source-file=src-repo-master.yaml variant=
 WARN[0000] error occurred while fetching remote and merge  branch=master destination=dst/repo@master error="[failed to merge src-repo/master: failed with 128 exit-code: fatal: refusing to merge unrelated histories\n, failed to perform merge --abort: failed with 128 exit-code: fatal: There is no merge to abort (MERGE_HEAD missing).\n]" local-repo=tmp/src/repo org=src repo=repo source=src/repo@master source-file=src-repo-master.yaml variant=
 ```
+
+[DPTP-1426]: https://issues.redhat.com/browse/DPTP-1426

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -215,18 +215,17 @@ type mockGit struct {
 	next     int
 	expected []mockGitCall
 
-	tc string
-	t  *testing.T
+	t *testing.T
 }
 
 func (m *mockGit) exec(_ *logrus.Entry, _ string, command ...string) (string, int, error) {
 	cmd := strings.Join(command, " ")
 	if m.next >= len(m.expected) {
-		m.t.Fatalf("%s:\nunexpected git call: %s", m.tc, cmd)
+		m.t.Fatalf("unexpected git call: %s", cmd)
 		return "", 0, nil
 	}
 	if m.expected[m.next].call != cmd {
-		m.t.Fatalf("%s:\nunexpected git call:\n  expected: %s\n  called:   %s", m.tc, m.expected[m.next].call, cmd)
+		m.t.Fatalf("unexpected git call:\n  expected: %s\n  called:   %s", m.expected[m.next].call, cmd)
 		return "", 0, nil
 	}
 
@@ -622,7 +621,6 @@ func TestMirror(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			git := mockGit{
 				expected: tc.expectedGitCalls,
-				tc:       tc.description,
 				t:        t,
 			}
 			m := gitSyncer{
@@ -638,13 +636,13 @@ func TestMirror(t *testing.T) {
 			}
 			err := m.mirror("repo-dir", tc.src, tc.dst)
 			if err == nil && tc.expectError {
-				t.Errorf("%s:\nexpected error, got nil", tc.description)
+				t.Error("expected error, got nil")
 			}
 			if err != nil && !tc.expectError {
-				t.Errorf("%s:\nunexpected error: %v", tc.description, err)
+				t.Errorf("unexpected error: %v", err)
 			}
 			if err = git.check(); err != nil {
-				t.Errorf("%s:\nbad git operation: %v", tc.description, err)
+				t.Errorf("bad git operation: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
I recently spent a good amount of time tracking this problem after a support
request only to discover it's intentional and rigorously undocumented policy.
While it's debatable whether all the silent failures we currently have are
preferrable to the problem described in DPTP-1426, this at least documents the
behavior to save future-us some time.