### PR TITLE
Add CCO prefix to testgrid informing

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -4,6 +4,7 @@ import "strings"
 
 func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 	testGridInformingPrefixes := []string{
+		"periodic-ci-openshift-cloud-credential-operator-",
 		"periodic-ci-openshift-cluster-control-plane-machine-set-operator-",
 		"periodic-ci-openshift-cluster-etcd-operator-",
 		"periodic-ci-openshift-hypershift-main-periodics-",


### PR DESCRIPTION
The Cloud Credential Operator has added support for STS-enabled clusters. We have a weekly e2e test that runs on an STS workflow and exercises creating a CredentialsRequest with correct parameters such that a Secret should be created.

We'd like to see this tracked with sippy.

Below is a link to a run of the test:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-cloud-credential-operator-master-e2e-aws-manual-oidc-cron/1680366890351857664
