### PR TITLE
test/e2e: fix optional operator tests

### DIFF
--- a/test/e2e/optional-operators/optional-operators.yaml
+++ b/test/e2e/optional-operators/optional-operators.yaml
@@ -39,11 +39,11 @@ tests:
   literal_steps:
     test:
     - as: verify
-      from: pipeline:ci-index
+      from: ci-index
       run_as_script: true
       grace_period: 10s
       commands: |
-        #!/bin/sh
+        #!/busybox/sh
         set -o nounset
         set -o errexit
         set -o pipefail
@@ -69,11 +69,11 @@ tests:
   literal_steps:
     test:
     - as: verify
-      from: pipeline:ci-index-named-bundle
+      from: ci-index-named-bundle
       run_as_script: true
       grace_period: 10s
       commands: |
-        #!/bin/sh
+        #!/busybox/sh
         set -o nounset
         set -o errexit
         set -o pipefail


### PR DESCRIPTION
This took _way_ too much time to figure out.

This test has been failing for a long time.  No one cared because it is executed
as a post-submit.  The reason for that is its average execution time is around
30m:

https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/branch-ci-openshift-ci-tools-master-e2e-oo-post

The failure is very puzzling:

```json
{
  "component": "entrypoint",
  "error": "could not start the process: fork/exec /var/run/configmaps/ci.openshift.io/multi-stage/verify: no such file or directory",
  "file": "k8s.io/test-infra/prow/entrypoint/run.go:79",
  "func": "k8s.io/test-infra/prow/entrypoint.Options.Run",
  "level": "error",
  "msg": "Error executing test process",
  "severity": "error",
  "time": "2022-11-18T19:50:39Z"
}
```

That is the `ConfigMap` which is used to mount the test script in every single
multi-stage test, so it cannot be completely non-functional.  Inspecting debug
containers showed the file is indeed present.

The key lead was the `run_as_script` option in the test configuration (which is
so obscure, the only users are we in our E2E tests): it executes the script
directly instead of via `bash`.  The punchline is: the error refers not to the
file mentioned in the message, but to the *interpreter* used to execute it, in
this case `/bin/sh`.

The base used for the images tested, `quay.io/operator-framework/opm`, God only
knows for what reason does not provide a shell at that path, and instead has
`busybox` installed at `/busybox`.  Changing the interpreter line to that makes
the pods work again.