### PR TITLE
improve logging when requesting a release payload

### DIFF
--- a/pkg/release/candidate/client.go
+++ b/pkg/release/candidate/client.go
@@ -72,7 +72,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, relative int) (
 		q.Add("rel", strconv.Itoa(relative))
 		req.URL.RawQuery = q.Encode()
 	}
-	logrus.Debugf("Requesting a release from %s", req.URL.String())
+	logrus.Infof("Requesting a release from %s", req.URL.String())
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to request latest release: %w", err)

--- a/pkg/release/config/client.go
+++ b/pkg/release/config/client.go
@@ -42,7 +42,7 @@ func resolveJobs(client release.HTTPClient, endpoint string, jobType JobType) ([
 	q.Add("jobType", string(jobType))
 	req.URL.RawQuery = q.Encode()
 
-	logrus.Debugf("Requesting a release controller's jobs in config from %s", req.URL.String())
+	logrus.Infof("Requesting a release controller's jobs in config from %s", req.URL.String())
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request release controller's jobs in config: %w", err)

--- a/pkg/release/official/client.go
+++ b/pkg/release/official/client.go
@@ -51,7 +51,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, release api.Rel
 	query.Add("channel", channel)
 	query.Add("arch", string(release.Architecture))
 	req.URL.RawQuery = query.Encode()
-	logrus.Debugf("Requesting %s from %s", targetName, req.URL.String())
+	logrus.Infof("Requesting %s from %s", targetName, req.URL.String())
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to request %s: %w", targetName, err)

--- a/pkg/release/prerelease/client.go
+++ b/pkg/release/prerelease/client.go
@@ -44,7 +44,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, bounds api.Vers
 	q := req.URL.Query()
 	q.Add("in", bounds.Query())
 	req.URL.RawQuery = q.Encode()
-	logrus.Debugf("Requesting a release from %s", req.URL.String())
+	logrus.Infof("Requesting a release from %s", req.URL.String())
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("failed to request latest release: %w", err)


### PR DESCRIPTION
The error is confusing when the user doesn't know from what URL ci-operator is trying to get the release. e.x https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-multiarch-master-nightly-4.13-ocp-e2e-sdn-serial-aws-arm64/1590299757518000128

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>