### PR TITLE
`pr-reminder`: add 'accepted' and 'lgtm' labels to output

### DIFF
--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -74,6 +74,8 @@ type config struct {
 // getInterestedLabels returns a set of those labels we are interested in when using the PR reminder
 func getInterestedLabels() sets.String {
 	var prLabels = sets.String{}
+	prLabels.Insert("approved")
+	prLabels.Insert("lgtm")
 	prLabels.Insert("do-not-merge/hold")
 	return prLabels
 }


### PR DESCRIPTION
This is another nice feature to see if a PR is worth opening. I tested it with the local script and received desired output.

<img width="619" alt="Screen Shot 2022-11-21 at 8 12 21 AM" src="https://user-images.githubusercontent.com/1794300/203064398-9f47dae3-e2f2-43fa-b14c-44d99166f84f.png">
