### PR TITLE
ci-operator: remove claim release image from input

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -290,7 +290,7 @@ func fromConfig(
 					if err != nil {
 						return nil, nil, results.ForReason("reading_release").ForError(fmt.Errorf("failed to read input release pullSpec %s: %w", name, err))
 					}
-					logrus.Infof("Resolved release %s to %s", name, pullSpec)
+					logrus.Infof("Using explicitly provided pull-spec for release %s (%s)", name, pullSpec)
 					target := rawStep.ReleaseImagesTagStepConfiguration.TargetName(name)
 					releaseStep = releasesteps.ImportReleaseStep(name, nodeName, target, pullSpec, true, config.Resources, podClient, jobSpec, pullSecret, nil)
 				} else {

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -54,8 +54,7 @@ type importReleaseStep struct {
 	name     string
 	nodeName string
 	target   string
-	// pullSpec is the fully-resolved pull spec of the release payload image we are importing
-	pullSpec string
+	source   ReleaseSource
 	// append determines if we wait for other processes to create images first
 	append     bool
 	resources  api.ResourceConfiguration
@@ -67,7 +66,8 @@ type importReleaseStep struct {
 }
 
 func (s *importReleaseStep) Inputs() (api.InputDefinition, error) {
-	return api.InputDefinition{s.pullSpec}, nil
+	input, err := s.source.PullSpec(context.Background())
+	return api.InputDefinition{input}, err
 }
 
 func (*importReleaseStep) Validate() error { return nil }
@@ -103,8 +103,10 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 	}
 
 	// tag the release image in and let it import
-	var pullSpec string
-
+	pullSpec, err := s.source.PullSpec(ctx)
+	if err != nil {
+		return err
+	}
 	// retry importing the image a few times because we might race against establishing credentials/roles
 	// and be unable to import images on the same cluster
 	streamImport := &imagev1.ImageStreamImport{
@@ -121,7 +123,7 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 					},
 					From: coreapi.ObjectReference{
 						Kind: "DockerImage",
-						Name: s.pullSpec,
+						Name: pullSpec,
 					},
 					ReferencePolicy: imagev1.TagReferencePolicy{
 						Type: imagev1.LocalTagReferencePolicy,
@@ -410,7 +412,7 @@ func (s *importReleaseStep) Objects() []ctrlruntimeclient.Object {
 // ImportReleaseStep imports an existing update payload image
 func ImportReleaseStep(
 	name, nodeName, target string,
-	pullSpec string,
+	source ReleaseSource,
 	append bool,
 	resources api.ResourceConfiguration,
 	client kubernetes.PodClient,
@@ -421,7 +423,7 @@ func ImportReleaseStep(
 		name:                           name,
 		nodeName:                       nodeName,
 		target:                         target,
-		pullSpec:                       pullSpec,
+		source:                         source,
 		append:                         append,
 		resources:                      resources,
 		client:                         client,

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -66,7 +66,7 @@ type importReleaseStep struct {
 }
 
 func (s *importReleaseStep) Inputs() (api.InputDefinition, error) {
-	input, err := s.source.PullSpec(context.Background())
+	input, err := s.source.Input(context.Background())
 	return api.InputDefinition{input}, err
 }
 

--- a/pkg/steps/release/source.go
+++ b/pkg/steps/release/source.go
@@ -1,0 +1,135 @@
+package release
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/release"
+	"github.com/openshift/ci-tools/pkg/release/candidate"
+	"github.com/openshift/ci-tools/pkg/release/official"
+	"github.com/openshift/ci-tools/pkg/release/prerelease"
+	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/utils"
+)
+
+// ReleaseSource holds information to resolve a release pull-spec
+// This is used to defer resolution in some cases until after a release is
+// known to be required, based on the pruned step graph.  This structure holds
+// the required configuration and clients until then.
+type ReleaseSource interface {
+	// PullSpec resolves the release pull-spec (if necessary) and returns it
+	PullSpec(ctx context.Context) (string, error)
+}
+
+// NewReleaseSourceFromPullSpec creates a fixed, pre-computed source
+func NewReleaseSourceFromPullSpec(s string) ReleaseSource {
+	ret := fixedReleaseSource(s)
+	return &ret
+}
+
+// NewReleaseSourceFromConfig uses the pull-spec of a published release payload
+func NewReleaseSourceFromConfig(
+	config *api.ReleaseConfiguration,
+	httpClient release.HTTPClient,
+) ReleaseSource {
+	return &configurationReleaseSource{
+		config: config,
+		client: httpClient,
+	}
+}
+
+// NewReleaseSourceFromClusterClaim determines the pull-spec for a cluster pool
+func NewReleaseSourceFromClusterClaim(
+	name string,
+	claim *api.ClusterClaim,
+	hiveClient ctrlruntimeclient.WithWatch,
+) ReleaseSource {
+	return &clusterClaimReleaseSource{
+		testName: name,
+		claim:    claim,
+		client:   hiveClient,
+	}
+}
+
+type fixedReleaseSource string
+
+func (s fixedReleaseSource) PullSpec(ctx context.Context) (string, error) {
+	return string(s), nil
+}
+
+type configurationReleaseSource struct {
+	pullSpec string
+	config   *api.ReleaseConfiguration
+	client   release.HTTPClient
+}
+
+func (s configurationReleaseSource) PullSpec(
+	ctx context.Context,
+) (string, error) {
+	if s.pullSpec == "" {
+		if err := s.resolvePullSpec(); err != nil {
+			return "", err
+		}
+	}
+	return s.pullSpec, nil
+}
+
+func (s *configurationReleaseSource) resolvePullSpec() (err error) {
+	var spec string
+	if c := s.config.Candidate; c != nil {
+		spec, err = candidate.ResolvePullSpec(s.client, *c)
+	} else if r := s.config.Release; r != nil {
+		spec, _, err = official.ResolvePullSpecAndVersion(s.client, *r)
+	} else if p := s.config.Prerelease; p != nil {
+		spec, err = prerelease.ResolvePullSpec(s.client, *p)
+	} else {
+		panic("invalid release configuration")
+	}
+	if err != nil {
+		return results.ForReason("resolving_release").ForError(fmt.Errorf("failed to resolve release %s: %w", s.config.Name, err))
+	}
+	s.pullSpec = spec
+	logrus.Infof("Resolved release %s to %s", s.config.Name, s.pullSpec)
+	return nil
+}
+
+type clusterClaimReleaseSource struct {
+	pullSpec string
+	testName string
+	claim    *api.ClusterClaim
+	client   ctrlruntimeclient.WithWatch
+}
+
+func (s clusterClaimReleaseSource) PullSpec(
+	ctx context.Context,
+) (string, error) {
+	if s.pullSpec == "" {
+		if err := s.resolvePullSpec(ctx); err != nil {
+			return "", err
+		}
+	}
+	return s.pullSpec, nil
+}
+
+func (s *clusterClaimReleaseSource) resolvePullSpec(ctx context.Context) error {
+	pool, err := utils.ClusterPoolFromClaim(ctx, s.claim, s.client)
+	if err != nil {
+		return err
+	}
+	key := types.NamespacedName{Name: pool.Spec.ImageSetRef.Name}
+	var set hivev1.ClusterImageSet
+	if err := s.client.Get(ctx, key, &set); err != nil {
+		return fmt.Errorf("failed to find cluster image set `%s` for cluster pool `%s`: %w", key.Name, pool.Name, err)
+	}
+	s.pullSpec = set.Spec.ReleaseImage
+	logrus.Infof("Resolved release %s to %s", s.claim.ClaimRelease(s.testName).ReleaseName, s.pullSpec)
+	return nil
+}

--- a/pkg/steps/release/source.go
+++ b/pkg/steps/release/source.go
@@ -25,6 +25,10 @@ import (
 // known to be required, based on the pruned step graph.  This structure holds
 // the required configuration and clients until then.
 type ReleaseSource interface {
+	// Input provides the value for the `Inputs` method of steps
+	// The return value may be empty if the pull-spec should not contribute to
+	// the input.
+	Input(ctx context.Context) (string, error)
 	// PullSpec resolves the release pull-spec (if necessary) and returns it
 	PullSpec(ctx context.Context) (string, error)
 }
@@ -65,6 +69,10 @@ func (s fixedReleaseSource) PullSpec(ctx context.Context) (string, error) {
 	return string(s), nil
 }
 
+func (s fixedReleaseSource) Input(ctx context.Context) (string, error) {
+	return s.PullSpec(ctx)
+}
+
 type configurationReleaseSource struct {
 	pullSpec string
 	config   *api.ReleaseConfiguration
@@ -80,6 +88,10 @@ func (s configurationReleaseSource) PullSpec(
 		}
 	}
 	return s.pullSpec, nil
+}
+
+func (s *configurationReleaseSource) Input(ctx context.Context) (string, error) {
+	return s.PullSpec(ctx)
 }
 
 func (s *configurationReleaseSource) resolvePullSpec() (err error) {
@@ -117,6 +129,10 @@ func (s clusterClaimReleaseSource) PullSpec(
 		}
 	}
 	return s.pullSpec, nil
+}
+
+func (s clusterClaimReleaseSource) Input(context.Context) (string, error) {
+	return "", nil
 }
 
 func (s *clusterClaimReleaseSource) resolvePullSpec(ctx context.Context) error {

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -144,6 +144,7 @@ func TestMultiStage(t *testing.T) {
 		{
 			name:     "e2e-claim",
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim"},
+			env:      []string{defaultJobSpec},
 			needHive: true,
 			success:  true,
 			output:   []string{`Imported release 4.11.`, `to tag release:latest-e2e-claim`, `e2e-claim-claim-step succeeded`},
@@ -151,6 +152,7 @@ func TestMultiStage(t *testing.T) {
 		{
 			name:     "e2e-claim-as-custom",
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim-as-custom"},
+			env:      []string{defaultJobSpec},
 			needHive: true,
 			success:  true,
 			output:   []string{`Imported release 4.11.`, `to tag release:custom-e2e-claim-as-custom`, `e2e-claim-as-custom-claim-step succeeded`},
@@ -158,6 +160,7 @@ func TestMultiStage(t *testing.T) {
 		{
 			name:     "e2e-claim depends on release image",
 			args:     []string{"--unresolved-config=cluster-claim.yaml", "--target=e2e-claim-depend-on-release-image"},
+			env:      []string{defaultJobSpec},
 			needHive: true,
 			success:  true,
 			output:   []string{`Imported release 4.11.`, `to tag release:latest-e2e-claim-depend-on-release-image`, `e2e-claim-depend-on-release-image-claim-step succeeded`},


### PR DESCRIPTION
These changes remove the pull-spec for the release payload image of the cluster
pool used by a test from the inputs used to determine the temporary test
namespace.

---

When a test requests a cluster from a pool (i.e. it has a `cluster_claim`), the
release payload configured for the pool, along with its images, is imported into
the test namespace (see https://github.com/openshift/ci-tools/pull/2074).  This
is done so that tests can use these images in the same way as they would other
types of releases.

---

The original implementation had a problem: since only tests with a
`cluster_claim` are given the Hive `kubeconfig`, other tests in the same
configuration would fail to obtain this information (see
https://github.com/openshift/ci-tools/pull/2092).

https://github.com/openshift/ci-tools/pull/2099 attempted to fix this by only
including the release import step when the client is present.  This has the
dubious effect of executing the test without claiming any cluster if the client
is not provided.  But, more importantly, it introduces another problem: since
the `ImportReleaseStep` declares the pull-spec of the release payload in its
`Inputs` --- as normally we want a separate test namespace if that pull-spec
has changed --- tests with an otherwise equal set of inputs are assigned
different temporary namespaces depending on whether they have a `cluster_claim`
or not.  E.g.:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hive/2029/pull-ci-openshift-hive-master-e2e/1661129286888722432
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hive/2029/pull-ci-openshift-hive-master-e2e-pool/1661129286913888256
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hive/2029/pull-ci-openshift-hive-master-images/1661129286939054080
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hive/2029/pull-ci-openshift-hive-master-unit/1661129286964219904
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_hive/2029/pull-ci-openshift-hive-master-verify/1661129286989385728

All of these jobs have the same set of inputs: they come from the same pull
request, have the same configuration, etc., but the first two are put into a
separate namespace.  While this is not a correctness problem (we could in
theory execute each test in its own namespace), this wastes resources since
none of the work (image builds, etc.) is shared between the two namespaces.

---

This behavior of `ImportReleaseStep` is desired in the case of regular release
payloads: we _want_ to import the new release if the pull-spec has changed, e.g.
if a new version is published.  But in the specific case of cluster pools, it is
not as important.  While some of them are regularly updated to use new payloads,
tests which use pools are not as concerned with using the absolute latest
versions.  Furthermore, it is already possible (in principle, at least) for a
test to import the release payload for a pool and later receive a lease for a
cluster provisioned with a different version.

For these reasons, these changes modify the `ImportReleaseStep` to only
conditionally include its pull-spec in the `Inputs`.  This continues to be done
for all cases, except now when the step is the result of a `cluster_claim`.

---

The release import refactoring in these changes is moderately over-abstracted
because it was part of the solution to an earlier conception I had of the
problem.  Still, it improves the mess that was the code in `pkg/defaults`, so
I'm including it here.

---

I want to monitor the deployment.

/hold