### PR TITLE
`pj-rehearse`: fix infrequent error when checking out work tree

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -84,6 +84,16 @@ func revParse(repoPath string, args ...string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+func gitFetch(candidatePath string) error {
+	cmd := exec.Command("git", "fetch")
+	cmd.Dir = candidatePath
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("'%s' failed with out: %s and error %w", cmd.Args, stdoutStderr, err)
+	}
+	return nil
+}
+
 func gitCheckout(candidatePath, baseSHA string) error {
 	cmd := exec.Command("git", "checkout", baseSHA)
 	cmd.Dir = candidatePath
@@ -158,6 +168,10 @@ func GetAllConfigsFromSHA(releaseRepoPath, sha string) (*ReleaseRepoConfig, erro
 	}
 	if restoreRev == "HEAD" {
 		restoreRev = currentSHA
+	}
+	// git fetch to be sure we are in sync
+	if err := gitFetch(releaseRepoPath); err != nil {
+		return nil, fmt.Errorf("could not fetch: %w", err)
 	}
 	if err := gitCheckout(releaseRepoPath, sha); err != nil {
 		return nil, fmt.Errorf("could not checkout worktree: %w", err)


### PR DESCRIPTION
Infrequently, we are seeing errors like the following:
```
could not load configuration from base revision of release repo: could not checkout worktree: '[git checkout 3b4aad5de6bb9bcffc01bc3c845589b54280c5ea]' failed with out: fatal: reference is not a tree: 3b4aad5de6bb9bcffc01bc3c845589b54280c5ea
and error exit status 128
```
For example, in this comment: https://github.com/openshift/release/pull/39156#issuecomment-1601294684

These resolve themselves, and seem to happen when the plugin is under a heavy load. I researched the error and for this [post](https://stackoverflow.com/questions/54225047/git-error-on-checkout-fatal-reference-is-not-a-tree) suggesting a `git fetch` prior to checkout. I want to try this and see if it reduces the occurrences of this error.