### PR TITLE
Improve test case analyzer titles, part 2

### DIFF
--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -43,6 +43,7 @@ type testCaseAnalyzerJobGetter struct {
 	network         string
 	excludeJobNames sets.String
 	includeJobNames sets.String
+	testNameSuffix  string
 	jobGCSPrefixes  *[]jobGCSPrefix
 	ciDataClient    jobrunaggregatorlib.CIDataClient
 }
@@ -332,6 +333,7 @@ type JobRunTestCaseAnalyzerOptions struct {
 	ciGCSClient         jobrunaggregatorlib.CIGCSClient
 	gcsClient           *storage.Client
 	testCaseCheckers    []TestCaseChecker
+	testNameSuffix      string
 	payloadInvocationID string
 	jobGCSPrefixes      *[]jobGCSPrefix
 	jobGetter           JobGetter
@@ -486,34 +488,7 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	platform := o.jobGetter.(*testCaseAnalyzerJobGetter).platform
-	network := o.jobGetter.(*testCaseAnalyzerJobGetter).network
-	infrastructure := o.jobGetter.(*testCaseAnalyzerJobGetter).infrastructure
-	include := o.jobGetter.(*testCaseAnalyzerJobGetter).includeJobNames
-	exclude := o.jobGetter.(*testCaseAnalyzerJobGetter).excludeJobNames
-
-	var testVariants []string
-	if platform != "" {
-		testVariants = append(testVariants, platform)
-	}
-	if network != "" {
-		testVariants = append(testVariants, network)
-	}
-	if infrastructure != "" {
-		testVariants = append(testVariants, infrastructure)
-	}
-
-	testVariantName := strings.Join(testVariants, "-")
-
-	if include.Len() > 0 {
-		testVariantName += fmt.Sprintf(" including=%s", strings.Join(include.List(), ","))
-	}
-	if exclude.Len() > 0 {
-		testVariantName += fmt.Sprintf(" excluding=%s", strings.Join(exclude.List(), ","))
-	}
-	testVariantName = strings.Trim(testVariantName, " ")
-
-	finishedJobRuns, unfinishedJobRuns, _, _, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, outputDir, testVariantName)
+	finishedJobRuns, unfinishedJobRuns, _, _, err := jobrunaggregatorlib.WaitAndGetAllFinishedJobRuns(ctx, timeToStopWaiting, o, outputDir, o.testNameSuffix)
 	if err != nil {
 		return err
 	}

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -299,7 +299,7 @@ func (f *JobRunsTestCaseAnalyzerFlags) Validate() error {
 func (f *JobRunsTestCaseAnalyzerFlags) testNameSuffix() string {
 	suffix := ""
 	if len(f.Platform) > 0 {
-		suffix += fmt.Sprintf("plaftorm:%s ", f.Platform)
+		suffix += fmt.Sprintf("platform:%s ", f.Platform)
 	}
 	if len(f.Network) > 0 {
 		suffix += fmt.Sprintf("network:%s ", f.Network)

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -305,10 +305,17 @@ func (f *JobRunsTestCaseAnalyzerFlags) testNameSuffix() string {
 		suffix += fmt.Sprintf("network:%s ", f.Network)
 	}
 	if len(f.Infrastructure) > 0 {
-		suffix += fmt.Sprintf("infrastructure:%s", f.Infrastructure)
+		suffix += fmt.Sprintf("infrastructure:%s ", f.Infrastructure)
 	}
-	suffix = strings.TrimSpace(suffix)
-	return suffix
+
+	if len(f.IncludeJobNames) > 0 {
+		suffix += fmt.Sprintf("including:%s ", strings.Join(f.IncludeJobNames, ","))
+	}
+	if len(f.ExcludeJobNames) > 0 {
+		suffix += fmt.Sprintf("excluding:%s ", strings.Join(f.ExcludeJobNames, ","))
+	}
+
+	return strings.TrimSpace(suffix)
 }
 
 // ToOptions creates a new JobRunTestCaseAnalyzerOptions struct
@@ -339,6 +346,7 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 		platform:       f.Platform,
 		infrastructure: f.Infrastructure,
 		network:        f.Network,
+		testNameSuffix: f.testNameSuffix(),
 		jobGCSPrefixes: &f.JobGCSPrefixes,
 		ciDataClient:   ciDataClient,
 	}
@@ -362,6 +370,7 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 		ciGCSClient:         ciGCSClient,
 		gcsClient:           gcsClient,
 		testCaseCheckers:    []TestCaseChecker{minimumRequiredPassesTestCaseChecker{installTestIdentifier, f.testNameSuffix(), f.MinimumSuccessfulTestCount}},
+		testNameSuffix:      f.testNameSuffix(),
 		payloadInvocationID: f.PayloadInvocationID,
 		jobGCSPrefixes:      &f.JobGCSPrefixes,
 		jobGetter:           jobGetter,


### PR DESCRIPTION
Follow-up to https://github.com/openshift/ci-tools/pull/3423, there's multiple places where we generate the title.  The junit test cases were missing the additional include/exclude information.

This makes it one place and plumbs it through to the aggregator and the test case analyzer.