### PR TITLE
Add new Power VS leases to control zoning

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1166,6 +1166,8 @@ const (
 	ClusterProfileIBMCloud              ClusterProfile = "ibmcloud"
 	ClusterProfileIBMCloudQE            ClusterProfile = "ibmcloud-qe"
 	ClusterProfilePOWERVS               ClusterProfile = "powervs"
+	ClusterProfilePOWERVS1              ClusterProfile = "powervs-1"
+	ClusterProfilePOWERVS2              ClusterProfile = "powervs-2"
 	ClusterProfileLibvirtPpc64le        ClusterProfile = "libvirt-ppc64le"
 	ClusterProfileLibvirtS390x          ClusterProfile = "libvirt-s390x"
 	ClusterProfileNutanix               ClusterProfile = "nutanix"
@@ -1262,6 +1264,8 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileIBMCloud,
 		ClusterProfileIBMCloudQE,
 		ClusterProfilePOWERVS,
+		ClusterProfilePOWERVS1,
+		ClusterProfilePOWERVS2,
 		ClusterProfileKubevirt,
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtS390x,
@@ -1376,6 +1380,10 @@ func (p ClusterProfile) ClusterType() string {
 		return "ibmcloud"
 	case ClusterProfilePOWERVS:
 		return "powervs"
+	case ClusterProfilePOWERVS1:
+		return "powervs-1"
+	case ClusterProfilePOWERVS2:
+		return "powervs-2"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le"
 	case ClusterProfileLibvirtS390x:
@@ -1532,6 +1540,10 @@ func (p ClusterProfile) LeaseType() string {
 		return "ibmcloud-qe-quota-slice"
 	case ClusterProfilePOWERVS:
 		return "powervs-quota-slice"
+	case ClusterProfilePOWERVS1:
+		return "powervs-1-quota-slice"
+	case ClusterProfilePOWERVS2:
+		return "powervs-2-quota-slice"
 	case ClusterProfileLibvirtPpc64le:
 		return "libvirt-ppc64le-quota-slice"
 	case ClusterProfileLibvirtS390x:
@@ -1662,7 +1674,7 @@ func (p ClusterProfile) Secret() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "nutanix", "nutanix-qe", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "powervs", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization":
+	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "nutanix", "nutanix-qe", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "powervs", "powervs-1", "powervs-2", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
Added two new leases for Power VS. Once they're present in openshift/release, we should be able to proceed with updating our jobs to use these, and then follow up with the removal of the old lease via https://github.com/openshift/ci-tools/pull/3352.