### PR TITLE
`observer pods` : propagate the entrypoint's child exit code 2

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -135,7 +135,7 @@ func (s *multiStageTestStep) generatePods(
 		labels := map[string]string{base_steps.LabelMetadataStep: step.As}
 		pod, err := base_steps.GenerateBasePod(s.jobSpec, labels, name, s.nodeName,
 			containerName, commands, image, resources, artifactDir, s.jobSpec.DecorationConfig,
-			s.jobSpec.RawSpec(), secretVolumeMounts, &base_steps.GeneratePodOptions{Clone: false})
+			s.jobSpec.RawSpec(), secretVolumeMounts, &base_steps.GeneratePodOptions{PropagateExitCode: genPodOpts.IsObserver})
 		if err != nil {
 			errs = append(errs, err)
 			continue


### PR DESCRIPTION
Add forgotten `PropagateExitCode: genPodOpts.IsObserver` flag inside `GenerateBasePod()` to really propagate the entrypoint's child exit code for observes.
#3560 
It must have been forgotten somehow. 