### PR TITLE
test/e2e: report setup errors using original `T`

### DIFF
--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -38,7 +38,7 @@ func TestProduce(t *testing.T) {
 	t.Parallel()
 	T := testhelper.NewT(interrupts.Context(), t)
 	prometheusAddr, info := prometheus.Initialize(T, T.TempDir(), rand.New(rand.NewSource(4641280330504625122)), false)
-	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), kubernetes.Prometheus(prometheusAddr))
+	kubeconfigFile := kubernetes.Fake(t, T, T.TempDir(), kubernetes.Prometheus(prometheusAddr))
 
 	dataDir := T.TempDir()
 	// we need to run the data collection in order of largest offsets as smaller ones subsume the data
@@ -130,7 +130,7 @@ func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
 func TestBuildPodAdmission(t *testing.T) {
 	t.Parallel()
 	T := testhelper.NewT(interrupts.Context(), t)
-	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), kubernetes.Builds(map[string]map[string]map[string]string{
+	kubeconfigFile := kubernetes.Fake(t, T, T.TempDir(), kubernetes.Builds(map[string]map[string]map[string]string{
 		"namespace": {
 			"withoutlabels": map[string]string{},
 			"withlabels": map[string]string{
@@ -242,7 +242,7 @@ func TestAdmission(t *testing.T) {
 	T := testhelper.NewT(interrupts.Context(), t)
 	prometheusAddr, _ := prometheus.Initialize(T, t.TempDir(), rand.New(rand.NewSource(4641280330504625122)), false)
 
-	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), kubernetes.Prometheus(prometheusAddr), kubernetes.Builds(map[string]map[string]map[string]string{
+	kubeconfigFile := kubernetes.Fake(t, T, T.TempDir(), kubernetes.Prometheus(prometheusAddr), kubernetes.Builds(map[string]map[string]map[string]string{
 		"namespace": {
 			"withoutlabels": map[string]string{},
 			"withlabels": map[string]string{

--- a/test/e2e/pod-scaler/local/main.go
+++ b/test/e2e/pod-scaler/local/main.go
@@ -57,7 +57,7 @@ func main() {
 	cacheDir := opts.cacheDir
 	if opts.cacheDir == "" {
 		prometheusAddr, _ := prometheus.Initialize(t.withName("pod-scaler/local/prometheus"), tmpDir, rand.New(rand.NewSource(time.Now().UnixNano())), true)
-		kubeconfigFile := kubernetes.Fake(t.withName("pod-scaler/local/kubernetes"), tmpDir, kubernetes.Prometheus(prometheusAddr))
+		kubeconfigFile := kubernetes.Fake(t, t.withName("pod-scaler/local/kubernetes"), tmpDir, kubernetes.Prometheus(prometheusAddr))
 
 		dataDir, err := os.MkdirTemp(tmpDir, "data")
 		if err != nil {


### PR DESCRIPTION
The E2E `testing.T` wrapper relies on a separate thread to process its `Error`
and `Fatal` messages, since it cannot call those directly from auxiliary
threads, as per the `testing` API requirements:

https://github.com/openshift/ci-tools/blob/a1166b0b93da6845b7c3a39ba3ea73e8e76a1ef1/pkg/testhelper/accessory.go#L85

However, in setup contexts like this, there is no thread yet (it is started by
the `Run` method), so the error is never seen.

---

Before:

```
=== CONT  TestBuildPodAdmission
    accessory.go:239: `kubernetes server` readiness probe: 404 after 1.507µs
    accessory.go:239: `kubernetes server` readiness probe: 404 after 1.012421675s
    accessory.go:239: `kubernetes server` readiness probe: 404 after 2.012596467s
    accessory.go:239: `kubernetes server` readiness probe: 404 after 3.012143864s
    accessory.go:239: `kubernetes server` readiness probe: 404 after 4.012940121s
    accessory.go:239: `kubernetes server` readiness probe: 404 after 5.012219659s
    accessory.go:239: `kubernetes server` readiness probe: 404 after 5.015205646s
    accessory.go:307: found a never-before-seen port, returning: 32777
    accessory.go:307: found a never-before-seen port, returning: 34143
    consumer.go:67: pod-scaler admission starting on port 32777
[test continues…]
```

After:

```console
=== CONT  TestBuildPodAdmission
    kubernetes.go:95: kubernetes server failed to listen: listen tcp 0.0.0.0:8000: bind: address already in use
--- FAIL: TestBuildPodAdmission (0.00s)
FAIL
FAIL    github.com/openshift/ci-tools/test/e2e/pod-scaler       0.062s
FAIL
make[1]: *** [Makefile:169: e2e] Error 1
make[1]: Leaving directory '/home/bbguimaraes/src/ci-tools'
make: *** [Makefile:194: local-e2e] Error 2
```

---

I don't know if this is the cause of failures such as:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3568/pull-ci-openshift-ci-tools-master-e2e/1688153984117772288

but these changes should allow us to know what goes wrong in general.