### PR TITLE
Rename ci-index job name if SkipBuildingIndex is true

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -128,14 +128,17 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 				containsUnnamedBundle = true
 				continue
 			}
-			indexName := api.IndexName(bundle.As)
-			jobBaseGen := newJobBaseBuilder().TestName(indexName)
+			testName := api.IndexName(bundle.As)
+			if bundle.SkipBuildingIndex {
+				testName = fmt.Sprintf("ci-bundle-%s", bundle.As)
+			}
+			jobBaseGen := newJobBaseBuilder().TestName(testName)
 			if bundle.SkipBuildingIndex {
 				jobBaseGen.PodSpec.Add(Targets(bundle.As))
 			} else {
-				jobBaseGen.PodSpec.Add(Targets(indexName))
+				jobBaseGen.PodSpec.Add(Targets(testName))
 			}
-			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, indexName, info))
+			presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, testName, info))
 		}
 		if containsUnnamedBundle {
 			name := string(api.PipelineImageStreamTagReferenceIndexImage)

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
@@ -5,14 +5,14 @@ presubmits:
     branches:
     - ^branch$
     - ^branch-
-    context: ci/prow/ci-index-my-bundle
+    context: ci/prow/ci-bundle-my-bundle
     decorate: true
     decoration_config:
       skip_cloning: true
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-organization-repository-branch-ci-index-my-bundle
-    rerun_command: /test ci-index-my-bundle
+    name: pull-ci-organization-repository-branch-ci-bundle-my-bundle
+    rerun_command: /test ci-bundle-my-bundle
     spec:
       containers:
       - args:
@@ -46,4 +46,4 @@ presubmits:
       - name: result-aggregator
         secret:
           secretName: result-aggregator
-    trigger: (?m)^/test( | .* )ci-index-my-bundle,?($|\s.*)
+    trigger: (?m)^/test( | .* )ci-bundle-my-bundle,?($|\s.*)


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CBN38N3MW/p1679493518125489?thread_ts=1678118334.237179&cid=CBN38N3MW

`SkipBuildingIndex` is to opt out building the index image.
This PR renames the job accordingly to reduce the confusion.
See the unit test for an example on the job name's change.

