### PR TITLE
`e2e`: mitigate observer pods tests flakiness - 2nd attempt

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -420,6 +420,8 @@ type options struct {
 	dependencyOverrides      stringSlice
 
 	targetAdditionalSuffix string
+
+	waitObservers bool
 }
 
 func bindOptions(flag *flag.FlagSet) *options {
@@ -489,6 +491,8 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.Var(&opt.dependencyOverrides, "dependency-override-param", "A repeatable option used to override dependencies with external pull specs. This parameter should be in the format ENVVARNAME=PULLSPEC, e.g. --dependency-override-param=OO_INDEX=registry.mydomain.com:5000/pushed/myimage. This would override the value for the OO_INDEX environment variable for any tests/steps that currently have that dependency configured.")
 
 	flag.StringVar(&opt.targetAdditionalSuffix, "target-additional-suffix", "", "Inject an additional suffix onto the targeted test's 'as' name. Used for adding an aggregate index")
+
+	flag.BoolVar(&opt.waitObservers, "wait-observers", false, "Wait for the observers to complete their execution")
 
 	opt.resultsOptions.Bind(flag)
 	return opt
@@ -874,7 +878,7 @@ func (o *options) Run() []error {
 	}
 
 	// load the graph from the configuration
-	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix)
+	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig, o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig, o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.waitObservers)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1446,7 +1446,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "")
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "", false)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -77,7 +77,7 @@ func TestGeneratePods(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", false)
 	step.test[0].Resources = api.ResourceRequirements{
 		Requests: api.ResourceList{api.ShmResource: "2G"},
 		Limits:   api.ResourceList{api.ShmResource: "2G"}}
@@ -155,7 +155,7 @@ func TestGenerateObservers(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", false)
 	ret, err := step.generateObservers(observers, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Test:        test,
 					Environment: tc.env,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "")
+			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "", false)
 			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -297,7 +297,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", false)
 	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -225,6 +225,7 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	}
 	observerContext, cancel := context.WithCancel(ctx)
 	observerDone := make(chan struct{})
+	defer close(observerDone)
 	go s.runObservers(observerContext, ctx, observers, observerDone)
 	s.flags |= shortCircuit
 	if err := s.runSteps(ctx, "pre", s.pre, env, secretVolumes, secretVolumeMounts); err != nil {

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -80,7 +80,7 @@ func TestRequires(t *testing.T) {
 				As:                                 "some-e2e",
 				ClusterClaim:                       tc.clusterClaim,
 				MultiStageTestConfigurationLiteral: &tc.steps,
-			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "")
+			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "", false)
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true

--- a/pkg/steps/multi_stage/run_test.go
+++ b/pkg/steps/multi_stage/run_test.go
@@ -110,7 +110,7 @@ func TestRun(t *testing.T) {
 					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: &yes}},
 					AllowSkipOnSuccess: &yes,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "")
+			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", false)
 			if err := step.Run(context.Background()); (err != nil) != (tc.failures != nil) {
 				t.Errorf("expected error: %t, got error: %v", (tc.failures != nil), err)
 			}
@@ -227,7 +227,7 @@ func TestJUnit(t *testing.T) {
 					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
 					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "")
+			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", false)
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {
 				t.Error(err)
 				return

--- a/test/e2e/observer/e2e_test.go
+++ b/test/e2e/observer/e2e_test.go
@@ -36,6 +36,7 @@ func TestObservers(t *testing.T) {
 			args: []string{
 				"--unresolved-config=simple-observer.yaml",
 				"--target=with-observer",
+				"--wait-observers",
 			},
 			env:     []string{defaultJobSpec},
 			success: true,
@@ -54,6 +55,7 @@ func TestObservers(t *testing.T) {
 			args: []string{
 				"--unresolved-config=failing-observer.yaml",
 				"--target=with-failing-observer",
+				"--wait-observers",
 			},
 			env:     []string{defaultJobSpec},
 			success: true,
@@ -70,6 +72,7 @@ func TestObservers(t *testing.T) {
 			args: []string{
 				"--unresolved-config=multi-observers.yaml",
 				"--target=multi-observers",
+				"--wait-observers",
 			},
 			env:     []string{defaultJobSpec},
 			success: true,


### PR DESCRIPTION
Second attempt since the first one [#3025](https://github.com/openshift/ci-tools/pull/3025) didn't gain enough consensus.

Tests history of [pull-ci-openshift-ci-tools-master-e2e](https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/pull-ci-openshift-ci-tools-master-e2e) shows that a lot of flakes are due to the e2e test: `observer failure must not affect tests` (reference [here](https://github.com/openshift/ci-tools/blob/ff60d549afed41d1adf49843a33c1dd6ffdc9284/test/e2e/observer/e2e_test.go#L53-L69)).

The purpose of the aforementioned test is to show that a failure in an observer pod doesn't affect the result of the whole test. Execution breakdown follows:
- run an observer that it is going to fail
- run a test that it is going to succeed
- check that the whole test passed (despite the failing observer)
- check that the observer has failed

The last step is the problematic one as it happens that, from time to time, the cluster doesn't timely execute the observer therefore the run goes well but the `e2e` fails cause it won't find any traces of the observer having failed.

This is the output of a typical flake:
```
        INFO[2023-05-30T15:19:09Z] Step with-failing-observer-failing-observer failed after 41s. 
        INFO[2023-05-30T15:19:09Z] Ran for 47s                                  
    test.go:89: got diff between expected and actual result: 
        --- artifacts/failing-observer-junit_operator.xml
        +++ /logs/artifacts/TestObservers_observer_failure_must_not_affect_tests/junit_operator.xml
        @@ -1,5 +1,5 @@
6 skipped lines...
        @@ -11,9 +11,6 @@
             <testcase name="Run multi-stage test test phase" time="whatever">
               <system-out>The collected steps of multi-stage phase test.</system-out>
             </testcase>
        -    <testcase name="Run multi-stage test with-failing-observer - with-failing-observer-failing-observer container test" time="whatever">
        -      <failure message="">+ echo &#39;this is going to fail&#39;&#xA;this is going to fail&#xA;+ exit 1&#xA;{&#34;component&#34;:&#34;entrypoint&#34;,&#34;error&#34;:&#34;wrapped process failed: exit status 1&#34;,&#34;file&#34;:&#34;k8s.io/test-infra/prow/entrypoint/run.go&#34;,&#34;func&#34;:&#34;k8s.io/test-infra/prow/entrypoint.Options.Run&#34;,&#34;level&#34;:&#34;error&#34;,&#34;msg&#34;:&#34;Error executing test process&#34;,&#34;severity&#34;:&#34;error&#34;,&#34;time&#34;:&#34;whatever&#34;}&#xA;error: failed to execute wrapped command: exit status 1&#xA;</failure>
        -    </testcase>
             <testcase name="Run multi-stage test with-failing-observer - with-failing-observer-noop-test container test" time="whatever"></testcase>
           </testsuite>
         </testsuites>
```
The e2e expects this [junit](https://github.com/openshift/ci-tools/blob/ecd2e4e9bb1f043ee926d99b8738b6969696a686/test/e2e/observer/artifacts/failing-observer-junit_operator.xml) from `ci-operator`.

The `events.json` (hopefully) shows what differs between a flake test and a regular one.

### 1. Flake - [pull-ci-openshift-ci-tools-master-e2e #1663556952866689024](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3453/pull-ci-openshift-ci-tools-master-e2e/1663556952866689024)

```sh
$ jq -r '.items[]|select(.involvedObject.name=="with-failing-observer-failing-observer")|.message' 'artifacts/e2e/e2e/artifacts/TestObservers_observer_failure_must_not_affect_tests/build-resources/events.json'

Successfully assigned ci-op-7dfld9dj/with-failing-observer-failing-observer to ip-10-0-151-222.ec2.internal
Add eth0 [10.129.92.123/23] from openshift-sdn
Pulling image "registry.access.redhat.com/ubi8"
Successfully pulled image "registry.access.redhat.com/ubi8" in 243.81715ms (243.82862ms including waiting)
Created container ci-scheduling-dns-wait
Started container ci-scheduling-dns-wait
Stopping container ci-scheduling-dns-wait
```

### 2. Good - [pull-ci-openshift-ci-tools-master-e2e #1650492591772274688](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3387/pull-ci-openshift-ci-tools-master-e2e/1650492591772274688)

```sh
$ jq -r '.items[]|select(.involvedObject.name=="with-failing-observer-failing-observer")|.message' \
	'artifacts/e2e/e2e/artifacts/TestObservers_observer_failure_must_not_affect_tests/build-resources/events.json'

Successfully assigned ci-op-497ymrqh/with-failing-observer-failing-observer to build04-c92hb-ci-tests-worker-b-m99zk
Add eth0 [10.131.92.99/23] from openshift-sdn
Pulling image "registry.access.redhat.com/ubi8"
Successfully pulled image "registry.access.redhat.com/ubi8" in 2.892584342s (2.892605805s including waiting)
Created container ci-scheduling-dns-wait
Started container ci-scheduling-dns-wait
Pulling image "registry.ci.openshift.org/ci/entrypoint:latest"
Successfully pulled image "registry.ci.openshift.org/ci/entrypoint:latest" in 308.037715ms (308.045255ms including waiting)
Created container place-entrypoint
Started container place-entrypoint
Pulling image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest"
Successfully pulled image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest" in 235.258834ms (235.273337ms including waiting)
Created container cp-entrypoint-wrapper
Started container cp-entrypoint-wrapper
Pulling image "image-registry.openshift-image-registry.svc:5000/ci-op-497ymrqh/pipeline@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e"
Successfully pulled image "image-registry.openshift-image-registry.svc:5000/ci-op-497ymrqh/pipeline@sha256:e4ca2ed0202e76be184e75fb26d14bf974193579039d5573fb2348664deef76e" in 501.897725ms (501.907511ms including waiting)
Created container test
Started container test
Pulling image "registry.ci.openshift.org/ci/sidecar:latest"
```

On the run **1.** the observer `with-failing-observer-failing-observer` hasn't even had the chance to execute; this is because the cluster hasn't run the pod timely (for any reasons), in the meantime [the test](https://github.com/openshift/ci-tools/blob/608ddbc8669846cd3d82a69dce295f5c49b56d3e/test/e2e/observer/failing-observer.yaml#L15-L22) completed and finally `ci-operator` [cancelled](https://github.com/openshift/ci-tools/blob/0c48f78a24588be367cec26a2f2a6080457f1ae9/pkg/steps/multi_stage/multi_stage.go#L238) any remaining observers.

This PR introduces a new flag `--wait-observers` to mitigate these kind of problems.
When `--wait-observers` is set, `ci-operator` performs a regular multi stage workflow (namely: it runs the observers then `pre` and `test` test steps) but then it waits for every observers to terminate before moving on.

I don't claim this would be the once and for all solution but it's probably worth a try.
Open to discussion and alternatives.
