### PR TITLE
`sprint-automation`: do not list sub-tasks in daily digest

### DIFF
--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -427,7 +427,7 @@ func sendNextWeeksRoleDigest(client *pagerduty.Client, slackClient *slack.Client
 }
 
 func getIssuesNeedingApproval(jiraClient *jiraapi.Client) ([]slack.Block, error) {
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND status="Review"`, jira.ProjectDPTP), nil)
+	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND status=Review AND issuetype!=Sub-task`, jira.ProjectDPTP), nil)
 	if err := jirautil.HandleJiraError(response, err); err != nil {
 		return nil, fmt.Errorf("could not query for Jira issues: %w", err)
 	}


### PR DESCRIPTION
We don't do acceptance review on sub-tasks so no need to list them in the daily team digest.

I tried out the query using the following [search page](https://issues.redhat.com/issues/?jql=project%3DDPTP%20AND%20status%3DReview%20AND%20issuetype!%3DSub-task)