### PR TITLE
Include Renamed Managed OpenShift Jobs To TestGrid Dashboards

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -255,7 +255,8 @@ func addDashboardTab(p prowConfig.Periodic,
 			strings.HasPrefix(prowName, "periodic-ci-openshift-release-master-ci-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-release-master-nightly-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-verification-tests-master-"),
-			strings.HasPrefix(prowName, "periodic-ci-shiftstack-shiftstack-ci-main-periodic-"):
+			strings.HasPrefix(prowName, "periodic-ci-shiftstack-shiftstack-ci-main-periodic-"),
+			strings.HasPrefix(prowName, "periodic-ci-openshift-osde2e-main-nightly-"):
 			stream = "ocp"
 		case strings.Contains(prowName, "-okd-"):
 			stream = "okd"


### PR DESCRIPTION
# What
This PR updates the testgrid-config-generator command to include Managed OpenShift (OSD, ROSA Classic, ROSA HCP) jobs within their corresponding test grid dashboards (informing or blocking). These jobs have been renamed as they are being refactored to be prowgen step registry style jobs. They no longer include the keyword `-ocp-` and would not be picked up for the correct test grid dashboards.

# Requires
- https://github.com/openshift/release/pull/41245

# For
- [SDCICD-1058](https://issues.redhat.com//browse/SDCICD-1058)