### PR TITLE
`pj-rehearse`: properly bubble up errors from loading configuration

### DIFF
--- a/cmd/config-change-trigger/main.go
+++ b/cmd/config-change-trigger/main.go
@@ -91,8 +91,11 @@ func main() {
 		}
 	}
 
-	prConfig := config.GetAllConfigs(o.releaseRepoPath, logger)
-	masterConfig, err := config.GetAllConfigsFromSHA(o.releaseRepoPath, fmt.Sprintf("%s^1", jobSpec.Refs.BaseSHA), logger)
+	prConfig, err := config.GetAllConfigs(o.releaseRepoPath)
+	if err != nil {
+		logger.WithError(err).Warn("could not load all configuration from candidate revision of release repo")
+	}
+	masterConfig, err := config.GetAllConfigsFromSHA(o.releaseRepoPath, fmt.Sprintf("%s^1", jobSpec.Refs.BaseSHA))
 	if err != nil {
 		logger.WithError(err).Fatal("could not load configuration from base revision of release repo")
 	}


### PR DESCRIPTION
We were logging errors from loading the release configuration, but not actually bubbling them up so that the user could see them. This change throws errors instead of just logging them. The existing error commenting logic will take it from there.

I also cleaned up some of the areas where we were mistakenly wrapping a nil error.

For: https://issues.redhat.com/browse/DPTP-3311