### PR TITLE
Handle the global pull secret on OSD clusters

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1576,7 +1576,7 @@ func TestUpdateSecrets(t *testing.T) {
 				"build01": fkcBuild01.CoreV1(),
 			}
 
-			actual := updateSecrets(clients, tc.secretsMap, tc.force, true)
+			actual := updateSecrets(clients, tc.secretsMap, tc.force, true, nil)
 			equalError(t, tc.expected, actual)
 
 			actualSecretsOnDefault, err := fkcDefault.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{})
@@ -2915,6 +2915,235 @@ func TestPruneIrrelevantConfiguration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pruneIrrelevantConfiguration(tc.given, sets.NewString("config-updater"))
 			if diff := cmp.Diff(tc.given, tc.expected); diff != "" {
+				t.Errorf("%s: actual differs from expected: %s", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestMutateGlobalPullSecret(t *testing.T) {
+	testCases := []struct {
+		name          string
+		original      *coreapi.Secret
+		secret        *coreapi.Secret
+		mutatedSecret *coreapi.Secret
+		expected      bool
+		expectedErr   error
+	}{
+		{
+			name:        "error on nil secret",
+			expectedErr: fmt.Errorf("failed to parse the constructed secret: failed to get content from nil secret"),
+		},
+		{
+			name:        "error on secret with empty data",
+			secret:      &coreapi.Secret{},
+			expectedErr: fmt.Errorf("failed to parse the constructed secret: failed to get content from an secret with no data"),
+		},
+		{
+			name: "error on secret with bad data",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			},
+			expectedErr: fmt.Errorf("failed to parse the constructed secret: there is no key in the secret: .dockerconfigjson"),
+		},
+		{
+			name: "error on secret with non-json data",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte("value"),
+				},
+			},
+			expectedErr: fmt.Errorf("failed to parse the constructed secret: failed to unmarshal the docker config: invalid character 'v' looking for beginning of value"),
+		},
+		{
+			name: "error on secret with bad json data",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{"key":"value"}`),
+				},
+			},
+			expectedErr: fmt.Errorf("failed to get token for registry.ci.openshift.org"),
+		},
+		{
+			name: "bad original",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"a": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		},
+		"c": {
+			"auth": "bar",
+			"email": "g"
+		}
+	}
+}`),
+				},
+			},
+			expectedErr: fmt.Errorf("failed to parse the original secret: failed to get content from nil secret"),
+		},
+		{
+			name: "bad original",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"a": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		},
+		"c": {
+			"auth": "bar",
+			"email": "g"
+		}
+	}
+}`),
+				},
+			},
+			expectedErr: fmt.Errorf("failed to parse the original secret: failed to get content from nil secret"),
+		},
+		{
+			name: "basic case: expired auth is replaced",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"a": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		},
+		"c": {
+			"auth": "bar",
+			"email": "g"
+		}
+	}
+}`),
+				},
+			},
+			original: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"osd": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "expired"
+		}
+	}
+}`),
+				},
+			},
+			expected: true,
+			mutatedSecret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+				},
+			},
+		},
+		{
+			name: "not mutated if the auth is still valid",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"a": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		},
+		"c": {
+			"auth": "bar",
+			"email": "g"
+		}
+	}
+}`),
+				},
+			},
+			original: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"osd": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		}
+	}
+}`),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "the auth for app.ci's registry is appended",
+			secret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"a": {
+			"auth": "foo",
+			"email": "e"
+		},
+		"registry.ci.openshift.org": {
+			"auth": "cool"
+		},
+		"c": {
+			"auth": "bar",
+			"email": "g"
+		}
+	}
+}`),
+				},
+			},
+			original: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte(`{
+	"auths": {
+		"osd": {
+			"auth": "foo",
+			"email": "e"
+		}
+	}
+}`),
+				},
+			},
+			expected: true,
+			mutatedSecret: &coreapi.Secret{
+				Data: map[string][]byte{
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, actualErr := mutateGlobalPullSecret(tc.original, tc.secret)
+			if diff := cmp.Diff(actualErr, tc.expectedErr, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: actualErr differs from expectedErr: %s", tc.name, diff)
+			}
+			if diff := cmp.Diff(actual, tc.expected); diff != "" && actualErr == nil {
+				t.Errorf("%s: actual differs from expected: %s", tc.name, diff)
+			}
+			if diff := cmp.Diff(tc.original, tc.mutatedSecret, testhelper.RuntimeObjectIgnoreRvTypeMeta); diff != "" && actual && actualErr == nil {
 				t.Errorf("%s: actual differs from expected: %s", tc.name, diff)
 			}
 		})

--- a/pkg/api/secretbootstrap/secretboostrap.go
+++ b/pkg/api/secretbootstrap/secretboostrap.go
@@ -239,3 +239,10 @@ func (c *Config) resolve() error {
 
 	return utilerrors.NewAggregate(errs)
 }
+
+const OSDGlobalPullSecretGroupName = "osd_global_pull_secret"
+
+// OSDGlobalPullSecretGroup returns the list of the OSD cluster names where we need to partially manage the global pull secret
+func (c *Config) OSDGlobalPullSecretGroup() []string {
+	return c.ClusterGroups[OSDGlobalPullSecretGroupName]
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-2795

Because of https://issues.redhat.com/browse/OHSS-16577, we want to handle it now and revert https://github.com/openshift/release/blob/0605597e1acbdb663239b03d9d7609cdbce9152c/clusters/app.ci/assets/dptp-controller-manager.yaml#L167

/cc @openshift/test-platform 