### PR TITLE
[private-org-sync] update potential errors to try to fetch a deeper history

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -263,6 +263,7 @@ func maybeTooShallow(pushOutput string) bool {
 		"shallow update not allowed",
 		"Updates were rejected because the remote contains work that you do",
 		"Updates were rejected because a pushed branch tip is behind its remote",
+		"remote unpack failed: index-pack failed",
 	}
 	for _, item := range patterns {
 		if strings.Contains(pushOutput, item) {


### PR DESCRIPTION
Fixes the periodic-openshift-release-private-org-sync job.

The tool has a way to determine when it should try to fetch a deeper commit history. Newer git versions seem to generate more errors that we didn't include in the cases. This PR just adds the case we are hitting in the job and allows the tool to retry with a deeper commit history.

/cc @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
