### PR TITLE
promotionreconciler considers isTag with manifests

### DIFF
--- a/pkg/api/helper/imagestreamtag.go
+++ b/pkg/api/helper/imagestreamtag.go
@@ -1,0 +1,45 @@
+package helper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/api/image/docker10"
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+// LabelsOnISTagImage the labels of the image underlying the given ImageStreamTag for the given arch
+func LabelsOnISTagImage(ctx context.Context, client ctrlruntimeclient.Client, isTag *imagev1.ImageStreamTag, arch api.ReleaseArchitecture) (map[string]string, error) {
+	dockerImageMetadata := isTag.Image.DockerImageMetadata
+	for _, imageManifest := range isTag.Image.DockerImageManifests {
+		if imageManifest.Architecture == string(arch) {
+			image := &imagev1.Image{}
+			// image is a cluster level CRD and thus no namespace should be provided to get the object
+			if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: imageManifest.Digest}, image); err != nil {
+				return nil, fmt.Errorf("failed to get Image %s: %w", imageManifest.Digest, err)
+			}
+			dockerImageMetadata = image.DockerImageMetadata
+			logrus.WithField("namespace", isTag.Namespace).WithField("name", isTag.Name).WithField("arch", string(arch)).Debug("Found the image in manifests")
+			break
+		}
+	}
+	metadata := &docker10.DockerImage{}
+	if len(dockerImageMetadata.Raw) == 0 {
+		return nil, fmt.Errorf("found no Docker image metadata for ImageStreamTag %s in %s", isTag.Name, isTag.Namespace)
+	}
+	if err := json.Unmarshal(dockerImageMetadata.Raw, metadata); err != nil {
+		return nil, fmt.Errorf("malformed Docker image metadata for ImageStreamTag %s in %s: %w", isTag.Name, isTag.Namespace, err)
+	}
+	if metadata.Config == nil {
+		logrus.WithField("namespace", isTag.Namespace).WithField("name", isTag.Name).WithField("arch", string(arch)).Debug("Found no config in Docker image metadata")
+		return nil, nil
+	}
+	return metadata.Config.Labels, nil
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2124,22 +2124,15 @@ func (m *MetadataWithTest) JobName(prefix string) string {
 	return m.Metadata.JobName(prefix, m.Test)
 }
 
-type Architecture string
-
-const (
-	AMD64Arch Architecture = "amd64"
-	ARM64Arch Architecture = "arm64"
-)
-
-var archToCluster = map[Architecture]Cluster{
-	ARM64Arch: ClusterARM01,
+var archToCluster = map[ReleaseArchitecture]Cluster{
+	ReleaseArchitectureARM64: ClusterARM01,
 }
 
-func (a Architecture) IsValid() bool {
+func (a ReleaseArchitecture) IsValid() bool {
 	return a.GetMappedCluster() != ""
 }
 
-func (a Architecture) GetMappedCluster() Cluster {
+func (a ReleaseArchitecture) GetMappedCluster() Cluster {
 	c, found := archToCluster[a]
 	if !found {
 		return ""

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -36,7 +36,7 @@ type Prowgen struct {
 	// Rehearsals declares any disabled rehearsals for jobs
 	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
 	// Set which architecture should the images be promoted from
-	AdditionalArchitectures []cioperatorapi.Architecture `json:"additional_architectures"`
+	AdditionalArchitectures []cioperatorapi.ReleaseArchitecture `json:"additional_architectures"`
 	// If true build images targeting multiple architectures
 	MultiArch bool `json:"multi_arch"`
 }

--- a/pkg/controller/promotionreconciler/reconciler_test.go
+++ b/pkg/controller/promotionreconciler/reconciler_test.go
@@ -64,7 +64,7 @@ func TestCommitForIST(t *testing.T) {
 			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
 				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
 			}
-			commit, err := commitForIST(ist)
+			commit, err := commitForIST(ist, fakectrlruntimeclient.NewFakeClient())
 			if err != nil {
 				t.Fatalf("failed to get ref for ist: %v", err)
 			}

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -247,12 +247,12 @@ func generatePostsubmitsForPromotion(jobBaseBuilderFactory func() *prowJobBaseBu
 	for _, opt := range options {
 		opt(opts)
 	}
-	architectures := append([]api.Architecture{api.AMD64Arch}, info.Config.AdditionalArchitectures...)
+	architectures := append([]api.ReleaseArchitecture{api.ReleaseArchitectureAMD64}, info.Config.AdditionalArchitectures...)
 	postsubmits := make([]prowconfig.Postsubmit, 0, len(architectures))
 	for _, arch := range architectures {
 		jobBaseBuilder := jobBaseBuilderFactory()
 		var jobBaseGen *prowJobBaseBuilder
-		if arch != api.AMD64Arch {
+		if arch != api.ReleaseArchitectureAMD64 {
 			testName := fmt.Sprintf("images-%s", string(arch))
 			cluster := arch.GetMappedCluster()
 			if cluster == "" {

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -285,8 +285,8 @@ func TestGeneratePostSubmitForPromotion(t *testing.T) {
 				},
 				Config: config.Prowgen{
 					MultiArch: true,
-					AdditionalArchitectures: []ciop.Architecture{
-						api.ARM64Arch,
+					AdditionalArchitectures: []ciop.ReleaseArchitecture{
+						api.ReleaseArchitectureARM64,
 					},
 				},
 			},
@@ -587,8 +587,8 @@ func TestGenerateJobs(t *testing.T) {
 			},
 			repoInfo: &ProwgenInfo{
 				Config: config.Prowgen{
-					AdditionalArchitectures: []ciop.Architecture{
-						api.ARM64Arch,
+					AdditionalArchitectures: []ciop.ReleaseArchitecture{
+						api.ReleaseArchitectureARM64,
 					},
 				},
 				Metadata: ciop.Metadata{

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -202,12 +202,12 @@ func TestDatabaseIndex(t *testing.T) {
 		name:        "no metadata",
 		istFile:     "testdata/isTags/pipeline_no_bytes_istag.yaml",
 		isTagName:   "pipeline:v4.10",
-		expectedErr: fmt.Errorf(`could not fetch Docker image metadata`),
+		expectedErr: fmt.Errorf(`failed to get value of the image label: found no Docker image metadata for ImageStreamTag pipeline:v4.10 in ns`),
 	}, {
 		name:        "malformed json",
 		istFile:     "testdata/isTags/pipeline_malformed_istag.yaml",
 		isTagName:   "pipeline:v4.10",
-		expectedErr: fmt.Errorf(`malformed Docker image metadata: json: cannot unmarshal string into Go value of type docker10.DockerImage`),
+		expectedErr: fmt.Errorf(`failed to get value of the image label: malformed Docker image metadata for ImageStreamTag pipeline:v4.10 in ns: json: cannot unmarshal string into Go value of type docker10.DockerImage`),
 	}, {
 		name:      "no labels",
 		istFile:   "testdata/isTags/pipeline_no_label_istag.yaml",

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -439,7 +439,7 @@ func constructMultiArchBuilds(build buildapi.Build, nodeArchitectures []string) 
 	for _, arch := range nodeArchitectures {
 		b := build
 
-		if arch != string(api.AMD64Arch) {
+		if arch != string(api.ReleaseArchitectureAMD64) {
 			b.Name = fmt.Sprintf("%s-%s", b.Name, arch)
 		}
 


### PR DESCRIPTION
Similar to 
https://github.com/openshift/ci-tools/pull/3521
that handles the istag in OO-Testing,
we make the promotionreconciler ready for istags with manifests.

Currently we do not hit the issue because CI does not build those isTags (openshift-build does not support multi-arch at the moment). But it might happen in the future.

/cc @openshift/test-platform 
/assign @droslean