### PR TITLE
Use Testplatform BigQuery for ProwJobs to upload alert/disruption/test data from

### DIFF
--- a/pkg/branchcuts/bumper/release-controller-config-bumper.go
+++ b/pkg/branchcuts/bumper/release-controller-config-bumper.go
@@ -81,21 +81,22 @@ func (b *ReleaseControllerConfigBumper) BumpFilename(filename string, _ *Release
 }
 
 /*
-	Candidate bumping fields:
-		.message
-		.mirrorPrefix
-		.name
-		.overrideCLIImage
-		.check.*.consistentImages.parent
-		.publish.*
-			.verifyBugs.previousReleaseTag
-				.name
-				.tag
-			.imageStreamRef.name
-			.tagRef.name
-		.verify
-			.* (this represents the name of the job)
-			.*.prowJob.name
+Candidate bumping fields:
+
+	.message
+	.mirrorPrefix
+	.name
+	.overrideCLIImage
+	.check.*.consistentImages.parent
+	.publish.*
+		.verifyBugs.previousReleaseTag
+			.name
+			.tag
+		.imageStreamRef.name
+		.tagRef.name
+	.verify
+		.* (this represents the name of the job)
+		.*.prowJob.name
 */
 func (b *ReleaseControllerConfigBumper) BumpContent(releaseConfig *ReleaseConfig) (*ReleaseConfig, error) {
 	if err := ReplaceWithNextVersionInPlace(&releaseConfig.Message, b.mm.Major); err != nil {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -85,9 +85,9 @@ type JobRunRow struct {
 	Cluster    string
 }
 
-// BigQueryJobRunRow is a transient struct for processing results from the bigquery jobs table.
-// Ultimately just used to convert to a prow.ProwJob.
-type BigQueryJobRunRow struct {
+// TestPlatformProwJobRow is a transient struct for processing results from the bigquery jobs table populated
+// by testplatform. ProwJob kube resources are stored here after we upload job artifacts to GCS.
+type TestPlatformProwJobRow struct {
 	JobName        string    `bigquery:"prowjob_job_name"`
 	State          string    `bigquery:"prowjob_state"`
 	BuildID        string    `bigquery:"prowjob_build_id"`

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -84,3 +84,16 @@ type JobRunRow struct {
 	ReleaseTag string
 	Cluster    string
 }
+
+// BigQueryJobRunRow is a transient struct for processing results from the bigquery jobs table.
+// Ultimately just used to convert to a prow.ProwJob.
+type BigQueryJobRunRow struct {
+	JobName        string    `bigquery:"prowjob_job_name"`
+	State          string    `bigquery:"prowjob_state"`
+	BuildID        string    `bigquery:"prowjob_build_id"`
+	Type           string    `bigquery:"prowjob_type"`
+	Cluster        string    `bigquery:"prowjob_cluster"`
+	StartTime      time.Time `bigquery:"prowjob_start_ts"`
+	CompletionTime time.Time `bigquery:"prowjob_completion_ts"`
+	URL            string    `bigquery:"prowjob_url"`
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -44,7 +44,7 @@ type JobLister interface {
 	// ListProwJobRunsSince lists from the testplatform BigQuery dataset in a separate project from
 	// where we normally operate. Job runs are inserted here just after their GCS artifacts are uploaded.
 	// This function is used for importing runs we do not yet have into our tables.
-	ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.BigQueryJobRunRow, error)
+	ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.TestPlatformProwJobRow, error)
 }
 
 type HistoricalDataClient interface {
@@ -306,7 +306,7 @@ ORDER BY EndTime ASC
 	return jobRunIDs, nil
 }
 
-func (c *ciDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.BigQueryJobRunRow, error) {
+func (c *ciDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.TestPlatformProwJobRow, error) {
 	// NOTE: this query is going to a different GCP project and data set to list the
 	// prow jobs stored by testplatform.
 	queryString := `SELECT 
@@ -331,9 +331,9 @@ func (c *ciDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Tim
 		return nil, fmt.Errorf("failed to query job table with %q: %w", queryString, err)
 	}
 
-	jobRuns := []*jobrunaggregatorapi.BigQueryJobRunRow{}
+	jobRuns := []*jobrunaggregatorapi.TestPlatformProwJobRow{}
 	for {
-		bqjr := &jobrunaggregatorapi.BigQueryJobRunRow{}
+		bqjr := &jobrunaggregatorapi.TestPlatformProwJobRow{}
 		err := jobRows.Next(bqjr)
 		if err == iterator.Done {
 			break

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
@@ -17,90 +16,11 @@ import (
 
 type CIGCSClient interface {
 	ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation, jobName, jobRunID string, logger logrus.FieldLogger) (jobrunaggregatorapi.JobRunInfo, error)
-
-	// ListJobRunNames returns a string channel for jobRunNames, an error channel for reporting errors during listing,
-	// and an error if the listing cannot begin.
-	ListJobRunNamesOlderThanFourHours(ctx context.Context, jobName, startingID string, logger logrus.FieldLogger) (chan string, chan error, error)
 }
 
 type ciGCSClient struct {
 	gcsClient     *storage.Client
 	gcsBucketName string
-}
-
-func (o *ciGCSClient) ListJobRunNamesOlderThanFourHours(ctx context.Context, jobName, startingID string, logger logrus.FieldLogger) (chan string, chan error, error) {
-	query := &storage.Query{
-		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
-		Prefix: "logs/" + jobName,
-
-		// TODO this field is apparently missing from this level of go/storage
-		// Omit owner and ACL fields for performance
-		//Projection: storage.ProjectionNoACL,
-	}
-
-	// Only retrieve the name and creation time for performance
-	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
-		return nil, nil, err
-	}
-
-	// When debugging, you can set the starting ID to a number such that you
-	// will process a relatively small number of jobsRuns.
-	query.StartOffset = fmt.Sprintf("logs/%s/%s", jobName, startingID)
-	logger.Debugf("starting from %v", query.StartOffset)
-
-	now := time.Now()
-
-	// Returns an iterator which iterates over the bucket query results.
-	// Unfortunately, this will list *all* files with the query prefix.
-	bkt := o.gcsClient.Bucket(o.gcsBucketName)
-	it := bkt.Objects(ctx, query)
-
-	errorCh := make(chan error, 100)
-	jobRunProcessingCh := make(chan string, 100)
-	// Find the query results we're the most interested in. In this case, we're interested in files called prowjob.json
-	// so that we only get each jobrun once and we queue them in a channel
-	go func() {
-		defer close(jobRunProcessingCh)
-
-		for {
-			if ctx.Err() != nil {
-				return
-			}
-
-			attrs, err := it.Next()
-			if err == iterator.Done {
-				// we're done adding values, so close the channel
-				return
-			}
-			if err != nil {
-				errorCh <- err
-				return
-			}
-
-			// TODO if it's more than 100 days old, we don't need it
-			if now.Sub(attrs.Created) > (100 * 24 * time.Hour) {
-				continue
-			}
-			// chosen because CI jobs only take four hours max (so far), so we only get completed jobs
-			// TODO: this needs to go up, we often bump beyond this.
-			if now.Sub(attrs.Created) < (4 * time.Hour) {
-				continue
-			}
-
-			switch {
-			case strings.HasSuffix(attrs.Name, "prowjob.json"):
-				jobRunId := filepath.Base(filepath.Dir(attrs.Name))
-				logger.WithField("jobRun", jobRunId).Debug("Queued jobrun")
-				jobRunProcessingCh <- jobRunId
-
-			default:
-				//fmt.Printf("checking %q\n", attrs.Name)
-			}
-		}
-	}()
-
-	return jobRunProcessingCh, errorCh, nil
 }
 
 func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation, jobName, jobRunID string, logger logrus.FieldLogger) (jobrunaggregatorapi.JobRunInfo, error) {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -177,6 +178,7 @@ func isReadQuotaError(err error) bool {
 		return false
 	}
 	if strings.Contains(err.Error(), "exceeded quota for concurrent queries") {
+		logrus.WithError(err).Warn("hit a read quota error")
 		return true
 	}
 	return false

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -44,61 +44,21 @@ func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggrega
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetLastJobRunWithTestRunDataForJobName(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
+func (c *retryingCIDataClient) GetLastJobRunFromTableForJobName(ctx context.Context, tableName, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
 	var ret *jobrunaggregatorapi.JobRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithTestRunDataForJobName(ctx, jobName)
+		ret, innerErr = c.delegate.GetLastJobRunFromTableForJobName(ctx, tableName, jobName)
 		return innerErr
 	})
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetLastJobRunWithDisruptionDataForJobName(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	var ret *jobrunaggregatorapi.JobRunRow
-	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
-		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithDisruptionDataForJobName(ctx, jobName)
-		return innerErr
-	})
-	return ret, err
-}
-
-func (c *retryingCIDataClient) GetLastJobRunWithAlertDataForJobName(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	var ret *jobrunaggregatorapi.JobRunRow
-	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
-		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithAlertDataForJobName(ctx, jobName)
-		return innerErr
-	})
-	return ret, err
-}
-
-func (c *retryingCIDataClient) GetLastJobRunWithTestRunDataEndTime(ctx context.Context) (*time.Time, error) {
+func (c *retryingCIDataClient) GetLastJobRunEndTimeFromTable(ctx context.Context, tableName string) (*time.Time, error) {
 	var ret *time.Time
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithTestRunDataEndTime(ctx)
-		return innerErr
-	})
-	return ret, err
-}
-
-func (c *retryingCIDataClient) GetLastJobRunWithDisruptionDataEndTime(ctx context.Context) (*time.Time, error) {
-	var ret *time.Time
-	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
-		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithDisruptionDataEndTime(ctx)
-		return innerErr
-	})
-	return ret, err
-}
-
-func (c *retryingCIDataClient) GetLastJobRunWithAlertDataEndTime(ctx context.Context) (*time.Time, error) {
-	var ret *time.Time
-	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
-		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunWithAlertDataEndTime(ctx)
+		ret, innerErr = c.delegate.GetLastJobRunEndTimeFromTable(ctx, tableName)
 		return innerErr
 	})
 	return ret, err

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -74,6 +74,36 @@ func (c *retryingCIDataClient) GetLastJobRunWithAlertDataForJobName(ctx context.
 	return ret, err
 }
 
+func (c *retryingCIDataClient) GetLastJobRunWithTestRunDataEndTime(ctx context.Context) (*time.Time, error) {
+	var ret *time.Time
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastJobRunWithTestRunDataEndTime(ctx)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastJobRunWithDisruptionDataEndTime(ctx context.Context) (*time.Time, error) {
+	var ret *time.Time
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastJobRunWithDisruptionDataEndTime(ctx)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastJobRunWithAlertDataEndTime(ctx context.Context) (*time.Time, error) {
+	var ret *time.Time
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastJobRunWithAlertDataEndTime(ctx)
+		return innerErr
+	})
+	return ret, err
+}
+
 func (c *retryingCIDataClient) GetLastAggregationForJob(ctx context.Context, frequency, jobName string) (*jobrunaggregatorapi.AggregatedTestRunRow, error) {
 	var ret *jobrunaggregatorapi.AggregatedTestRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -74,8 +74,8 @@ func (c *retryingCIDataClient) GetLastJobRunEndTimeFromTable(ctx context.Context
 	return ret, err
 }
 
-func (c *retryingCIDataClient) ListUploadedJobRunIDsSinceFromTable(ctx context.Context, table string, since *time.Time) ([]string, error) {
-	var ret []string
+func (c *retryingCIDataClient) ListUploadedJobRunIDsSinceFromTable(ctx context.Context, table string, since *time.Time) (map[string]bool, error) {
+	var ret map[string]bool
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.ListUploadedJobRunIDsSinceFromTable(ctx, table, since)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -45,16 +45,6 @@ func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggrega
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetLastJobRunFromTableForJobName(ctx context.Context, tableName, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	var ret *jobrunaggregatorapi.JobRunRow
-	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
-		var innerErr error
-		ret, innerErr = c.delegate.GetLastJobRunFromTableForJobName(ctx, tableName, jobName)
-		return innerErr
-	})
-	return ret, err
-}
-
 func (c *retryingCIDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.BigQueryJobRunRow, error) {
 	var ret []*jobrunaggregatorapi.BigQueryJobRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -54,6 +54,16 @@ func (c *retryingCIDataClient) GetLastJobRunFromTableForJobName(ctx context.Cont
 	return ret, err
 }
 
+func (c *retryingCIDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.BigQueryJobRunRow, error) {
+	var ret []*jobrunaggregatorapi.BigQueryJobRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListProwJobRunsSince(ctx, since)
+		return innerErr
+	})
+	return ret, err
+}
+
 func (c *retryingCIDataClient) GetLastJobRunEndTimeFromTable(ctx context.Context, tableName string) (*time.Time, error) {
 	var ret *time.Time
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -45,8 +45,8 @@ func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggrega
 	return ret, err
 }
 
-func (c *retryingCIDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.BigQueryJobRunRow, error) {
-	var ret []*jobrunaggregatorapi.BigQueryJobRunRow
+func (c *retryingCIDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Time) ([]*jobrunaggregatorapi.TestPlatformProwJobRow, error) {
+	var ret []*jobrunaggregatorapi.TestPlatformProwJobRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.ListProwJobRunsSince(ctx, since)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -64,6 +64,16 @@ func (c *retryingCIDataClient) GetLastJobRunEndTimeFromTable(ctx context.Context
 	return ret, err
 }
 
+func (c *retryingCIDataClient) ListUploadedJobRunIDsSinceFromTable(ctx context.Context, table string, since *time.Time) ([]string, error) {
+	var ret []string
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListUploadedJobRunIDsSinceFromTable(ctx, table, since)
+		return innerErr
+	})
+	return ret, err
+}
+
 func (c *retryingCIDataClient) GetLastAggregationForJob(ctx context.Context, frequency, jobName string) (*jobrunaggregatorapi.AggregatedTestRunRow, error) {
 	var ret *jobrunaggregatorapi.AggregatedTestRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -146,10 +146,6 @@ func newAlertUploader(alertInserter jobrunaggregatorlib.BigQueryInserter,
 	}
 }
 
-func (o *alertUploader) getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	return o.ciDataClient.GetLastJobRunFromTableForJobName(ctx, jobrunaggregatorapi.AlertJobRunTableName, jobName)
-}
-
 func (o *alertUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error) {
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.AlertJobRunTableName)
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -127,6 +127,7 @@ func (f *BigQueryAlertUploadFlags) ToOptions(ctx context.Context) (*allJobsLoade
 			return true
 		},
 		getLastJobRunWithDataFn: ciDataClient.GetLastJobRunWithAlertDataForJobName,
+		getLastJobRunEndTimeFn:  ciDataClient.GetLastJobRunWithAlertDataEndTime,
 		jobRunUploader:          newAlertUploader(backendAlertTableInserter),
 		logLevel:                f.LogLevel,
 	}, nil

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -154,6 +154,10 @@ func (o *alertUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.AlertJobRunTableName)
 }
 
+func (o *alertUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.AlertJobRunTableName, since)
+}
+
 func (o *alertUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
 	logger.Info("uploading alert results")
 	alertData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "alert")

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -154,7 +154,7 @@ func (o *alertUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.AlertJobRunTableName)
 }
 
-func (o *alertUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+func (o *alertUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error) {
 	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.AlertJobRunTableName, since)
 }
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
@@ -118,6 +118,7 @@ func (f *BigQueryTestRunUploadFlags) ToOptions(ctx context.Context) (*allJobsLoa
 		jobRunInserter:              jobRunTableInserter,
 		shouldCollectedDataForJobFn: wantsTestRunData,
 		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithTestRunDataForJobName,
+		getLastJobRunEndTimeFn:      ciDataClient.GetLastJobRunWithTestRunDataEndTime,
 		jobRunUploader:              newTestRunUploader(testRunTableInserter),
 		logLevel:                    f.LogLevel,
 	}, nil

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
@@ -117,9 +117,7 @@ func (f *BigQueryTestRunUploadFlags) ToOptions(ctx context.Context) (*allJobsLoa
 
 		jobRunInserter:              jobRunTableInserter,
 		shouldCollectedDataForJobFn: wantsTestRunData,
-		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithTestRunDataForJobName,
-		getLastJobRunEndTimeFn:      ciDataClient.GetLastJobRunWithTestRunDataEndTime,
-		jobRunUploader:              newTestRunUploader(testRunTableInserter),
+		jobRunUploader:              newTestRunUploader(testRunTableInserter, ciDataClient),
 		logLevel:                    f.LogLevel,
 	}, nil
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -140,10 +140,6 @@ func newDisruptionUploader(backendDisruptionInserter jobrunaggregatorlib.BigQuer
 	}
 }
 
-func (o *disruptionUploader) getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	return o.ciDataClient.GetLastJobRunFromTableForJobName(ctx, jobrunaggregatorapi.DisruptionJobRunTableName, jobName)
-}
-
 func (o *disruptionUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error) {
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName)
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -148,7 +148,7 @@ func (o *disruptionUploader) getLastUploadedJobRunEndTime(ctx context.Context) (
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName)
 }
 
-func (o *disruptionUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+func (o *disruptionUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error) {
 	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName, since)
 }
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -121,6 +121,7 @@ func (f *BigQueryDisruptionUploadFlags) ToOptions(ctx context.Context) (*allJobs
 		jobRunInserter:              jobRunTableInserter,
 		shouldCollectedDataForJobFn: wantsDisruptionData,
 		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithDisruptionDataForJobName,
+		getLastJobRunEndTimeFn:      ciDataClient.GetLastJobRunWithDisruptionDataEndTime,
 		jobRunUploader:              newDisruptionUploader(backendDisruptionTableInserter),
 		logLevel:                    f.LogLevel,
 	}, nil

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -3,6 +3,7 @@ package jobrunbigqueryloader
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -120,21 +121,31 @@ func (f *BigQueryDisruptionUploadFlags) ToOptions(ctx context.Context) (*allJobs
 
 		jobRunInserter:              jobRunTableInserter,
 		shouldCollectedDataForJobFn: wantsDisruptionData,
-		getLastJobRunWithDataFn:     ciDataClient.GetLastJobRunWithDisruptionDataForJobName,
-		getLastJobRunEndTimeFn:      ciDataClient.GetLastJobRunWithDisruptionDataEndTime,
-		jobRunUploader:              newDisruptionUploader(backendDisruptionTableInserter),
+		jobRunUploader:              newDisruptionUploader(backendDisruptionTableInserter, ciDataClient),
 		logLevel:                    f.LogLevel,
 	}, nil
 }
 
 type disruptionUploader struct {
 	backendDisruptionInserter jobrunaggregatorlib.BigQueryInserter
+	ciDataClient              jobrunaggregatorlib.CIDataClient
 }
 
-func newDisruptionUploader(backendDisruptionInserter jobrunaggregatorlib.BigQueryInserter) uploader {
+func newDisruptionUploader(backendDisruptionInserter jobrunaggregatorlib.BigQueryInserter,
+	ciDataClient jobrunaggregatorlib.CIDataClient) uploader {
+
 	return &disruptionUploader{
 		backendDisruptionInserter: backendDisruptionInserter,
+		ciDataClient:              ciDataClient,
 	}
+}
+
+func (o *disruptionUploader) getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
+	return o.ciDataClient.GetLastJobRunFromTableForJobName(ctx, jobrunaggregatorapi.DisruptionJobRunTableName, jobName)
+}
+
+func (o *disruptionUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error) {
+	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName)
 }
 
 func (o *disruptionUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob,

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -148,6 +148,10 @@ func (o *disruptionUploader) getLastUploadedJobRunEndTime(ctx context.Context) (
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName)
 }
 
+func (o *disruptionUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.DisruptionJobRunTableName, since)
+}
+
 func (o *disruptionUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob,
 	logger logrus.FieldLogger) error {
 	logger.Info("uploading backend disruption results")

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
@@ -35,7 +35,7 @@ func (o *testRunUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*ti
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.LegacyJobRunTableName)
 }
 
-func (o *testRunUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+func (o *testRunUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error) {
 	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.LegacyJobRunTableName, since)
 }
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
@@ -35,6 +35,10 @@ func (o *testRunUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*ti
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.LegacyJobRunTableName)
 }
 
+func (o *testRunUploader) listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error) {
+	return o.ciDataClient.ListUploadedJobRunIDsSinceFromTable(ctx, jobrunaggregatorapi.LegacyJobRunTableName, since)
+}
+
 func (o *testRunUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
 	logger.Info("uploading junit test runs")
 	combinedJunitContent, err := jobRun.GetCombinedJUnitTestSuites(ctx)

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/test_run_uploader.go
@@ -27,10 +27,6 @@ func newTestRunUploader(testRunInserter jobrunaggregatorlib.BigQueryInserter,
 	}
 }
 
-func (o *testRunUploader) getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error) {
-	return o.ciDataClient.GetLastJobRunFromTableForJobName(ctx, jobrunaggregatorapi.LegacyJobRunTableName, jobName)
-}
-
 func (o *testRunUploader) getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error) {
 	return o.ciDataClient.GetLastJobRunEndTimeFromTable(ctx, jobrunaggregatorapi.LegacyJobRunTableName)
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -7,13 +7,18 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
-
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+)
+
+const (
+	// workerCount is the number of goroutines we run for concurrently importing job runs.
+	// This bounds both our access to reading artifacts from GCS, as well as our writes
+	// to BigQuery.
+	workerCount = 20
 )
 
 type shouldCollectDataForJobFunc func(job jobrunaggregatorapi.JobRow) bool
@@ -94,28 +99,54 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("error listing job runs to import: %w", err)
 	}
-	logrus.WithField("importCount", len(jobRunsToImport)).Info("found job runs to import")
+	logrus.WithField("recentJobRuns", len(jobRunsToImport)).Info("found job runs to potentially import")
+
+	// Populate a channel with all the job runs we want to import, worker threads will pull
+	// from here until there's nothing left.
+	jobRunsToImportCh := make(chan *jobrunaggregatorapi.BigQueryJobRunRow, jobCount)
+	for i := range jobRunsToImport {
+		jr := jobRunsToImport[i]
+
+		// skip if the run is not from a job we care about:
+		jobRow, ok := jobRowsMap[jr.JobName]
+		if !ok {
+			logrus.WithFields(logrus.Fields{"job": jr.JobName, "run": jr.BuildID}).Debug("skipping job run for job not in our table")
+			continue
+		}
+
+		if !o.shouldCollectedDataForJobFn(jobRow) {
+			logrus.WithFields(logrus.Fields{"job": jr.JobName, "run": jr.BuildID}).Debug("skipping job run for job we do not import this type of data for")
+			continue
+		}
+
+		// skip if we already have it:
+		if _, ok := existingJobRunIDs[jr.BuildID]; ok {
+			logrus.WithFields(logrus.Fields{"job": jr.JobName, "run": jr.BuildID}).Debug("skipping job run we already have imported")
+			continue
+		}
+		jobRunsToImportCh <- jr
+	}
+	close(jobRunsToImportCh)
+	logrus.WithField("runsToImport", len(jobRunsToImportCh)).Info("job runs to import after filtering")
 
 	errs := []error{}
-	/*
-		wg := sync.WaitGroup{}
-		logrus.Infof("Launching threads to upload test runs for %d jobs", jobCount)
-		errChan := make(chan error, jobCount)
-		for i := 0; i < 20; i++ {
-			wg.Add(1)
-			go o.processJobs(ctx, &wg, i, jobCount, jobChan, errChan)
-		}
 
-		wg.Wait()
-		logrus.Infof("WaitGroup completed")
-		close(errChan)
+	logrus.WithField("workers", workerCount).Info("Launching goroutines for concurrent uploads")
+	wg := sync.WaitGroup{}
+	errChan := make(chan error, jobCount)
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go o.processJobRuns(ctx, &wg, i, jobCount, jobRunsToImportCh, errChan)
+	}
 
+	wg.Wait()
+	logrus.Infof("WaitGroup completed")
+	close(errChan)
 
-		for e := range errChan {
-			logrus.WithError(e).Error("error encountered during upload")
-			errs = append(errs, e)
-		}
-	*/
+	for e := range errChan {
+		logrus.WithError(e).Error("error encountered during upload")
+		errs = append(errs, e)
+	}
 
 	duration := time.Now().Sub(start)
 	logrus.WithFields(logrus.Fields{
@@ -127,151 +158,35 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// processJobs is started in several concurrent goroutines to pull jobs to process from the jobChan. Errors are sent
+// processJobRuns is started in several concurrent goroutines to pull job runs to process from the channel. Errors are sent
 // to the errChan for aggregation in the main thread.
-func (o *allJobsLoaderOptions) processJobs(ctx context.Context, wg *sync.WaitGroup, workerThread, jobCount int, jobChan <-chan jobrunaggregatorapi.JobRow, errChan chan<- error) {
+func (o *allJobsLoaderOptions) processJobRuns(ctx context.Context, wg *sync.WaitGroup, workerThread, jobCount int, jobRunsToImportCh <-chan *jobrunaggregatorapi.BigQueryJobRunRow, errChan chan<- error) {
 	defer wg.Done()
-	for job := range jobChan {
-		jobLogger := logrus.WithFields(logrus.Fields{
-			"job":    job.JobName,
+	for job := range jobRunsToImportCh {
+		jrLogger := logrus.WithFields(logrus.Fields{
 			"worker": workerThread,
+			"job":    job.JobName,
+			"run":    job.BuildID,
 		})
-		// log how many job remain to be processed
-		jobLogger.WithField("remaining", fmt.Sprintf("%d/%d", len(jobChan), jobCount)).Info("pulled job from queue")
+		// log how many job runs remain to be processed
+		jrLogger.WithField("remaining", fmt.Sprintf("%d/%d", len(jobRunsToImportCh), jobCount)).Info("pulled job run from queue")
 
-		if !o.shouldCollectedDataForJobFn(job) {
-			jobLogger.Info("skipping job")
-			continue
-		}
-
-		jobLoader := o.newJobBigQueryLoaderOptions(job, jobLogger)
-		err := jobLoader.Run(ctx)
-		if err != nil {
-			jobLogger.WithError(err).Error("error uploading job runs for job")
+		jobRunInserter := o.newJobRunBigQueryLoaderOptions(job.JobName, job.BuildID, jrLogger)
+		if err := jobRunInserter.Run(ctx); err != nil {
+			jrLogger.WithError(err).Error("error inserting job run")
 			errChan <- err
 		}
+		jrLogger.Info("finished processing job run")
 	}
 	logrus.WithField("worker", workerThread).Info("worker thread complete")
 }
-func (o *allJobsLoaderOptions) newJobBigQueryLoaderOptions(job jobrunaggregatorapi.JobRow, logger logrus.FieldLogger) *jobLoaderOptions {
 
-	return &jobLoaderOptions{
-		jobName:                   job.JobName,
-		gcsClient:                 o.gcsClient,
-		numberOfConcurrentReaders: 20,
-		jobRunInserter:            o.jobRunInserter,
-		jobRunUploader:            o.jobRunUploader,
-		logger:                    logger,
-	}
-}
-
-// jobLoaderOptions
-// 1. reads a local cache of prowjob.json and junit files for a particular job.
-// 2. for every junit file
-// 3. reads all junit for the each jobrun
-// 4. constructs a synthentic junit that includes every test and assigns pass/fail to each test
-type jobLoaderOptions struct {
-	jobName string
-
-	// GCSClient is used to read the prowjob data
-	gcsClient jobrunaggregatorlib.CIGCSClient
-
-	numberOfConcurrentReaders int64
-	jobRunInserter            jobrunaggregatorlib.BigQueryInserter
-
-	jobRunUploader uploader
-
-	logger logrus.FieldLogger
-}
-
-func (o *jobLoaderOptions) Run(ctx context.Context) error {
-
-	o.logger.Info("processing job")
-	lastJobRun, err := o.jobRunUploader.getLastUploadedJobRunForJob(ctx, o.jobName)
-	if err != nil {
-		return err
-	}
-	o.logger.WithField("lastJobRun", lastJobRun).Info("found last job run")
-	startingJobRunID := "0"
-	if lastJobRun != nil {
-		startingJobRunID = jobrunaggregatorlib.NextJobRunID(lastJobRun.Name)
-	}
-	o.logger.WithField("startingJobRunID", startingJobRunID).Info("startingJobRunID")
-
-	jobRunProcessingCh, errorCh, err := o.gcsClient.ListJobRunNamesOlderThanFourHours(ctx, o.jobName, startingJobRunID, o.logger)
-	if err != nil {
-		return err
-	}
-	o.logger.Info("job run processing channels established")
-
-	insertionErrorLock := sync.Mutex{}
-	insertionErrors := []error{}
-	go func() {
-		insertionErrorLock.Lock()
-		defer insertionErrorLock.Unlock()
-
-		// exits when the channel closes
-		for err := range errorCh {
-			o.logger.WithError(err).Error("insertion error")
-			insertionErrors = append(insertionErrors, err)
-		}
-	}()
-
-	// we want to process the insertion in-order so we can choose to stop an upload on the first error
-	lastDoneUploadingCh := make(chan struct{})
-	concurrentWorkers := semaphore.NewWeighted(o.numberOfConcurrentReaders)
-	currentUploaders := sync.WaitGroup{}
-	close(lastDoneUploadingCh)
-	for jobRunID := range jobRunProcessingCh {
-		jobRunInserter := o.newJobRunBigQueryLoaderOptions(jobRunID, lastDoneUploadingCh, o.logger)
-		lastDoneUploadingCh = jobRunInserter.doneUploading
-		jrLogger := o.logger.WithField("jobRun", jobRunID)
-
-		jrLogger.Info("acquiring concurrentWorker")
-		if err := concurrentWorkers.Acquire(ctx, 1); err != nil {
-			jrLogger.WithError(err).Info("context is done")
-			// this means the context is done
-			return err
-		}
-		jrLogger.Info("concurrentWorker acquired")
-
-		currentUploaders.Add(1)
-		go func(jrID string) {
-			defer concurrentWorkers.Release(1)
-			defer jrLogger.Info("concurrentWorker released")
-			defer currentUploaders.Done()
-			defer jrLogger.Info("concurrentUploader Done")
-
-			jrLogger.WithField("jobRunID", jrID).Info("inserting job run")
-			if err := jobRunInserter.Run(ctx); err != nil {
-				jrLogger.WithField("jobRun", jrID).WithError(err).Error("error inserting job run")
-				errorCh <- err
-			}
-		}(jobRunID)
-		jrLogger.Info("finished processing job run")
-	}
-	currentUploaders.Wait()
-
-	// at this point we're done finding new jobs (jobRunProcessingCh is closed) and we've finished all jobRun insertions
-	// (the waitGroup is done).  This means all error reporting is finished, so close the errorCh, then wait to complete
-	// all the error gathering
-	o.logger.Info("completed processing job runs")
-
-	close(errorCh)
-	insertionErrorLock.Lock()
-	defer insertionErrorLock.Unlock()
-
-	return utilerrors.NewAggregate(insertionErrors)
-}
-
-func (o *jobLoaderOptions) newJobRunBigQueryLoaderOptions(jobRunID string, readyToUpload chan struct{}, logger logrus.FieldLogger) *jobRunLoaderOptions {
+func (o *allJobsLoaderOptions) newJobRunBigQueryLoaderOptions(jobName, jobRunID string, logger logrus.FieldLogger) *jobRunLoaderOptions {
 	return &jobRunLoaderOptions{
-		jobName:        o.jobName,
+		jobName:        jobName,
 		jobRunID:       jobRunID,
 		gcsClient:      o.gcsClient,
-		readyToUpload:  readyToUpload,
 		jobRunInserter: o.jobRunInserter,
-		doneUploading:  make(chan struct{}),
 		jobRunUploader: o.jobRunUploader,
 		logger:         logger.WithField("jobRun", jobRunID),
 	}
@@ -281,7 +196,7 @@ type uploader interface {
 	uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error
 	getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error)
 	getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error)
-	listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error)
+	listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error)
 }
 
 // jobRunLoaderOptions
@@ -295,19 +210,18 @@ type jobRunLoaderOptions struct {
 	// GCSClient is used to read the prowjob data
 	gcsClient jobrunaggregatorlib.CIGCSClient
 
-	readyToUpload  chan struct{}
 	jobRunInserter jobrunaggregatorlib.BigQueryInserter
-	doneUploading  chan struct{}
 
 	jobRunUploader uploader
 	logger         logrus.FieldLogger
 }
 
 func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
-	defer close(o.doneUploading)
 
 	o.logger.Debug("Analyzing jobrun")
 
+	// TODO: probably don't need to read the prowjob.json anymore, remove this, we already got it
+	// from bigquery.
 	jobRun, err := o.readJobRunFromGCS(ctx)
 	if err != nil {
 		o.logger.WithError(err).Error("error reading job run from GCS")
@@ -316,16 +230,6 @@ func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
 	// this can happen if there is no prowjob.json, so no work to do.
 	if jobRun == nil {
 		return nil
-	}
-
-	// TODO we *could* read to see if we've already uploaded this.  That doesn't see necessary based on how
-	//  we decide to pull the data to upload though.
-
-	// wait until it is ready to upload before continuing
-	select {
-	case <-ctx.Done():
-		return nil
-	case <-o.readyToUpload:
 	}
 
 	if err := o.uploadJobRun(ctx, jobRun); err != nil {

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -243,7 +243,7 @@ func (o *jobRunLoaderOptions) uploadJobRun(ctx context.Context, jobRun jobrunagg
 	if err != nil {
 		return err
 	}
-	o.logger.Info("uploading prowjob.yaml")
+	o.logger.Info("inserting job run row")
 	jobRunRow := newJobRunRow(jobRun, prowJob)
 	if err := o.jobRunInserter.Put(ctx, jobRunRow); err != nil {
 		o.logger.WithError(err).Error("error inserting job run row")

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -103,7 +103,7 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 
 	// Populate a channel with all the job runs we want to import, worker threads will pull
 	// from here until there's nothing left.
-	jobRunsToImportCh := make(chan *jobrunaggregatorapi.BigQueryJobRunRow, jobCount)
+	jobRunsToImportCh := make(chan *jobrunaggregatorapi.TestPlatformProwJobRow, jobCount)
 	for i := range jobRunsToImport {
 		jr := jobRunsToImport[i]
 
@@ -160,7 +160,7 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 
 // processJobRuns is started in several concurrent goroutines to pull job runs to process from the channel. Errors are sent
 // to the errChan for aggregation in the main thread.
-func (o *allJobsLoaderOptions) processJobRuns(ctx context.Context, wg *sync.WaitGroup, workerThread, origRunsToImportCount int, jobRunsToImportCh <-chan *jobrunaggregatorapi.BigQueryJobRunRow, errChan chan<- error) {
+func (o *allJobsLoaderOptions) processJobRuns(ctx context.Context, wg *sync.WaitGroup, workerThread, origRunsToImportCount int, jobRunsToImportCh <-chan *jobrunaggregatorapi.TestPlatformProwJobRow, errChan chan<- error) {
 	defer wg.Done()
 	for job := range jobRunsToImportCh {
 		jrLogger := logrus.WithFields(logrus.Fields{

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -193,9 +193,9 @@ func (o *allJobsLoaderOptions) newJobRunBigQueryLoaderOptions(jobName, jobRunID 
 	}
 }
 
+// uploader encapsulates the logic for lookups and uploads specific to each type of content we ingest. (disruption, alerting, test runs, etc)
 type uploader interface {
 	uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error
-	getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error)
 	getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error)
 	listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error)
 }
@@ -221,8 +221,6 @@ func (o *jobRunLoaderOptions) Run(ctx context.Context) error {
 
 	o.logger.Debug("Analyzing jobrun")
 
-	// TODO: probably don't need to read the prowjob.json anymore, remove this, we already got it
-	// from bigquery.
 	jobRun, err := o.readJobRunFromGCS(ctx)
 	if err != nil {
 		o.logger.WithError(err).Error("error reading job run from GCS")

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -86,6 +86,11 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 	// Lookup the known prow job IDs (already uploaded) that ended within this window. BigQuery does not
 	// prevent us from inserting duplicate rows, we have to do it ourselves. We'll compare
 	// each incoming prow job to make sure it's not in the list we've already inserted.
+	existingJobRunIDs, err := o.jobRunUploader.listUploadedJobRunIDsSince(ctx, &listProwJobsSince)
+	if err != nil {
+		return fmt.Errorf("error listing uploaded job run IDs: %w", err)
+	}
+	logrus.WithField("idCount", len(existingJobRunIDs)).Info("found existing job run IDs")
 
 	errs := []error{}
 	/*
@@ -272,6 +277,7 @@ type uploader interface {
 	uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error
 	getLastUploadedJobRunForJob(ctx context.Context, jobName string) (*jobrunaggregatorapi.JobRunRow, error)
 	getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error)
+	listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) ([]string, error)
 }
 
 // jobRunLoaderOptions

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -10,11 +10,9 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-
-	sets "k8s.io/apimachinery/pkg/util/sets"
-
 	jobrunaggregatorapi "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	jobrunaggregatorlib "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockCIDataClient is a mock of CIDataClient interface.
@@ -100,49 +98,19 @@ func (mr *MockCIDataClientMockRecorder) GetLastAggregationForJob(arg0, arg1, arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastAggregationForJob", reflect.TypeOf((*MockCIDataClient)(nil).GetLastAggregationForJob), arg0, arg1, arg2)
 }
 
-// GetLastJobRunWithAlertDataForJobName mocks base method.
-func (m *MockCIDataClient) GetLastJobRunWithAlertDataForJobName(arg0 context.Context, arg1 string) (*jobrunaggregatorapi.JobRunRow, error) {
+// GetLastJobRunEndTimeFromTable mocks base method.
+func (m *MockCIDataClient) GetLastJobRunEndTimeFromTable(arg0 context.Context, arg1 string) (*time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastJobRunWithAlertDataForJobName", arg0, arg1)
-	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
+	ret := m.ctrl.Call(m, "GetLastJobRunEndTimeFromTable", arg0, arg1)
+	ret0, _ := ret[0].(*time.Time)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLastJobRunWithAlertDataForJobName indicates an expected call of GetLastJobRunWithAlertDataForJobName.
-func (mr *MockCIDataClientMockRecorder) GetLastJobRunWithAlertDataForJobName(arg0, arg1 interface{}) *gomock.Call {
+// GetLastJobRunEndTimeFromTable indicates an expected call of GetLastJobRunEndTimeFromTable.
+func (mr *MockCIDataClientMockRecorder) GetLastJobRunEndTimeFromTable(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastJobRunWithAlertDataForJobName", reflect.TypeOf((*MockCIDataClient)(nil).GetLastJobRunWithAlertDataForJobName), arg0, arg1)
-}
-
-// GetLastJobRunWithDisruptionDataForJobName mocks base method.
-func (m *MockCIDataClient) GetLastJobRunWithDisruptionDataForJobName(arg0 context.Context, arg1 string) (*jobrunaggregatorapi.JobRunRow, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastJobRunWithDisruptionDataForJobName", arg0, arg1)
-	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLastJobRunWithDisruptionDataForJobName indicates an expected call of GetLastJobRunWithDisruptionDataForJobName.
-func (mr *MockCIDataClientMockRecorder) GetLastJobRunWithDisruptionDataForJobName(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastJobRunWithDisruptionDataForJobName", reflect.TypeOf((*MockCIDataClient)(nil).GetLastJobRunWithDisruptionDataForJobName), arg0, arg1)
-}
-
-// GetLastJobRunWithTestRunDataForJobName mocks base method.
-func (m *MockCIDataClient) GetLastJobRunWithTestRunDataForJobName(arg0 context.Context, arg1 string) (*jobrunaggregatorapi.JobRunRow, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastJobRunWithTestRunDataForJobName", arg0, arg1)
-	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLastJobRunWithTestRunDataForJobName indicates an expected call of GetLastJobRunWithTestRunDataForJobName.
-func (mr *MockCIDataClientMockRecorder) GetLastJobRunWithTestRunDataForJobName(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastJobRunWithTestRunDataForJobName", reflect.TypeOf((*MockCIDataClient)(nil).GetLastJobRunWithTestRunDataForJobName), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastJobRunEndTimeFromTable", reflect.TypeOf((*MockCIDataClient)(nil).GetLastJobRunEndTimeFromTable), arg0, arg1)
 }
 
 // ListAggregatedTestRunsForJob mocks base method.
@@ -205,6 +173,21 @@ func (mr *MockCIDataClientMockRecorder) ListDisruptionHistoricalData(arg0 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListDisruptionHistoricalData", reflect.TypeOf((*MockCIDataClient)(nil).ListDisruptionHistoricalData), arg0)
 }
 
+// ListProwJobRunsSince mocks base method.
+func (m *MockCIDataClient) ListProwJobRunsSince(arg0 context.Context, arg1 *time.Time) ([]*jobrunaggregatorapi.TestPlatformProwJobRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProwJobRunsSince", arg0, arg1)
+	ret0, _ := ret[0].([]*jobrunaggregatorapi.TestPlatformProwJobRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListProwJobRunsSince indicates an expected call of ListProwJobRunsSince.
+func (mr *MockCIDataClientMockRecorder) ListProwJobRunsSince(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProwJobRunsSince", reflect.TypeOf((*MockCIDataClient)(nil).ListProwJobRunsSince), arg0, arg1)
+}
+
 // ListReleaseTags mocks base method.
 func (m *MockCIDataClient) ListReleaseTags(arg0 context.Context) (sets.String, error) {
 	m.ctrl.T.Helper()
@@ -233,4 +216,19 @@ func (m *MockCIDataClient) ListUnifiedTestRunsForJobAfterDay(arg0 context.Contex
 func (mr *MockCIDataClientMockRecorder) ListUnifiedTestRunsForJobAfterDay(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUnifiedTestRunsForJobAfterDay", reflect.TypeOf((*MockCIDataClient)(nil).ListUnifiedTestRunsForJobAfterDay), arg0, arg1, arg2)
+}
+
+// ListUploadedJobRunIDsSinceFromTable mocks base method.
+func (m *MockCIDataClient) ListUploadedJobRunIDsSinceFromTable(arg0 context.Context, arg1 string, arg2 *time.Time) (map[string]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUploadedJobRunIDsSinceFromTable", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUploadedJobRunIDsSinceFromTable indicates an expected call of ListUploadedJobRunIDsSinceFromTable.
+func (mr *MockCIDataClientMockRecorder) ListUploadedJobRunIDsSinceFromTable(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUploadedJobRunIDsSinceFromTable", reflect.TypeOf((*MockCIDataClient)(nil).ListUploadedJobRunIDsSinceFromTable), arg0, arg1, arg2)
 }

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -10,9 +10,11 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
+	sets "k8s.io/apimachinery/pkg/util/sets"
+
 	jobrunaggregatorapi "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	jobrunaggregatorlib "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
-	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockCIDataClient is a mock of CIDataClient interface.


### PR DESCRIPTION
After on-going problems with deadlocks, we decided to rewrite the top layer of the importers for alert, disruption, and test run data that is being uploaded into bigquery. 

This PR replaces all the concurrency code, and switches from discovering job runs via scanning GCS buckets to instead querying the bigquery table testplatform uploads all prowjobs to. 

We limit to 10 concurrent goroutines, each of which can be pulling from GCS or inserting in bigquery. 

The change relies on job run end times now, we lookup the last job run end time we inserted at the start, then query the testplatform prowjobs for any that ended since then, plus a 30 minute buffer. The code additinally lists all the prowjobs we already uploaded since that 30 minute buffer time, to avoid duplicate detection. (we do believe there are duplicates going in today, and bigquery will not prevent it)

Once we list the potentially new prowjobs to import, we compare each to see if it's from a job we care about, or if it's a job run ID we already have. If both checks pass we proceed to import the job as we used to.

I attempted to replace the querying of prowjob.json from GCS, because we have all that data from the testplatform table, I got a long way with this in terms of the uploaders, but then ran into problems with the aggregation and analysis code using what I'd just changed. I abandoned this effort to cut out one of the files we read, but I do have it locally and may take another shot later.

[TRT-772](https://issues.redhat.com//browse/TRT-772)