### PR TITLE
Include the manifest list on the output images on all builds

### DIFF
--- a/cmd/multi-arch-builder-controller/main.go
+++ b/cmd/multi-arch-builder-controller/main.go
@@ -23,7 +23,8 @@ import (
 )
 
 type options struct {
-	dryRun bool
+	dryRun        bool
+	dockerCfgPath string
 }
 
 func gatherOptions() (*options, error) {
@@ -31,6 +32,7 @@ func gatherOptions() (*options, error) {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether to run the controller-manager with dry-run")
+	fs.StringVar(&o.dockerCfgPath, "docker-cfg", "/.docker/config.json", "Path of the registry credentials configuration file")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return o, fmt.Errorf("failed to parse flags: %w", err)
@@ -79,7 +81,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to retrieve the node architectures")
 	}
 
-	if err := multiarchbuildconfig.AddToManager(mgr, nodeArchitectures); err != nil {
+	if err := multiarchbuildconfig.AddToManager(mgr, nodeArchitectures, o.dockerCfgPath); err != nil {
 		logrus.WithError(err).Fatal("Failed to add multiarchbuildconfig controller to manager")
 	}
 

--- a/images/ci-operator/Dockerfile
+++ b/images/ci-operator/Dockerfile
@@ -1,5 +1,7 @@
+FROM mplatform/manifest-tool as builder
 FROM quay.io/centos/centos:stream8
-LABEL maintainer="skuznets@redhat.com"
+
+COPY --from=builder /manifest-tool /usr/bin/manifest-tool
 
 RUN yum install -y git python2
 RUN alternatives --set python /usr/bin/python2

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
@@ -19,6 +19,7 @@ import (
 	buildv1 "github.com/openshift/api/build/v1"
 
 	v1 "github.com/openshift/ci-tools/pkg/api/multiarchbuildconfig/v1"
+	"github.com/openshift/ci-tools/pkg/manifestpusher"
 )
 
 func TestCheckAllBuildsFinished(t *testing.T) {
@@ -108,7 +109,7 @@ func TestReconcile(t *testing.T) {
 		name           string
 		inputMabc      *v1.MultiArchBuildConfig
 		expectedMabc   *v1.MultiArchBuildConfig
-		manifestPusher ManifestPusher
+		manifestPusher manifestpusher.ManifestPusher
 	}{
 		{
 			name: "Early exit on SuccessState",

--- a/pkg/manifestpusher/manifestpusher.go
+++ b/pkg/manifestpusher/manifestpusher.go
@@ -1,0 +1,107 @@
+package manifestpusher
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+
+	buildv1 "github.com/openshift/api/build/v1"
+)
+
+const (
+	nodeArchitectureLabel = "kubernetes.io/arch"
+)
+
+type ManifestPusher interface {
+	PushImageWithManifest(builds map[string]*buildv1.Build, targetImageRef string) error
+}
+
+func NewManifestPushfer(logger *logrus.Entry, registryURL string, dockercfgPath string) ManifestPusher {
+	return &manifestPusher{
+		logger:        logger,
+		registryURL:   registryURL,
+		dockercfgPath: dockercfgPath,
+	}
+}
+
+type manifestPusher struct {
+	logger        *logrus.Entry
+	registryURL   string
+	dockercfgPath string
+}
+
+// pushOutputImageWithManifest constructs a manifest-tool command to create and push a new image with all images that we built
+// in the manifest list based on their architecture.
+//
+// Example command:
+// /usr/bin/manifest-tool push from-args \
+// --platforms linux/amd64 --template registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-amd64 \
+// --platforms linux/arm64 --template registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-arm64 \
+// --target registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest
+func (m manifestPusher) PushImageWithManifest(builds map[string]*buildv1.Build, targetImageRef string) error {
+	args := []string{
+		"--debug",
+		"--insecure",
+		"--docker-cfg", m.dockercfgPath,
+		"push", "from-args",
+	}
+	for _, build := range builds {
+		args = append(args, []string{
+			"--platforms",
+			fmt.Sprintf("linux/%s", build.Spec.NodeSelector[nodeArchitectureLabel]),
+			"--template",
+			fmt.Sprintf("%s/%s/%s", m.registryURL, build.Spec.Output.To.Namespace, build.Spec.Output.To.Name),
+		}...)
+	}
+
+	args = append(args, []string{
+		"--target",
+		fmt.Sprintf("%s/%s", m.registryURL, targetImageRef),
+	}...)
+
+	cmd := exec.Command("manifest-tool", args...)
+
+	cmdOutput := &bytes.Buffer{}
+	cmdError := &bytes.Buffer{}
+	cmd.Stdout = cmdOutput
+	cmd.Stderr = cmdError
+
+	m.logger.Debugf("Running command: %s", cmd.String())
+	err := cmd.Run()
+	if err != nil {
+		m.logger.WithError(err).WithField("output", cmdOutput.String()).WithField("error_output", cmdError.String()).Error("manifest-tool command failed")
+		return err
+	}
+	m.logger.WithField("output", cmdOutput.String()).Debug("manifest-tool command succeeded")
+
+	m.logger.Infof("Image %s created", targetImageRef)
+	return nil
+}
+
+func CreateDockerCfg(tokenPath, registryURL, dest string) error {
+	token, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return fmt.Errorf("error reading token: %w", err)
+	}
+
+	authString := base64.StdEncoding.EncodeToString([]byte("serviceaccount:" + string(token)))
+
+	configContent := fmt.Sprintf(`{
+		"auths": {
+			"%s": {
+				"auth": "%s"
+			}
+		}
+	}`, registryURL, authString)
+
+	if err = os.WriteFile(dest, []byte(configContent), 0755); err != nil {
+		return fmt.Errorf("error writing %s: %w", dest, err)
+
+	}
+
+	return nil
+}

--- a/pkg/manifestpusher/manifestpusher.go
+++ b/pkg/manifestpusher/manifestpusher.go
@@ -2,9 +2,7 @@ package manifestpusher
 
 import (
 	"bytes"
-	"encoding/base64"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/sirupsen/logrus"
@@ -79,29 +77,5 @@ func (m manifestPusher) PushImageWithManifest(builds map[string]*buildv1.Build, 
 	m.logger.WithField("output", cmdOutput.String()).Debug("manifest-tool command succeeded")
 
 	m.logger.Infof("Image %s created", targetImageRef)
-	return nil
-}
-
-func CreateDockerCfg(tokenPath, registryURL, dest string) error {
-	token, err := os.ReadFile(tokenPath)
-	if err != nil {
-		return fmt.Errorf("error reading token: %w", err)
-	}
-
-	authString := base64.StdEncoding.EncodeToString([]byte("serviceaccount:" + string(token)))
-
-	configContent := fmt.Sprintf(`{
-		"auths": {
-			"%s": {
-				"auth": "%s"
-			}
-		}
-	}`, registryURL, authString)
-
-	if err = os.WriteFile(dest, []byte(configContent), 0755); err != nil {
-		return fmt.Errorf("error writing %s: %w", dest, err)
-
-	}
-
 	return nil
 }

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -46,7 +46,7 @@ func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return handleBuild(ctx, s.client, s.podClient, *buildFromSource(
+	return handleBuilds(ctx, s.client, s.podClient, *buildFromSource(
 		s.jobSpec, s.config.From, s.config.To,
 		buildapi.BuildSource{
 			Type:       buildapi.BuildSourceDockerfile,

--- a/test/e2e/framework/ci-operator.go
+++ b/test/e2e/framework/ci-operator.go
@@ -89,6 +89,7 @@ func newCiOperatorCommand(t *T) CiOperatorCommand {
 		GCSPushCredentialsFlag(t),
 	)
 	cmd.Env = append(cmd.Env, KubernetesClientEnv(t)...)
+	cmd.Env = append(cmd.Env, "PATH=$PATH:/usr/bin")
 	cmd.Env = append(cmd.Env, fmt.Sprintf("ARTIFACTS=%s", artifactDir))
 	return CiOperatorCommand{
 		cmd:         cmd,


### PR DESCRIPTION
This PR:

- Migrates the manifest pusher into its own package for generalized usage.
- Transform all ci-operator builds to be architecture-specific.  
- Start using the `manifest-tool` tool in ci-operator to generate the final image with the manifest list included.


I already did some testing with the `vega-project` images. See job https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/branch-ci-vega-project-ccb-operator-master-images/1695214240392024064

The final images that ended up in `apps.ci` cluster include the manifest list. 


/cc @openshift/test-platform @danilo-gemoli @jmguzik @deepsm007 @bbguimaraes 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>