### PR TITLE
Validate indexGeneratorStep

### DIFF
--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -114,7 +114,6 @@ func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
 	}
 	opmCommand = fmt.Sprintf("%s]", opmCommand)
 	dockerCommands = append(dockerCommands, opmCommand)
-	dockerCommands = append(dockerCommands, fmt.Sprintf("RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' %s) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)", IndexDockerfileName))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -59,7 +59,6 @@ func TestIndexGenDockerfile(t *testing.T) {
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -78,7 +77,6 @@ COPY --from=builder /database/ database`,
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -98,7 +96,6 @@ COPY --from=builder /database/ database`,
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate", "--from-index", "some-reg/target-namespace/pipeline@the-index"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -1,17 +1,21 @@
 package steps
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	apiimagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestIndexGenDockerfile(t *testing.T) {
@@ -110,6 +114,68 @@ COPY --from=builder /database/ database`,
 			}
 			if testCase.expected != generated {
 				t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(testCase.expected, generated))
+			}
+		})
+	}
+}
+
+func TestValidateIndexGeneratorStep(t *testing.T) {
+	testCases := []struct {
+		name      string
+		step      indexGeneratorStep
+		istFile   string
+		baseIndex string
+		expected  error
+	}{{
+		name:      "base case",
+		istFile:   "testdata/isTags/pipeline_v4.10_istag.yaml",
+		baseIndex: "v4.10",
+	}, {
+		name:      "not found",
+		istFile:   "testdata/isTags/pipeline_v4.10_istag.yaml",
+		baseIndex: "ghost",
+		expected:  fmt.Errorf(`failed to determine if the image ns/pipeline:ghost is sqlite based index: could not fetch source ImageStreamTag: imagestreamtags.image.openshift.io "pipeline:ghost" not found`),
+	}, {
+		name:      "no metadata",
+		istFile:   "testdata/isTags/pipeline_no_bytes_istag.yaml",
+		baseIndex: "v4.10",
+		expected:  fmt.Errorf(`failed to determine if the image ns/pipeline:v4.10 is sqlite based index: could not fetch Docker image metadata for ImageStreamTag pipeline:v4.10`),
+	}, {
+		name:      "malformed json",
+		istFile:   "testdata/isTags/pipeline_malformed_istag.yaml",
+		baseIndex: "v4.10",
+		expected:  fmt.Errorf(`failed to determine if the image ns/pipeline:v4.10 is sqlite based index: malformed Docker image metadata on ImageStreamTag: json: cannot unmarshal string into Go value of type docker10.DockerImage`),
+	}, {
+		name:      "no labels",
+		istFile:   "testdata/isTags/pipeline_no_label_istag.yaml",
+		baseIndex: "v4.10",
+		expected:  fmt.Errorf(`opm index commands, which are used by the ci-operator, interact only with a database index, but the base index is not one. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/`),
+	}, {
+		name:      "v4.11",
+		istFile:   "testdata/isTags/pipeline_v4.11_istag.yaml",
+		baseIndex: "v4.11",
+		expected:  fmt.Errorf(`opm index commands, which are used by the ci-operator, interact only with a database index, but the base index is not one. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/`),
+	}}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rawImageStreamTag, err := ioutil.ReadFile(testCase.istFile)
+			if err != nil {
+				t.Fatalf("failed to read imagestreamtag fixture: %v", err)
+			}
+			ist := &apiimagev1.ImageStreamTag{}
+			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
+				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
+			}
+			testCase.step = indexGeneratorStep{
+				client: NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist).Build()), nil),
+				config: api.IndexGeneratorStepConfiguration{
+					BaseIndex: testCase.baseIndex,
+				},
+				jobSpec: &api.JobSpec{},
+			}
+			testCase.step.jobSpec.SetNamespace("ns")
+			if diff := cmp.Diff(testCase.expected, testCase.step.Validate(), testhelper.EquateErrorMessage); diff != "" {
+				t.Fatalf("error did not match expected, diff: %s", diff)
 			}
 		})
 	}

--- a/pkg/steps/testdata/isTags/pipeline_malformed_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_malformed_istag.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata: malformed-json
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_no_bytes_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_no_bytes_istag.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.openshift.io/v1
+image:
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_no_label_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_no_label_istag.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - registry
+        - serve
+        - --database
+        - /database/index.db
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframafework.io.index.database.v1: /database/index.db
+        vendor: Red Hat, Inc.
+        version: v4.10.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_v4.10_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_v4.10_istag.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - registry
+        - serve
+        - --database
+        - /database/index.db
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframework.io.index.database.v1: /database/index.db
+        vendor: Red Hat, Inc.
+        version: v4.10.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_v4.11_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_v4.11_istag.yaml
@@ -1,0 +1,24 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - serve
+        - /configs
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframework.io.index.configs.v1: /configs
+        vendor: Red Hat, Inc.
+        version: v4.11.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.11
+  namespace: ns


### PR DESCRIPTION
This PR not going to fix https://issues.redhat.com/browse/DPTP-2969. Instead it does what it should have been done in https://github.com/openshift/ci-tools/pull/2818 as the short term solution to https://issues.redhat.com/browse/DPTP-2692

- Reverted https://github.com/openshift/ci-tools/pull/2818/files because the build errored out earlier. 
- Based on [the finding](https://issues.redhat.com/browse/DPTP-2969?focusedCommentId=21311180&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21311180), the job fails at the validation stage of steps if ci-operator detects that index in the config is not database format.

We still need to figure out how to adopt the middle term solution with the help of the operator team.

/cc https://github.com/orgs/openshift/teams/test-platform @gallettilance