### PR TITLE
prefer podman authentication file locations

### DIFF
--- a/pkg/steps/clusterinstall/template.go
+++ b/pkg/steps/clusterinstall/template.go
@@ -143,6 +143,8 @@ objects:
         value: /tmp/artifacts
       - name: HOME
         value: /tmp/home
+      - name: XDG_RUNTIME_DIR
+        value: /tmp/home/run
       - name: IMAGE_FORMAT
         value: ${IMAGE_FORMAT}
       - name: KUBECONFIG
@@ -244,7 +246,7 @@ objects:
           done
         }
 
-        mkdir -p "${HOME}"
+        mkdir -p "${HOME}" "${XDG_RUNTIME_DIR}"
 
         # Share oc with other containers
         cp "$(command -v oc)" /tmp/shared
@@ -402,6 +404,8 @@ objects:
         value: test
       - name: HOME
         value: /tmp
+      - name: XDG_RUNTIME_DIR
+        value: /tmp/run
       - name: INSTALL_INITIAL_RELEASE
       - name: RELEASE_IMAGE_INITIAL
       command:
@@ -415,6 +419,7 @@ objects:
         trap 'CHILDREN=$(jobs -p); if test -n "${CHILDREN}"; then kill ${CHILDREN} && wait; fi' TERM
         cp "$(command -v openshift-install)" /tmp
         mkdir ${ARTIFACT_DIR}/installer
+        mkdir -p "${XDG_RUNTIME_DIR}"
 
         function has_variant() {
           regex="(^|,)$1($|,)"
@@ -433,7 +438,7 @@ objects:
 
           # mirror the release image and override the release image to point to the mirrored one
           mkdir /tmp/.docker && cp /etc/openshift-installer/pull-secret /tmp/.docker/config.json
-          oc registry login
+          oc registry login --to /tmp/.docker/config.json
           MIRROR_BASE=$( oc get is release -o 'jsonpath={.status.publicDockerImageRepository}' )
           oc adm release new --from-release ${RELEASE_IMAGE_LATEST} --to-image ${MIRROR_BASE}-scratch:release --mirror ${MIRROR_BASE}-scratch || echo 'ignore: the release could not be reproduced from its inputs'
           oc adm release mirror --from ${MIRROR_BASE}-scratch:release --to ${MIRROR_BASE} --to-release-image ${MIRROR_BASE}:mirrored
@@ -944,6 +949,8 @@ objects:
         value: test
       - name: HOME
         value: /tmp
+      - name: XDG_RUNTIME_DIR
+        value: /tmp/run
       - name: LC_ALL
         value: en_US.UTF-8
       command:
@@ -975,7 +982,7 @@ objects:
           export PATH=$PATH:/tmp/shared
 
           echo "Gathering artifacts ..."
-          mkdir -p ${ARTIFACT_DIR}/pods ${ARTIFACT_DIR}/nodes ${ARTIFACT_DIR}/metrics ${ARTIFACT_DIR}/bootstrap ${ARTIFACT_DIR}/network
+          mkdir -p ${ARTIFACT_DIR}/pods ${ARTIFACT_DIR}/nodes ${ARTIFACT_DIR}/metrics ${ARTIFACT_DIR}/bootstrap ${ARTIFACT_DIR}/network "${XDG_RUNTIME_DIR}"
 
           oc --insecure-skip-tls-verify --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.metadata.name}{"\n"}{end}' > /tmp/nodes
           oc --insecure-skip-tls-verify --request-timeout=5s get nodes -o jsonpath --template '{range .items[*]}{.spec.providerID}{"\n"}{end}' | sed 's|.*/||' > /tmp/node-provider-IDs

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -212,6 +212,8 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		Commands: fmt.Sprintf(`
 set -xeuo pipefail
 export HOME=/tmp
+export XDG_RUNTIME_DIR=/tmp/run
+mkdir -p "${XDG_RUNTIME_DIR}"
 oc registry login
 oc adm release new --max-per-registry=32 -n %q --from-image-stream %q --to-image-base %q --to-image %q --name %q
 oc adm release extract --from=%q --to=${ARTIFACT_DIR}/release-payload-%s

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -171,11 +171,12 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 	commands := fmt.Sprintf(`
 set -euo pipefail
 export HOME=/tmp
-mkdir -p $HOME/.docker
+export XDG_RUNTIME_DIR=/tmp/run
+mkdir -p $HOME/.docker "${XDG_RUNTIME_DIR}"
 if [[ -d /pull ]]; then
 	cp /pull/.dockerconfigjson $HOME/.docker/config.json
 fi
-oc registry login
+oc registry login --to $HOME/.docker/config.json
 oc adm release extract --from=%q --file=image-references > ${ARTIFACT_DIR}/%s
 # while release creation may happen more than once in the lifetime of a test
 # namespace, only one release creation Pod will ever run at once. Therefore,


### PR DESCRIPTION
we want to remove preference for docker auth files in favor of podman ones in https://github.com/openshift/oc/pull/1376. Since ci-operator depends on the cli (oc) we need to first merge the changes here before  the changes in oc can be merged. This change was announced in [4.10](https://docs.openshift.com/container-platform/4.10/release_notes/ocp-4-10-release-notes.html#ocp-4-10-oc-commands-obtain-credentials-from-podman-config) and a proper warning was shown when using oc commands that work with registries since then.

- podman ~/.docker/config.json is deprecated in favor of podman authentication file locations (default is ${XDG_RUNTIME_DIR}/containers/auth.json)
- oc registry login will try to write to this location so XDG_RUNTIME_DIR environment variable must be present and the XDG_RUNTIME_DIR directory created/accessible. Places that need to manipulate with ~/.docker/config.json for backwards compatibility reasons need to specify --to or --registry-config
- other oc commands that lookup credentials from registry authentication files will first try the podman locations and if the credentials are not found, oc will fallback and check ~/.docker/config.json
