### PR TITLE
Prepare for partitioned TestRuns table in BigQuery

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
@@ -1,6 +1,8 @@
 package jobrunaggregatorapi
 
-import "time"
+import (
+	"cloud.google.com/go/bigquery"
+)
 
 const (
 	AlertsTableName = "Alerts"
@@ -70,10 +72,10 @@ type AlertRow struct {
 	Namespace       string
 	Level           string
 	AlertSeconds    int
-	JobName         string
+	JobName         bigquery.NullString
 	JobRunName      string
-	JobRunStartTime time.Time
-	JobRunEndTime   time.Time
-	Cluster         string
-	ReleaseTag      string
+	JobRunStartTime bigquery.NullTimestamp
+	JobRunEndTime   bigquery.NullTimestamp
+	Cluster         bigquery.NullString
+	ReleaseTag      bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
@@ -1,5 +1,7 @@
 package jobrunaggregatorapi
 
+import "time"
+
 const (
 	AlertsTableName = "Alerts"
 
@@ -64,9 +66,14 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 )
 
 type AlertRow struct {
-	JobRunName   string
-	Name         string
-	Namespace    string
-	Level        string
-	AlertSeconds int
+	Name            string
+	Namespace       string
+	Level           string
+	AlertSeconds    int
+	JobName         string
+	JobRunName      string
+	JobRunStartTime time.Time
+	JobRunEndTime   time.Time
+	Cluster         string
+	ReleaseTag      string
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -1,6 +1,8 @@
 package jobrunaggregatorapi
 
-import "time"
+import (
+	"cloud.google.com/go/bigquery"
+)
 
 const (
 	unifiedBackendDisruptionSchema = `
@@ -31,10 +33,10 @@ const BackendDisruptionTableName = "BackendDisruption"
 type BackendDisruptionRow struct {
 	BackendName       string
 	DisruptionSeconds int
-	JobName           string
+	JobName           bigquery.NullString
 	JobRunName        string
-	JobRunStartTime   time.Time
-	JobRunEndTime     time.Time
-	ReleaseTag        string
-	Cluster           string
+	JobRunStartTime   bigquery.NullTimestamp
+	JobRunEndTime     bigquery.NullTimestamp
+	Cluster           bigquery.NullString
+	ReleaseTag        bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -1,5 +1,7 @@
 package jobrunaggregatorapi
 
+import "time"
+
 const (
 	unifiedBackendDisruptionSchema = `
 SELECT 
@@ -28,6 +30,11 @@ const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {
 	BackendName       string
-	JobRunName        string
 	DisruptionSeconds int
+	JobName           string
+	JobRunName        string
+	JobRunStartTime   time.Time
+	JobRunEndTime     time.Time
+	ReleaseTag        string
+	Cluster           string
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -1,5 +1,7 @@
 package jobrunaggregatorapi
 
+import "time"
+
 const (
 	TestRunTableName = "TestRuns"
 
@@ -43,9 +45,13 @@ const (
 
 // Move here from jobrunbigqueryloader/types.go
 type TestRunRow struct {
-	Name       string
-	JobRunName string
-	JobName    string
-	Status     string
-	TestSuite  string
+	Name            string
+	Status          string
+	TestSuite       string
+	JobName         string
+	JobRunName      string
+	JobRunStartTime time.Time
+	JobRunEndTime   time.Time
+	ReleaseTag      string
+	Cluster         string
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -1,6 +1,8 @@
 package jobrunaggregatorapi
 
-import "time"
+import (
+	"cloud.google.com/go/bigquery"
+)
 
 const (
 	TestRunTableName = "TestRuns"
@@ -48,10 +50,10 @@ type TestRunRow struct {
 	Name            string
 	Status          string
 	TestSuite       string
-	JobName         string
+	JobName         bigquery.NullString
 	JobRunName      string
-	JobRunStartTime time.Time
-	JobRunEndTime   time.Time
-	ReleaseTag      string
-	Cluster         string
+	JobRunStartTime bigquery.NullTimestamp
+	JobRunEndTime   bigquery.NullTimestamp
+	Cluster         bigquery.NullString
+	ReleaseTag      bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -224,16 +225,31 @@ func populateZeros(jobRunRow *jobrunaggregatorapi.JobRunRow,
 				"AlertLevel":     known.AlertLevel,
 			}).Debug("injecting 0s for a known but not observed alert on this run")
 			observedAlertRows = append(observedAlertRows, jobrunaggregatorapi.AlertRow{
-				Name:            known.AlertName,
-				Namespace:       known.AlertNamespace,
-				Level:           known.AlertLevel,
-				AlertSeconds:    0,
-				JobName:         jobRunRow.JobName,
-				JobRunName:      jobRunRow.Name,
-				JobRunStartTime: jobRunRow.StartTime,
-				JobRunEndTime:   jobRunRow.EndTime,
-				Cluster:         jobRunRow.Cluster,
-				ReleaseTag:      jobRunRow.ReleaseTag,
+				Name:         known.AlertName,
+				Namespace:    known.AlertNamespace,
+				Level:        known.AlertLevel,
+				AlertSeconds: 0,
+				JobName: bigquery.NullString{
+					StringVal: jobRunRow.JobName,
+					Valid:     true,
+				},
+				JobRunName: jobRunRow.Name,
+				JobRunStartTime: bigquery.NullTimestamp{
+					Timestamp: jobRunRow.StartTime,
+					Valid:     true,
+				},
+				JobRunEndTime: bigquery.NullTimestamp{
+					Timestamp: jobRunRow.EndTime,
+					Valid:     true,
+				},
+				Cluster: bigquery.NullString{
+					StringVal: jobRunRow.Cluster,
+					Valid:     true,
+				},
+				ReleaseTag: bigquery.NullString{
+					StringVal: jobRunRow.ReleaseTag,
+					Valid:     true,
+				},
 			})
 			injectedCtr++
 		}
@@ -321,16 +337,31 @@ func getAlertsFromPerJobRunData(alertData map[string]string, jobRunRow *jobrunag
 	ret := []jobrunaggregatorapi.AlertRow{}
 	for _, alert := range alertList {
 		ret = append(ret, jobrunaggregatorapi.AlertRow{
-			Name:            alert.Name,
-			Namespace:       alert.Namespace,
-			Level:           string(alert.Level),
-			AlertSeconds:    int(math.Ceil(alert.Duration.Seconds())),
-			JobName:         jobRunRow.JobName,
-			JobRunName:      jobRunRow.Name,
-			JobRunStartTime: jobRunRow.StartTime,
-			JobRunEndTime:   jobRunRow.EndTime,
-			Cluster:         jobRunRow.Cluster,
-			ReleaseTag:      jobRunRow.ReleaseTag,
+			Name:         alert.Name,
+			Namespace:    alert.Namespace,
+			Level:        string(alert.Level),
+			AlertSeconds: int(math.Ceil(alert.Duration.Seconds())),
+			JobName: bigquery.NullString{
+				StringVal: jobRunRow.JobName,
+				Valid:     true,
+			},
+			JobRunName: jobRunRow.Name,
+			JobRunStartTime: bigquery.NullTimestamp{
+				Timestamp: jobRunRow.StartTime,
+				Valid:     true,
+			},
+			JobRunEndTime: bigquery.NullTimestamp{
+				Timestamp: jobRunRow.EndTime,
+				Valid:     true,
+			},
+			Cluster: bigquery.NullString{
+				StringVal: jobRunRow.Cluster,
+				Valid:     true,
+			},
+			ReleaseTag: bigquery.NullString{
+				StringVal: jobRunRow.ReleaseTag,
+				Valid:     true,
+			},
 		})
 	}
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -14,7 +14,6 @@ import (
 	"github.com/spf13/pflag"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
@@ -169,7 +168,7 @@ func (o *alertUploader) listUploadedJobRunIDsSince(ctx context.Context, since *t
 }
 
 func (o *alertUploader) uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo,
-	jobRelease string, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error {
+	jobRelease string, jobRunRow *jobrunaggregatorapi.JobRunRow, logger logrus.FieldLogger) error {
 	logger.Info("uploading alert results")
 	alertData, err := jobRun.GetOpenShiftTestsFilesWithPrefix(ctx, "alert")
 	if err != nil {
@@ -177,10 +176,10 @@ func (o *alertUploader) uploadContent(ctx context.Context, jobRun jobrunaggregat
 	}
 	logger.Debug("got test files with prefix")
 	if len(alertData) > 0 {
-		alertRows := getAlertsFromPerJobRunData(alertData, jobRun.GetJobRunID())
+		alertRows := getAlertsFromPerJobRunData(alertData, jobRunRow)
 
 		// pass cache of known alerts in.
-		alertRows = populateZeros(o.knownAlertsCache, alertRows, jobRelease, jobRun.GetJobRunID(), logger)
+		alertRows = populateZeros(jobRunRow, o.knownAlertsCache, alertRows, jobRelease, logger)
 
 		if err := o.alertInserter.Put(ctx, alertRows); err != nil {
 			return err
@@ -198,8 +197,10 @@ func (o *alertUploader) uploadContent(ctx context.Context, jobRun jobrunaggregat
 // alerts.
 // For details on calculating the list of all known alerts, see ListAllKnownAlerts in the data client,
 // but TL;DR, it's every alert/namespace combo we've ever observed for a given release.
-func populateZeros(knownAlertsCache *KnownAlertsCache, observedAlertRows []jobrunaggregatorapi.AlertRow,
-	release, jobRunID string, logger logrus.FieldLogger) []jobrunaggregatorapi.AlertRow {
+func populateZeros(jobRunRow *jobrunaggregatorapi.JobRunRow,
+	knownAlertsCache *KnownAlertsCache,
+	observedAlertRows []jobrunaggregatorapi.AlertRow,
+	release string, logger logrus.FieldLogger) []jobrunaggregatorapi.AlertRow {
 
 	origCount := len(observedAlertRows)
 	injectedCtr := 0
@@ -223,11 +224,16 @@ func populateZeros(knownAlertsCache *KnownAlertsCache, observedAlertRows []jobru
 				"AlertLevel":     known.AlertLevel,
 			}).Debug("injecting 0s for a known but not observed alert on this run")
 			observedAlertRows = append(observedAlertRows, jobrunaggregatorapi.AlertRow{
-				JobRunName:   jobRunID,
-				Name:         known.AlertName,
-				Namespace:    known.AlertNamespace,
-				Level:        known.AlertLevel,
-				AlertSeconds: 0,
+				Name:            known.AlertName,
+				Namespace:       known.AlertNamespace,
+				Level:           known.AlertLevel,
+				AlertSeconds:    0,
+				JobName:         jobRunRow.JobName,
+				JobRunName:      jobRunRow.Name,
+				JobRunStartTime: jobRunRow.StartTime,
+				JobRunEndTime:   jobRunRow.EndTime,
+				Cluster:         jobRunRow.Cluster,
+				ReleaseTag:      jobRunRow.ReleaseTag,
 			})
 			injectedCtr++
 		}
@@ -280,7 +286,7 @@ type Alert struct {
 	Duration metav1.Duration
 }
 
-func getAlertsFromPerJobRunData(alertData map[string]string, jobRunID string) []jobrunaggregatorapi.AlertRow {
+func getAlertsFromPerJobRunData(alertData map[string]string, jobRunRow *jobrunaggregatorapi.JobRunRow) []jobrunaggregatorapi.AlertRow {
 	alertMap := map[AlertKey]*Alert{}
 
 	for _, alertJSON := range alertData {
@@ -315,11 +321,16 @@ func getAlertsFromPerJobRunData(alertData map[string]string, jobRunID string) []
 	ret := []jobrunaggregatorapi.AlertRow{}
 	for _, alert := range alertList {
 		ret = append(ret, jobrunaggregatorapi.AlertRow{
-			JobRunName:   jobRunID,
-			Name:         alert.Name,
-			Namespace:    alert.Namespace,
-			Level:        string(alert.Level),
-			AlertSeconds: int(math.Ceil(alert.Duration.Seconds())),
+			Name:            alert.Name,
+			Namespace:       alert.Namespace,
+			Level:           string(alert.Level),
+			AlertSeconds:    int(math.Ceil(alert.Duration.Seconds())),
+			JobName:         jobRunRow.JobName,
+			JobRunName:      jobRunRow.Name,
+			JobRunStartTime: jobRunRow.StartTime,
+			JobRunEndTime:   jobRunRow.EndTime,
+			Cluster:         jobRunRow.Cluster,
+			ReleaseTag:      jobRunRow.ReleaseTag,
 		})
 	}
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
@@ -255,8 +255,11 @@ func TestPopulateZeros(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			results := populateZeros(knownAlertsCache, test.observedAlerts,
-				"4.13", "1000", logrus.WithField("test", test.name))
+			jobRunRow := &jobrunaggregatorapi.JobRunRow{
+				Name: "1000",
+			}
+			results := populateZeros(jobRunRow, knownAlertsCache, test.observedAlerts,
+				"4.13", logrus.WithField("test", test.name))
 			assert.Equal(t, test.expectedAlertsToUpload, results)
 		})
 	}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
@@ -256,7 +257,58 @@ func TestPopulateZeros(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			jobRunRow := &jobrunaggregatorapi.JobRunRow{
-				Name: "1000",
+				Name:       "1000",
+				JobName:    "foobar-job",
+				Cluster:    "build01",
+				ReleaseTag: "",
+			}
+			// Add some more detail to the observed/expected alerts as the bigquery null
+			// types get quite verbose to include in every test:
+			for i := range test.observedAlerts {
+				test.observedAlerts[i].JobName = bigquery.NullString{
+					StringVal: "foobar-job",
+					Valid:     true,
+				}
+				test.observedAlerts[i].Cluster = bigquery.NullString{
+					StringVal: "build01",
+					Valid:     true,
+				}
+				test.observedAlerts[i].ReleaseTag = bigquery.NullString{
+					StringVal: "",
+					Valid:     true,
+				}
+				test.observedAlerts[i].JobRunStartTime = bigquery.NullTimestamp{
+					Timestamp: time.Time{},
+					Valid:     true,
+				}
+				test.observedAlerts[i].JobRunEndTime = bigquery.NullTimestamp{
+					Timestamp: time.Time{},
+					Valid:     true,
+				}
+			}
+			// Add some more detail to the observed/expected alerts as the bigquery null
+			// types get quite verbose to include in every test:
+			for i := range test.expectedAlertsToUpload {
+				test.expectedAlertsToUpload[i].JobName = bigquery.NullString{
+					StringVal: "foobar-job",
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].Cluster = bigquery.NullString{
+					StringVal: "build01",
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].ReleaseTag = bigquery.NullString{
+					StringVal: "",
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].JobRunStartTime = bigquery.NullTimestamp{
+					Timestamp: time.Time{},
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].JobRunEndTime = bigquery.NullTimestamp{
+					Timestamp: time.Time{},
+					Valid:     true,
+				}
 			}
 			results := populateZeros(jobRunRow, knownAlertsCache, test.observedAlerts,
 				"4.13", logrus.WithField("test", test.name))

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -186,12 +187,27 @@ func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRun
 		row := &jobrunaggregatorapi.BackendDisruptionRow{
 			BackendName:       backendName,
 			DisruptionSeconds: unavailability.SecondsUnavailable,
-			JobName:           jobRunRow.JobName,
-			JobRunName:        jobRunRow.Name,
-			JobRunStartTime:   jobRunRow.StartTime,
-			JobRunEndTime:     jobRunRow.EndTime,
-			Cluster:           jobRunRow.Cluster,
-			ReleaseTag:        jobRunRow.ReleaseTag,
+			JobName: bigquery.NullString{
+				StringVal: jobRunRow.JobName,
+				Valid:     true,
+			},
+			JobRunName: jobRunRow.Name,
+			JobRunStartTime: bigquery.NullTimestamp{
+				Timestamp: jobRunRow.StartTime,
+				Valid:     true,
+			},
+			JobRunEndTime: bigquery.NullTimestamp{
+				Timestamp: jobRunRow.EndTime,
+				Valid:     true,
+			},
+			Cluster: bigquery.NullString{
+				StringVal: jobRunRow.Cluster,
+				Valid:     true,
+			},
+			ReleaseTag: bigquery.NullString{
+				StringVal: jobRunRow.ReleaseTag,
+				Valid:     true,
+			},
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
@@ -39,12 +39,16 @@ func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob
 
 }
 
-func newTestRunRow(jobRun jobrunaggregatorapi.JobRunInfo, status string, testSuiteStr string, testCase *junit.TestCase) *jobrunaggregatorapi.TestRunRow {
+func newTestRunRow(jobRunRow *jobrunaggregatorapi.JobRunRow, status string, testSuiteStr string, testCase *junit.TestCase) *jobrunaggregatorapi.TestRunRow {
 	return &jobrunaggregatorapi.TestRunRow{
-		Name:       testCase.Name,
-		JobRunName: jobRun.GetJobRunID(),
-		JobName:    jobRun.GetJobName(),
-		Status:     status,
-		TestSuite:  testSuiteStr,
+		Name:            testCase.Name,
+		Status:          status,
+		TestSuite:       testSuiteStr,
+		JobName:         jobRunRow.JobName,
+		JobRunName:      jobRunRow.Name,
+		JobRunStartTime: jobRunRow.StartTime,
+		JobRunEndTime:   jobRunRow.EndTime,
+		ReleaseTag:      jobRunRow.ReleaseTag,
+		Cluster:         jobRunRow.Cluster,
 	}
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
@@ -41,14 +41,29 @@ func newJobRunRow(jobRun jobrunaggregatorapi.JobRunInfo, prowJob *prowv1.ProwJob
 
 func newTestRunRow(jobRunRow *jobrunaggregatorapi.JobRunRow, status string, testSuiteStr string, testCase *junit.TestCase) *jobrunaggregatorapi.TestRunRow {
 	return &jobrunaggregatorapi.TestRunRow{
-		Name:            testCase.Name,
-		Status:          status,
-		TestSuite:       testSuiteStr,
-		JobName:         jobRunRow.JobName,
-		JobRunName:      jobRunRow.Name,
-		JobRunStartTime: jobRunRow.StartTime,
-		JobRunEndTime:   jobRunRow.EndTime,
-		ReleaseTag:      jobRunRow.ReleaseTag,
-		Cluster:         jobRunRow.Cluster,
+		Name:      testCase.Name,
+		Status:    status,
+		TestSuite: testSuiteStr,
+		JobName: bigquery.NullString{
+			StringVal: jobRunRow.JobName,
+			Valid:     true,
+		},
+		JobRunName: jobRunRow.Name,
+		JobRunStartTime: bigquery.NullTimestamp{
+			Timestamp: jobRunRow.StartTime,
+			Valid:     true,
+		},
+		JobRunEndTime: bigquery.NullTimestamp{
+			Timestamp: jobRunRow.EndTime,
+			Valid:     true,
+		},
+		Cluster: bigquery.NullString{
+			StringVal: jobRunRow.Cluster,
+			Valid:     true,
+		},
+		ReleaseTag: bigquery.NullString{
+			StringVal: jobRunRow.ReleaseTag,
+			Valid:     true,
+		},
 	}
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
@@ -198,7 +197,7 @@ func (o *allJobsLoaderOptions) newJobRunBigQueryLoaderOptions(jobName, jobRunID,
 
 // uploader encapsulates the logic for lookups and uploads specific to each type of content we ingest. (disruption, alerting, test runs, etc)
 type uploader interface {
-	uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, release string, prowJob *prowv1.ProwJob, logger logrus.FieldLogger) error
+	uploadContent(ctx context.Context, jobRun jobrunaggregatorapi.JobRunInfo, release string, jobRunRow *jobrunaggregatorapi.JobRunRow, logger logrus.FieldLogger) error
 	getLastUploadedJobRunEndTime(ctx context.Context) (*time.Time, error)
 	listUploadedJobRunIDsSince(ctx context.Context, since *time.Time) (map[string]bool, error)
 }
@@ -263,7 +262,7 @@ func (o *jobRunLoaderOptions) uploadJobRun(ctx context.Context, jobRun jobrunagg
 	}
 
 	o.logger.Infof("uploading content for jobrun")
-	if err := o.jobRunUploader.uploadContent(ctx, jobRun, o.jobRelease, prowJob, o.logger); err != nil {
+	if err := o.jobRunUploader.uploadContent(ctx, jobRun, o.jobRelease, jobRunRow, o.logger); err != nil {
 		o.logger.WithError(err).Error("error uploading content")
 		return err
 	}


### PR DESCRIPTION
This table is over 200GB dating back more than 2 years. It's costing us
roughly 20$ a day to query it for our test run summary table which powers
test aggregation.

We want to move to partitioned tables which must be done delicately.
Firstly however we need a time column to partition on, which was not
present on TestRows previously.

I've added the four new columns already to the table, they are empty for
all past rows.

I also have a query ready that builds a new partitioned table with all
the current data.

The plan is to:

- merge this change and start updating these columns when we upload
- when the test run uploader is NOT running:
  - build the new table with a different name
  - rename TestRuns to TestRuns_OLD
  - rename new table to TestRuns

All columns will then be populated, and new incoming rows will as well.

[TRT-1104](https://issues.redhat.com//browse/TRT-1104)
