### PR TITLE
Fix issue DPTP-3440 Add server-side apply support

### DIFF
--- a/cmd/applyconfig/README.md
+++ b/cmd/applyconfig/README.md
@@ -20,6 +20,7 @@ that, it adds several lightweight features required by Test Platform team, its w
    resource that would be placed in that namespace are not yet present in the cluster (in a normal dry run, applying the
    resource to a namespace that does not exist in the cluster would fail). It does so by bookkeeping which namespaces
    would be applied if not in dry run, and creating them temporarily if they do not exist.
+7. Add `--server-side` to the `apply` command if a filename starts with `SS_`
 
 ## Why it exists
 


### PR DESCRIPTION
This PR introduce a flag to enable `--server-side` apply globally.
This PR also introduce a feature to use server-side apply for config files with file name starts with `SS_`.

Related to an HyperShift bug generating a large CRD which cannot be applied on client-side.
Ref: https://issues.redhat.com/browse/HOSTEDCP-985

cc. @hongkailiu 