### PR TITLE
Create a dedicated aws cluster profile for managed aws cspi qe

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1161,7 +1161,7 @@ const (
 	ClusterProfileAWS1QE                ClusterProfile = "aws-1-qe"
 	ClusterProfileAWSSdQE               ClusterProfile = "aws-sd-qe"
 	ClusterProfileAWSGluster            ClusterProfile = "aws-gluster"
-	ClusterProfileAWSMSIQE              ClusterProfile = "aws-msi-qe"
+	ClusterProfileAWSManagedCSPIQE      ClusterProfile = "aws-managed-cspi-qe"
 	ClusterProfileAWSOSDMSP             ClusterProfile = "aws-osd-msp"
 	ClusterProfileAWSOutpost            ClusterProfile = "aws-outpost"
 	ClusterProfileAWSINTEROPQE          ClusterProfile = "aws-interop-qe"
@@ -1246,7 +1246,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSChinaQE,
 		ClusterProfileAWSGluster,
-		ClusterProfileAWSMSIQE,
+		ClusterProfileAWSManagedCSPIQE,
 		ClusterProfileAWSGovCloudQE,
 		ClusterProfileAWSOSDMSP,
 		ClusterProfileAWSQE,
@@ -1328,7 +1328,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSGluster,
-		ClusterProfileAWSMSIQE,
+		ClusterProfileAWSManagedCSPIQE,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWS2,
 		ClusterProfileAWS3,
@@ -1482,8 +1482,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-china-qe-quota-slice"
 	case ClusterProfileAWSCSPIQE:
 		return "aws-cspi-qe-quota-slice"
-	case ClusterProfileAWSMSIQE:
-		return "aws-msi-qe-quota-slice"
+	case ClusterProfileAWSManagedCSPIQE:
+		return "aws-managed-cspi-qe-quota-slice"
 	case ClusterProfileAWSGovCloudQE:
 		return "aws-usgov-qe-quota-slice"
 	case ClusterProfileAWSSC2SQE:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1161,6 +1161,7 @@ const (
 	ClusterProfileAWS1QE                ClusterProfile = "aws-1-qe"
 	ClusterProfileAWSSdQE               ClusterProfile = "aws-sd-qe"
 	ClusterProfileAWSGluster            ClusterProfile = "aws-gluster"
+	ClusterProfileAWSMSIQE              ClusterProfile = "aws-msi-qe"
 	ClusterProfileAWSOSDMSP             ClusterProfile = "aws-osd-msp"
 	ClusterProfileAWSOutpost            ClusterProfile = "aws-outpost"
 	ClusterProfileAWSINTEROPQE          ClusterProfile = "aws-interop-qe"
@@ -1245,6 +1246,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSChinaQE,
 		ClusterProfileAWSGluster,
+		ClusterProfileAWSMSIQE,
 		ClusterProfileAWSGovCloudQE,
 		ClusterProfileAWSOSDMSP,
 		ClusterProfileAWSQE,
@@ -1326,6 +1328,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSGluster,
+		ClusterProfileAWSMSIQE,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWS2,
 		ClusterProfileAWS3,
@@ -1479,6 +1482,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-china-qe-quota-slice"
 	case ClusterProfileAWSCSPIQE:
 		return "aws-cspi-qe-quota-slice"
+	case ClusterProfileAWSMSIQE:
+		return "aws-msi-qe-quota-slice"
 	case ClusterProfileAWSGovCloudQE:
 		return "aws-usgov-qe-quota-slice"
 	case ClusterProfileAWSSC2SQE:


### PR DESCRIPTION
The MSI (managed services integration) team requires a dedicated cluster profile for spinning up openshift clusters using our AWS account.  The profile will be used for add-ons, services, and layered products testing on ROSA and Hypershift.