### PR TITLE
`check-gh-automation`: stop mis-categorizing the prowgen config as a repo

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -196,6 +196,10 @@ func gatherModifiedRepos(releaseRepoPath string, logger *logrus.Entry) []string 
 	for _, c := range configs {
 		path := strings.TrimPrefix(c, config.CiopConfigInRepoPath+"/")
 		split := strings.Split(path, "/")
+		if split[1] == ".config.prowgen" {
+			continue
+		}
+
 		orgRepos.Insert(fmt.Sprintf("%s/%s", split[0], split[1]))
 	}
 


### PR DESCRIPTION
We shouldn't add prowgen config files that are named `.config.prowgen` as repos to check in the tool.

For: https://issues.redhat.com/browse/DPTP-3204