### PR TITLE
multi-stage: properly name role binding

### DIFF
--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -141,9 +141,13 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 			Subjects:   subj,
 		},
 		{
-			ObjectMeta: meta.ObjectMeta{Namespace: ns, Name: "test-runner-view-binding", Labels: labels},
-			RoleRef:    rbacapi.RoleRef{Kind: "ClusterRole", Name: "view"},
-			Subjects:   subj,
+			ObjectMeta: meta.ObjectMeta{
+				Namespace: ns,
+				Name:      s.name + "-view",
+				Labels:    labels,
+			},
+			RoleRef:  rbacapi.RoleRef{Kind: "ClusterRole", Name: "view"},
+			Subjects: subj,
 		},
 	}
 	if s.vpnConf != nil {


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/1684 added an extra role binding to
the `ServiceAccount` used by each multi-stage test.  However, the name it uses
is not unique, meaning a single binding will be created (`util.CreateRBACs`
ignores already-existing bindings with the same name).

This problem went unnoticed for this long because the jobs which depend on this
functionality usually get their own namespace.  This was discovered while
investigating a test which abuses this (very abusable) mechanism to look at
parts of the temporary namespace it should have no business looking at:

https://redhat-internal.slack.com/archives/CBN38N3MW/p1687185233834439

While not meant to make that particular case work, this is a legitimate
correctness problem.