### PR TITLE
`pod-scaler`: effectively undo e2e race fix to determine if it causes memory leak

### DIFF
--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -72,13 +72,9 @@ func (c *cacheReloader) reload() {
 		return
 	}
 	c.lock.Lock()
-	if len(c.subscribers) > 0 {
-		c.lastUpdated = lastUpdated
-		for _, subscriber := range c.subscribers {
-			subscriber <- data
-		}
-	} else {
-		logger.Warn("no subscribers yet, won't mark as loaded")
+	c.lastUpdated = lastUpdated
+	for _, subscriber := range c.subscribers {
+		subscriber <- data
 	}
 	c.lock.Unlock()
 	logger.Debug("Newer update loaded.")
@@ -93,10 +89,6 @@ func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, 
 	}
 	logger.Debugf("digesting %d infos.", len(infos))
 	loadDone := digest(logger, infos...)
-	// Now that the initial subscriptions are completed, lets make sure they are updated
-	for _, info := range infos {
-		info.data.reload()
-	}
 	interrupts.Run(func(ctx context.Context) {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
It appears there is some memory leak causing the `pod-scaler` admission controller and ui to have a very large amount of memory used in the `inactive_anon` category. I have a hunch that it might be due to a change I made a long time ago in: https://github.com/openshift/ci-tools/pull/2883 to attempt to fix a race that only occurred in the e2e tests. I want to verify this by effectively reverting the change. If this is the cause I will come up with a different way to solve the race issue in the e2e tests.