### PR TITLE
`ci-operator`: add new UNIQUE_HASH env var which includes jobName and targetAdditionalSuffix when available

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -140,7 +140,7 @@ of dynamic parameters that are inferred from previous steps. These parameters ar
     The job name in a form safe for use as a Kubernetes resource name.
 
   JOB_NAME_HASH
-    A short hash of the job name for making tasks unique.
+    A short hash of the job name, including target-additional-suffix if supplied, for making tasks unique.
 
   RPM_REPO_<org>_<repo>
     If the job creates RPMs this will be the public URL that can be used as the
@@ -694,7 +694,7 @@ func (o *options) Complete() error {
 		return err
 	}
 
-	appendAdditionalSuffixToTarget(o)
+	handleTargetAdditionalSuffix(o)
 
 	return overrideTestStepDependencyParams(o)
 }
@@ -718,11 +718,11 @@ func parseKeyValParams(input []string, paramType string) (map[string]string, err
 	return params, nil
 }
 
-func appendAdditionalSuffixToTarget(o *options) {
+func handleTargetAdditionalSuffix(o *options) {
 	if o.targetAdditionalSuffix == "" {
 		return
 	}
-
+	o.jobSpec.TargetAdditionalSuffix = o.targetAdditionalSuffix
 	for i, test := range o.configSpec.Tests {
 		for j, target := range o.targets.values {
 			if test.As == target {

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -140,7 +140,10 @@ of dynamic parameters that are inferred from previous steps. These parameters ar
     The job name in a form safe for use as a Kubernetes resource name.
 
   JOB_NAME_HASH
-    A short hash of the job name, including target-additional-suffix if supplied, for making tasks unique.
+    A short hash of the job name for making tasks unique. This will not account for the target-additional-suffix.
+
+  UNIQUE_HASH
+	A hash for making tasks unique, even when the job name may be the same due to using the target-additional-suffix.
 
   RPM_REPO_<org>_<repo>
     If the job creates RPMs this will be the public URL that can be used as the
@@ -1709,7 +1712,7 @@ func loadLeaseCredentials(leaseServerCredentialsFile string) (string, func() []b
 
 func (o *options) initializeLeaseClient() error {
 	var err error
-	owner := o.namespace + "-" + o.jobSpec.JobNameHash()
+	owner := o.namespace + "-" + o.jobSpec.UniqueHash()
 	username, passwordGetter, err := loadLeaseCredentials(o.leaseServerCredentialsFile)
 	if err != nil {
 		return fmt.Errorf("failed to load lease credentials: %w", err)

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1544,7 +1544,7 @@ func TestGenerateAuthorAccessRoleBinding(t *testing.T) {
 	}
 }
 
-func TestAppendAdditionalSuffixToTarget(t *testing.T) {
+func TestHandleTargetAdditionalSuffix(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		targetAdditionalSuffix string
@@ -1572,7 +1572,7 @@ func TestAppendAdditionalSuffixToTarget(t *testing.T) {
 			tests:                  []api.TestStepConfiguration{{As: "e2e"}},
 			expectedTests:          []api.TestStepConfiguration{{As: "e2e-1"}},
 			jobSpec:                api.JobSpec{Target: "e2e"},
-			expectedJobSpec:        api.JobSpec{Target: "e2e-1"},
+			expectedJobSpec:        api.JobSpec{Target: "e2e-1", TargetAdditionalSuffix: "1"},
 		},
 		{
 			name:                   "target-additional-suffix set with multiple targets",
@@ -1582,7 +1582,7 @@ func TestAppendAdditionalSuffixToTarget(t *testing.T) {
 			tests:                  []api.TestStepConfiguration{{As: "e2e"}, {As: "unit"}},
 			expectedTests:          []api.TestStepConfiguration{{As: "e2e-1"}, {As: "unit-1"}},
 			jobSpec:                api.JobSpec{Target: "e2e"},
-			expectedJobSpec:        api.JobSpec{Target: "e2e-1"},
+			expectedJobSpec:        api.JobSpec{Target: "e2e-1", TargetAdditionalSuffix: "1"},
 		},
 	}
 	for _, tc := range testCases {
@@ -1596,7 +1596,7 @@ func TestAppendAdditionalSuffixToTarget(t *testing.T) {
 				targets: tc.targets,
 			}
 
-			appendAdditionalSuffixToTarget(o)
+			handleTargetAdditionalSuffix(o)
 
 			if diff := cmp.Diff(tc.expectedTargets.values, o.targets.values); diff != "" {
 				t.Fatalf("expectedTargets differ from actual, diff: %s", diff)

--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -73,14 +73,16 @@ func (s *JobSpec) Inputs() InputDefinition {
 	return InputDefinition{string(raw)}
 }
 
-// JobNameHash returns a 5 character hash of the job name with the
-// targetAdditionalSuffix appended where applicable
 func (s JobSpec) JobNameHash() string {
-	jobName := s.Job
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s.Job)))[:5]
+}
+
+func (s JobSpec) UniqueHash() string {
+	job := s.Job
 	if s.TargetAdditionalSuffix != "" {
-		jobName += fmt.Sprintf("-%s", s.TargetAdditionalSuffix)
+		job += fmt.Sprintf("-%s", s.TargetAdditionalSuffix)
 	}
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(jobName)))[:5]
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(job)))[:5]
 }
 
 // ResolveSpecFromEnv will determine the Refs being

--- a/pkg/api/job_spec.go
+++ b/pkg/api/job_spec.go
@@ -27,8 +27,9 @@ type JobSpec struct {
 	// if set, any new artifacts will be a child of this object
 	owner *meta.OwnerReference
 
-	Metadata Metadata
-	Target   string
+	Metadata               Metadata
+	Target                 string
+	TargetAdditionalSuffix string
 }
 
 // Namespace returns the namespace of the job. Must not be evaluated
@@ -72,8 +73,14 @@ func (s *JobSpec) Inputs() InputDefinition {
 	return InputDefinition{string(raw)}
 }
 
+// JobNameHash returns a 5 character hash of the job name with the
+// targetAdditionalSuffix appended where applicable
 func (s JobSpec) JobNameHash() string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(s.Job)))[:5]
+	jobName := s.Job
+	if s.TargetAdditionalSuffix != "" {
+		jobName += fmt.Sprintf("-%s", s.TargetAdditionalSuffix)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(jobName)))[:5]
 }
 
 // ResolveSpecFromEnv will determine the Refs being

--- a/pkg/api/job_spec_test.go
+++ b/pkg/api/job_spec_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+)
+
+func TestJobNameHash(t *testing.T) {
+	testCases := []struct {
+		name     string
+		jobSpec  JobSpec
+		expected string
+	}{
+		{
+			name: "basic",
+			jobSpec: JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job: "some-job",
+				},
+			},
+			expected: "21d89",
+		},
+		{
+			name: "target additional suffix supplied",
+			jobSpec: JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job: "some-job",
+				},
+				TargetAdditionalSuffix: "1",
+			},
+			expected: "02c64",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jobNameHash := tc.jobSpec.JobNameHash()
+			if diff := cmp.Diff(jobNameHash, tc.expected); diff != "" {
+				t.Fatalf("jobNameHash doesn't match expected, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/api/job_spec_test.go
+++ b/pkg/api/job_spec_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
 )
 
-func TestJobNameHash(t *testing.T) {
+func TestUniqueHash(t *testing.T) {
 	testCases := []struct {
 		name     string
 		jobSpec  JobSpec
@@ -36,9 +36,9 @@ func TestJobNameHash(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			jobNameHash := tc.jobSpec.JobNameHash()
-			if diff := cmp.Diff(jobNameHash, tc.expected); diff != "" {
-				t.Fatalf("jobNameHash doesn't match expected, diff: %s", diff)
+			uniqueHash := tc.jobSpec.UniqueHash()
+			if diff := cmp.Diff(uniqueHash, tc.expected); diff != "" {
+				t.Fatalf("uniqueHash doesn't match expected, diff: %s", diff)
 			}
 		})
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -147,6 +147,7 @@ func fromConfig(
 	params.Add("JOB_NAME", func() (string, error) { return jobSpec.Job, nil })
 	params.Add("JOB_NAME_HASH", func() (string, error) { return jobSpec.JobNameHash(), nil })
 	params.Add("JOB_NAME_SAFE", func() (string, error) { return strings.Replace(jobSpec.Job, "_", "-", -1), nil })
+	params.Add("UNIQUE_HASH", func() (string, error) { return jobSpec.UniqueHash(), nil })
 	params.Add("NAMESPACE", func() (string, error) { return jobSpec.Namespace(), nil })
 	inputImages := make(inputImageSet)
 	var overridableSteps, buildSteps, postSteps []api.Step

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1439,6 +1439,7 @@ func TestFromConfig(t *testing.T) {
 					Job:  "job_name",
 					Refs: tc.refs,
 				},
+				TargetAdditionalSuffix: "1",
 			}
 			jobSpec.SetNamespace(ns)
 			params := api.NewDeferredParameters(tc.env)
@@ -1469,6 +1470,7 @@ func TestFromConfig(t *testing.T) {
 				"JOB_NAME":      "job_name",
 				"JOB_NAME_HASH": jobSpec.JobNameHash(),
 				"JOB_NAME_SAFE": "job-name",
+				"UNIQUE_HASH":   jobSpec.UniqueHash(),
 				"NAMESPACE":     ns,
 			} {
 				tc.expectedParams[k] = v

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -181,6 +181,7 @@ func (s *multiStageTestStep) generatePods(
 			{Name: "NAMESPACE", Value: s.jobSpec.Namespace()},
 			{Name: "JOB_NAME_SAFE", Value: strings.Replace(s.name, "_", "-", -1)},
 			{Name: "JOB_NAME_HASH", Value: s.jobSpec.JobNameHash()},
+			{Name: "UNIQUE_HASH", Value: s.jobSpec.UniqueHash()},
 		}...)
 		container.Env = append(container.Env, env...)
 		container.Env = append(container.Env, s.generateParams(step.Environment)...)

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -66,6 +66,8 @@
         value: test
       - name: JOB_NAME_HASH
         value: 5e8c9
+      - name: UNIQUE_HASH
+        value: 5e8c9
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig
       - name: KUBECONFIGMINIMAL
@@ -215,6 +217,8 @@
       - name: JOB_NAME_SAFE
         value: test
       - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: UNIQUE_HASH
         value: 5e8c9
       - name: KUBECONFIG
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -66,6 +66,8 @@
         value: test
       - name: JOB_NAME_HASH
         value: 5e8c9
+      - name: UNIQUE_HASH
+        value: 5e8c9
       - name: RELEASE_IMAGE_INITIAL
         value: release:initial
       - name: RELEASE_IMAGE_LATEST
@@ -233,6 +235,8 @@
         value: test
       - name: JOB_NAME_HASH
         value: 5e8c9
+      - name: UNIQUE_HASH
+        value: 5e8c9
       - name: RELEASE_IMAGE_INITIAL
         value: release:initial
       - name: RELEASE_IMAGE_LATEST
@@ -392,6 +396,8 @@
       - name: JOB_NAME_SAFE
         value: test
       - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: UNIQUE_HASH
         value: 5e8c9
       - name: RELEASE_IMAGE_INITIAL
         value: release:initial
@@ -558,6 +564,8 @@
       - name: JOB_NAME_SAFE
         value: test
       - name: JOB_NAME_HASH
+        value: 5e8c9
+      - name: UNIQUE_HASH
         value: 5e8c9
       - name: RELEASE_IMAGE_INITIAL
         value: release:initial


### PR DESCRIPTION
There were reported errors with aggregate jobs like the following, found in this [log](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/openshift-origin-27894-ci-4.14-upgrade-from-stable-4.13-e2e-azure-sdn-upgrade/1658692416556765184):
```
Error: A resource with the ID "/subscriptions/72e3a972-58b0-4afc-bd4f-da89b39ccebd/resourceGroups/os4-common/providers/Microsoft.Network/dnsZones/ci2.azure.devcluster.openshift.com/CNAME/api.ci-op-iz4zs9r6-12383" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_dns_cname_record" for more information.
```
These jobs install the cluster utilizing configuration like the following, found in this [step](https://steps.ci.openshift.org/reference/ipi-conf):
```
cluster_name=${NAMESPACE}-${JOB_NAME_HASH}
```
The `JOB_NAME_HASH` is the same for each aggregated job. This is due to not being able to change the actual job name for each aggregate job as that would mess the aggregator up.

This adds a new `UNIQUE_HASH` env var that will be used in these cases and includes the `targetAdditionalSuffix`.

/cc @bbguimaraes @jmguzik 