### PR TITLE
Include operating on manifests and create the corresponding images to the graph

### DIFF
--- a/cmd/image-graph-generator/main.go
+++ b/cmd/image-graph-generator/main.go
@@ -9,37 +9,29 @@ import (
 	graphql "github.com/shurcooL/graphql"
 	"github.com/sirupsen/logrus"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"github.com/openshift/ci-tools/pkg/api"
-	"github.com/openshift/ci-tools/pkg/config"
 	imagegraphgenerator "github.com/openshift/ci-tools/pkg/image-graph-generator"
 )
 
 type options struct {
-	configsPath     string
+	releaseRepoPath string
 	dgraphAddress   string
-	imageMirrorPath string
 }
 
 func (o options) validate() error {
 	if o.dgraphAddress == "" {
-		return fmt.Errorf("graphql-endpoint-address is not specified")
+		return fmt.Errorf("--graphql-endpoint-address is not specified")
 	}
-	if o.configsPath == "" {
-		return fmt.Errorf("--ci-operator-configs-path is not specified")
+	if o.releaseRepoPath == "" {
+		return fmt.Errorf("--release-repo is not specified")
 	}
-	if o.imageMirrorPath == "" {
-		return fmt.Errorf("--image-mirroring-path is not specified")
-	}
+
 	return nil
 }
 
 func parseOptions() options {
 	var o options
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-	fs.StringVar(&o.configsPath, "ci-operator-configs-path", "", "Path to ci-operator configurations.")
-	fs.StringVar(&o.imageMirrorPath, "image-mirroring-path", "", "Path to image mirroring mapping files.")
+	fs.StringVar(&o.releaseRepoPath, "release-repo", "", "Path to the openshift/release repository.")
 	fs.StringVar(&o.dgraphAddress, "graphql-endpoint-address", "", "Address of the Dgraph's graphql endpoint.")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -55,46 +47,20 @@ func main() {
 	}
 	graphqlClient := graphql.NewClient(o.dgraphAddress, http.DefaultClient)
 
-	operator := imagegraphgenerator.NewOperator(graphqlClient)
+	operator := imagegraphgenerator.NewOperator(graphqlClient, o.releaseRepoPath)
 
 	if err := operator.Load(); err != nil {
 		logrus.WithError(err).Fatal("couldn't load operator")
 	}
 
-	if err := operator.UpdateMirrorMappings(o.imageMirrorPath); err != nil {
+	if err := operator.UpdateMirrorMappings(); err != nil {
 		logrus.WithError(err).Fatal("couldn't update mirrored images")
 	}
-
-	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
-		if i.Org == "openshift-priv" {
-			return nil
-		}
-
-		if err := operator.AddBranchRef(i.Org, i.Repo, i.Branch); err != nil {
-			return err
-		}
-		branchID := operator.Branches()[fmt.Sprintf("%s/%s:%s", i.Org, i.Repo, i.Branch)]
-
-		if c.PromotionConfiguration == nil {
-			return nil
-		}
-
-		var errs []error
-		for _, image := range c.BaseImages {
-			if err := operator.UpdateBaseImage(image); err != nil {
-				errs = append(errs, err)
-			}
-		}
-
-		for _, image := range c.Images {
-			if err := operator.UpdateImage(image, c, branchID); err != nil {
-				errs = append(errs, err)
-			}
-		}
-		return utilerrors.NewAggregate(errs)
+	if err := operator.AddManifestImages(); err != nil {
+		logrus.WithError(err).Fatal("couldn't update images from manifests")
 	}
 
-	if err := config.OperateOnCIOperatorConfigDir(o.configsPath, callback); err != nil {
+	if err := operator.OperateOnCIOperatorConfigs(); err != nil {
 		logrus.WithError(err).Fatal("error while operating in ci-operator configuration files")
 	}
 }

--- a/pkg/image-graph-generator/images.go
+++ b/pkg/image-graph-generator/images.go
@@ -21,21 +21,6 @@ type ImageRef struct {
 	Children       []ImageRef  `graphql:"children"`
 }
 
-func (o *Operator) UpdateBaseImage(baseImage api.ImageStreamTagReference) error {
-	imageRef := &ImageRef{
-		Name:           baseImage.ISTagName(),
-		ImageStreamRef: baseImage.Name,
-		Namespace:      baseImage.Namespace,
-	}
-	if id, ok := o.images[baseImage.ISTagName()]; ok {
-		if err := o.updateImageRef(imageRef, id); err != nil {
-			return err
-		}
-		return nil
-	}
-	return nil
-}
-
 func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfiguration, c *api.ReleaseBuildConfiguration, branchID string) error {
 	imageName := fmt.Sprintf("%s/%s:%s", c.PromotionConfiguration.Namespace, c.PromotionConfiguration.Name, string(image.To))
 	if c.PromotionConfiguration.Name == "" {

--- a/pkg/image-graph-generator/manifests.go
+++ b/pkg/image-graph-generator/manifests.go
@@ -1,0 +1,172 @@
+package imagegraphgenerator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	buildv1 "github.com/openshift/api/build/v1"
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+var (
+	coreScheme   = scheme.Scheme
+	codecFactory = serializer.NewCodecFactory(coreScheme)
+)
+
+func init() {
+	utilruntime.Must(imagev1.AddToScheme(coreScheme))
+	utilruntime.Must(buildv1.AddToScheme(coreScheme))
+}
+
+func (o *Operator) loadManifests(path string) error {
+	err := filepath.Walk(path,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if ext := filepath.Ext(info.Name()); ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+
+			d, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+
+			// The YAML file could hold multiple objects separated by `---`
+			dataList := strings.Split(string(d), "---")
+			for _, data := range dataList {
+				requiredObj, _ := runtime.Decode(codecFactory.UniversalDecoder(corev1.SchemeGroupVersion), []byte(data))
+				list, ok := requiredObj.(*corev1.List)
+				if ok {
+					for _, object := range list.Items {
+						o.importObject(object.Raw)
+					}
+				} else {
+					o.importObject([]byte(data))
+				}
+
+			}
+			return nil
+		})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o *Operator) importObject(object []byte) {
+	isObject, _ := runtime.Decode(codecFactory.UniversalDecoder(imagev1.SchemeGroupVersion), object)
+	if is, ok := isObject.(*imagev1.ImageStream); ok {
+		o.imageStreams = append(o.imageStreams, *is)
+		return
+	}
+
+	bcObject, _ := runtime.Decode(codecFactory.UniversalDecoder(buildv1.SchemeGroupVersion), object)
+	if bc, ok := bcObject.(*buildv1.BuildConfig); ok {
+		o.buildConfigs = append(o.buildConfigs, *bc)
+		return
+	}
+}
+
+func (o *Operator) AddManifestImages() error {
+	for _, is := range o.imageStreams {
+		for _, tag := range is.Spec.Tags {
+			fullname := fmt.Sprintf("%s/%s:%s", is.Namespace, is.Name, tag.Name)
+			imageRef := &ImageRef{
+				Name:           fullname,
+				Namespace:      is.Namespace,
+				ImageStreamRef: is.Name,
+			}
+			if tag.From != nil {
+				imageRef.Source = tag.From.Name
+			}
+			if id, ok := o.images[fullname]; !ok {
+				if err := o.addImageRef(imageRef); err != nil {
+					return err
+				}
+			} else {
+				if err := o.updateImageRef(imageRef, id); err != nil {
+					return err
+				}
+			}
+		}
+
+	}
+
+	for _, bc := range o.buildConfigs {
+		namespace := bc.Spec.Output.To.Namespace
+		if namespace == "" {
+			namespace = bc.Namespace
+		}
+		name := fmt.Sprintf("%s/%s", namespace, bc.Spec.Output.To.Name)
+
+		imageRef := &ImageRef{
+			Name:           name,
+			Namespace:      namespace,
+			ImageStreamRef: bc.Spec.Output.To.Name,
+		}
+
+		// The buildConfig can be based on another image. This can be specified under the
+		// docker strategy.
+		if dockerStrategy := bc.Spec.Strategy.DockerStrategy; dockerStrategy != nil {
+			if from := dockerStrategy.From; from != nil {
+				var fullName string
+				var namespace string
+
+				switch from.Kind {
+				case "ImageStreamTag":
+					namespace := from.Namespace
+					if namespace == "" {
+						namespace = bc.Namespace
+					}
+					fullName = fmt.Sprintf("%s/%s", namespace, from.Name)
+				case "DockerImage":
+					if strings.HasPrefix(from.Name, api.ServiceDomainAPPCIRegistry) {
+						splitted := strings.Split(from.Name, "/")
+						namespace = splitted[1]
+						name = splitted[2]
+					}
+				}
+
+				if fullName != "" && namespace != "" {
+					parent := &ImageRef{
+						Name:           fullName,
+						Namespace:      namespace,
+						ImageStreamRef: from.Name,
+					}
+
+					if _, ok := o.images[name]; !ok {
+						if err := o.addImageRef(parent); err != nil {
+							return err
+						}
+					}
+					imageRef.Parent = parent
+				}
+			}
+		}
+
+		if id, ok := o.images[name]; !ok {
+			if err := o.addImageRef(imageRef); err != nil {
+				return err
+			}
+		} else {
+			if err := o.updateImageRef(imageRef, id); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/image-graph-generator/mirror_mappings.go
+++ b/pkg/image-graph-generator/mirror_mappings.go
@@ -14,8 +14,8 @@ const (
 	mappingFilePrefix = "mapping_"
 )
 
-func (o *Operator) UpdateMirrorMappings(path string) error {
-	err := filepath.Walk(path,
+func (o *Operator) UpdateMirrorMappings() error {
+	err := filepath.Walk(filepath.Join(o.releaseRepoPath, ReleaseMirrorMappingsPath),
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err


### PR DESCRIPTION
The tool now gets only the release repo path as a flag and hardcodes the required subdir that we need to operate on. We now read all YAML files in `clusters/app.ci` directory and load all `ImageStream` and `BuildConfigs`. 


/cc @danilo-gemoli @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>