### PR TITLE
`pj-rehearse`: change logging to info for non-platform errors

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -959,7 +959,7 @@ func (e *Executor) waitForJobs(jobs sets.String, selector ctrlruntimeclient.List
 
 			switch pj.Status.State {
 			case pjapi.FailureState, pjapi.AbortedState, pjapi.ErrorState:
-				e.logger.WithFields(fields).Error("Job failed")
+				e.logger.WithFields(fields).Info("Job failed")
 				success = false
 			case pjapi.SuccessState:
 				e.logger.WithFields(fields).Info("Job succeeded")

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -944,7 +944,7 @@ func TestWaitForJobsLog(t *testing.T) {
 	}
 	successState, failureState := pjapi.SuccessState, pjapi.FailureState
 	check(hook, "success", logrus.InfoLevel, &successState)
-	check(hook, "failure", logrus.ErrorLevel, &failureState)
+	check(hook, "failure", logrus.InfoLevel, &failureState)
 }
 
 func TestFilterPresubmits(t *testing.T) {

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -350,7 +350,7 @@ func (r RehearsalConfig) RehearseJobs(candidate RehearsalCandidate, candidatePat
 		logger.WithError(err).Error("Failed to rehearse jobs")
 		return false, utilerrors.NewAggregate(errs)
 	} else if !success {
-		logger.Error("Some jobs failed their rehearsal runs")
+		logger.Info("Some jobs failed their rehearsal runs")
 	} else {
 		logger.Info("All jobs were rehearsed successfully")
 	}


### PR DESCRIPTION
I was looking through error logs following https://github.com/openshift/release/blob/master/docs/dptp-triage-sop/logs/README.md, and noticed some errors that `pj-rehearse` is throwing. These aren't actually platform level errors and should simply be logged at the `info` level.

/cc @openshift/test-platform 