### PR TITLE
[prowgen] merge additional_architectures when repo defines them

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -66,6 +66,9 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	if defaults.Rehearsals.DisableAll {
 		p.Rehearsals.DisableAll = true
 	}
+	if defaults.AdditionalArchitectures != nil {
+		p.AdditionalArchitectures = defaults.AdditionalArchitectures
+	}
 	p.Rehearsals.DisabledRehearsals = append(p.Rehearsals.DisabledRehearsals, defaults.Rehearsals.DisabledRehearsals...)
 }
 


### PR DESCRIPTION
A continuation of https://github.com/openshift/ci-tools/pull/3137.

This allows resetting the ``additional_architectures`` list in a
repository configuration when it's also defined in the organization
configuration.

Required due to arm64 builds failing for assisted-installer
repositories.