### PR TITLE
sync-rover-groups: collect users' cost center

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ github-ldap-user-group-creator: $(TMPDIR)/.github-ldap-user-group-creator-kubeco
 .PHONY: github-ldap-user-group-creator
 
 sync-rover-groups:
-	go run  ./cmd/sync-rover-groups --manifest-dir=$(release_folder)/clusters --config-file=$(release_folder)/core-services/sync-rover-groups/_config.yaml --mapping-file=/tmp/mapping.yaml --log-level=debug
+	go run  ./cmd/sync-rover-groups --manifest-dir=$(release_folder)/clusters --config-file=$(release_folder)/core-services/sync-rover-groups/_config.yaml --mapping-file=/tmp/mapping.yaml --github-users-file=/tmp/users.yaml --log-level=debug
 .PHONY: sync-rover-groups
 
 $(TMPDIR)/.cluster-display-kubeconfig-dir:

--- a/cmd/sync-rover-groups/ldap_test.go
+++ b/cmd/sync-rover-groups/ldap_test.go
@@ -33,25 +33,26 @@ func TestResolve(t *testing.T) {
 	}{
 		{
 			name: "base case",
-			r: &ldapGroupResolver{&fakeLDAPConn{
-				searchResult: &ldapv3.SearchResult{
-					Entries: []*ldapv3.Entry{
-						{
-							DN: "cn=test-platform-ci-admins,ou=adhoc,ou=managedGroups,dc=redhat,dc=com",
-							Attributes: []*ldapv3.EntryAttribute{
-								{
-									Name: "uniqueMember",
-									Values: []string{
-										"uid=tom,ou=users,dc=redhat,dc=com",
-										"uid=jerry,ou=users,dc=redhat,dc=com",
+			r: &ldapGroupResolver{users: nil,
+				conn: &fakeLDAPConn{
+					searchResult: &ldapv3.SearchResult{
+						Entries: []*ldapv3.Entry{
+							{
+								DN: "cn=test-platform-ci-admins,ou=adhoc,ou=managedGroups,dc=redhat,dc=com",
+								Attributes: []*ldapv3.EntryAttribute{
+									{
+										Name: "uniqueMember",
+										Values: []string{
+											"uid=tom,ou=users,dc=redhat,dc=com",
+											"uid=jerry,ou=users,dc=redhat,dc=com",
+										},
 									},
 								},
 							},
 						},
 					},
+					err: nil,
 				},
-				err: nil,
-			},
 			},
 			group: "some-group",
 			expected: &Group{


### PR DESCRIPTION
This is the first step of https://issues.redhat.com/browse/DPTP-3436
Uploading data to bigquery will be within another tool since `sync-rover-groups` runs on psi.
We need to keep things simple as before: output a file and create CM with the file on `app.ci`.

/cc @jupierce 