### PR TITLE
`pj-rehearse`: apply filtering to ALL selected jobs

### DIFF
--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -973,6 +973,7 @@ func TestFilterPresubmits(t *testing.T) {
 		{
 			description: "multiple jobs, some allowed",
 			presubmits: config.Presubmits{"org/repo": {
+				*makePresubmit(canBeRehearsed, true, "pull-ci-organization-repo-master-test-0"),
 				*makePresubmit(map[string]string{}, false, "pull-ci-organization-repo-master-test-1"),
 				*makePresubmit(canBeRehearsed, false, "pull-ci-organization-repo-master-test-2"),
 				*makePresubmit(map[string]string{}, false, "pull-ci-organization-repo-master-test-3"),
@@ -994,8 +995,8 @@ func TestFilterPresubmits(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			filterPresubmits(&tc.presubmits, logrus.New())
-			if diff := cmp.Diff(tc.expected, tc.presubmits, cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Presubmit{})); diff != "" {
+			presubmits := filterPresubmits(tc.presubmits, logrus.New())
+			if diff := cmp.Diff(tc.expected, presubmits, cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Presubmit{})); diff != "" {
 				t.Fatalf("filtered didn't match expected, diff: %s", diff)
 			}
 		})
@@ -1039,30 +1040,30 @@ func TestFilterPeriodics(t *testing.T) {
 	}{
 		{
 			description: "basic periodic job, allowed",
-			periodics:   config.Periodics{"org/repo": *makePeriodic(canBeRehearsed, false)},
-			expected:    config.Periodics{"org/repo": *makePeriodic(canBeRehearsed, false)},
+			periodics:   config.Periodics{"periodic-test": *makePeriodic(canBeRehearsed, false)},
+			expected:    config.Periodics{"periodic-test": *makePeriodic(canBeRehearsed, false)},
 		},
 		{
 			description: "job with no rehearse label, not allowed",
-			periodics:   config.Periodics{"org/repo": *makePeriodic(map[string]string{}, false)},
+			periodics:   config.Periodics{"periodic-test": *makePeriodic(map[string]string{}, false)},
 			expected:    config.Periodics{},
 		},
 		{
 			description: "hidden job, not allowed",
-			periodics:   config.Periodics{"org/repo": *makePeriodic(canBeRehearsed, true)},
+			periodics:   config.Periodics{"periodic-test": *makePeriodic(canBeRehearsed, true)},
 			expected:    config.Periodics{},
 		},
 		{
 			description: "multiple repos, some jobs allowed",
-			periodics: config.Periodics{"org/repo": *makePeriodic(canBeRehearsed, false),
-				"org/different": *makePeriodic(map[string]string{}, false)},
-			expected: config.Periodics{"org/repo": *makePeriodic(canBeRehearsed, false)},
+			periodics: config.Periodics{"periodic-test": *makePeriodic(canBeRehearsed, false),
+				"other-test": *makePeriodic(map[string]string{}, false)},
+			expected: config.Periodics{"periodic-test": *makePeriodic(canBeRehearsed, false)},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			filterPeriodics(tc.periodics, logrus.New())
-			if diff := cmp.Diff(tc.expected, tc.periodics, cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Periodic{})); diff != "" {
+			periodics := filterPeriodics(tc.periodics, logrus.New())
+			if diff := cmp.Diff(tc.expected, periodics, cmp.AllowUnexported(prowconfig.Brancher{}, prowconfig.RegexpChangeMatcher{}, prowconfig.Periodic{})); diff != "" {
 				t.Fatalf("filtered didn't match expected, diff: %s", diff)
 			}
 		})

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -141,15 +141,9 @@ func (r RehearsalConfig) DetermineAffectedJobs(candidate RehearsalCandidate, can
 	}
 
 	presubmits := config.Presubmits{}
+	presubmits.AddAll(diffs.GetChangedPresubmits(masterConfig.Prow, prConfig.Prow, logger), config.ChangedPresubmit)
 	periodics := config.Periodics{}
-
-	changedPeriodics := diffs.GetChangedPeriodics(masterConfig.Prow, prConfig.Prow, logger)
-	filterPeriodics(changedPeriodics, logger)
-	periodics.AddAll(changedPeriodics, config.ChangedPeriodic)
-
-	changedPresubmits := diffs.GetChangedPresubmits(masterConfig.Prow, prConfig.Prow, logger)
-	filterPresubmits(&changedPresubmits, logger)
-	presubmits.AddAll(changedPresubmits, config.ChangedPresubmit)
+	periodics.AddAll(diffs.GetChangedPeriodics(masterConfig.Prow, prConfig.Prow, logger), config.ChangedPeriodic)
 
 	// We can only detect changes if we managed to load both ci-operator config versions
 	if masterConfig.CiOperator != nil && prConfig.CiOperator != nil {
@@ -190,7 +184,7 @@ func (r RehearsalConfig) DetermineAffectedJobs(candidate RehearsalCandidate, can
 		presubmits.AddAll(presubmitsForClusterProfiles, config.ChangedClusterProfile)
 	}
 
-	return presubmits, periodics, changedTemplates, changedClusterProfiles, nil
+	return filterPresubmits(presubmits, logger), filterPeriodics(periodics, logger), changedTemplates, changedClusterProfiles, nil
 }
 
 func (r RehearsalConfig) SetupJobs(candidate RehearsalCandidate, candidatePath string, presubmits config.Presubmits, periodics config.Periodics, rehearsalTemplates, rehearsalClusterProfiles *ConfigMaps, limit int, logger *logrus.Entry) (*config.ReleaseRepoConfig, *pjapi.Refs, apihelper.ImageStreamTagMap, []*prowconfig.Presubmit, error) {


### PR DESCRIPTION
When the filtering logic was moved up in the process in https://github.com/openshift/ci-tools/pull/3130, it was, incorrectly, only applied to the directly modified jobs. This results in jobs that are chosen, for example, from changed registry content not being filtered out due to being `hidden`.

I also modified the filtering logic to not filter in place anymore as it is confusing to reason with that way.

/cc @hongkailiu @droslean @openshift/test-platform 