### PR TITLE
`pj-rehearse`: add usage details to the response from refresh command

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -266,6 +266,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					fileLocation := s.dumpAffectedJobsToGCS(pullRequest, presubmits, periodics, jobCount, logger)
 					jobTableLines = append(jobTableLines, fmt.Sprintf("A full list of affected jobs can be found [here](%s%s)", s.rehearsalConfig.GCSBrowserPrefix, fileLocation))
 				}
+				jobTableLines = append(jobTableLines, s.getUsageDetailsLines()...)
 				if err = s.ghc.CreateComment(org, repo, number, strings.Join(jobTableLines, "\n")); err != nil {
 					logger.WithError(err).Error("failed to create comment")
 				}


### PR DESCRIPTION
I've noticed a couple of PRs recently which were opened with a merge conflict or some other issue causing `pj-rehearse` to not give usage detail on the initial comment. We should make sure that the `/pj-rehearse refresh` command also shows the usage details.

/cc @openshift/test-platform 