### PR TITLE
`sprint-automation`: remove secondary triage roles

### DIFF
--- a/cmd/sprint-automation/README.md
+++ b/cmd/sprint-automation/README.md
@@ -10,5 +10,5 @@ Test Platform's daily helper. Utilizes slack and pager duty to do things such as
 # Local testing
 You can test out `sprint-automation` utilizing the `dptp-robot-testing` and the `hack/local-sprint-automation.sh` script:
 - Make sure to join the `dptp-robot-testing` slack space.
-- Run the `hack/local-sprint-automation.sh` script like so: `bash local-sprint-automation.sh`
+- Run the `hack/local-sprint-automation.sh` script like so: `RELEASE_REPO_DIR=<path to release repo dir> bash hack/local-sprint-automation.sh`
 - Now you can go into `dptp-robot-testing` and watch the output of your local `sprint-automation` run.

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -184,13 +184,9 @@ func main() {
 
 const (
 	primaryOnCallQuery                = "DPTP Primary On-Call"
-	secondaryUSOnCallQuery            = "DPTP Secondary On-Call (US)"
-	secondaryEUOnCallQuery            = "DPTP Secondary On-Call (EU)"
 	helpdeskQuery                     = "DPTP Help Desk"
 	intakeQuery                       = "DPTP Intake"
 	roleTriagePrimary                 = "@dptp-triage Primary"
-	roleTriageSecondaryUS             = "@dptp-triage Secondary (US)"
-	roleTriageSecondaryEU             = "@dptp-triage Secondary (EU)"
 	roleHelpdesk                      = "@dptp-helpdesk"
 	roleIntake                        = "@dptp-intake"
 	jiraUnassignedAssigneeDisplayName = "<Unassigned>"
@@ -211,7 +207,7 @@ func sendTeamDigest(userIdsByRole map[string]user, jiraClient *jiraapi.Client, s
 
 func getPagerDutyBlocks(userIdsByRole map[string]user) []slack.Block {
 	var fields []*slack.TextBlockObject
-	for _, role := range []string{roleTriagePrimary, roleTriageSecondaryUS, roleTriageSecondaryEU, roleHelpdesk, roleIntake} {
+	for _, role := range []string{roleTriagePrimary, roleHelpdesk, roleIntake} {
 		fields = append(fields, &slack.TextBlockObject{
 			Type: slack.PlainTextType,
 			Text: role,
@@ -274,14 +270,6 @@ func usersOnCallAtTime(client *pagerduty.Client, slackClient *slack.Client, year
 		{
 			role:  roleTriagePrimary,
 			query: primaryOnCallQuery,
-		},
-		{
-			role:  roleTriageSecondaryUS,
-			query: secondaryUSOnCallQuery,
-		},
-		{
-			role:  roleTriageSecondaryEU,
-			query: secondaryEUOnCallQuery,
 		},
 		{
 			role:  roleHelpdesk,


### PR DESCRIPTION
As discussed in the retro, we no longer require these roles and they aren't providing us value. Removing them from the daily digest. I will clean up the schedules in PagerDuty post-merge.