### PR TITLE
`pj-rehearse`: don't ack the rehearsals when we just request to run a job

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -340,7 +340,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					if autoAckMode && success {
 						s.acknowledgeRehearsals(org, repo, number, logger)
 					}
-				} else {
+				} else if !requestedOnly {
 					s.acknowledgeRehearsals(org, repo, number, logger)
 					if err = s.ghc.CreateComment(org, repo, number, fmt.Sprintf("@%s: no rehearsable tests are affected by this change", user)); err != nil {
 						logger.WithError(err).Error("failed to create comment")


### PR DESCRIPTION
We should never apply the `rehearsals-ack` label when the user has simply requested to run a job. Even if that job is not found or unaffected.

/cc @droslean @openshift/test-platform 