### PR TITLE
Remove duplicated mirror upon tag_by_commit

### DIFF
--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -570,6 +570,14 @@ func TestGetPromotionPod(t *testing.T) {
 			},
 			namespace: "ci-op-zyvwvffx",
 		},
+		{
+			name: "tag_by_commit is true",
+			imageMirror: map[string]string{
+				"registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:latest":                                   "registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a",
+				"registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:a2a9ab5a9df0024caa4b40eac7464d065ce9547e": "registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a",
+			},
+			namespace: "ci-op-9bdij1f6",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_tag_by_commit_is_true.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_tag_by_commit_is_true.yaml
@@ -1,0 +1,29 @@
+metadata:
+  creationTimestamp: null
+  name: promotion
+  namespace: ci-op-9bdij1f6
+spec:
+  containers:
+  - args:
+    - oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true
+      --max-per-registry=20 registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a=quay.io/openshift/ci:20230605_sha256_61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a
+      registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a=quay.io/openshift/ci:openstack-k8s-operators_ci-framework-image_a2a9ab5a9df0024caa4b40eac7464d065ce9547e
+      registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a=registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:a2a9ab5a9df0024caa4b40eac7464d065ce9547e
+      registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a=quay.io/openshift/ci:openstack-k8s-operators_ci-framework-image_latest
+      registry.build03.ci.openshift.org/ci-op-9bdij1f6/pipeline@sha256:61f8d86d5ebe135e37c547144978d66c1c6cd30f3034df1bae81d0fe3d4b073a=registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:latest
+    command:
+    - /bin/sh
+    - -c
+    image: registry.ci.openshift.org/ocp/4.12:cli
+    name: promotion
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/push-secret
+      name: push-secret
+      readOnly: true
+  restartPolicy: Never
+  volumes:
+  - name: push-secret
+    secret:
+      secretName: registry-push-credentials-ci-central
+status: {}


### PR DESCRIPTION
Reported by @cjeanner 

https://redhat-internal.slack.com/archives/CBN38N3MW/p1686661568593859?thread_ts=1686658797.038549&cid=CBN38N3MW

```
INFO[2023-06-13T14:00:29Z] Logs for container promotion in pod promotion: 
INFO[[20](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-openstack-k8s-operators-ci-framework-main-images/1668618533803659264#1:build-log.txt%3A20)23-06-13T14:00:29Z] error: each destination tag may only be specified once: quay.io/openshift/ci:20230613_sha256_285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18 
INFO[2023-06-13T14:00:31Z] Ran for 3m10s
```

With the promotion pod:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/branch-ci-openstack-k8s-operators-ci-framework-main-images/1668618533803659264/artifacts/build-resources/pods.json
```
oc image mirror --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true --max-per-registry=20 registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=quay.io/openshift/ci:20230613_sha256_285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18 registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=quay.io/openshift/ci:openstack-k8s-operators_ci-framework-image_2e0a707f1da50299e09f19d6a4da355fa721c080 registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:2e0a707f1da50299e09f19d6a4da355fa721c080 registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=quay.io/openshift/ci:20230613_sha256_285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18 registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=quay.io/openshift/ci:openstack-k8s-operators_ci-framework-image_latest registry.build03.ci.openshift.org/ci-op-9jzfzvf7/pipeline@sha256:285bb49158ee4149465db685334cf3ce10f2da71a17994405a8eef67b46c7e18=registry.ci.openshift.org/openstack-k8s-operators/ci-framework-image:latest
```