### PR TITLE
One build for aggregate payload jobs

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -451,7 +451,6 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 
 	var aggregateIndex *int
 	if aggregatedOptions != nil {
-		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
 		if aggregatedOptions.labels != nil {
 			for k, v := range aggregatedOptions.labels {
 				labels[k] = v

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -3,13 +3,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-0
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -35,7 +35,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-0
     pod_spec:
       containers:
       - args:
@@ -81,13 +81,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-1
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -113,7 +113,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-1
     pod_spec:
       containers:
       - args:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -41,7 +41,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-0
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -119,7 +119,7 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-1
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name


### PR DESCRIPTION
Attempt number 2 of testing this out. The issue with the original attempt is that the job names were all the same and they weren't able to run in the same namespace. This will ensure that they are different. We could still face issues with resolving the jobs in the aggregator job, but this trial will show us exactly where those issues are.

/cc @jmguzik 