### PR TITLE
Add `rehearsals-ack` label on uninterested `openshift-bot` PRs

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/test-infra/prow/labels"
 
 	"github.com/openshift/ci-tools/pkg/promotion"
+	"github.com/openshift/ci-tools/pkg/rehearse"
 )
 
 const (
@@ -278,6 +279,7 @@ func main() {
 
 	labelsToAdd := []string{
 		"tide/merge-method-merge",
+		rehearse.RehearsalsAckLabel,
 	}
 	if o.selfApprove {
 		logrus.Infof("Self-approving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)

--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/plugins/ownersconfig"
 	"k8s.io/test-infra/prow/repoowners"
+
+	"github.com/openshift/ci-tools/pkg/rehearse"
 )
 
 const (
@@ -504,7 +506,9 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to push changes.")
 	}
 
-	var labelsToAdd []string
+	labelsToAdd := []string{
+		rehearse.RehearsalsAckLabel,
+	}
 	if o.selfApprove {
 		logrus.Infof("Self-aproving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	rehearsalsAckLabel = "rehearsals-ack"
 	needsOkToTestLabel = "needs-ok-to-test"
 	rehearseNormal     = "/pj-rehearse"
 	rehearseMore       = "/pj-rehearse more"
@@ -61,7 +60,7 @@ func (s *server) helpProvider(_ []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, e
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       rehearseAck,
-		Description: fmt.Sprintf("Acknowledge the rehearsal result (either passing, failing, or skipped), and add the '%s' label allowing merge once other requirements are met.", rehearsalsAckLabel),
+		Description: fmt.Sprintf("Acknowledge the rehearsal result (either passing, failing, or skipped), and add the '%s' label allowing merge once other requirements are met.", rehearse.RehearsalsAckLabel),
 		WhoCanUse:   "Anyone can use on trusted PRs",
 		Examples:    []string{rehearseAck},
 	})
@@ -85,19 +84,19 @@ func (s *server) helpProvider(_ []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, e
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       rehearseSkip,
-		Description: fmt.Sprintf("Opt-out of rehearsals for this PR, and add the '%s' label allowing merge once other requirements are met.", rehearsalsAckLabel),
+		Description: fmt.Sprintf("Opt-out of rehearsals for this PR, and add the '%s' label allowing merge once other requirements are met.", rehearse.RehearsalsAckLabel),
 		WhoCanUse:   "Anyone can use on trusted PRs",
 		Examples:    []string{rehearseSkip},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       rehearseReject,
-		Description: fmt.Sprintf("Un-acknowledge the rehearsals and remove the '%s' label blocking merge until it is added back.", rehearsalsAckLabel),
+		Description: fmt.Sprintf("Un-acknowledge the rehearsals and remove the '%s' label blocking merge until it is added back.", rehearse.RehearsalsAckLabel),
 		WhoCanUse:   "Anyone can use on trusted PRs",
 		Examples:    []string{rehearseReject},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       rehearseAutoAck,
-		Description: fmt.Sprintf("Run up to %d affected job rehearsals for the change in the PR, and add the '%s' label on success.", s.rehearsalConfig.NormalLimit, rehearsalsAckLabel),
+		Description: fmt.Sprintf("Run up to %d affected job rehearsals for the change in the PR, and add the '%s' label on success.", s.rehearsalConfig.NormalLimit, rehearse.RehearsalsAckLabel),
 		WhoCanUse:   "Anyone can use on trusted PRs",
 		Examples:    []string{rehearseAutoAck},
 	})
@@ -229,8 +228,8 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 			case rehearseAck, rehearseSkip:
 				s.acknowledgeRehearsals(org, repo, number, logger)
 			case rehearseReject:
-				if err := s.ghc.RemoveLabel(org, repo, number, rehearsalsAckLabel); err != nil {
-					logger.WithError(err).Errorf("failed to remove '%s' label", rehearsalsAckLabel)
+				if err := s.ghc.RemoveLabel(org, repo, number, rehearse.RehearsalsAckLabel); err != nil {
+					logger.WithError(err).Errorf("failed to remove '%s' label", rehearse.RehearsalsAckLabel)
 				}
 			case rehearseRefresh:
 				presubmits, periodics, _, _, err := s.getAffectedJobs(pullRequest, logger)
@@ -445,17 +444,17 @@ func (s *server) getUsageDetailsLines() []string {
 		fmt.Sprintf("Comment: `%s` to opt-out of rehearsals", rehearseSkip),
 		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals", rehearseMore, rc.MoreLimit),
 		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals", rehearseMax, rc.MaxLimit),
-		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals, and add the `%s` label on success", rehearseAutoAck, rc.NormalLimit, rehearsalsAckLabel),
+		fmt.Sprintf("Comment: `%s` to run up to %d rehearsals, and add the `%s` label on success", rehearseAutoAck, rc.NormalLimit, rehearse.RehearsalsAckLabel),
 		fmt.Sprintf("Comment: `%s` to get an updated list of affected jobs (useful if you have new pushes to the branch)", rehearseRefresh),
 		"",
-		fmt.Sprintf("Once you are satisfied with the results of the rehearsals, comment: `%s` to unblock merge. When the `%s` label is present on your PR, merge will no longer be blocked by rehearsals.", rehearseAck, rehearsalsAckLabel),
-		fmt.Sprintf("If you would like the `%s` label removed, comment: `%s` to re-block merging.", rehearsalsAckLabel, rehearseReject),
+		fmt.Sprintf("Once you are satisfied with the results of the rehearsals, comment: `%s` to unblock merge. When the `%s` label is present on your PR, merge will no longer be blocked by rehearsals.", rehearseAck, rehearse.RehearsalsAckLabel),
+		fmt.Sprintf("If you would like the `%s` label removed, comment: `%s` to re-block merging.", rehearse.RehearsalsAckLabel, rehearseReject),
 		"</details>",
 	}
 }
 
 func (s *server) acknowledgeRehearsals(org, repo string, number int, logger *logrus.Entry) {
-	if err := s.ghc.AddLabel(org, repo, number, rehearsalsAckLabel); err != nil {
-		logger.WithError(err).Errorf("failed to add '%s' label", rehearsalsAckLabel)
+	if err := s.ghc.AddLabel(org, repo, number, rehearse.RehearsalsAckLabel); err != nil {
+		logger.WithError(err).Errorf("failed to add '%s' label", rehearse.RehearsalsAckLabel)
 	}
 }

--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/dispatcher"
 	"github.com/openshift/ci-tools/pkg/github/prcreation"
+	"github.com/openshift/ci-tools/pkg/rehearse"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
@@ -472,7 +473,7 @@ func main() {
 	}
 
 	title := fmt.Sprintf("%s at %s", matchTitle, time.Now().Format(time.RFC1123))
-	if err := o.PRCreationOptions.UpsertPR(o.targetDir, githubOrg, githubRepo, upstreamBranch, title, prcreation.PrAssignee(o.assign), prcreation.MatchTitle(matchTitle)); err != nil {
+	if err := o.PRCreationOptions.UpsertPR(o.targetDir, githubOrg, githubRepo, upstreamBranch, title, prcreation.PrAssignee(o.assign), prcreation.MatchTitle(matchTitle), prcreation.AdditionalLabels([]string{rehearse.RehearsalsAckLabel})); err != nil {
 		logrus.WithError(err).Fatalf("failed to upsert PR")
 	}
 }

--- a/pkg/github/prcreation/prcreation.go
+++ b/pkg/github/prcreation/prcreation.go
@@ -47,6 +47,7 @@ func (o *PRCreationOptions) Finalize() error {
 type PrOptions struct {
 	prBody           string
 	matchTitle       string
+	additionalLabels []string
 	prAssignee       string
 	gitCommitMessage string
 	skipPRCreation   bool
@@ -74,6 +75,12 @@ func GitCommitMessage(gitCommitMessage string) PrOption {
 func MatchTitle(matchTitle string) PrOption {
 	return func(args *PrOptions) {
 		args.matchTitle = matchTitle
+	}
+}
+
+func AdditionalLabels(additionalLabels []string) PrOption {
+	return func(args *PrOptions) {
+		args.additionalLabels = additionalLabels
 	}
 }
 
@@ -180,7 +187,7 @@ func (o *PRCreationOptions) UpsertPR(localSourceDir, org, repo, branch, prTitle 
 		return nil
 	}
 
-	var labelsToAdd []string
+	labelsToAdd := prArgs.additionalLabels
 	if o.SelfApprove {
 		l.Infof("Self-aproving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -40,8 +40,9 @@ import (
 )
 
 const (
-	appCIContextName = string(api.ClusterAPPCI)
-	buildCache       = "build-cache"
+	RehearsalsAckLabel = "rehearsals-ack"
+	appCIContextName   = string(api.ClusterAPPCI)
+	buildCache         = "build-cache"
 )
 
 type RehearsalConfig struct {


### PR DESCRIPTION
The following jobs will need to have rehearsals skipped (and thus have the label applied) in order to add the `rehearsals-ack`  label to the merge criteria. This is needed so that the `periodic-prow-auto-bump` job can auto merge only if all rehearsals pass.

1. autoconfigbrancher
2. autoowners
3. prow-job-dispatcher

I considered adding this as a parameter to each of these tools, but it seems like something that is unlikely to change as long as we are using the plugin as we will never care about rehearsals for these.

For: https://issues.redhat.com/browse/DPTP-3218

/cc @droslean @openshift/test-platform 