### PR TITLE
test/e2e: wait for fake Kubernetes server

### DIFF
--- a/test/e2e/pod-scaler/kubernetes/kubernetes.go
+++ b/test/e2e/pod-scaler/kubernetes/kubernetes.go
@@ -76,7 +76,10 @@ func Builds(labelsByNamespacedName map[string]map[string]map[string]string) Opti
 
 // Fake serves fake data as if it were a k8s apiserver
 func Fake(t testhelper.TestingTInterface, tmpDir string, options ...Option) string {
-	o := Options{Patterns: map[string]http.HandlerFunc{}}
+	readyPath := "/healthz/ready"
+	o := Options{Patterns: map[string]http.HandlerFunc{
+		readyPath: func(w http.ResponseWriter, _ *http.Request) {},
+	}}
 	for _, option := range options {
 		option(&o)
 	}
@@ -139,5 +142,6 @@ func Fake(t testhelper.TestingTInterface, tmpDir string, options ...Option) stri
 	}, kubeconfig, false); err != nil {
 		t.Fatalf("Failed to write temporary kubeconfig file: %v", err)
 	}
+	testhelper.WaitForHTTP200(fmt.Sprintf("http://127.0.0.1:%s%s", k8sPort, readyPath), "kubernetes server", 90, t)
 	return kubeconfigFile.Name()
 }


### PR DESCRIPTION
Example sporadic failure: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3491/pull-ci-openshift-ci-tools-master-e2e/1678797589270499328#1:build-log.txt%3A35

Reproducible with:

```console
$ git diff --unified=1
diff --git a/test/e2e/pod-scaler/kubernetes/kubernetes.go b/test/e2e/pod-scaler/kubernetes/kubernetes.go
index 39d9894f0..394aa1db4 100644
--- a/test/e2e/pod-scaler/kubernetes/kubernetes.go
+++ b/test/e2e/pod-scaler/kubernetes/kubernetes.go
@@ -11,2 +11,3 @@ import (
        "net/http"
+       "time"

@@ -94,2 +95,3 @@ func Fake(t testhelper.TestingTInterface, tmpDir string, options ...Option) stri
        go func() {
+               time.Sleep(10 * time.Second)
                if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
$ make local-e2e PACKAGES=./test/e2e/pod-scaler TESTFLAGS='--count 1 --run TestBuildPodAdmission/pod_associated_with_a_build_with_labels'
…
    --- FAIL: TestBuildPodAdmission/pod_associated_with_a_build_with_labels (0.02s)
…
        TRAC[2023-07-20T12:17:08+02:00] Handling labels on Pod created for a Build.   build=withlabels component=pod-scaler admission name=withlabels-build
        ERRO[2023-07-20T12:17:08+02:00] Could not get Build for Pod.                  build=withlabels component=pod-scaler admission error=Get "http://0.0.0.0:45451/apis/build.openshift.io/v1/namespaces/namespace/builds/withlabels": dial tcp 0.0.0.0:45451: connect: connec
tion refused name=withlabels-build
FAIL
FAIL    github.com/openshift/ci-tools/test/e2e/pod-scaler       1.927s
FAIL
make[1]: *** [Makefile:169: e2e] Error 1
make[1]: Leaving directory '/home/bbguimaraes/src/ci-tools'
make: *** [Makefile:194: local-e2e] Error 2
```