### PR TITLE
ci-secret-bootstrap: log some stats of secrets

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -397,10 +397,14 @@ func constructSecrets(config secretbootstrap.Config, client secrets.ReadOnlyClie
 	}
 
 	var err error
+	statBefore := generateSecretStats(secretsByClusterAndName)
+	logrus.WithField("count", statBefore.count).WithField("median", statBefore.median).Info("Secret stats before fetching user secrets")
 	secretsByClusterAndName, err = fetchUserSecrets(secretsByClusterAndName, client, config.UserSecretsTargetClusters)
 	if err != nil {
 		errs = append(errs, err)
 	}
+	statAfter := generateSecretStats(secretsByClusterAndName)
+	logrus.WithField("count", statAfter.count).WithField("median", statAfter.median).Info("Secret stats after fetching user secrets")
 
 	result := map[string][]*coreapi.Secret{}
 	for cluster, secretMap := range secretsByClusterAndName {

--- a/cmd/ci-secret-bootstrap/secretstats.go
+++ b/cmd/ci-secret-bootstrap/secretstats.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/montanaflynn/stats"
+	"github.com/sirupsen/logrus"
+
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type secretStats struct {
+	// count is the total number of the secrets
+	count int
+	// median is the median of the size of the data of the secrets
+	// the size is counted by the sum of length of each key and its value in the secret's data
+	median float64
+}
+
+func generateSecretStats(secretsByClusterAndName map[string]map[types.NamespacedName]coreapi.Secret) secretStats {
+	if len(secretsByClusterAndName) == 0 {
+		return secretStats{}
+	}
+	count := 0
+	var size []float64
+	for _, secretMap := range secretsByClusterAndName {
+		count += len(secretMap)
+		for _, secret := range secretMap {
+			size = append(size, float64(getSize(secret)))
+		}
+	}
+	median, err := stats.Median(size)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to calculate the median")
+		return secretStats{}
+	}
+	result := secretStats{count: count, median: median}
+	return result
+}
+
+func getSize(secret coreapi.Secret) int {
+	size := 0
+	for k, v := range secret.Data {
+		size = size + len(k) + len(v)
+	}
+	return size
+}

--- a/cmd/ci-secret-bootstrap/secretstats_test.go
+++ b/cmd/ci-secret-bootstrap/secretstats_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestGenerateSecretStats(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		secretsByClusterAndName map[string]map[types.NamespacedName]coreapi.Secret
+		expected                secretStats
+	}{
+		{
+			name: "nil input",
+		},
+		{
+			name: "basic case",
+			secretsByClusterAndName: map[string]map[types.NamespacedName]coreapi.Secret{
+				"app.ci": {
+					types.NamespacedName{Name: "bar", Namespace: "ns1"}: coreapi.Secret{
+						Data: map[string][]byte{
+							"key1": []byte("value1"),
+							"key2": []byte("value2"),
+						},
+					},
+					types.NamespacedName{Name: "foo", Namespace: "ns2"}: coreapi.Secret{
+						Data: map[string][]byte{
+							"key2": []byte("a"),
+							"key3": []byte("b"),
+						},
+					},
+				},
+				"b01": {
+					types.NamespacedName{Name: "bar", Namespace: "ns3"}: coreapi.Secret{
+						Data: map[string][]byte{
+							"key": []byte("value1"),
+						},
+					},
+				},
+			},
+			expected: secretStats{count: 3, median: 10},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := generateSecretStats(tc.secretsByClusterAndName)
+			if diff := cmp.Diff(tc.expected, actual, cmp.Comparer(func(x, y secretStats) bool {
+				return cmp.Diff(x.count, y.count) == "" && cmp.Diff(x.median, y.median) == ""
+			})); diff != "" {
+				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The [job history](https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/job-history/gs/origin-ci-private/logs/periodic-ci-secret-bootstrap) shows that it takes 35m to execute the job which seems quite long.
IIRC, it took about 2m when we just switch from BitWarden to Vault.
Most of the time is spent on updating the secrets on the cluster.

We want to show some stats info to understand the work.