### PR TITLE
allow for promotion by tag in `openshift-priv` mirrored repos

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -235,7 +235,12 @@ func privateBaseImages(baseImages map[string]api.ImageStreamTagReference) {
 
 func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
 	if promotion.Namespace == ocpNamespace {
-		promotion.Name = fmt.Sprintf("%s-priv", promotion.Name)
+		if promotion.Name != "" {
+			promotion.Name = fmt.Sprintf("%s-priv", promotion.Name)
+		} else { // promotion.Tag must be set
+			promotion.Tag = fmt.Sprintf("%s-priv", promotion.Tag)
+		}
+		promotion.TagByCommit = false // Never use tag_by_commit for mirrored repos
 		promotion.Namespace = privatePromotionNamespace
 	}
 }

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -199,9 +199,14 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 		expected  *api.PromotionConfiguration
 	}{
 		{
-			id:        "changes expected",
+			id:        "promoted by name",
 			promotion: &api.PromotionConfiguration{Name: "4.x", Namespace: "ocp"},
 			expected:  &api.PromotionConfiguration{Name: "4.x-priv", Namespace: "ocp-private"},
+		},
+		{
+			id:        "promoted by tag",
+			promotion: &api.PromotionConfiguration{Tag: "4.x", Namespace: "ocp"},
+			expected:  &api.PromotionConfiguration{Tag: "4.x-priv", Namespace: "ocp-private"},
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -208,6 +208,11 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 			promotion: &api.PromotionConfiguration{Tag: "4.x", Namespace: "ocp"},
 			expected:  &api.PromotionConfiguration{Tag: "4.x-priv", Namespace: "ocp-private"},
 		},
+		{
+			id:        "promoted by tag, includes tag_by_commit",
+			promotion: &api.PromotionConfiguration{Tag: "4.x", Namespace: "ocp", TagByCommit: true},
+			expected:  &api.PromotionConfiguration{Tag: "4.x-priv", Namespace: "ocp-private"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.id, func(t *testing.T) {

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/looper/super-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  tag: 4.14
+  namespace: ocp
+  tag_by_commit: true
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: looper

--- a/test/integration/ci-operator-config-mirror/input/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/super/looper/super-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  tag: 4.14
+  namespace: ocp
+  tag_by_commit: true
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: looper

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/looper/super-priv-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/looper/super-priv-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/looper
+images:
+- from: base
+  to: test-image
+promotion:
+  namespace: ocp-private
+  tag: 4.14-priv
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: looper

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/looper/super-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  tag: 4.14
+  namespace: ocp
+  tag_by_commit: true
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: looper

--- a/test/integration/ci-operator-config-mirror/output/super-priv/looper/super-priv-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/looper/super-priv-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+canonical_go_repository: github.com/super/looper
+images:
+- from: base
+  to: test-image
+promotion:
+  namespace: ocp-private
+  tag: 4.14-priv
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super-priv
+  repo: looper

--- a/test/integration/ci-operator-config-mirror/output/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super/looper/super-looper-master.yaml
@@ -1,0 +1,35 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+images:
+- from: base
+  to: test-image
+promotion:
+  tag: 4.14
+  namespace: ocp
+  tag_by_commit: true
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+zz_generated_metadata:
+  branch: master
+  org: super
+  repo: looper


### PR DESCRIPTION
Auto-config-brancher has errors like the following when promotion by tag is configured:
```
time="2023-07-31T08:01:59Z" level=error msg="Failed to load CI Operator configuration" error="invalid ci-operator config: invalid configuration: promotion: both name and tag defined" source-file=ci-operator/config/openshift-priv/lvm-operator/openshift-priv-lvm-operator-main.yaml
```

We need to add the `-priv` suffix to the `tag` name when configured this way and **not** the `name` itself. We also should not mirror the `tag_by_commit` value as it is not useful and will result in many unnecessary images.

For: https://issues.redhat.com/browse/DPTP-3583