### PR TITLE
Use redhat-internal.slack.com

### DIFF
--- a/pkg/jira/issues.go
+++ b/pkg/jira/issues.go
@@ -104,7 +104,7 @@ func (f *filer) resolveRequester(reporter string, logger *logrus.Entry) (string,
 	slackUser, err := f.slackClient.GetUserInfo(reporter)
 	if err != nil {
 		logger.WithError(err).Warn("could not search Slack for requester")
-		suffix = fmt.Sprintf("[a Slack user|%s/team/%s]", slackutil.CoreOSURL, reporter)
+		suffix = fmt.Sprintf("[a Slack user|%s/team/%s]", slackutil.RedHatInternalURL, reporter)
 	} else {
 		jiraUsers, response, err := f.jiraClient.FindUser(slackUser.RealName)
 		if err := jirautil.HandleJiraError(response, err); err != nil {
@@ -113,7 +113,7 @@ func (f *filer) resolveRequester(reporter string, logger *logrus.Entry) (string,
 		if len(jiraUsers) != 0 {
 			requester = &jiraUsers[0]
 		}
-		suffix = fmt.Sprintf("Slack user [%s|%s/team/%s]", slackUser.RealName, slackutil.CoreOSURL, slackUser.ID)
+		suffix = fmt.Sprintf("Slack user [%s|%s/team/%s]", slackUser.RealName, slackutil.RedHatInternalURL, slackUser.ID)
 	}
 
 	if requester == nil {

--- a/pkg/jira/issues_test.go
+++ b/pkg/jira/issues_test.go
@@ -97,7 +97,7 @@ func TestResolveRequester(t *testing.T) {
 				},
 			},
 			reporter:       "skuznets",
-			expectedSuffix: "Slack user [Steve Kuznetsov|https://coreos.slack.com/team/slackIdentifier]",
+			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
 			expectedUser:   &jira.User{AccountID: "jiraIdentifier"},
 		},
 		{
@@ -118,7 +118,7 @@ func TestResolveRequester(t *testing.T) {
 				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
 			},
 			reporter:       "skuznets",
-			expectedSuffix: "Slack user [Steve Kuznetsov|https://coreos.slack.com/team/slackIdentifier]",
+			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
 			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
 		},
 		{
@@ -139,7 +139,7 @@ func TestResolveRequester(t *testing.T) {
 				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
 			},
 			reporter:       "skuznets",
-			expectedSuffix: "Slack user [Steve Kuznetsov|https://coreos.slack.com/team/slackIdentifier]",
+			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
 			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
 		},
 		{
@@ -154,7 +154,7 @@ func TestResolveRequester(t *testing.T) {
 				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
 			},
 			reporter:       "skuznets",
-			expectedSuffix: "[a Slack user|https://coreos.slack.com/team/skuznets]",
+			expectedSuffix: "[a Slack user|https://redhat-internal.slack.com/team/skuznets]",
 			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
 		},
 	}

--- a/pkg/slack/modals/incident/view.go
+++ b/pkg/slack/modals/incident/view.go
@@ -155,17 +155,17 @@ func slackEntityFormatFuncs(client infoGetter) template.FuncMap {
 			user, err := client.GetUserInfo(input)
 			if err != nil {
 				logrus.WithError(err).Warn("Could not look up user-provided Slack user ID for pretty printing.")
-				return fmt.Sprintf("[user profile|https://coreos.slack.com/team/%s]", input)
+				return fmt.Sprintf("[user profile|https://redhat-internal.slack.com/team/%s]", input)
 			}
-			return fmt.Sprintf("[%s|https://coreos.slack.com/team/%s]", user.RealName, user.ID)
+			return fmt.Sprintf("[%s|https://redhat-internal.slack.com/team/%s]", user.RealName, user.ID)
 		},
 		"slackChannelLink": func(input string) string {
 			channel, err := client.GetConversationInfo(input, false)
 			if err != nil {
 				logrus.WithError(err).Warn("Could not look up user-provided Slack channel ID for pretty printing.")
-				return fmt.Sprintf("[channel|https://coreos.slack.com/archives/%s]", input)
+				return fmt.Sprintf("[channel|https://redhat-internal.slack.com/archives/%s]", input)
 			}
-			return fmt.Sprintf("[#%s|https://coreos.slack.com/archives/%s]", channel.Name, channel.ID)
+			return fmt.Sprintf("[#%s|https://redhat-internal.slack.com/archives/%s]", channel.Name, channel.ID)
 		},
 	}
 }

--- a/pkg/slack/modals/incident/view_test.go
+++ b/pkg/slack/modals/incident/view_test.go
@@ -101,9 +101,9 @@ func TestProcessSubmissionHandler(t *testing.T) {
 The bootstrap node auto-approver is down for the fiftieth time.
 
 ||Name||Link||
-|Slack Incident Channel|[#secret|https://coreos.slack.com/archives/C01B31AT7K4]|
+|Slack Incident Channel|[#secret|https://redhat-internal.slack.com/archives/C01B31AT7K4]|
 |Tracking Bugzilla Bug(s)|https://bugzilla.redhat.com/show_bug.cgi?id=123123123213123|
-|SME Name|[The Dude|https://coreos.slack.com/team/U01AZU9H0BF]|
+|SME Name|[The Dude|https://redhat-internal.slack.com/team/U01AZU9H0BF]|
 
 h3. Impact
 Nodes are not ready and no jobs run.
@@ -147,9 +147,9 @@ func TestIssueParameters(t *testing.T) {
 The bootstrap node auto-approver is down for the fiftieth time.
 
 ||Name||Link||
-|Slack Incident Channel|[channel|https://coreos.slack.com/archives/C01B31AT7K4]|
+|Slack Incident Channel|[channel|https://redhat-internal.slack.com/archives/C01B31AT7K4]|
 |Tracking Bugzilla Bug(s)|https://bugzilla.redhat.com/show_bug.cgi?id=123123123213123|
-|SME Name|[user profile|https://coreos.slack.com/team/U01AZU9H0BF]|
+|SME Name|[user profile|https://redhat-internal.slack.com/team/U01AZU9H0BF]|
 
 h3. Impact
 Nodes are not ready and no jobs run.
@@ -164,9 +164,9 @@ So surprising!`,
 The bootstrap node auto-approver is down for the fiftieth time.
 
 ||Name||Link||
-|Slack Incident Channel|[#secret|https://coreos.slack.com/archives/C01B31AT7K5]|
+|Slack Incident Channel|[#secret|https://redhat-internal.slack.com/archives/C01B31AT7K5]|
 |Tracking Bugzilla Bug(s)|https://bugzilla.redhat.com/show_bug.cgi?id=123123123213123|
-|SME Name|[The Dude|https://coreos.slack.com/team/U01AZU9H0BG]|
+|SME Name|[The Dude|https://redhat-internal.slack.com/team/U01AZU9H0BG]|
 
 h3. Impact
 Nodes are not ready and no jobs run.

--- a/pkg/slack/util.go
+++ b/pkg/slack/util.go
@@ -1,4 +1,4 @@
 package slack
 
-// CoreOSURL is the hostname for the CoreOS Slack
-const CoreOSURL = "https://coreos.slack.com"
+// RedHatInternalURL is the hostname for the CoreOS Slack
+const RedHatInternalURL = "https://redhat-internal.slack.com"


### PR DESCRIPTION
Generated by

> rg coreos.slack -l | while read file; do gsed -i 's/coreos.slack.com/redhat-internal.slack.com/g' $file; done

/cc @openshift/test-platform @jupierce 

/hold

Do it tomorrow?

From the letter:

"Check your Slack integrations and update references to the old workspace URL. The workspace URL for the CoreOS workspace will change from https://coreos.slack.com/ to https://redhat-internal.slack.com/ on Friday, December 16th, at 9 AM EST. Developers should update any workflows, webhooks, bots, custom or third-party applications that reference the old URL to ensure the link works."