### PR TITLE
ci-operator: do not log cancelled observers

### DIFF
--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -123,7 +123,7 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 	for _, pod := range pods {
 		go func(p coreapi.Pod) {
 			<-ctx.Done()
-			logrus.Info("Signalling observers to terminate...")
+			logrus.Infof("Signalling observer pod %q to terminate...", p.Name)
 			if err := s.client.Delete(context.Background(), &p); err != nil {
 				logrus.WithError(err).Warn("failed to trigger observer to stop")
 			}

--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -100,7 +100,7 @@ func (s *multiStageTestStep) runSteps(
 func (s *multiStageTestStep) runPods(ctx context.Context, pods []coreapi.Pod, bestEffortSteps sets.String) error {
 	var errs []error
 	for _, pod := range pods {
-		err := s.runPod(ctx, &pod, base_steps.NewTestCaseNotifier(util.NopNotifier))
+		err := s.runPod(ctx, &pod, base_steps.NewTestCaseNotifier(util.NopNotifier), util.WaitForPodFlag(0))
 		if err == nil {
 			continue
 		}
@@ -129,7 +129,7 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 			}
 		}(pod)
 		go func(p coreapi.Pod) {
-			err := s.runPod(textCtx, &p, base_steps.NewTestCaseNotifier(util.NopNotifier))
+			err := s.runPod(textCtx, &p, base_steps.NewTestCaseNotifier(util.NopNotifier), util.Interruptible)
 			if ctx.Err() == nil {
 				// when the observer is cancelled, we get an error here that we need to ignore, as it's not an error
 				// for the Pod to be deleted when it's cancelled, it's just expected
@@ -150,14 +150,14 @@ func (s *multiStageTestStep) runObservers(ctx, textCtx context.Context, pods []c
 	done <- struct{}{}
 }
 
-func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notifier *base_steps.TestCaseNotifier) error {
+func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notifier *base_steps.TestCaseNotifier, flags util.WaitForPodFlag) error {
 	start := time.Now()
 	logrus.Infof("Running step %s.", pod.Name)
 	client := s.client.WithNewLoggingClient()
 	if _, err := util.CreateOrRestartPod(ctx, client, pod); err != nil {
 		return fmt.Errorf("failed to create or restart %s pod: %w", pod.Name, err)
 	}
-	newPod, err := util.WaitForPodCompletion(ctx, client, pod.Namespace, pod.Name, notifier, util.WaitForPodFlag(0))
+	newPod, err := util.WaitForPodCompletion(ctx, client, pod.Namespace, pod.Name, notifier, flags)
 	if newPod != nil {
 		pod = newPod
 	}

--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -157,7 +157,7 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	if _, err := util.CreateOrRestartPod(ctx, client, pod); err != nil {
 		return fmt.Errorf("failed to create or restart %s pod: %w", pod.Name, err)
 	}
-	newPod, err := util.WaitForPodCompletion(ctx, client, pod.Namespace, pod.Name, notifier, false)
+	newPod, err := util.WaitForPodCompletion(ctx, client, pod.Namespace, pod.Name, notifier, util.WaitForPodFlag(0))
 	if newPod != nil {
 		pod = newPod
 	}

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -120,8 +120,11 @@ func (s *podStep) run(ctx context.Context) error {
 	defer func() {
 		s.subTests = testCaseNotifier.SubTests(s.Description() + " - ")
 	}()
-
-	if _, err := util.WaitForPodCompletion(ctx, s.client, pod.Namespace, pod.Name, testCaseNotifier, s.config.SkipLogs); err != nil {
+	var flags util.WaitForPodFlag
+	if s.config.SkipLogs {
+		flags |= util.SkipLogs
+	}
+	if _, err := util.WaitForPodCompletion(ctx, s.client, pod.Namespace, pod.Name, testCaseNotifier, flags); err != nil {
 		return fmt.Errorf("%s %q failed: %w", s.name, pod.Name, err)
 	}
 	return nil
@@ -378,5 +381,5 @@ func RunPod(ctx context.Context, podClient kubernetes.PodClient, pod *coreapi.Po
 	if err != nil {
 		return pod, err
 	}
-	return util.WaitForPodCompletion(ctx, podClient, pod.Namespace, pod.Name, nil, true)
+	return util.WaitForPodCompletion(ctx, podClient, pod.Namespace, pod.Name, nil, util.SkipLogs)
 }

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -200,8 +200,8 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	logrus.Infof("Creating release image %s.", destination)
 	podConfig := steps.PodStepConfiguration{
-		SkipLogs: true,
-		As:       fmt.Sprintf("release-%s", s.name),
+		WaitFlags: util.SkipLogs,
+		As:        fmt.Sprintf("release-%s", s.name),
 		From: api.ImageStreamTagReference{
 			Name: streamName,
 			Tag:  "cli",

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -193,7 +193,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 
 	// run adm release extract and grab the raw image-references from the payload
 	podConfig := steps.PodStepConfiguration{
-		SkipLogs:           true,
+		WaitFlags:          util.SkipLogs,
 		As:                 target,
 		From:               *cliImage,
 		Labels:             map[string]string{Label: s.name},

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -171,7 +171,7 @@ func (s *templateExecutionStep) run(ctx context.Context) error {
 	for _, ref := range instance.Status.Objects {
 		switch {
 		case ref.Ref.Kind == "Pod" && ref.Ref.APIVersion == "v1":
-			_, err := util.WaitForPodCompletion(context.TODO(), s.podClient, s.jobSpec.Namespace(), ref.Ref.Name, testCaseNotifier, false)
+			_, err := util.WaitForPodCompletion(context.TODO(), s.podClient, s.jobSpec.Namespace(), ref.Ref.Name, testCaseNotifier, util.WaitForPodFlag(0))
 			s.subTests = append(s.subTests, testCaseNotifier.SubTests(fmt.Sprintf("%s - %s ", s.Description(), ref.Ref.Name))...)
 			if err != nil {
 				return fmt.Errorf("template pod %q failed: %w", ref.Ref.Name, err)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,11 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
+// Zero returns the zero value of a type
+func Zero[T any]() (_ T) {
+	return
+}
+
 // SortSlice is a generic version of sort.Slice
 func SortSlice[T constraints.Ordered](s []T) {
 	sort.Slice(s, func(i, j int) bool { return s[i] < s[j] })
@@ -50,11 +55,15 @@ func RemoveIf[T any](s []T, p func(T) bool) []T {
 	return s[:i]
 }
 
+// IsBitSet tests if a single specific bit is set in a value
+func IsBitSet[T constraints.Integer](x, b T) bool {
+	return x&b != Zero[T]()
+}
+
 // PopCount returns the number of "true" argument values.
 func PopCount[T comparable](xs ...T) (ret uint) {
-	var z T
 	for _, x := range xs {
-		if x != z {
+		if x != Zero[T]() {
 			ret += 1
 		}
 	}


### PR DESCRIPTION
Now that pod deletion events are properly reported as a result of
https://github.com/openshift/ci-tools/pull/3281, the output log for jobs which
use observer pods contains unnecessary warnings when they are cancelled, e.g.:

```
INFO[2023-05-16T08:37:20Z] Running multi-stage phase post
INFO[2023-05-16T08:37:20Z] Signalling observers to terminate...
INFO[2023-05-16T08:37:20Z] Running step e2e-telco5g-ptp-gather-must-gather.
WARN[2023-05-16T08:37:20Z] Pod e2e-telco5g-ptp-observers-resource-watch is being unexpectedly deleted
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.13-e2e-telco5g-ptp/1658390573033197568#1:build-log.txt%3A26-29

This is done via a `DELETE` call, as is normal in Kubernetes, so these changes
suppress logging in those situations.