### PR TITLE
First pass at logging improvements for job run analyzer

### DIFF
--- a/pkg/jobrunaggregator/cmd.go
+++ b/pkg/jobrunaggregator/cmd.go
@@ -1,6 +1,7 @@
 package jobrunaggregator
 
 import (
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatoranalyzer"
@@ -17,6 +18,14 @@ func NewJobAggregatorCommand() *cobra.Command {
 		Use:  "job-run-aggregator",
 		Long: `Commands associated with CI job run aggregation`,
 	}
+
+	// Add some millisecond precision to log timestamps, useful for debugging performance.
+	formatter := new(log.TextFormatter)
+	formatter.TimestampFormat = "2006-01-02T15:04:05.000Z07:00"
+	formatter.FullTimestamp = true
+	formatter.DisableColors = false
+	log.SetFormatter(formatter)
+	log.SetLevel(log.DebugLevel)
 
 	cmd.AddCommand(jobrunbigqueryloader.NewBigQueryTestRunUploadFlagsCommand())
 	cmd.AddCommand(jobrunbigqueryloader.NewBigQueryDisruptionUploadFlagsCommand())

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/api/iterator"
 
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -126,7 +127,10 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 		switch {
 		case strings.HasSuffix(attrs.Name, "prowjob.json"):
 			jobRunId := filepath.Base(filepath.Dir(attrs.Name))
-			jobRunInfo, err := a.ciGCSClient.ReadJobRunFromGCS(ctx, a.gcsPrefix, a.jobName, jobRunId)
+			jobRunInfo, err := a.ciGCSClient.ReadJobRunFromGCS(ctx, a.gcsPrefix, a.jobName, jobRunId, logrus.WithFields(logrus.Fields{
+				"job":    a.jobName,
+				"jobRun": jobRunId,
+			}))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
@@ -2,8 +2,9 @@ package jobrunbigqueryloader
 
 import (
 	"context"
-	"fmt"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
@@ -22,8 +23,8 @@ func newTestRunUploader(testRunInserter jobrunaggregatorlib.BigQueryInserter) up
 	}
 }
 
-func (o *testRunUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob) error {
-	fmt.Printf("  uploading junit test runs: %q/%q\n", jobRun.GetJobName(), jobRun.GetJobRunID())
+func (o *testRunUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
+	logger.Infof("uploading junit test runs: %q/%q", jobRun.GetJobName(), jobRun.GetJobRunID())
 	combinedJunitContent, err := jobRun.GetCombinedJUnitTestSuites(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Jobs are locking up, we would like timestamp information to be able to
start debugging where when and why.

There was some inconsistent use of logrus in here already but mostly
just fmt.Prints.

Rough attempt at structured contextual logging.
