### PR TITLE
reduce job run query size

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -69,8 +69,8 @@ func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context)
 }
 
 func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
-	// if it hasn't been more than hour since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(1 * time.Hour)
+	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
+	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -46,7 +46,7 @@ type JobRunAggregatorAnalyzerOptions struct {
 func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	errorsInARow := 0
 	for {
-		jobsToAggregate, err := o.jobRunLocator.FindRelatedJobs(ctx)
+		jobsToAggregate, err := o.jobRunLocator.FindRelatedJobRuns(ctx)
 		if err == nil {
 			return jobsToAggregate, nil
 		}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -864,6 +864,7 @@ func (it *UnifiedTestRunRowIterator) Next() (*jobrunaggregatorapi.UnifiedTestRun
 }
 
 func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
+	logrus.Info("called GetJobRunForJobNameBeforeTime")
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
 		`SELECT Name
 FROM DATA_SET_LOCATION.JobRuns
@@ -894,6 +895,7 @@ LIMIT 1
 }
 
 func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
+	logrus.Info("called GetJobRunForJobNameAfterTime")
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
 		`SELECT Name
 FROM DATA_SET_LOCATION.JobRuns

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -20,11 +20,11 @@ type AggregationJobClient interface {
 	// GetJobRunForJobNameBeforeTime returns the jobRun closest to, but BEFORE, the time provided.
 	// This is useful for bounding a query of GCS buckets in a window.
 	// nil means that no jobRun was found before the specified time.
-	GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error)
+	GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error)
 	// GetJobRunForJobNameAfterTime returns the jobRun closest to, but AFTER, the time provided.
 	// This is useful for bounding a query of GCS buckets in a window.
 	// nil means that no jobRun as found after the specified time.
-	GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error)
+	GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error)
 
 	// GetBackendDisruptionRowCountByJob gets the row count for disruption data for one job
 	GetBackendDisruptionRowCountByJob(ctx context.Context, jobName, masterNodesUpdated string) (uint64, error)
@@ -863,7 +863,7 @@ func (it *UnifiedTestRunRowIterator) Next() (*jobrunaggregatorapi.UnifiedTestRun
 	return ret, nil
 }
 
-func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
 		`SELECT *
 FROM DATA_SET_LOCATION.JobRuns
@@ -879,21 +879,21 @@ LIMIT 1
 	}
 	rowIterator, err := query.Read(ctx)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	ret := &jobrunaggregatorapi.JobRunRow{}
 	err = rowIterator.Next(ret)
 	if err == iterator.Done {
-		return nil, nil
+		return "", nil
 	}
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return ret, nil
+	return ret.Name, nil
 }
 
-func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
 		`SELECT *
 FROM DATA_SET_LOCATION.JobRuns
@@ -909,18 +909,18 @@ LIMIT 1
 	}
 	rowIterator, err := query.Read(ctx)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	ret := &jobrunaggregatorapi.JobRunRow{}
 	err = rowIterator.Next(ret)
 	if err == iterator.Done {
-		return nil, nil
+		return "", nil
 	}
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	return ret, nil
+	return ret.Name, nil
 }
 
 func (c *ciDataClient) ListAggregatedTestRunsForJob(ctx context.Context, frequency, jobName string, startDay time.Time) ([]jobrunaggregatorapi.AggregatedTestRunRow, error) {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -865,7 +865,7 @@ func (it *UnifiedTestRunRowIterator) Next() (*jobrunaggregatorapi.UnifiedTestRun
 
 func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
-		`SELECT *
+		`SELECT Name
 FROM DATA_SET_LOCATION.JobRuns
 WHERE JobRuns.StartTime <= @TimeCutOff and JobRuns.JobName = @JobName
 ORDER BY JobRuns.StartTime DESC
@@ -895,7 +895,7 @@ LIMIT 1
 
 func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
-		`SELECT *
+		`SELECT Name
 FROM DATA_SET_LOCATION.JobRuns
 WHERE JobRuns.StartTime >= @TimeCutOff and JobRuns.JobName = @JobName
 ORDER BY JobRuns.StartTime ASC

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -24,7 +24,7 @@ var (
 )
 
 type JobRunLocator interface {
-	FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
+	FindRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
 }
 
 type prowJobMatcherFunc func(prowJob *prowjobv1.ProwJob) bool
@@ -66,9 +66,9 @@ func NewPayloadAnalysisJobLocator(
 	}
 }
 
-// FindRelatedJobs returns a slice of JobRunInfo which has info contained in GCS buckets
+// FindRelatedJobRuns returns a slice of JobRunInfo which has info contained in GCS buckets
 // used to determine pass/fail.
-func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
+func (a *analysisJobAggregator) FindRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	startOfJobRunWindow := a.startTime.Add(-1 * JobSearchWindowStartOffset)
 	endOfJobRunWindow := a.startTime.Add(JobSearchWindowEndOffset)
 	startingJobRun, err := a.ciDataClient.GetJobRunForJobNameBeforeTime(ctx, a.jobName, startOfJobRunWindow)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -94,15 +94,15 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
 		return nil, err
 	}
-	if startingJobRun == nil {
+	if startingJobRun == "" {
 		// For debugging, you can set this to a jobID that is not that far away from
 		// jobs related to what you are trying to aggregate.
 		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, "0")
 	} else {
-		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, startingJobRun.Name)
+		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, startingJobRun)
 	}
-	if endingJobRun != nil {
-		query.EndOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, endingJobRun.Name)
+	if endingJobRun != "" {
+		query.EndOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, endingJobRun)
 	}
 	fmt.Printf("  starting from %v, ending at %q\n", query.StartOffset, query.EndOffset)
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -116,8 +116,8 @@ func (c *retryingCIDataClient) ListReleaseTags(ctx context.Context) (sets.String
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
-	var ret *jobrunaggregatorapi.JobRunRow
+func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
+	var ret string
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.GetJobRunForJobNameBeforeTime(ctx, jobName, targetTime)
@@ -126,8 +126,8 @@ func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
-	var ret *jobrunaggregatorapi.JobRunRow
+func (c *retryingCIDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
+	var ret string
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.GetJobRunForJobNameAfterTime(ctx, jobName, targetTime)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -108,7 +108,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		if len(unfinishedJobRunNames) > 0 {
 			fmt.Printf("found %d unfinished related jobRuns: %v\n", len(unfinishedJobRunNames), strings.Join(unfinishedJobRunNames, ", "))
 			select {
-			case <-time.After(2 * time.Minute):
+			case <-time.After(10 * time.Minute):
 				continue
 			case <-ctx.Done():
 				return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, ctx.Err()

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -45,11 +45,6 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	variantInfo string) ([]jobrunaggregatorapi.JobRunInfo, []jobrunaggregatorapi.JobRunInfo, []string, []string, error) {
 	clock := clock.RealClock{}
 
-	// Polling involves some queries that can add up to substantial costs, there's little
-	// point as we have no jobs running in under 2 hours.
-	fmt.Println("waiting 2h for sub-jobs to complete before we start polling")
-	time.Sleep(2 * time.Hour)
-
 	var finishedJobRuns []jobrunaggregatorapi.JobRunInfo
 	var finishedJobRunNames []string
 	var unfinishedJobRuns []jobrunaggregatorapi.JobRunInfo

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -45,6 +45,11 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	variantInfo string) ([]jobrunaggregatorapi.JobRunInfo, []jobrunaggregatorapi.JobRunInfo, []string, []string, error) {
 	clock := clock.RealClock{}
 
+	// Polling involves some queries that can add up to substantial costs, there's little
+	// point as we have no jobs running in under 2 hours.
+	fmt.Println("waiting 2h for sub-jobs to complete before we start polling")
+	time.Sleep(2 * time.Hour)
+
 	var finishedJobRuns []jobrunaggregatorapi.JobRunInfo
 	var finishedJobRunNames []string
 	var unfinishedJobRuns []jobrunaggregatorapi.JobRunInfo

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -481,8 +481,8 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("error creating output directory %q: %w", outputDir, err)
 	}
 
-	// if it hasn't been more than hour since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(1 * time.Hour)
+	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
+	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
 
 	durationToWait := o.timeout - 20*time.Minute
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -349,7 +349,7 @@ func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context
 	jobName string, jobRunLocator jobrunaggregatorlib.JobRunLocator) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	errorsInARow := 0
 	for {
-		jobRuns, err := jobRunLocator.FindRelatedJobs(ctx)
+		jobRuns, err := jobRunLocator.FindRelatedJobRuns(ctx)
 		if err != nil {
 			if errorsInARow > 20 {
 				fmt.Printf("give up finding job runs for %s after retries: %v", jobName, err)
@@ -372,9 +372,10 @@ func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context
 	}
 }
 
-// GetRelatedJobRuns gets all related job runs for analysis
+// GetRelatedJobRuns gets all related job runs for analysis which are associated with this payload.
 func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRunsToReturn []jobrunaggregatorapi.JobRunInfo
+
 	jobs, err := o.jobGetter.GetJobs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get related jobs: %w", err)

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -10,9 +10,11 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
+	sets "k8s.io/apimachinery/pkg/util/sets"
+
 	jobrunaggregatorapi "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	jobrunaggregatorlib "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
-	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockCIDataClient is a mock of CIDataClient interface.

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -10,11 +10,9 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-
-	sets "k8s.io/apimachinery/pkg/util/sets"
-
 	jobrunaggregatorapi "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	jobrunaggregatorlib "github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockCIDataClient is a mock of CIDataClient interface.
@@ -71,10 +69,10 @@ func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionStatisticsByJob(arg0
 }
 
 // GetJobRunForJobNameAfterTime mocks base method.
-func (m *MockCIDataClient) GetJobRunForJobNameAfterTime(arg0 context.Context, arg1 string, arg2 time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+func (m *MockCIDataClient) GetJobRunForJobNameAfterTime(arg0 context.Context, arg1 string, arg2 time.Time) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobRunForJobNameAfterTime", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -86,10 +84,10 @@ func (mr *MockCIDataClientMockRecorder) GetJobRunForJobNameAfterTime(arg0, arg1,
 }
 
 // GetJobRunForJobNameBeforeTime mocks base method.
-func (m *MockCIDataClient) GetJobRunForJobNameBeforeTime(arg0 context.Context, arg1 string, arg2 time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+func (m *MockCIDataClient) GetJobRunForJobNameBeforeTime(arg0 context.Context, arg1 string, arg2 time.Time) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobRunForJobNameBeforeTime", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Discovered the involved queries are running 380k a day, and while small, adding up to processing almost 40TB daily.

- Only select the job run name when querying before/after time. (50%)
- Poll every 10 min for aggregated jobs to finish instead of 2 (80%)
- Wait 2 hours before beginning to poll for aggregated sub-job completion (50-75%)

Reductions should pile onto one another, this may cut costs dramatically.
