### PR TITLE
cluster-init: add push credentials for quay.io/openshift/ci

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -125,6 +125,11 @@ func generateRegistryPushCredentialsSecret(o options) secretbootstrap.SecretConf
 					Item:        buildUFarm,
 					RegistryURL: api.ServiceDomainAPPCIRegistry,
 				},
+				{
+					AuthField:   "auth",
+					Item:        "quay-io-push-credentials",
+					RegistryURL: "quay.io/openshift/ci",
+				},
 			}),
 		},
 		To: []secretbootstrap.SecretContext{

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -273,6 +273,9 @@ secret_configs:
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
+      - auth_field: auth
+        item: quay-io-push-credentials
+        registry_url: quay.io/openshift/ci
   to:
   - cluster: newCluster
     name: registry-push-credentials-ci-central

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -283,6 +283,9 @@ secret_configs:
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
+      - auth_field: auth
+        item: quay-io-push-credentials
+        registry_url: quay.io/openshift/ci
   to:
   - cluster: existingCluster
     name: registry-push-credentials-ci-central


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-3452

The credentials have been stored in Vault.

/cc @openshift/test-platform @jupierce 