### PR TITLE
pkg/util: demote msg. to debug log when skipped

### DIFF
--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -538,7 +538,13 @@ func podLogDeletion(
 	if IsBitSet(flags, Interruptible) {
 		logrus.Debugf("Pod %s is being deleted as expected", pod.Name)
 	} else {
-		logrus.Warningf("Pod %s is being unexpectedly deleted:\n%s", pod.Name, getEventsForPod(ctx, &pod, podClient))
+		var f func(string, ...interface{})
+		if IsBitSet(flags, SkipLogs) {
+			f = logrus.Debugf
+		} else {
+			f = logrus.Warningf
+		}
+		f("Pod %s is being unexpectedly deleted:\n%s", pod.Name, getEventsForPod(ctx, &pod, podClient))
 	}
 }
 

--- a/pkg/util/pods.go
+++ b/pkg/util/pods.go
@@ -207,13 +207,7 @@ func processPodEvent(
 	}
 	skipLogs := IsBitSet(flags, SkipLogs)
 	podLogNewFailedContainers(podClient, pod, completed, notifier, skipLogs)
-	if pod.DeletionTimestamp != nil {
-		if IsBitSet(flags, Interruptible) {
-			logrus.Debugf("Pod %s is being deleted as expected", pod.Name)
-		} else {
-			logrus.Warningf("Pod %s is being unexpectedly deleted:\n%s", pod.Name, getEventsForPod(ctx, pod, podClient))
-		}
-	}
+	podLogDeletion(ctx, podClient, flags, *pod)
 	if podJobIsOK(pod) {
 		if !skipLogs {
 			logrus.Debugf("Pod %s succeeded after %s", pod.Name, podDuration(pod).Truncate(time.Second))
@@ -534,6 +528,22 @@ func podLogNewFailedContainers(podClient kubernetes.PodClient, pod *corev1.Pod, 
 	// if there are no running containers and we're in a terminal state, mark the pod complete
 	if (pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded) && len(podRunningContainers(pod)) == 0 {
 		notifier.Complete(pod.Name)
+	}
+}
+
+func podLogDeletion(
+	ctx context.Context,
+	podClient kubernetes.PodClient,
+	flags WaitForPodFlag,
+	pod corev1.Pod,
+) {
+	if pod.DeletionTimestamp == nil {
+		return
+	}
+	if IsBitSet(flags, Interruptible) {
+		logrus.Debugf("Pod %s is being deleted as expected", pod.Name)
+	} else {
+		logrus.Warningf("Pod %s is being unexpectedly deleted:\n%s", pod.Name, getEventsForPod(ctx, &pod, podClient))
 	}
 }
 


### PR DESCRIPTION
As introduction, `SkipLogs` is used by the implementation of some steps when
they require a pod in the test namespace to perform some action.  This is the
case for:

- promotion
- release image import
- release image creation

Note that in the case of the latter two, a single pod is created and potentially
watched by several `ci-operator` instances.

---

These changes are motivated by search results for pods which are unexpectedly
deleted showing primarily `release-*` pods:

https://search.ci.openshift.org/?type=build-log&name=&excludeName=&maxAge=24h&maxMatches=5&maxBytes=20971520&groupBy=job&context=1&search=pod+.%2A+is+being+unexpectedly+deleted

The first hint as to what the cause is is that these are all aborted jobs (or
would be, if they hadn't failed due to this problem).  These happen when more
than one `ci-operator` instance is waiting for the pod, which is the case when
they all want to import the same release into the same namespace.

When the jobs are aborted, the termination signal is sent to all `ci-operator`
instances.  One of them (unpredictably) will be the first to receive the signal
and will delete the pod as part of its interruption handling.  The others may
see either this deletion or the termination signal first.  The former will cause
them to emit the error.

This can be seen, for example, in the first (oldest) column for revision `
ac86d9a` in this pull request:

https://prow.ci.openshift.org/pr-history/?org=stackrox&repo=stackrox&pr=6532

These jobs first see the signal:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-13-operator-e2e-tests/1670736240829272064
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-13-core-bpf-qa-e2e-tests/1670736233224998912
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-13-sensor-integration-tests/1670736247519186944

While these see the deletion (initiated by one of the previous jobs) and fail:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-10-operator-e2e-tests/1670736230674862080
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-10-qa-e2e-tests/1670736230712610816
- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/stackrox_stackrox/6532/pull-ci-stackrox-stackrox-master-ocp-4-10-sensor-integration-tests/1670736231505334272

---

With these changes, the (user) logs in the same scenario are:

```
INFO[2023-06-20T12:29:57Z] Creating release image registry.build01.ci.openshift.org/bbguimaraes/release:latest.
INFO[2023-06-20T12:30:03Z] Received signal.                              signal=terminated
INFO[2023-06-20T12:30:05Z] error: Process interrupted with signal terminated, cancelling execution...
INFO[2023-06-20T12:30:05Z] cleanup: Deleting release pod release-latest
INFO[2023-06-20T12:30:05Z] Ran for 17s
ERRO[2023-06-20T12:30:05Z] Some steps failed:
ERRO[2023-06-20T12:30:05Z]
  * could not run steps: execution cancelled
  * could not run steps: step [release:latest] failed: release "release-latest" failed: could not watch pod: context canceled
```

for processes which see the interruption first and

```
INFO[2023-06-20T12:29:57Z] Creating release image registry.build01.ci.openshift.org/bbguimaraes/release:latest.
WARN[2023-06-20T12:30:21Z] error: Unable to retrieve logs from failed pod container release.  error=pods "release-latest" not found
INFO[2023-06-20T12:30:23Z] Ran for 35s
ERRO[2023-06-20T12:30:23Z] Some steps failed:
ERRO[2023-06-20T12:30:23Z]
  * could not run steps: step [release:latest] failed: release "release-latest" failed: could not watch pod: the pod bbguimaraes/release-latest failed after 23s (failed containers: release): ContainerFailed one or more containers exited

Container release exited with code 130, reason Error
---
bd3c65c153afc658cabe638636c35631557ed9 oc-mirror
info: Loading sha256:9323fb02c892fea0d831407174074e3ae8cf9ffa9ce0a855a8c2fe593c0026d2 operator-marketplace
info: Loading sha256:7b187148d957a9ca44e610314d301e773077186694a90d6420bd83dfd6c886a4 service-ca-operator
info: Loading sha256:8c730385700e7f98195fcd289609b0e67bf1021ff9f0d9d3f96c72944916f62d vsphere-problem-detector
info: Loading sha256:f96dc951288c2ba27b188ac3fbecb1c0202750f749636c6a03cdb9f84d6887cf vsphere-cluster-api-controllers
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:168","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Entrypoint received interrupt: terminated","severity":"error","time":"2023-06-20T12:30:05Z"}
info: Included 179 images from 60 input operators into the release
Warning: the default reading order of registry auth file will be changed from "${HOME}/.docker/config.json" to podman registry config locations in the future version. "${HOME}/.docker/config.json" is deprecated, but can still be used for storing credentials as a fallback. See https://github.com/containers/image/blob/main/docs/containers-auth.json.5.md for the order of podman registry config locations.
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:254","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15s grace period","severity":"error","time":"2023-06-20T12:30:20Z"}
{"component":"entrypoint","error":"os: process already finished","file":"k8s.io/test-infra/prow/entrypoint/run.go:256","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Could not kill process after grace period","severity":"error","time":"2023-06-20T12:30:20Z"}
{"component":"entrypoint","error":"process aborted","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2023-06-20T12:30:20Z"}
---
```

for pods which see the deletion first (and are not interrupted before finishing,
of course).  The debug log will contain the "unexpectedly deleted" error and the
events, in cases where the deletion has a different origin and needs to be
investigated.