### PR TITLE
secret-bootstrap: update secrets only when needed

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -558,16 +558,21 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 				}
 
 				if !shouldCreate {
-					if !force && !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) {
+					differentData := !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data)
+					if !force && differentData {
 						logger.Errorf("actual secret data differs the expected")
 						errs = append(errs, fmt.Errorf("secret %s:%s/%s needs updating in place, use --force to do so", cluster, secret.Namespace, secret.Name))
 						continue
 					}
-					if _, err := secretClient.Update(context.TODO(), secret, metav1.UpdateOptions{DryRun: dryRunOptions}); err != nil {
-						errs = append(errs, fmt.Errorf("error updating secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
-						continue
+					if existingSecret.Labels == nil || existingSecret.Labels[api.DPTPRequesterLabel] != "ci-secret-bootstrap" || differentData {
+						if _, err := secretClient.Update(context.TODO(), secret, metav1.UpdateOptions{DryRun: dryRunOptions}); err != nil {
+							errs = append(errs, fmt.Errorf("error updating secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
+							continue
+						}
+						logger.Debug("secret updated")
+					} else {
+						logger.Debug("secret skipped")
 					}
-					logger.Debug("secret updated")
 				}
 			}
 

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1404,10 +1404,9 @@ func TestUpdateSecrets(t *testing.T) {
 			existSecretsOnDefault: []runtime.Object{
 				&coreapi.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:              "prod-secret-1",
-						Namespace:         "namespace-1",
-						Labels:            map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
-						CreationTimestamp: metav1.NewTime(time.Now()),
+						Name:      "prod-secret-1",
+						Namespace: "namespace-1",
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"},
 					},
 					Data: map[string][]byte{
 						"key-name-1": []byte("abc"),


### PR DESCRIPTION
```
curl -s 'https://storage.googleapis.com/origin-ci-private/logs/periodic-ci-secret-bootstrap/1611087940132278272/build-log.txt?Expires=1672953333&GoogleAccessId=openshift-private%40openshift-ci-private.iam.gserviceaccount.com&Signature=MAafQFIoqlLieE7B%2BVkAv8BhBrKfjsMfF9fv2UljBm15RUpNOn%2FdEVOQdujtTstaWu2ml4jCR43L%2Bzlp68VNO0aM%2FFyPwbZmmYUInQwuLYEIdpPHr3IojtvecaCxliYlBhEdNFGXpKwIB0Cn9eTVxXmyFjbHToJYD32R%2BdvghjkyMC3%2F3jmq44v9%2B%2BuaEeGuJYIdHEPp7OUdeclX2BUCWKRywe0mKh%2FgrbRum5i9Dajs9dWmbWh8SUIpEo2eaBSsekExxupqQBB%2FOQcjOkJZBuMLkMmWjU%2FpGmIYSnx9%2FOPrfs7eONUrxWluxAinPNBQo3q9jeNTjHTGPLxSVOE8yA%3D%3D' | grep "secret updated" | wc -l
    3484
```

I would like to reduce the execution time of the job.