### PR TITLE
pod-scaler admission: add step as possible workload type

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -299,5 +299,8 @@ func determineWorkloadType(annotations, labels map[string]string) string {
 	if _, isProwjob := labels["prow.k8s.io/job"]; isProwjob {
 		return "prowjob"
 	}
+	if _, isStep := labels[steps.LabelMetadataStep]; isStep {
+		return "step"
+	}
 	return "undefined"
 }

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	pod_scaler "github.com/openshift/ci-tools/pkg/pod-scaler"
 	"github.com/openshift/ci-tools/pkg/rehearse"
+	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -1027,6 +1028,11 @@ func TestDetermineWorkloadType(t *testing.T) {
 			name:     "prowjob",
 			labels:   map[string]string{"prow.k8s.io/job": "jobName"},
 			expected: "prowjob",
+		},
+		{
+			name:     "step",
+			labels:   map[string]string{steps.LabelMetadataStep: "e2e"},
+			expected: "step",
 		},
 	}
 


### PR DESCRIPTION
This adds (multi-stage) `step` as a possible workload type for `pod_scaler_admission_high_determined_memory` metric.

part of [DPTP-2929](https://issues.redhat.com/browse/DPTP-2929)
/cc smg247