### PR TITLE
Use ocp/4.12:cli to promote images

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -224,7 +224,7 @@ func getPromotionPod(imageMirrorTarget map[string]string, namespace string) *cor
 			Containers: []coreapi.Container{
 				{
 					Name:    "promotion",
-					Image:   fmt.Sprintf("%s/%s/4.8:cli", api.DomainForService(api.ServiceRegistry), api.ResolveMultiArchNamespaceFor("ocp")),
+					Image:   fmt.Sprintf("%s/%s/4.12:cli", api.DomainForService(api.ServiceRegistry), api.ResolveMultiArchNamespaceFor("ocp")),
 					Command: command,
 					Args:    args,
 					VolumeMounts: []coreapi.VolumeMount{

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -11,7 +11,7 @@ spec:
     command:
     - /bin/sh
     - -c
-    image: registry.ci.openshift.org/ocp/4.8:cli
+    image: registry.ci.openshift.org/ocp/4.12:cli
     name: promotion
     resources: {}
     volumeMounts:


### PR DESCRIPTION
```console
oc get istag -n ocp 4.12:cli
NAME       IMAGE REFERENCE                                                                                                                     UPDATED
4.12:cli   image-registry.openshift-image-registry.svc:5000/ocp/4.12@sha256:f93a29f8d7455a5067ecde85394835bda877174193ab693b2b010d96c8cd9183   6 weeks ago
```