### PR TITLE
Copy kubeconfig-minimal as soon as it is available for observers

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -207,6 +207,7 @@ func (s *multiStageTestStep) generatePods(
 		} else if needsKubeConfig {
 			container.Env = append(container.Env, []coreapi.EnvVar{
 				{Name: "KUBECONFIG", Value: filepath.Join(SecretMountPath, "kubeconfig")},
+				{Name: "KUBECONFIGMINIMAL", Value: filepath.Join(SecretMountPath, "kubeconfig-minimal")},
 				{Name: "KUBEADMIN_PASSWORD_FILE", Value: filepath.Join(SecretMountPath, "kubeadmin-password")},
 			}...)
 		}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -62,6 +62,8 @@
         value: 5e8c9
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE
@@ -204,6 +206,8 @@
         value: 5e8c9
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -68,6 +68,8 @@
         value: uuid
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE
@@ -227,6 +229,8 @@
         value: uuid
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE
@@ -379,6 +383,8 @@
         value: uuid
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE
@@ -537,6 +543,8 @@
         value: uuid
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
+      - name: KUBECONFIGMINIMAL
+        value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: CLUSTER_TYPE


### PR DESCRIPTION
Installer could make multiple updates to kubeconfig during the install process. Some steps like observers will like to get the kubeconfig as soon as it is minimally functioning. In https://github.com/openshift/release/pull/35992, the install step will copy the minimally functioning kubeconfig to kubeconfig-minimal and export KUBECONFIGMINIMAL for pods. I did not create a temporary kubeconfig-minimal for each pod as I do not expect this to be modified. But if it is needed, I can update the PR with that. 

[TRT-761](https://issues.redhat.com/browse/TRT-761)