### PR TITLE
Fix a lint issue

### DIFF
--- a/pkg/prowgen/podspec_test.go
+++ b/pkg/prowgen/podspec_test.go
@@ -153,6 +153,7 @@ func TestTargetAdditionalSuffix(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			tc := tc
 			t.Parallel()
 			g := NewCiOperatorPodSpecGenerator()
 			g.Add(TargetAdditionalSuffix(tc.input))


### PR DESCRIPTION
Hit this issue after upgrade `golangci-lint` to the following version:
(I did the upgrade for other issues)

```
$ golangci-lint --version                                                         
golangci-lint has version 1.52.2 built with go1.20.2 from da04413a on 2023-03-25T18:11:28Z

$ make lint 
./hack/lint.sh
+ echo 'Running golangci-lint'
Running golangci-lint
+ [[ /Users/hongkliu = \/ ]]
+ [[ -n '' ]]
+ golangci-lint run --build-tags e2e,e2e_framework,optional_operators
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
pkg/prowgen/podspec_test.go:158:33: loopclosure: loop variable tc captured by func literal (govet)
                        g.Add(TargetAdditionalSuffix(tc.input))
                                                     ^
make: *** [lint] Error 1

```

Stole the solution from [here](https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721)