### PR TITLE
OKD-141 : Generate sippy config with the OKD jobs

### DIFF
--- a/cmd/sippy-config-generator/main.go
+++ b/cmd/sippy-config-generator/main.go
@@ -147,12 +147,12 @@ func main() {
 	})
 
 	for _, p := range jobConfig.Periodics {
-		if strings.Contains(p.Name, "-okd") {
-			// Don't include OKD jobs
-			continue
-		}
-
 		if release, ok := p.Labels["job-release"]; ok {
+			// include OKD jobs but as a different release by appending `okd`
+			// to the release name.
+			if strings.Contains(p.Name, "-okd") {
+				release = fmt.Sprintf("%s-okd", release)
+			}
 			if _, ok := sippyConfig.Releases[release]; !ok {
 				sippyConfig.Releases[release] = v1sippy.ReleaseConfig{
 					Jobs:          make(map[string]bool),


### PR DESCRIPTION
PR is for updating the sippy-config-generator tool to include the OKD jobs along with existing OCP jobs in the generated sippy config. OKD jobs will added under a different release to segregate from the OCP jobs and the release name used for OKD jobs will be of the form `<release>-okd`.