### PR TITLE
Remove index from input-hash to facilitate a single build for aggregated jobs

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -450,7 +450,6 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 
 	hashInput := prowgen.CustomHashInput(prpqrName)
 	if aggregatedOptions != nil {
-		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
 		if aggregatedOptions.labels != nil {
 			for k, v := range aggregatedOptions.labels {
 				labels[k] = v

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -41,7 +41,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-0
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -119,7 +119,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-1
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name


### PR DESCRIPTION
There is no guarantee that this will actually work, but we are unsure of a decent way to test this idea without merging it and trying to run one. The possible consequence could be that each test overwrites the last, and only one actual test is run. We will merge this and find out if that happens, or if it functions as desired.

For: https://issues.redhat.com/browse/DPTP-3310

/hold to rollout when we can test