### PR TITLE
trt-945: support MasterNodesUpdated indicator

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -27,7 +27,8 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {
-	BackendName       string
-	JobRunName        string
-	DisruptionSeconds int
+	BackendName        string
+	JobRunName         string
+	DisruptionSeconds  int
+	MasterNodesUpdated string
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -163,7 +163,11 @@ func (o *disruptionUploader) uploadContent(ctx context.Context, jobRun jobrunagg
 		return nil
 	}
 
-	clusterData, _ := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "cluster-data")
+	clusterData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "cluster-data")
+	if err != nil {
+		// log but continue on
+		logger.WithError(err).Error("error getting cluster-data in GetOpenShiftTestsFilesWithPrefix")
+	}
 
 	return o.uploadBackendDisruptionFromDirectData(ctx, jobRun.GetJobRunID(), clusterData, backendDisruptionData, logger)
 }


### PR DESCRIPTION
Includes MasterNodesUpdated flag in BackendDisruptionRow uploaded to BigQuery to differentiate between jobs that triggered node updates and those that don't. 