### PR TITLE
`prowgen`: use ci-operator-arm64 IS on `arm01`

### DIFF
--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -230,7 +230,7 @@ func (p *prowJobBaseBuilder) Build(namePrefix string) prowconfig.JobBase {
 	case string(cioperatorapi.ClusterARM01):
 		p.PodSpec = p.PodSpec.Add(
 			func(spec *corev1.PodSpec) error {
-				spec.Containers[0].Image = fmt.Sprintf("%s/ci-arm64/ci-operator:latest", cioperatorapi.ServiceDomainArm01Registry)
+				spec.Containers[0].Image = fmt.Sprintf("%s/ci/ci-operator-arm64:latest", cioperatorapi.ServiceDomainArm01Registry)
 				return nil
 			},
 		)

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
@@ -15,7 +15,7 @@ spec:
     - --target=simple
     command:
     - ci-operator
-    image: registry.arm-build01.arm-build.devcluster.openshift.com/ci-arm64/ci-operator:latest
+    image: registry.arm-build01.arm-build.devcluster.openshift.com/ci/ci-operator-arm64:latest
     imagePullPolicy: Always
     name: ""
     resources:


### PR DESCRIPTION
ProwGen now force the use of the image `ci/ci-operator-arm64:latest` on the `arm01` cluster.
Jira card: [DPTP-3590](https://issues.redhat.com/browse/DPTP-3590)

/cc @droslean 