### PR TITLE
Change the way clusters are disabled during failover

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -450,15 +450,6 @@ func main() {
 		}
 	}
 
-	if config.DetermineE2EByJob == true && config.IsAnyBuildClusterDisabled() {
-		config.DetermineE2EByJob = false
-		config.IgnoreE2EByJobAssignment = true
-	}
-	if config.IgnoreE2EByJobAssignment == true && !config.IsAnyBuildClusterDisabled() {
-		config.DetermineE2EByJob = true
-		config.IgnoreE2EByJobAssignment = false
-	}
-
 	logrus.Info("Dispatching ...")
 	if err := dispatchJobs(context.TODO(), o.prowJobConfigDir, o.maxConcurrency, config, jobVolumes); err != nil {
 		logrus.WithError(err).Fatal("Failed to dispatch")

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -24,8 +24,6 @@ type Config struct {
 	DetermineE2EByJob bool `json:"determineE2EByJob,omitempty"`
 	// the cluster cluster name if no other condition matches
 	Default api.Cluster `json:"default"`
-	// Do not change the cluster setting if the job is manually assigned to the same cloud as the one for the e2e test
-	IgnoreE2EByJobAssignment bool `json:"ignoreE2EByJobAssignment,omitempty"`
 	// the cluster name for ssh bastion jobs
 	SSHBastion api.Cluster `json:"sshBastion"`
 	// the cluster names for kvm jobs
@@ -43,8 +41,6 @@ type Config struct {
 type BuildFarmConfig struct {
 	FilenamesRaw []string    `json:"filenames,omitempty"`
 	Filenames    sets.String `json:"-"`
-
-	Disabled bool `json:"disabled,omitempty"`
 }
 
 // JobGroups maps a group of jobs to a cluster
@@ -134,15 +130,7 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 	if config.DetermineE2EByJob {
 		if cloud := DetermineCloud(jobBase); cloud != "" {
 			if clusters, ok := config.BuildFarmCloud[api.Cloud(cloud)]; ok {
-				return api.Cluster(clusters[len(filepath.Base(path))%len(clusters)]), false, nil
-			}
-		}
-	}
-
-	if config.IgnoreE2EByJobAssignment {
-		if cloud := DetermineCloud(jobBase); cloud != "" {
-			if clusters, ok := config.BuildFarmCloud[api.Cloud(cloud)]; ok {
-				if jobBase.Cluster == clusters[len(filepath.Base(path))%len(clusters)] {
+				if len(clusters) > 0 {
 					return api.Cluster(clusters[len(filepath.Base(path))%len(clusters)]), false, nil
 				}
 			}

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -208,21 +208,6 @@ func isSSHBastionJob(base prowconfig.JobBase) bool {
 	return false
 }
 
-// IsAnyBuildClusterDisabled returns if any of the build clusters is disabled
-func (config *Config) IsAnyBuildClusterDisabled() bool {
-	if len(config.BuildFarm) == 0 {
-		return true
-	}
-	for provider := range config.BuildFarm {
-		for cluster := range config.BuildFarm[provider] {
-			if config.BuildFarm[provider][cluster].Disabled == true {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // IsInBuildFarm returns the cloudProvider if the cluster is in the build farm; empty string otherwise.
 func (config *Config) IsInBuildFarm(clusterName api.Cluster) api.Cloud {
 	for cloudProvider, v := range config.BuildFarm {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -687,36 +687,3 @@ func TestValidate(t *testing.T) {
 		})
 	}
 }
-
-func TestConfigIsAnyBuildClusterDisabled(t *testing.T) {
-	tests := []struct {
-		name      string
-		buildFarm map[api.Cloud]map[api.Cluster]*BuildFarmConfig
-		want      bool
-	}{
-		{
-			name: "empty BuildFarm",
-			want: true,
-		},
-		{
-			name:      "Buildfarm not disabled",
-			buildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{"aws": {"build01": &BuildFarmConfig{Disabled: false}}},
-			want:      false,
-		},
-		{
-			name:      "Buildfarm disabled",
-			buildFarm: map[api.Cloud]map[api.Cluster]*BuildFarmConfig{"aws": {"build01": &BuildFarmConfig{Disabled: true}}},
-			want:      true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config := &Config{
-				BuildFarm: tt.buildFarm,
-			}
-			if got := config.IsAnyBuildClusterDisabled(); got != tt.want {
-				t.Errorf("Config.IsAnyBuildClusterDisabled() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -372,9 +372,6 @@ func TestGetClusterForJob(t *testing.T) {
 }
 
 func TestDetermineClusterForJob(t *testing.T) {
-	configIgnoreE2EByJobAssignment := configWithBuildFarmWithJobsAndDetermineE2EByJob
-	configIgnoreE2EByJobAssignment.DetermineE2EByJob = false
-	configIgnoreE2EByJobAssignment.IgnoreE2EByJobAssignment = true
 	testCases := []struct {
 		name                   string
 		config                 *Config
@@ -523,26 +520,6 @@ func TestDetermineClusterForJob(t *testing.T) {
 			},
 			expected:               "build01",
 			expectedCanBeRelocated: false,
-		},
-		{
-			name:   "IgnoreE2EByJobAssignment: aws assigned",
-			config: &configIgnoreE2EByJobAssignment,
-			jobBase: config.JobBase{Agent: "kubernetes", Name: "some-e2e-job",
-				Labels:  map[string]string{"ci-operator.openshift.io/cloud": "aws"},
-				Cluster: "build01",
-			},
-			expected:               "build01",
-			expectedCanBeRelocated: false,
-		},
-		{
-			name:   "IgnoreE2EByJobAssignment: gcp assigned",
-			config: &configIgnoreE2EByJobAssignment,
-			jobBase: config.JobBase{Agent: "kubernetes", Name: "some-e2e-job",
-				Labels:  map[string]string{"ci-operator.openshift.io/cloud": "aws"},
-				Cluster: "build02",
-			},
-			expected:               "api.ci",
-			expectedCanBeRelocated: true,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
- revert https://github.com/openshift/ci-tools/commit/ef2a28d87bc879fdc3f1bdd27a890c6da4be3544
-  remove `IgnoreE2EByJobAssignment`
- change the way clusters are added and deleted 
- add get HTTP to know provider

/cc @hongkailiu 