### PR TITLE
Revert "Skip disruption aggregation for azure jobs for now"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -78,11 +78,6 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 				return nil, err
 			}
 
-			// Temporarily skip all azure disruption aggregation due to https://issues.redhat.com/browse/TRT-889
-			if strings.Contains(o.jobName, "azure") {
-				status = testCaseSkipped
-			}
-
 			testCaseName := fmt.Sprintf(testCaseNamePattern, backendName)
 			testSuiteName := "aggregated-disruption"
 			junitTestCase, err := disruptionToJUnitTestCase(testCaseName, testSuiteName, jobGCSBucketRoot, failedJobRunIDs, successfulJobRunIDs, status, message)


### PR DESCRIPTION
Reverts openshift/ci-tools#3317

We are past the point of needing to allow azure disruption to pass through unchecked.  Reverting.