### PR TITLE
trt-945: fix to update JobRunRow not backend disruption row

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -50,6 +50,12 @@ const (
     "description": "the build farm cluster that the CI job ran on: build01, build02, build03, vsphere, etc",
     "type": "STRING",
     "mode": "NULLABLE"
+  },
+  {
+    "name": "MasterNodesUpdated",
+    "description": "indicator if master nodes restarted during the jobrun",
+    "type": "STRING",
+    "mode": "NULLABLE"
   }
 ]
 `
@@ -76,13 +82,14 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 )
 
 type JobRunRow struct {
-	Name       string
-	JobName    string
-	Status     string
-	StartTime  time.Time
-	EndTime    time.Time
-	ReleaseTag string
-	Cluster    string
+	Name               string
+	JobName            string
+	Status             string
+	StartTime          time.Time
+	EndTime            time.Time
+	ReleaseTag         string
+	Cluster            string
+	MasterNodesUpdated string
 }
 
 // TestPlatformProwJobRow is a transient struct for processing results from the bigquery jobs table populated

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
@@ -9,19 +9,20 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
-func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob) *jobrunaggregatorapi.JobRunRow {
+func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob, masterNodesUpdated string) *jobrunaggregatorapi.JobRunRow {
 	var endTime time.Time
 	if prowJob.Status.CompletionTime != nil {
 		endTime = prowJob.Status.CompletionTime.Time
 	}
 	return &jobrunaggregatorapi.JobRunRow{
-		Name:       jobRun.GetJobRunID(),
-		JobName:    jobRun.GetJobName(),
-		Status:     string(prowJob.Status.State),
-		StartTime:  prowJob.Status.StartTime.Time,
-		EndTime:    endTime,
-		ReleaseTag: prowJob.Labels["release.openshift.io/analysis"],
-		Cluster:    prowJob.Spec.Cluster,
+		Name:               jobRun.GetJobRunID(),
+		JobName:            jobRun.GetJobName(),
+		Status:             string(prowJob.Status.State),
+		StartTime:          prowJob.Status.StartTime.Time,
+		EndTime:            endTime,
+		ReleaseTag:         prowJob.Labels["release.openshift.io/analysis"],
+		Cluster:            prowJob.Spec.Cluster,
+		MasterNodesUpdated: masterNodesUpdated,
 	}
 
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -248,7 +248,15 @@ func (o *jobRunLoaderOptions) uploadJobRun(ctx context.Context, jobRun jobrunagg
 		return err
 	}
 	o.logger.Info("inserting job run row")
-	jobRunRow := newJobRunRow(jobRun, prowJob)
+
+	clusterData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "cluster-data")
+	if err != nil {
+		// log but continue on
+		o.logger.WithError(err).Error("error getting cluster-data in GetOpenShiftTestsFilesWithPrefix")
+	}
+	masterNodesUpdated := jobrunaggregatorlib.GetMasterNodesUpdatedStatusFromClusterData(clusterData)
+
+	jobRunRow := newJobRunRow(jobRun, prowJob, masterNodesUpdated)
 	if err := o.jobRunInserter.Put(ctx, jobRunRow); err != nil {
 		o.logger.WithError(err).Error("error inserting job run row")
 		return err


### PR DESCRIPTION
Includes MasterNodesUpdated flag in JobRunRow uploaded to BigQuery to differentiate between jobs that triggered node updates and those that don't.