### PR TITLE
pkg/util: list all pending containers in errors

### DIFF
--- a/pkg/util/pods_test.go
+++ b/pkg/util/pods_test.go
@@ -49,7 +49,6 @@ func TestCheckPending(t *testing.T) {
 			},
 		},
 	}
-	err := errors.New(`container "waiting" has not started in 1h0m0s`)
 	for _, tc := range []struct {
 		// input
 		name string
@@ -148,7 +147,7 @@ func TestCheckPending(t *testing.T) {
 				ContainerStatuses:     []corev1.ContainerStatus{waiting1},
 			},
 		},
-		err: err,
+		err: errors.New("containers have not started in 1h0m0s: waiting0, waiting1"),
 	}, {
 		name: "init container is waiting within limit",
 		pod: corev1.Pod{
@@ -174,7 +173,7 @@ func TestCheckPending(t *testing.T) {
 				ContainerStatuses: []corev1.ContainerStatus{waiting1},
 			},
 		},
-		err: err,
+		err: errors.New("containers have not started in 1h0m0s: waiting0, waiting1"),
 	}, {
 		name: "pod is pending within limit",
 		pod: corev1.Pod{
@@ -196,7 +195,7 @@ func TestCheckPending(t *testing.T) {
 				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
-		err: err,
+		err: errors.New("containers have not started in 1h0m0s: waiting0"),
 	}, {
 		name: "pod with init container is pending within limit",
 		pod: corev1.Pod{
@@ -220,7 +219,7 @@ func TestCheckPending(t *testing.T) {
 				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
-		err: err,
+		err: errors.New("containers have not started in 1h0m0s: waiting0"),
 	}, {
 		name: "pod is pending inside limit without container information",
 		pod: corev1.Pod{

--- a/pkg/util/pods_test.go
+++ b/pkg/util/pods_test.go
@@ -21,8 +21,14 @@ func TestCheckPending(t *testing.T) {
 			Running: &corev1.ContainerStateRunning{},
 		},
 	}
-	waiting := corev1.ContainerStatus{
-		Name: "waiting",
+	waiting0 := corev1.ContainerStatus{
+		Name: "waiting0",
+		State: corev1.ContainerState{
+			Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+		},
+	}
+	waiting1 := corev1.ContainerStatus{
+		Name: "waiting1",
 		State: corev1.ContainerState{
 			Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
 		},
@@ -105,7 +111,7 @@ func TestCheckPending(t *testing.T) {
 			Status: corev1.PodStatus{
 				Phase:                 corev1.PodPending,
 				InitContainerStatuses: []corev1.ContainerStatus{running},
-				ContainerStatuses:     []corev1.ContainerStatus{waiting},
+				ContainerStatuses:     []corev1.ContainerStatus{waiting0},
 			},
 		},
 		next: now.Add(timeout),
@@ -117,7 +123,7 @@ func TestCheckPending(t *testing.T) {
 				InitContainerStatuses: []corev1.ContainerStatus{
 					terminatedOutside, running,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{waiting},
+				ContainerStatuses: []corev1.ContainerStatus{waiting0},
 			},
 		},
 		next: now.Add(timeout),
@@ -127,8 +133,8 @@ func TestCheckPending(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: withinLimit},
 			Status: corev1.PodStatus{
 				Phase:                 corev1.PodPending,
-				InitContainerStatuses: []corev1.ContainerStatus{waiting},
-				ContainerStatuses:     []corev1.ContainerStatus{waiting},
+				InitContainerStatuses: []corev1.ContainerStatus{waiting0},
+				ContainerStatuses:     []corev1.ContainerStatus{waiting1},
 			},
 		},
 		next: withinLimit.Add(timeout),
@@ -138,8 +144,8 @@ func TestCheckPending(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: outsideLimit},
 			Status: corev1.PodStatus{
 				Phase:                 corev1.PodPending,
-				InitContainerStatuses: []corev1.ContainerStatus{waiting},
-				ContainerStatuses:     []corev1.ContainerStatus{waiting},
+				InitContainerStatuses: []corev1.ContainerStatus{waiting0},
+				ContainerStatuses:     []corev1.ContainerStatus{waiting1},
 			},
 		},
 		err: err,
@@ -150,9 +156,9 @@ func TestCheckPending(t *testing.T) {
 			Status: corev1.PodStatus{
 				Phase: corev1.PodPending,
 				InitContainerStatuses: []corev1.ContainerStatus{
-					terminatedWithin, waiting,
+					terminatedWithin, waiting0,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{waiting},
+				ContainerStatuses: []corev1.ContainerStatus{waiting1},
 			},
 		},
 		next: withinLimit.Add(timeout),
@@ -163,9 +169,9 @@ func TestCheckPending(t *testing.T) {
 			Status: corev1.PodStatus{
 				Phase: corev1.PodPending,
 				InitContainerStatuses: []corev1.ContainerStatus{
-					terminatedOutside, waiting,
+					terminatedOutside, waiting0,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{waiting},
+				ContainerStatuses: []corev1.ContainerStatus{waiting1},
 			},
 		},
 		err: err,
@@ -175,7 +181,7 @@ func TestCheckPending(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{CreationTimestamp: withinLimit},
 			Status: corev1.PodStatus{
 				Phase:             corev1.PodPending,
-				ContainerStatuses: []corev1.ContainerStatus{running, waiting},
+				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
 		next: withinLimit.Add(timeout),
@@ -187,7 +193,7 @@ func TestCheckPending(t *testing.T) {
 				InitContainerStatuses: []corev1.ContainerStatus{
 					terminatedOutside,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{running, waiting},
+				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
 		err: err,
@@ -199,7 +205,7 @@ func TestCheckPending(t *testing.T) {
 				InitContainerStatuses: []corev1.ContainerStatus{
 					terminatedWithin,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{running, waiting},
+				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
 		next: withinLimit.Add(timeout),
@@ -211,7 +217,7 @@ func TestCheckPending(t *testing.T) {
 				InitContainerStatuses: []corev1.ContainerStatus{
 					terminatedOutside,
 				},
-				ContainerStatuses: []corev1.ContainerStatus{running, waiting},
+				ContainerStatuses: []corev1.ContainerStatus{running, waiting0},
 			},
 		},
 		err: err,


### PR DESCRIPTION
The error message emitted when a pod stays pending for too long, while correct,
can be misleading, since it includes only the first container which failed the
verification.  E.g.:

```
INFO[2023-06-06T02:21:07Z] pod pending for more than 30m0s: container "sidecar" has not started in 30m0.000680857s:
```

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-service-release-ocm-2.8-e2e-ai-operator-ztp-3masters-periodic/1665871399811551232#1:build-log.txt%3A105

These changes instead list all containers so that the message presents a more
accurate idea of the state of the pod.

Before:

```
* could not run steps: step pending failed: "pending" test steps failed: "pending" pod "pending-test" failed: pod pending for more than 1s: container "place-entrypoint" has not started in 1.000401108s:
```

After:

```
* could not run steps: step pending failed: "pending" test steps failed: "pending" pod "pending-test" failed: pod pending for more than 1s: containers have not started in 1.163234545s: cp-entrypoint-wrapper, place-entrypoint, sidecar, test:
```