### PR TITLE
`repo-init`: don't duplicate plugins that are already configured at the org level

### DIFF
--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -69,8 +69,8 @@ func TestEditPluginConfig(t *testing.T) {
 			pluginConfig: &plugins.Configuration{
 				Plugins: map[string]plugins.OrgPlugins{
 					"openshift":        {Plugins: []string{"foo"}},
-					"openshift/origin": {Plugins: []string{"bar"}},
-					"org":              {Plugins: []string{"other"}},
+					"openshift/origin": {Plugins: []string{"bar", "baz"}},
+					"org":              {Plugins: []string{"other", "bar"}},
 				},
 				ExternalPlugins: map[string][]plugins.ExternalPlugin{
 					"openshift": {{Endpoint: "oops"}},
@@ -81,9 +81,9 @@ func TestEditPluginConfig(t *testing.T) {
 			expected: &plugins.Configuration{
 				Plugins: map[string]plugins.OrgPlugins{
 					"openshift":        {Plugins: []string{"foo"}},
-					"openshift/origin": {Plugins: []string{"bar"}},
-					"org":              {Plugins: []string{"other"}},
-					"org/repo":         {Plugins: []string{"bar"}},
+					"openshift/origin": {Plugins: []string{"bar", "baz"}},
+					"org":              {Plugins: []string{"other", "bar"}},
+					"org/repo":         {Plugins: []string{"baz"}},
 				},
 				ExternalPlugins: map[string][]plugins.ExternalPlugin{
 					"openshift": {{Endpoint: "oops"}},


### PR DESCRIPTION
Currently, when a plugin is listed in the `openshift/origin` plugin config, it will be added to a newly configured repo's config as well. This works as long as that same plugin isn't listed in the org's config file (assuming one exists). If that is the case it results in an error while attempting to load the plugin config in `determinize-prow-config` like:
```
level=fatal msg="could not update Prow plugin configuration" error="could not load Prow plugin configuration: plugins [approve] are duplicated for openshift-assisted/assisted-grafana and openshift-assisted"
```

In order to resolve this when a plugin config for the repo's org exists, we should prune each of those configured plugins out of the resulting list.

For: https://issues.redhat.com/browse/DPTP-3222