### PR TITLE
Revert "Replace use of JobRuns tables in ci data client"

### DIFF
--- a/pkg/jobrunaggregator/cmd.go
+++ b/pkg/jobrunaggregator/cmd.go
@@ -25,7 +25,7 @@ func NewJobAggregatorCommand() *cobra.Command {
 	formatter.FullTimestamp = true
 	formatter.DisableColors = false
 	log.SetFormatter(formatter)
-	log.SetLevel(log.InfoLevel)
+	log.SetLevel(log.DebugLevel)
 
 	cmd.AddCommand(jobrunbigqueryloader.NewBigQueryTestRunUploadFlagsCommand())
 	cmd.AddCommand(jobrunbigqueryloader.NewBigQueryDisruptionUploadFlagsCommand())


### PR DESCRIPTION
Reverts openshift/ci-tools#3523

@jupierce reached out regarding a high spike in bigquery costs.  Noted that the query against TestRuns suddenly showed up increasing costs 38x.

https://redhat-internal.slack.com/archives/C02K89U2EV8/p1691423995759719

Need to step back and review.

Justin pointed out that the JobRuns table is about 150MB, the query changed to the TestRuns table which is 252GB, explaining the huge jump in costs.