### PR TITLE
Standardize check for periodic

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -167,7 +167,7 @@ func main() {
 		// don't copy periodics and postsubmits
 		var tests []api.TestStepConfiguration
 		for _, test := range rbc.Tests {
-			if test.Cron == nil && test.Interval == nil && !test.Postsubmit {
+			if !test.IsPeriodic() && !test.Postsubmit {
 				tests = append(tests, test)
 			}
 		}

--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -154,7 +154,7 @@ func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases 
 // removePeriodics removes periodic tests from the configuration
 func removePeriodics(tests *[]api.TestStepConfiguration) {
 	for i := len(*tests) - 1; i >= 0; i-- {
-		if !(*tests)[i].Portable && ((*tests)[i].Cron != nil || (*tests)[i].Interval != nil) {
+		if !(*tests)[i].Portable && (*tests)[i].IsPeriodic() {
 			*tests = append((*tests)[:i], (*tests)[i+1:]...)
 		}
 	}

--- a/cmd/payload-testing-prow-plugin/filetestresolver.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver.go
@@ -18,7 +18,7 @@ func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
 		if configurations, configOK := v["release"]; configOK {
 			for _, configuration := range configurations {
 				for _, element := range configuration.Tests {
-					if element.Cron != nil || element.Interval != nil || element.ReleaseController {
+					if element.IsPeriodic() {
 						jobName := configuration.Metadata.JobName(jc.PeriodicPrefix, element.As)
 						if jobName == job {
 							return api.MetadataWithTest{

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -730,6 +730,10 @@ func (config TestStepConfiguration) TargetName() string {
 	return config.As
 }
 
+func (config TestStepConfiguration) IsPeriodic() bool {
+	return config.Interval != nil || config.MinimumInterval != nil || config.Cron != nil || config.ReleaseController
+}
+
 // Cloud is the name of a cloud provider, e.g., aws cluster topology, etc.
 type Cloud string
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -50,7 +50,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 		g := NewProwJobBaseBuilderForTest(configSpec, info, NewCiOperatorPodSpecGenerator(), element)
 		disableRehearsal := rehearsals.DisableAll || disabledRehearsals.Has(element.As)
 
-		if element.Cron != nil || element.Interval != nil || element.MinimumInterval != nil || element.ReleaseController {
+		if element.IsPeriodic() {
 			cron := ""
 			if element.Cron != nil {
 				cron = *element.Cron

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -596,7 +596,7 @@ func selectJobsForRegistryStep(node registry.Node, configs []*config.DataWithInf
 			switch {
 			case test.Postsubmit:
 				continue // We do not handle postsubmits
-			case test.Cron != nil || test.Interval != nil:
+			case test.IsPeriodic():
 				jobName = cfg.Info.JobName(jobconfig.PeriodicPrefix, test.As)
 				if periodic, ok := allPeriodics[jobName]; ok {
 					selectJob = func() {


### PR DESCRIPTION
When the `minimum_interval` field was added in https://github.com/openshift/ci-tools/pull/2980, only some of the checks were updated to include it. An important missing place is in `pj-rehearse`, where we will, consequently, not pick up any jobs that are configured with the field as being affected. In order to solve this problem permanently I have standardized the check for a test being a periodic, and replaced all usages with the new method.

/cc @openshift/test-platform 

For: https://issues.redhat.com/browse/DPTP-3264