### PR TITLE
apply global git configuration to private-org-sync Dockerfile

### DIFF
--- a/images/private-org-sync/Dockerfile
+++ b/images/private-org-sync/Dockerfile
@@ -1,6 +1,8 @@
 FROM quay.io/centos/centos:stream8
-LABEL maintainer="muller@redhat.com"
+LABEL maintainer="nmoraiti@redhat.com"
 
 RUN yum install -y git && yum clean all
+RUN git config --global core.compression 9
+
 ADD private-org-sync /usr/bin/private-org-sync
 ENTRYPOINT ["/usr/bin/private-org-sync"]


### PR DESCRIPTION
This is an attempt to solve errors like:

remote: fatal: did not receive expected object XXXXXXXX
error: remote unpack failed: index-pack failed


see https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/?job=periodic-openshift-release-private-org-sync 

/cc @openshift/test-platform @smg247 



Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
