### PR TITLE
OTA-905: cincinnati client: query integration & staging instances

### DIFF
--- a/pkg/release/official/client.go
+++ b/pkg/release/official/client.go
@@ -3,7 +3,7 @@ package official
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sort"
@@ -60,7 +60,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, release api.Rel
 		return "", "", fmt.Errorf("failed to request %s: got a nil response", targetName)
 	}
 	defer resp.Body.Close()
-	data, readErr := ioutil.ReadAll(resp.Body)
+	data, readErr := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return "", "", fmt.Errorf("failed to request %s: server responded with %d: %s", targetName, resp.StatusCode, data)
 	}


### PR DESCRIPTION
OTA maintains staging (identical to production) and integration (running on engineering candidate OCP clusters) Cincinnati instances. We are searching for traffic that we could route to especially the integration one, so that we can find possible problems with engineering candidate early.
    
All the instances are serving identical data (up to some minimal skew coming from when individual instance scrape their source data) so we should be able to easily use the integration instance first, then the staging one, and if needed, use the production one as a backstop.

After:

```console
$ ci-operator --org stackrox --repo stackrox --branch master --target=[images] --git-ref=stackrox/stackrox@master
...
INFO[2023-06-26T16:11:20+02:00] Requesting 4.12 from https://api.integration.openshift.com/api/upgrades_info/v1/graph?arch=amd64&channel=fast-4.12 
INFO[2023-06-26T16:11:21+02:00] Resolved release latest to quay.io/openshift-release-dev/ocp-release@sha256:ba7956f5c2aae61c8ff3ab1ab2ee7e625db9b1c8964a65339764db79c148e4e6
```

Before:
```console
$ ci-operator --org stackrox --repo stackrox --branch master --target=[images] --git-ref=stackrox/stackrox@master
...
INFO[2023-06-26T16:14:56+02:00] Requesting 4.12 from https://api.openshift.com/api/upgrades_info/v1/graph?arch=amd64&channel=fast-4.12 
INFO[2023-06-26T16:14:57+02:00] Resolved release latest to quay.io/openshift-release-dev/ocp-release@sha256:ba7956f5c2aae61c8ff3ab1ab2ee7e625db9b1c8964a65339764db79c148e4e6
```

We can see that the release was resolved to the same pullspec after querying both api.integration.openshift.com and api.openshift.com/api endpoints.