### PR TITLE
`observer pods`: propagate the entrypoint's child exit code

### DIFF
--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -286,7 +286,9 @@ func addPodUtils(
 	blobStorageOptions.SubDir = artifactDir
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, decorate.PlaceEntrypoint(decorationConfig, toolsMount))
 
-	wrapperOptions, err := decorate.InjectEntrypoint(&pod.Spec.Containers[0], decorationConfig.Timeout.Get(), decorationConfig.GracePeriod.Get(), "", "", false, false, logMount, toolsMount)
+	wrapperOptions, err := decorate.InjectEntrypoint(&pod.Spec.Containers[0],
+		decorationConfig.Timeout.Get(), decorationConfig.GracePeriod.Get(), "", "",
+		generatePodOptions.PropagateExitCode, false, logMount, toolsMount)
 	if err != nil {
 		return fmt.Errorf("could not inject entrypoint: %w", err)
 	}

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -271,7 +271,15 @@ func removeFile(podClient kubernetes.PodClient, ns, name, containerName string, 
 	return nil
 }
 
-func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.DecorationConfig, rawJobSpec string, secretsToCensor []coreapi.VolumeMount, clone bool, jobSpec *api.JobSpec) error {
+func addPodUtils(
+	pod *coreapi.Pod,
+	artifactDir string,
+	decorationConfig *prowv1.DecorationConfig,
+	rawJobSpec string,
+	secretsToCensor []coreapi.VolumeMount,
+	generatePodOptions *GeneratePodOptions,
+	jobSpec *api.JobSpec,
+) error {
 	logMount, logVolume := decorate.LogMountAndVolume()
 	toolsMount, toolsVolume := decorate.ToolsMountAndVolume()
 	blobStorageVolumes, blobStorageMounts, blobStorageOptions := decorate.BlobStorageOptions(*decorationConfig, false)
@@ -293,7 +301,7 @@ func addPodUtils(pod *coreapi.Pod, artifactDir string, decorationConfig *prowv1.
 	pod.Spec.Volumes = append(pod.Spec.Volumes, logVolume, toolsVolume)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, blobStorageVolumes...)
 
-	if clone {
+	if generatePodOptions.Clone {
 		// Unless build_root.from_repository: true is set, the decorationConfig the ci-operator pod gets has cloning
 		// disabled.
 		decorationConfig := *decorationConfig

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -661,7 +661,7 @@ func TestAddPodUtils(t *testing.T) {
 		},
 		GCSCredentialsSecret: func() *string { s := "gce-sa-credentials-gcs-publisher"; return &s }(),
 	}, "rawspec", []coreapi.VolumeMount{{Name: "secret", MountPath: "/secret"}},
-		&GeneratePodOptions{Clone: false}, nil); err != nil {
+		&GeneratePodOptions{Clone: false, PropagateExitCode: true}, nil); err != nil {
 		t.Errorf("failed to decorate: %v", err)
 	}
 	testhelper.CompareWithFixture(t, base)

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -660,7 +660,8 @@ func TestAddPodUtils(t *testing.T) {
 			PathStrategy: prowv1.PathStrategyExplicit,
 		},
 		GCSCredentialsSecret: func() *string { s := "gce-sa-credentials-gcs-publisher"; return &s }(),
-	}, "rawspec", []coreapi.VolumeMount{{Name: "secret", MountPath: "/secret"}}, false, nil); err != nil {
+	}, "rawspec", []coreapi.VolumeMount{{Name: "secret", MountPath: "/secret"}},
+		&GeneratePodOptions{Clone: false}, nil); err != nil {
 		t.Errorf("failed to decorate: %v", err)
 	}
 	testhelper.CompareWithFixture(t, base)

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -133,7 +133,9 @@ func (s *multiStageTestStep) generatePods(
 			commands = []string{"/bin/bash", "-c", CommandPrefix + step.Commands}
 		}
 		labels := map[string]string{base_steps.LabelMetadataStep: step.As}
-		pod, err := base_steps.GenerateBasePod(s.jobSpec, labels, name, s.nodeName, containerName, commands, image, resources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts, false)
+		pod, err := base_steps.GenerateBasePod(s.jobSpec, labels, name, s.nodeName,
+			containerName, commands, image, resources, artifactDir, s.jobSpec.DecorationConfig,
+			s.jobSpec.RawSpec(), secretVolumeMounts, &base_steps.GeneratePodOptions{Clone: false})
 		if err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -56,7 +56,8 @@ type PodStepConfiguration struct {
 }
 
 type GeneratePodOptions struct {
-	Clone bool
+	Clone             bool
+	PropagateExitCode bool
 }
 
 type podStep struct {
@@ -292,7 +293,7 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 	pod, err := GenerateBasePod(s.jobSpec, s.config.Labels, s.config.As,
 		s.config.NodeName, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands},
 		image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(),
-		secretVolumeMounts, &GeneratePodOptions{Clone: clone})
+		secretVolumeMounts, &GeneratePodOptions{Clone: clone, PropagateExitCode: false})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -55,6 +55,10 @@ type PodStepConfiguration struct {
 	Clone              bool
 }
 
+type GeneratePodOptions struct {
+	Clone bool
+}
+
 type podStep struct {
 	name      string
 	config    PodStepConfiguration
@@ -197,7 +201,7 @@ func GenerateBasePod(
 	decorationConfig *v1.DecorationConfig,
 	rawJobSpec string,
 	secretsToCensor []coreapi.VolumeMount,
-	clone bool,
+	generatePodOptions *GeneratePodOptions,
 ) (*coreapi.Pod, error) {
 	envMap, err := downwardapi.EnvForSpec(jobSpec.JobSpec)
 	envMap[openshiftCIEnv] = "true"
@@ -238,7 +242,7 @@ func GenerateBasePod(
 	}...)
 
 	artifactDir = fmt.Sprintf("artifacts/%s", artifactDir)
-	if err := addPodUtils(pod, artifactDir, decorationConfig, rawJobSpec, secretsToCensor, clone, jobSpec); err != nil {
+	if err := addPodUtils(pod, artifactDir, decorationConfig, rawJobSpec, secretsToCensor, generatePodOptions, jobSpec); err != nil {
 		return nil, fmt.Errorf("failed to decorate pod: %w", err)
 	}
 	return pod, nil
@@ -285,7 +289,10 @@ func (s *podStep) generatePodForStep(image string, containerResources coreapi.Re
 	}
 
 	artifactDir := s.name
-	pod, err := GenerateBasePod(s.jobSpec, s.config.Labels, s.config.As, s.config.NodeName, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands}, image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(), secretVolumeMounts, clone)
+	pod, err := GenerateBasePod(s.jobSpec, s.config.Labels, s.config.As,
+		s.config.NodeName, s.name, []string{"/bin/bash", "-c", "#!/bin/bash\nset -eu\n" + s.config.Commands},
+		image, containerResources, artifactDir, s.jobSpec.DecorationConfig, s.jobSpec.RawSpec(),
+		secretVolumeMounts, &GeneratePodOptions{Clone: clone})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/steps/testdata/zz_fixture_TestAddPodUtils.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestAddPodUtils.yaml
@@ -9,7 +9,7 @@ spec:
     - /tools/entrypoint
     env:
     - name: ENTRYPOINT_OPTIONS
-      value: '{"timeout":14400000000000,"grace_period":1800000000000,"artifact_dir":"/logs/artifacts","args":["cmd","arg1","arg2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
+      value: '{"timeout":14400000000000,"grace_period":1800000000000,"artifact_dir":"/logs/artifacts","propagate_error_code":true,"args":["cmd","arg1","arg2"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}'
     - name: ARTIFACT_DIR
       value: /logs/artifacts
     name: test


### PR DESCRIPTION
This PR tries to solve [DPTP-3533](https://issues.redhat.com//browse/DPTP-3533). Using the new option from upstream [#30169](https://github.com/kubernetes/test-infra/pull/30169), we can propagate the exit code from observers to entrypoint and remove confusion to people when they analyze their job status.