### PR TITLE
`payload-testing`: allow for aborting all payload jobs for a PR with a command

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -370,7 +369,7 @@ func (s *server) abortAll(logger *logrus.Entry, ic github.IssueCommentEvent) str
 		// and must not overwrite changes made to it in the interim by the responsible agent.
 		// The accepted trade-off for now is that this leads to failure if unrelated fields where changed
 		// by another different actor.
-		if err = s.kubeClient.Update(s.ctx, job); err != nil && !apierrors.IsConflict(err) {
+		if err = s.kubeClient.Update(s.ctx, job); err != nil {
 			jobLogger.WithError(err).Errorf("failed to abort prowjob")
 			return fmt.Sprintf("failed to abort payload job: %s for pull request %s/%s#%d", job.Name, org, repo, prNumber)
 		} else {
@@ -385,7 +384,7 @@ func (s *server) getPayloadJobsForPR(org, repo string, prNumber int) ([]string, 
 	var l prpqv1.PullRequestPayloadQualificationRunList
 	labelSelector, err := labelSelectorForPayloadPRPQRs(org, repo, prNumber)
 	if err != nil {
-		return nil, fmt.Errorf("could not create label selector for prpqrs genearted for pull request %s/%s#%d: %w", org, repo, prNumber, err)
+		return nil, fmt.Errorf("could not create label selector for prpqrs generated for pull request %s/%s#%d: %w", org, repo, prNumber, err)
 	}
 	opt := ctrlruntimeclient.ListOptions{Namespace: s.namespace, LabelSelector: labelSelector}
 	if err := s.kubeClient.List(s.ctx, &l, &opt); err != nil {

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -7,11 +7,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/openshift/ci-tools/pkg/api"
-	prpqv1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
-	"github.com/openshift/ci-tools/pkg/release/config"
-	"github.com/openshift/ci-tools/pkg/testhelper"
 	"github.com/sirupsen/logrus"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -19,6 +16,11 @@ import (
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/kube"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	prpqv1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+	"github.com/openshift/ci-tools/pkg/release/config"
+	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
 func (j1 jobSetSpecification) Equals(j2 jobSetSpecification) bool {


### PR DESCRIPTION
Similarly to `pj-rehearse`, this will add a way to comment `/payload-abort` to abort all currently running payload testing jobs for a specific PR.

For: https://issues.redhat.com/browse/DPTP-3322