### PR TITLE
Pod-scaler admission: Better prow job names

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -291,16 +291,23 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 	mutateResources(pod.Spec.Containers)
 }
 
+const (
+	WorkloadTypeProwjob   = "prowjob"
+	WorkloadTypeBuild     = "build"
+	WorkloadTypeStep      = "step"
+	WorkloadTypeUndefined = "undefined"
+)
+
 // determineWorkloadType returns the workload type to be used in metrics
 func determineWorkloadType(annotations, labels map[string]string) string {
 	if _, isBuildPod := annotations[buildv1.BuildLabel]; isBuildPod {
-		return "build"
+		return WorkloadTypeBuild
 	}
 	if _, isProwjob := labels["prow.k8s.io/job"]; isProwjob {
-		return "prowjob"
+		return WorkloadTypeProwjob
 	}
 	if _, isStep := labels[steps.LabelMetadataStep]; isStep {
-		return "step"
+		return WorkloadTypeStep
 	}
-	return "undefined"
+	return WorkloadTypeUndefined
 }

--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -197,7 +197,7 @@ func mutatePodLabels(pod *corev1.Pod, build *buildv1.Build) {
 }
 
 // useOursIfLarger updates fields in theirs when ours are larger
-func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, podName, workloadType string, reporter results.PodScalerReporter, logger *logrus.Entry) {
+func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, workloadName, workloadType string, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	for _, item := range []*corev1.ResourceRequirements{allOfOurs, allOfTheirs} {
 		if item.Requests == nil {
 			item.Requests = corev1.ResourceList{}
@@ -220,7 +220,7 @@ func useOursIfLarger(allOfOurs, allOfTheirs *corev1.ResourceRequirements, podNam
 				logger.Debugf("determined %s %s of %s to be larger than %s configured", field, pair.resource, our.String(), their.String())
 				(*pair.theirs)[field] = our
 				if their.Value() > 0 && our.Value() > (their.Value()*10) {
-					reporter.ReportResourceConfigurationWarning(podName, workloadType, their.String(), our.String(), field.String())
+					reporter.ReportResourceConfigurationWarning(workloadName, workloadType, their.String(), our.String(), field.String())
 				}
 			}
 		}
@@ -279,7 +279,9 @@ func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceL
 			resources, recommendationExists := server.recommendedRequestFor(meta)
 			if recommendationExists {
 				logger.Debugf("recommendation exists for: %s", containers[i].Name)
-				useOursIfLarger(&resources, &containers[i].Resources, fmt.Sprintf("%s-%s", pod.Name, containers[i].Name), determineWorkloadType(pod.Annotations, pod.Labels), reporter, logger)
+				workloadType := determineWorkloadType(pod.Annotations, pod.Labels)
+				workloadName := determineWorkloadName(pod.Name, containers[i].Name, workloadType, pod.Labels)
+				useOursIfLarger(&resources, &containers[i].Resources, workloadName, workloadType, reporter, logger)
 				if mutateResourceLimits {
 					reconcileLimits(&containers[i].Resources)
 				}
@@ -310,4 +312,12 @@ func determineWorkloadType(annotations, labels map[string]string) string {
 		return WorkloadTypeStep
 	}
 	return WorkloadTypeUndefined
+}
+
+// determineWorkloadName returns the workload name we will see in the metrics
+func determineWorkloadName(podName, containerName, workloadType string, labels map[string]string) string {
+	if workloadType == WorkloadTypeProwjob {
+		return labels["prow.k8s.io/job"]
+	}
+	return fmt.Sprintf("%s-%s", podName, containerName)
 }

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -1044,3 +1044,45 @@ func TestDetermineWorkloadType(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineWorkloadName(t *testing.T) {
+	testCases := []struct {
+		name         string
+		workloadType string
+		labels       map[string]string
+		expected     string
+	}{
+		{
+			name:         "workload is prowjob",
+			workloadType: WorkloadTypeProwjob,
+			labels:       map[string]string{"prow.k8s.io/job": "prowjobName"},
+			expected:     "prowjobName",
+		},
+		{
+			name:         "workload is a step",
+			workloadType: WorkloadTypeStep,
+			labels:       nil,
+			expected:     "pod-container",
+		},
+		{
+			name:         "workload is a build",
+			workloadType: WorkloadTypeBuild,
+			labels:       nil,
+			expected:     "pod-container",
+		},
+		{
+			name:         "workload type is undefined",
+			workloadType: WorkloadTypeUndefined,
+			labels:       nil,
+			expected:     "pod-container",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if diff := cmp.Diff(determineWorkloadName("pod", "container", tc.workloadType, tc.labels), tc.expected); diff != "" {
+				t.Errorf("result differs from expected output, diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -1017,22 +1017,22 @@ func TestDetermineWorkloadType(t *testing.T) {
 			name:        "no labels or annotations",
 			annotations: map[string]string{},
 			labels:      map[string]string{},
-			expected:    "undefined",
+			expected:    WorkloadTypeUndefined,
 		},
 		{
 			name:        "build pod",
 			annotations: map[string]string{buildv1.BuildLabel: "buildName"},
-			expected:    "build",
+			expected:    WorkloadTypeBuild,
 		},
 		{
 			name:     "prowjob",
 			labels:   map[string]string{"prow.k8s.io/job": "jobName"},
-			expected: "prowjob",
+			expected: WorkloadTypeProwjob,
 		},
 		{
 			name:     "step",
 			labels:   map[string]string{steps.LabelMetadataStep: "e2e"},
-			expected: "step",
+			expected: WorkloadTypeStep,
 		},
 	}
 


### PR DESCRIPTION
Makes the workload name used in the `pod_scaler_admission_high_determined_resource` prometheus metric more meaningful in case the workload is a prowjob.

Before, the workload name would be something like `a06d0538-c4dd-11ed-9b5b-0a580a8005dc-test`. Now it will provide the actual name of the prowjob, using the `prow.k8s.io/job` label.