### PR TITLE
`ci-operator`: trim target-additional-suffix from profile secret name

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -870,7 +870,7 @@ func (o *options) Run() []error {
 	}
 
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost, o.nodeName, nodeArchitectures)
+	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1446,7 +1446,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "")
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "")
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -77,7 +77,7 @@ func TestGeneratePods(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
 	step.test[0].Resources = api.ResourceRequirements{
 		Requests: api.ResourceList{api.ShmResource: "2G"},
 		Limits:   api.ResourceList{api.ShmResource: "2G"}}
@@ -155,7 +155,7 @@ func TestGenerateObservers(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
 	ret, err := step.generateObservers(observers, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Test:        test,
 					Environment: tc.env,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name")
+			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "")
 			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -297,7 +297,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
 	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -80,7 +80,7 @@ func TestRequires(t *testing.T) {
 				As:                                 "some-e2e",
 				ClusterClaim:                       tc.clusterClaim,
 				MultiStageTestConfigurationLiteral: &tc.steps,
-			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name")
+			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "")
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true
@@ -249,6 +249,37 @@ func TestEnvironment(t *testing.T) {
 			})
 			if diff := cmp.Diff(tc.expected, got); diff != "" {
 				t.Errorf("%s: result differs from expected:\n %s", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestProfileSecretName(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name             string
+		stepName         string
+		additionalSuffix string
+		expected         string
+	}{
+		{
+			name:     "no additional suffix",
+			stepName: "step",
+			expected: "step-cluster-profile",
+		},
+		{
+			name:             "additional suffix",
+			stepName:         "step-0",
+			additionalSuffix: "0",
+			expected:         "step-cluster-profile",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			step := multiStageTestStep{name: tc.stepName, additionalSuffix: tc.additionalSuffix}
+			result := step.profileSecretName()
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Fatalf("result does not match expected, diff: %s", diff)
 			}
 		})
 	}

--- a/pkg/steps/multi_stage/run_test.go
+++ b/pkg/steps/multi_stage/run_test.go
@@ -97,7 +97,7 @@ func TestRun(t *testing.T) {
 					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: &yes}},
 					AllowSkipOnSuccess: &yes,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name")
+			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "")
 			if err := step.Run(context.Background()); (err != nil) != (tc.failures != nil) {
 				t.Errorf("expected error: %t, got error: %v", (tc.failures != nil), err)
 			}
@@ -210,7 +210,7 @@ func TestJUnit(t *testing.T) {
 					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
 					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name")
+			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "")
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {
 				t.Error(err)
 				return


### PR DESCRIPTION
The additional suffix is currently part of the cluster profile secret name when present. This secret needs to be shared among all iterations of the test, and should not be duplicated. Therefore, the suffix should be trimmed off to resolve the secret. This will prevent errors like the following when using the `target-additional-suffix` param:
```
could not run steps: step e2e-aws-sdn-serial-1 failed: could not get cluster profile secret "e2e-aws-sdn-serial-1-cluster-profile": secrets "e2e-aws-sdn-serial-1-cluster-profile" not found
```

For: https://issues.redhat.com/browse/DPTP-3310