### PR TITLE
WIP: Revert commit 83e40a69b: add the preserve original import policy on t…

### DIFF
--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -373,7 +373,6 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 		Spec: imagev1.ImageStreamImportSpec{
 			Import: true,
 			Images: []imagev1.ImageImportSpec{{
-				ImportPolicy: imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 				From: corev1.ObjectReference{
 					Kind: "DockerImage",
 					Name: pullSpec,

--- a/pkg/controller/test-images-distributor/test_images_distributor_test.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor_test.go
@@ -317,7 +317,6 @@ func TestReconcile(t *testing.T) {
 					},
 					To:              &corev1.LocalObjectReference{Name: "Question"},
 					ReferencePolicy: imagev1.TagReferencePolicy{Type: "Local"},
-					ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 				}},
 			},
 			Status: imagev1.ImageStreamImportStatus{


### PR DESCRIPTION
…est image distribution

The commit broke `ci/prow/ci-index-gcp-filestore-csi-driver-operator-bundle` test:
```
step ci-index-gcp-filestore-csi-driver-operator-bundle failed: failed to get workingDir: could not fetch source ImageStreamTag: imagestreamtags.image.openshift.io "pipeline:ci-index-gcp-filestore-csi-driver-operator-bundle-gen" not found
```
(https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_gcp-filestore-csi-driver-operator/40/pull-ci-openshift-gcp-filestore-csi-driver-operator-main-ci-index-gcp-filestore-csi-driver-operator-bundle/1673792616501612544)