### PR TITLE
PowerVS: remove old powervs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1165,7 +1165,6 @@ const (
 	ClusterProfileGCP2                  ClusterProfile = "gcp-openshift-gce-devel-ci-2"
 	ClusterProfileIBMCloud              ClusterProfile = "ibmcloud"
 	ClusterProfileIBMCloudQE            ClusterProfile = "ibmcloud-qe"
-	ClusterProfilePOWERVS               ClusterProfile = "powervs"
 	ClusterProfilePOWERVS1              ClusterProfile = "powervs-1"
 	ClusterProfilePOWERVS2              ClusterProfile = "powervs-2"
 	ClusterProfileLibvirtPpc64le        ClusterProfile = "libvirt-ppc64le"
@@ -1264,7 +1263,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileHyperShift,
 		ClusterProfileIBMCloud,
 		ClusterProfileIBMCloudQE,
-		ClusterProfilePOWERVS,
 		ClusterProfilePOWERVS1,
 		ClusterProfilePOWERVS2,
 		ClusterProfileKubevirt,
@@ -1379,8 +1377,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileIBMCloud,
 		ClusterProfileIBMCloudQE:
 		return "ibmcloud"
-	case ClusterProfilePOWERVS:
-		return "powervs"
 	case ClusterProfilePOWERVS1:
 		return "powervs-1"
 	case ClusterProfilePOWERVS2:
@@ -1541,8 +1537,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "ibmcloud-quota-slice"
 	case ClusterProfileIBMCloudQE:
 		return "ibmcloud-qe-quota-slice"
-	case ClusterProfilePOWERVS:
-		return "powervs-quota-slice"
 	case ClusterProfilePOWERVS1:
 		return "powervs-1-quota-slice"
 	case ClusterProfilePOWERVS2:
@@ -1679,7 +1673,7 @@ func (p ClusterProfile) Secret() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "powervs", "powervs-1", "powervs-2", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization":
+	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "libvirt-ppc64le", "libvirt-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "vsphere", "ovirt", "packet", "packet-edge", "powervs-1", "powervs-2", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
Recently, we switched from powervs to powervs-1
and powervs-2.  Now we need to cleanup the old
powervs.