### PR TITLE
[LPTOCPCI-210] Add New aws-cspi-qe-vpn Cluster Profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1127,6 +1127,7 @@ const (
 	ClusterProfileAWSCentos             ClusterProfile = "aws-centos"
 	ClusterProfileAWSCentos40           ClusterProfile = "aws-centos-40"
 	ClusterProfileAWSCSPIQE             ClusterProfile = "aws-cspi-qe"
+	ClusterProfileAWSCSPIQEVPN          ClusterProfile = "aws-cspi-qe-vpn"
 	ClusterProfileAWSQE                 ClusterProfile = "aws-qe"
 	ClusterProfileAWSC2SQE              ClusterProfile = "aws-c2s-qe"
 	ClusterProfileAWSChinaQE            ClusterProfile = "aws-china-qe"
@@ -1223,6 +1224,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSCSPIQE,
+		ClusterProfileAWSCSPIQEVPN,
 		ClusterProfileAWSChinaQE,
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSManagedCSPIQE,
@@ -1311,6 +1313,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSCentos,
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSCSPIQE,
+		ClusterProfileAWSCSPIQEVPN,
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSManagedCSPIQE,
 		ClusterProfileAWSCPaaS,
@@ -1473,6 +1476,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-china-qe-quota-slice"
 	case ClusterProfileAWSCSPIQE:
 		return "aws-cspi-qe-quota-slice"
+	case ClusterProfileAWSCSPIQEVPN:
+		return "aws-cspi-qe-vpn-quota-slice"
 	case ClusterProfileAWSManagedCSPIQE:
 		return "aws-managed-cspi-qe-quota-slice"
 	case ClusterProfileAWSGovCloudQE:


### PR DESCRIPTION
The CSPI QE team would like to create a new cluster profile to attempt using the [VPN capabilities built in to OpenShift CI](https://docs.google.com/document/d/1mPjrHVS1EvmLdq4kGhRazTpGu6xVZDyGpVAphVZhX4w/edit?resourcekey=0-KA-qXXq1J2bTR7o6Kit9Vw#heading=h.x9snb54sjlu9)

**Related PRs**
- [openshift/release #38901](https://github.com/openshift/release/pull/38901)