### PR TITLE
[ci-operator] pass a null logger to controllerruntime when the verbose option is false

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/bombsimon/logrusr/v3"
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -55,6 +56,7 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	crcontrollerutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/yaml"
 
 	buildv1 "github.com/openshift/api/build/v1"
@@ -200,6 +202,8 @@ func main() {
 	if err := flagSet.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("failed to parse flags")
 	}
+
+	ctrlruntimelog.SetLogger(logr.New(ctrlruntimelog.NullLogSink{}))
 	if opt.verbose {
 		fs := flag.NewFlagSet("", flag.ExitOnError)
 		klog.InitFlags(fs)

--- a/go.mod
+++ b/go.mod
@@ -115,7 +115,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fsouza/go-dockerclient v1.6.3 // indirect
 	github.com/fvbommel/sortorder v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
+	github.com/go-logr/logr v1.2.4
 	github.com/gobuffalo/flect v0.2.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect


### PR DESCRIPTION
After the changes in the `controllerruntime` library that have been made in https://github.com/kubernetes-sigs/controller-runtime/pull/2317 it makes it necessary to pass a logger/

This change fixes the logged tracebacks in jobs. e.x https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openshift-cluster-node-tuning-operator-release-4.11-images/1663911500558897152#1:build-log.txt%3A20-48

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
