### PR TITLE
Append timestamp to job-run-summary HTML

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -95,7 +95,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		}
 
 		summaryHTML := htmlForJobRuns(ctx, finishedJobRuns, unfinishedJobRuns, variantInfo)
-		if err := ioutil.WriteFile(filepath.Join(outputDir, "job-run-summary.html"), []byte(summaryHTML), 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outputDir, fmt.Sprintf("job-run-summary-%d.html", time.Now().UnixMilli())), []byte(summaryHTML), 0644); err != nil {
 			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 		}
 


### PR DESCRIPTION
On install analysis pages[1], all but the first HTML lens file's accordion is opened. This is because the lens uses the filename as the ID, and all job-run-summary.html files are named the same.

This adds a timestamp suffix to the filename, which will work now that https://github.com/openshift/release/pull/39387 is merged.

[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-install-analysis-all/1658711214819119104