### PR TITLE
cluster-display: update error handling for cluster list

### DIFF
--- a/cmd/cluster-display/main.go
+++ b/cmd/cluster-display/main.go
@@ -124,47 +124,59 @@ func getClusterPage(ctx context.Context, clients map[string]ctrlruntimeclient.Cl
 		if skipHive && cluster == string(api.HiveCluster) {
 			continue
 		}
-		consoleHost, err := api.ResolveConsoleHost(ctx, client)
+		clusterInfo, err := getClusterInfo(ctx, cluster, client)
 		if err != nil {
-			return nil, fmt.Errorf("failed to resolve the console host for cluster %s: %w", cluster, err)
+			logrus.WithError(err)
+			clusterInfo["error"] = "cannot reach cluster"
 		}
-		registryHost, err := api.ResolveImageRegistryHost(ctx, client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve the image registry host for cluster %s: %w", cluster, err)
-		}
-		cv := &configv1.ClusterVersion{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: "version"}, cv); err != nil {
-			return nil, fmt.Errorf("failed to get ClusterVersion for cluster %s: %w", cluster, err)
-		}
-		if len(cv.Status.History) == 0 {
-			return nil, fmt.Errorf("failed to get ClusterVersion for cluster %s: no history found", cluster)
-		}
-		infra := &configv1.Infrastructure{}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: "cluster"}, infra); err != nil {
-			return nil, fmt.Errorf("failed to get Infrastructure for cluster %s: %w", cluster, err)
-		}
-		version := cv.Status.History[0].Version
-		product, err := resolveProduct(ctx, client, version)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve the product for cluster %s: %w", cluster, err)
-		}
-
-		cloud := string(infra.Status.PlatformStatus.Type)
-		data = append(data, map[string]string{
-			"cluster":      cluster,
-			"consoleHost":  consoleHost,
-			"registryHost": registryHost,
-			"version":      version,
-			"product":      product,
-			"cloud":        cloud,
-		})
-
+		data = append(data, clusterInfo)
 	}
 
 	sort.Slice(data, func(i, j int) bool {
 		return data[i]["cluster"] < data[j]["cluster"]
 	})
 	return &Page{Data: data}, nil
+}
+
+func getClusterInfo(ctx context.Context, cluster string, client ctrlruntimeclient.Client) (map[string]string, error) {
+	var data = map[string]string{
+		"cluster": cluster,
+	}
+	consoleHost, err := api.ResolveConsoleHost(ctx, client)
+	if err != nil {
+		return data, fmt.Errorf("failed to resolve the console host for cluster %s: %w", cluster, err)
+	}
+	registryHost, err := api.ResolveImageRegistryHost(ctx, client)
+	if err != nil {
+		return data, fmt.Errorf("failed to resolve the image registry host for cluster %s: %w", cluster, err)
+	}
+	cv := &configv1.ClusterVersion{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: "version"}, cv); err != nil {
+		return data, fmt.Errorf("failed to get ClusterVersion for cluster %s: %w", cluster, err)
+	}
+	if len(cv.Status.History) == 0 {
+		return data, fmt.Errorf("failed to get ClusterVersion for cluster %s: no history found", cluster)
+	}
+	infra := &configv1.Infrastructure{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: "cluster"}, infra); err != nil {
+		return data, fmt.Errorf("failed to get Infrastructure for cluster %s: %w", cluster, err)
+	}
+	version := cv.Status.History[0].Version
+	product, err := resolveProduct(ctx, client, version)
+	if err != nil {
+		return data, fmt.Errorf("failed to resolve the product for cluster %s: %w", cluster, err)
+	}
+	cloud := string(infra.Status.PlatformStatus.Type)
+
+	return map[string]string{
+		"cluster":      cluster,
+		"consoleHost":  consoleHost,
+		"registryHost": registryHost,
+		"version":      version,
+		"product":      product,
+		"cloud":        cloud,
+		"error":        "",
+	}, nil
 }
 
 func resolveProduct(ctx context.Context, client ctrlruntimeclient.Client, version string) (string, error) {
@@ -208,10 +220,6 @@ func getRouter(ctx context.Context, hiveClient ctrlruntimeclient.Client, clients
 			page, err = getClusterPage(ctx, allClients, skipHive)
 		default:
 			http.Error(w, fmt.Sprintf("Unknown crd: %s", crd), http.StatusBadRequest)
-			return
-		}
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 		if err != nil {

--- a/cmd/cluster-display/main_test.go
+++ b/cmd/cluster-display/main_test.go
@@ -137,7 +137,7 @@ func (g *fakeClusterGetter) GetClusterDetails(ctx context.Context, cluster strin
 		return map[string]string{
 			"cluster": cluster,
 			"error":   "cannot reach cluster",
-		}, fmt.Errorf("an error occured")
+		}, fmt.Errorf("an error occurred")
 	}
 	return map[string]string{
 		"cluster": cluster,

--- a/cmd/cluster-display/main_test.go
+++ b/cmd/cluster-display/main_test.go
@@ -130,29 +130,82 @@ func TestGetRouter(t *testing.T) {
 	}
 }
 
+type fakeClusterGetter struct{}
+
+func (g *fakeClusterGetter) GetClusterDetails(ctx context.Context, cluster string, client ctrlruntimeclient.Client) (map[string]string, error) {
+	if cluster == "badCluster" {
+		return map[string]string{
+			"cluster": cluster,
+			"error":   "cannot reach cluster",
+		}, fmt.Errorf("an error occured")
+	}
+	return map[string]string{
+		"cluster": cluster,
+		"error":   "",
+	}, nil
+}
+
 func TestGetClusterPage(t *testing.T) {
 	testCases := []struct {
 		name     string
 		clients  map[string]ctrlruntimeclient.Client
+		getter   ClusterInfoGetter
 		expected []map[string]string
 	}{
 		{
-			name: "Client with error",
+			name: "Clients without errors",
 			clients: map[string]ctrlruntimeclient.Client{
-				"app.ci": fakectrlruntimeclient.NewClientBuilder().Build(),
+				"cluster1": fakectrlruntimeclient.NewClientBuilder().Build(),
+				"cluster2": fakectrlruntimeclient.NewClientBuilder().Build(),
 			},
 			expected: []map[string]string{
 				{
-					"cluster": "app.ci",
+					"cluster": "cluster1",
+					"error":   "",
+				},
+				{
+					"cluster": "cluster2",
+					"error":   "",
+				},
+			},
+			getter: &fakeClusterGetter{},
+		},
+		{
+			name: "Client with error",
+			clients: map[string]ctrlruntimeclient.Client{
+				"badCluster": fakectrlruntimeclient.NewClientBuilder().Build(),
+			},
+			expected: []map[string]string{
+				{
+					"cluster": "badCluster",
 					"error":   "cannot reach cluster",
 				},
 			},
+			getter: &clusterInfoGetter{},
+		},
+		{
+			name: "One client with error",
+			clients: map[string]ctrlruntimeclient.Client{
+				"okCluster":  fakectrlruntimeclient.NewClientBuilder().Build(),
+				"badCluster": fakectrlruntimeclient.NewClientBuilder().Build(),
+			},
+			expected: []map[string]string{
+				{
+					"cluster": "badCluster",
+					"error":   "cannot reach cluster",
+				},
+				{
+					"cluster": "okCluster",
+					"error":   "",
+				},
+			},
+			getter: &fakeClusterGetter{},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			page, _ := getClusterPage(context.TODO(), tc.clients, true)
+			page, _ := getClusterPage(context.TODO(), tc.clients, true, tc.getter)
 			if diff := cmp.Diff(page.Data, tc.expected); diff != "" {
 				t.Errorf("result differs from expected output, diff:\n%s", diff)
 			}

--- a/cmd/cluster-display/main_test.go
+++ b/cmd/cluster-display/main_test.go
@@ -129,3 +129,33 @@ func TestGetRouter(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClusterPage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		clients  map[string]ctrlruntimeclient.Client
+		expected []map[string]string
+	}{
+		{
+			name: "Client with error",
+			clients: map[string]ctrlruntimeclient.Client{
+				"app.ci": fakectrlruntimeclient.NewClientBuilder().Build(),
+			},
+			expected: []map[string]string{
+				{
+					"cluster": "app.ci",
+					"error":   "cannot reach cluster",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			page, _ := getClusterPage(context.TODO(), tc.clients, true)
+			if diff := cmp.Diff(page.Data, tc.expected); diff != "" {
+				t.Errorf("result differs from expected output, diff:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updated error handling so that if there's an error regarding one cluster, the error is logged, and the rest of the clusters are _not_ skipped.

for https://issues.redhat.com/browse/DPTP-3086

/cc smg247