### PR TITLE
Support creating testgrid dashboards automatically for manged service…

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -223,6 +223,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case strings.Contains(prowName, "-lp-interop"):
 			// OpenShift layered product interop testing
 			dashboardType = "informing"
+		case strings.Contains(prowName, "CSPI-QE-MSI"):
+			// Managed Services Integration (MSI) testing
+			dashboardType = "informing"
 		default:
 			// unknown labels or non standard jobs do not appear in testgrid
 			return
@@ -259,6 +262,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case strings.Contains(prowName, "-lp-interop"):
 			// OpenShift layered product interop testing
 			stream = "lp-interop"
+		case strings.Contains(prowName, "CSPI-QE-MSI"):
+			// Managed Services Integration (MSI) testing
+			stream = "CSPI-QE-MSI"
 		default:
 			logrus.Warningf("unrecognized release type in job: %s", prowName)
 			return


### PR DESCRIPTION
### Proposed Change
This change adds support to testgrid-config-generator to provide the ability to auto create dashboards in test grid for Managed Services Integration (MSI) testing. For every addon release, MSI runs a set of tests. 

The change to testgrid-config-generator adds new case statements checking prow job names for a unique string `CSPI-QE-MSI` which indicate jobs are MSI testing (under CSPI org).

This change will allow dashboards to be created like the following:

redhat-openshift-CSPI-QE-MSI-release-4.12-informing

### Verification
Simulation to verify change and new dashboard being generated.
```
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-image-mirroring\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-image-mirroring.yaml
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics-origin-release-images\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-periodics-origin-release-images.yaml
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-periodics.yaml
WARN[0002] unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.10-nightly-operator-e2e 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.9-nightly-operator-e2e 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-arm-periodic 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-periodic 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-azure 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-gcp 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-azure 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-gcp 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-conformance 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-microshift-release-4.13-nightly-conformance-parallel 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-microshift-release-4.13-nightly-conformance-serial 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-gcp-nightly 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-assemble 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-osd-ephemeral 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-azure-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-gcp-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-metal 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-vsphere-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-aws-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-aws-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-gcp-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-azure-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-gcp-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift 
WARN[0002] unrecognized release type in job: release-openshift-release-analysis-aggregator 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-arm64 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift-hosted 
INFO[0002] Finished generating TestGrid dashboards.     
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-image-mirroring\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-image-mirroring.yaml
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics-origin-release-images\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-periodics-origin-release-images.yaml
WARN[0000] Failed to determine info for prow job config  error="file name was not prefixed with \"ci-operator-jobs-\": \"infra-periodics\"" source-file=../../../openshift-ci-release/ci-operator/jobs/infra-periodics.yaml
WARN[0002] unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.10-nightly-operator-e2e 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-aws-efs-csi-driver-operator-release-4.9-nightly-operator-e2e 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-azure 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.13-periodics-e2e-gcp 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-arm-periodic 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-e2e-aws-periodic 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.12-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-aws 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-aws-arm 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-azure 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.14-periodics-e2e-gcp 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.13-periodics-e2e-aws-ovn-conformance 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn-conformance 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-microshift-release-4.13-nightly-conformance-parallel 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-microshift-release-4.13-nightly-conformance-serial 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-aws-nightly 
WARN[0002] unrecognized release type in job: periodic-ci-openshift-openshift-ansible-release-3.11-e2e-gcp-nightly 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-assemble 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-osd-ephemeral 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-azure-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-gcp-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-metal 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-vsphere-modern 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-aws-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-aws-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-okd-installer-e2e-gcp-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-azure-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-e2e-gcp-upgrade 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift 
WARN[0002] unrecognized release type in job: release-openshift-release-analysis-aggregator 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-aws-arm64 
WARN[0002] release is not in -X.Y- form and will go into the generic informing dashboard: release-openshift-origin-installer-launch-hypershift-hosted 
INFO[0002] Finished generating TestGrid dashboards.     
```

```
❯ git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   config/testgrids/openshift/groups.yaml
	modified:   config/testgrids/openshift/redhat-openshift-ocp-release-4.13-blocking.yaml
	modified:   config/testgrids/openshift/redhat-openshift-ocp-release-4.13-informing.yaml
	modified:   config/testgrids/openshift/redhat-openshift-ocp-release-4.14-blocking.yaml
	modified:   config/testgrids/openshift/redhat-openshift-ocp-release-4.14-informing.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	config/testgrids/openshift/redhat-openshift-CSPI-QE-MSI-release-4.12-informing.yaml

no changes added to commit (use "git add" and/or "git commit -a")
```

```
❯ cat config/testgrids/openshift/redhat-openshift-CSPI-QE-MSI-release-4.12-informing.yaml
dashboards:
- dashboard_tab:
  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
    code_search_path: https://github.com/openshift/origin/search
    code_search_url_template:
      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
    file_bug_template:
      options:
      - key: classification
        value: Red Hat
      - key: product
        value: OpenShift Container Platform
      - key: cf_internal_whiteboard
        value: buildcop
      - key: short_desc
        value: 'test: <test-name>'
      - key: cf_environment
        value: 'test: <test-name>'
      - key: comment
        value: 'test: <test-name> failed, see job: <link>'
      url: https://bugzilla.redhat.com/enter_bug.cgi
    name: periodic-ci-CSPI-QE-MSI-nvidia-gpu-addon-poc-tests
    open_bug_template:
      url: https://github.com/openshift/origin/issues/
    open_test_template:
      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
    results_url_template:
      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
    test_group_name: periodic-ci-CSPI-QE-MSI-nvidia-gpu-addon-poc-tests
  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
    code_search_path: https://github.com/openshift/origin/search
    code_search_url_template:
      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
    file_bug_template:
      options:
      - key: classification
        value: Red Hat
      - key: product
        value: OpenShift Container Platform
      - key: cf_internal_whiteboard
        value: buildcop
      - key: short_desc
        value: 'test: <test-name>'
      - key: cf_environment
        value: 'test: <test-name>'
      - key: comment
        value: 'test: <test-name> failed, see job: <link>'
      url: https://bugzilla.redhat.com/enter_bug.cgi
    name: periodic-ci-CSPI-QE-MSI-rdbaas-operator-addon-poc-tests
    open_bug_template:
      url: https://github.com/openshift/origin/issues/
    open_test_template:
      url: https://prow.ci.openshift.org/view/gs/<gcs_prefix>/<changelist>
    results_url_template:
      url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
    test_group_name: periodic-ci-CSPI-QE-MSI-rdbaas-operator-addon-poc-tests
  name: redhat-openshift-CSPI-QE-MSI-release-4.12-informing
test_groups:
- gcs_prefix: origin-ci-test/logs/periodic-ci-CSPI-QE-MSI-nvidia-gpu-addon-poc-tests
  name: periodic-ci-CSPI-QE-MSI-nvidia-gpu-addon-poc-tests
- gcs_prefix: origin-ci-test/logs/periodic-ci-CSPI-QE-MSI-rdbaas-operator-addon-poc-tests
  name: periodic-ci-CSPI-QE-MSI-rdbaas-operator-addon-poc-tests
```