### PR TITLE
Exclude new backends to avoid failing in aggregated jobs

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -17,8 +17,23 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 )
 
+// isExcludedDisruptionBackend returns true of any of the given backends are in the
+// disruption backend name.  Essentially, we want to skip testing of these disruption
+// backends for now as they run and gather more data.
 func isExcludedDisruptionBackend(name string) bool {
-	return strings.Contains(name, "ci-cluster-network-liveness")
+	excludedNames := []string{
+		"ci-cluster-network-liveness",
+		"kube-api-http1-external-lb",
+		"kube-api-http2-external-lb",
+		"openshift-api-http2-external-lb",
+	}
+
+	for _, excludedName := range excludedNames {
+		if strings.Contains(name, excludedName) {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx context.Context, jobGCSBucketRoot string, finishedJobsToAggregate []jobrunaggregatorapi.JobRunInfo, masterNodesUpdated string) (*junit.TestSuite, error) {


### PR DESCRIPTION
[TRT-1095](https://issues.redhat.com//browse/TRT-1095)

The new backends are enumerated in the [backend_disruption...json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-sdn-upgrade/1670859884670750720/artifacts/e2e-aws-sdn-upgrade/openshift-e2e-test/artifacts/junit/backend-disruption_20230619-190241.json) file and not present in the older backend_disruption...json files like [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.14-e2e-aws-sdn-upgrade/1666971942701240320/artifacts/e2e-aws-sdn-upgrade/openshift-e2e-test/artifacts/junit/backend-disruption_20230609-012950.json).

To get the list of new ones, I did this and compared current one with one before the new backends were added.

```bash
$ cat backend-disruption_20230619-190241.json |jq '.BackendDisruptions|keys[]'
```

Reference: the new backends were added in [these functions](https://github.com/openshift/origin/blob/820c58876441812f2704aaf39abd48a26d465901/test/extended/util/disruption/controlplane/known_backends.go#L285-L373).