### PR TITLE
Limit concurrency of bigquery job uploads, fix memory spikes

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -81,7 +82,7 @@ func NewDryRunInserter(out io.Writer, table string) BigQueryInserter {
 func (d dryRunInserter) Put(ctx context.Context, src interface{}) (err error) {
 	srcVal := reflect.ValueOf(src)
 	if srcVal.Kind() != reflect.Slice {
-		fmt.Fprintf(d.out, "INSERT into %v: %v\n", d.table, src)
+		logrus.Debugf("INSERT into %s: %v", d.table, src)
 		return
 	}
 
@@ -89,6 +90,7 @@ func (d dryRunInserter) Put(ctx context.Context, src interface{}) (err error) {
 		return
 	}
 
+	// Accumulate bulk insert debugging into a buffer so it's not mixed with concurrent logging from other goroutines:
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "BULK INSERT into %v\n", d.table)
 	for i := 0; i < srcVal.Len(); i++ {
@@ -107,12 +109,11 @@ func (d dryRunInserter) Put(ctx context.Context, src interface{}) (err error) {
 			fmt.Fprintf(buf, "\tINSERT into %v: JobName=%v\n", d.table, s.JobName)
 
 		default:
-
 			// If we don't know the type, output something generic.
 			fmt.Fprintf(buf, "\tINSERT into %v: %#v\n", d.table, s)
 		}
 	}
-	fmt.Fprint(d.out, buf.String())
+	logrus.Debug(buf.String())
 
 	return nil
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
@@ -83,6 +83,7 @@ func (o *ciGCSClient) ListJobRunNamesOlderThanFourHours(ctx context.Context, job
 				continue
 			}
 			// chosen because CI jobs only take four hours max (so far), so we only get completed jobs
+			// TODO: this needs to go up, we often bump beyond this.
 			if now.Sub(attrs.Created) < (4 * time.Hour) {
 				continue
 			}
@@ -103,7 +104,7 @@ func (o *ciGCSClient) ListJobRunNamesOlderThanFourHours(ctx context.Context, job
 }
 
 func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation, jobName, jobRunID string, logger logrus.FieldLogger) (jobrunaggregatorapi.JobRunInfo, error) {
-	logger.Infof("reading job run %v/%v", jobGCSRootLocation, jobRunID)
+	logger.Debugf("reading job run %s/%s", jobGCSRootLocation, jobRunID)
 
 	query := &storage.Query{
 		// This ends up being the equivalent of:
@@ -144,7 +145,7 @@ func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation,
 
 		switch {
 		case strings.HasSuffix(attrs.Name, "prowjob.json"):
-			logger.Infof("found %s", attrs.Name)
+			logger.Debugf("found %s", attrs.Name)
 			jobRunId := filepath.Base(filepath.Dir(attrs.Name))
 			if jobRun == nil {
 				jobRun = jobrunaggregatorapi.NewGCSJobRun(bkt, jobGCSRootLocation, jobName, jobRunId)
@@ -152,7 +153,7 @@ func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation,
 			jobRun.SetGCSProwJobPath(attrs.Name)
 
 		case strings.HasSuffix(attrs.Name, ".xml") && strings.Contains(attrs.Name, "/junit"):
-			logger.Infof("found %s", attrs.Name)
+			logger.Debugf("found %s", attrs.Name)
 			nameParts := strings.Split(attrs.Name, "/")
 			if len(nameParts) < 4 {
 				continue

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -23,7 +23,8 @@ type BigQueryAlertUploadFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 
-	DryRun bool
+	DryRun   bool
+	LogLevel string
 }
 
 func NewBigQueryAlertUploadFlags() *BigQueryAlertUploadFlags {
@@ -38,6 +39,7 @@ func (f *BigQueryAlertUploadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.Authentication.BindFlags(fs)
 
 	fs.BoolVar(&f.DryRun, "dry-run", f.DryRun, "Run the command, but don't mutate data.")
+	fs.StringVar(&f.LogLevel, "log-level", f.LogLevel, "Log level (trace,debug,info,warn,error) (default: info)")
 }
 
 func NewBigQueryAlertUploadFlagsCommand() *cobra.Command {
@@ -126,6 +128,7 @@ func (f *BigQueryAlertUploadFlags) ToOptions(ctx context.Context) (*allJobsLoade
 		},
 		getLastJobRunWithDataFn: ciDataClient.GetLastJobRunWithAlertDataForJobName,
 		jobRunUploader:          newAlertUploader(backendAlertTableInserter),
+		logLevel:                f.LogLevel,
 	}, nil
 }
 
@@ -140,7 +143,7 @@ func newAlertUploader(alertInserter jobrunaggregatorlib.BigQueryInserter) upload
 }
 
 func (o *alertUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
-	logger.Infof("uploading alert results: %q/%q", jobRun.GetJobName(), jobRun.GetJobRunID())
+	logger.Info("uploading alert results")
 	alertData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "alert")
 	if err != nil {
 		return err

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
@@ -16,7 +16,8 @@ type BigQueryTestRunUploadFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 
-	DryRun bool
+	DryRun   bool
+	LogLevel string
 }
 
 func NewBigQueryTestRunUploadFlags() *BigQueryTestRunUploadFlags {
@@ -31,6 +32,7 @@ func (f *BigQueryTestRunUploadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.Authentication.BindFlags(fs)
 
 	fs.BoolVar(&f.DryRun, "dry-run", f.DryRun, "Run the command, but don't mutate data.")
+	fs.StringVar(&f.LogLevel, "log-level", f.LogLevel, "Log level (trace,debug,info,warn,error) (default: info)")
 }
 
 func NewBigQueryTestRunUploadFlagsCommand() *cobra.Command {
@@ -117,5 +119,6 @@ func (f *BigQueryTestRunUploadFlags) ToOptions(ctx context.Context) (*allJobsLoa
 		shouldCollectedDataForJobFn: wantsTestRunData,
 		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithTestRunDataForJobName,
 		jobRunUploader:              newTestRunUploader(testRunTableInserter),
+		logLevel:                    f.LogLevel,
 	}, nil
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -19,7 +19,8 @@ type BigQueryDisruptionUploadFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 
-	DryRun bool
+	DryRun   bool
+	LogLevel string
 }
 
 func NewBigQueryDisruptionUploadFlags() *BigQueryDisruptionUploadFlags {
@@ -34,6 +35,7 @@ func (f *BigQueryDisruptionUploadFlags) BindFlags(fs *pflag.FlagSet) {
 	f.Authentication.BindFlags(fs)
 
 	fs.BoolVar(&f.DryRun, "dry-run", f.DryRun, "Run the command, but don't mutate data.")
+	fs.StringVar(&f.LogLevel, "log-level", f.LogLevel, "Log level (trace,debug,info,warn,error) (default: info)")
 }
 
 func NewBigQueryDisruptionUploadFlagsCommand() *cobra.Command {
@@ -120,6 +122,7 @@ func (f *BigQueryDisruptionUploadFlags) ToOptions(ctx context.Context) (*allJobs
 		shouldCollectedDataForJobFn: wantsDisruptionData,
 		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithDisruptionDataForJobName,
 		jobRunUploader:              newDisruptionUploader(backendDisruptionTableInserter),
+		logLevel:                    f.LogLevel,
 	}, nil
 }
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
@@ -24,7 +24,7 @@ func newTestRunUploader(testRunInserter jobrunaggregatorlib.BigQueryInserter) up
 }
 
 func (o *testRunUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
-	logger.Infof("uploading junit test runs: %q/%q", jobRun.GetJobName(), jobRun.GetJobRunID())
+	logger.Info("uploading junit test runs")
 	combinedJunitContent, err := jobRun.GetCombinedJUnitTestSuites(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
[TRT-772](https://issues.redhat.com//browse/TRT-772)

Upload jobs for alerts, disruption, and test runs are all seemingly locking up in dpcr cluster. Logs stop, pod stays running forever.

In debugging the lockups in the uploader jobs, I found that removing the top level of concurrency, which appears to be queuing up every job unbounded and attempting to process them all as fast as the cpu can, the problem went away.  Upload times then got a little too long particularly for the test runs without any concurrency though.

This change adds a new implementation for concurrency at the job level bounding to 10 goroutines pulling from a channel until there's nothing left.

Note that there is a second layer of concurrency at the job run level, where we limit to 20 concurrent uploads. I think this means we could be doing up to 20*10 = 200 concurrent uploads to google storage. 

As a side bonus, this implementation no longer spikes up to 6GB as we try to process everything at once. Memory usage now seems to bounce around between 300-600MB.

I have added logging that gives a rough idea how far along the job queue we are. We don't know how many runs each job will have to upload, but it's something to give us an indication of how far along we are.
