### PR TITLE
entrypoint-wrapper: create Git configuration

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -163,10 +163,13 @@ func (s *multiStageTestStep) generatePods(
 		pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{Name: homeVolumeName, VolumeSource: coreapi.VolumeSource{EmptyDir: &coreapi.EmptyDirVolumeSource{}}})
 		pod.Spec.Volumes = append(pod.Spec.Volumes, secretVolumes...)
 		for idx := range pod.Spec.Containers {
-			if pod.Spec.Containers[idx].Name != containerName {
-				continue
+			if c := &pod.Spec.Containers[idx]; c.Name == containerName {
+				c.VolumeMounts = append(c.VolumeMounts, coreapi.VolumeMount{
+					Name:      homeVolumeName,
+					MountPath: "/alabama",
+				})
+				break
 			}
-			pod.Spec.Containers[idx].VolumeMounts = append(pod.Spec.Containers[idx].VolumeMounts, coreapi.VolumeMount{Name: homeVolumeName, MountPath: "/alabama"})
 		}
 
 		addSecretWrapper(pod, s.vpnConf, !needsKubeConfig, genPodOpts)


### PR DESCRIPTION
Newer versions of Git refuse to interact with a repository owned by another
user, independently of file permissions.  This is a problem in CI since
source code is usually cloned by UID 0 and read by unprivileged users.

With this change, `entrypoint-wrapper` creates a Git configuration file in
the home directory if it does not already exist (n.b.: this directory is
already provided as a temporary `EmptyDir` volume to `entrypoint-wrapper`
in multi-stage tests).  This file will disable the ownership verification
using the following entry:

    [safe]
        directory = *

Tests which want to have better control over their configuration can
rewrite this file or use one of the other configuration methods in Git:

- https://git-scm.com/docs/git-config.html#FILES
- https://git-scm.com/docs/git-config.html#SCOPES

---

For review, testing this with our current CI will be… interesting.
Documentation pull request will come soon.

/hold