### PR TITLE
`payload-testing`: One build for aggregate jobs

### DIFF
--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -130,8 +130,9 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-1
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=1
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:
@@ -208,8 +209,9 @@
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --input-hash=prpqr-test-0
+        - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
+        - --target-additional-suffix=0
         - --target=test-name
         - --with-test-from=test-org/test-repo@test-branch:test-name
         command:


### PR DESCRIPTION
Re-enable https://github.com/openshift/ci-tools/pull/3415. I have fixed the issue by adding a new `UNIQUE_HASH`: https://github.com/openshift/ci-tools/pull/3437, and utilizing it everywhere: https://github.com/openshift/release/pull/40229. 

For: https://issues.redhat.com/browse/DPTP-3310

This reverts commit 8980f0e1