### PR TITLE
Support creating testgrid dashboards automatically for openshift layered product interop testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /_output
 index.js
 
+# vscode
+.vscode/
 
 # default working dir
 /job-aggregator-working-dir

--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -220,6 +220,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case util.IsSpecialInformingJobOnTestGrid(prowName):
 			// the standard release periodics should always appear in testgrid
 			dashboardType = "informing"
+		case strings.Contains(prowName, "-lp-interop"):
+			// OpenShift layered product interop testing
+			dashboardType = "informing"
 		default:
 			// unknown labels or non standard jobs do not appear in testgrid
 			return
@@ -253,6 +256,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case strings.HasPrefix(prowName, "promote-release-openshift-"):
 			// TODO fix these jobs to have a consistent name
 			stream = "ocp"
+		case strings.Contains(prowName, "-lp-interop"):
+			// OpenShift layered product interop testing
+			stream = "lp-interop"
 		default:
 			logrus.Warningf("unrecognized release type in job: %s", prowName)
 			return


### PR DESCRIPTION
# Proposed Change

This change adds support to `testgrid-config-generator` to provide the ability to auto create dashboards in test grid for OpenShift layered product interoperability testing. For every OpenShift release throughout the development/testing phases, layered products verify their interoperability on the unreleased OpenShift release. This testing ensures we maintain a healthy Red Hat portfolio of products on top of OpenShift. Reducing bugs customers may face when they upgrade their OpenShift cluster to the next available version (allowing their running layered products to be unaffected).

The change to testgrid-config-generator adds new case statements checking prow job names for a unique string `lp-interop` which indicate jobs are layered product interop testing.

Since there are 30+ layered products being tested (resulting in large prow jobs per OpenShift release), manually submitting PRs to test-infra or adding to the _allow-list.yml is time consuming/error prone if forgetting to add a job when its being created.

This change will allow dashboards to be created like the following:
 * redhat-openshift-lp-interop-release-4.12-informing
 * redhat-openshift-lp-interop-release-4.13-informing

# Verification

Simulation to verify change and new dashboard being generated.

```
time="2023-02-09T14:12:41-05:00" level=warning msg="Failed to determine info for prow job config" error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-image-mirroring-multi-arch\"" source-file=/home/rywillia/sdqe/release/ci-operator/jobs/infra-image-mirroring-multi-arch.yaml
time="2023-02-09T14:12:41-05:00" level=warning msg="Failed to determine info for prow job config" error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-image-mirroring\"" source-file=/home/rywillia/sdqe/release/ci-operator/jobs/infra-image-mirroring.yaml
time="2023-02-09T14:12:41-05:00" level=warning msg="Failed to determine info for prow job config" error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics-origin-release-images\"" source-file=/home/rywillia/sdqe/release/ci-operator/jobs/infra-periodics-origin-release-images.yaml
time="2023-02-09T14:12:41-05:00" level=warning msg="Failed to determine info for prow job config" error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics\"" source-file=/home/rywillia/sdqe/release/ci-operator/jobs/infra-periodics.yaml
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.10-nightly-operator-e2e"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.9-nightly-operator-e2e"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-arm-periodic"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-periodic"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws-arm"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws-arm"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-azure"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-gcp"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-gcp-nightly"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-assemble"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-osd-ephemeral"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-modern"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-azure-modern"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-gcp-modern"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-metal"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-vsphere-modern"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-aws-upgrade"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-aws-upgrade"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-gcp-upgrade"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-azure-upgrade"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-gcp-upgrade"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift"
time="2023-02-09T14:13:08-05:00" level=warning msg="unrecognized release type in job: release-openshift-release-analysis-aggregator"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-arm64"
time="2023-02-09T14:13:08-05:00" level=warning msg="release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift-hosted"
time="2023-02-09T14:13:10-05:00" level=info msg="Finished generating TestGrid dashboards."
Process 1174835 has exited with status 0
Detaching
```

```
[rywillia@t14s test-infra]$ git status
On branch master
Your branch is ahead of 'origin/master' by 746 commits.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   config/testgrids/openshift/groups.yaml
	modified:   config/testgrids/openshift/redhat-openshift-ocp-release-4.12-informing.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	config/testgrids/openshift/redhat-openshift-lp-interop-release-4.12-informing.yaml

no changes added to commit (use "git add" and/or "git commit -a")
[rywillia@t14s test-infra]$ cat config/testgrids/openshift/redhat-openshift-lp-interop-release-4.12-informing.yaml
dashboards:
- dashboard_tab:
  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
    code_search_path: https://github.com/openshift/origin/search
    code_search_url_template:
      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
    file_bug_template:
      options:
      - key: classification
        value: Red Hat
      - key: product
        value: OpenShift Container Platform
      - key: cf_internal_whiteboard
        value: buildcop
      - key: short_desc
        value: 'test: <test-name>'
      - key: cf_environment
        value: 'test: <test-name>'
      - key: comment
        value: 'test: <test-name> failed, see job: <link>'
      url: https://bugzilla.redhat.com/enter_bug.cgi
    name: periodic-ci-calebevans-windup-ui-tests-ocpci_interop-lp-interop-ocp4.12-mtr-interop-aws
    open_bug_template:
      url: https://github.com/openshift/origin/issues/
    open_test_template:
      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
    results_url_template:
      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
    test_group_name: periodic-ci-calebevans-windup-ui-tests-ocpci_interop-lp-interop-ocp4.12-mtr-interop-aws
  name: redhat-openshift-lp-interop-release-4.12-informing
test_groups:
- gcs_prefix: origin-ci-test/logs/periodic-ci-calebevans-windup-ui-tests-ocpci_interop-lp-interop-ocp4.12-mtr-interop-aws
  name: periodic-ci-calebevans-windup-ui-tests-ocpci_interop-lp-interop-ocp4.12-mtr-interop-aws
```

# Comments

cc' @ascerra @calebevans 
