### PR TITLE
`pj-rehearse`: allow for rehearsal of specific jobs

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -44,10 +44,8 @@ const (
 	// LabelContext exposes the context the job would have had running normally
 	LabelContext = "ci.openshift.io/rehearse.context"
 
-	defaultRehearsalRerunCommand = "/pj-rehearse"
-	defaultRehearsalTrigger      = `(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$`
-	logRehearsalJob              = "rehearsal-job"
-	logCiopConfigFile            = "ciop-config-file"
+	logRehearsalJob   = "rehearsal-job"
+	logCiopConfigFile = "ciop-config-file"
 
 	clusterTypeEnvName = "CLUSTER_TYPE"
 )
@@ -166,8 +164,8 @@ func makeRehearsalPresubmit(source *prowconfig.Presubmit, repo string, prNumber 
 	shortName := contextFor(source)
 	rehearsal.Context = fmt.Sprintf("ci/rehearse/%s%s", ghContext, shortName)
 
-	rehearsal.RerunCommand = defaultRehearsalRerunCommand
-	rehearsal.Trigger = defaultRehearsalTrigger
+	rehearsal.RerunCommand = "/pj-rehearse " + source.Name
+	rehearsal.Trigger = "/pj-rehearse " + source.Name
 	rehearsal.Optional = true
 	if rehearsal.Labels == nil {
 		rehearsal.Labels = map[string]string{}

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_hidden_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -9,7 +9,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 spec:
   containers:
   - args:
@@ -19,4 +19,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 spec:
   containers:
   - args:
@@ -23,4 +23,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_different_org_repo_than_refs_with_custom_config.yaml
@@ -19,7 +19,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 skip_fetch_head: true
 spec:
   containers:
@@ -30,4 +30,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_but_different_repo_than_refs.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 spec:
   containers:
   - args:
@@ -23,4 +23,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_job_that_belong_to_the_same_org_repo_with_refs.yaml
@@ -8,7 +8,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 spec:
   containers:
   - args:
@@ -18,4 +18,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
+++ b/pkg/rehearse/testdata/zz_fixture_TestMakeRehearsalPresubmit_reporting_configuration_is_stripped_from_rehearsals_to_avoid_polluting.yaml
@@ -13,7 +13,7 @@ labels:
   ci.openshift.io/rehearse.context: test
 name: rehearse-123-pull-ci-org-repo-branch-test
 optional: true
-rerun_command: /pj-rehearse
+rerun_command: /pj-rehearse pull-ci-org-repo-branch-test
 spec:
   containers:
   - args:
@@ -23,4 +23,4 @@ spec:
     - ci-operator
     name: ""
     resources: {}
-trigger: '(?m)^/test (?:.*? )?pj-rehearse(?: .*?)?$'
+trigger: /pj-rehearse pull-ci-org-repo-branch-test

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -247,7 +247,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-duper-e2e
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -327,7 +327,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-duper-no-ciop
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -410,7 +410,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-duper-periodic-with-unresolved-config
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -492,7 +492,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-duper-periodic-with-unresolved-config-no-target
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -596,7 +596,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-trooper-master-changed-and-uses-changed-workflow
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -700,7 +700,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse periodic-ci-super-trooper-master-changed-periodic
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -790,7 +790,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-duper-ciop-cfg-change-custom
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -894,7 +894,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-duper-ciop-cfg-change-images
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1003,7 +1003,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-duper-cluster-profile-test-profile
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1089,7 +1089,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-duper-master-cmd
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1198,7 +1198,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-duper-master-e2e-aws
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1307,7 +1307,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-trooper-master-e2e-aws
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1411,7 +1411,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1515,7 +1515,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage5
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z
@@ -1619,7 +1619,7 @@
         sha: test_sha
       repo: release
     report: true
-    rerun_command: /pj-rehearse
+    rerun_command: /pj-rehearse pull-ci-super-trooper-master-unit
     type: presubmit
   status:
     startTime: 2020-06-22T22:25:00Z


### PR DESCRIPTION
The long-awaited feature of being able to specify which job(s) to be rehearsed! This allows for comments like `/pj-rehearse some-test some-other-test` to trigger one or more of the affected jobs from the list that is commented on each PR.

![Screen Shot 2022-12-05 at 12 17 33 PM](https://user-images.githubusercontent.com/1794300/205730964-553a300a-3c32-4d20-8a07-ad7bae28652a.png)

For: https://issues.redhat.com/browse/DPTP-3170

/cc @droslean @openshift/test-platform 