### PR TITLE
Fix dispatcher issue when failover happens and colocation is enabled

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -443,6 +443,15 @@ func main() {
 		}
 	}
 
+	if config.DetermineE2EByJob == true && config.IsAnyBuildClusterDisabled() {
+		config.DetermineE2EByJob = false
+		config.IgnoreE2EByJobAssignment = true
+	}
+	if config.IgnoreE2EByJobAssignment == true && !config.IsAnyBuildClusterDisabled() {
+		config.DetermineE2EByJob = true
+		config.IgnoreE2EByJobAssignment = false
+	}
+
 	logrus.Info("Dispatching ...")
 	if err := dispatchJobs(context.TODO(), o.prowJobConfigDir, o.maxConcurrency, config, jobVolumes); err != nil {
 		logrus.WithError(err).Fatal("Failed to dispatch")

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -208,6 +208,21 @@ func isSSHBastionJob(base prowconfig.JobBase) bool {
 	return false
 }
 
+// IsAnyBuildClusterDisabled returns if any of the build clusters is disabled
+func (config *Config) IsAnyBuildClusterDisabled() bool {
+	if len(config.BuildFarm) == 0 {
+		return true
+	}
+	for provider := range config.BuildFarm {
+		for cluster := range config.BuildFarm[provider] {
+			if config.BuildFarm[provider][cluster].Disabled == true {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IsInBuildFarm returns the cloudProvider if the cluster is in the build farm; empty string otherwise.
 func (config *Config) IsInBuildFarm(clusterName api.Cluster) api.Cloud {
 	for cloudProvider, v := range config.BuildFarm {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -687,3 +687,36 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigIsAnyBuildClusterDisabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		buildFarm map[api.Cloud]map[api.Cluster]*BuildFarmConfig
+		want      bool
+	}{
+		{
+			name: "empty BuildFarm",
+			want: true,
+		},
+		{
+			name:      "Buildfarm not disabled",
+			buildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{"aws": {"build01": &BuildFarmConfig{Disabled: false}}},
+			want:      false,
+		},
+		{
+			name:      "Buildfarm disabled",
+			buildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{"aws": {"build01": &BuildFarmConfig{Disabled: true}}},
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				BuildFarm: tt.buildFarm,
+			}
+			if got := config.IsAnyBuildClusterDisabled(); got != tt.want {
+				t.Errorf("Config.IsAnyBuildClusterDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When there is a failover and colocation is enabled (`DetermineE2EByJob`) some jobs are not moved from the broken cluster. This feature detects enabled colocation and replaces it for the time of the incident with optional colocation setting (`IgnoreE2EByJobAssignment`).

`IgnoreE2EByJobAssignment` means the job could be colocated or not; both states are accepted. It was developed to enable gradual colocation (% of jobs in batch PR). The incident is a similar situation, as some of the jobs need to be colocated and others not (these from the failing cluster).

Not using this flag and disabling `DetermineE2EByJob` means a complete rearrangement of jobs, the resulting PR will fallback to not colocated jobs for the time of the incident which may lead to scaling problems and will need to be again reverted after the incident, so it is not the desired direction.

/cc @hongkailiu 

Signed-off-by: Jakub Guzik <jguzik@redhat.com>