### PR TITLE
remove unused cluster profile azure_marketplace_qe

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1155,7 +1155,6 @@ const (
 	ClusterProfileAzureMag              ClusterProfile = "azuremag"
 	ClusterProfileAzureQE               ClusterProfile = "azure-qe"
 	ClusterProfileAzureArm64QE          ClusterProfile = "azure-arm64-qe"
-	ClusterProfileAzureMarketPlaceQE    ClusterProfile = "azure-marketplace-qe"
 	ClusterProfileAzureMagQE            ClusterProfile = "azuremag-qe"
 	ClusterProfileEquinixOcpMetal       ClusterProfile = "equinix-ocp-metal"
 	ClusterProfileEquinixOcpMetalQE     ClusterProfile = "equinix-ocp-metal-qe"
@@ -1258,7 +1257,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureMag,
 		ClusterProfileAzureMagQE,
 		ClusterProfileAzureQE,
-		ClusterProfileAzureMarketPlaceQE,
 		ClusterProfileAzureStack,
 		ClusterProfileAzureStackQE,
 		ClusterProfileEquinixOcpMetal,
@@ -1368,7 +1366,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAzure4,
 		ClusterProfileAzureArc,
 		ClusterProfileAzureQE,
-		ClusterProfileAzureMarketPlaceQE,
 		ClusterProfileAzureVirtualization:
 		return "azure4"
 	case
@@ -1553,8 +1550,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "azuremag-qe-quota-slice"
 	case ClusterProfileAzureArm64QE:
 		return "azure-arm64-qe-quota-slice"
-	case ClusterProfileAzureMarketPlaceQE:
-		return "azure-marketplace-qe-quota-slice"
 	case ClusterProfileAzureVirtualization:
 		return "azure-virtualization-quota-slice"
 	case ClusterProfileEquinixOcpMetal:


### PR DESCRIPTION
removed unused cluster profile azure-marketplace-qe based on https://github.com/openshift/release/pull/42330

Depend on https://github.com/openshift/release/pull/42718