### PR TITLE
trt-945: fix to use NullString for MasterNodesUpdated

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -1,6 +1,10 @@
 package jobrunaggregatorapi
 
-import "time"
+import (
+	"time"
+
+	"cloud.google.com/go/bigquery"
+)
 
 const (
 	LegacyJobRunTableName     = "JobRuns"
@@ -89,7 +93,7 @@ type JobRunRow struct {
 	EndTime            time.Time
 	ReleaseTag         string
 	Cluster            string
-	MasterNodesUpdated string
+	MasterNodesUpdated bigquery.NullString
 }
 
 // TestPlatformProwJobRow is a transient struct for processing results from the bigquery jobs table populated

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
@@ -3,6 +3,8 @@ package jobrunbigqueryloader
 import (
 	"time"
 
+	"cloud.google.com/go/bigquery"
+
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -14,6 +16,16 @@ func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob
 	if prowJob.Status.CompletionTime != nil {
 		endTime = prowJob.Status.CompletionTime.Time
 	}
+
+	var nsMasterNodesUpdated bigquery.NullString
+
+	if len(masterNodesUpdated) > 0 {
+		nsMasterNodesUpdated = bigquery.NullString{
+			StringVal: masterNodesUpdated,
+			Valid:     true,
+		}
+	}
+
 	return &jobrunaggregatorapi.JobRunRow{
 		Name:               jobRun.GetJobRunID(),
 		JobName:            jobRun.GetJobName(),
@@ -22,7 +34,7 @@ func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob
 		EndTime:            endTime,
 		ReleaseTag:         prowJob.Labels["release.openshift.io/analysis"],
 		Cluster:            prowJob.Spec.Cluster,
-		MasterNodesUpdated: masterNodesUpdated,
+		MasterNodesUpdated: nsMasterNodesUpdated,
 	}
 
 }


### PR DESCRIPTION
bigquery: NULL values cannot be read into structs