### PR TITLE
`pj-rehearse`: double wait for ist creation

### DIFF
--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -619,7 +619,7 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 			if err := istImportClient.Create(ctx, istImport); err != nil && !apierrors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create imagestreamtag %s: %w", requiredImageStreamTag, err)
 			}
-			if err := wait.Poll(5*second, 30*second, func() (bool, error) {
+			if err := wait.Poll(5*second, 60*second, func() (bool, error) {
 				if err := client.Get(ctx, requiredImageStreamTag, &imagev1.ImageStreamTag{}); err != nil {
 					if apierrors.IsNotFound(err) {
 						return false, nil
@@ -628,6 +628,7 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 				}
 				return true, nil
 			}); err != nil {
+				istLog.WithError(err).Errorf("failed waiting for imagestreamtag to appear")
 				return fmt.Errorf("failed waiting for imagestreamtag %s to appear: %w", requiredImageStreamTag, err)
 			}
 


### PR DESCRIPTION
It appears that `pj-rehearse` is occasionally throwing the following error:
```
pj-rehearse: failed to create rehearsal jobs ERROR: 'failed to ensure imagestreamtags in cluster build03: failed waiting for imagestreamtag ocp/4.8:elasticsearch-operator-src to appear: timed out waiting for the condition'. If the problem persists, please contact Test Platform.
```
I haven't seen it much myself, but I have no good way of knowing the frequency since we aren't also logging it. I think we should double the wait time, and also log it so I can check the frequency in a week or so and see if anything else needs to be done.

/cc @openshift/test-platform 

For: https://issues.redhat.com/browse/DPTP-3241