### PR TITLE
Operate on builds based on the list of architectures supported in the cluster

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -75,6 +75,7 @@ func FromConfig(
 	hiveKubeconfig *rest.Config,
 	consoleHost string,
 	nodeName string,
+	nodeArchitectures []string,
 ) ([]api.Step, []api.Step, error) {
 	crclient, err := ctrlruntimeclient.NewWithWatch(clusterConfig, ctrlruntimeclient.Options{})
 	crclient = secretrecordingclient.Wrap(crclient, censor)
@@ -86,7 +87,7 @@ func FromConfig(
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get build client for cluster config: %w", err)
 	}
-	buildClient := steps.NewBuildClient(client, buildGetter.RESTClient())
+	buildClient := steps.NewBuildClient(client, buildGetter.RESTClient(), nodeArchitectures)
 
 	templateGetter, err := templateclientset.NewForConfig(clusterConfig)
 	if err != nil {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1039,7 +1039,7 @@ func TestFromConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	buildClient := steps.NewBuildClient(client, nil)
+	buildClient := steps.NewBuildClient(client, nil, nil)
 	var templateClient steps.TemplateClient
 	podClient := kubernetes.NewPodClient(client, nil, nil, 0)
 

--- a/pkg/steps/build_client.go
+++ b/pkg/steps/build_client.go
@@ -15,17 +15,20 @@ import (
 type BuildClient interface {
 	loggingclient.LoggingClient
 	Logs(namespace, name string, options *buildapi.BuildLogOptions) (io.ReadCloser, error)
+	NodeArchitectures() []string
 }
 
 type buildClient struct {
 	loggingclient.LoggingClient
-	client rest.Interface
+	client            rest.Interface
+	nodeArchitectures []string
 }
 
-func NewBuildClient(client loggingclient.LoggingClient, restClient rest.Interface) BuildClient {
+func NewBuildClient(client loggingclient.LoggingClient, restClient rest.Interface, nodeArchitectures []string) BuildClient {
 	return &buildClient{
-		LoggingClient: client,
-		client:        restClient,
+		LoggingClient:     client,
+		client:            restClient,
+		nodeArchitectures: nodeArchitectures,
 	}
 }
 
@@ -37,4 +40,8 @@ func (c *buildClient) Logs(namespace, name string, options *buildapi.BuildLogOpt
 		SubResource("log").
 		VersionedParams(options, scheme.ParameterCodec).
 		Stream(context.TODO())
+}
+
+func (c *buildClient) NodeArchitectures() []string {
+	return c.nodeArchitectures
 }

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -75,7 +75,7 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 	)
-	return handleBuild(ctx, s.client, *build)
+	return handleBuilds(ctx, s.client, *build)
 }
 
 func replaceCommand(pullSpec, with string) string {

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -42,7 +42,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 			secretName = s.cloneAuthConfig.Secret.Name
 		}
 
-		return handleBuild(ctx, s.buildClient, *buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
+		return handleBuilds(ctx, s.buildClient, *buildFromSource(s.jobSpec, "", api.PipelineImageStreamTagReferenceRoot, buildapi.BuildSource{
 			Type:         buildapi.BuildSourceGit,
 			Dockerfile:   s.config.DockerfileLiteral,
 			ContextDir:   s.config.ContextDir,

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -121,7 +121,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 	)
-	err = handleBuild(ctx, s.client, *build)
+	err = handleBuilds(ctx, s.client, *build)
 	if err != nil && strings.Contains(err.Error(), "error checking provided apis") {
 		return results.ForReason("generating_index").WithError(err).Errorf("failed to generate operator index due to invalid bundle info: %v", err)
 	}

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -218,7 +218,7 @@ func TestDatabaseIndex(t *testing.T) {
 			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
 				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
 			}
-			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist).Build()), nil),
+			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist).Build()), nil, nil),
 				testCase.isTagName, "ns")
 			if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("actual did not match expected, diff: %s", diff)

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -61,7 +61,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.pullSecret,
 		s.config.BuildArgs,
 	)
-	return handleBuild(ctx, s.client, *build)
+	return handleBuilds(ctx, s.client, *build)
 }
 
 type workingDir func(tag string) (string, error)

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -48,7 +48,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return handleBuild(ctx, s.client, *buildFromSource(
+	return handleBuilds(ctx, s.client, *buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,


### PR DESCRIPTION
/cc @openshift/test-platform @bbguimaraes 

1. Add the node architectures in the build client
2. We now add a nodeSelector to every build to specify the node with the desired architecture. E.x `kubernetes.io/arch: amd64` 
3. Spawn a build for each architecture for each image. 