### PR TITLE
TRT-1120: Support single pass to collect gcs files

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -143,6 +143,14 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	for i := range finishedJobsToAggregate {
 		jobRun := finishedJobsToAggregate[i]
 
+		// Initialize our junits and file names.
+		// We aren't required to do this but if we
+		// do we can catch any errors and bail.
+		err := jobRun.GetJobRunFromGCS(ctx)
+		if err != nil {
+			return err
+		}
+
 		// We found a case where the first job failed to upgrade but the others didn't
 		// original logic stopped on the first flag we found which indicated master nodes did not update
 		// and led to lower disruption values being used, causing failures.
@@ -156,7 +164,7 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 			updatedFlag := jobrunaggregatorlib.GetMasterNodesUpdatedStatusFromClusterData(clusterData)
 
 			// if we have any value set it here
-			// if we set a 'Y' here it we won't come back in this loop based on the check above
+			// if we set a 'Y' here we won't come back in this loop based on the check above
 			if len(updatedFlag) > 0 {
 				masterNodesUpdated = updatedFlag
 			}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -30,6 +30,7 @@ type gcsJobRun struct {
 	jobRunID            string
 	gcsProwJobPath      string
 	gcsJunitPaths       []string
+	gcsFileNames        []string
 
 	pathToContent map[string][]byte
 }
@@ -61,6 +62,9 @@ func (j *gcsJobRun) SetGCSProwJobPath(gcsProwJobPath string) {
 func (j *gcsJobRun) AddGCSJunitPaths(junitPaths ...string) {
 	j.gcsJunitPaths = append(j.gcsJunitPaths, junitPaths...)
 }
+func (j *gcsJobRun) AddGCSProwJobFileNames(fileNames ...string) {
+	j.gcsFileNames = append(j.gcsFileNames, fileNames...)
+}
 
 func (j *gcsJobRun) WriteCache(ctx context.Context, parentDir string) error {
 	if err := j.writeCache(ctx, parentDir); err != nil {
@@ -82,7 +86,7 @@ func (j *gcsJobRun) writeCache(ctx context.Context, parentDir string) error {
 		return fmt.Errorf("error serializing prowjob for %q: %w", j.GetJobRunID(), err)
 	}
 
-	contentMap, err := j.GetAllContent(ctx)
+	contentMap, err := j.getAllContent(ctx)
 	if err != nil {
 		return err
 	}
@@ -140,7 +144,73 @@ func (j *gcsJobRun) writeCache(ctx context.Context, parentDir string) error {
 	return nil
 }
 
+func (j *gcsJobRun) GetJobRunFromGCS(ctx context.Context) error {
+	query := &storage.Query{
+		// This ends up being the equivalent of:
+		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/1671747590984568832
+		// the next directory step is based on some bit of metadata I don't recognize
+		Prefix: j.jobRunGCSBucketRoot,
+
+		// TODO this field is apparently missing from this level of go/storage
+		// Omit owner and ACL fields for performance
+		// Projection: storage.ProjectionNoACL,
+	}
+
+	// Only retrieve the name and creation time for performance
+	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
+		return err
+	}
+
+	// Returns an iterator which iterates over the bucket query results.
+	// this will list *all* files with the query prefix.
+	it := j.bkt.Objects(ctx, query)
+
+	// Find the query results we're the most interested in.
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			// we're done adding values
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// if we have a directory then skip
+		if len(attrs.Name) == 0 {
+			continue
+		}
+
+		// add the name
+		j.AddGCSProwJobFileNames(attrs.Name)
+
+		// see if it is a junit
+		if strings.HasSuffix(attrs.Name, ".xml") && strings.Contains(attrs.Name, "/junit") {
+			logrus.Debugf("found %s", attrs.Name)
+			j.AddGCSJunitPaths(attrs.Name)
+		}
+	}
+
+	return nil
+}
+
+func (j *gcsJobRun) validateJobRunFromGCS(ctx context.Context) error {
+	if nil == j.gcsFileNames {
+		return j.GetJobRunFromGCS(ctx)
+	}
+
+	return nil
+}
+
 func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.TestSuites, error) {
+
+	// verifies we have loaded the available file for the job run
+	err := j.validateJobRunFromGCS(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
 	testSuites := &junit.TestSuites{}
 	for _, junitFile := range j.GetGCSJunitPaths() {
 		logrus.Debug("getting junit file content content from GCS")
@@ -193,53 +263,34 @@ func isParseFloatError(err error) bool {
 }
 
 func (j *gcsJobRun) GetOpenShiftTestsFilesWithPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+
+	// verifies we have loaded the available file for the job run
+	err := j.validateJobRunFromGCS(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	fileNames := j.gcsFileNames
+
 	regex, err := regexp.Compile("/" + prefix + "[^/]*")
 	if err != nil {
 		return nil, err
 	}
 	ret := map[string]string{}
 
-	query := &storage.Query{
-		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
-		// the next directory step is based on some bit of metadata I don't recognize
-		Prefix: j.jobRunGCSBucketRoot,
+	// Find the query results we're the most interested in.
+	for _, name := range fileNames {
 
-		// TODO this field is apparently missing from this level of go/storage
-		// Omit owner and ACL fields for performance
-		//Projection: storage.ProjectionNoACL,
-	}
-
-	// Only retrieve the name and creation time for performance
-	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
-		return nil, err
-	}
-
-	// Returns an iterator which iterates over the bucket query results.
-	// Unfortunately, this will list *all* files with the query prefix.
-	it := j.bkt.Objects(ctx, query)
-
-	// Find the query results we're the most interested in. In this case, we're interested in files called prowjob.json
-	// so that we only get each jobrun once and we queue them in a channel
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			// we're done adding values, so close the channel
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if !regex.MatchString(attrs.Name) {
+		if !regex.MatchString(name) {
 			continue
 		}
 
-		content, err := j.getCurrentContent(ctx, attrs.Name)
+		content, err := j.getCurrentContent(ctx, name)
 		if err != nil {
 			return nil, err
 		}
-		ret[attrs.Name] = string(content)
+		ret[name] = string(content)
 	}
 
 	return ret, nil
@@ -301,7 +352,7 @@ func (j *gcsJobRun) getCurrentContent(ctx context.Context, path string) ([]byte,
 
 }
 
-func (j *gcsJobRun) GetAllContent(ctx context.Context) (map[string][]byte, error) {
+func (j *gcsJobRun) getAllContent(ctx context.Context) (map[string][]byte, error) {
 	if len(j.pathToContent) > 0 {
 		return j.pathToContent, nil
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/interfaces.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/interfaces.go
@@ -30,14 +30,15 @@ type JobRunInfo interface {
 	GetGCSJunitPaths() []string
 	SetGCSProwJobPath(gcsProwJobPath string)
 	AddGCSJunitPaths(junitPaths ...string)
+	AddGCSProwJobFileNames(fileNames ...string)
 
 	GetProwJob(ctx context.Context) (*prowjobv1.ProwJob, error)
+	GetJobRunFromGCS(ctx context.Context) error
 	GetCombinedJUnitTestSuites(ctx context.Context) (*junit.TestSuites, error)
 	// GetOpenShiftTestsFilesWithPrefix checks the datasource for "openshift-e2e-test/artifacts/junit/<prefix>*"
 	// and returns that content indexed by local filename.  This is useful for things like back-disruption and alerts.
 	GetOpenShiftTestsFilesWithPrefix(ctx context.Context, prefix string) (map[string]string, error)
 	GetContent(ctx context.Context, path string) ([]byte, error)
-	GetAllContent(ctx context.Context) (map[string][]byte, error)
 	ClearAllContent()
 
 	WriteCache(ctx context.Context, parentDir string) error

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/jobruninfo_mock.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/jobruninfo_mock.go
@@ -54,6 +54,22 @@ func (mr *MockJobRunInfoMockRecorder) AddGCSJunitPaths(arg0 ...interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGCSJunitPaths", reflect.TypeOf((*MockJobRunInfo)(nil).AddGCSJunitPaths), arg0...)
 }
 
+// AddGCSProwJobFileNames mocks base method.
+func (m *MockJobRunInfo) AddGCSProwJobFileNames(arg0 ...string) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "AddGCSProwJobFileNames", varargs...)
+}
+
+// AddGCSProwJobFileNames indicates an expected call of AddGCSProwJobFileNames.
+func (mr *MockJobRunInfoMockRecorder) AddGCSProwJobFileNames(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddGCSProwJobFileNames", reflect.TypeOf((*MockJobRunInfo)(nil).AddGCSProwJobFileNames), arg0...)
+}
+
 // ClearAllContent mocks base method.
 func (m *MockJobRunInfo) ClearAllContent() {
 	m.ctrl.T.Helper()
@@ -64,21 +80,6 @@ func (m *MockJobRunInfo) ClearAllContent() {
 func (mr *MockJobRunInfoMockRecorder) ClearAllContent() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAllContent", reflect.TypeOf((*MockJobRunInfo)(nil).ClearAllContent))
-}
-
-// GetAllContent mocks base method.
-func (m *MockJobRunInfo) GetAllContent(arg0 context.Context) (map[string][]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllContent", arg0)
-	ret0, _ := ret[0].(map[string][]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllContent indicates an expected call of GetAllContent.
-func (mr *MockJobRunInfoMockRecorder) GetAllContent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllContent", reflect.TypeOf((*MockJobRunInfo)(nil).GetAllContent), arg0)
 }
 
 // GetCombinedJUnitTestSuites mocks base method.
@@ -179,6 +180,20 @@ func (m *MockJobRunInfo) GetJobName() string {
 func (mr *MockJobRunInfoMockRecorder) GetJobName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobName", reflect.TypeOf((*MockJobRunInfo)(nil).GetJobName))
+}
+
+// GetJobRunFromGCS mocks base method.
+func (m *MockJobRunInfo) GetJobRunFromGCS(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetJobRunFromGCS", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetJobRunFromGCS indicates an expected call of GetJobRunFromGCS.
+func (mr *MockJobRunInfoMockRecorder) GetJobRunFromGCS(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobRunFromGCS", reflect.TypeOf((*MockJobRunInfo)(nil).GetJobRunFromGCS), arg0)
 }
 
 // GetJobRunID mocks base method.

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/gcs_client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
@@ -28,78 +26,12 @@ type ciGCSClient struct {
 func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation, jobName, jobRunID string, logger logrus.FieldLogger) (jobrunaggregatorapi.JobRunInfo, error) {
 	logger.Debugf("reading job run %s/%s", jobGCSRootLocation, jobRunID)
 
-	query := &storage.Query{
-		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
-		Prefix: jobGCSRootLocation,
-
-		// TODO this field is apparently missing from this level of go/storage
-		// Omit owner and ACL fields for performance
-		//Projection: storage.ProjectionNoACL,
-	}
-
-	// Only retrieve the name and creation time for performance
-	if err := query.SetAttrSelection([]string{"Name", "Created", "Generation"}); err != nil {
-		return nil, err
-	}
-	// start reading for this jobrun bucket
-	query.StartOffset = fmt.Sprintf("%s/%s", jobGCSRootLocation, jobRunID)
-	// end reading after this jobrun bucket
-	query.EndOffset = fmt.Sprintf("%s/%s", jobGCSRootLocation, NextJobRunID(jobRunID))
-
-	// Returns an iterator which iterates over the bucket query results.
-	// Unfortunately, this will list *all* files with the query prefix.
 	bkt := o.gcsClient.Bucket(o.gcsBucketName)
-	it := bkt.Objects(ctx, query)
+	prowJobPath := fmt.Sprintf("%s/%s/prowjob.json", jobGCSRootLocation, jobRunID)
+	jobRunId := filepath.Base(filepath.Dir(prowJobPath))
 
-	// Find the query results we're the most interested in. In this case, we're
-	// interested in files called prowjob.json that were created less than 24
-	// hours ago.
-	var jobRun jobrunaggregatorapi.JobRunInfo
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		switch {
-		case strings.HasSuffix(attrs.Name, "prowjob.json"):
-			logger.Debugf("found %s", attrs.Name)
-			jobRunId := filepath.Base(filepath.Dir(attrs.Name))
-			if jobRun == nil {
-				jobRun = jobrunaggregatorapi.NewGCSJobRun(bkt, jobGCSRootLocation, jobName, jobRunId)
-			}
-			jobRun.SetGCSProwJobPath(attrs.Name)
-
-		case strings.HasSuffix(attrs.Name, ".xml") && strings.Contains(attrs.Name, "/junit"):
-			logger.Debugf("found %s", attrs.Name)
-			nameParts := strings.Split(attrs.Name, "/")
-			if len(nameParts) < 4 {
-				continue
-			}
-			jobRunId := nameParts[2]
-			if jobRun == nil {
-				jobRun = jobrunaggregatorapi.NewGCSJobRun(bkt, jobGCSRootLocation, jobName, jobRunId)
-			}
-			jobRun.AddGCSJunitPaths(attrs.Name)
-
-		default:
-			//fmt.Printf("checking %q\n", attrs.Name)
-		}
-	}
-
-	// eliminate items without prowjob.json and ones that aren't finished
-	if jobRun == nil {
-		logger.Info("removing job run because it doesn't have a prowjob.json")
-		return nil, nil
-	}
-	if len(jobRun.GetGCSProwJobPath()) == 0 {
-		logger.Info("removing job run because it doesn't have a prowjob.json but does have junit")
-		return nil, nil
-	}
+	jobRun := jobrunaggregatorapi.NewGCSJobRun(bkt, jobGCSRootLocation, jobName, jobRunId)
+	jobRun.SetGCSProwJobPath(prowJobPath)
 	_, err := jobRun.GetProwJob(ctx)
 	if err != nil {
 		logger.WithError(err).Error("failed to get prowjob")
@@ -109,17 +41,6 @@ func (o *ciGCSClient) ReadJobRunFromGCS(ctx context.Context, jobGCSRootLocation,
 	return jobRun, nil
 }
 
-func NextJobRunID(curr string) string {
-	if len(curr) == 0 {
-		return "0"
-	}
-	idAsInt, err := strconv.ParseInt(curr, 10, 64)
-	if err != nil {
-		panic(err)
-	}
-	return fmt.Sprintf("%d", idAsInt+1)
-}
-
 func (o *ciGCSClient) ReadRelatedJobRuns(ctx context.Context,
 	jobName, gcsPrefix, startingJobRunID, endingJobRunID string,
 	matcherFunc prowJobMatcherFunc) ([]jobrunaggregatorapi.JobRunInfo, error) {
@@ -127,18 +48,14 @@ func (o *ciGCSClient) ReadRelatedJobRuns(ctx context.Context,
 	logrus.Debugf("searching GCS for related job runs in %s between %s and %s", gcsPrefix, startingJobRunID, endingJobRunID)
 	query := &storage.Query{
 		// This ends up being the equivalent of:
-		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade
-		Prefix: gcsPrefix,
+		// https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-upgrade-from-stable-4.8-e2e-metal-ipi-upgrade/
+		Prefix: fmt.Sprintf("%s/", gcsPrefix),
 
 		// TODO this field is apparently missing from this level of go/storage
 		// Omit owner and ACL fields for performance
-		//Projection: storage.ProjectionNoACL,
+		// Projection: storage.ProjectionNoACL,
 	}
 
-	// Only retrieve the name and creation time for performance
-	if err := query.SetAttrSelection([]string{"Name", "Created"}); err != nil {
-		return nil, err
-	}
 	if startingJobRunID == "" {
 		// For debugging, you can set this to a jobID that is not that far away from
 		// jobs related to what you are trying to aggregate.
@@ -149,10 +66,14 @@ func (o *ciGCSClient) ReadRelatedJobRuns(ctx context.Context,
 	if endingJobRunID != "" {
 		query.EndOffset = fmt.Sprintf("%s/%s", gcsPrefix, endingJobRunID)
 	}
+
+	// restrict the query to just one level down
+	query.Delimiter = "/"
+
 	fmt.Printf("  starting from %v, ending at %q\n", query.StartOffset, query.EndOffset)
 
 	// Returns an iterator which iterates over the bucket query results.
-	// Unfortunately, this will list *all* files with the query prefix.
+	// This will list all the folders under the prefix
 	bkt := o.gcsClient.Bucket(o.gcsBucketName)
 	it := bkt.Objects(ctx, query)
 
@@ -169,28 +90,25 @@ func (o *ciGCSClient) ReadRelatedJobRuns(ctx context.Context,
 			return nil, err
 		}
 
-		switch {
-		case strings.HasSuffix(attrs.Name, "prowjob.json"):
-			jobRunId := filepath.Base(filepath.Dir(attrs.Name))
-			jobRunInfo, err := o.ReadJobRunFromGCS(ctx, gcsPrefix, jobName, jobRunId, logrus.WithFields(logrus.Fields{
-				"job":    jobName,
-				"jobRun": jobRunId,
-			}))
-			if err != nil {
-				return nil, err
-			}
-			prowJob, err := jobRunInfo.GetProwJob(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get prowjob for %q/%q: %w", jobName, jobRunId, err)
-			}
+		// we are only interested in directories for this pass since we know the file we want
+		if len(attrs.Name) > 0 {
+			continue
+		}
 
-			if matcherFunc(prowJob) {
-				relatedJobRuns = append(relatedJobRuns, jobRunInfo)
-				break
-			}
+		// we only need prowjob.json at this time
+		prowJobPath := fmt.Sprintf("%s%s", attrs.Prefix, "prowjob.json")
+		logrus.Debugf("found %s", attrs.Name)
+		jobRunId := filepath.Base(filepath.Dir(prowJobPath))
+		jobRun := jobrunaggregatorapi.NewGCSJobRun(bkt, gcsPrefix, jobName, jobRunId)
+		jobRun.SetGCSProwJobPath(prowJobPath)
 
-		default:
-			//fmt.Printf("checking %q\n", attrs.Name)
+		prowJob, err := jobRun.GetProwJob(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get prowjob for %q/%q: %w", jobName, jobRunId, err)
+		}
+
+		if matcherFunc(prowJob) {
+			relatedJobRuns = append(relatedJobRuns, jobRun)
 		}
 	}
 	return relatedJobRuns, nil


### PR DESCRIPTION
- Simplifies finding / loading prowjob.json by looking specifically for the file and not a full scan.
- Delays the full scan until specifically called or artifacts are requested
- Caches artifact names so we don't have to perform multiple scans for different resources