### PR TITLE
TRT-1071: Honor MasterNodesUpdated flag when present for aggregated d…

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -27,10 +27,10 @@ type AggregationJobClient interface {
 	GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error)
 
 	// GetBackendDisruptionRowCountByJob gets the row count for disruption data for one job
-	GetBackendDisruptionRowCountByJob(ctx context.Context, jobName string) (uint64, error)
+	GetBackendDisruptionRowCountByJob(ctx context.Context, jobName, masterNodesUpdated string) (uint64, error)
 
 	// GetBackendDisruptionStatisticsByJob gets the mean and p95 disruption per backend from the week from 10 days ago.
-	GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error)
+	GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName, masterNodesUpdated string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error)
 
 	ListAggregatedTestRunsForJob(ctx context.Context, frequency, jobName string, startDay time.Time) ([]jobrunaggregatorapi.AggregatedTestRunRow, error)
 }
@@ -340,8 +340,21 @@ func (c *ciDataClient) ListProwJobRunsSince(ctx context.Context, since *time.Tim
 	return jobRuns, nil
 }
 
-func (c *ciDataClient) GetBackendDisruptionRowCountByJob(ctx context.Context, jobName string) (uint64, error) {
-	queryString := c.dataCoordinates.SubstituteDataSetLocation(`
+func buildMasterNodesUpdatedSQL(masterNodesUpdated string) string {
+	// pass in masterNodesUpdated flag
+	// empty string omits the condition for the preflag data / unable to determine
+	// or we look for the relevant N or Y
+	masterNodesUpdatedSQL := ""
+
+	if len(masterNodesUpdated) > 0 {
+		masterNodesUpdatedSQL = fmt.Sprintf("AND MasterNodesUpdated = '%s'", masterNodesUpdated)
+	}
+
+	return masterNodesUpdatedSQL
+}
+
+func (c *ciDataClient) GetBackendDisruptionRowCountByJob(ctx context.Context, jobName, masterNodesUpdated string) (uint64, error) {
+	queryString := c.dataCoordinates.SubstituteDataSetLocation(fmt.Sprintf(`
 SELECT Count(Name) AS TotalRows
 FROM
 	DATA_SET_LOCATION.BackendDisruption_JobRuns
@@ -349,7 +362,7 @@ WHERE
     StartTime <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
 AND
 	JobName = @JobName
-`)
+%s`, buildMasterNodesUpdatedSQL(masterNodesUpdated)))
 
 	query := c.client.Query(queryString)
 	query.QueryConfig.Parameters = []bigquery.QueryParameter{
@@ -371,10 +384,11 @@ AND
 	return uint64(rowCount.TotalRows), nil
 }
 
-func (c *ciDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
+func (c *ciDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName, masterNodesUpdated string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
 	rows := make([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, 0)
+	masterNodesUpdatedSQL := buildMasterNodesUpdatedSQL(masterNodesUpdated)
 
-	queryString := c.dataCoordinates.SubstituteDataSetLocation(`
+	queryString := c.dataCoordinates.SubstituteDataSetLocation(fmt.Sprintf(`
 SELECT
     p95.BackendName,
     P95.P1,
@@ -693,6 +707,7 @@ FROM
                     TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
                 AND
                     JobRuns.JobName = @JobName
+                %s
             )
             GROUP BY
                 BackendName
@@ -713,12 +728,13 @@ LEFT JOIN
                 TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
             AND
                 JobRuns.JobName = @JobName
+            %s
             GROUP BY
                 BackendName
       ) mean
 ON
     (p95.BackendName = mean.BackendName)
-`)
+`, masterNodesUpdatedSQL, masterNodesUpdatedSQL))
 	query := c.client.Query(queryString)
 	query.QueryConfig.Parameters = []bigquery.QueryParameter{
 		{Name: "JobName", Value: jobName},

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -26,21 +26,21 @@ func NewRetryingCIDataClient(delegate CIDataClient) CIDataClient {
 	}
 }
 
-func (c *retryingCIDataClient) GetBackendDisruptionRowCountByJob(ctx context.Context, jobName string) (uint64, error) {
+func (c *retryingCIDataClient) GetBackendDisruptionRowCountByJob(ctx context.Context, jobName, masterNodesUpdated string) (uint64, error) {
 	var ret uint64
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
-		ret, innerErr = c.delegate.GetBackendDisruptionRowCountByJob(ctx, jobName)
+		ret, innerErr = c.delegate.GetBackendDisruptionRowCountByJob(ctx, jobName, masterNodesUpdated)
 		return innerErr
 	})
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
+func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.Context, jobName, masterNodesUpdated string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
 	var ret []jobrunaggregatorapi.BackendDisruptionStatisticsRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
-		ret, innerErr = c.delegate.GetBackendDisruptionStatisticsByJob(ctx, jobName)
+		ret, innerErr = c.delegate.GetBackendDisruptionStatisticsByJob(ctx, jobName, masterNodesUpdated)
 		return innerErr
 	})
 	return ret, err

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -41,33 +41,33 @@ func (m *MockCIDataClient) EXPECT() *MockCIDataClientMockRecorder {
 }
 
 // GetBackendDisruptionRowCountByJob mocks base method.
-func (m *MockCIDataClient) GetBackendDisruptionRowCountByJob(arg0 context.Context, arg1 string) (uint64, error) {
+func (m *MockCIDataClient) GetBackendDisruptionRowCountByJob(arg0 context.Context, arg1, arg2 string) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackendDisruptionRowCountByJob", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetBackendDisruptionRowCountByJob", arg0, arg1, arg2)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBackendDisruptionRowCountByJob indicates an expected call of GetBackendDisruptionRowCountByJob.
-func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionRowCountByJob(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionRowCountByJob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendDisruptionRowCountByJob", reflect.TypeOf((*MockCIDataClient)(nil).GetBackendDisruptionRowCountByJob), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendDisruptionRowCountByJob", reflect.TypeOf((*MockCIDataClient)(nil).GetBackendDisruptionRowCountByJob), arg0, arg1, arg2)
 }
 
 // GetBackendDisruptionStatisticsByJob mocks base method.
-func (m *MockCIDataClient) GetBackendDisruptionStatisticsByJob(arg0 context.Context, arg1 string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
+func (m *MockCIDataClient) GetBackendDisruptionStatisticsByJob(arg0 context.Context, arg1, arg2 string) ([]jobrunaggregatorapi.BackendDisruptionStatisticsRow, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackendDisruptionStatisticsByJob", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetBackendDisruptionStatisticsByJob", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]jobrunaggregatorapi.BackendDisruptionStatisticsRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBackendDisruptionStatisticsByJob indicates an expected call of GetBackendDisruptionStatisticsByJob.
-func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionStatisticsByJob(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionStatisticsByJob(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendDisruptionStatisticsByJob", reflect.TypeOf((*MockCIDataClient)(nil).GetBackendDisruptionStatisticsByJob), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendDisruptionStatisticsByJob", reflect.TypeOf((*MockCIDataClient)(nil).GetBackendDisruptionStatisticsByJob), arg0, arg1, arg2)
 }
 
 // GetJobRunForJobNameAfterTime mocks base method.


### PR DESCRIPTION
Looks for the MasterNodesUpdated flag in the JobRun(s) cluster-data json file

If present includes the Y / N value in the where clause for aggregated disruption queries

If not present it is a noop and no additional where clause is added

Intention is to produce better aggregation disruption backstop data by comparing current run data to job runs that went through a similar path