### PR TITLE
Add workaround for https://github.com/webpack/webpack/issues/14532

### DIFF
--- a/cmd/pod-scaler/frontend/.npmrc
+++ b/cmd/pod-scaler/frontend/.npmrc
@@ -1,2 +1,1 @@
 node-options="--openssl-legacy-provider"
-engine-strict=true


### PR DESCRIPTION
Unable to build with the new `centos:9` build root. The following error is present:
```
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:130:10)
    at BulkUpdateDecorator.hashFactory (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/util/createHash.js:145:18)
    at BulkUpdateDecorator.update (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/util/createHash.js:46:50)
    at SourceMapSource.updateHash (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/node_modules/webpack-sources/lib/SourceMapSource.js:231:8)
    at NormalModule._initBuildHash (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/NormalModule.js:874:17)
    at handleParseResult (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/NormalModule.js:940:10)
    at /go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/NormalModule.js:1032:4
    at processResult (/go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/NormalModule.js:749:11)
    at /go/src/github.com/openshift/ci-tools/cmd/pod-scaler/frontend/node_modules/webpack/lib/NormalModule.js:813:5 {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
```

I tracked it down to https://github.com/webpack/webpack/issues/14532. adding this flag is one of the workarounds suggested there. Let's try it.