### PR TITLE
Failed the build upon a file-based catalog index (2)

### DIFF
--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -114,7 +114,6 @@ func (s *indexGeneratorStep) indexGenDockerfile() (string, error) {
 	}
 	opmCommand = fmt.Sprintf("%s]", opmCommand)
 	dockerCommands = append(dockerCommands, opmCommand)
-	dockerCommands = append(dockerCommands, fmt.Sprintf("RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' %s) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)", IndexDockerfileName))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("FROM %s:%s", api.PipelineImageStream, api.PipelineImageStreamTagReferenceSource))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("WORKDIR %s", IndexDataDirectory))
 	dockerCommands = append(dockerCommands, fmt.Sprintf("COPY --from=builder %s %s", IndexDockerfileName, IndexDockerfileName))

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -2,13 +2,19 @@ package steps
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	buildapi "github.com/openshift/api/build/v1"
+	"github.com/openshift/api/image/docker10"
+	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
@@ -33,6 +39,25 @@ func (s *indexGeneratorStep) Inputs() (api.InputDefinition, error) {
 
 func (*indexGeneratorStep) Validate() error { return nil }
 
+func databaseIndex(client ctrlruntimeclient.Client, name, namespace string) (bool, error) {
+	ist := &imagev1.ImageStreamTag{}
+	if err := client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: name}, ist); err != nil {
+		return false, fmt.Errorf("could not fetch source ImageStreamTag: %w", err)
+	}
+	metadata := &docker10.DockerImage{}
+	if len(ist.Image.DockerImageMetadata.Raw) == 0 {
+		return false, fmt.Errorf("could not fetch Docker image metadata for ImageStreamTag %s", ist.Name)
+	}
+	if err := json.Unmarshal(ist.Image.DockerImageMetadata.Raw, metadata); err != nil {
+		return false, fmt.Errorf("malformed Docker image metadata on ImageStreamTag: %w", err)
+	}
+	if metadata.Config == nil || metadata.Config.Labels == nil {
+		return false, nil
+	}
+	_, ok := metadata.Config.Labels["operators.operatorframework.io.index.database.v1"]
+	return ok, nil
+}
+
 func (s *indexGeneratorStep) Run(ctx context.Context) error {
 	return results.ForReason("building_index_generator").ForError(s.run(ctx))
 }
@@ -42,6 +67,18 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 	workingDir, err := getWorkingDir(s.client, source, s.jobSpec.Namespace())
 	if err != nil {
 		return fmt.Errorf("failed to get workingDir: %w", err)
+	}
+	if s.config.BaseIndex != "" {
+		source := fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.BaseIndex)
+		ok, err := databaseIndex(s.client, source, s.jobSpec.Namespace())
+		if err != nil {
+			return fmt.Errorf("failed to determine if the image %s/%s is sqlite based index: %w", s.jobSpec.Namespace(), source, err)
+		}
+		if !ok {
+			return errors.New("opm index commands, which are used by the ci-operator, interact only with a database index, but the base index is not one. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/")
+		} else {
+			logrus.Debug("The base index image is sqlite based")
+		}
 	}
 	dockerfile, err := s.indexGenDockerfile()
 	if err != nil {

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -59,7 +59,6 @@ func TestIndexGenDockerfile(t *testing.T) {
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -78,7 +77,6 @@ COPY --from=builder /database/ database`,
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile
@@ -98,7 +96,6 @@ COPY --from=builder /database/ database`,
 COPY .dockerconfigjson .
 RUN mkdir $HOME/.docker && mv .dockerconfigjson $HOME/.docker/config.json
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate", "--from-index", "some-reg/target-namespace/pipeline@the-index"]
-RUN (! grep -q 'operators.operatorframework.io.index.configs.v1=' index.Dockerfile) || (>&2 echo 'error: This is a file-based catalog index and opm index commands are not possible against this type of index. Please refer to the FBC docs here: https://olm.operatorframework.io/docs/reference/file-based-catalogs/'; exit 1)
 FROM pipeline:src
 WORKDIR /index-data
 COPY --from=builder index.Dockerfile index.Dockerfile

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -1,17 +1,21 @@
 package steps
 
 import (
+	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/yaml"
 
 	apiimagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func TestIndexGenDockerfile(t *testing.T) {
@@ -110,6 +114,64 @@ COPY --from=builder /database/ database`,
 			}
 			if testCase.expected != generated {
 				t.Errorf("Generated opm index dockerfile does not equal expected:\n%s", cmp.Diff(testCase.expected, generated))
+			}
+		})
+	}
+}
+
+func TestDatabaseIndex(t *testing.T) {
+	testCases := []struct {
+		name        string
+		istFile     string
+		isTagName   string
+		expected    bool
+		expectedErr error
+	}{{
+		name:      "base case",
+		istFile:   "testdata/isTags/pipeline_v4.10_istag.yaml",
+		isTagName: "pipeline:v4.10",
+		expected:  true,
+	}, {
+		name:        "not found",
+		istFile:     "testdata/isTags/pipeline_v4.10_istag.yaml",
+		isTagName:   "ghost:ghost",
+		expectedErr: fmt.Errorf(`could not fetch source ImageStreamTag: imagestreamtags.image.openshift.io "ghost:ghost" not found`),
+	}, {
+		name:        "no metadata",
+		istFile:     "testdata/isTags/pipeline_no_bytes_istag.yaml",
+		isTagName:   "pipeline:v4.10",
+		expectedErr: fmt.Errorf(`could not fetch Docker image metadata for ImageStreamTag pipeline:v4.10`),
+	}, {
+		name:        "malformed json",
+		istFile:     "testdata/isTags/pipeline_malformed_istag.yaml",
+		isTagName:   "pipeline:v4.10",
+		expectedErr: fmt.Errorf(`malformed Docker image metadata on ImageStreamTag: json: cannot unmarshal string into Go value of type docker10.DockerImage`),
+	}, {
+		name:      "no labels",
+		istFile:   "testdata/isTags/pipeline_no_label_istag.yaml",
+		isTagName: "pipeline:v4.10",
+	}, {
+		name:      "v4.11",
+		istFile:   "testdata/isTags/pipeline_v4.11_istag.yaml",
+		isTagName: "pipeline:v4.11",
+	}}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			rawImageStreamTag, err := ioutil.ReadFile(testCase.istFile)
+			if err != nil {
+				t.Fatalf("failed to read imagestreamtag fixture: %v", err)
+			}
+			ist := &apiimagev1.ImageStreamTag{}
+			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
+				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
+			}
+			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist).Build()), nil),
+				testCase.isTagName, "ns")
+			if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
+				t.Fatalf("actual did not match expected, diff: %s", diff)
+			}
+			if diff := cmp.Diff(testCase.expected, actual); actualErr == nil && diff != "" {
+				t.Fatalf("error did not match expected, diff: %s", diff)
 			}
 		})
 	}

--- a/pkg/steps/testdata/isTags/pipeline_malformed_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_malformed_istag.yaml
@@ -1,0 +1,9 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata: malformed-json
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_no_bytes_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_no_bytes_istag.yaml
@@ -1,0 +1,8 @@
+apiVersion: image.openshift.io/v1
+image:
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_no_label_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_no_label_istag.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - registry
+        - serve
+        - --database
+        - /database/index.db
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframafework.io.index.database.v1: /database/index.db
+        vendor: Red Hat, Inc.
+        version: v4.10.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_v4.10_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_v4.10_istag.yaml
@@ -1,0 +1,26 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - registry
+        - serve
+        - --database
+        - /database/index.db
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframework.io.index.database.v1: /database/index.db
+        vendor: Red Hat, Inc.
+        version: v4.10.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.10
+  namespace: ns

--- a/pkg/steps/testdata/isTags/pipeline_v4.11_istag.yaml
+++ b/pkg/steps/testdata/isTags/pipeline_v4.11_istag.yaml
@@ -1,0 +1,24 @@
+apiVersion: image.openshift.io/v1
+image:
+  dockerImageMetadata:
+    Architecture: amd64
+    Config:
+      Cmd:
+        - serve
+        - /configs
+      Entrypoint:
+        - /bin/opm
+      Env:
+        - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        - container=oci
+      Labels:
+        operators.operatorframework.io.index.configs.v1: /configs
+        vendor: Red Hat, Inc.
+        version: v4.11.0
+      WorkingDir: /registry
+kind: ImageStreamTag
+lookupPolicy:
+  local: false
+metadata:
+  name: pipeline:v4.11
+  namespace: ns


### PR DESCRIPTION
Replacing https://github.com/openshift/ci-tools/pull/3169

This PR not going to fix https://issues.redhat.com/browse/DPTP-2969. Instead it does what it should have been done in https://github.com/openshift/ci-tools/pull/2818 as the short term solution to https://issues.redhat.com/browse/DPTP-2692

- Reverted https://github.com/openshift/ci-tools/pull/2818/files because the build errored out earlier. 
- Based on [the finding](https://issues.redhat.com/browse/DPTP-2969?focusedCommentId=21311180&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21311180), the job fails at the runtime of steps to compose the build if ci-operator detects that index in the config is not database format.

We still need to figure out how to adopt the middle term solution with the help of the operator team.

/cc https://github.com/orgs/openshift/teams/test-platform @grokspawn 