### PR TITLE
remove disrupt 100 run filter

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -37,7 +37,7 @@ func (a *AlertHistoricalDataRow) GetJobData() HistoricalJobData {
 	return a.HistoricalJobData
 }
 func (a *AlertHistoricalDataRow) GetName() string {
-	return a.AlertName
+	return fmt.Sprintf("%s %s %s", a.AlertName, a.AlertNamespace, a.AlertLevel)
 }
 func (a *AlertHistoricalDataRow) GetP99() string {
 	return a.P99

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -126,7 +126,6 @@ func (c *ciDataClient) ListDisruptionHistoricalData(ctx context.Context) ([]jobr
 		GROUP BY
 			BackendName, Release, FromRelease, Platform, Architecture, Network, Topology
 	)
-	WHERE JobRuns >= 100
 	ORDER BY Release, FromRelease, Platform, Architecture, Network, Topology, BackendName
     `)
 	query := c.client.Query(queryString)

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/util.go
@@ -15,6 +15,11 @@ import (
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 )
 
+// minJobRuns is the minimum number of runs for which we'll do a comparison in the pull request message.
+// if under this, we don't particularly care if you're up or down, though we will still include you in the
+// data file, and let origin sort out what to do with that data.
+const minJobRuns = 100
+
 func readHistoricalDataFile(filePath, dataType string) ([]jobrunaggregatorapi.HistoricalData, error) {
 	currentData, err := os.ReadFile(filePath)
 	if err != nil {
@@ -131,7 +136,7 @@ func formatTableOutput(data []parsedJobData, filter bool) string {
 	buffer.WriteString("| Name | Release | From | Arch | Network | Platform | Topology | Job Results | P95 | P95 % Increase | P99 | P99 % Increase |\n")
 	buffer.WriteString("| ---- | ------- | ---- | ---- | ------- | -------- |--------- | ----------- | --- | -------------- | --- | -------------- |\n")
 	for _, d := range data {
-		if d.TimeDiffP99 == 0 && filter {
+		if (d.JobResults < minJobRuns || d.TimeDiffP99 == 0) && filter {
 			continue
 		}
 		buffer.WriteString(


### PR DESCRIPTION
We recently expanded the alert data file to include namespace and level. 
Origin is being updated to skip anything in the data file with less than 100 job runs, but previously we actually filtered them out entirely via the query, at least for disruption. 

This change makes disruption include them as well, to be consistent. It will be up to origin to decide what to enforce.

This also updates the PR message to show the new data for alerts, and hide rows from the tables with less than 100 runs, as we do not care to see whether they are up or down.

[TRT-769](https://issues.redhat.com//browse/TRT-769)