### PR TITLE
promoted-image-governor: do not log succecss deleting on errors

### DIFF
--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -545,6 +545,7 @@ func main() {
 		},
 		}); err != nil {
 			errs = append(errs, err)
+			continue
 		}
 		logrus.WithField("tag", tag.ISTagName()).Info("image stream tag is deleted")
 	}


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-promoted-image-governor/1618988937689174016#1:build-log.txt%3A70425

```
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:538","func":"main.main","level":"info","msg":"deleting tag","severity":"info","tag":"cnv/4.10:src-upgrade-ci","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:549","func":"main.main","level":"info","msg":"image stream tag is deleted","severity":"info","tag":"cnv/4.10:src-upgrade-ci","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:538","func":"main.main","level":"info","msg":"deleting tag","severity":"info","tag":"openshift/ocm-2.3:assisted-installer","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:549","func":"main.main","level":"info","msg":"image stream tag is deleted","severity":"info","tag":"openshift/ocm-2.3:assisted-installer","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:538","func":"main.main","level":"info","msg":"deleting tag","severity":"info","tag":"openshift/ocm-2.3:assisted-test-infra","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:549","func":"main.main","level":"info","msg":"image stream tag is deleted","severity":"info","tag":"openshift/ocm-2.3:assisted-test-infra","time":"2023-01-27T15:11:13Z"}
{"component":"promoted-image-governor","error":"[imagestreamtags.image.openshift.io \"4.11:src-upgrade-ci\" not found, imagestreamtags.image.openshift.io \"ocm-2.3:assisted-installer-controller\" not found, imagestreamtags.image.openshift.io \"4.13:src-upgrade-ci\" not found, imagestreamtags.image.openshift.io \"ocm-2.3:assisted-installer-agent\" not found, imagestreamtags.image.openshift.io \"ocm-2.3:assisted-service\" not found, imagestreamtags.image.openshift.io \"4.12:src-upgrade-ci\" not found, imagestreamtags.image.openshift.io \"4.10:src-upgrade-ci\" not found, imagestreamtags.image.openshift.io \"ocm-2.3:assisted-installer\" not found, imagestreamtags.image.openshift.io \"ocm-2.3:assisted-test-infra\" not found]","file":"/go/src/github.com/openshift/ci-tools/cmd/promoted-image-governor/main.go:552","func":"main.main","level":"fatal","msg":"could not delete tags","severity":"fatal","time":"2023-01-27T15:11:13Z"}
```

The logging above is so confusing.
Why we are trying to delete an non-existing tag is another issue, not in the scope of this PR.

