### PR TITLE
Revert "Append timestamp to job-run-summary HTML"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -95,7 +95,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		}
 
 		summaryHTML := htmlForJobRuns(ctx, finishedJobRuns, unfinishedJobRuns, variantInfo)
-		if err := ioutil.WriteFile(filepath.Join(outputDir, fmt.Sprintf("job-run-summary-%d.html", time.Now().UnixMilli())), []byte(summaryHTML), 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(outputDir, "job-run-summary.html"), []byte(summaryHTML), 0644); err != nil {
 			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 		}
 


### PR DESCRIPTION
Reverts openshift/ci-tools#3434

I didn't realize the aggregator writes the file out multiple times: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-azure-ovn-upgrade-4.14-micro-release-openshift-release-analysis-aggregator/1659049262366855168

I think I'll just try to fix this in prow.
