### PR TITLE
pod-scaler: subscribe, then reload

### DIFF
--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -89,6 +89,7 @@ func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, 
 	for id, d := range digesters {
 		for _, item := range data[id] {
 			s := make(chan *pod_scaler.CachedQuery, 1)
+			item.subscribe(s)
 			infos = append(infos, digestInfo{
 				name:         item.name,
 				data:         item,
@@ -144,7 +145,6 @@ func digest(logger *logrus.Entry, infos ...digestInfo) <-chan interface{} {
 		thisOnce := &sync.Once{}
 		interrupts.Run(func(ctx context.Context) {
 			subLogger := logger.WithField("subscription", info.name)
-			info.data.subscribe(info.subscription)
 			subLogger.Debug("Starting subscription.")
 			for {
 				select {

--- a/cmd/pod-scaler/consumer.go
+++ b/cmd/pod-scaler/consumer.go
@@ -88,7 +88,13 @@ func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, 
 	var infos []digestInfo
 	for id, d := range digesters {
 		for _, item := range data[id] {
-			infos = append(infos, digestInfo{name: item.name, data: item, digest: d})
+			s := make(chan *pod_scaler.CachedQuery, 1)
+			infos = append(infos, digestInfo{
+				name:         item.name,
+				data:         item,
+				digest:       d,
+				subscription: s,
+			})
 		}
 	}
 	logger.Debugf("digesting %d infos.", len(infos))
@@ -112,9 +118,10 @@ func digestAll(data map[string][]*cacheReloader, digesters map[string]digester, 
 type digester func(query *pod_scaler.CachedQuery)
 
 type digestInfo struct {
-	name   string
-	data   *cacheReloader
-	digest digester
+	name         string
+	data         *cacheReloader
+	digest       digester
+	subscription chan *pod_scaler.CachedQuery
 }
 
 func digest(logger *logrus.Entry, infos ...digestInfo) <-chan interface{} {
@@ -137,15 +144,14 @@ func digest(logger *logrus.Entry, infos ...digestInfo) <-chan interface{} {
 		thisOnce := &sync.Once{}
 		interrupts.Run(func(ctx context.Context) {
 			subLogger := logger.WithField("subscription", info.name)
-			subscription := make(chan *pod_scaler.CachedQuery, 1)
-			info.data.subscribe(subscription)
+			info.data.subscribe(info.subscription)
 			subLogger.Debug("Starting subscription.")
 			for {
 				select {
 				case <-ctx.Done():
 					subLogger.Debug("Subscription cancelled.")
 					return
-				case data := <-subscription:
+				case data := <-info.subscription:
 					subLogger.Debug("Digesting new data from subscription.")
 					info.digest(data)
 					thisOnce.Do(update)


### PR DESCRIPTION
This corrects a race condition in the current order of operations: the
subscription happens after the loading process begins, which can cause updates
to be missed.  While not a problem in practice, since the loading process is
much longer, it can sometimes cause E2E tests to be delayed:

- https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3533/pull-ci-openshift-ci-tools-master-e2e/1677005009184624640
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3533/pull-ci-openshift-ci-tools-master-e2e/1677005009184624640/artifacts/e2e/e2e/build-log.txt

The delay is caused by the readiness probe, which never succeeds since the
reloading interval is currently one hour.  The test still passes because it has
a timeout period of 5m for the probe, after which it will continue executing.

This is all harmless (though the race condition is legitimate), so this change
is mostly about correctness.