### PR TITLE
`ci-operator`: Add helper to set target-additional-suffix

### DIFF
--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -563,6 +563,14 @@ func CustomHashInput(input string) PodSpecMutator {
 	}
 }
 
+func TargetAdditionalSuffix(suffix string) PodSpecMutator {
+	return func(spec *corev1.PodSpec) error {
+		container := &spec.Containers[0]
+		addUniqueParameter(container, fmt.Sprintf("--target-additional-suffix=%s", suffix))
+		return nil
+	}
+}
+
 // InjectTestFrom configures ci-operator to inject the specified test from the
 // specified ci-operator config into the base config and target it
 func InjectTestFrom(source *cioperatorapi.MetadataWithTest) PodSpecMutator {

--- a/pkg/prowgen/podspec_test.go
+++ b/pkg/prowgen/podspec_test.go
@@ -140,6 +140,31 @@ func TestTargets(t *testing.T) {
 	}
 }
 
+func TestTargetAdditionalSuffix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "target additional suffix is added",
+			input: "1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewCiOperatorPodSpecGenerator()
+			g.Add(TargetAdditionalSuffix(tc.input))
+			podspec, err := g.Build()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			testhelper.CompareWithFixture(t, podspec)
+		})
+	}
+}
+
 func TestCustomHashInput(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
@@ -1,0 +1,32 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  - --target-additional-suffix=1
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator


### PR DESCRIPTION
Follow up to: https://github.com/openshift/ci-tools/pull/3354. We need a function to help us actually set this argument.

For: https://issues.redhat.com/browse/DPTP-3310