### PR TITLE
add etcd_golang-1.19 to streams to ignore mirror=false from

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -282,7 +282,7 @@ func replaceStream(streamName string, streamMap StreamMap) (string, error) {
 	}
 	//TODO: this is a temporary workaround until https://github.com/openshift-eng/ocp-build-data/commit/155694be74cb2f020f6fafeaf6e4b3fba89646a2 is reverted/changed
 	// We need to allow the: 'golang', 'rhel-9-golang', and 'etcd_golang' streams through in the meantime
-	if streamName != "golang" && streamName != "rhel-9-golang" && streamName != "etcd_golang" {
+	if streamName != "golang" && streamName != "rhel-9-golang" && streamName != "etcd_golang" && streamName != "etcd_golang-1.19" {
 		if replacement.Mirror == nil || !*replacement.Mirror {
 			return "", fmt.Errorf("stream.yaml.%s.mirror is set to false, can not dereference", streamName)
 		}

--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -282,7 +282,7 @@ func replaceStream(streamName string, streamMap StreamMap) (string, error) {
 	}
 	//TODO: this is a temporary workaround until https://github.com/openshift-eng/ocp-build-data/commit/155694be74cb2f020f6fafeaf6e4b3fba89646a2 is reverted/changed
 	// We need to allow the: 'golang', 'rhel-9-golang', and 'etcd_golang' streams through in the meantime
-	if streamName != "golang" && streamName != "rhel-9-golang" && streamName != "etcd_golang" && streamName != "etcd_golang-1.19" {
+	if streamName != "golang" && streamName != "golang-1.19" && streamName != "rhel-9-golang" && streamName != "etcd_golang" && streamName != "etcd_golang-1.19" && streamName != "rhel-9-golang-1.19" {
 		if replacement.Mirror == nil || !*replacement.Mirror {
 			return "", fmt.Errorf("stream.yaml.%s.mirror is set to false, can not dereference", streamName)
 		}


### PR DESCRIPTION
We have another stream that we need to ignore the `mirror: false` config on: `etcd_golang-1.19`. The following error was found in the latest auto-config-brancher [log](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-prow-auto-config-brancher/1676682589462597632):
```
failed to load ocp build data configs: failed dereferencing config for images/ose-etcd.yml: [failed to replace .from.0.stream: stream.yaml.etcd_golang-1.19.mirror is set to false, can not dereference, failed to dereference from.builder.0
``` 

I have now added all the other streams preemptively from the original commit that sets mirror to false: https://github.com/openshift-eng/ocp-build-data/commit/f75a59a27a17ae4cf716901acedeed3363915b67.

Follow up to https://github.com/openshift/ci-tools/pull/3511