### PR TITLE
github-ldap-user-group-creator: upload users to bigquery

### DIFF
--- a/cmd/sync-rover-groups/ldap.go
+++ b/cmd/sync-rover-groups/ldap.go
@@ -8,11 +8,13 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/openshift/ci-tools/pkg/rover"
 )
 
 type ldapGroupResolver struct {
 	conn  ldapConn
-	users []User
+	users []rover.User
 }
 
 type ldapConn interface {
@@ -80,7 +82,7 @@ func (r *ldapGroupResolver) resolve(name string) (*Group, error) {
 	}, nil
 }
 
-func (r *ldapGroupResolver) collectGitHubUsers() ([]User, error) {
+func (r *ldapGroupResolver) collectGitHubUsers() ([]rover.User, error) {
 	if r.conn == nil {
 		return nil, fmt.Errorf("ldapGroupResolver's connection is nil")
 	}
@@ -102,7 +104,7 @@ func (r *ldapGroupResolver) collectGitHubUsers() ([]User, error) {
 		return nil, nil
 	}
 
-	var ret []User
+	var ret []rover.User
 
 	for _, entry := range result.Entries {
 		kerberosID := entry.GetAttributeValue("uid")
@@ -120,7 +122,7 @@ func (r *ldapGroupResolver) collectGitHubUsers() ([]User, error) {
 			logrus.WithField("kerberosID", kerberosID).WithField("entry", entry).Warn("failed to parse GitHub ID")
 			continue
 		}
-		ret = append(ret, User{UID: kerberosID, GitHubUsername: gitHubID, CostCenter: entry.GetAttributeValue("rhatCostCenter")})
+		ret = append(ret, rover.User{UID: kerberosID, GitHubUsername: gitHubID, CostCenter: entry.GetAttributeValue("rhatCostCenter")})
 	}
 
 	return ret, nil

--- a/cmd/sync-rover-groups/main.go
+++ b/cmd/sync-rover-groups/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/group"
+	"github.com/openshift/ci-tools/pkg/rover"
 )
 
 type options struct {
@@ -170,16 +171,10 @@ type Group struct {
 	Members []string `json:"members"`
 }
 
-type User struct {
-	GitHubUsername string `json:"github_username,omitempty"`
-	UID            string `json:"uid,omitempty"`
-	CostCenter     string `json:"cost_center,omitempty"`
-}
-
 type groupResolver interface {
 	resolve(name string) (*Group, error)
 	getGitHubUserKerberosIDMapping() (map[string]string, error)
-	collectGitHubUsers() ([]User, error)
+	collectGitHubUsers() ([]rover.User, error)
 }
 
 type groupCollector interface {

--- a/pkg/rover/bigquery.go
+++ b/pkg/rover/bigquery.go
@@ -1,0 +1,21 @@
+package rover
+
+import (
+	"time"
+
+	"cloud.google.com/go/bigquery"
+)
+
+type UserItem struct {
+	User
+	Created time.Time
+}
+
+func (u *UserItem) Save() (map[string]bigquery.Value, string, error) {
+	return map[string]bigquery.Value{
+		"github_username": u.GitHubUsername,
+		"uid":             u.UID,
+		"cost_center":     u.CostCenter,
+		"created":         u.Created,
+	}, bigquery.NoDedupeID, nil
+}

--- a/pkg/rover/types.go
+++ b/pkg/rover/types.go
@@ -1,0 +1,7 @@
+package rover
+
+type User struct {
+	GitHubUsername string `json:"github_username,omitempty"`
+	UID            string `json:"uid,omitempty"`
+	CostCenter     string `json:"cost_center,omitempty"`
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-3436

<img width="679" alt="Screenshot 2023-05-03 at 6 29 58 AM" src="https://user-images.githubusercontent.com/4013349/235897864-4061cb77-9c22-466c-85ed-765cd8e7a0b0.png">

I modify the table schema: `created`: Mode (`NULLABLE`) with a default value of `CURRENT_DATETIME()`.
It was `REQUIRED`.
We do not need to specify the value upon inserting.

---
Update: Redefined table schema. `created` is back to Required but as type TIMESTAMP which seems more GoLang friendly.

<img width="912" alt="Screenshot 2023-05-03 at 10 33 55 AM" src="https://user-images.githubusercontent.com/4013349/235958470-6526f03f-dee4-4f7b-bc5b-456bd417b9a5.png">

Tested with running the tool locally for 2 batches: `created` is the same `now` for every record in the batch. "This is for trivial pruning".



/hold

Need to change the job spec accordingly.

/cc @jupierce 