### PR TITLE
split the job-config-master-* config maps into master and main

### DIFF
--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -110,7 +110,7 @@ var fourXBranches = regexp.MustCompile(`^(release|enterprise|openshift)-(4\.[0-9
 func FlavorForBranch(branch string) string {
 	var flavor string
 	if branch == "master" || branch == "main" {
-		flavor = "master"
+		flavor = branch
 	} else if m := fourXBranches.FindStringSubmatch(branch); m != nil {
 		flavor = m[2] // the 4.x release string
 	} else if m := releaseBranches.FindStringSubmatch(branch); m != nil {

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -107,9 +107,9 @@ func TestMetadata_ConfigMapName(t *testing.T) {
 			expected: "ci-operator-master-configs",
 		},
 		{
-			name:     "main branch goes to master configmap",
+			name:     "main branch goes to main configmap",
 			branch:   "main",
-			expected: "ci-operator-master-configs",
+			expected: "ci-operator-main-configs",
 		},
 		{
 			name:     "openshift 3.6 branch goes to 3.x configmap",

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -75,7 +75,7 @@ func (i *Info) ConfigMapName() string {
 		return fmt.Sprintf("job-config-%s", cioperatorapi.FlavorForBranch(""))
 	}
 	flavor := cioperatorapi.FlavorForBranch(i.Branch)
-	if flavor == "master" {
+	if flavor == "master" || flavor == "main" {
 		return fmt.Sprintf("job-config-%s-%s", flavor, i.Type)
 	}
 

--- a/pkg/jobconfig/files_test.go
+++ b/pkg/jobconfig/files_test.go
@@ -730,10 +730,22 @@ func TestInfo_ConfigMapName(t *testing.T) {
 			expected: "job-config-master-presubmits",
 		},
 		{
+			name:     "main branch goes to main configmap",
+			branch:   "main",
+			jobType:  "presubmits",
+			expected: "job-config-main-presubmits",
+		},
+		{
 			name:     "master branch goes to master configmap",
 			branch:   "master",
 			jobType:  "postsubmits",
 			expected: "job-config-master-postsubmits",
+		},
+		{
+			name:     "main branch goes to master configmap",
+			branch:   "main",
+			jobType:  "postsubmits",
+			expected: "job-config-main-postsubmits",
 		},
 		{
 			name:     "periodic without relationship to a repo goes to misc",
@@ -746,6 +758,12 @@ func TestInfo_ConfigMapName(t *testing.T) {
 			branch:   "master",
 			jobType:  "periodics",
 			expected: "job-config-master-periodics",
+		},
+		{
+			name:     "periodic with relationship to a repo main branch goes to branch shard",
+			branch:   "main",
+			jobType:  "periodics",
+			expected: "job-config-main-periodics",
 		},
 		{
 			name:     "periodic with relationship to a repo branch goes to branch shard",


### PR DESCRIPTION
We are splitting `main` from `master` in the CMs. More details can be found in: https://github.com/openshift/release/pull/39565.

/hold this change will need to be coordinated with https://github.com/openshift/release/pull/39565

For: https://issues.redhat.com/browse/DPTP-3430