### PR TITLE
`pj-rehearse` plugin: stop importing build-cache imagestreamtags

### DIFF
--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -41,6 +41,7 @@ import (
 
 const (
 	appCIContextName = string(api.ClusterAPPCI)
+	buildCache       = "build-cache"
 )
 
 type RehearsalConfig struct {
@@ -568,6 +569,10 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 	g, ctx := errgroup.WithContext(ctx)
 
 	for _, ist := range ists {
+		// We can't import build-cache ists, and ci-operator doesn't care that it is missing
+		if ist.Namespace == buildCache {
+			continue
+		}
 		requiredImageStreamTag := ist
 		g.Go(func() error {
 			istLog := log.WithFields(logrus.Fields{"ist-namespace": requiredImageStreamTag.Namespace, "ist-name": requiredImageStreamTag.Name})


### PR DESCRIPTION
`build-cache` imagestreamtag importing always fails on new repo rehearsals. `ci-operator` doesn't care that the tags aren't present, so it just emits an error that is un-actionable and ultimately expected. See [slack thread](https://coreos.slack.com/archives/CBN38N3MW/p1667485385109159).

/cc @droslean @openshift/test-platform 