### PR TITLE
Fix `entrypoint-wrapper` integration tests

### DIFF
--- a/cmd/entrypoint-wrapper/main.go
+++ b/cmd/entrypoint-wrapper/main.go
@@ -340,11 +340,11 @@ func manageHome(proc *exec.Cmd) string {
 // manageGitConfig creates a default Git configuration file if necessary
 // This configuration will contain a `safe.directory` entry disabling the file
 // ownership verification (see `git-config(1)`).  If an existing configuration
-// file is found, no changes are made.
+// file is found or the home directory does not exist, no changes are made.
 func manageGitConfig(home string) error {
 	path := filepath.Join(home, ".gitconfig")
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
-	if errors.Is(err, fs.ErrExist) {
+	if errors.Is(err, fs.ErrExist) || errors.Is(err, fs.ErrNotExist) {
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/test/integration/entrypoint-wrapper.sh
+++ b/test/integration/entrypoint-wrapper.sh
@@ -8,6 +8,7 @@ function cleanup() {
 trap "cleanup" EXIT
 
 dir=${BASETMPDIR}
+export HOME=${dir}/home
 export SHARED_DIR=${dir}/shared
 export TMPDIR=${dir}/tmp
 export CLI_DIR="/cli-dir"
@@ -29,7 +30,7 @@ fail() {
 }
 
 setup_test() {
-    mkdir -p "${SHARED_DIR}"
+    mkdir --parents "${HOME}" "${SHARED_DIR}"
     echo test0 > "${SHARED_DIR}/test0.txt"
     printf %s > "${SECRET}" '{' \
         '"kind":"Secret",' \

--- a/test/integration/entrypoint-wrapper.sh
+++ b/test/integration/entrypoint-wrapper.sh
@@ -136,7 +136,7 @@ test_git_config() {
     local f=$d/.gitconfig
     mkdir --parents "$d"
     printf '[safe]\n    directory = test\n' > "$f"
-    if ! HOME=$d entrypoint-wrapper --dry-run > /dev/null \
+    if ! GIT_CONFIG_COUNT=0 HOME=$d entrypoint-wrapper --dry-run > /dev/null \
         bash -c '[[ "$(git config safe.directory)" == "test" ]]'
     then
         fail '[ERROR] entrypoint-wrapper failed'


### PR DESCRIPTION
This was missed in https://github.com/openshift/ci-tools/pull/3292 since CI was
not working at that time and these tests pass locally.

e.g.: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3282/pull-ci-openshift-ci-tools-master-integration/1625502343464226816

Unit tests will fail as expected, this only corrects integration tests.