### PR TITLE
entrypoint-wrapper: make int. test more reliable

### DIFF
--- a/test/integration/entrypoint-wrapper.sh
+++ b/test/integration/entrypoint-wrapper.sh
@@ -188,8 +188,9 @@ test_copy_kubeconfig() {
     ( sleep 1 && mv "${dir}/kubeconfig.new" "${dir}/kubeconfig" ) &
     if ! v=$( \
         KUBECONFIG="${dir}/kubeconfig" \
-        entrypoint-wrapper --dry-run \
-            bash -c 'for i in {0..9}; do if [[ -f "${KUBECONFIG}" ]]; then cat "${KUBECONFIG}" >&3; break; fi; sleep 0.2; done' \
+            timeout 5s \
+            entrypoint-wrapper --dry-run \
+            bash -c 'until [[ -f "${KUBECONFIG}" ]]; do sleep 0.2; done; cat "${KUBECONFIG}" >&3' \
         3>&1 > /dev/null 2> "${ERR}")
     then
         fail '[ERROR] entrypoint-wrapper failed'


### PR DESCRIPTION
While I cannot make this test fail on my machine even after executing it
continuously for hours, _everything_ is possible in CI: we see cases where
apparently one process does not get scheduled quickly enough and the existing
error margin is not enough:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3282/pull-ci-openshift-ci-tools-master-integration/1625825839356579840
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3282/pull-ci-openshift-ci-tools-master-integration/1625841861811769344

This change makes the failure case more explicit and very scientifically
increases the timeout to five seconds.