### PR TITLE
include multi01 cluster on registry domain resolving

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -21,6 +21,7 @@ const (
 	ServiceDomainAPPCIRegistry   = "registry.ci.openshift.org"
 	ServiceDomainVSphereRegistry = "registry.apps.build01-us-west-2.vmc.ci.openshift.org"
 	ServiceDomainArm01Registry   = "registry.arm-build01.arm-build.devcluster.openshift.com"
+	ServiceDomainMulti01Registry = "registry.multi-build01.arm-build.devcluster.openshift.com"
 )
 
 type Service string
@@ -69,6 +70,9 @@ func RegistryDomainForClusterName(clusterName string) (string, error) {
 	}
 	if clusterName == string(ClusterARM01) {
 		return ServiceDomainArm01Registry, nil
+	}
+	if clusterName == string(ClusterMulti01) {
+		return ServiceDomainMulti01Registry, nil
 	}
 	if buildClusterRegEx.MatchString(clusterName) {
 		return fmt.Sprintf("registry.%s.ci.openshift.org", clusterName), nil

--- a/pkg/api/domain_test.go
+++ b/pkg/api/domain_test.go
@@ -74,6 +74,11 @@ func TestRegistryDomainForClusterName(t *testing.T) {
 			expected:    "registry.arm-build01.arm-build.devcluster.openshift.com",
 		},
 		{
+			name:        "multi01",
+			clusterName: "multi01",
+			expected:    "registry.multi-build01.arm-build.devcluster.openshift.com",
+		},
+		{
 			name:        "build01",
 			clusterName: "build01",
 			expected:    "registry.build01.ci.openshift.org",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -612,6 +612,7 @@ const (
 	ClusterVSphere Cluster = "vsphere"
 	ClusterARM01   Cluster = "arm01"
 	ClusterHive    Cluster = "hive"
+	ClusterMulti01 Cluster = "multi01"
 )
 
 // TestStepConfiguration describes a step that runs a


### PR DESCRIPTION
After https://github.com/openshift/release/pull/37563 the `multi01` cluster is now in the CI farm. 
This PR allows `dptp-controller` to resolve the registry domain for `multi01` cluster


/cc @openshift/test-platform 



Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
