### PR TITLE
Revert "oo-testing: opt out building index image"

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1855,9 +1855,6 @@ type Bundle struct {
 	// UpdateGraph defines the update mode to use when adding the bundle to the base index.
 	// Can be: semver (default), semver-skippatch, or replaces
 	UpdateGraph IndexUpdate `json:"update_graph,omitempty"`
-	// Skip building the index image for this bundle. Default to false.
-	// This field works only for named bundles, i.e., "as" is not empty.
-	SkipBuildingIndex bool `json:"skip_building_index,omitempty"`
 }
 
 // IndexGeneratorStepConfiguration describes a step that creates an index database and

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -703,30 +703,26 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 				},
 			}
 			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: bundle})
-			if !bundleConfig.SkipBuildingIndex {
-				// Build index generator
-				indexName := api.PipelineImageStreamTagReference(api.IndexName(bundleConfig.As))
-				updateGraph := bundleConfig.UpdateGraph
-				if updateGraph == "" {
-					updateGraph = api.IndexUpdateSemver
-				}
-				buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
-					To:            api.IndexGeneratorName(indexName),
-					OperatorIndex: []string{bundleConfig.As},
-					BaseIndex:     bundleConfig.BaseIndex,
-					UpdateGraph:   updateGraph,
-				}})
-				// Build the index
-				index := &api.ProjectDirectoryImageBuildStepConfiguration{
-					To: indexName,
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
-						DockerfilePath: steps.IndexDockerfileName,
-					},
-				}
-				buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index})
-			} else {
-				logrus.WithField("bundle", bundleConfig.As).Info("Skipped building index image")
+			// Build index generator
+			indexName := api.PipelineImageStreamTagReference(api.IndexName(bundleConfig.As))
+			updateGraph := bundleConfig.UpdateGraph
+			if updateGraph == "" {
+				updateGraph = api.IndexUpdateSemver
 			}
+			buildSteps = append(buildSteps, api.StepConfiguration{IndexGeneratorStepConfiguration: &api.IndexGeneratorStepConfiguration{
+				To:            api.IndexGeneratorName(indexName),
+				OperatorIndex: []string{bundleConfig.As},
+				BaseIndex:     bundleConfig.BaseIndex,
+				UpdateGraph:   updateGraph,
+			}})
+			// Build the index
+			index := &api.ProjectDirectoryImageBuildStepConfiguration{
+				To: indexName,
+				ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+					DockerfilePath: steps.IndexDockerfileName,
+				},
+			}
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index})
 		}
 		// Build non-named bundles following old naming system
 		var bundles []string

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1011,7 +1011,6 @@ func TestFromConfig(t *testing.T) {
 			"base_image", "base_rpm_image-without-rpms", "rpms",
 			"src", "bin", "to",
 			"ci-bundle0", "ci-index",
-			"my-bundle", "ci-index-my-bundle",
 		},
 	}, {
 		name: "release",
@@ -1141,50 +1140,6 @@ func TestFromConfig(t *testing.T) {
 		expectedParams: map[string]string{
 			"LOCAL_IMAGE_CI_BUNDLE0": "public_docker_image_repository:ci-bundle0",
 			"LOCAL_IMAGE_CI_INDEX":   "public_docker_image_repository:ci-index",
-		},
-	}, {
-		name: "named bundle source",
-		config: api.ReleaseBuildConfiguration{
-			Operator: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:             "my-bundle",
-					DockerfilePath: "dockerfile_path",
-					ContextDir:     "context_dir",
-				}},
-			},
-		},
-		expectedSteps: []string{
-			"src-bundle",
-			"my-bundle",
-			"ci-index-my-bundle-gen",
-			"ci-index-my-bundle",
-			"[output-images]",
-			"[images]",
-		},
-		expectedParams: map[string]string{
-			"LOCAL_IMAGE_CI_INDEX_MY_BUNDLE": "public_docker_image_repository:ci-index-my-bundle",
-			"LOCAL_IMAGE_MY_BUNDLE":          "public_docker_image_repository:my-bundle",
-		},
-	}, {
-		name: "named bundle source with index skipped",
-		config: api.ReleaseBuildConfiguration{
-			Operator: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:                "my-bundle",
-					DockerfilePath:    "dockerfile_path",
-					ContextDir:        "context_dir",
-					SkipBuildingIndex: true,
-				}},
-			},
-		},
-		expectedSteps: []string{
-			"src-bundle",
-			"my-bundle",
-			"[output-images]",
-			"[images]",
-		},
-		expectedParams: map[string]string{
-			"LOCAL_IMAGE_MY_BUNDLE": "public_docker_image_repository:my-bundle",
 		},
 	}, {
 		name: "image build",

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -296,10 +296,7 @@ func validateOperator(ctx *configContext, input *api.OperatorStepConfiguration, 
 			validationErrors = append(validationErrors, err)
 		}
 		if bundle.As == "" && bundle.BaseIndex != "" {
-			validationErrors = append(validationErrors, ctxN.AddField("base_index").errorf("base_index requires 'as' to be set"))
-		}
-		if bundle.As == "" && bundle.SkipBuildingIndex {
-			validationErrors = append(validationErrors, ctxN.AddField("skip_building_index").errorf("skip_building_index requires 'as' to be set"))
+			validationErrors = append(validationErrors, ctxN.AddField("base_index").errorf("base_index requires as to be set"))
 		}
 		if bundle.UpdateGraph != "" {
 			if bundle.BaseIndex == "" {

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -535,7 +535,7 @@ func TestValidateOperator(t *testing.T) {
 			},
 			withResolvesTo: goodStepLink,
 			output: []error{
-				errors.New("operator.bundles[0].base_index: base_index requires 'as' to be set"),
+				errors.New("operator.bundles[0].base_index: base_index requires as to be set"),
 			},
 		},
 		{
@@ -550,46 +550,6 @@ func TestValidateOperator(t *testing.T) {
 			withResolvesTo: goodStepLink,
 			output: []error{
 				errors.New("operator.bundles[0].update_graph: update_graph must be semver, semver-skippatch, or replaces"),
-			},
-		},
-		{
-			name: "SkipBuildingIndex can be set",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					As:                "my-bundle",
-					DockerfilePath:    "./dockerfile",
-					ContextDir:        ".",
-					BaseIndex:         "an-index",
-					UpdateGraph:       "replaces",
-					SkipBuildingIndex: true,
-				}},
-				Substitutions: []api.PullSpecSubstitution{
-					{
-						PullSpec: "original",
-						With:     "substitute",
-					},
-				},
-			},
-			withResolvesTo: goodStepLink,
-		},
-		{
-			name: "SkipBuildingIndex cannot be set on an unnamed bundle",
-			input: &api.OperatorStepConfiguration{
-				Bundles: []api.Bundle{{
-					DockerfilePath:    "./dockerfile",
-					ContextDir:        ".",
-					SkipBuildingIndex: true,
-				}},
-				Substitutions: []api.PullSpecSubstitution{
-					{
-						PullSpec: "original",
-						With:     "substitute",
-					},
-				},
-			},
-			withResolvesTo: goodStepLink,
-			output: []error{
-				errors.New("operator.bundles[0].skip_building_index: skip_building_index requires 'as' to be set"),
 			},
 		},
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -142,9 +142,6 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          context_dir: ' '\n" +
 	"          # DockerfilePath defines where the dockerfile for build the bundle exists relative to the contextdir\n" +
 	"          dockerfile_path: ' '\n" +
-	"          # Skip building the index image for this bundle. Default to false.\n" +
-	"          # This field works only for named bundles, i.e., \"as\" is not empty.\n" +
-	"          skip_building_index: true\n" +
 	"          # UpdateGraph defines the update mode to use when adding the bundle to the base index.\n" +
 	"          # Can be: semver (default), semver-skippatch, or replaces\n" +
 	"          update_graph: ' '\n" +


### PR DESCRIPTION
Reverts openshift/ci-tools#3327


It seems that the steps are smart enough to skip the index build if it is not needed.
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/37236/rehearse-37236-pull-ci-rh-ecosystem-edge-kernel-module-management-main-e2e-in-cluster-build/1635371934931750912

We do not need to specify it explicitly at all.

/cc @smg247 

