### PR TITLE
test/e2e: relax pending test check

### DIFF
--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -211,11 +211,8 @@ func TestMultiStage(t *testing.T) {
 				"--unresolved-config", "config.yaml",
 				"--target", "pending",
 			},
-			env: []string{defaultJobSpec},
-			output: []string{
-				`pod pending for more than 30s: container \"test\" has not started in`,
-				"Error: ErrImagePull",
-			},
+			env:    []string{defaultJobSpec},
+			output: []string{`pod pending for more than 30s:`},
 		},
 	}
 


### PR DESCRIPTION
This test is meant to cause a pending timeout using a non-existent image.  It
works as intended, but it intentionally uses a short timeout period so that it
executes quickly.  It may happen that the timeout happens for other reasons
(this is after all what the actual verification is meant to detect), leading to
test failures such as the one seen here:

https://github.com/openshift/ci-tools/pull/3390#issuecomment-1520443642

Since the reason for the delay is not relevant for this test, only that it be
detected and properly reported, this change relaxes the error message searched
in the logs such that any pending situation satisfies the test.