### PR TITLE
Revert "reduce job run query size"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -46,7 +46,7 @@ type JobRunAggregatorAnalyzerOptions struct {
 func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	errorsInARow := 0
 	for {
-		jobsToAggregate, err := o.jobRunLocator.FindRelatedJobRuns(ctx)
+		jobsToAggregate, err := o.jobRunLocator.FindRelatedJobs(ctx)
 		if err == nil {
 			return jobsToAggregate, nil
 		}
@@ -69,8 +69,8 @@ func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context)
 }
 
 func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
-	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
+	// if it hasn't been more than hour since the jobRuns started, the list isn't complete.
+	readyAt := o.jobRunStartEstimate.Add(1 * time.Hour)
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -20,11 +20,11 @@ type AggregationJobClient interface {
 	// GetJobRunForJobNameBeforeTime returns the jobRun closest to, but BEFORE, the time provided.
 	// This is useful for bounding a query of GCS buckets in a window.
 	// nil means that no jobRun was found before the specified time.
-	GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error)
+	GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error)
 	// GetJobRunForJobNameAfterTime returns the jobRun closest to, but AFTER, the time provided.
 	// This is useful for bounding a query of GCS buckets in a window.
 	// nil means that no jobRun as found after the specified time.
-	GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error)
+	GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error)
 
 	// GetBackendDisruptionRowCountByJob gets the row count for disruption data for one job
 	GetBackendDisruptionRowCountByJob(ctx context.Context, jobName, masterNodesUpdated string) (uint64, error)
@@ -863,10 +863,9 @@ func (it *UnifiedTestRunRowIterator) Next() (*jobrunaggregatorapi.UnifiedTestRun
 	return ret, nil
 }
 
-func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
-	logrus.Info("called GetJobRunForJobNameBeforeTime")
+func (c *ciDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
-		`SELECT Name
+		`SELECT *
 FROM DATA_SET_LOCATION.JobRuns
 WHERE JobRuns.StartTime <= @TimeCutOff and JobRuns.JobName = @JobName
 ORDER BY JobRuns.StartTime DESC
@@ -880,24 +879,23 @@ LIMIT 1
 	}
 	rowIterator, err := query.Read(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ret := &jobrunaggregatorapi.JobRunRow{}
 	err = rowIterator.Next(ret)
 	if err == iterator.Done {
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return ret.Name, nil
+	return ret, nil
 }
 
-func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
-	logrus.Info("called GetJobRunForJobNameAfterTime")
+func (c *ciDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(
-		`SELECT Name
+		`SELECT *
 FROM DATA_SET_LOCATION.JobRuns
 WHERE JobRuns.StartTime >= @TimeCutOff and JobRuns.JobName = @JobName
 ORDER BY JobRuns.StartTime ASC
@@ -911,18 +909,18 @@ LIMIT 1
 	}
 	rowIterator, err := query.Read(ctx)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ret := &jobrunaggregatorapi.JobRunRow{}
 	err = rowIterator.Next(ret)
 	if err == iterator.Done {
-		return "", nil
+		return nil, nil
 	}
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return ret.Name, nil
+	return ret, nil
 }
 
 func (c *ciDataClient) ListAggregatedTestRunsForJob(ctx context.Context, frequency, jobName string, startDay time.Time) ([]jobrunaggregatorapi.AggregatedTestRunRow, error) {

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -24,7 +24,7 @@ var (
 )
 
 type JobRunLocator interface {
-	FindRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
+	FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
 }
 
 type prowJobMatcherFunc func(prowJob *prowjobv1.ProwJob) bool
@@ -66,9 +66,9 @@ func NewPayloadAnalysisJobLocator(
 	}
 }
 
-// FindRelatedJobRuns returns a slice of JobRunInfo which has info contained in GCS buckets
+// FindRelatedJobs returns a slice of JobRunInfo which has info contained in GCS buckets
 // used to determine pass/fail.
-func (a *analysisJobAggregator) FindRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
+func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	startOfJobRunWindow := a.startTime.Add(-1 * JobSearchWindowStartOffset)
 	endOfJobRunWindow := a.startTime.Add(JobSearchWindowEndOffset)
 	startingJobRun, err := a.ciDataClient.GetJobRunForJobNameBeforeTime(ctx, a.jobName, startOfJobRunWindow)
@@ -94,15 +94,15 @@ func (a *analysisJobAggregator) FindRelatedJobRuns(ctx context.Context) ([]jobru
 	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
 		return nil, err
 	}
-	if startingJobRun == "" {
+	if startingJobRun == nil {
 		// For debugging, you can set this to a jobID that is not that far away from
 		// jobs related to what you are trying to aggregate.
 		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, "0")
 	} else {
-		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, startingJobRun)
+		query.StartOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, startingJobRun.Name)
 	}
-	if endingJobRun != "" {
-		query.EndOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, endingJobRun)
+	if endingJobRun != nil {
+		query.EndOffset = fmt.Sprintf("%s/%s", a.gcsPrefix, endingJobRun.Name)
 	}
 	fmt.Printf("  starting from %v, ending at %q\n", query.StartOffset, query.EndOffset)
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -116,8 +116,8 @@ func (c *retryingCIDataClient) ListReleaseTags(ctx context.Context) (sets.String
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
-	var ret string
+func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.GetJobRunForJobNameBeforeTime(ctx, jobName, targetTime)
@@ -126,8 +126,8 @@ func (c *retryingCIDataClient) GetJobRunForJobNameBeforeTime(ctx context.Context
 	return ret, err
 }
 
-func (c *retryingCIDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (string, error) {
-	var ret string
+func (c *retryingCIDataClient) GetJobRunForJobNameAfterTime(ctx context.Context, jobName string, targetTime time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
+	var ret *jobrunaggregatorapi.JobRunRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.GetJobRunForJobNameAfterTime(ctx, jobName, targetTime)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -45,14 +45,6 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	variantInfo string) ([]jobrunaggregatorapi.JobRunInfo, []jobrunaggregatorapi.JobRunInfo, []string, []string, error) {
 	clock := clock.RealClock{}
 
-	// We only look up related job runs once, we've already waiting hours before reaching this
-	// point so all our payload jobs should have been launched by now.
-	// This can get expensive as it presently has to look at all jobs we know about, all runs in the time window, and
-	// check each runs prowjob.json to see if it's associated with the payload we're interested. Doing it within the
-	// for loop was very expensive.
-	// TODO: could optimize here by querying from https://prow.ci.openshift.org/prowjobs.js instead of all the rest.
-	relatedJobRuns, err := jobRunGetter.GetRelatedJobRuns(ctx)
-
 	var finishedJobRuns []jobrunaggregatorapi.JobRunInfo
 	var finishedJobRunNames []string
 	var unfinishedJobRuns []jobrunaggregatorapi.JobRunInfo
@@ -64,6 +56,8 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		unfinishedJobRuns = []jobrunaggregatorapi.JobRunInfo{}
 		finishedJobRunNames = []string{}
 		unfinishedJobRunNames = []string{}
+
+		relatedJobRuns, err := jobRunGetter.GetRelatedJobRuns(ctx)
 
 		if err != nil {
 			return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
@@ -114,7 +108,7 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 		if len(unfinishedJobRunNames) > 0 {
 			fmt.Printf("found %d unfinished related jobRuns: %v\n", len(unfinishedJobRunNames), strings.Join(unfinishedJobRunNames, ", "))
 			select {
-			case <-time.After(10 * time.Minute):
+			case <-time.After(2 * time.Minute):
 				continue
 			case <-ctx.Done():
 				return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, ctx.Err()

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -349,7 +349,7 @@ func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context
 	jobName string, jobRunLocator jobrunaggregatorlib.JobRunLocator) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	errorsInARow := 0
 	for {
-		jobRuns, err := jobRunLocator.FindRelatedJobRuns(ctx)
+		jobRuns, err := jobRunLocator.FindRelatedJobs(ctx)
 		if err != nil {
 			if errorsInARow > 20 {
 				fmt.Printf("give up finding job runs for %s after retries: %v", jobName, err)
@@ -372,10 +372,9 @@ func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context
 	}
 }
 
-// GetRelatedJobRuns gets all related job runs for analysis which are associated with this payload.
+// GetRelatedJobRuns gets all related job runs for analysis
 func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRunsToReturn []jobrunaggregatorapi.JobRunInfo
-
 	jobs, err := o.jobGetter.GetJobs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get related jobs: %w", err)
@@ -482,8 +481,8 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 		return fmt.Errorf("error creating output directory %q: %w", outputDir, err)
 	}
 
-	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
+	// if it hasn't been more than hour since the jobRuns started, the list isn't complete.
+	readyAt := o.jobRunStartEstimate.Add(1 * time.Hour)
 
 	durationToWait := o.timeout - 20*time.Minute
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cidataclient_test.go
@@ -71,10 +71,10 @@ func (mr *MockCIDataClientMockRecorder) GetBackendDisruptionStatisticsByJob(arg0
 }
 
 // GetJobRunForJobNameAfterTime mocks base method.
-func (m *MockCIDataClient) GetJobRunForJobNameAfterTime(arg0 context.Context, arg1 string, arg2 time.Time) (string, error) {
+func (m *MockCIDataClient) GetJobRunForJobNameAfterTime(arg0 context.Context, arg1 string, arg2 time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobRunForJobNameAfterTime", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -86,10 +86,10 @@ func (mr *MockCIDataClientMockRecorder) GetJobRunForJobNameAfterTime(arg0, arg1,
 }
 
 // GetJobRunForJobNameBeforeTime mocks base method.
-func (m *MockCIDataClient) GetJobRunForJobNameBeforeTime(arg0 context.Context, arg1 string, arg2 time.Time) (string, error) {
+func (m *MockCIDataClient) GetJobRunForJobNameBeforeTime(arg0 context.Context, arg1 string, arg2 time.Time) (*jobrunaggregatorapi.JobRunRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobRunForJobNameBeforeTime", arg0, arg1, arg2)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(*jobrunaggregatorapi.JobRunRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Reverts openshift/ci-tools#3482

Observing aggregated jobs indicating they are not completing when they appear to have actually completed.

Putting up revert since this change is directly related to aggregated jobs.