### PR TITLE
`prowgen`: promote on `multi01`

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -14,7 +14,6 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/util"
 	"github.com/openshift/ci-tools/pkg/util/gzip"
@@ -37,7 +36,9 @@ type Prowgen struct {
 	// Rehearsals declares any disabled rehearsals for jobs
 	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
 	// Set which architecture should the images be promoted from
-	AdditionalArchitectures []api.Architecture `json:"additional_architectures"`
+	AdditionalArchitectures []cioperatorapi.Architecture `json:"additional_architectures"`
+	// If true build images targeting multiple architectures
+	MultiArch bool `json:"multi_arch"`
 }
 
 func (p *Prowgen) Validate() error {
@@ -50,7 +51,7 @@ func (p *Prowgen) Validate() error {
 	}
 	if len(invalidArchs) > 0 {
 		e := fmt.Errorf("architectures %s are not valid, available ones are: %s",
-			strings.Join(invalidArchs, ", "), strings.Join(api.GetAvailableArchitectures(), ", "))
+			strings.Join(invalidArchs, ", "), strings.Join(cioperatorapi.GetAvailableArchitectures(), ", "))
 		errs = append(errs, e)
 	}
 	return utilerrors.NewAggregate(errs)
@@ -68,6 +69,9 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	}
 	if defaults.AdditionalArchitectures != nil {
 		p.AdditionalArchitectures = defaults.AdditionalArchitectures
+	}
+	if defaults.MultiArch {
+		p.MultiArch = true
 	}
 	p.Rehearsals.DisabledRehearsals = append(p.Rehearsals.DisabledRehearsals, defaults.Rehearsals.DisabledRehearsals...)
 }

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -643,7 +643,7 @@ func (c *ciOperatorPodSpecGenerator) MustBuild() *corev1.PodSpec {
 type fakePodSpecBuilder int
 
 func (f *fakePodSpecBuilder) Add(_ ...PodSpecMutator) CiOperatorPodSpecGenerator {
-	return nil
+	return f
 }
 func (f *fakePodSpecBuilder) Build() (*corev1.PodSpec, error) {
 	return nil, nil

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_default_cluster_only.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_default_cluster_only.yaml
@@ -1,0 +1,11 @@
+- agent: kubernetes
+  always_run: true
+  branches:
+  - ^branch$
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  labels:
+    ci-operator.openshift.io/is-promotion: "true"
+  max_concurrency: 1
+  name: branch-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_spawn_on_multi01_and_arm01.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_spawn_on_multi01_and_arm01.yaml
@@ -1,0 +1,26 @@
+- agent: kubernetes
+  always_run: true
+  branches:
+  - ^branch$
+  cluster: multi01
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  labels:
+    ci-operator.openshift.io/cluster: multi01
+    ci-operator.openshift.io/is-promotion: "true"
+  max_concurrency: 1
+  name: branch-ci-organization-repository-branch-images
+- agent: kubernetes
+  always_run: true
+  branches:
+  - ^branch$
+  cluster: arm01
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  labels:
+    ci-operator.openshift.io/cluster: arm01
+    ci-operator.openshift.io/is-promotion: "true"
+  max_concurrency: 1
+  name: branch-ci-organization-repository-branch-images-arm64

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_spawn_on_multi01_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForPromotion_spawn_on_multi01_cluster.yaml
@@ -1,0 +1,13 @@
+- agent: kubernetes
+  always_run: true
+  branches:
+  - ^branch$
+  cluster: multi01
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  labels:
+    ci-operator.openshift.io/cluster: multi01
+    ci-operator.openshift.io/is-promotion: "true"
+  max_concurrency: 1
+  name: branch-ci-organization-repository-branch-images


### PR DESCRIPTION
`prowgen` generates one additional promotion job on `multi01` when the configuration flag `multi_arch` is set.
~~This new configuration replaces the old `additional_architectures`, therefore the following PRs have been reverted:~~
- ~~[Prowgen: multiarch postsubmit images #3053](https://github.com/openshift/ci-tools/pull/3053)~~  
- ~~[[prowgen] merge additional_architectures when repo defines them #3153](https://github.com/openshift/ci-tools/pull/3153)~~  

More details here: [DPTP-3463](https://issues.redhat.com/browse/DPTP-3463)

/cc @droslean @deepsm007
/label tide/merge-method-squash