### PR TITLE
ci-secret-generator: validation command

### DIFF
--- a/pkg/api/secretgenerator/secretgenerator.go
+++ b/pkg/api/secretgenerator/secretgenerator.go
@@ -80,8 +80,9 @@ func (c Config) IsFieldGenerated(name, component string) bool {
 }
 
 type FieldGenerator struct {
-	Name string `json:"name,omitempty"`
-	Cmd  string `json:"cmd,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Cmd        string `json:"cmd,omitempty"`
+	Validation string `json:"validation,omitempty"`
 }
 
 type SecretItem struct {

--- a/pkg/api/secretgenerator/secretgenerator_test.go
+++ b/pkg/api/secretgenerator/secretgenerator_test.go
@@ -28,6 +28,9 @@ func TestLoadConfigFromPath(t *testing.T) {
 		{
 			name: "two parameters with multiple values",
 		},
+		{
+			name: "validation_command",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/api/secretgenerator/testdata/TestLoadConfigFromPath/validation_command.yaml
+++ b/pkg/api/secretgenerator/testdata/TestLoadConfigFromPath/validation_command.yaml
@@ -1,0 +1,5 @@
+- item_name: Item1
+  fields:
+  - cmd: echo -n Attachment1
+    name: Attachment1
+    validation: grep -E ^Attachment1$

--- a/pkg/api/secretgenerator/testdata/zz_fixture_TestLoadConfigFromPath_validation_command.yaml
+++ b/pkg/api/secretgenerator/testdata/zz_fixture_TestLoadConfigFromPath_validation_command.yaml
@@ -1,0 +1,5 @@
+- fields:
+  - cmd: echo -n Attachment1
+    name: Attachment1
+    validation: grep -E ^Attachment1$
+  item_name: Item1


### PR DESCRIPTION
This PR tries to realize [DPTP-3032](https://issues.redhat.com/browse/DPTP-3032).
A new validation field has been introduced on `ci-secret-generator` configuration. 
It checks the output of the command that was issued before and then, if it succeeds, updates the secret.
/cc @hongkailiu 