### PR TITLE
dptp-pools-cm: recognize controller hypershift_namespace_reconciler

### DIFF
--- a/cmd/dptp-pools-cm/main.go
+++ b/cmd/dptp-pools-cm/main.go
@@ -23,6 +23,7 @@ import (
 
 var allControllers = sets.NewString(
 	poolspullsecretprovider.ControllerName,
+	hypershiftnamespacereconciler.ControllerName,
 )
 
 type options struct {


### PR DESCRIPTION
I forgot to do it in https://github.com/openshift/ci-tools/pull/3228

It led to (with `--enable-controller=hypershift_namespace_reconciler`):

```
{"component":"dptp-pools-cm","error":"the following controllers are unknown but were disabled via --disable-controller: [hypershift_namespace_reconciler]","file":"/go/src/github.com/openshift/ci-tools/cmd/dptp-pools-cm/main.go:78","func":"main.main","level":"fatal","msg":"Failed to get options","severity":"fatal","time":"2023-01-06T21:41:33Z"}
```