### PR TITLE
`pj-rehearse`: downgrade useless warning to debug

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -233,7 +233,7 @@ func filterPeriodics(changedPeriodics config.Periodics, logger logrus.FieldLogge
 		}
 
 		if !hasRehearsableLabel(periodic.Labels) {
-			jobLogger.Warnf("job is not allowed to be rehearsed. Label %s is required", jobconfig.CanBeRehearsedLabel)
+			jobLogger.Debugf("job is not allowed to be rehearsed. Label %s is required", jobconfig.CanBeRehearsedLabel)
 			continue
 		}
 


### PR DESCRIPTION
We have this warning in our logs, but now that this is a plugin it shouldn't be warning level.