### PR TITLE
Store MasterNodesUpdated and JobRunStatus with every result as well

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
@@ -68,14 +68,16 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 )
 
 type AlertRow struct {
-	Name            string
-	Namespace       string
-	Level           string
-	AlertSeconds    int
-	JobName         bigquery.NullString
-	JobRunName      string
-	JobRunStartTime bigquery.NullTimestamp
-	JobRunEndTime   bigquery.NullTimestamp
-	Cluster         bigquery.NullString
-	ReleaseTag      bigquery.NullString
+	Name               string
+	Namespace          string
+	Level              string
+	AlertSeconds       int
+	JobName            bigquery.NullString
+	JobRunName         string
+	JobRunStartTime    bigquery.NullTimestamp
+	JobRunEndTime      bigquery.NullTimestamp
+	Cluster            bigquery.NullString
+	ReleaseTag         bigquery.NullString
+	MasterNodesUpdated bigquery.NullString
+	JobRunStatus       bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -31,12 +31,14 @@ INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.Job
 const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {
-	BackendName       string
-	DisruptionSeconds int
-	JobName           bigquery.NullString
-	JobRunName        string
-	JobRunStartTime   bigquery.NullTimestamp
-	JobRunEndTime     bigquery.NullTimestamp
-	Cluster           bigquery.NullString
-	ReleaseTag        bigquery.NullString
+	BackendName        string
+	DisruptionSeconds  int
+	JobName            bigquery.NullString
+	JobRunName         string
+	JobRunStartTime    bigquery.NullTimestamp
+	JobRunEndTime      bigquery.NullTimestamp
+	Cluster            bigquery.NullString
+	ReleaseTag         bigquery.NullString
+	MasterNodesUpdated bigquery.NullString
+	JobRunStatus       bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -47,13 +47,15 @@ const (
 
 // Move here from jobrunbigqueryloader/types.go
 type TestRunRow struct {
-	Name            string
-	Status          string
-	TestSuite       string
-	JobName         bigquery.NullString
-	JobRunName      string
-	JobRunStartTime bigquery.NullTimestamp
-	JobRunEndTime   bigquery.NullTimestamp
-	Cluster         bigquery.NullString
-	ReleaseTag      bigquery.NullString
+	Name               string
+	Status             string
+	TestSuite          string
+	JobName            bigquery.NullString
+	JobRunName         string
+	JobRunStartTime    bigquery.NullTimestamp
+	JobRunEndTime      bigquery.NullTimestamp
+	Cluster            bigquery.NullString
+	ReleaseTag         bigquery.NullString
+	MasterNodesUpdated bigquery.NullString
+	JobRunStatus       bigquery.NullString
 }

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -250,6 +250,11 @@ func populateZeros(jobRunRow *jobrunaggregatorapi.JobRunRow,
 					StringVal: jobRunRow.ReleaseTag,
 					Valid:     true,
 				},
+				JobRunStatus: bigquery.NullString{
+					StringVal: jobRunRow.Status,
+					Valid:     true,
+				},
+				MasterNodesUpdated: jobRunRow.MasterNodesUpdated,
 			})
 			injectedCtr++
 		}
@@ -362,6 +367,11 @@ func getAlertsFromPerJobRunData(alertData map[string]string, jobRunRow *jobrunag
 				StringVal: jobRunRow.ReleaseTag,
 				Valid:     true,
 			},
+			JobRunStatus: bigquery.NullString{
+				StringVal: jobRunRow.Status,
+				Valid:     true,
+			},
+			MasterNodesUpdated: jobRunRow.MasterNodesUpdated,
 		})
 	}
 

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert_test.go
@@ -257,10 +257,11 @@ func TestPopulateZeros(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			jobRunRow := &jobrunaggregatorapi.JobRunRow{
-				Name:       "1000",
-				JobName:    "foobar-job",
-				Cluster:    "build01",
-				ReleaseTag: "",
+				Name:               "1000",
+				JobName:            "foobar-job",
+				Cluster:            "build01",
+				ReleaseTag:         "",
+				MasterNodesUpdated: bigquery.NullString{StringVal: "", Valid: true},
 			}
 			// Add some more detail to the observed/expected alerts as the bigquery null
 			// types get quite verbose to include in every test:
@@ -285,6 +286,14 @@ func TestPopulateZeros(t *testing.T) {
 					Timestamp: time.Time{},
 					Valid:     true,
 				}
+				test.observedAlerts[i].JobRunStatus = bigquery.NullString{
+					StringVal: "",
+					Valid:     true,
+				}
+				test.observedAlerts[i].MasterNodesUpdated = bigquery.NullString{
+					StringVal: "",
+					Valid:     true,
+				}
 			}
 			// Add some more detail to the observed/expected alerts as the bigquery null
 			// types get quite verbose to include in every test:
@@ -307,6 +316,14 @@ func TestPopulateZeros(t *testing.T) {
 				}
 				test.expectedAlertsToUpload[i].JobRunEndTime = bigquery.NullTimestamp{
 					Timestamp: time.Time{},
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].JobRunStatus = bigquery.NullString{
+					StringVal: "",
+					Valid:     true,
+				}
+				test.expectedAlertsToUpload[i].MasterNodesUpdated = bigquery.NullString{
+					StringVal: "",
 					Valid:     true,
 				}
 			}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/disruption.go
@@ -208,6 +208,11 @@ func (o *disruptionUploader) uploadBackendDisruption(ctx context.Context, jobRun
 				StringVal: jobRunRow.ReleaseTag,
 				Valid:     true,
 			},
+			JobRunStatus: bigquery.NullString{
+				StringVal: jobRunRow.Status,
+				Valid:     true,
+			},
+			MasterNodesUpdated: jobRunRow.MasterNodesUpdated,
 		}
 		rows = append(rows, row)
 	}

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/types.go
@@ -65,5 +65,10 @@ func newTestRunRow(jobRunRow *jobrunaggregatorapi.JobRunRow, status string, test
 			StringVal: jobRunRow.ReleaseTag,
 			Valid:     true,
 		},
+		JobRunStatus: bigquery.NullString{
+			StringVal: jobRunRow.Status,
+			Valid:     true,
+		},
+		MasterNodesUpdated: jobRunRow.MasterNodesUpdated,
 	}
 }


### PR DESCRIPTION
Similar to yesterday, we're working to join less and deduplicate the job run tables entirely which all hold the same data
