### PR TITLE
One build for aggregate jobs (v. 3)

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -469,6 +470,9 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		}
 		jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, fakeProwgenInfo, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[i])
 		jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(inject))
+		if aggregateIndex != nil {
+			jobBaseGen.PodSpec.Add(prowgen.TargetAdditionalSuffix(strconv.Itoa(*aggregateIndex)))
+		}
 
 		// Avoid sharing when we run the same job multiple times.
 		// PRPQR name should be safe to use as a discriminating input, because

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -229,7 +229,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			}
 			prowjobsToCreate = append(prowjobsToCreate, aggregatedProwjobs...)
 
-			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest)
+			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest, nil)
 			aggregatorJob, err := generateAggregatorJob(baseMetadata, uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix), req.Name, req.Namespace, r.prowConfigGetter.Config(), time.Now(), submitted)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate an aggregator prowjob")
@@ -437,35 +437,31 @@ func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, injec
 type aggregatedOptions struct {
 	labels          map[string]string
 	aggregatedIndex int
-	releaseJobName  string
 }
 
 func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, pr *v1.PullRequestUnderTest, mimickedJob string, inject *api.MetadataWithTest, aggregatedOptions *aggregatedOptions) (*prowv1.ProwJob, error) {
 	fakeProwgenInfo := &prowgen.ProwgenInfo{Metadata: *baseCiop}
 
-	var annotations map[string]string
+	annotations := map[string]string{
+		releaseJobNameAnnotation: mimickedJob,
+	}
 	labels := map[string]string{
 		releaseJobNameLabel: jobNameHash(mimickedJob),
 	}
 
-	hashInput := prowgen.CustomHashInput(prpqrName)
+	var aggregateIndex *int
 	if aggregatedOptions != nil {
-		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
 		if aggregatedOptions.labels != nil {
 			for k, v := range aggregatedOptions.labels {
 				labels[k] = v
 			}
 		}
-		annotations = map[string]string{
-			releaseJobNameAnnotation: aggregatedOptions.releaseJobName,
-		}
+		aggregateIndex = &aggregatedOptions.aggregatedIndex
 	} else {
 		labels[v1.PullRequestPayloadQualificationRunLabel] = prpqrName
-		annotations = map[string]string{
-			releaseJobNameAnnotation: mimickedJob,
-		}
 	}
 
+	hashInput := prowgen.CustomHashInput(prpqrName)
 	var periodic *prowconfig.Periodic
 	for i := range ciopConfig.Tests {
 		if ciopConfig.Tests[i].As != inject.Test {
@@ -494,7 +490,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
 			options.Cron = "@yearly"
 		})
-		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
+		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr, aggregateIndex)
 		break
 	}
 	// We did not find the injected test: this is a bug
@@ -547,7 +543,6 @@ func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfigur
 		opts := &aggregatedOptions{
 			labels:          map[string]string{aggregationIDLabel: uid},
 			aggregatedIndex: i,
-			releaseJobName:  spec.JobName(jobconfig.PeriodicPrefix),
 		}
 		jobName := fmt.Sprintf("%s-%d", spec.JobName(jobconfig.PeriodicPrefix), i)
 
@@ -626,10 +621,14 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 	return &pj, nil
 }
 
-func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest) string {
+func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest, index *int) string {
 	var variant string
 	if inject.Variant != "" {
 		variant = fmt.Sprintf("-%s", inject.Variant)
 	}
-	return fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+	jobName := fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+	if index != nil {
+		jobName = fmt.Sprintf("%s-%d", jobName, *index)
+	}
+	return jobName
 }

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -3,13 +3,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-0
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -35,13 +35,13 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-0
     pod_spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-0
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -81,13 +81,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-1
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -113,13 +113,13 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-1
     pod_spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-1
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=0
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:
@@ -121,6 +122,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=1
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -563,6 +563,14 @@ func CustomHashInput(input string) PodSpecMutator {
 	}
 }
 
+func TargetAdditionalSuffix(suffix string) PodSpecMutator {
+	return func(spec *corev1.PodSpec) error {
+		container := &spec.Containers[0]
+		addUniqueParameter(container, fmt.Sprintf("--target-additional-suffix=%s", suffix))
+		return nil
+	}
+}
+
 // InjectTestFrom configures ci-operator to inject the specified test from the
 // specified ci-operator config into the base config and target it
 func InjectTestFrom(source *cioperatorapi.MetadataWithTest) PodSpecMutator {

--- a/pkg/prowgen/podspec_test.go
+++ b/pkg/prowgen/podspec_test.go
@@ -140,6 +140,31 @@ func TestTargets(t *testing.T) {
 	}
 }
 
+func TestTargetAdditionalSuffix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "target additional suffix is added",
+			input: "1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewCiOperatorPodSpecGenerator()
+			g.Add(TargetAdditionalSuffix(tc.input))
+			podspec, err := g.Build()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			testhelper.CompareWithFixture(t, podspec)
+		})
+	}
+}
+
 func TestCustomHashInput(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
@@ -1,0 +1,32 @@
+containers:
+- args:
+  - --gcs-upload-secret=/secrets/gcs/service-account.json
+  - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+  - --report-credentials-file=/etc/report/credentials
+  - --target-additional-suffix=1
+  command:
+  - ci-operator
+  image: ci-operator:latest
+  imagePullPolicy: Always
+  name: ""
+  resources:
+    requests:
+      cpu: 10m
+  volumeMounts:
+  - mountPath: /secrets/gcs
+    name: gcs-credentials
+    readOnly: true
+  - mountPath: /etc/pull-secret
+    name: pull-secret
+    readOnly: true
+  - mountPath: /etc/report
+    name: result-aggregator
+    readOnly: true
+serviceAccountName: ci-operator
+volumes:
+- name: pull-secret
+  secret:
+    secretName: registry-pull-credentials
+- name: result-aggregator
+  secret:
+    secretName: result-aggregator


### PR DESCRIPTION
The third attempt at a solution for this. This time we will use a newly added `ci-operator` option to add a suffix to the in-process target for each test. This will allow them to be differentiated so that secrets (and other things) don't collide. Hopefully, this will get us past that part and we can discover any other problems we may have here.

/hold require https://github.com/openshift/ci-tools/pull/3355