### PR TITLE
`pod-scaler consumer`: add logging to diagnose readiness issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ cmd/pod-scaler/frontend/dist: cmd/pod-scaler/frontend/node_modules
 
 local-pod-scaler-ui: cmd/pod-scaler/frontend/node_modules $(HOME)/.cache/pod-scaler/steps/container_memory_working_set_bytes.json
 	go run -tags e2e,e2e_framework ./test/e2e/pod-scaler/local/main.go --cache-dir $(HOME)/.cache/pod-scaler --serve-dev-ui
-.PHONY: local-pod-scaler
+.PHONY: local-pod-scaler-ui
 
 $(HOME)/.cache/pod-scaler/steps/container_memory_working_set_bytes.json:
 	mkdir -p $(HOME)/.cache/pod-scaler

--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -118,6 +118,7 @@ func digest(logger *logrus.Entry, infos ...digestInfo) <-chan interface{} {
 		defer loadLock.Unlock()
 		if loaded != len(infos)-1 {
 			loaded += 1
+			logger.Debugf("Now loaded %d info(s) out of %d", loaded, len(infos))
 		} else {
 			loadDone <- struct{}{}
 		}

--- a/test/e2e/pod-scaler/run/consumer.go
+++ b/test/e2e/pod-scaler/run/consumer.go
@@ -100,7 +100,7 @@ func Admission(t testhelper.TestingTInterface, dataDir, kubeconfig string, paren
 func UI(t testhelper.TestingTInterface, dataDir string, parent context.Context, stream bool) string {
 	serverHostname := "127.0.0.1"
 	podScalerFlags := []string{
-		"--loglevel=info",
+		"--loglevel=trace",
 		"--log-style=text",
 		"--cache-dir", dataDir,
 		"--mode=consumer.ui",


### PR DESCRIPTION
Adding a new log line to diagnose why the `pod-scaler-ui` readiness probe always seems to be throwing a `404`. I think this may have something to do with the memory leaks. I also made some changes to try this locally, but it does become ready there eventually.