### PR TITLE
Remove quay.io's crentials from the push secret

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -143,6 +143,12 @@ func generateRegistryPullCredentialsSecret(o options) secretbootstrap.SecretConf
 					Item:        buildUFarm,
 					RegistryURL: api.ServiceDomainAPPCIRegistry,
 				},
+				{
+					AuthField:   "auth",
+					EmailField:  "email",
+					Item:        "quay.io-pull-secret",
+					RegistryURL: "quay.io",
+				},
 			}),
 		},
 		To: []secretbootstrap.SecretContext{
@@ -169,12 +175,6 @@ func generatePushPullSecretFrom(clusterName string, items []secretbootstrap.Dock
 				AuthField:   registryCommandTokenField(clusterName, pull),
 				Item:        buildUFarm,
 				RegistryURL: registryUrlFor(clusterName),
-			},
-			{
-				AuthField:   "auth",
-				EmailField:  "email",
-				Item:        "quay.io-pull-secret",
-				RegistryURL: "quay.io",
 			},
 		},
 	}

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -270,10 +270,6 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -298,13 +294,13 @@ secret_configs:
       - auth_field: token_image-puller_newCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.newCluster.ci.openshift.org
+      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.ci.openshift.org
       - auth_field: auth
         email_field: email
         item: quay.io-pull-secret
         registry_url: quay.io
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
   to:
   - cluster: newCluster
     name: registry-pull-credentials

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -280,10 +280,6 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
-      - auth_field: auth
-        email_field: email
-        item: quay.io-pull-secret
-        registry_url: quay.io
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
@@ -308,13 +304,13 @@ secret_configs:
       - auth_field: token_image-puller_existingCluster_reg_auth_value.txt
         item: build_farm
         registry_url: registry.existingCluster.ci.openshift.org
+      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
+        item: build_farm
+        registry_url: registry.ci.openshift.org
       - auth_field: auth
         email_field: email
         item: quay.io-pull-secret
         registry_url: quay.io
-      - auth_field: token_image-puller_app.ci_reg_auth_value.txt
-        item: build_farm
-        registry_url: registry.ci.openshift.org
   to:
   - cluster: existingCluster
     name: registry-pull-credentials


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/2998/files modified both push and push secret but it should not have the former.
The modified function is shared by both secrets.
This PR fixed it.

/cc @droslean 

/hold

Need the PR to fix the breaking changes