### PR TITLE
pkg/defaults: correct release steps for claims

### DIFF
--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1303,7 +1303,12 @@ func TestFromConfig(t *testing.T) {
 				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{},
 			}},
 		},
-		expectedSteps: []string{"[release:latest-fast-as-heck-aws]", "fast-as-heck-aws", "[images]"},
+		expectedSteps: []string{
+			"[release:latest-fast-as-heck-aws]",
+			"fast-as-heck-aws",
+			"[output-images]",
+			"[images]",
+		},
 	}, {
 		name: "container test with a claim",
 		config: api.ReleaseBuildConfiguration{


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openstack-k8s-operators_install_yamls/401/pull-ci-openstack-k8s-operators-install_yamls-main-images/1679343679455629312

As usual, at the bottom of an outage there is a comment such as this one:

https://github.com/openshift/ci-tools/blob/978b7cfb65f0775bdaf2ddda00c3811f1c553b63/pkg/defaults/defaults.go#L178-L179

In this case, since we now always add the `ImportReleaseStep` corresponding to a
test which has a cluster claim, we always set `hasReleaseStep` to `true`, and so
never add a `StableImagesTagStep` to the graph.

However, that `ImportReleaseStep` is specific to the test: it creates its own
`stable-${test_name}` `ImageStream` and not `stable`, which `hasReleaseStep`
implies.  This is fine for the job which executes the test itself, as tests know
that they have a claim and adjust their requirements accordingly:

https://github.com/openshift/ci-tools/blob/978b7cfb65f0775bdaf2ddda00c3811f1c553b63/pkg/steps/multi_stage/multi_stage.go#L247

However, setting `hasReleaseStep` is incorrect, particularly for other jobs
using the same configuration (e.g. image builds), as it specifically means
another step will create the `stable` stream:

https://github.com/openshift/ci-tools/blob/978b7cfb65f0775bdaf2ddda00c3811f1c553b63/pkg/defaults/defaults.go#L340-L344
https://github.com/openshift/ci-tools/blob/978b7cfb65f0775bdaf2ddda00c3811f1c553b63/pkg/steps/release/release_images.go#L73-L76

It was incorrect before the previous change, but not noticeable since most jobs
execute a single target.

---

```console
$ git rev-parse --short HEAD
978b7cfb6
$ go run ./cmd/ci-operator/ --config /tmp/config.json --target '[images]' --print-graph
INFO[2023-07-13T10:07:20+02:00] unset version 0
INFO[2023-07-13T10:07:20+02:00] Resolved source https://github.com/openshift/ci-tools to master@978b7cfb
INFO[2023-07-13T10:07:22+02:00] Using namespace https://console.build01.ci.openshift.org/k8s/cluster/projects/ci-op-p9lnrg76
INFO[2023-07-13T10:07:22+02:00] Ran for 1s
ERRO[2023-07-13T10:07:22+02:00] Some steps failed:
ERRO[2023-07-13T10:07:22+02:00]
  * could not sort nodes
  * steps are missing dependencies
  * step [images] is missing dependencies: <&api.externalImageLink{namespace:"", name:"stable", tag:"openstack-operator-ci-build-deploy"}>, <&api.externalImageLink{namespace:"", name:"stable", tag:"openstack-operator-ci-pre-commit"}>
  * step [output:stable:openstack-operator-ci-build-deploy] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>
  * step [output:stable:openstack-operator-ci-pre-commit] is missing dependencies: <&api.internalImageStreamLink{name:"stable"}>
exit status 1
```

```console
$ git switch --quiet has_release_step
$ go run ./cmd/ci-operator/ --config /tmp/config.json --target '[images]' --print-graph
INFO[2023-07-13T10:07:52+02:00] unset version 0
INFO[2023-07-13T10:07:52+02:00] Resolved source https://github.com/openshift/ci-tools to master@978b7cfb
INFO[2023-07-13T10:07:54+02:00] Using namespace https://console.build01.ci.openshift.org/k8s/cluster/projects/ci-op-b9xnk7m0
INFO[2023-07-13T10:07:54+02:00] Running [input:root], [input:cli], [input:opm-builder], [output-images], src, openstack-operator-ci-build-deploy, [output:stable:openstack-operator-ci-build-deploy], openstack-operator-ci-pre-commit, [output:stable:openstack-operator-ci-pre-commit], [images]
src [input:root]
openstack-operator-ci-build-deploy [input:cli]
openstack-operator-ci-build-deploy [input:opm-builder]
openstack-operator-ci-build-deploy src
[output:stable:openstack-operator-ci-build-deploy] [output-images]
[output:stable:openstack-operator-ci-build-deploy] openstack-operator-ci-build-deploy
openstack-operator-ci-pre-commit src
[output:stable:openstack-operator-ci-pre-commit] [output-images]
[output:stable:openstack-operator-ci-pre-commit] openstack-operator-ci-pre-commit
[images] [output:stable:openstack-operator-ci-build-deploy]
[images] [output:stable:openstack-operator-ci-pre-commit]
INFO[2023-07-13T10:07:54+02:00] Ran for 1s
```