### PR TITLE
Revert "Remove index from input-hash to facilitate a single build for aggregated jobs"

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -450,6 +450,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 
 	hashInput := prowgen.CustomHashInput(prpqrName)
 	if aggregatedOptions != nil {
+		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
 		if aggregatedOptions.labels != nil {
 			for k, v := range aggregatedOptions.labels {
 				labels[k] = v

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -41,7 +41,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test
+        - --input-hash=prpqr-test-0
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -119,7 +119,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test
+        - --input-hash=prpqr-test-1
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name


### PR DESCRIPTION
Didn't quite work, we need to find a way to differentiate the individual tests still.

Reverts openshift/ci-tools#3340