### PR TITLE
Auto create layered product rosa-hypershift interop testing test grid dashboard.

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -223,6 +223,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case strings.Contains(prowName, "-lp-interop"):
 			// OpenShift layered product interop testing
 			dashboardType = "informing"
+		case strings.Contains(prowName, "-lp-rosa-hypershift"):
+			// OpenShift layered product rosa hypershift interop testing
+			dashboardType = "informing"
 		case strings.Contains(prowName, "CSPI-QE-MSI"):
 			// Managed Services Integration (MSI) testing
 			dashboardType = "informing"
@@ -262,6 +265,9 @@ func addDashboardTab(p prowConfig.Periodic,
 		case strings.Contains(prowName, "-lp-interop"):
 			// OpenShift layered product interop testing
 			stream = "lp-interop"
+		case strings.Contains(prowName, "-lp-rosa-hypershift"):
+			// OpenShift layered product rosa hypershift interop testing
+			stream = "lp-rosa-hypershift"
 		case strings.Contains(prowName, "CSPI-QE-MSI"):
 			// Managed Services Integration (MSI) testing
 			stream = "CSPI-QE-MSI"


### PR DESCRIPTION
We are now extending layered product interop efforts to cover rosa hypershift testing. Since we are testing many layered products, manually submitting PRs to test-infra or adding to the _allow-list.yml is time consuming/error prone if forgetting to add a job when its being created.

This change updates the testgrid config generator command to create dashboards for layered product rosa-hypershift interop testing based on jobs containing a unique string 'lp-rosa-hypershift'.

These dashboards will provide easy insight/visibility into the health of the red hat portfolio on top of openshift releases.

This change will allow a dashboard to be created like the following:
 * redhat-openshift-lp-rosa-hypershift-release-4.13-informing
