### PR TITLE
test/e2e: use latest OCP releases

### DIFF
--- a/test/e2e/simple/dynamic-releases.yaml
+++ b/test/e2e/simple/dynamic-releases.yaml
@@ -7,33 +7,33 @@ releases:
   initial:
     candidate:
       product: okd
-      version: "4.3"
+      version: "4.10"
   latest:
     release:
       channel: stable
-      version: "4.4"
+      version: "4.11"
   custom:
     candidate:
       product: ocp
       architecture: amd64
       stream: nightly
-      version: "4.10"
+      version: "4.11"
       relative: 1
   pre:
     prerelease:
       product: ocp
       version_bounds:
-        lower: "4.4.0"
-        upper: "4.10.0-0"
+        lower: "4.10.0"
+        upper: "4.11.0-0"
   mainframe:
     release:
-      version: "4.7"
+      version: "4.11"
       channel: stable
       architecture: s390x
   assembled:
     integration:
       namespace: ocp
-      name: "4.7"
+      name: "4.11"
 resources:
   '*':
     requests:


### PR DESCRIPTION
This is currently causing tests to fail, e.g.:

```
INFO[2023-03-02T09:48:30Z] Requesting a release from https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4.3.0-0.okd/latest
INFO[2023-03-02T09:48:30Z] Ran for 0s
ERRO[2023-03-02T09:48:30Z] Some steps failed:
ERRO[2023-03-02T09:48:30Z]
  * failed to generate steps from config: failed to resolve release initial: failed to request latest release: server responded with 404: no release configuration exists with the requested name
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3281/pull-ci-openshift-ci-tools-master-e2e/1631222115392819200

```console
$ curl -sS https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4.3.0-0.okd/latest
no release configuration exists with the requested name
```