### PR TITLE
Fix aggregated disruption tests being silently skipped

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -347,7 +347,7 @@ func buildMasterNodesUpdatedSQL(masterNodesUpdated string) string {
 	masterNodesUpdatedSQL := ""
 
 	if len(masterNodesUpdated) > 0 {
-		masterNodesUpdatedSQL = fmt.Sprintf("AND MasterNodesUpdated = '%s'", masterNodesUpdated)
+		masterNodesUpdatedSQL = fmt.Sprintf("AND JobRuns.MasterNodesUpdated = '%s'", masterNodesUpdated)
 	}
 
 	return masterNodesUpdatedSQL
@@ -357,7 +357,7 @@ func (c *ciDataClient) GetBackendDisruptionRowCountByJob(ctx context.Context, jo
 	queryString := c.dataCoordinates.SubstituteDataSetLocation(fmt.Sprintf(`
 SELECT Count(Name) AS TotalRows
 FROM
-	DATA_SET_LOCATION.BackendDisruption_JobRuns
+	DATA_SET_LOCATION.BackendDisruption_JobRuns AS JobRuns
 WHERE
     StartTime <= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
 AND


### PR DESCRIPTION
on ambiguous MasterNodesUpdated

This column was added to BackendDisruption yesterday, and now this query
is broken. To fix we specify the table to use, which is an alias defined
in both queries that call this function.
