### PR TITLE
Fix the update of OSD global pull secrets

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -518,8 +518,8 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 					errs = append(errs, fmt.Errorf("failed to mutate secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
 				} else {
 					if mutated {
-						if _, err := secretClient.Update(context.TODO(), secret, metav1.UpdateOptions{DryRun: dryRunOptions}); err != nil {
-							errs = append(errs, fmt.Errorf("error updating secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
+						if _, err := secretClient.Update(context.TODO(), existingSecret, metav1.UpdateOptions{DryRun: dryRunOptions}); err != nil {
+							errs = append(errs, fmt.Errorf("error updating global pull secret %s:%s/%s: %w", cluster, existingSecret.Namespace, existingSecret.Name, err))
 						}
 						logger.Debug("global pull secret updated")
 					} else {
@@ -583,6 +583,7 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 	return utilerrors.NewAggregate(errs)
 }
 
+// mutateGlobalPullSecret mutates the original secret based on the refreshed value stored in another secret.
 func mutateGlobalPullSecret(original, secret *coreapi.Secret) (bool, error) {
 	dockerConfig, err := dockerConfigJSON(secret)
 	if err != nil {

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -2990,29 +2990,6 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expectedErr: fmt.Errorf("failed to parse the original secret: failed to get content from nil secret"),
 		},
 		{
-			name: "bad original",
-			secret: &coreapi.Secret{
-				Data: map[string][]byte{
-					".dockerconfigjson": []byte(`{
-	"auths": {
-		"a": {
-			"auth": "foo",
-			"email": "e"
-		},
-		"registry.ci.openshift.org": {
-			"auth": "cool"
-		},
-		"c": {
-			"auth": "bar",
-			"email": "g"
-		}
-	}
-}`),
-				},
-			},
-			expectedErr: fmt.Errorf("failed to parse the original secret: failed to get content from nil secret"),
-		},
-		{
 			name: "basic case: expired auth is replaced",
 			secret: &coreapi.Secret{
 				Data: map[string][]byte{
@@ -3047,12 +3024,14 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 	}
 }`),
 				},
+				Type: coreapi.SecretTypeDockerConfigJson,
 			},
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
+				Type: coreapi.SecretTypeDockerConfigJson,
 			},
 		},
 		{
@@ -3125,12 +3104,14 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 	}
 }`),
 				},
+				Type: coreapi.SecretTypeDockerConfigJson,
 			},
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
 					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
+				Type: coreapi.SecretTypeDockerConfigJson,
 			},
 		},
 	}


### PR DESCRIPTION
```
{"component":"XX-secret-bootstrap","error":"failed to update secrets: [error updating secret build03:openshift-config/pull-secret: Secret \"pull-secret\" is invalid: type: Invalid value: \"Opaque\": field is immutable, failed to check if namespace test-credentials exists: Get \"https://api.build02.gcp.xx.openshift.org:6443/api/v1/namespaces/test-credentials\": dial tcp: lookup api.build02.gcp.XX.openshift.org on 172.30.0.10:53: read udp 10.129.129.240:43287-\u003e172.30.0.10:53: read: connection refused, error updating secret build05:openshift-config/pull-secret: Secret \"pull-secret\" is invalid: type: Invalid value: \"Opaque\": field is immutable, error updating secret build04:openshift-config/pull-secret: Secret \"pull-secret\" is invalid: type: Invalid value: \"Opaque\": field is immutable]","file":"/go/src/github.com/openshift/XX-tools/cmd/XX-secret-bootstrap/main.go:893","func":"main.main","level":"fatal","msg":"errors while updating secrets","severity":"fatal","time":"2022-12-13T22:50:50Z"}
```

/cc @openshift/test-platform 