### PR TITLE
ci-operator: add reason for missing dependencies

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -899,7 +899,7 @@ func (o *options) Run() []error {
 	}
 	stepList, errs := nodes.TopologicalSort()
 	if errs != nil {
-		return append([]error{errors.New("could not sort nodes")}, errs...)
+		return append([]error{results.ForReason("building_graph").ForError(errors.New("could not sort nodes"))}, errs...)
 	}
 	logrus.Infof("Running %s", strings.Join(nodeNames(stepList), ", "))
 	if o.printGraph {


### PR DESCRIPTION
The alert is currently not very helpful:

```
[FIRING:1] high-ci-operator-infra-error-rate (ci unknown critical)
An excessive amount of CI Operator executions are failing with unknown, which is an infrastructure issue. See CI search.
```

Reuse the same reason used for other graph building problems.