### PR TITLE
Fix e2e "assembled releases function": releases 4.5.* EOL

### DIFF
--- a/test/e2e/multi-stage/integration-releases.yaml
+++ b/test/e2e/multi-stage/integration-releases.yaml
@@ -8,11 +8,11 @@ releases:
     candidate:
       product: ocp
       stream: nightly
-      version: "4.5"
+      version: "4.11"
   latest:
     integration:
       namespace: ocp
-      name: "4.7"
+      name: "4.13"
 resources:
   '*':
     requests:
@@ -22,14 +22,14 @@ tests:
     steps:
       test:
         - as: initial
-          commands: grep -q '4.5' <<<"$( cluster-version-operator version )"
+          commands: grep -q '4.11' <<<"$( cluster-version-operator version )"
           from: "release:initial"
           resources:
             requests:
               cpu: 10m
               memory: 10Mi
         - as: initial-cli
-          commands: grep -q '4.5' <<<"$( oc version )"
+          commands: grep -q '4.11' <<<"$( oc version )"
           from: "stable-initial:cli"
           resources:
             requests:


### PR DESCRIPTION
Releases `4.5.*` hit EOL and then they are no longer available:
```
Requesting a release from https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4.5.0-0.nightly/latest 
�[36mINFO�[0m[2022-12-13T22:35:44Z] Ran for 1s                                   
�[31mERRO�[0m[2022-12-13T22:35:44Z] Some steps failed:                           
�[31mERRO�[0m[2022-12-13T22:35:44Z] 
* failed to generate steps from config: failed to resolve release initial: failed to request latest release: server responded with 404: no tags exist within the release that satisfy the request 
```
as it was in #3200, e2e test "TestMultiStage: assembled releases function" fails peremptorily.