### PR TITLE
Override the build labels only with non-empty values

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -700,10 +700,16 @@ func addLabelsToBuild(refs *prowv1.Refs, build *buildapi.Build, contextDir strin
 	}
 
 	for k, v := range labels {
-		build.Spec.Output.ImageLabels = append(build.Spec.Output.ImageLabels, buildapi.ImageLabel{
-			Name:  k,
-			Value: v,
-		})
+		// set only non-empty values
+		// Sometimes we get empty value e.g., of refs.BaseSHA where we should
+		// give the build-api the chance to fill in the values
+		// https://issues.redhat.com/browse/OCPBUGS-3785?focusedId=22143769&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22143769
+		if v != "" {
+			build.Spec.Output.ImageLabels = append(build.Spec.Output.ImageLabels, buildapi.ImageLabel{
+				Name:  k,
+				Value: v,
+			})
+		}
 	}
 	sort.Slice(build.Spec.Output.ImageLabels, func(i, j int) bool {
 		return build.Spec.Output.ImageLabels[i].Name < build.Spec.Output.ImageLabels[j].Name

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args.yaml
@@ -15,19 +15,6 @@ metadata:
 spec:
   nodeSelector: null
   output:
-    imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: 'pipeline:'

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_title_in_pull_gets_squashed.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_title_in_pull_gets_squashed.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -17,20 +17,8 @@ spec:
   nodeSelector: null
   output:
     imageLabels:
-    - name: io.openshift.build.commit.author
-    - name: io.openshift.build.commit.date
-    - name: io.openshift.build.commit.id
-    - name: io.openshift.build.commit.message
-    - name: io.openshift.build.commit.ref
-    - name: io.openshift.build.name
-    - name: io.openshift.build.namespace
-    - name: io.openshift.build.source-context-dir
-    - name: io.openshift.build.source-location
     - name: io.openshift.ci.from.root
       value: imagedigest
-    - name: vcs-ref
-    - name: vcs-type
-    - name: vcs-url
     to:
       kind: ImageStreamTag
       name: pipeline:src


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-3785

We found the cases where `labels("io.openshift.build.commit.id")=""`.
So we stop doing it by this PR.

We could also try to stop doing it in general for the labels that build-api supports.
But let us do the baby steps here.

@apoorvajagtap @bbguimaraes 