### PR TITLE
Revert "ci-operator: optionally decorate test pods"

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/remotecommand"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -278,69 +277,48 @@ func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.
 	blobStorageVolumes, blobStorageMounts, blobStorageOptions := decorate.BlobStorageOptions(*decorationConfig, false)
 	blobStorageOptions.SubDir = artifactDir
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, decorate.PlaceEntrypoint(decorationConfig, toolsMount))
-	pod.Spec.Volumes = append(pod.Spec.Volumes, logVolume, toolsVolume)
+
 	wrapperOptions, err := decorate.InjectEntrypoint(&pod.Spec.Containers[0], decorationConfig.Timeout.Get(), decorationConfig.GracePeriod.Get(), "", "", false, logMount, toolsMount)
 	if err != nil {
 		return fmt.Errorf("could not inject entrypoint: %w", err)
 	}
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, coreapi.EnvVar{Name: artifactEnv, Value: logMount.MountPath + "/artifacts"})
-	if decorationConfig.GCSConfiguration != nil {
-		sidecar, err := decorate.Sidecar(decorationConfig, blobStorageOptions, blobStorageMounts, logMount, nil, rawJobSpec, !decorate.RequirePassingEntries, true, secretsToCensor, *wrapperOptions)
-		if err != nil {
-			return fmt.Errorf("could not create sidecar: %w", err)
-		}
-		pod.Spec.Containers = append(pod.Spec.Containers, *sidecar)
-		pod.Spec.Volumes = append(pod.Spec.Volumes, blobStorageVolumes...)
-	}
-	if clone {
-		if err := addCloning(pod, *decorationConfig, rawJobSpec, jobSpec, logMount, blobStorageOptions, blobStorageMounts); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
-func addCloning(
-	pod *coreapi.Pod,
-	decorationConfig prowv1.DecorationConfig,
-	rawJobSpec string,
-	jobSpec *api.JobSpec,
-	logMount coreapi.VolumeMount,
-	blobStorageOptions gcsupload.Options,
-	blobStorageMounts []coreapi.VolumeMount,
-) error {
-	// Unless build_root.from_repository: true is set, the decorationConfig the
-	// ci-operator pod gets has cloning disabled.
-	decorationConfig.SkipCloning = nil
-	codeMount, codeVolume := decorate.CodeMountAndVolume()
-	cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{
-		Spec: prowv1.ProwJobSpec{
-			Refs:             jobSpec.Refs,
-			ExtraRefs:        jobSpec.ExtraRefs,
-			DecorationConfig: &decorationConfig,
-		},
-	}, codeMount, logMount)
+	sidecar, err := decorate.Sidecar(decorationConfig, blobStorageOptions, blobStorageMounts, logMount, nil, rawJobSpec, !decorate.RequirePassingEntries, true, secretsToCensor, *wrapperOptions)
 	if err != nil {
-		return fmt.Errorf("failed to construct clonerefs: %w", err)
+		return fmt.Errorf("could not create sidecar: %w", err)
 	}
-	if len(refs) == 0 {
-		return nil
-	}
-	pod.Spec.InitContainers = util.Insert(pod.Spec.InitContainers, 0, *cloneRefsContainer)
-	pod.Spec.Volumes = append(pod.Spec.Volumes, codeVolume)
-	pod.Spec.Volumes = append(pod.Spec.Volumes, cloneRefsVolumes...)
-	if len(refs) > 0 {
-		for i, container := range pod.Spec.Containers {
-			pod.Spec.Containers[i].WorkingDir = decorate.DetermineWorkDir(codeMount.MountPath, refs)
-			pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, codeMount)
+	pod.Spec.Containers = append(pod.Spec.Containers, *sidecar)
+
+	pod.Spec.Volumes = append(pod.Spec.Volumes, logVolume, toolsVolume)
+	pod.Spec.Volumes = append(pod.Spec.Volumes, blobStorageVolumes...)
+
+	if clone {
+		// Unless build_root.from_repository: true is set, the decorationConfig the ci-operator pod gets has cloning
+		// disabled.
+		decorationConfig := *decorationConfig
+		decorationConfig.SkipCloning = nil
+
+		codeMount, codeVolume := decorate.CodeMountAndVolume()
+		cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Refs: jobSpec.Refs, ExtraRefs: jobSpec.ExtraRefs, DecorationConfig: &decorationConfig}}, codeMount, logMount)
+		if err != nil {
+			return fmt.Errorf("failed to construct clonerefs: %w", err)
 		}
-	}
-	if decorationConfig.GCSConfiguration != nil {
 		initUpload, err := decorate.InitUpload(&decorationConfig, blobStorageOptions, blobStorageMounts, &logMount, nil, rawJobSpec)
 		if err != nil {
-			return fmt.Errorf("failed to construct initupload: %w", err)
+			return fmt.Errorf("failed to get initUpload container: %w", err)
 		}
-		pod.Spec.InitContainers = util.Insert(pod.Spec.InitContainers, 1, *initUpload)
+		pod.Spec.InitContainers = append([]corev1.Container{*cloneRefsContainer, *initUpload}, pod.Spec.InitContainers...)
+		pod.Spec.Volumes = append(pod.Spec.Volumes, codeVolume)
+		pod.Spec.Volumes = append(pod.Spec.Volumes, cloneRefsVolumes...)
+
+		if len(refs) > 0 {
+			for i, container := range pod.Spec.Containers {
+				pod.Spec.Containers[i].WorkingDir = decorate.DetermineWorkDir(codeMount.MountPath, refs)
+				pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, codeMount)
+			}
+		}
+
 	}
 	return nil
 }

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -67,9 +67,8 @@ func TestGeneratePods(t *testing.T) {
 			},
 			Type: "postsubmit",
 			DecorationConfig: &prowapi.DecorationConfig{
-				GCSConfiguration: &prowapi.GCSConfiguration{},
-				Timeout:          &prowapi.Duration{Duration: time.Minute},
-				GracePeriod:      &prowapi.Duration{Duration: time.Second},
+				Timeout:     &prowapi.Duration{Duration: time.Minute},
+				GracePeriod: &prowapi.Duration{Duration: time.Second},
 				UtilityImages: &prowapi.UtilityImages{
 					Sidecar:    "sidecar",
 					Entrypoint: "entrypoint",
@@ -146,9 +145,8 @@ func TestGenerateObservers(t *testing.T) {
 			},
 			Type: "postsubmit",
 			DecorationConfig: &prowapi.DecorationConfig{
-				GCSConfiguration: &prowapi.GCSConfiguration{},
-				Timeout:          &prowapi.Duration{Duration: time.Minute},
-				GracePeriod:      &prowapi.Duration{Duration: time.Second},
+				Timeout:     &prowapi.Duration{Duration: time.Minute},
+				GracePeriod: &prowapi.Duration{Duration: time.Second},
 				UtilityImages: &prowapi.UtilityImages{
 					Sidecar:    "sidecar",
 					Entrypoint: "entrypoint",

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -32,7 +32,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"2m0s","grace_period":"4s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"2m0s","grace_period":"4s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -184,7 +184,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -32,7 +32,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"1h0m0s","grace_period":"20s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"1h0m0s","grace_period":"20s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -201,7 +201,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -364,7 +364,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI
@@ -531,7 +531,7 @@
       - name: JOB_SPEC
         value: '{"type":"postsubmit","job":"job","buildid":"build id","prowjobid":"prow
           job id","refs":{"org":"org","repo":"repo","base_ref":"base ref","base_sha":"base
-          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{}}}'
+          sha"},"decoration_config":{"timeout":"2h0m0s","grace_period":"15s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
       - name: JOB_TYPE
         value: postsubmit
       - name: OPENSHIFT_CI

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -199,21 +199,11 @@ func GenerateBasePod(
 	secretsToCensor []coreapi.VolumeMount,
 	clone bool,
 ) (*coreapi.Pod, error) {
-	var env []coreapi.EnvVar
-	if jobSpec.JobSpec.Refs != nil {
-		envMap, err := downwardapi.EnvForSpec(jobSpec.JobSpec)
-		if err != nil {
-			return nil, err
-		}
-		envMap[openshiftCIEnv] = "true"
-		env = decorate.KubeEnv(envMap)
+	envMap, err := downwardapi.EnvForSpec(jobSpec.JobSpec)
+	envMap[openshiftCIEnv] = "true"
+	if err != nil {
+		return nil, err
 	}
-	// FIXME: Fix this workaround upstream and the delete this code as soon as possible
-	env = append(env, []coreapi.EnvVar{
-		{Name: "GIT_CONFIG_COUNT", Value: "1"},
-		{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
-		{Name: "GIT_CONFIG_VALUE_0", Value: "*"},
-	}...)
 	pod := &coreapi.Pod{
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
@@ -230,7 +220,7 @@ func GenerateBasePod(
 			Containers: []coreapi.Container{
 				{
 					Image:                    image,
-					Env:                      env,
+					Env:                      decorate.KubeEnv(envMap),
 					Name:                     containerName,
 					Command:                  command,
 					Resources:                containerResources,
@@ -239,6 +229,14 @@ func GenerateBasePod(
 			},
 		},
 	}
+
+	// FIXME: Fix this workaround upstream and the delete this code as soon as possible
+	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, []coreapi.EnvVar{
+		{Name: "GIT_CONFIG_COUNT", Value: "1"},
+		{Name: "GIT_CONFIG_KEY_0", Value: "safe.directory"},
+		{Name: "GIT_CONFIG_VALUE_0", Value: "*"},
+	}...)
+
 	artifactDir = fmt.Sprintf("artifacts/%s", artifactDir)
 	if err := addPodUtils(pod, artifactDir, decorationConfig, rawJobSpec, secretsToCensor, clone, jobSpec); err != nil {
 		return nil, fmt.Errorf("failed to decorate pod: %w", err)

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -60,9 +60,8 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 				BaseSHA: "base-sha",
 			},
 			DecorationConfig: &prowapi.DecorationConfig{
-				GCSConfiguration: &prowapi.GCSConfiguration{},
-				Timeout:          &prowapi.Duration{Duration: time.Minute},
-				GracePeriod:      &prowapi.Duration{Duration: time.Second},
+				Timeout:     &prowapi.Duration{Duration: time.Minute},
+				GracePeriod: &prowapi.Duration{Duration: time.Second},
 				UtilityImages: &prowapi.UtilityImages{
 					Sidecar:    "sidecar",
 					Entrypoint: "entrypoint",
@@ -259,7 +258,6 @@ func expectedPodStepTemplate() *podStep {
 				BuildID:   "podStep.jobSpec.BuildId",
 				ProwJobID: "podStep.jobSpec.ProwJobID",
 				Type:      "periodic",
-				Refs:      &prowapi.Refs{},
 				DecorationConfig: &prowapi.DecorationConfig{
 					Timeout:     &prowapi.Duration{Duration: time.Minute},
 					GracePeriod: &prowapi.Duration{Duration: time.Second},

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -28,7 +28,7 @@ spec:
     - name: JOB_NAME
       value: very-cool-prow-job
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{},"skip_cloning":true}}'
+      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"skip_cloning":true}}'
     - name: JOB_TYPE
       value: presubmit
     - name: OPENSHIFT_CI

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -28,7 +28,7 @@ spec:
     - name: JOB_NAME
       value: very-cool-prow-job
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{},"skip_cloning":true}}'
+      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"skip_cloning":true}}'
     - name: JOB_TYPE
       value: presubmit
     - name: OPENSHIFT_CI

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
@@ -28,7 +28,7 @@ spec:
     - name: JOB_NAME
       value: very-cool-prow-job
     - name: JOB_SPEC
-      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"gcs_configuration":{},"skip_cloning":true}}'
+      value: '{"type":"presubmit","job":"very-cool-prow-job","buildid":"test-build-id","prowjobid":"prow-job-id","refs":{"org":"org","repo":"repo","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":123,"author":"","sha":"72532003f9e01e89f455187dd92c275204bc9781"}]},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"},"skip_cloning":true}}'
     - name: JOB_TYPE
       value: presubmit
     - name: OPENSHIFT_CI

--- a/pkg/steps/testdata/zz_fixture_envTestGetPodObjectMounts_with_cluster_claim.yaml
+++ b/pkg/steps/testdata/zz_fixture_envTestGetPodObjectMounts_with_cluster_claim.yaml
@@ -5,7 +5,7 @@
 - name: JOB_NAME
   value: podStep.jobSpec.Job
 - name: JOB_SPEC
-  value: '{"type":"periodic","job":"podStep.jobSpec.Job","buildid":"podStep.jobSpec.BuildId","prowjobid":"podStep.jobSpec.ProwJobID","refs":{"org":"","repo":""},"decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
+  value: '{"type":"periodic","job":"podStep.jobSpec.Job","buildid":"podStep.jobSpec.BuildId","prowjobid":"podStep.jobSpec.ProwJobID","decoration_config":{"timeout":"1m0s","grace_period":"1s","utility_images":{"entrypoint":"entrypoint","sidecar":"sidecar"}}}'
 - name: JOB_TYPE
   value: periodic
 - name: OPENSHIFT_CI

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -78,11 +78,3 @@ func PopCount[T comparable](xs ...T) (ret uint) {
 	}
 	return
 }
-
-// Insert adds an element to a given position in the slice
-func Insert[T any](s []T, i int, x T) []T {
-	s = append(s, Zero[T]())
-	copy(s[i+1:], s[i:])
-	s[i] = x
-	return s
-}

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -24,9 +24,6 @@ func TestSimpleExitCodes(t *testing.T) {
 
 	const defaultJobSpec = `{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`
 	const jobSpecWithSkipClone = `{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]},"decoration_config":{"skip_cloning":true,"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`
-	const jobSpecWithoutGCS = `{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}}}}`
-	const jobSpecWithoutRefs = `{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"origin-ci-test","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`
-	const jobSpecMinimal = `{"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e","buildid":"0","prowjobid":"uuid","decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest"},"resources":{"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}}}}}`
 	var testCases = []struct {
 		name    string
 		args    []string
@@ -38,27 +35,6 @@ func TestSimpleExitCodes(t *testing.T) {
 			name:    "success on one successful target",
 			args:    []string{"--target=success"},
 			success: true,
-			output:  []string{"Container test in pod success completed successfully"},
-		},
-		{
-			name:    "success on one successful target without artifacts",
-			args:    []string{"--target=success"},
-			success: true,
-			jobSpec: jobSpecWithoutGCS,
-			output:  []string{"Container test in pod success completed successfully"},
-		},
-		{
-			name:    "success on one successful target without refs",
-			args:    []string{"--target=success"},
-			success: true,
-			jobSpec: jobSpecWithoutRefs,
-			output:  []string{"Container test in pod success completed successfully"},
-		},
-		{
-			name:    "success on one successful target with minimal spec",
-			args:    []string{"--target=success"},
-			success: true,
-			jobSpec: jobSpecMinimal,
 			output:  []string{"Container test in pod success completed successfully"},
 		},
 		{


### PR DESCRIPTION
Reverts openshift/ci-tools#3319

This PR breaks existing jobs, including Cluster Bot.
Ref: https://redhat-internal.slack.com/archives/CBN38N3MW/p1688573508473129
@bbguimaraes 