### PR TITLE
`pod-scaler` producer: parse retention duration out of full result

### DIFF
--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -190,7 +190,10 @@ func (q *querier) execute(ctx context.Context, c *clusterMetadata, until time.Ti
 	if err != nil {
 		return fmt.Errorf("could not query Prometheus runtime info: %w", err)
 	}
-	retention, err := model.ParseDuration(runtime.StorageRetention)
+	storageRetention := runtime.StorageRetention
+	// storageRetention may look like "11d or 90Gib" or "30d" depending on the configuration
+	parts := strings.Split(storageRetention, " ")
+	retention, err := model.ParseDuration(parts[0])
 	if err != nil {
 		return fmt.Errorf("could not determine Prometheus retention duration: %w", err)
 	}


### PR DESCRIPTION
Starting around 11/02/22 the pod-scaler producer has been throwing errors like the following in all of the OSD managed clusters:
```
{"cluster":"build03","component":"pod-scaler","error":"could not determine Prometheus retention duration: not a valid duration string: \"11d or 90GiB\""}
```
This appears to be due to some recent change in the retention policy that OSD made. We have no better way to grab the duration piece of the policy, but it seems like if it is configured as a duration **or** a size then the duration comes first. This will work for the OSD clusters and the clusters we manage.

I will be monitoring the deployment to verify that this error goes away post-merge.