### PR TITLE
`pod-scaler`: remove `preemptionPolicy` on pod when adding `priorityClassName`

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -351,7 +351,8 @@ func (m *podMutator) addPriorityClass(pod *corev1.Pod) {
 	}
 
 	if shouldAdd(pod.Spec.Containers) || shouldAdd(pod.Spec.InitContainers) {
-		pod.Spec.Priority = nil // We cannot have Priority defined if we add the PriorityClassName
+		pod.Spec.Priority = nil         // We cannot have Priority defined if we add the PriorityClassName
+		pod.Spec.PreemptionPolicy = nil // We cannot have PreemptionPolicy defined if we are using a priority class with preemption of "Never"
 		pod.Spec.PriorityClassName = priorityClassName
 	}
 }

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -1091,6 +1091,7 @@ func TestDetermineWorkloadName(t *testing.T) {
 func TestAddPriorityClass(t *testing.T) {
 	priority := new(int32)
 	*priority = 10
+	preemptionPolicy := corev1.PreemptLowerPriority
 
 	testCases := []struct {
 		name     string
@@ -1139,12 +1140,13 @@ func TestAddPriorityClass(t *testing.T) {
 			}},
 		},
 		{
-			name: "cpu above configured amount for priority scheduling with priority defined",
+			name: "cpu above configured amount for priority scheduling with priority and preemption policy defined",
 			pod: &corev1.Pod{Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("9")}}},
 				},
-				Priority: priority,
+				Priority:         priority,
+				PreemptionPolicy: &preemptionPolicy,
 			}},
 			expected: &corev1.Pod{Spec: corev1.PodSpec{
 				Containers: []corev1.Container{


### PR DESCRIPTION
Reports of errors like the following now that we are using a priority class with `Never` preempt policy defined:
```
error=pods "go-unit-tests-stackrox-initial" is forbidden: the string value of PreemptionPolicy (PreemptLowerPriority) must not be provided in pod spec; priority admission controller computed Never from the given PriorityClass name
```

Follows up on: https://github.com/openshift/ci-tools/pull/3444/files