### PR TITLE
`pj-rehearse`: fix error comment format

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -393,7 +393,7 @@ func (s *server) getAffectedJobs(pullRequest *github.PullRequest, logger *logrus
 }
 
 func (s *server) reportFailure(message string, err error, org, repo, user string, number int, addContact, addUsageDetails bool, l *logrus.Entry) {
-	comment := fmt.Sprintf("@%s, `pj-rehearse`: %s ERROR: \n ```\n%v\n```.", user, message, err)
+	comment := fmt.Sprintf("@%s, `pj-rehearse`: %s ERROR: \n ```\n%v\n```\n", user, message, err)
 	if addContact {
 		comment += " If the problem persists, please [contact](https://docs.ci.openshift.org/docs/getting-started/useful-links/#contact) Test Platform."
 	}


### PR DESCRIPTION
The [error](https://github.com/openshift/release/pull/37779#issuecomment-1488826394) still doesn't quite look right. We need a new line after closing the pre-formatted block.

/cc @openshift/test-platform 