### PR TITLE
`ci-operator`: allow the option to set a target-additional-suffix for aggregate tests

### DIFF
--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -39,6 +39,13 @@ func TestMultiStage(t *testing.T) {
 			output:  []string{"Container test in pod success completed successfully"},
 		},
 		{
+			name:    "target-additional-suffix set",
+			args:    []string{"--target=success", "--target-additional-suffix=1"},
+			env:     []string{defaultJobSpec},
+			success: true,
+			output:  []string{"Container test in pod success-1 completed successfully"},
+		},
+		{
 			name:    "without references",
 			args:    []string{"--unresolved-config=config.yaml", "--target=without-references"},
 			env:     []string{defaultJobSpec},


### PR DESCRIPTION
When attempting to run every iteration of an aggregate payload job in a single namespace, we are seeing collisions when creating secrets for tests coming from: https://github.com/openshift/ci-tools/blob/66c77caff1dae103c14862fab46540d96775bfb5/pkg/steps/multi_stage/init.go#L30-L31

We need the ability to append an index to the end of the test's `As` field. This will allow us to differentiate the individual runs within the namespace.

There will be a follow up to this to make the `prpqr_resolver` utilize this option.

For: https://issues.redhat.com/browse/DPTP-3310