### PR TITLE
`pod-scaler consumers`: don't reload as often

### DIFF
--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -23,7 +23,7 @@ func newReloader(name string, cache cache) *cacheReloader {
 		}),
 		lock: &sync.RWMutex{},
 	}
-	interrupts.TickLiteral(reloader.reload, 10*time.Minute)
+	interrupts.TickLiteral(reloader.reload, time.Hour)
 	return reloader
 }
 
@@ -120,6 +120,7 @@ func digest(logger *logrus.Entry, infos ...digestInfo) <-chan interface{} {
 			loaded += 1
 			logger.Debugf("Now loaded %d info(s) out of %d", loaded, len(infos))
 		} else {
+			logger.Debugf("Now loaded all %d info(s)", len(infos))
 			loadDone <- struct{}{}
 		}
 	}


### PR DESCRIPTION
The logging added in: https://github.com/openshift/ci-tools/pull/3496 has illuminated a major issue with the `pod-scaler` consumers. They take 25-30 minutes to load new data due to the scale of data that we now have, but they then attempt to reload that data every 10 minutes. I believe this is causing the high memory usage as they are just constantly reloading data. I bumped the reload time up to 1 hour to monitor this for a bit, but we may find that we should change it to 2 or 3 hours even to further reduce costs. The producer only produces new data every 2 hours, but I still have a hunch that this constant churn is the culprit here.