### PR TITLE
Update the importReleaseStep to use the PreserveOriginal import mode

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -123,6 +123,9 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 						Kind: "DockerImage",
 						Name: s.pullSpec,
 					},
+					ImportPolicy: imagev1.TagImportPolicy{
+						ImportMode: imagev1.ImportModePreserveOriginal,
+					},
 					ReferencePolicy: imagev1.TagReferencePolicy{
 						Type: imagev1.LocalTagReferencePolicy,
 					},
@@ -266,6 +269,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 		for _, tag := range releaseIS.Spec.Tags {
 			existing.Insert(tag.Name)
 			tag.ReferencePolicy.Type = imagev1.LocalTagReferencePolicy
+			tag.ImportPolicy.ImportMode = imagev1.ImportModePreserveOriginal
 			tags = append(tags, tag)
 		}
 		for _, tag := range stable.Spec.Tags {
@@ -274,6 +278,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 			}
 			existing.Insert(tag.Name)
 			tag.ReferencePolicy.Type = imagev1.LocalTagReferencePolicy
+			tag.ImportPolicy.ImportMode = imagev1.ImportModePreserveOriginal
 			tags = append(tags, tag)
 		}
 		stable.Spec.Tags = tags


### PR DESCRIPTION
Since OCP 4.13, the internal registry supports the PreserveOriginal import mode for ImageStreamTags when the ReferencePolicy is set to local.

Using the PreserveOriginal import mode for the ImageStreamTags of the imported release payload will allow testing the non-amd64 control plane cluster scenarios when installing via the multi-arch payload.

This will only affect tests importing a multi-arch release payload and is harmless otherwise.

cc @tvardema @jaypoulz @Prashanth684 