### PR TITLE
Makefile: add Hive token target for `local-e2e`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ CLUSTER ?= build01
 local-e2e: \
 	$(TMPDIR)/.ci-operator-kubeconfig \
 	$(TMPDIR)/hive-kubeconfig \
+	$(TMPDIR)/sa.hive.hive.token.txt \
 	$(TMPDIR)/local-secret/.dockerconfigjson \
 	$(TMPDIR)/remote-secret/.dockerconfigjson \
 	$(TMPDIR)/gcs/service-account.json \
@@ -297,9 +298,11 @@ $(TMPDIR)/.ci-operator-kubeconfig:
 	oc --context $(CLUSTER) -n test-credentials extract secret/ci-operator --keys kubeconfig --keys sa.ci-operator.$(CLUSTER).token.txt --to $(TMPDIR)
 	mv $(TMPDIR)/kubeconfig "$@"
 
-
 $(TMPDIR)/hive-kubeconfig:
 	oc --context $(CLUSTER) --as system:admin --namespace test-credentials get secret hive-hive-credentials -o 'jsonpath={.data.kubeconfig}' | base64 --decode > "$@"
+
+$(TMPDIR)/sa.hive.hive.token.txt:
+	oc --context $(CLUSTER) --namespace test-credentials extract secret/hive-hive-credentials --keys sa.hive.hive.token.txt --to $(TMPDIR)
 
 $(TMPDIR)/local-secret/.dockerconfigjson:
 	mkdir -p $(TMPDIR)/local-secret


### PR DESCRIPTION
```console
$ make local-e2e
[…]
--- FAIL: TestMultiStage (0.00s)
    --- FAIL: TestMultiStage/e2e-claim-as-custom (1.15s)
[…]
            ERRO[2023-01-16T17:26:07Z] Failed to load arguments.                     error=could not load Hive kube config from path /tmp/hive-kubeconfig: could not load client configuration: open /tmp/sa.hive.hive.token.txt: no such file or directory
[…]
```