### PR TITLE
sync-rover-group: remove flag/mapping-file

### DIFF
--- a/cmd/sync-rover-groups/ldap.go
+++ b/cmd/sync-rover-groups/ldap.go
@@ -128,18 +128,6 @@ func (r *ldapGroupResolver) collectGitHubUsers() ([]rover.User, error) {
 	return ret, nil
 }
 
-func (r *ldapGroupResolver) getGitHubUserKerberosIDMapping() (map[string]string, error) {
-	users, err := r.collectGitHubUsers()
-	if err != nil {
-		return nil, fmt.Errorf("failed to collect GitHub users: %w", err)
-	}
-	ret := map[string]string{}
-	for _, user := range users {
-		ret[user.GitHubUsername] = user.UID
-	}
-	return ret, nil
-}
-
 // getGitHubID returns the GitHub ID from the value
 // which are the values of "rhatSocialURL" fields set up by Red Hatters at Rover.
 // A user can have multiple "rhatSocialURL"s for GitHub, Twitter, LinkedIn etc, even multiple for GitHub.


### PR DESCRIPTION
We do not use it any more.
https://github.com/openshift/release/pull/38974/files#diff-ed413ba53b67d2df6c1895585d183e7f54b62d6f2b8a5df53ed0027029507c25R22

It has been replaced by the `users.yaml`.

https://issues.redhat.com/browse/DPTP-3436