### PR TITLE
Fix ci-tools failing test on missing 4.5 release

### DIFF
--- a/pkg/release/candidate/client_test.go
+++ b/pkg/release/candidate/client_test.go
@@ -77,9 +77,9 @@ func TestEndpoint(t *testing.T) {
 				Product:      api.ReleaseProductOCP,
 				Architecture: api.ReleaseArchitectureAMD64,
 				Stream:       api.ReleaseStreamCI,
-				Version:      "4.5",
+				Version:      "4.11",
 			},
-			output: "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.5.0-0.ci/latest",
+			output: "https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.11.0-0.ci/latest",
 		},
 		{
 			input: api.Candidate{

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -14,7 +14,7 @@ resources:
       cpu: 10m
 tag_specification:
   namespace: ocp
-  name: "4.5"
+  name: "4.11"
 releases:
   custom:
     candidate:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -139,21 +139,21 @@ func TestMultiStage(t *testing.T) {
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim"},
 			needHive: true,
 			success:  true,
-			output:   []string{`Imported release 4.7.`, `to tag release:latest-e2e-claim`, `e2e-claim-claim-step succeeded`},
+			output:   []string{`Imported release 4.11.`, `to tag release:latest-e2e-claim`, `e2e-claim-claim-step succeeded`},
 		},
 		{
 			name:     "e2e-claim-as-custom",
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim-as-custom"},
 			needHive: true,
 			success:  true,
-			output:   []string{`Imported release 4.7.`, `to tag release:custom-e2e-claim-as-custom`, `e2e-claim-as-custom-claim-step succeeded`},
+			output:   []string{`Imported release 4.11.`, `to tag release:custom-e2e-claim-as-custom`, `e2e-claim-as-custom-claim-step succeeded`},
 		},
 		{
 			name:     "e2e-claim depends on release image",
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim-depend-on-release-image"},
 			needHive: true,
 			success:  true,
-			output:   []string{`Imported release 4.7.`, `to tag release:latest-e2e-claim-depend-on-release-image`, `e2e-claim-depend-on-release-image-claim-step succeeded`},
+			output:   []string{`Imported release 4.11.`, `to tag release:latest-e2e-claim-depend-on-release-image`, `e2e-claim-depend-on-release-image-claim-step succeeded`},
 		},
 		{
 			name:    "assembled releases function",
@@ -161,8 +161,8 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Imported release 4.5.`, `images to tag release:initial`,
-				`Snapshot integration stream into release 4.7.`, `-latest to tag release:latest`,
+				`Imported release 4.11.`, `images to tag release:initial`,
+				`Snapshot integration stream into release 4.11.`, `-latest to tag release:latest`,
 				`verify-releases-initial succeeded`, `verify-releases-initial-cli succeeded`,
 				`verify-releases-latest succeeded`, `verify-releases-latest-cli succeeded`,
 			},
@@ -173,7 +173,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.7.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.11.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},
@@ -183,7 +183,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.7.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.11.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},

--- a/test/e2e/multi-stage/integration-releases.yaml
+++ b/test/e2e/multi-stage/integration-releases.yaml
@@ -8,11 +8,11 @@ releases:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.5"
+      version: "4.10"
   latest:
     integration:
       namespace: ocp
-      name: "4.7"
+      name: "4.11"
 resources:
   '*':
     requests:
@@ -22,14 +22,14 @@ tests:
     steps:
       test:
         - as: initial
-          commands: grep -q '4.5' <<<"$( cluster-version-operator version )"
+          commands: grep -q '4.10' <<<"$( cluster-version-operator version )"
           from: "release:initial"
           resources:
             requests:
               cpu: 10m
               memory: 10Mi
         - as: initial-cli
-          commands: grep -q '4.5' <<<"$( oc version )"
+          commands: grep -q '4.10' <<<"$( oc version )"
           from: "stable-initial:cli"
           resources:
             requests:


### PR DESCRIPTION
4.5 is EOL, use 4.11 instead for the ci-stream test case.