### PR TITLE
Revert "trt-945: support MasterNodesUpdated indicator"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -27,8 +27,7 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {
-	BackendName        string
-	JobRunName         string
-	DisruptionSeconds  int
-	MasterNodesUpdated string
+	BackendName       string
+	JobRunName        string
+	DisruptionSeconds int
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/disruption.go
@@ -3,9 +3,6 @@ package jobrunaggregatorlib
 import (
 	"encoding/json"
 	"math"
-	"strings"
-
-	"github.com/sirupsen/logrus"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -51,48 +48,6 @@ type BackendDisruption struct {
 	DisruptionMessages []string
 }
 
-// ClusterData is defined in origin/platformidentification/types.go
-// it is duplicated in a minimized form here
-type ClusterData struct {
-	MasterNodesUpdated string
-}
-
-// GetMasterNodesUpdatedStatusFromClusterData takes multiple file contents as a copy of the ClusterData
-// file is created for multiple test phases (upgrade / conformance) in the same manor that multiple disruption
-// files are created for the multiple phases
-func GetMasterNodesUpdatedStatusFromClusterData(clusterData map[string]string) string {
-	// default is unknown
-	masterNodesUpdated := ""
-
-	// there can be multiple files (upgrade / conformance) if any of them indicate the master nodes updated
-	// we indicate that for the entire run
-	for _, clusterdataResults := range clusterData {
-		if len(clusterdataResults) == 0 {
-			continue
-		}
-
-		cd := &ClusterData{}
-		if err := json.Unmarshal([]byte(clusterdataResults), cd); err != nil {
-			logrus.WithError(err).Error("error unmarshalling clusterdataJson")
-			continue
-		}
-
-		// if the value is y then return it
-		// as it supersedes all other values
-		if strings.ToUpper(cd.MasterNodesUpdated) == "Y" {
-			return cd.MasterNodesUpdated
-		}
-
-		// if we don't have a value yet use whatever value we have coming in
-		if len(masterNodesUpdated) == 0 {
-			masterNodesUpdated = cd.MasterNodesUpdated
-			continue
-		}
-	}
-
-	return masterNodesUpdated
-}
-
 func GetServerAvailabilityResultsFromDirectData(backendDisruptionData map[string]string) map[string]AvailabilityResult {
 	availabilityResultsByName := map[string]AvailabilityResult{}
 
@@ -102,7 +57,6 @@ func GetServerAvailabilityResultsFromDirectData(backendDisruptionData map[string
 		}
 		allDisruptions := &BackendDisruptionList{}
 		if err := json.Unmarshal([]byte(disruptionJSON), allDisruptions); err != nil {
-			logrus.WithError(err).Error("error unmarshalling disruptionJson")
 			continue
 		}
 


### PR DESCRIPTION
Reverts openshift/ci-tools#3397

Seeing:

time="2023-04-28T12:01:01.916Z" level=error msg="error encountered during upload" error="jobrun/periodic-ci-openshift-release-master-nightly-4.13-e2e-aws-sdn-upgrade/1651882596604317696 failed to upload to bigquery: 22 row insertions failed (insertion of row [insertID: \"LlXlxhtRMFdmGlr6pZAxTddc97V\"; insertIndex: 0] failed with error: {Location: \"MasterNodesUpdated\"; Message: \"no such field: MasterNodesUpdated.\"; Reason: \"invalid\"}, insertion of row [insertID: \"A0fmGF69DgvRbcPpxzsVhhnw2ME\"; insertIndex: 1] failed with error: {Location: \"MasterNodesUpdated\"; Message: \"no such field: MasterNodesUpdated.\"; Reason: \"invalid\"}, insertion of row [insertID: \"pvs6R4NaOVmRFWU9diwXBTcNzZ7\"; insertIndex: 2] failed with error: {Location: \"MasterNodesUpdated\"; Message: \"no such field: MasterNodesUpdated.\"; Reason: \"invalid\"}, ...)