### PR TITLE
Add cluster-control-plane-machine-set-operator to sippy/testgrid

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -4,14 +4,15 @@ import "strings"
 
 func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 	testGridInformingPrefixes := []string{
-		"release-openshift-",
-		"promote-release-openshift-",
+		"periodic-ci-openshift-cluster-control-plane-machine-set-operator-",
 		"periodic-ci-openshift-hypershift-main-periodics-",
 		"periodic-ci-openshift-multiarch",
 		"periodic-ci-openshift-release-master-ci-",
-		"periodic-ci-openshift-release-master-okd-",
 		"periodic-ci-openshift-release-master-nightly-",
+		"periodic-ci-openshift-release-master-okd-",
 		"periodic-ci-shiftstack-shiftstack-ci-main-periodic-",
+		"promote-release-openshift-",
+		"release-openshift-",
 	}
 	for _, prefix := range testGridInformingPrefixes {
 		if strings.HasPrefix(jobName, prefix) {


### PR DESCRIPTION
[TRT-794](https://issues.redhat.com//browse/TRT-794)

This adds
periodic-ci-openshift-cluster-control-plane-machine-set-operator-* to testgrid and sippy for data collection. It also alphabetizes the list.