### PR TITLE
test/e2e: mark logging wrapper as helpers

### DIFF
--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -58,11 +58,13 @@ type T struct {
 
 // the testing.T logger is not threadsafe...
 func (t *T) Log(args ...interface{}) {
+	t.T.Helper()
 	t.T.Log(args...)
 }
 
 // the testing.T logger is not threadsafe...
 func (t *T) Logf(format string, args ...interface{}) {
+	t.T.Helper()
 	t.T.Logf(format, args...)
 }
 


### PR DESCRIPTION
Otherwise `Log`/`Logf` calls mention the wrappers as the originating source code
location.