### PR TITLE
Add support for updating alert/disruption data for a past release.

### DIFF
--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/analyzer.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -23,22 +26,41 @@ const (
 )
 
 type JobRunHistoricalDataAnalyzerOptions struct {
-	ciDataClient jobrunaggregatorlib.CIDataClient
-	outputFile   string
-	newFile      string
-	currentFile  string
-	dataType     string
-	leeway       float64
+	ciDataClient  jobrunaggregatorlib.CIDataClient
+	outputFile    string
+	newFile       string
+	currentFile   string
+	dataType      string
+	leeway        float64
+	targetRelease string
 }
 
 func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
+
 	var newHistoricalData []jobrunaggregatorapi.HistoricalData
 
-	// We check what the current active release version is
-	currentRelease, previousRelease, err := fetchCurrentRelease()
-	if err != nil {
-		return err
+	// targetRelease will either be what the caller specified on the CLI, or the most recent release.
+	// previousRelease will be the one prior to targetRelease.
+	var targetRelease, previousRelease string
+	var err error
+	if o.targetRelease != "" {
+		// If we were given a target release, use that:
+		targetRelease = o.targetRelease
+		tokens := strings.Split(o.targetRelease, ".")
+		minor, err := strconv.Atoi(tokens[1])
+		prevMinor := minor - 1
+		if err != nil {
+			return errors.Wrap(err, "error calculating previous minor version for "+targetRelease)
+		}
+		previousRelease = fmt.Sprintf("%s.%d", tokens[0], prevMinor)
+	} else {
+		// We check what the current active release version is
+		targetRelease, previousRelease, err = fetchCurrentRelease()
+		if err != nil {
+			return err
+		}
 	}
+	fmt.Printf("Using target release: %s, prior release: %s\n", targetRelease, previousRelease)
 
 	currentHistoricalData, err := readHistoricalDataFile(o.currentFile, o.dataType)
 	if err != nil {
@@ -83,7 +105,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
 	if newReleaseUpdate {
 		newReleaseDataCount := 0
 		for _, data := range newDataMap {
-			if data.GetJobData().Release == currentRelease && data.GetJobRuns() > newReleaseJobRunsThreshold {
+			if data.GetJobData().Release == targetRelease && data.GetJobRuns() > newReleaseJobRunsThreshold {
 				newReleaseDataCount++
 			}
 		}
@@ -92,15 +114,15 @@ func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
 			fmt.Printf("We are in release transition from %s to %s. We continue to use old release data set for the following reason:\n"+
 				"- The number of new release data set need to reach at least %d percent of the number of the old release data set.\n"+
 				"- Currently we have only %d new release data set and the required number is %d based on old release data set count of %d\n",
-				previousRelease, currentRelease, int(releaseTransitionDataMinThresholdRatio*100), newReleaseDataCount,
+				previousRelease, targetRelease, int(releaseTransitionDataMinThresholdRatio*100), newReleaseDataCount,
 				int(float64(len(currentDataMap))*releaseTransitionDataMinThresholdRatio), len(currentDataMap))
 			newReleaseUpdate = false
-			currentRelease = previousRelease
+			targetRelease = previousRelease
 		} else {
 			msg := fmt.Sprintf("We are transitioning to use data set from new release %s for the following reason:\n"+
 				"- The number of new release data set has reached at least %d percent of the number of the old release data set.\n"+
 				"- Currently we have %d new release data set and the required number is %d based on old release data set count of %d\n",
-				currentRelease, int(releaseTransitionDataMinThresholdRatio*100), newReleaseDataCount,
+				targetRelease, int(releaseTransitionDataMinThresholdRatio*100), newReleaseDataCount,
 				int(float64(len(currentDataMap))*releaseTransitionDataMinThresholdRatio), len(currentDataMap))
 			if err := requireReviewFile(msg); err != nil {
 				return err
@@ -108,7 +130,7 @@ func (o *JobRunHistoricalDataAnalyzerOptions) Run(ctx context.Context) error {
 		}
 	}
 
-	result := o.compareAndUpdate(newDataMap, currentDataMap, currentRelease, newReleaseUpdate)
+	result := o.compareAndUpdate(newDataMap, currentDataMap, targetRelease, newReleaseUpdate)
 
 	err = o.renderResultFiles(result)
 	if err != nil {

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/cmd.go
@@ -17,12 +17,13 @@ type JobRunHistoricalDataAnalyzerFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 
-	NewFile       string
-	CurrentFile   string
-	DataType      string
-	Leeway        float64
-	OutputFile    string
-	TargetRelease string
+	NewFile         string
+	CurrentFile     string
+	DataType        string
+	Leeway          float64
+	OutputFile      string
+	TargetRelease   string
+	PreviousRelease string
 }
 
 var supportedDataTypes = sets.NewString("alerts", "disruptions")
@@ -43,6 +44,7 @@ func (f *JobRunHistoricalDataAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.CurrentFile, "current", f.CurrentFile, "local file with the current query results")
 	fs.StringVar(&f.OutputFile, "output-file", f.OutputFile, "output file for the resulting comparison results")
 	fs.StringVar(&f.TargetRelease, "target-release", f.TargetRelease, "override for release to generate data for, omit to use the most recent release. Be sure to checkout the correct branch for --current.")
+	fs.StringVar(&f.PreviousRelease, "previous-release", f.PreviousRelease, "override for previous release to generate data when we do not have enough for target release. Must be specified if using --target-release.")
 	fs.Float64Var(&f.Leeway, "leeway", f.Leeway, "percent leeway threshold for increased time diff")
 }
 
@@ -66,6 +68,10 @@ func (f *JobRunHistoricalDataAnalyzerFlags) Validate() error {
 		return fmt.Errorf("leeway percent must be above 0")
 	}
 
+	if f.TargetRelease != "" && f.PreviousRelease == "" {
+		return fmt.Errorf("must specify --previous-release with --target-release")
+	}
+
 	return nil
 }
 
@@ -84,13 +90,14 @@ func (f *JobRunHistoricalDataAnalyzerFlags) ToOptions(ctx context.Context) (*Job
 	}
 
 	return &JobRunHistoricalDataAnalyzerOptions{
-		ciDataClient:  ciDataClient,
-		newFile:       f.NewFile,
-		currentFile:   f.CurrentFile,
-		leeway:        f.Leeway,
-		dataType:      f.DataType,
-		outputFile:    f.OutputFile,
-		targetRelease: f.TargetRelease,
+		ciDataClient:    ciDataClient,
+		newFile:         f.NewFile,
+		currentFile:     f.CurrentFile,
+		leeway:          f.Leeway,
+		dataType:        f.DataType,
+		outputFile:      f.OutputFile,
+		targetRelease:   f.TargetRelease,
+		previousRelease: f.PreviousRelease,
 	}, nil
 }
 

--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/cmd.go
@@ -17,11 +17,12 @@ type JobRunHistoricalDataAnalyzerFlags struct {
 	DataCoordinates *jobrunaggregatorlib.BigQueryDataCoordinates
 	Authentication  *jobrunaggregatorlib.GoogleAuthenticationFlags
 
-	NewFile     string
-	CurrentFile string
-	DataType    string
-	Leeway      float64
-	OutputFile  string
+	NewFile       string
+	CurrentFile   string
+	DataType      string
+	Leeway        float64
+	OutputFile    string
+	TargetRelease string
 }
 
 var supportedDataTypes = sets.NewString("alerts", "disruptions")
@@ -41,6 +42,7 @@ func (f *JobRunHistoricalDataAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.NewFile, "new", f.NewFile, "local file with the new query results to compare against")
 	fs.StringVar(&f.CurrentFile, "current", f.CurrentFile, "local file with the current query results")
 	fs.StringVar(&f.OutputFile, "output-file", f.OutputFile, "output file for the resulting comparison results")
+	fs.StringVar(&f.TargetRelease, "target-release", f.TargetRelease, "override for release to generate data for, omit to use the most recent release. Be sure to checkout the correct branch for --current.")
 	fs.Float64Var(&f.Leeway, "leeway", f.Leeway, "percent leeway threshold for increased time diff")
 }
 
@@ -82,12 +84,13 @@ func (f *JobRunHistoricalDataAnalyzerFlags) ToOptions(ctx context.Context) (*Job
 	}
 
 	return &JobRunHistoricalDataAnalyzerOptions{
-		ciDataClient: ciDataClient,
-		newFile:      f.NewFile,
-		currentFile:  f.CurrentFile,
-		leeway:       f.Leeway,
-		dataType:     f.DataType,
-		outputFile:   f.OutputFile,
+		ciDataClient:  ciDataClient,
+		newFile:       f.NewFile,
+		currentFile:   f.CurrentFile,
+		leeway:        f.Leeway,
+		dataType:      f.DataType,
+		outputFile:    f.OutputFile,
+		targetRelease: f.TargetRelease,
 	}, nil
 }
 


### PR DESCRIPTION
We'd always assumed that branch point became permanent for disruption data, but this did not hold up for 4.13 when we had to merge a known regression after branching.

This adds support for a --target-release option on the command to override the normal lookup of the most recent release.

I have not updated the dev focused local hack/job-run-aggregator-analyzer.sh as it would cause logic explosion the way it's currently working and I don't know enough bash to avoid that. This would be used with a direct invocation today or manually hacking up the script locally.

[TRT-911](https://issues.redhat.com//browse/TRT-911)