### PR TITLE
fix nutanix disconnected profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1270,6 +1270,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileLibvirtS390x,
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
+		ClusterProfileNutanixQEDis,
 		ClusterProfileOSDEphemeral,
 		ClusterProfileOpenStack,
 		ClusterProfileOpenStackHwoffload,


### PR DESCRIPTION
nutanix disconnected profile missed to add `ClusterProfileNutanixQEDis`, fix it.