### PR TITLE
`agents`: initialization failures do not result in an error

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -49,7 +49,7 @@ func (o *options) parse() error {
 	if err := o.loadResolver(registryDir); err != nil {
 		return fmt.Errorf("failed to load registry: %w", err)
 	}
-	ciOPConfigAgent, err := agents.NewConfigAgent(o.ConfigDir, agents.WithOrg(o.Org), agents.WithRepo(o.Repo))
+	ciOPConfigAgent, err := agents.NewConfigAgent(o.ConfigDir, nil, agents.WithOrg(o.Org), agents.WithRepo(o.Repo))
 	if err != nil {
 		return fmt.Errorf("failed to create CI Op config agent: %w", err)
 	}

--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -182,12 +182,14 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("Failed to get config agent: %v", err)
 	}
+	go func() { logrus.Fatal(<-configErrCh) }()
 
 	registryErrCh := make(chan error)
 	registryAgent, err := agents.NewRegistryAgent(o.registryPath, registryErrCh, agents.WithRegistryMetrics(configresolverMetrics.ErrorRate), agents.WithRegistryFlat(o.flatRegistry), registryAgentOption)
 	if err != nil {
 		logrus.Fatalf("Failed to get registry agent: %v", err)
 	}
+	go func() { logrus.Fatal(<-registryErrCh) }()
 
 	if o.validateOnly {
 		os.Exit(0)

--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -183,7 +183,8 @@ func main() {
 		logrus.Fatalf("Failed to get config agent: %v", err)
 	}
 
-	registryAgent, err := agents.NewRegistryAgent(o.registryPath, agents.WithRegistryMetrics(configresolverMetrics.ErrorRate), agents.WithRegistryFlat(o.flatRegistry), registryAgentOption)
+	registryErrCh := make(chan error)
+	registryAgent, err := agents.NewRegistryAgent(o.registryPath, registryErrCh, agents.WithRegistryMetrics(configresolverMetrics.ErrorRate), agents.WithRegistryFlat(o.flatRegistry), registryAgentOption)
 	if err != nil {
 		logrus.Fatalf("Failed to get registry agent: %v", err)
 	}

--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -177,7 +177,8 @@ func main() {
 		interrupts.Run(watcher)
 	}
 
-	configAgent, err := agents.NewConfigAgent(o.configPath, agents.WithConfigMetrics(configresolverMetrics.ErrorRate), configAgentOption)
+	configErrCh := make(chan error)
+	configAgent, err := agents.NewConfigAgent(o.configPath, configErrCh, agents.WithConfigMetrics(configresolverMetrics.ErrorRate), configAgentOption)
 	if err != nil {
 		logrus.Fatalf("Failed to get config agent: %v", err)
 	}

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -332,7 +332,8 @@ func main() {
 		}
 		interrupts.Run(watcher)
 	}
-	ciOPConfigAgent, err := agents.NewConfigAgent(opts.ciOperatorconfigPath, configAgentOption)
+	configErrCh := make(chan error)
+	ciOPConfigAgent, err := agents.NewConfigAgent(opts.ciOperatorconfigPath, configErrCh, configAgentOption)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to construct ci-operator config agent")
 	}

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -337,6 +337,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to construct ci-operator config agent")
 	}
+	go func() { logrus.Fatal(<-configErrCh) }()
 	configAgent, err := opts.prowconfig.ConfigAgent()
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to start config agent")
@@ -454,6 +455,7 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to construct registryAgent")
 		}
+		go func() { logrus.Fatal(<-registryErrCh) }()
 
 		registriesExceptAppCI := sets.NewString()
 		for cluster := range allClustersExceptRegistryCluster {

--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -449,7 +449,8 @@ func main() {
 	}
 
 	if opts.enabledControllersSet.Has(testimagesdistributor.ControllerName) {
-		registryConfigAgent, err := agents.NewRegistryAgent(opts.stepConfigPath, registryAgentOption)
+		registryErrCh := make(chan error)
+		registryConfigAgent, err := agents.NewRegistryAgent(opts.stepConfigPath, registryErrCh, registryAgentOption)
 		if err != nil {
 			logrus.WithError(err).Fatal("failed to construct registryAgent")
 		}

--- a/cmd/payload-testing-prow-plugin/filetestresolver_test.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver_test.go
@@ -78,7 +78,7 @@ func TestFileTestResolver(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			configAgent, err := agents.NewConfigAgent(tc.dir)
+			configAgent, err := agents.NewConfigAgent(tc.dir, nil)
 			if err != nil {
 				t.Fatalf("Failed to get config agent: %v", err)
 			}

--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -142,7 +142,8 @@ func main() {
 		logger.WithError(err).WithField("context", appCIContextName).Fatal("could not get client for kube config")
 	}
 
-	configAgent, err := agents.NewConfigAgent(o.ciOpConfigDir)
+	// TODO: add error handling
+	configAgent, err := agents.NewConfigAgent(o.ciOpConfigDir, nil)
 	if err != nil {
 		logger.WithError(err).Fatal("could not get config agent")
 	}

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -226,10 +226,6 @@ func OperateOnCIOperatorConfigSubdir(configDir, subDir string, callback ConfigIt
 		return filepath.WalkDir(filepath.Join(configDir, subDir), func(path string, info fs.DirEntry, err error) error {
 			if err != nil {
 				logrus.WithField("source-file", path).WithError(err).Error("Failed to walk CI Operator configuration dir")
-				// file may not exist due to race condition between the reload and k8s removing deleted/moved symlinks in a confimap directory; ignore it
-				if os.IsNotExist(err) {
-					return nil
-				}
 				return err
 			}
 			if isMountSpecialFile(info.Name()) {

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -136,7 +136,7 @@ func NewConfigAgent(configPath string, errCh chan error, opts ...ConfigAgentOpti
 		opt.UniversalSymlinkWatcher.ConfigEventFn = a.reloadConfig
 	}
 
-	return a, startWatchers(configPath, a.reloadConfig, a.errorMetrics, opt.UniversalSymlinkWatcher)
+	return a, startWatchers(configPath, errCh, a.reloadConfig, a.errorMetrics, opt.UniversalSymlinkWatcher)
 }
 
 // GetMatchingConfig loads a configuration that matches the metadata,

--- a/pkg/load/agents/configAgent.go
+++ b/pkg/load/agents/configAgent.go
@@ -117,7 +117,7 @@ func WithRepo(repo string) ConfigAgentOption {
 
 // NewConfigAgent returns a ConfigAgent interface that automatically reloads when
 // configs are changed on disk.
-func NewConfigAgent(configPath string, opts ...ConfigAgentOption) (ConfigAgent, error) {
+func NewConfigAgent(configPath string, errCh chan error, opts ...ConfigAgentOption) (ConfigAgent, error) {
 	opt := &ConfigAgentOptions{}
 	for _, o := range opts {
 		o(opt)

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -76,7 +76,7 @@ func WithRegistryFlat(v bool) RegistryAgentOption {
 
 // NewRegistryAgent returns a RegistryAgent interface that automatically reloads when
 // the registry is changed on disk.
-func NewRegistryAgent(registryPath string, opts ...RegistryAgentOption) (RegistryAgent, error) {
+func NewRegistryAgent(registryPath string, errCh chan error, opts ...RegistryAgentOption) (RegistryAgent, error) {
 	opt := &RegistryAgentOptions{}
 	for _, o := range opts {
 		o(opt)

--- a/pkg/load/agents/registryAgent.go
+++ b/pkg/load/agents/registryAgent.go
@@ -106,7 +106,7 @@ func NewRegistryAgent(registryPath string, errCh chan error, opts ...RegistryAge
 		opt.UniversalSymlinkWatcher.RegistryEventFn = a.loadRegistry
 	}
 
-	return a, startWatchers(registryPath, a.loadRegistry, a.errorMetrics, opt.UniversalSymlinkWatcher)
+	return a, startWatchers(registryPath, errCh, a.loadRegistry, a.errorMetrics, opt.UniversalSymlinkWatcher)
 }
 
 // ResolveConfig uses the registryAgent's resolver to resolve a provided ReleaseBuildConfiguration

--- a/pkg/load/agents/utils.go
+++ b/pkg/load/agents/utils.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 )
 
-func startWatchers(path string, callback func() error, metric *prometheus.CounterVec, universalSymlinkWatcher *UniversalSymlinkWatcher) error {
+func startWatchers(path string, errCh chan<- error, callback func() error, metric *prometheus.CounterVec, universalSymlinkWatcher *UniversalSymlinkWatcher) error {
 	var watchers []func(context.Context)
 
 	if universalSymlinkWatcher != nil {
@@ -22,6 +22,7 @@ func startWatchers(path string, callback func() error, metric *prometheus.Counte
 			errFunc := func(err error, msg string) {
 				recordErrorForMetric(metric, msg)
 				logrus.WithError(err).Error(msg)
+				errCh <- err
 			}
 
 			for {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -56,10 +55,6 @@ func Registry(root string, flags RegistryFlag) (registry.ReferenceByName, regist
 	}
 	err := filepath.WalkDir(root, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
-			// file may not exist due to race condition between the reload and k8s removing deleted/moved symlinks in a confimap directory; ignore it
-			if os.IsNotExist(err) {
-				return nil
-			}
 			return err
 		}
 		if strings.HasPrefix(info.Name(), "..") {


### PR DESCRIPTION
This PR was supposed to solve failures during the initialization and runtime of the `ci-operator-configresolver`. Instead, it was figured out, that the issue is mostly connected to the `agents` and touches also other services (`dptp-conotroller-manager`). In this PR is implemented channeled error forwarding for the `ConfigAgent` and `RegistryAgent`.