### PR TITLE
payload-testing: renamed jobs name, add requestor, link to docs, links for release controller and its config

### DIFF
--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -76,8 +76,9 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
   <li>Release: {{ .Release }}</li>
   <li>Specifier: {{ .Specifier }}</li>
   {{ with .Revision }}<li>Revision: {{ . }}</li>{{ end }}
-{{ end }}
+  {{ configLink . }}
 </ul>
+{{ end }}
 
 <h2>Jobs</h2>
 <ul>
@@ -247,6 +248,18 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 			release := template.HTMLEscapeString(config.Release)
 			spec := template.HTMLEscapeString(config.Specifier)
 			ret := fmt.Sprintf(`%s's '/payload %s %s %s' on %s`, author, ocp, release, spec, created)
+			return template.HTML(ret)
+		},
+		"configLink": func(config *prpqv1.ReleaseControllerConfig) template.HTML {
+			ocp := template.HTMLEscapeString(config.OCP)
+			release := template.HTMLEscapeString(config.Release)
+			suffix := ""
+			if release == "ci" {
+				suffix = "-ci"
+			}
+			ret := fmt.Sprintf(`<li><a href="https://amd64.ocp.releases.ci.openshift.org/#%s.0-0.%s">Release controller %s %s</a></li>
+				<li><a href="https://github.com/openshift/release/blob/master/core-services/release-controller/_releases/release-ocp-%s%s.json">Release controller config %s %s</a></li>`,
+				ocp, release, ocp, release, ocp, suffix, ocp, release)
 			return template.HTML(ret)
 		},
 		"jobStatus": func(i int) *prpqv1.PullRequestPayloadJobStatus {

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -22,6 +22,7 @@ const (
 	aggregatorPrefix = "aggregator-"
 
 	runsURL   = "/runs/"
+	docURL    = "https://docs.ci.openshift.org/docs/release-oversight/payload-testing/"
 	bodyStart = `
 <div class="container">`
 	pageEnd = `
@@ -48,6 +49,7 @@ const (
 <h1>{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}</h1>
 
 <p class="text-right">{{ returnLink }}</p>
+<p class="text-right">{{ documentationLink }}</p>
 
 Created: {{ .ObjectMeta.CreationTimestamp }} 
 
@@ -197,6 +199,9 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 	tmpl.Funcs(template.FuncMap{
 		"returnLink": func() template.HTML {
 			return template.HTML(fmt.Sprintf(`<a href="%s">%s</a>`, runsURL, "back to runs"))
+		},
+		"documentationLink": func() template.HTML {
+			return template.HTML(fmt.Sprintf(`<a href="%s" target="_blank">%s</a>`, docURL, "documentation"))
 		},
 		"prLink": func(pr *prpqv1.PullRequestUnderTest) template.HTML {
 			org := template.HTMLEscapeString(pr.Org)

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -48,6 +48,8 @@ const (
 <p class="text-right">{{ returnLink }}</p>
 <p class="text-right">{{ documentationLink }}</p>
 
+<h3>Requestor: {{ commentLink .ObjectMeta .Spec.PullRequest.PullRequest .Spec.Jobs.ReleaseControllerConfig }}</h3>
+
 Created: {{ .ObjectMeta.CreationTimestamp }} 
 
 {{ with .Spec }}
@@ -236,6 +238,15 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 			org := template.HTMLEscapeString(pr.Org)
 			repo := template.HTMLEscapeString(pr.Repo)
 			ret := fmt.Sprintf(`<a href="https://github.com/%s/%s/commit/%s">%s</a>`, org, repo, h, h)
+			return template.HTML(ret)
+		},
+		"commentLink": func(obj *metav1.ObjectMeta, pr *prpqv1.PullRequest, config *prpqv1.ReleaseControllerConfig) template.HTML {
+			created := obj.GetCreationTimestamp().Format("Jan 2, 2006 15:04")
+			author := template.HTMLEscapeString(pr.Author)
+			ocp := template.HTMLEscapeString(config.OCP)
+			release := template.HTMLEscapeString(config.Release)
+			spec := template.HTMLEscapeString(config.Specifier)
+			ret := fmt.Sprintf(`%s's '/payload %s %s %s' on %s`, author, ocp, release, spec, created)
 			return template.HTML(ret)
 		},
 		"jobStatus": func(i int) *prpqv1.PullRequestPayloadJobStatus {

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -25,6 +25,22 @@ const (
 	runsURL   = "/runs/"
 	docURL    = "https://docs.ci.openshift.org/docs/release-oversight/payload-testing/"
 	bodyStart = `
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+<a class="navbar-brand" href=` + runsURL + `>Pull Request Payload Qualification Runs</a>
+<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+	<span class="navbar-toggler-icon"></span>
+</button>
+<div class="collapse navbar-collapse" id="navbarSupportedContent">
+	<ul class="navbar-nav mr-auto">
+	<li class="nav-item">
+		<a class="nav-link" href=` + docURL + ` target="_blank">Documentation</a>
+	</li>
+	<li class="nav-item">
+	<a class="nav-link" href=` + runsURL + `>Back to runs</a>
+	</li>
+	</ul>
+</div>
+</nav>
 <div class="container">`
 	pageEnd = `
   <p class="small">Source code for this page located on <a href="https://github.com/openshift/ci-tools">GitHub</a></p>
@@ -44,9 +60,6 @@ const (
 	runTitle    = "Pull Request Payload Qualification Run - %s"
 	runTemplate = `
 <h1>{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}</h1>
-
-<p class="text-right">{{ returnLink }}</p>
-<p class="text-right">{{ documentationLink }}</p>
 
 <h3>Requestor: {{ commentLink .ObjectMeta .Spec.PullRequest.PullRequest .Spec.Jobs.ReleaseControllerConfig }}</h3>
 
@@ -208,12 +221,6 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 	}
 	tmpl := template.New("runTemplate")
 	tmpl.Funcs(template.FuncMap{
-		"returnLink": func() template.HTML {
-			return template.HTML(fmt.Sprintf(`<a href="%s">%s</a>`, runsURL, "back to runs"))
-		},
-		"documentationLink": func() template.HTML {
-			return template.HTML(fmt.Sprintf(`<a href="%s" target="_blank">%s</a>`, docURL, "documentation"))
-		},
 		"prLink": func(pr *prpqv1.PullRequestUnderTest) template.HTML {
 			org := template.HTMLEscapeString(pr.Org)
 			repo := template.HTMLEscapeString(pr.Repo)

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -143,8 +144,8 @@ type server struct {
 func newServer(client ctrlruntimeclient.Client, ctx context.Context, namespace string) (server, error) {
 	runsListTemplate, err := template.New("runsListTemplate").Funcs(template.FuncMap{
 		"runLink": func(obj *metav1.ObjectMeta, pr *prpqv1.PullRequest) template.HTML {
-			objName := obj.GetName()
-			objNS := obj.GetNamespace()
+			objName := obj.Name
+			objNS := obj.Namespace
 			ident := objName[len(objName)-6:]
 			author := template.HTMLEscapeString(pr.Author)
 			title := template.HTMLEscapeString(pr.Title)
@@ -249,7 +250,7 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 			return template.HTML(ret)
 		},
 		"commentLink": func(obj *metav1.ObjectMeta, pr *prpqv1.PullRequest, config *prpqv1.ReleaseControllerConfig) template.HTML {
-			created := obj.GetCreationTimestamp().Format("Jan 2, 2006 15:04")
+			created := obj.CreationTimestamp.Format(time.RFC3339)
 			author := template.HTMLEscapeString(pr.Author)
 			ocp := template.HTMLEscapeString(config.OCP)
 			release := template.HTMLEscapeString(config.Release)

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -6,12 +6,10 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -86,8 +84,6 @@ const (
 	runTitle    = "Pull Request Payload Qualification Run - %s"
 	runTemplate = `
 <h1>{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}</h1>
-
-<h3>Requestor: {{ commentLink .ObjectMeta .Spec.PullRequest.PullRequest .Spec.Jobs.ReleaseControllerConfig }}</h3>
 
 Created: {{ .ObjectMeta.CreationTimestamp }} 
 
@@ -285,15 +281,6 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 			org := template.HTMLEscapeString(pr.Org)
 			repo := template.HTMLEscapeString(pr.Repo)
 			ret := fmt.Sprintf(`<a href="https://github.com/%s/%s/commit/%s">%s</a>`, org, repo, h, h)
-			return template.HTML(ret)
-		},
-		"commentLink": func(obj *metav1.ObjectMeta, pr *prpqv1.PullRequest, config *prpqv1.ReleaseControllerConfig) template.HTML {
-			created := obj.CreationTimestamp.Format(time.RFC3339)
-			author := template.HTMLEscapeString(pr.Author)
-			ocp := template.HTMLEscapeString(config.OCP)
-			release := template.HTMLEscapeString(config.Release)
-			spec := template.HTMLEscapeString(config.Specifier)
-			ret := fmt.Sprintf(`%s's '/payload %s %s %s' on %s`, author, ocp, release, spec, created)
 			return template.HTML(ret)
 		},
 		"configLink": func(config *prpqv1.ReleaseControllerConfig) template.HTML {

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -37,7 +37,7 @@ const (
 		<a class="nav-link" href=` + docURL + ` target="_blank">Documentation</a>
 	</li>
 	<li class="nav-item">
-	<a class="nav-link" href=` + runsURL + `>Back to runs</a>
+	<a class="nav-link" href=` + runsURL + `>Runs</a>
 	</li>
 	</ul>
 </div>
@@ -63,14 +63,14 @@ const (
 			<td>
 			{{ with .ObjectMeta }}
 				{{ with $url := printf "%s/%s" .Namespace .Name }}
-				<b>Name:</b> <a href="` + runsURL + `{{ $url }}">{{ $url }}</a>
+				<a href="` + runsURL + `{{ $url }}">{{ $url }}</a>
 				{{ end }}
 			{{ end }}
 			</td>
 			<td>
 			{{ with .Spec.PullRequest }}
 				<p>Author: {{ .PullRequest.Author }}</p>
-				<p>Name: {{ prLink . }}</p>
+				<p>Title: {{ prLink . }}</p>
 			{{ end }}
 			</td>
 		</tr>

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -53,20 +53,18 @@ const (
 		<tr>
 			<th title="The name of the Pull Request Payload Qualification Run" class="info">Name</th>
 			<th title="The repository of pull request" class="info">Repository</th>
-			<th title="Hovering over the number will display the name of the pull request" class="info">Pull Request</th>
+			<th title="The number and name of the pull request" class="info">Pull Request</th>
 		</tr>
 	</thead>
 	<tbody>
 		{{ range .Items }}
 		<tr>
 			<td>
-			<nobr>
 			{{ with .ObjectMeta }}
 				{{ with $url := printf "%s/%s" .Namespace .Name }}
-				<a href="` + runsURL + `{{ $url }}">{{ $url }}</a>
+				<a class="text-nowrap" href="` + runsURL + `{{ $url }}">{{ $url }}</a>
 				{{ end }}
 			{{ end }}
-			</nobr>
 			</td>
 			<td>
 			{{ with .Spec.PullRequest }}
@@ -167,8 +165,8 @@ func prLink(pr *prpqv1.PullRequestUnderTest) template.HTML {
 	repo := template.HTMLEscapeString(pr.Repo)
 	title := template.HTMLEscapeString(pr.PullRequest.Title)
 	n := pr.PullRequest.Number
-	ret := fmt.Sprintf(`<a href="http://github.com/%s/%s/pull/%d">%s</a>`,
-		org, repo, n, title)
+	ret := fmt.Sprintf(`<a href="http://github.com/%s/%s/pull/%d">#%d: %s</a>`,
+		org, repo, n, n, title)
 	return template.HTML(ret)
 }
 

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -90,8 +90,8 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
   <li>Release: {{ .Release }}</li>
   <li>Specifier: {{ .Specifier }}</li>
   {{ with .Revision }}<li>Revision: {{ . }}</li>{{ end }}
-  {{ configLink . }}
 </ul>
+{{ configLink . }}
 {{ end }}
 
 <h2>Jobs</h2>
@@ -265,9 +265,12 @@ func (s *server) runDetails(w http.ResponseWriter, r *http.Request) {
 			if release == "ci" {
 				suffix = "-ci"
 			}
-			ret := fmt.Sprintf(`<li><a href="https://amd64.ocp.releases.ci.openshift.org/#%s.0-0.%s">Release controller %s %s</a></li>
-				<li><a href="https://github.com/openshift/release/blob/master/core-services/release-controller/_releases/release-ocp-%s%s.json">Release controller config %s %s</a></li>`,
-				ocp, release, ocp, release, ocp, suffix, ocp, release)
+			ret := fmt.Sprintf(`
+			<h2>Release controller</h2>
+			<ul>
+				<li><a href="https://amd64.ocp.releases.ci.openshift.org/#%s.0-0.%s">Release status</a></li>
+				<li><a href="https://github.com/openshift/release/blob/master/core-services/release-controller/_releases/release-ocp-%s%s.json">Configuration</a></li>
+			</ul>`, ocp, release, ocp, suffix)
 			return template.HTML(ret)
 		},
 		"jobStatus": func(i int) *prpqv1.PullRequestPayloadJobStatus {

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -60,11 +60,13 @@ const (
 		{{ range .Items }}
 		<tr>
 			<td>
+			<nobr>
 			{{ with .ObjectMeta }}
 				{{ with $url := printf "%s/%s" .Namespace .Name }}
 				<a href="` + runsURL + `{{ $url }}">{{ $url }}</a>
 				{{ end }}
 			{{ end }}
+			</nobr>
 			</td>
 			<td>
 			{{ with .Spec.PullRequest }}
@@ -165,8 +167,8 @@ func prLink(pr *prpqv1.PullRequestUnderTest) template.HTML {
 	repo := template.HTMLEscapeString(pr.Repo)
 	title := template.HTMLEscapeString(pr.PullRequest.Title)
 	n := pr.PullRequest.Number
-	ret := fmt.Sprintf(`#<a href="http://github.com/%s/%s/pull/%d" title="%s" class="info">%d</a>`,
-		org, repo, n, title, n)
+	ret := fmt.Sprintf(`<a href="http://github.com/%s/%s/pull/%d">%s</a>`,
+		org, repo, n, title)
 	return template.HTML(ret)
 }
 


### PR DESCRIPTION
First PR for this task. Where I changed names of jobs to more readable form. Added requestor without link for now.
Added link for docs, release controller and its config.
I will continue with link comment to Requestor: [like here](https://github.com/openshift/ci-tools/pull/2902/commits/4050b31e6f14e984ee85c691d58fef062fb0fbb7)
[DPTP-2641](https://issues.redhat.com/browse/DPTP-2641)

/cc @bbguimaraes