### PR TITLE
TRT-1091: Add second pass for disruption checks with fuzzy comparison

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -442,14 +442,39 @@ func (a *weeklyAverageFromTenDays) CheckPercentileDisruption(ctx context.Context
 		return failureJobRunIDs, []string{}, testCaseSkipped, message, nil
 	}
 
-	failureJobRunIDs, successJobRunIDs, testCaseFailed, summary := a.checkPercentileDisruption(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, percentile)
+	failureJobRunIDs, successJobRunIDs, testCaseFailed, summary := a.checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, percentile)
 	return failureJobRunIDs, successJobRunIDs, testCaseFailed, messagePrefix + summary, nil
 }
 
-func (a *weeklyAverageFromTenDays) checkPercentileDisruption(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, historicalDisruptionStatistic backendDisruptionStats, thresholdPercentile int) ([]string, []string, testCaseStatus, string) {
+func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, historicalDisruptionStatistic backendDisruptionStats, thresholdPercentile int) ([]string, []string, testCaseStatus, string) {
+	historicalThreshold := historicalDisruptionStatistic.percentileByIndex[thresholdPercentile]
+	requiredNumberOfPasses, noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary := a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalThreshold, thresholdPercentile, 0)
+	numberOfPasses := len(noGraceSuccessJobRunIDs)
+	if numberOfPasses >= requiredNumberOfPasses {
+		return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
+	}
+
+	// the +1 is to have at least 1s, the 5 is arbitrary because it made forrest feel good and the denominator makes the grace smaller
+	// when there are more job runs that need to be better
+	graceSeconds := ((int(historicalThreshold) / 5) + 1) / (requiredNumberOfPasses - numberOfPasses)
+	if graceSeconds <= 0 {
+		return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
+	}
+	thresholdWithGrace := historicalThreshold + float64(graceSeconds)
+
+	_, withGraceFailureJobRunIDs, withGraceSuccessJobRunIDs, withGraceTestCasePassed, withGraceSummary := a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, thresholdWithGrace, thresholdPercentile, graceSeconds)
+	return withGraceFailureJobRunIDs, withGraceSuccessJobRunIDs, withGraceTestCasePassed, withGraceSummary
+}
+
+func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithoutGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, historicalDisruptionStatistic backendDisruptionStats, thresholdPercentile int) ([]string, []string, testCaseStatus, string) {
+	historicalThreshold := historicalDisruptionStatistic.percentileByIndex[thresholdPercentile]
+	_, noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary := a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalThreshold, thresholdPercentile, 0)
+	return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
+}
+
+func (a *weeklyAverageFromTenDays) innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, threshold float64, thresholdPercentile int, graceSeconds int) (int, []string, []string, testCaseStatus, string) {
 	failureJobRunIDs := []string{}
 	successJobRunIDs := []string{}
-	threshold := historicalDisruptionStatistic.percentileByIndex[thresholdPercentile]
 	successRuns := []string{} // each string example: jobRunID=5s
 	failureRuns := []string{} // each string example: jobRunID=5s
 
@@ -474,38 +499,43 @@ func (a *weeklyAverageFromTenDays) checkPercentileDisruption(jobRunIDToAvailabil
 	if requiredNumberOfPasses <= 0 {
 		message := fmt.Sprintf("Current percentile is so low that we cannot latch, skipping (P%d=%.2fs successes=%v failures=%v)", thresholdPercentile, threshold, successRuns, failureRuns)
 		failureJobRunIDs = sets.StringKeySet(jobRunIDToAvailabilityResultForBackend).List()
-		return failureJobRunIDs, successJobRunIDs, testCaseSkipped, message
+		return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCaseSkipped, message
 	}
 
 	if numberOfPasses == 0 {
 		summary := fmt.Sprintf("Zero successful runs, we require at least one success to pass  (P%d=%.2fs failures=%v)", thresholdPercentile, threshold, failureRuns)
-		return failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
+		return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
 	}
 	if numberOfAttempts < 3 {
 		summary := fmt.Sprintf("We require at least three attempts to pass  (P%d=%.2fs successes=%v failures=%v)",
 			thresholdPercentile, threshold, successRuns, failureRuns)
-		return failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
+		return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
+	}
+
+	graceAdded := ""
+	if graceSeconds > 0 {
+		graceAdded = fmt.Sprintf("(grace=%d) ", graceSeconds)
 	}
 
 	if numberOfPasses < requiredNumberOfPasses {
-		summary := fmt.Sprintf("Failed: Passed %d times, failed %d times.  (P%d=%.2fs requiredPasses=%d successes=%v failures=%v)",
+		summary := fmt.Sprintf("Failed: Passed %d times, failed %d times.  (P%d=%.2fs %srequiredPasses=%d successes=%v failures=%v)",
 			numberOfPasses,
 			numberOfFailures,
-			thresholdPercentile, threshold,
+			thresholdPercentile, threshold, graceAdded,
 			requiredNumberOfPasses,
 			successRuns, failureRuns,
 		)
-		return failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
+		return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCaseFailed, summary
 	}
 
-	summary := fmt.Sprintf("Passed: Passed %d times, failed %d times.  (P%d=%.2fs requiredPasses=%d successes=%v failures=%v)",
+	summary := fmt.Sprintf("Passed: Passed %d times, failed %d times.  (P%d=%.2fs %srequiredPasses=%d successes=%v failures=%v)",
 		numberOfPasses,
 		numberOfFailures,
-		thresholdPercentile, threshold,
+		thresholdPercentile, threshold, graceAdded,
 		requiredNumberOfPasses,
 		successRuns, failureRuns,
 	)
-	return failureJobRunIDs, successJobRunIDs, testCasePassed, summary
+	return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCasePassed, summary
 }
 
 // getPercentileRank returns the maximum percentile that is at or below the disruptionThresholdSeconds
@@ -543,7 +573,7 @@ func (a *weeklyAverageFromTenDays) CheckPercentileRankDisruption(ctx context.Con
 
 	thresholdPercentile := getPercentileRank(historicalDisruptionStatistic, maxDisruptionSeconds)
 
-	failureJobRunIDs, successJobRunIDs, testCasePassed, summary := a.checkPercentileDisruption(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, thresholdPercentile)
+	failureJobRunIDs, successJobRunIDs, testCasePassed, summary := a.checkPercentileDisruptionWithoutGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, thresholdPercentile)
 	return failureJobRunIDs, successJobRunIDs, testCasePassed, messagePrefix + summary, nil
 }
 

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail_test.go
@@ -1,0 +1,277 @@
+package jobrunaggregatoranalyzer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+)
+
+func createJobRunIDToAvailabilityResultForBackend(disruptions []int) map[string]jobrunaggregatorlib.AvailabilityResult {
+	jobRunIDToAvailabilityResultForBackend := make(map[string]jobrunaggregatorlib.AvailabilityResult)
+	for i, disruption := range disruptions {
+		jobRunIDToAvailabilityResultForBackend[fmt.Sprintf("run_%d", i)] = jobrunaggregatorlib.AvailabilityResult{SecondsUnavailable: disruption}
+	}
+
+	return jobRunIDToAvailabilityResultForBackend
+}
+
+func TestCheckPercentileDisruption(t *testing.T) {
+	weeklyAverageFromTenDays := weeklyAverageFromTenDays{}
+
+	tests := []struct {
+		name                 string
+		disruptions          []int
+		thresholdPercentile  int
+		historicalDisruption float64
+		status               testCaseStatus
+		failedCount          int
+		successCount         int
+		supportsFuzziness    bool
+	}{
+		{
+			// Required Passes for 95th percentile is 6
+			// no disruption so it passes
+			name:                 "Test 95th Percentile 0's Pass",
+			disruptions:          []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			thresholdPercentile:  95,
+			historicalDisruption: 7,
+			status:               testCasePassed,
+			failedCount:          0,
+			successCount:         10,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// all over on disruption so it fails
+			name:                 "Test 95th Percentile all 1 over Fail",
+			disruptions:          []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8},
+			thresholdPercentile:  95,
+			historicalDisruption: 7,
+			status:               testCaseFailed,
+			failedCount:          10,
+			successCount:         0,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 5 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 5) = 2
+			// The Disruption value that == 7 gets flipped to pass
+			name:                 "Test 95th Percentile Fuzzy Pass",
+			disruptions:          []int{5, 5, 5, 6, 6, 7, 9, 9, 9, 9},
+			thresholdPercentile:  95,
+			historicalDisruption: 6,
+			status:               testCasePassed,
+			failedCount:          4,
+			successCount:         6,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 4 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 1
+			// The Disruption values that == 7 get flipped to passes
+			name:                 "Test 95th Percentile Multi Fuzzy Pass",
+			disruptions:          []int{5, 5, 5, 6, 7, 7, 8, 8, 8, 86},
+			thresholdPercentile:  95,
+			historicalDisruption: 6,
+			status:               testCasePassed,
+			failedCount:          4,
+			successCount:         6,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 4 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 1
+			// The Disruption value that == 7 gets flipped to pass
+			// But the 8s and above do not, so we don't have enough passes
+			name:                 "Test 95th Percentile Multi Fuzzy Fail",
+			disruptions:          []int{5, 5, 5, 6, 7, 8, 8, 9, 9, 86},
+			thresholdPercentile:  95,
+			historicalDisruption: 6,
+			status:               testCaseFailed,
+			failedCount:          5,
+			successCount:         5,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 4 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 10
+			// The Disruption values that are < 113 get flipped to pass
+			// The 113 and above does not, but we have enough passes
+			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy Pass",
+			disruptions:          []int{99, 105, 101, 102, 101, 108, 108, 112, 113, 186},
+			thresholdPercentile:  95,
+			historicalDisruption: 102,
+			status:               testCasePassed,
+			failedCount:          2,
+			successCount:         8,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 4 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 10
+			// The Disruption values that are < 113 get flipped to pass
+			// The 113 and above does not, so we don't have enough passes
+			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy Failed",
+			disruptions:          []int{99, 105, 101, 102, 101, 147, 113, 113, 113, 186},
+			thresholdPercentile:  95,
+			historicalDisruption: 102,
+			status:               testCaseFailed,
+			failedCount:          5,
+			successCount:         5,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 95th percentile is 6
+			// 4 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 2) = 5
+			// The Disruption values that are < 108 get flipped to pass
+			// But the 108s and above do not, so we don't have enough passes
+			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy High Multiplier Fail",
+			disruptions:          []int{99, 105, 101, 107, 107, 108, 108, 109, 109, 186},
+			thresholdPercentile:  95,
+			historicalDisruption: 102,
+			status:               testCaseFailed,
+			failedCount:          5,
+			successCount:         5,
+			supportsFuzziness:    true,
+		},
+
+		// https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/aggregated-azure-ovn-upgrade-4.14-micro-release-openshift-release-analysis-aggregator/1671560866929053696
+		//		{Failed: Passed 3 times, failed 6 times.  (P85=1.30s requiredPasses=4
+		//		successes=[1671334508823056384=1s 1671334507992584192=0s 1671334507128557568=0s]
+		//		failures=[1671334503768920064=5s 1671334504733609984=5s 1671334506289696768=2s
+		//		1671334509678694400=2s 1671334505455030272=3s 1671334510496583680=4s])
+		//		name: kube-api-new-connections disruption P85 should not be worse
+		{
+			// Required Passes for 85th percentile is 4
+			name:                 "Test 85th Percentile Pass",
+			disruptions:          []int{1, 0, 0, 5, 5, 2, 2, 3, 4},
+			thresholdPercentile:  85,
+			historicalDisruption: 1.30,
+			status:               testCasePassed,
+			failedCount:          4,
+			successCount:         5,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 85th percentile is 4
+			// Compare same case as above but with fuzzy matching disabled to ensure the flag works properly
+			name:                 "Test 85th Percentile Fail no fuzzy matching",
+			disruptions:          []int{1, 0, 0, 5, 5, 2, 2, 3, 4},
+			thresholdPercentile:  85,
+			historicalDisruption: 1.30,
+			status:               testCaseFailed,
+			failedCount:          6,
+			successCount:         3,
+			supportsFuzziness:    false,
+		},
+
+		// we don't want fuzzy matching for the zero-disruption should not be worse tests
+		// so the supportsFuzziness flag is false
+		// openshift-api-reused-connections zero-disruption should not be worse
+		//
+		// Failed: Passed 2 times, failed 7 times. (P81=0.00s requiredPasses=3
+		// successes=[1671560859370917888=0s 1671560863581999104=0s]
+		// failures=[1671560858532057088=4s 1671560863154180096=4s 1671560857697390592=1s 1671560860734066688=5s
+		// 1671560861057028096=1s 1671560866081804288=1s 1671560856858529792=2s])
+		{
+			// Required Passes for 81th percentile is 3
+			// Validate failure with fuzzy matching disabled
+			name:                 "Test 81th Percentile zero disruption should not be worse, no fuzzy matching",
+			disruptions:          []int{0, 0, 4, 4, 1, 5, 1, 1, 2},
+			thresholdPercentile:  81,
+			historicalDisruption: 0,
+			status:               testCaseFailed,
+			failedCount:          7,
+			successCount:         2,
+			supportsFuzziness:    false,
+		},
+		{
+			// Required Passes for 80th percentile is 4
+			// 4 Natural Passes
+			name:                 "Test 80th Percentile Pass",
+			disruptions:          []int{0, 0, 1, 1, 2, 2, 2, 2, 2, 2},
+			thresholdPercentile:  80,
+			historicalDisruption: 1,
+			status:               testCasePassed,
+			failedCount:          6,
+			successCount:         4,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 80th percentile is 4
+			// 3 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (4 - 3) = 1
+			// The Disruption values that == 2 get flipped to passes
+			name:                 "Test 80th Percentile Xtra Fuzzy Pass",
+			disruptions:          []int{0, 0, 1, 2, 2, 6, 3, 4, 5, 8},
+			thresholdPercentile:  80,
+			historicalDisruption: 1,
+			status:               testCasePassed,
+			failedCount:          5,
+			successCount:         5,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 80th percentile is 4
+			// 2 Natural Passes
+			// graceSeconds = ((historicalDisruption / 5) + 1) / (4 - 2) = 0
+			// There are no disruption values that get flipped since (2-1)*2 = 2 and our Fuzz Threshold is 1
+			// But the 8s and above do not so we don't have enough passes
+			name:                 "Test 80th Percentile Fuzzy Fail",
+			disruptions:          []int{0, 0, 2, 2, 2, 2, 2, 2, 2, 2},
+			thresholdPercentile:  80,
+			historicalDisruption: 1,
+			status:               testCaseFailed,
+			failedCount:          8,
+			successCount:         2,
+			supportsFuzziness:    true,
+		},
+		{
+			// Required Passes for 80th percentile is 6
+			// all disruption, so it fails
+			name:                 "Test 80th Percentile all 1 over Fail",
+			disruptions:          []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			thresholdPercentile:  80,
+			historicalDisruption: 0,
+			status:               testCaseFailed,
+			failedCount:          10,
+			successCount:         0,
+			supportsFuzziness:    true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			jobRunIDToAvailabilityResultForBackend := createJobRunIDToAvailabilityResultForBackend(test.disruptions)
+			historicalDisruptionStatistic := backendDisruptionStats{
+				percentileByIndex: make([]float64, 100),
+			}
+			historicalDisruptionStatistic.percentileByIndex[test.thresholdPercentile] = test.historicalDisruption
+
+			var failureJobRunIDs []string
+			var successJobRunIDs []string
+			var status testCaseStatus
+			var summary string
+			if test.supportsFuzziness {
+				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile)
+			} else {
+				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithoutGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile)
+			}
+
+			assert.NotNil(t, summary, "Invalid summary for: %s", test.name)
+			assert.Equal(t, test.failedCount, len(failureJobRunIDs), "Invalid failed test cont for: %s", test.name)
+			assert.Equal(t, test.successCount, len(successJobRunIDs), "Invalid success test cont for: %s", test.name)
+			assert.Equal(t, test.status, status, "Invalid success test cont for: %s", test.name)
+		})
+	}
+}


### PR DESCRIPTION
Adds a second check for aggregated disruption.

Made the fuzzy matching optional and disabled for the `zero-disruption should not be worse` tests

Diffs the expected number of passes from the actual passes in the first pass.  Uses that as a multiplier, the close we were to passing the lower the multiplier.

Diffs the historical disruption value from the actual disruption and multiplies this by the multiplier to create a fuzz value

Creates a fuzzThreshold based on the historical disruption value,  currently 4 and under  = 1, 5-9 = 2, 10-14 = 3, etc.

Checks to see if the fuzz value is less than or equal to the fuzzThreshold and if so considers it a pass.

We should be able to adjust the calculation for the fuzzThreshold to increase / decrease as needed.