### PR TITLE
pkg/util: include time stamp in logged events

### DIFF
--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -587,10 +587,10 @@ func getEventsForPod(ctx context.Context, pod *corev1.Pod, client ctrlruntimecli
 		logrus.WithError(err).Warn("Could not fetch events.")
 		return ""
 	}
-	builder := &strings.Builder{}
-	_, _ = builder.WriteString(fmt.Sprintf("Found %d events for Pod %s:", len(events.Items), pod.Name))
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Found %d events for Pod %s:", len(events.Items), pod.Name))
 	for _, event := range events.Items {
-		_, _ = builder.WriteString(fmt.Sprintf("\n* %dx %s: %s", event.Count, event.Source.Component, event.Message))
+		builder.WriteString(fmt.Sprintf("\n* %s %dx %s: %s", event.LastTimestamp.Format(time.RFC3339), event.Count, event.Source.Component, event.Message))
 	}
 	return builder.String()
 }


### PR DESCRIPTION
This makes it easier to determine which event is responsible when the pending
timeout expires:

```
INFO[2023-06-07T17:49:40Z] Running step pending-test.
INFO[2023-06-07T17:49:48Z] pod pending for more than 5s: containers have not started in 5.001088214s: test:
* Container test is not ready with reason ImagePullBackOff and message Back-off pulling image "image-registry.openshift-image-registry.svc:5000/bbguimaraes/stable:404"
Found 19 events for Pod pending-test:
* 0001-01-01T00:00:00Z 0x : Successfully assigned bbguimaraes/pending-test to ip-10-0-164-197.ec2.internal
* 2023-06-07T17:49:42Z 1x multus: Add eth0 [10.129.18.96/23] from openshift-sdn
* 2023-06-07T17:49:42Z 1x kubelet: Pulling image "registry.ci.openshift.org/ci/entrypoint:latest"
* 2023-06-07T17:49:42Z 1x kubelet: Successfully pulled image "registry.ci.openshift.org/ci/entrypoint:latest" in 114.507786ms (114.518736ms including waiting)
* 2023-06-07T17:49:42Z 1x kubelet: Created container place-entrypoint
* 2023-06-07T17:49:42Z 1x kubelet: Started container place-entrypoint
* 2023-06-07T17:49:43Z 1x kubelet: Pulling image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest"
* 2023-06-07T17:49:43Z 1x kubelet: Successfully pulled image "registry.ci.openshift.org/ci/entrypoint-wrapper:latest" in 51.213103ms (51.221923ms including waiting)
* 2023-06-07T17:49:43Z 1x kubelet: Created container cp-entrypoint-wrapper
* 2023-06-07T17:49:43Z 1x kubelet: Started container cp-entrypoint-wrapper
* 2023-06-07T17:49:44Z 1x kubelet: Pulling image "image-registry.openshift-image-registry.svc:5000/bbguimaraes/stable:404"
* 2023-06-07T17:49:44Z 1x kubelet: Failed to pull image "image-registry.openshift-image-registry.svc:5000/bbguimaraes/stable:404": rpc error: code = Unknown desc = reading manifest 404 in image-registry.openshift-image-registry.svc:5000/bbguimaraes/stable: manifest unknown
* 2023-06-07T17:49:44Z 1x kubelet: Error: ErrImagePull
* 2023-06-07T17:49:44Z 1x kubelet: Pulling image "registry.ci.openshift.org/ci/sidecar:latest"
* 2023-06-07T17:49:44Z 1x kubelet: Successfully pulled image "registry.ci.openshift.org/ci/sidecar:latest" in 162.152625ms (162.158915ms including waiting)
* 2023-06-07T17:49:44Z 1x kubelet: Created container sidecar
* 2023-06-07T17:49:44Z 1x kubelet: Started container sidecar
* 2023-06-07T17:49:46Z 2x kubelet: Back-off pulling image "image-registry.openshift-image-registry.svc:5000/bbguimaraes/stable:404"
* 2023-06-07T17:49:46Z 2x kubelet: Error: ImagePullBackOff
```

As mentioned in eef1137f3a45567b36ba0b7c8507c608bcc91b9a, the same information
is present in the artifacts, but is included here for convenience.

https://issues.redhat.com/browse/DPTP-3473