### PR TITLE
TRT-1204: Support static list of JobRuns

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -2,7 +2,6 @@ package jobrunaggregatoranalyzer
 
 import (
 	"context"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -48,26 +47,6 @@ type JobRunAggregatorAnalyzerOptions struct {
 	prowJobMatcherFunc  jobrunaggregatorlib.ProwJobMatcherFunc
 
 	staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
-}
-
-func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]jobrunaggregatorlib.JobRunIdentifier, error) {
-	var jsonBytes []byte
-	var jobRuns []jobrunaggregatorlib.JobRunIdentifier
-	var err error
-	if len(staticRunInfoJSON) == 0 {
-		jsonBytes, err = os.ReadFile(staticRunInfoPath)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		jsonBytes = []byte(staticRunInfoJSON)
-	}
-
-	if err = json.Unmarshal(jsonBytes, &jobRuns); err != nil {
-		return nil, err
-	}
-
-	return jobRuns, nil
 }
 
 func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -89,8 +89,9 @@ func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context)
 	return jobRuns, nil
 }
 
-func (o *JobRunAggregatorAnalyzerOptions) SetRelatedJobRuns(jobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier) {
+func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRunsFromIdentifiers(ctx context.Context, jobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	o.staticJobRunIdentifiers = jobRunIdentifiers
+	return o.GetRelatedJobRuns(ctx)
 }
 
 // GetRelatedJobRuns gets all related job runs for analysis

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -47,12 +47,12 @@ type JobRunAggregatorAnalyzerOptions struct {
 	jobStateQuerySource string
 	prowJobMatcherFunc  jobrunaggregatorlib.ProwJobMatcherFunc
 
-	staticJobRunInfo []JobRunInfo
+	staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
 }
 
-func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]JobRunInfo, error) {
+func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]jobrunaggregatorlib.JobRunIdentifier, error) {
 	var jsonBytes []byte
-	var jobRuns []JobRunInfo
+	var jobRuns []jobrunaggregatorlib.JobRunIdentifier
 	var err error
 	if len(staticRunInfoJSON) == 0 {
 		jsonBytes, err = os.ReadFile(staticRunInfoPath)
@@ -72,7 +72,7 @@ func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]JobRunI
 
 func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRuns []jobrunaggregatorapi.JobRunInfo
-	for _, job := range o.staticJobRunInfo {
+	for _, job := range o.staticJobRunIdentifiers {
 		// in this context passing the job name is optional for the
 		// static job runs but if it is present then check to make sure it matches
 		if len(job.JobName) > 0 && strings.Compare(job.JobName, o.jobName) != 0 {
@@ -89,10 +89,14 @@ func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context)
 	return jobRuns, nil
 }
 
+func (o *JobRunAggregatorAnalyzerOptions) SetRelatedJobRuns(jobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier) {
+	o.staticJobRunIdentifiers = jobRunIdentifiers
+}
+
 // GetRelatedJobRuns gets all related job runs for analysis
 func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
-	// allow for the list of ids to be passed in via JSON
-	if len(o.staticJobRunInfo) > 0 {
+	// allow for the list of ids to be passed in
+	if len(o.staticJobRunIdentifiers) > 0 {
 		return o.loadStaticJobRuns(ctx)
 	}
 

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -23,6 +23,16 @@ const (
 	testPayloadtag = "4.14.0-0.ci-2023-06-18-131345"
 )
 
+func TestParseStaticJobRunInfo(t *testing.T) {
+	// example json and validation we can unmarshal
+	staticJSON := `[{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762997483114496"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762998317780992"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762999165030400"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000020668416"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000834363392"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763001673224192"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763002516279296"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763003355140096"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763004194000896"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763005460680704"}]`
+	jobRunInfo, err := GetStaticJobRunInfo(staticJSON, "")
+	if err != nil {
+		t.Fatalf("Failed to parse static JobRunInfo json: %v", err)
+	}
+	assert.Equal(t, 10, len(jobRunInfo), "Invalid JobRunInfo length")
+}
+
 func TestAnalyzer(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -74,8 +74,8 @@ func TestAnalyzer(t *testing.T) {
 			endPayloadJobRunWindow := payloadStartTime.Add(jobrunaggregatorlib.JobSearchWindowEndOffset)
 
 			mockDataClient := jobrunaggregatorlib.NewMockCIDataClient(mockCtrl)
-			mockDataClient.EXPECT().GetJobRunForJobNameBeforeTime(gomock.Any(), testJobName, startPayloadJobRunWindow).Return("1000", nil).Times(2)
-			mockDataClient.EXPECT().GetJobRunForJobNameAfterTime(gomock.Any(), testJobName, endPayloadJobRunWindow).Return("2000", nil).Times(2)
+			mockDataClient.EXPECT().GetJobRunForJobNameBeforeTime(gomock.Any(), testJobName, startPayloadJobRunWindow).Return("1000", nil).Times(1)
+			mockDataClient.EXPECT().GetJobRunForJobNameAfterTime(gomock.Any(), testJobName, endPayloadJobRunWindow).Return("2000", nil).Times(1)
 
 			mockGCSClient := jobrunaggregatorlib.NewMockCIGCSClient(mockCtrl)
 			mockGCSClient.EXPECT().ReadRelatedJobRuns(
@@ -84,7 +84,11 @@ func TestAnalyzer(t *testing.T) {
 				fmt.Sprintf("logs/%s", testJobName),
 				"1000",
 				"2000",
-				gomock.Any()).Return(tc.jobRunInfos, nil).Times(2)
+				gomock.Any()).Return(tc.jobRunInfos, nil).Times(1)
+
+			for _, ri := range tc.jobRunInfos {
+				mockGCSClient.EXPECT().ReadJobRunFromGCS(gomock.Any(), gomock.Any(), testJobName, ri.GetJobRunID(), gomock.Any()).Return(ri, nil)
+			}
 
 			analyzer := JobRunAggregatorAnalyzerOptions{
 				jobRunLocator: jobrunaggregatorlib.NewPayloadAnalysisJobLocatorForReleaseController(

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -26,7 +26,7 @@ const (
 func TestParseStaticJobRunInfo(t *testing.T) {
 	// example json and validation we can unmarshal
 	staticJSON := `[{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762997483114496"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762998317780992"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762999165030400"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000020668416"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000834363392"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763001673224192"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763002516279296"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763003355140096"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763004194000896"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763005460680704"}]`
-	jobRunInfo, err := GetStaticJobRunInfo(staticJSON, "")
+	jobRunInfo, err := jobrunaggregatorlib.GetStaticJobRunInfo(staticJSON, "")
 	if err != nil {
 		t.Fatalf("Failed to parse static JobRunInfo json: %v", err)
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -157,7 +157,7 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 
 	var staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
 	if len(f.StaticJobRunIdentifierJSON) > 0 || len(f.StaticJobRunIdentifierPath) > 0 {
-		staticJobRunIdentifiers, err = GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
+		staticJobRunIdentifiers, err = jobrunaggregatorlib.GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -29,8 +29,8 @@ type JobRunsAnalyzerFlags struct {
 	EstimatedJobStartTimeString string
 	JobStateQuerySource         string
 
-	StaticRunInfoPath string
-	StaticRunInfoJSON string
+	StaticJobRunIdentifierPath string
+	StaticJobRunIdentifierJSON string
 }
 
 func NewJobRunsAnalyzerFlags() *JobRunsAnalyzerFlags {
@@ -60,8 +60,8 @@ func (f *JobRunsAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobStateQuerySource, "query-source", jobrunaggregatorlib.JobStateQuerySourceBigQuery, "The source from which job states are found. It is either bigquery or cluster")
 
 	// optional for local use or potentially gangway results
-	fs.StringVar(&f.StaticRunInfoPath, "staticRunInfoPath", f.StaticRunInfoPath, "The optional path to a file containing JSON formatted JobRunInfo array used for aggregated analysis")
-	fs.StringVar(&f.StaticRunInfoJSON, "staticRunInfoJSON", f.StaticRunInfoJSON, "The optional JSON formatted string of JobRunInfo array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierPath, "staticRunInfoPath", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierJSON, "staticRunInfoJSON", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
 
 }
 
@@ -155,9 +155,9 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 		return nil, err
 	}
 
-	var staticJobRunInfo []JobRunInfo
-	if len(f.StaticRunInfoJSON) > 0 || len(f.StaticRunInfoPath) > 0 {
-		staticJobRunInfo, err = GetStaticJobRunInfo(f.StaticRunInfoJSON, f.StaticRunInfoPath)
+	var staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
+	if len(f.StaticJobRunIdentifierJSON) > 0 || len(f.StaticJobRunIdentifierPath) > 0 {
+		staticJobRunIdentifiers, err = GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
 		if err != nil {
 			return nil, err
 		}
@@ -199,18 +199,18 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 	}
 
 	return &JobRunAggregatorAnalyzerOptions{
-		explicitGCSPrefix:   f.ExplicitGCSPrefix,
-		jobRunLocator:       jobRunLocator,
-		passFailCalculator:  newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 6, ciDataClient),
-		jobName:             f.JobName,
-		payloadTag:          f.PayloadTag,
-		workingDir:          f.WorkingDir,
-		jobRunStartEstimate: estimatedStartTime,
-		clock:               clock.RealClock{},
-		timeout:             f.Timeout,
-		prowJobClient:       prowJobClient,
-		jobStateQuerySource: f.JobStateQuerySource,
-		prowJobMatcherFunc:  prowJobMatcherFunc,
-		staticJobRunInfo:    staticJobRunInfo,
+		explicitGCSPrefix:       f.ExplicitGCSPrefix,
+		jobRunLocator:           jobRunLocator,
+		passFailCalculator:      newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 6, ciDataClient),
+		jobName:                 f.JobName,
+		payloadTag:              f.PayloadTag,
+		workingDir:              f.WorkingDir,
+		jobRunStartEstimate:     estimatedStartTime,
+		clock:                   clock.RealClock{},
+		timeout:                 f.Timeout,
+		prowJobClient:           prowJobClient,
+		jobStateQuerySource:     f.JobStateQuerySource,
+		prowJobMatcherFunc:      prowJobMatcherFunc,
+		staticJobRunIdentifiers: staticJobRunIdentifiers,
 	}, nil
 }

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -60,8 +60,8 @@ func (f *JobRunsAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobStateQuerySource, "query-source", jobrunaggregatorlib.JobStateQuerySourceBigQuery, "The source from which job states are found. It is either bigquery or cluster")
 
 	// optional for local use or potentially gangway results
-	fs.StringVar(&f.StaticJobRunIdentifierPath, "staticRunInfoPath", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
-	fs.StringVar(&f.StaticJobRunIdentifierJSON, "staticRunInfoJSON", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierPath, "static-run-info-path", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierJSON, "static-run-info-json", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
 
 }
 

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -18,6 +20,7 @@ var (
 
 type JobRunLocator interface {
 	FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
+	FindJob(ctx context.Context, jobRunID string) (jobrunaggregatorapi.JobRunInfo, error)
 }
 
 // ProwJobMatcherFunc defines a function signature for matching prow jobs. The function is
@@ -80,4 +83,8 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 	}
 
 	return a.ciGCSClient.ReadRelatedJobRuns(ctx, a.jobName, a.gcsPrefix, startingJobRunID, endingJobRunID, a.prowJobMatcher)
+}
+
+func (a *analysisJobAggregator) FindJob(ctx context.Context, jobRunID string) (jobrunaggregatorapi.JobRunInfo, error) {
+	return a.ciGCSClient.ReadJobRunFromGCS(ctx, a.gcsPrefix, a.jobName, jobRunID, logrus.New())
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -2,6 +2,7 @@ package jobrunaggregatorlib
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,11 +45,31 @@ type JobRunIdentifier struct {
 	JobRunID string
 }
 
+func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]JobRunIdentifier, error) {
+	var jsonBytes []byte
+	var jobRuns []JobRunIdentifier
+	var err error
+	if len(staticRunInfoJSON) == 0 {
+		jsonBytes, err = os.ReadFile(staticRunInfoPath)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		jsonBytes = []byte(staticRunInfoJSON)
+	}
+
+	if err = json.Unmarshal(jsonBytes, &jobRuns); err != nil {
+		return nil, err
+	}
+
+	return jobRuns, nil
+}
+
 type JobRunGetter interface {
 	// GetRelatedJobRuns gets all related job runs for analysis
 	GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
 
-	// GetRelatedJobRunsFromIdentifiers passes along minimal information known about the jobs already so we can skip
+	// GetRelatedJobRunsFromIdentifiers passes along minimal information known about the jobs already so that we can skip
 	// querying and go directly to fetching the full job details when GetRelatedJobRuns is called
 	GetRelatedJobRunsFromIdentifiers(ctx context.Context, jobRunIdentifiers []JobRunIdentifier) ([]jobrunaggregatorapi.JobRunInfo, error)
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -18,6 +18,7 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobclientset "k8s.io/test-infra/prow/client/clientset/versioned"
 	prowjobinformers "k8s.io/test-infra/prow/client/informers/externalversions"
+	v1 "k8s.io/test-infra/prow/client/informers/externalversions/prowjobs/v1"
 	"k8s.io/utils/clock"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -38,14 +39,23 @@ var (
 	KnownQuerySources = sets.Set[string]{JobStateQuerySourceBigQuery: sets.Empty{}, JobStateQuerySourceCluster: sets.Empty{}}
 )
 
+type JobRunIdentifier struct {
+	JobName  string
+	JobRunID string
+}
+
 type JobRunGetter interface {
 	// GetRelatedJobRuns gets all related job runs for analysis
 	GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
+
+	// SetRelatedJobRuns sets minimal information known about the jobs already so we can skip
+	// querying and go directly to fetching the full job details when GetRelatedJobRuns is called
+	SetRelatedJobRuns([]JobRunIdentifier)
 }
 
 type JobRunWaiter interface {
 	// Wait waits until all job runs finish, or time out
-	Wait(ctx context.Context) error
+	Wait(ctx context.Context) ([]JobRunIdentifier, error)
 }
 
 // WaitUntilTime waits until readAt time has passed
@@ -110,17 +120,20 @@ type BigQueryJobRunWaiter struct {
 	TimeToStopWaiting time.Time
 }
 
-func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) error {
+func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, error) {
 	clock := clock.RealClock{}
 	relatedJobRuns, err := w.JobRunGetter.GetRelatedJobRuns(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	var finishedJobRuns, unfinishedJobRuns []jobrunaggregatorapi.JobRunInfo
+	var unfinishedJobRunNames []string
 
 	for {
 		fmt.Println() // for prettier logs
 
-		_, _, _, unfinishedJobRunNames := getAllFinishedJobRuns(ctx, relatedJobRuns)
+		finishedJobRuns, unfinishedJobRuns, _, unfinishedJobRunNames = getAllFinishedJobRuns(ctx, relatedJobRuns)
 
 		// ready or not, it's time to check
 		if clock.Now().After(w.TimeToStopWaiting) {
@@ -134,13 +147,26 @@ func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) error {
 			case <-time.After(10 * time.Minute):
 				continue
 			case <-ctx.Done():
-				return ctx.Err()
+				return nil, ctx.Err()
 			}
 		}
 
 		break
 	}
-	return nil
+
+	// Optional if we don't want to change the BigQuery path we can remove
+	// This will save us from making an additional lookup immediately
+	// after this call returns
+	jobRunIdentifiers := make([]JobRunIdentifier, 0)
+	for _, jobRunInfo := range finishedJobRuns {
+		jobRunIdentifiers = append(jobRunIdentifiers, JobRunIdentifier{JobRunID: jobRunInfo.GetJobRunID(), JobName: jobRunInfo.GetJobName()})
+	}
+
+	for _, jobRunInfo := range unfinishedJobRuns {
+		jobRunIdentifiers = append(jobRunIdentifiers, JobRunIdentifier{JobRunID: jobRunInfo.GetJobRunID(), JobName: jobRunInfo.GetJobName()})
+	}
+
+	return jobRunIdentifiers, nil
 }
 
 // ClusterJobRunWaiter implements a waiter that will wait for job completion based on live stats for prow jobs
@@ -157,32 +183,49 @@ type ClusterJobRunWaiter struct {
 	ProwJobMatcherFunc ProwJobMatcherFunc
 }
 
-func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) bool {
+func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) (bool, map[string]*prowv1.ProwJob) {
 	uncompletedJobMap := map[string]*prowv1.ProwJob{}
-	totalMatchedJobs := 0
+	matchedJobMap := map[string]*prowv1.ProwJob{}
+
 	for _, prowJob := range allItems {
 		if !w.ProwJobMatcherFunc(prowJob) {
 			continue
 		}
-		totalMatchedJobs++
+		jobRunID := prowJob.Labels[prowJobJobRunIDLabel]
+		matchedJobMap[jobRunID] = prowJob
 		if prowJob.Status.CompletionTime != nil {
 			continue
 		}
 
-		jobRunID := prowJob.Labels[prowJobJobRunIDLabel]
 		uncompletedJobMap[jobRunID] = prowJob
 	}
 	if len(uncompletedJobMap) == 0 {
 		logrus.Info("all jobs completed")
-		return true
+		return true, matchedJobMap
 	}
-	logrus.Infof("%d/%d jobs completed, waiting for: [%v]", totalMatchedJobs-len(uncompletedJobMap), totalMatchedJobs, strings.Join(sets.StringKeySet(uncompletedJobMap).List(), ", "))
-	return false
+	logrus.Infof("%d/%d jobs completed, waiting for: [%v]", len(matchedJobMap)-len(uncompletedJobMap), len(matchedJobMap), strings.Join(sets.StringKeySet(uncompletedJobMap).List(), ", "))
+	return false, matchedJobMap
 }
 
-func (w *ClusterJobRunWaiter) Wait(ctx context.Context) error {
+func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobInformer v1.ProwJobInformer) (bool, map[string]*prowv1.ProwJob, error) {
+	allItems, err := prowJobInformer.Lister().List(labels.Everything())
+	if err != nil {
+		logrus.Infof("Error listing prow jobs: %v", err)
+		// this is a change from the prior code, confirm if that was intentional
+		// if err != nil {
+		//				logrus.Infof("Error listing prow jobs: %v", err)
+		//				return false, nil
+		//			}
+		return false, nil, err
+	}
+
+	allDone, matchedJobs := w.allProwJobsFinished(allItems)
+	return allDone, matchedJobs, nil
+}
+
+func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, error) {
 	if w.ProwJobClient == nil {
-		return fmt.Errorf("prowjob client is missing")
+		return nil, fmt.Errorf("prowjob client is missing")
 	}
 
 	prowJobInformerFactory := prowjobinformers.NewSharedInformerFactory(w.ProwJobClient, 24*time.Hour)
@@ -193,7 +236,7 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) error {
 	hasSynced := prowJobInformer.Informer().HasSynced
 	go prowJobInformerFactory.Start(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), hasSynced) {
-		return fmt.Errorf("prowjob informer sync error")
+		return nil, fmt.Errorf("prowjob informer sync error")
 	}
 	timeout := time.Until(w.TimeToStopWaiting)
 	if timeout < 0 {
@@ -208,22 +251,29 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) error {
 		timeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			allItems, err := prowJobInformer.Lister().List(labels.Everything())
-			if err != nil {
-				logrus.Infof("Error listing prow jobs: %v", err)
-				return false, nil
-			}
-
-			if w.allProwJobsFinished(allItems) {
-				return true, nil
-			}
-			return false, nil
+			allDone, _, err := w.checkMatchedJobsForCompletion(prowJobInformer)
+			return allDone, err
 		},
 	)
 	if err != nil && err != context.DeadlineExceeded {
-		return fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
+		return nil, fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
 	}
-	return nil
+
+	// one more time to get the matched jobs
+	_, matchedJobs, err := w.checkMatchedJobsForCompletion(prowJobInformer)
+
+	if err != nil && err != context.DeadlineExceeded {
+		return nil, fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
+	}
+
+	jobRuns := make([]JobRunIdentifier, len(matchedJobs))
+	count := 0
+	for _, value := range matchedJobs {
+		jobRuns[count] = JobRunIdentifier{JobName: value.Spec.Job, JobRunID: value.Status.BuildID}
+		count += 1
+	}
+
+	return jobRuns, nil
 }
 
 // WaitAndGetAllFinishedJobRuns waits for all job runs to finish until timeToStopWaiting. It returns all finished and unfinished job runs
@@ -237,12 +287,16 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	finishedJobRunNames := []string{}
 	unfinishedJobRunNames := []string{}
 
-	err := waiter.Wait(ctx)
+	matchedJobs, err := waiter.Wait(ctx)
 	if err != nil {
 		logrus.Errorf("finished waiting with error %+v", err)
 		return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 	}
 	logrus.Infof("finished waiting")
+
+	if len(matchedJobs) > 0 {
+		jobRunGetter.SetRelatedJobRuns(matchedJobs)
+	}
 
 	// Refresh the job runs content one last time
 	relatedJobRuns, err := jobRunGetter.GetRelatedJobRuns(ctx)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -210,12 +210,6 @@ func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) (b
 func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobInformer v1.ProwJobInformer) (bool, map[string]*prowv1.ProwJob, error) {
 	allItems, err := prowJobInformer.Lister().List(labels.Everything())
 	if err != nil {
-		logrus.Infof("Error listing prow jobs: %v", err)
-		// this is a change from the prior code, confirm if that was intentional
-		// if err != nil {
-		//				logrus.Infof("Error listing prow jobs: %v", err)
-		//				return false, nil
-		//			}
 		return false, nil, err
 	}
 
@@ -252,6 +246,13 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, err
 		true,
 		func(ctx context.Context) (bool, error) {
 			allDone, _, err := w.checkMatchedJobsForCompletion(prowJobInformer)
+
+			if err != nil {
+				// log and suppress the error
+				logrus.Infof("Error listing prow jobs: %v", err)
+				return false, nil
+			}
+
 			return allDone, err
 		},
 	)

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util_test.go
@@ -193,7 +193,7 @@ func TestAllProwJobFinished(t *testing.T) {
 				TimeToStopWaiting:  time.Now(),
 				ProwJobMatcherFunc: tt.ProwJobMatcherFunc,
 			}
-			result := waiter.allProwJobsFinished(tt.allItems)
+			result, _ := waiter.allProwJobsFinished(tt.allItems)
 			assert.Equal(t, tt.result, result, "Test %s expecting %v, got %v", tt.name, tt.result, result)
 		})
 	}

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -16,6 +16,7 @@ import (
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobclientset "k8s.io/test-infra/prow/client/clientset/versioned"
 
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatoranalyzer"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
 	"github.com/openshift/ci-tools/pkg/junit"
@@ -407,6 +408,8 @@ type JobRunTestCaseAnalyzerOptions struct {
 	prowJobClient       *prowjobclientset.Clientset
 	jobStateQuerySource string
 	prowJobMatcherFunc  jobrunaggregatorlib.ProwJobMatcherFunc
+
+	staticJobRunInfo []jobrunaggregatoranalyzer.JobRunInfo
 }
 
 func (o *JobRunTestCaseAnalyzerOptions) shouldAggregateJob(prowJob *prowjobv1.ProwJob) bool {
@@ -432,6 +435,12 @@ func (o *JobRunTestCaseAnalyzerOptions) shouldAggregateJob(prowJob *prowjobv1.Pr
 
 func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context,
 	jobName string, jobRunLocator jobrunaggregatorlib.JobRunLocator) ([]jobrunaggregatorapi.JobRunInfo, error) {
+
+	// allow for the list of ids to be passed in via JSON
+	if len(o.staticJobRunInfo) > 0 {
+		return o.loadStaticJobRuns(ctx, jobName, jobRunLocator)
+	}
+
 	errorsInARow := 0
 	for {
 		jobRuns, err := jobRunLocator.FindRelatedJobs(ctx)
@@ -457,10 +466,53 @@ func (o *JobRunTestCaseAnalyzerOptions) findJobRunsWithRetry(ctx context.Context
 	}
 }
 
+func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobRuns(ctx context.Context, jobName string, jobRunLocator jobrunaggregatorlib.JobRunLocator) ([]jobrunaggregatorapi.JobRunInfo, error) {
+	var outputRuns []jobrunaggregatorapi.JobRunInfo
+	for _, jobRun := range o.staticJobRunInfo {
+		if jobRun.JobName != jobName {
+			continue
+		}
+
+		jobRun, err := jobRunLocator.FindJob(ctx, jobRun.JobRunID)
+		if err != nil {
+			return nil, err
+		}
+		if jobRun != nil {
+			outputRuns = append(outputRuns, jobRun)
+		}
+	}
+	return outputRuns, nil
+}
+
+func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobs() []jobrunaggregatorapi.JobRow {
+	rows := make([]jobrunaggregatorapi.JobRow, 0)
+	uniqueNames := sets.Set[string]{}
+
+	for _, r := range o.staticJobRunInfo {
+		// only one row per unique job name
+		if !uniqueNames.Has(r.JobName) {
+			// we only care about returning JobName
+			rows = append(rows, jobrunaggregatorapi.JobRow{JobName: r.JobName})
+			uniqueNames.Insert(r.JobName)
+		}
+	}
+
+	return rows
+}
+
 // GetRelatedJobRuns gets all related job runs for analysis
 func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRunsToReturn []jobrunaggregatorapi.JobRunInfo
-	jobs, err := o.jobGetter.GetJobs(ctx)
+	var jobs []jobrunaggregatorapi.JobRow
+	var err error
+
+	// allow for the list of ids to be passed in via JSON
+	if len(o.staticJobRunInfo) > 0 {
+		jobs = o.loadStaticJobs()
+	} else {
+		jobs, err = o.jobGetter.GetJobs(ctx)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to get related jobs: %w", err)
 	}

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -499,8 +499,9 @@ func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobs() []jobrunaggregatorapi.J
 	return rows
 }
 
-func (o *JobRunTestCaseAnalyzerOptions) SetRelatedJobRuns(jobRunIDs []jobrunaggregatorlib.JobRunIdentifier) {
-	o.staticJobRunIdentifiers = jobRunIDs
+func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRunsFromIdentifiers(ctx context.Context, jobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier) ([]jobrunaggregatorapi.JobRunInfo, error) {
+	o.staticJobRunIdentifiers = jobRunIdentifiers
+	return o.GetRelatedJobRuns(ctx)
 }
 
 // GetRelatedJobRuns gets all related job runs for analysis

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -99,8 +99,8 @@ type JobRunsTestCaseAnalyzerFlags struct {
 	IncludeJobNames             []string
 	JobStateQuerySource         string
 
-	StaticRunInfoPath string
-	StaticRunInfoJSON string
+	StaticJobRunIdentifierPath string
+	StaticJobRunIdentifierJSON string
 }
 
 func NewJobRunsTestCaseAnalyzerFlags() *JobRunsTestCaseAnalyzerFlags {
@@ -140,8 +140,8 @@ func (f *JobRunsTestCaseAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobStateQuerySource, "query-source", jobrunaggregatorlib.JobStateQuerySourceBigQuery, "The source from which job states are found. It is either bigquery or cluster")
 
 	// optional for local use or potentially gangway results
-	fs.StringVar(&f.StaticRunInfoPath, "staticRunInfoPath", f.StaticRunInfoPath, "The optional path to a file containing JSON formatted JobRunInfo array used for aggregated analysis")
-	fs.StringVar(&f.StaticRunInfoJSON, "staticRunInfoJSON", f.StaticRunInfoJSON, "The optional JSON formatted string of JobRunInfo array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierPath, "staticRunInfoPath", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierJSON, "staticRunInfoJSON", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
 
 }
 
@@ -334,9 +334,9 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 
 	jobGetter := NewTestCaseAnalyzerJobGetter(f.Platform, f.Infrastructure, f.Network, f.testNameSuffix(), f.ExcludeJobNames, f.IncludeJobNames, &f.JobGCSPrefixes, ciDataClient)
 
-	var staticJobRunInfo []jobrunaggregatoranalyzer.JobRunInfo
-	if len(f.StaticRunInfoJSON) > 0 || len(f.StaticRunInfoPath) > 0 {
-		staticJobRunInfo, err = jobrunaggregatoranalyzer.GetStaticJobRunInfo(f.StaticRunInfoJSON, f.StaticRunInfoPath)
+	var staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
+	if len(f.StaticJobRunIdentifierJSON) > 0 || len(f.StaticJobRunIdentifierPath) > 0 {
+		staticJobRunIdentifiers, err = jobrunaggregatoranalyzer.GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
 		if err != nil {
 			return nil, err
 		}
@@ -376,6 +376,6 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 		jobStateQuerySource: f.JobStateQuerySource,
 		prowJobMatcherFunc:  jobGetter.shouldAggregateJob,
 
-		staticJobRunInfo: staticJobRunInfo,
+		staticJobRunIdentifiers: staticJobRunIdentifiers,
 	}, nil
 }

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -140,8 +140,8 @@ func (f *JobRunsTestCaseAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&f.JobStateQuerySource, "query-source", jobrunaggregatorlib.JobStateQuerySourceBigQuery, "The source from which job states are found. It is either bigquery or cluster")
 
 	// optional for local use or potentially gangway results
-	fs.StringVar(&f.StaticJobRunIdentifierPath, "staticRunInfoPath", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
-	fs.StringVar(&f.StaticJobRunIdentifierJSON, "staticRunInfoJSON", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierPath, "static-run-info-path", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
+	fs.StringVar(&f.StaticJobRunIdentifierJSON, "static-run-info-json", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
 
 }
 

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowjobclientset "k8s.io/test-infra/prow/client/clientset/versioned"
 
-	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatoranalyzer"
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
 )
 
@@ -336,7 +335,7 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 
 	var staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
 	if len(f.StaticJobRunIdentifierJSON) > 0 || len(f.StaticJobRunIdentifierPath) > 0 {
-		staticJobRunIdentifiers, err = jobrunaggregatoranalyzer.GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
+		staticJobRunIdentifiers, err = jobrunaggregatorlib.GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Allows a list of JobRunIdentifier objects to be passed in for analysis bypassing bigquery lookup to reduces costs and allow external tooling to designate runs to be analyzed.

JobRunIdentifier can be passed in via the command to specify a static list of identifiers for analysis.  Additionally JobRunIdentifier is now set when using BigQueryJobRunWaiter or ClusterJobRunWaiter to skip additional / unnecessary calls to bigquery for JobRun data. 