### PR TITLE
ignore etcd

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -175,6 +175,7 @@ func main() {
 				"--current-release-minor=" + versionSplit[1],
 				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/origin-aggregated-logging",
 				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/console",
+				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/etcd",
 			},
 		},
 		{


### PR DESCRIPTION
To update the golang version of o/etcd we need to disable the bot, which seems to revert the golang changes.