### PR TITLE
Update historical disruption query

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_historical_data.go
@@ -2,6 +2,8 @@ package jobrunaggregatorapi
 
 import (
 	"fmt"
+
+	"cloud.google.com/go/bigquery"
 )
 
 type HistoricalData interface {
@@ -14,12 +16,13 @@ type HistoricalData interface {
 }
 
 type HistoricalJobData struct {
-	Release      string
-	FromRelease  string
-	Platform     string
-	Architecture string
-	Network      string
-	Topology     string
+	Release            string
+	FromRelease        string
+	Platform           string
+	Architecture       string
+	Network            string
+	Topology           string
+	MasterNodesUpdated bigquery.NullString
 	// JobRuns is the number of job runs that were included when we queried the historical data.
 	JobRuns int
 }


### PR DESCRIPTION
We now use 30 days instead of 21, we believe things are stable enough to
move up and this may help smooth out some of the weekly variance in the
data in this file.

Switched to use the latest daily report instead of a separate copy of
the same query, which was left behind when MasterNodesUpdated was
handled elsewhere.

We now use MasterNodesUpdated != N for the P99 limits, which implies
either Y or null for past releases. We want to use the worst case for
now as we recently did with aggregation.
