### PR TITLE
Use P95 for more meaningful comparison in disruption allowances update PRs

### DIFF
--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
@@ -118,8 +118,8 @@ func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
 // compareAndUpdate This will compare the recently pulled information and compare it to the currently existing data.
 // We run our comparison by first checking if we are in a newReleaseEvent, meaning master is now pointing on a new release, then we clean out the current data and generate the results new.
 //
-// If we're in a normal cycle, we then run through our regular comparisons, the primary one being P99.
-// We check if the old P99 value is higher than the new by calculating the time difference and the percentage difference.
+// If we're in a normal cycle, we then run through our regular comparisons, the primary one being P95.
+// We check if the old P95 value is higher than the new by calculating the time difference and the percentage difference.
 // If a new value is higher AND the percent difference is higher than the leeway desired, we count that as an increase and record it as part of the results,
 // we also record the decreases.
 //
@@ -130,8 +130,8 @@ func (o *JobRunHistoricalDataAnalyzerOptions) compareAndUpdate(newData, currentD
 	if newReleaseEvent {
 		currentData = make(map[string]jobrunaggregatorapi.HistoricalData, 0)
 	}
-	increaseCount := 0
-	decreaseCount := 0
+	increaseCountP95 := 0
+	decreaseCountP95 := 0
 	results := []parsedJobData{}
 	added := []string{}
 	for key, new := range newData {
@@ -142,31 +142,31 @@ func (o *JobRunHistoricalDataAnalyzerOptions) compareAndUpdate(newData, currentD
 		}
 
 		newP99 := getDurationFromString(new.GetP99())
-		newP95 := getDurationFromString(new.GetP99())
+		newP95 := getDurationFromString(new.GetP95())
 		d := parsedJobData{}
 
 		// If the current data contains the new data, check and record the time diff
 		if old, ok := currentData[key]; ok {
-			oldP99 := getDurationFromString(old.GetP99())
+			oldP95 := getDurationFromString(old.GetP95())
 
 			d.HistoricalData = new
 			d.DurationP99 = newP99
 			d.DurationP95 = newP95
 			d.JobResults = new.GetJobRuns()
 
-			timeDiff := newP99 - oldP99
-			percentDiff := 0.0
-			if oldP99 != 0 {
-				percentDiff = (float64(timeDiff) / float64(oldP99)) * 100
+			timeDiffP95 := newP95 - oldP95
+			percentDiffP95 := 0.0
+			if oldP95 != 0 {
+				percentDiffP95 = (float64(timeDiffP95) / float64(oldP95)) * 100
 			}
-			if newP99 > oldP99 && percentDiff > o.leeway {
-				increaseCount += 1
-				d.TimeDiff = timeDiff
-				d.PercentTimeDiff = percentDiff
-				d.PrevP99 = oldP99
+			if newP95 > oldP95 && percentDiffP95 > o.leeway {
+				increaseCountP95 += 1
+				d.TimeDiffP95 = timeDiffP95
+				d.PercentTimeDiffP95 = percentDiffP95
+				d.PrevP95 = oldP95
 			}
-			if newP99 < oldP99 {
-				decreaseCount += 1
+			if newP95 < oldP95 {
+				decreaseCountP95 += 1
 			}
 		} else {
 			d.HistoricalData = new
@@ -194,8 +194,8 @@ func (o *JobRunHistoricalDataAnalyzerOptions) compareAndUpdate(newData, currentD
 	}
 
 	return compareResults{
-		increaseCount:   increaseCount,
-		decreaseCount:   decreaseCount,
+		increaseCount:   increaseCountP95,
+		decreaseCount:   decreaseCountP95,
 		addedJobs:       added,
 		jobs:            results,
 		missingJobs:     missingJobs,

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/types.go
@@ -11,9 +11,9 @@ import (
 var prTemplate string
 
 type parsedJobData struct {
-	PercentTimeDiff                    float64       `json:"-"`
-	TimeDiff                           time.Duration `json:"-"`
-	PrevP99                            time.Duration `json:"-"`
+	PercentTimeDiffP95                 float64       `json:"-"`
+	TimeDiffP95                        time.Duration `json:"-"`
+	PrevP95                            time.Duration `json:"-"`
 	DurationP95                        time.Duration `json:"-"`
 	DurationP99                        time.Duration `json:"-"`
 	JobResults                         int           `json:"-"`

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
@@ -125,13 +125,13 @@ func fetchCurrentRelease() (current string, previous string, err error) {
 
 func formatTableOutput(data []parsedJobData, filter bool) string {
 	sort.SliceStable(data, func(i, j int) bool {
-		return data[i].TimeDiff > data[j].TimeDiff
+		return data[i].TimeDiffP95 > data[j].TimeDiffP95
 	})
 	var buffer bytes.Buffer
-	buffer.WriteString("| Name | Release | From | Arch | Network | Platform | Topology | Prev P99 | P99 | Job Results | Time Increase | Percent Increase |\n")
-	buffer.WriteString("| ---- | ------- | ---- | ---- | ------- | -------- |--------- | -------- | --- | ----------- | ------------- | ---------------- |\n")
+	buffer.WriteString("| Name | Release | From | Arch | Network | Platform | Topology | Prev P95 | P95 | Job Results | P95 Time Increase | P95 Percent Increase |\n")
+	buffer.WriteString("| ---- | ------- | ---- | ---- | ------- | -------- |--------- | -------- | --- | ----------- | ----------------- | -------------------- |\n")
 	for _, d := range data {
-		if d.TimeDiff == 0 && filter {
+		if d.TimeDiffP95 == 0 && filter {
 			continue
 		}
 		buffer.WriteString(
@@ -143,11 +143,11 @@ func formatTableOutput(data []parsedJobData, filter bool) string {
 				d.GetJobData().Network,
 				d.GetJobData().Platform,
 				d.GetJobData().Topology,
-				d.PrevP99,
-				d.DurationP99,
+				d.PrevP95,
+				d.DurationP95,
 				d.JobResults,
-				d.TimeDiff,
-				d.PercentTimeDiff,
+				d.TimeDiffP95,
+				d.PercentTimeDiffP95,
 			),
 		)
 	}


### PR DESCRIPTION
TRT-705

Instead of P99, we will show previous P95, current P95, time increase, and percent increase.