### PR TITLE
`payload-testing`: force telco5g jobs to build05

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -487,7 +487,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		switch {
 		case strings.Contains(inject.Test, "vsphere"):
 			jobBaseGen.Cluster("vsphere")
-		case strings.Contains(inject.Test, "metal"):
+		case strings.Contains(inject.Test, "metal") || strings.Contains(inject.Test, "telco5g"):
 			jobBaseGen.Cluster("build05")
 		default:
 			jobBaseGen.Cluster("build01")


### PR DESCRIPTION
just like any job with `metal` in the name, the `telco5g` jobs need to run on `build05` in order to have any chance at succeeding.