### PR TITLE
Update alert data to include more alerts, namespaces and levels, and the number of job runs that hit that combo

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -49,8 +49,10 @@ func (a *AlertHistoricalDataRow) GetJobRuns() int {
 	return a.JobRuns
 }
 func (a *AlertHistoricalDataRow) GetKey() string {
-	return fmt.Sprintf("%s_%s_%s_%s_%s_%s_%s",
+	return fmt.Sprintf("%s_%s_%s_%s_%s_%s_%s_%s_%s",
 		a.AlertName,
+		a.AlertNamespace,
+		a.AlertLevel,
 		a.FromRelease,
 		a.Release,
 		a.Architecture,

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -25,7 +25,9 @@ type HistoricalJobData struct {
 }
 
 type AlertHistoricalDataRow struct {
-	AlertName string
+	AlertName      string
+	AlertNamespace string
+	AlertLevel     string
 	HistoricalJobData
 	P95 string
 	P99 string

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -165,22 +165,6 @@ func (c *ciDataClient) ListAlertHistoricalData(ctx context.Context) ([]jobrunagg
 			JobRuns,
             IFNULL(SAFE_CAST(P95 AS STRING), "0.0") AS P95, IFNULL(SAFE_CAST(P99 AS STRING), "0.0") AS P99
     FROM DATA_SET_LOCATION.Alerts_Unified_LastWeek_P95
-    WHERE
-        alertName = "etcdMembersDown" or 
-        alertName = "etcdGRPCRequestsSlow" or 
-        alertName = "etcdHighNumberOfFailedGRPCRequests" or 
-        alertName = "etcdMemberCommunicationSlow" or 
-        alertName = "etcdNoLeader" or 
-        alertName = "etcdHighFsyncDurations" or 
-        alertName = "etcdHighCommitDurations" or 
-        alertName = "etcdInsufficientMembers" or 
-        alertName = "etcdHighNumberOfLeaderChanges" or 
-        alertName = "KubeAPIErrorBudgetBurn" or 
-        alertName = "KubeClientErrors" or 
-        alertName = "KubePersistentVolumeErrors" or 
-        alertName = "MCDDrainError" or 
-        alertName = "PrometheusOperatorWatchErrors" or
-        alertName = "VSphereOpenshiftNodeHealthFail"
     ORDER BY 
         AlertName, Release, FromRelease, Topology, Platform, Network
     `)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -162,6 +162,7 @@ func (c *ciDataClient) ListAlertHistoricalData(ctx context.Context) ([]jobrunagg
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(`
     SELECT AlertName,
             Release, FromRelease, Platform, Architecture, Network, Topology,
+			JobRuns,
             IFNULL(SAFE_CAST(P95 AS STRING), "0.0") AS P95, IFNULL(SAFE_CAST(P99 AS STRING), "0.0") AS P99
     FROM DATA_SET_LOCATION.Alerts_Unified_LastWeek_P95
     WHERE

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -160,13 +160,13 @@ func (c *ciDataClient) ListDisruptionHistoricalData(ctx context.Context) ([]jobr
 
 func (c *ciDataClient) ListAlertHistoricalData(ctx context.Context) ([]jobrunaggregatorapi.HistoricalData, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(`
-    SELECT AlertName,
+    SELECT AlertName, AlertNamespace, AlertLevel,
             Release, FromRelease, Platform, Architecture, Network, Topology,
 			JobRuns,
             IFNULL(SAFE_CAST(P95 AS STRING), "0.0") AS P95, IFNULL(SAFE_CAST(P99 AS STRING), "0.0") AS P99
     FROM DATA_SET_LOCATION.Alerts_Unified_LastWeek_P95
     ORDER BY 
-        AlertName, Release, FromRelease, Topology, Platform, Network
+        Release, AlertName, AlertNamespace, AlertLevel, FromRelease, Topology, Platform, Network
     `)
 	query := c.client.Query(queryString)
 	disruptionRow, err := query.Read(ctx)


### PR DESCRIPTION
- Include JobRuns count in alerts query results
- Stop limiting the alerts we send to origin for testing
- Send alert namespace and level in data file for origin
- Fix alert comparisons when generating the weekly PR

I think this will actually work ok in origin even as it is now, but I do expect to have the origin PR up well before the Friday update, so I think this is safe to merge any time. The origin PR will include a new copy of query_results.json so it works.

[TRT-769](https://issues.redhat.com//browse/TRT-769)