### PR TITLE
Fix auto-config-brancher

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -280,8 +280,12 @@ func replaceStream(streamName string, streamMap StreamMap) (string, error) {
 	if replacement.UpstreamImage == "" {
 		return "", fmt.Errorf("stream.yml.%s.upstream_image is an empty string", streamName)
 	}
-	if replacement.Mirror == nil || !*replacement.Mirror {
-		return "", fmt.Errorf("stream.yaml.%s.mirror is set to false, can not dereference", streamName)
+	//TODO: this is a temporary workaround until https://github.com/openshift-eng/ocp-build-data/commit/155694be74cb2f020f6fafeaf6e4b3fba89646a2 is reverted/changed
+	// We need to allow the: 'golang', 'rhel-9-golang', and 'etcd_golang' streams through in the meantime
+	if streamName != "golang" && streamName != "rhel-9-golang" && streamName != "etcd_golang" {
+		if replacement.Mirror == nil || !*replacement.Mirror {
+			return "", fmt.Errorf("stream.yaml.%s.mirror is set to false, can not dereference", streamName)
+		}
 	}
 	return replacement.UpstreamImage, nil
 }

--- a/pkg/api/ocpbuilddata/types_test.go
+++ b/pkg/api/ocpbuilddata/types_test.go
@@ -178,14 +178,28 @@ func TestDereferenceConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "config.from.stream doesn't get replaced when stream has mirror: false",
+			name: "config.from.stream gets replaced when stream has mirror: false and is in workaround list",
 			config: OCPImageConfig{
 				From: OCPImageConfigFrom{
 					OCPImageConfigFromStream: OCPImageConfigFromStream{Stream: "golang"},
 				},
 			},
-			streamMap:     StreamMap{"golang": {UpstreamImage: "openshift/golang-builder:rhel_8_golang_1.14", Mirror: utilpointer.BoolPtr(false)}},
-			expectedError: errors.New("[failed to replace .from.stream: stream.yaml.golang.mirror is set to false, can not dereference, failed to find replacement for .from.stream]"),
+			streamMap: StreamMap{"golang": {UpstreamImage: "openshift/golang-builder:rhel_8_golang_1.14", Mirror: utilpointer.BoolPtr(false)}},
+			expectedConfig: OCPImageConfig{
+				From: OCPImageConfigFrom{
+					OCPImageConfigFromStream: OCPImageConfigFromStream{Stream: "openshift/golang-builder:rhel_8_golang_1.14"},
+				},
+			},
+		},
+		{
+			name: "config.from.stream doesn't get replaced when stream has mirror: false",
+			config: OCPImageConfig{
+				From: OCPImageConfigFrom{
+					OCPImageConfigFromStream: OCPImageConfigFromStream{Stream: "some-stream"},
+				},
+			},
+			streamMap:     StreamMap{"some-stream": {UpstreamImage: "openshift/some-stream-builder:rhel_8_golang_1.14", Mirror: utilpointer.BoolPtr(false)}},
+			expectedError: errors.New("[failed to replace .from.stream: stream.yaml.some-stream.mirror is set to false, can not dereference, failed to find replacement for .from.stream]"),
 		},
 		{
 			name: "config.from.member gets replaced",


### PR DESCRIPTION
We need to hardcode specific streams to bypass mirror check as workaround until https://github.com/openshift-eng/ocp-build-data/commit/155694be74cb2f020f6fafeaf6e4b3fba89646a2 is reverted/changed.