### PR TITLE
ci-operator: use a single PDB

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1345,15 +1345,11 @@ func (o *options) initializeNamespace() error {
 			logrus.Debugf("Updated secret %s", secret.Name)
 		}
 	}
-
-	for _, pdbLabelKey := range []string{buildv1.BuildLabel, steps.CreatedByCILabel} {
-		pdb, mutateFn := pdb(pdbLabelKey, o.namespace)
-		if _, err := crcontrollerutil.CreateOrUpdate(ctx, client, pdb, mutateFn); err != nil && !kerrors.IsAlreadyExists(err) {
-			return fmt.Errorf("failed to create pdb for label key %s: %w", pdbLabelKey, err)
-		}
-		logrus.Debugf("Created PDB for pods with %s label", pdbLabelKey)
+	pdb, mutateFn := pdb(steps.CreatedByCILabel, o.namespace)
+	if _, err := crcontrollerutil.CreateOrUpdate(ctx, client, pdb, mutateFn); err != nil && !kerrors.IsAlreadyExists(err) {
+		return fmt.Errorf("failed to create pdb for label key %s: %w", steps.CreatedByCILabel, err)
 	}
-
+	logrus.Debugf("Created PDB for pods with %s label", steps.CreatedByCILabel)
 	return nil
 }
 


### PR DESCRIPTION
Our current setup results in ambiguous `PodDisruptionBudget` objects:

```
 Warning	MultiplePodDisruptionBudgets	2m43s			controllermanager	Pod "ci-op-z7dvfmlm"/"slack-bot-build" matches multiple PodDisruptionBudgets.  Chose "ci-operator-created-by-ci" arbitrarily.
  Warning	Failed				2m43s			kubelet			Error: Kubelet may be retrying requests that are timing out in CRI-O due to system load: context deadline exceeded: error reserving ctr name k8s_docker-build_slack-bot-build_ci-op-z7dvfmlm_fb72dce6-359a-4292-956a-31a4f138883e_0 for id 3aca8a54def6d6a407e2634c57cb16193567801d295b6ab74c92a2f2e06b979c: name is reserved
  Warning	Failed				43s (x4 over 8m45s)	kubelet			Error: context deadline exceeded
  Warning	MultiplePodDisruptionBudgets	42s (x15 over 50m)	controllermanager	Pod "ci-op-z7dvfmlm"/"slack-bot-build" matches multiple PodDisruptionBudgets.  Chose "ci-operator-openshift.io-build.name" arbitrarily.
```

This is because the `created-by-ci` label is also added to builds, and is
propagated to their respective pods for the ones which are affected by our
PDBs:

```console
$ oc --context app.ci get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
ci
coreos
$ oc --context build01 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
ci
$ oc --context build01 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
$ oc --context build02 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
$ oc --context build03 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
$ oc --context build04 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
$ oc --context build05 get pods --all-namespaces -o json | jq -r '.items[]|select(.metadata.labels|(.["openshift.io/build.name"] and (.["created-by-ci"]|not))).metadata.namespace' | sort -u
```

https://issues.redhat.com/browse/DPTP-2841