### PR TITLE
Specify initial `localgit` branch

### DIFF
--- a/cmd/ci-operator-yaml-creator/main_test.go
+++ b/cmd/ci-operator-yaml-creator/main_test.go
@@ -109,6 +109,7 @@ zz_generated_metadata:
 			if err != nil {
 				t.Fatalf("failed to create localgit: %v", err)
 			}
+			localgit.InitialBranch = "master"
 			defer func() {
 				if err := localgit.Clean(); err != nil {
 					t.Errorf("localgit cleanup failed: %v", err)

--- a/cmd/publicize/server_test.go
+++ b/cmd/publicize/server_test.go
@@ -218,6 +218,7 @@ func TestMergeAndPushToRemote(t *testing.T) {
 	if err != nil {
 		t.Fatalf("couldn't create localgit: %v", err)
 	}
+	localgit.InitialBranch = "master"
 
 	defer func() {
 		if err := gc.Clean(); err != nil {


### PR DESCRIPTION
These unit tests started failing locally for me recently. Apparently, some git update I made defaulted the initial branch to `main` rather than `master`. We can just specify the initial branch as `master` to resolve this.

/cc @openshift/test-platform 