### PR TITLE
One build for aggregate jobs v.4

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -229,7 +230,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			}
 			prowjobsToCreate = append(prowjobsToCreate, aggregatedProwjobs...)
 
-			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest)
+			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest, nil)
 			aggregatorJob, err := generateAggregatorJob(baseMetadata, uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix), req.Name, req.Namespace, r.prowConfigGetter.Config(), time.Now(), submitted)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate an aggregator prowjob")
@@ -437,35 +438,31 @@ func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, injec
 type aggregatedOptions struct {
 	labels          map[string]string
 	aggregatedIndex int
-	releaseJobName  string
 }
 
 func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, pr *v1.PullRequestUnderTest, mimickedJob string, inject *api.MetadataWithTest, aggregatedOptions *aggregatedOptions) (*prowv1.ProwJob, error) {
 	fakeProwgenInfo := &prowgen.ProwgenInfo{Metadata: *baseCiop}
 
-	var annotations map[string]string
+	annotations := map[string]string{
+		releaseJobNameAnnotation: mimickedJob,
+	}
 	labels := map[string]string{
 		releaseJobNameLabel: jobNameHash(mimickedJob),
 	}
 
-	hashInput := prowgen.CustomHashInput(prpqrName)
+	var aggregateIndex *int
 	if aggregatedOptions != nil {
-		hashInput = prowgen.CustomHashInput(fmt.Sprintf("%s-%d", prpqrName, aggregatedOptions.aggregatedIndex))
 		if aggregatedOptions.labels != nil {
 			for k, v := range aggregatedOptions.labels {
 				labels[k] = v
 			}
 		}
-		annotations = map[string]string{
-			releaseJobNameAnnotation: aggregatedOptions.releaseJobName,
-		}
+		aggregateIndex = &aggregatedOptions.aggregatedIndex
 	} else {
 		labels[v1.PullRequestPayloadQualificationRunLabel] = prpqrName
-		annotations = map[string]string{
-			releaseJobNameAnnotation: mimickedJob,
-		}
 	}
 
+	hashInput := prowgen.CustomHashInput(prpqrName)
 	var periodic *prowconfig.Periodic
 	for i := range ciopConfig.Tests {
 		if ciopConfig.Tests[i].As != inject.Test {
@@ -473,6 +470,9 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		}
 		jobBaseGen := prowgen.NewProwJobBaseBuilderForTest(ciopConfig, fakeProwgenInfo, prowgen.NewCiOperatorPodSpecGenerator(), ciopConfig.Tests[i])
 		jobBaseGen.PodSpec.Add(prowgen.InjectTestFrom(inject))
+		if aggregateIndex != nil {
+			jobBaseGen.PodSpec.Add(prowgen.TargetAdditionalSuffix(strconv.Itoa(*aggregateIndex)))
+		}
 
 		// Avoid sharing when we run the same job multiple times.
 		// PRPQR name should be safe to use as a discriminating input, because
@@ -494,7 +494,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
 			options.Cron = "@yearly"
 		})
-		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
+		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr, aggregateIndex)
 		break
 	}
 	// We did not find the injected test: this is a bug
@@ -547,7 +547,6 @@ func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfigur
 		opts := &aggregatedOptions{
 			labels:          map[string]string{aggregationIDLabel: uid},
 			aggregatedIndex: i,
-			releaseJobName:  spec.JobName(jobconfig.PeriodicPrefix),
 		}
 		jobName := fmt.Sprintf("%s-%d", spec.JobName(jobconfig.PeriodicPrefix), i)
 
@@ -626,10 +625,14 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 	return &pj, nil
 }
 
-func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest) string {
+func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest, index *int) string {
 	var variant string
 	if inject.Variant != "" {
 		variant = fmt.Sprintf("-%s", inject.Variant)
 	}
-	return fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+	jobName := fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+	if index != nil {
+		jobName = fmt.Sprintf("%s-%d", jobName, *index)
+	}
+	return jobName
 }

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -269,7 +269,8 @@ func (f *fakeResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.
 		Metadata: *base,
 		Tests: []api.TestStepConfiguration{
 			{
-				As: testSource.Test,
+				As:     testSource.Test,
+				Secret: &api.Secret{Name: "secret"},
 			},
 		},
 	}, nil

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret-0
         - --target-additional-suffix=0
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -64,6 +65,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret-0
+          name: secret-0
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -72,6 +76,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret-0
+        secret:
+          secretName: secret-0
     report: true
     type: periodic
   status:
@@ -122,6 +129,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret-1
         - --target-additional-suffix=1
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
@@ -143,6 +151,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret-1
+          name: secret-1
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -151,6 +162,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret-1
+        secret:
+          secretName: secret-1
     report: true
     type: periodic
   status:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -3,13 +3,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-0
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-0
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -35,14 +35,15 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-0
     pod_spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-0
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=0
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:
@@ -81,13 +82,13 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-1
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
@@ -113,14 +114,15 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-name
+    job: test-org-test-repo-100-test-name-1
     pod_spec:
       containers:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-1
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=1
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:
@@ -63,6 +64,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret
+          name: secret
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -71,6 +75,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret
+        secret:
+          secretName: secret
     report: true
     type: periodic
   status:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret
         - --target=test-name-metal
         - --with-test-from=test-org/test-repo@test-branch:test-name-metal
         command:
@@ -63,6 +64,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret
+          name: secret
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -71,6 +75,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret
+        secret:
+          secretName: secret
     report: true
     type: periodic
   status:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch__test-variant:test-name
         command:
@@ -63,6 +64,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret
+          name: secret
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -71,6 +75,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret
+        secret:
+          secretName: secret
     report: true
     type: periodic
   status:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -43,6 +43,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret
         - --target=test-name-vsphere
         - --with-test-from=test-org/test-repo@test-branch:test-name-vsphere
         command:
@@ -63,6 +64,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret
+          name: secret
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -71,6 +75,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret
+        secret:
+          secretName: secret
     report: true
     type: periodic
   status:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -67,6 +67,7 @@
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/secret
         - --target=test-name-2
         - --with-test-from=test-org/test-repo@test-branch:test-name-2
         command:
@@ -87,6 +88,9 @@
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
+        - mountPath: /secrets/secret
+          name: secret
+          readOnly: true
       serviceAccountName: ci-operator
       volumes:
       - name: pull-secret
@@ -95,6 +99,9 @@
       - name: result-aggregator
         secret:
           secretName: result-aggregator
+      - name: secret
+        secret:
+          secretName: secret
     report: true
     type: periodic
   status:


### PR DESCRIPTION
Our 4th take at testing this out. The difference this time is the secrets in the `ci-operator` container definition will also have the aggregate index suffix. This will prevent the issue where the cluster-profile (and potentially other) secrets are not named as expected.

/cc @jmguzik 

/hold to coordinate the testing with rollout and for https://github.com/openshift/ci-tools/pull/3363