### PR TITLE
Fix issue DPTP-3484 Fix ci-chat-bot section

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -303,6 +303,15 @@ func updateClusterDisplay(c *secretbootstrap.Config, o options) error {
 func updateChatBotSecret(c *secretbootstrap.Config, o options) error {
 	const chatBot = "ci-chat-bot"
 	name := chatBot + "-kubeconfigs"
+	if o.useTokenFileInKubeconfig {
+		keyAndFieldToken := serviceAccountTokenFile(chatBot, o.clusterName)
+		if err := updateSecretItemContext(c, name, string(api.ClusterAPPCI), keyAndFieldToken, secretbootstrap.ItemContext{
+			Field: keyAndFieldToken,
+			Item:  chatBot,
+		}); err != nil {
+			return err
+		}
+	}
 	keyAndField := serviceAccountKubeconfigPath(chatBot, o.clusterName)
 	return updateSecretItemContext(c, name, string(api.ClusterAPPCI), keyAndField, secretbootstrap.ItemContext{
 		Field: keyAndField,

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -251,6 +251,9 @@ secret_configs:
     sa.ci-chat-bot.newCluster.config:
       field: sa.ci-chat-bot.newCluster.config
       item: ci-chat-bot
+    sa.ci-chat-bot.newCluster.token.txt:
+      field: sa.ci-chat-bot.newCluster.token.txt
+      item: ci-chat-bot
   to:
   - cluster: app.ci
     name: ci-chat-bot-kubeconfigs

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -251,6 +251,9 @@ secret_configs:
     sa.ci-chat-bot.existingCluster.config:
       field: sa.ci-chat-bot.existingCluster.config
       item: ci-chat-bot
+    sa.ci-chat-bot.existingCluster.token.txt:
+      field: sa.ci-chat-bot.existingCluster.token.txt
+      item: ci-chat-bot
   to:
   - cluster: app.ci
     name: ci-chat-bot-kubeconfigs


### PR DESCRIPTION
This PR fixes that `sa.ci-chat-bot.build08.token.txt` is missing from `core-services/ci-secret-bootstrap/_config.yaml`.