### PR TITLE
pkg/steps: fix unit tests

### DIFF
--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -49,6 +49,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":120000000000,"grace_period":4000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
           -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
@@ -193,6 +199,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
           -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -49,6 +49,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":3600000000000,"grace_period":20000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
           -eu\ncommand0"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
@@ -210,6 +216,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
           -eu\ncommand1"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
@@ -365,6 +377,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/var/run/configmaps/ci.openshift.io/multi-stage/step2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
       - name: ARTIFACT_DIR
@@ -524,6 +542,12 @@
         value: repo
       - name: REPO_OWNER
         value: org
+      - name: GIT_CONFIG_COUNT
+        value: "1"
+      - name: GIT_CONFIG_KEY_0
+        value: safe.directory
+      - name: GIT_CONFIG_VALUE_0
+        value: '*'
       - name: ENTRYPOINT_OPTIONS
         value: '{"timeout":7200000000000,"grace_period":15000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
           -eu\ncommand3"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -49,6 +49,12 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
+    - name: GIT_CONFIG_COUNT
+      value: "1"
+    - name: GIT_CONFIG_KEY_0
+      value: safe.directory
+    - name: GIT_CONFIG_VALUE_0
+      value: '*'
     - name: ENTRYPOINT_OPTIONS
       value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
         -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -49,6 +49,12 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
+    - name: GIT_CONFIG_COUNT
+      value: "1"
+    - name: GIT_CONFIG_KEY_0
+      value: safe.directory
+    - name: GIT_CONFIG_VALUE_0
+      value: '*'
     - name: ENTRYPOINT_OPTIONS
       value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
         -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
@@ -49,6 +49,12 @@ spec:
       value: repo
     - name: REPO_OWNER
       value: org
+    - name: GIT_CONFIG_COUNT
+      value: "1"
+    - name: GIT_CONFIG_KEY_0
+      value: safe.directory
+    - name: GIT_CONFIG_VALUE_0
+      value: '*'
     - name: ENTRYPOINT_OPTIONS
       value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
         -eu\nlaunch-tests"],"container_name":"StepName","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'

--- a/pkg/steps/testdata/zz_fixture_envTestGetPodObjectMounts_with_cluster_claim.yaml
+++ b/pkg/steps/testdata/zz_fixture_envTestGetPodObjectMounts_with_cluster_claim.yaml
@@ -12,6 +12,12 @@
   value: "true"
 - name: PROW_JOB_ID
   value: podStep.jobSpec.ProwJobID
+- name: GIT_CONFIG_COUNT
+  value: "1"
+- name: GIT_CONFIG_KEY_0
+  value: safe.directory
+- name: GIT_CONFIG_VALUE_0
+  value: '*'
 - name: ENTRYPOINT_OPTIONS
   value: '{"timeout":60000000000,"grace_period":1000000000,"artifact_dir":"/logs/artifacts","args":["/bin/bash","-c","#!/bin/bash\nset
     -eu\npodStep.config.Command"],"container_name":"podStep.name","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'


### PR DESCRIPTION
This corrects the test failures after the changes introduced in
https://github.com/openshift/ci-tools/pull/3293, when CI was not functioning to
block it.