### PR TITLE
pkg/steps: emit detailed build errors in debug log

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -499,7 +499,7 @@ func waitForBuildDeletion(ctx context.Context, client ctrlruntimeclient.Client, 
 
 func isInfraReason(reason buildapi.StatusReason) bool {
 	infraReasons := []buildapi.StatusReason{
-		buildapi.StatusReason("BuildPodEvicted"), // vendoring to get this is so hard
+		buildapi.StatusReasonBuildPodEvicted,
 		buildapi.StatusReasonBuildPodDeleted,
 		buildapi.StatusReasonBuildPodExists,
 		buildapi.StatusReasonCannotCreateBuildPod,

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -533,10 +533,10 @@ func hintsAtInfraReason(logSnippet string) bool {
 }
 
 func waitForBuildOrTimeout(ctx context.Context, buildClient BuildClient, namespace, name string) error {
-	return waitForBuild(ctx, buildClient, namespace, name, 0, buildDuration)
+	return waitForBuild(ctx, buildClient, namespace, name, buildDuration)
 }
 
-func waitForBuild(ctx context.Context, buildClient BuildClient, namespace, name string, timeout time.Duration, buildDurationFunc func(*buildapi.Build) time.Duration) error {
+func waitForBuild(ctx context.Context, buildClient BuildClient, namespace, name string, buildDurationFunc func(*buildapi.Build) time.Duration) error {
 	isOK := func(b *buildapi.Build) bool {
 		return b.Status.Phase == buildapi.BuildPhaseComplete
 	}
@@ -569,7 +569,7 @@ func waitForBuild(ctx context.Context, buildClient BuildClient, namespace, name 
 		return false, nil
 	}
 
-	return kubernetes.WaitForConditionOnObject(ctx, buildClient, ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: name}, &buildapi.BuildList{}, &buildapi.Build{}, evaluatorFunc, timeout)
+	return kubernetes.WaitForConditionOnObject(ctx, buildClient, ctrlruntimeclient.ObjectKey{Namespace: namespace, Name: name}, &buildapi.BuildList{}, &buildapi.Build{}, evaluatorFunc, 0)
 }
 
 func buildDuration(build *buildapi.Build) time.Duration {

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -386,6 +386,8 @@ func init() {
 }
 
 func TestWaitForBuild(t *testing.T) {
+	now := meta.Time{Time: time.Now()}
+	start, end := meta.Time{Time: now.Time.Add(-3 * time.Second)}, now
 	var testCases = []struct {
 		name        string
 		buildClient BuildClient
@@ -400,7 +402,9 @@ func TestWaitForBuild(t *testing.T) {
 						Namespace: "some-ns",
 					},
 					Status: buildapi.BuildStatus{
-						Phase: buildapi.BuildPhaseComplete,
+						Phase:               buildapi.BuildPhaseComplete,
+						StartTimestamp:      &start,
+						CompletionTimestamp: &end,
 					},
 				}).Build()), nil, nil),
 		},
@@ -413,10 +417,12 @@ func TestWaitForBuild(t *testing.T) {
 						Namespace: "some-ns",
 					},
 					Status: buildapi.BuildStatus{
-						Phase:      buildapi.BuildPhaseCancelled,
-						Reason:     "reason",
-						Message:    "msg",
-						LogSnippet: "snippet",
+						Phase:               buildapi.BuildPhaseCancelled,
+						Reason:              "reason",
+						Message:             "msg",
+						LogSnippet:          "snippet",
+						StartTimestamp:      &start,
+						CompletionTimestamp: &end,
 					},
 				}).Build()), "abc\n"), // the line break is for gotestsum https://github.com/gotestyourself/gotestsum/issues/141#issuecomment-1209146526
 			expected: fmt.Errorf("%s\n\n%s", "the build some-build failed after 3s with reason reason: msg", "snippet"),
@@ -425,9 +431,7 @@ func TestWaitForBuild(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual := waitForBuild(context.TODO(), testCase.buildClient, "some-ns", "some-build", func(build *buildapi.Build) time.Duration {
-				return 3 * time.Second
-			})
+			actual := waitForBuild(context.TODO(), testCase.buildClient, "some-ns", "some-build")
 			if diff := cmp.Diff(testCase.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("%s: mismatch (-expected +actual), diff: %s", testCase.name, diff)
 			}

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -392,11 +392,6 @@ func TestWaitForBuild(t *testing.T) {
 		expected    error
 	}{
 		{
-			name:        "timeout",
-			buildClient: NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects().Build()), nil, nil),
-			expected:    fmt.Errorf("timed out waiting for the condition"),
-		},
-		{
 			name: "build succeeded",
 			buildClient: NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
 				&buildapi.Build{
@@ -430,7 +425,7 @@ func TestWaitForBuild(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual := waitForBuild(context.TODO(), testCase.buildClient, "some-ns", "some-build", 90*time.Millisecond, func(build *buildapi.Build) time.Duration {
+			actual := waitForBuild(context.TODO(), testCase.buildClient, "some-ns", "some-build", func(build *buildapi.Build) time.Duration {
 				return 3 * time.Second
 			})
 			if diff := cmp.Diff(testCase.expected, actual, testhelper.EquateErrorMessage); diff != "" {


### PR DESCRIPTION
It can be difficult to identify when builds are reused based on the main
output:

```
…
INFO[2023-04-20T13:18:59Z] Building failure
INFO[2023-04-20T13:19:31Z] Build failure failed, printing logs:
…
STEP 3/5: RUN false
error: build error: error building at STEP "RUN false": error while running runtime: exit status 1
INFO[2023-04-20T13:19:32Z] Ran for 44s
ERRO[2023-04-20T13:19:32Z] Some steps failed:
ERRO[2023-04-20T13:19:32Z]
  * could not run steps: step failure failed: error occurred handling build failure: the build failure failed after 32s with reason DockerBuildFailed: Dockerfile build strategy has failed.
…
```

Other than a few accidental log messages from the build environment, there is
no temporal information in the build logs.  This is especially problematic for
permanent failures which will never succeed without the deletion of the build,
either directly or via the deletion of the test namespace.

Identifying this type of scenario requires searching the artifacts for the
generated `Build` objects, which is laborious at best but can also be
impossible in the infamous case of the reuse of a build scheduled on a node
which has since been removed from the cluster.

To make it easier to identify these cases, more information is now emitted:

- a message in the main log informs whether builds are created or reused
- a message in the debug log details failure conditions

```
INFO[2023-04-20T13:23:57Z] Building failure
INFO[2023-04-20T13:23:57Z] Found existing build "failure"
INFO[2023-04-20T13:23:57Z] Build failure failed, printing logs:
```

```
$ jq --raw-output '[.time,.msg]|join(" ")' ci-operator.log
2023-04-20T13:23:50Z Building failure
…
2023-04-20T13:23:57Z Building failure
2023-04-20T13:23:57Z Found existing build "failure"
2023-04-20T13:23:57Z Waiting for build to be complete.
2023-04-20T13:23:57Z Build failure failed, printing logs:
2023-04-20T13:23:58Z Build "failure" (created at 2023-04-20 13:20:45 +0000 UTC) classified as legitimate failure, will not be retried
…
```

For nonexistent pods:

```
$ ci-operator …
…
INFO[2023-04-20T13:26:54Z] Building failure
INFO[2023-04-20T13:26:55Z] Found existing build "failure"
INFO[2023-04-20T13:26:55Z] Build failure failed, printing logs:
WARN[2023-04-20T13:26:55Z] Unable to retrieve logs from failed build     error=pod "failure-build" not found
…
```

```
$ jq … ci-operator.log
2022-08-15T10:21:58Z unset version 0
…
2023-04-20T13:26:54Z Building failure
2023-04-20T13:26:55Z Found existing build "failure"
2023-04-20T13:26:55Z Waiting for build to be complete.
2023-04-20T13:26:55Z Build failure failed, printing logs:
2023-04-20T13:26:55Z Unable to retrieve logs from failed build
2023-04-20T13:26:55Z Build "failure" (created at 2023-04-20 13:20:45 +0000 UTC) classified as legitimate failure, will not be retried
…
```

https://issues.redhat.com/browse/DPTP-2836