### PR TITLE
Add more logs to the job primer and skip jobs without a Platform

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/create_jobs.go
+++ b/pkg/jobrunaggregator/jobtableprimer/create_jobs.go
@@ -37,10 +37,17 @@ func (o *CreateJobsOptions) Run(ctx context.Context) error {
 			continue
 		}
 
+		if len(jobToCreate.Platform) == 0 {
+			// if this table has no Platform, don't add it.
+			continue
+		}
 		missingJobs = append(missingJobs, jobToCreate)
 	}
 
 	fmt.Printf("Inserting %d jobs\n", len(missingJobs))
+	for job := range missingJobs {
+		fmt.Println(job)
+	}
 	if err := o.jobInserter.Put(ctx, missingJobs); err != nil {
 		return err
 	}

--- a/pkg/jobrunaggregator/jobtableprimer/job_typer.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_typer.go
@@ -3,6 +3,8 @@ package jobtableprimer
 import (
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 )
 
@@ -33,6 +35,8 @@ func newJob(name string) *jobRowBuilder {
 		platform = alibaba
 	case strings.Contains(name, "ibmcloud"):
 		platform = ibmcloud
+	default:
+		logrus.Warnf("Unable to detemrine platform for job %s: %s\n", name, platform)
 	}
 
 	architecture := ""


### PR DESCRIPTION
[TRT-826](https://issues.redhat.com//browse/TRT-826)

When the `Jobs` table (for disruption testing) in Big Query is updated, the logs are terse so you cannot see what got added.

This PR:

* adds more logging so you can see what jobs are added
* prevents jobs from being added where the `Platform` column/attribute could not be determined (a warning is also emitted)

These changes prevent errors going forward, but the current `Jobs` table has entries that don't have a `Platform` value.  To fix this, I believe we must destroy and re-create the `Jobs` table (as big query tables are immutable).
