### PR TITLE
TRT-1281: single command multiple uploaders 

### DIFF
--- a/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/cmd.go
@@ -100,15 +100,54 @@ func (f *BigQueryTestRunUploadFlags) ToOptions(ctx context.Context) (*allJobsLoa
 
 	var jobRunTableInserter jobrunaggregatorlib.BigQueryInserter
 	var testRunTableInserter jobrunaggregatorlib.BigQueryInserter
+
+	var backendAlertTableInserter jobrunaggregatorlib.BigQueryInserter
+	var backendDisruptionTableInserter jobrunaggregatorlib.BigQueryInserter
+
 	if !f.DryRun {
 		ciDataSet := bigQueryClient.Dataset(f.DataCoordinates.DataSetID)
 		jobRunTable := ciDataSet.Table(jobrunaggregatorapi.LegacyJobRunTableName)
 		testRunTable := ciDataSet.Table(jobrunaggregatorlib.TestRunTableName)
 		jobRunTableInserter = jobRunTable.Inserter()
 		testRunTableInserter = testRunTable.Inserter()
+
+		// could start with dry run for the new uploaders if we wanted
+		// backendAlertTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.AlertsTableName)
+		// backendDisruptionTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.BackendDisruptionTableName)
+
+		// backendAlertTable := ciDataSet.Table(jobrunaggregatorapi.AlertsTableName)
+		// backendAlertTableInserter = backendAlertTable.Inserter()
+		// backendDisruptionTable := ciDataSet.Table(jobrunaggregatorapi.BackendDisruptionTableName)
+		// backendDisruptionTableInserter = backendDisruptionTable.Inserter()
+
 	} else {
 		jobRunTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.LegacyJobRunTableName)
 		testRunTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorlib.TestRunTableName)
+
+		backendAlertTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.AlertsTableName)
+		backendDisruptionTableInserter = jobrunaggregatorlib.NewDryRunInserter(os.Stdout, jobrunaggregatorapi.BackendDisruptionTableName)
+	}
+
+	jobRunUploaderRegistry := JobRunUploaderRegistry{}
+	testRunUploader := newTestRunUploader(testRunTableInserter, ciDataClient)
+	pendingUploadLister := newTestRunPendingUploadLister(ciDataClient)
+	jobRunUploaderRegistry.Register("testRunUploader", testRunUploader)
+
+	// Temporarily only support in dry run mode for now
+	// Do we want to support a date specific switchover so
+	// we can run both alert && disruption uploaders and stop uploading
+	// at a specific date / time as well as adding them here via the registry
+	// and have them start uploading after that specific date / time
+	// Before we can switch we have to make sure nothing is querying the other JobRuns tables
+	// DisruptionJobRunTableName = "BackendDisruption_JobRuns"
+	//	AlertJobRunTableName      = "Alerts_JobRuns"
+	if f.DryRun {
+		alertUploader, err := newAlertUploader(backendAlertTableInserter, ciDataClient)
+		if err != nil {
+			return nil, err
+		}
+		jobRunUploaderRegistry.Register("alertUploader", alertUploader)
+		jobRunUploaderRegistry.Register("disruptionUploader", newDisruptionUploader(backendDisruptionTableInserter, ciDataClient))
 	}
 
 	return &allJobsLoaderOptions{
@@ -117,7 +156,8 @@ func (f *BigQueryTestRunUploadFlags) ToOptions(ctx context.Context) (*allJobsLoa
 
 		jobRunInserter:              jobRunTableInserter,
 		shouldCollectedDataForJobFn: wantsTestRunData,
-		jobRunUploader:              newTestRunUploader(testRunTableInserter, ciDataClient),
+		jobRunUploaderRegistry:      jobRunUploaderRegistry,
+		pendingUploadJobsLister:     pendingUploadLister,
 		logLevel:                    f.LogLevel,
 	}, nil
 }


### PR DESCRIPTION
Updated to add an uploader registry that relies on a common JobRuns table.

Prior work done in [TRT-1120](https://issues.redhat.com//browse/TRT-1120) reduces GCS enumeration to a single pass

Still need to coordinate removing the existing alert and disruption loader and removing references to those jobs tables

Updated to reference [TRT-1281](https://issues.redhat.com//browse/TRT-1281).  Current plan is to get support in place with the uploader registry and work through reducing the commands down to a single process separately.