### PR TITLE
OPRUN-1873: ci-operator: allow accessory promotions

### DIFF
--- a/cmd/autopublicizeconfig/main.go
+++ b/cmd/autopublicizeconfig/main.go
@@ -187,7 +187,7 @@ func getReposForPrivateOrg(releaseRepoPath string, allowlist map[string][]string
 	}
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
-		if !api.BuildsOfficialImages(c, api.WithoutOKD) {
+		if !api.BuildsOfficialImages(c.PromotionConfiguration, api.WithoutOKD) {
 			return nil
 		}
 

--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -124,7 +124,7 @@ func main() {
 			logger.Warnf("Repository %s doesn't belong to the %s organization but it is whitelisted", repoInfo.Repo, o.onlyOrg)
 		}
 
-		if !api.BuildsOfficialImages(rbc, api.WithoutOKD) && !o.WhitelistConfig.IsWhitelisted(repoInfo) {
+		if !api.BuildsOfficialImages(rbc.PromotionConfiguration, api.WithoutOKD) && !o.WhitelistConfig.IsWhitelisted(repoInfo) {
 			logger.Warn("Skipping...")
 			return nil
 		}
@@ -160,7 +160,7 @@ func main() {
 		}
 
 		if rbc.PromotionConfiguration != nil {
-			if !api.BuildsOfficialImages(rbc, api.WithoutOKD) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
+			if !api.BuildsOfficialImages(rbc.PromotionConfiguration, api.WithoutOKD) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
 				logger.Warn("Repo is whitelisted. Disable promotion...")
 				rbc.PromotionConfiguration.Disabled = true
 			}

--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -237,7 +237,7 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) string {
 		logger.WithError(err).Error("could not resolve ci-operator's config")
 		return formatError(fmt.Errorf("could not resolve ci-operator's config for %s/%s/%s: %w", org, repo, pr.Base.Ref, err))
 	}
-	if !api.PromotesOfficialImages(ciOpConfig, api.WithOKD) {
+	if !api.PromotesOfficialImages(ciOpConfig.PromotionConfiguration, api.WithOKD) {
 		logger.Info("the repo does not contribute to the OpenShift official images")
 		return fmt.Sprintf("the repo %s/%s does not contribute to the OpenShift official images", org, repo)
 	}

--- a/cmd/private-org-peribolos-sync/main.go
+++ b/cmd/private-org-peribolos-sync/main.go
@@ -180,7 +180,7 @@ func getReposForPrivateOrg(releaseRepoPath string, whitelist map[string][]string
 	}
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
-		if !api.BuildsOfficialImages(c, api.WithoutOKD) {
+		if !api.BuildsOfficialImages(c.PromotionConfiguration, api.WithoutOKD) {
 			return nil
 		}
 

--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -534,7 +534,7 @@ func (o *options) makeFilter(callback func(*api.ReleaseBuildConfiguration, *conf
 		if o.repo != "" && o.repo != fmt.Sprintf("%s/%s", i.Org, i.Repo) {
 			return nil
 		}
-		if !api.BuildsOfficialImages(c, api.WithoutOKD) {
+		if !api.BuildsOfficialImages(c.PromotionConfiguration, api.WithoutOKD) {
 			return nil
 		}
 		return callback(c, i)

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -103,10 +103,10 @@ func TestOptionsMakeFilter(t *testing.T) {
 		},
 	}
 	// Check that our assumptions about what is an official image still holds
-	if !api.BuildsOfficialImages(official, api.WithoutOKD) {
+	if !api.BuildsOfficialImages(official.PromotionConfiguration, api.WithoutOKD) {
 		t.Fatal("Test data assumed to be official images are not official images")
 	}
-	if api.BuildsOfficialImages(notOfficial, api.WithoutOKD) {
+	if api.BuildsOfficialImages(notOfficial.PromotionConfiguration, api.WithoutOKD) {
 		t.Fatal("Test data assumed to be non-official images are official images")
 	}
 	testcases := []struct {

--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -144,7 +144,7 @@ func getOrgReposWithOfficialImages(configDir string, whitelist map[string][]stri
 
 	callback := func(c *api.ReleaseBuildConfiguration, i *config.Info) error {
 
-		if !api.BuildsOfficialImages(c, api.WithoutOKD) {
+		if !api.BuildsOfficialImages(c.PromotionConfiguration, api.WithoutOKD) {
 			return nil
 		}
 

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -53,7 +53,7 @@ func TestPromotesOfficialImages(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			if actual, expected := PromotesOfficialImages(testCase.configSpec, WithOKD), testCase.expected; actual != expected {
+			if actual, expected := PromotesOfficialImages(testCase.configSpec.PromotionConfiguration, WithOKD), testCase.expected; actual != expected {
 				t.Errorf("%s: did not identify official promotion correctly, expected %v got %v", testCase.name, expected, actual)
 			}
 		})

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -86,6 +86,14 @@ type ReleaseBuildConfiguration struct {
 	// If no promotion is defined, it is defaulted from the ReleaseTagConfiguration.
 	PromotionConfiguration *PromotionConfiguration `json:"promotion,omitempty"`
 
+	// AccessoryPromotionConfiguration determines how accessory images are
+	// promoted by this command. This promotion follows all the same rules
+	// as the main promotion, except that additional_images are required, as
+	// all promotions in these stanzas are opt-in, not opt-out like the main
+	// one. Furthermore, accessory promotion stanzas cannot be used to promote
+	// to official streams.
+	AccessoryPromotionConfiguration []PromotionConfiguration `json:"accessory_promotion,omitempty"`
+
 	// Resources is a set of resource requests or limits over the
 	// input types. The special name '*' may be used to set default
 	// requests and limits.

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -1410,6 +1410,13 @@ func (in *ReleaseBuildConfiguration) DeepCopyInto(out *ReleaseBuildConfiguration
 		*out = new(PromotionConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AccessoryPromotionConfiguration != nil {
+		in, out := &in.AccessoryPromotionConfiguration, &out.AccessoryPromotionConfiguration
+		*out = make([]PromotionConfiguration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = make(ResourceConfiguration, len(*in))

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -103,7 +103,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 	if len(imageTargets) > 0 {
 		// Identify which jobs need to have a release payload explicitly requested
 		var presubmitTargets = sets.List(imageTargets)
-		if api.PromotesOfficialImages(configSpec, api.WithOKD) {
+		if api.PromotesOfficialImages(configSpec.PromotionConfiguration, api.WithOKD) {
 			presubmitTargets = append(presubmitTargets, "[release:latest]")
 		}
 		jobBaseGen := newJobBaseBuilder().TestName("images")

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -274,6 +274,34 @@ func TestPromotedTags(t *testing.T) {
 				{Namespace: "ocp", Name: "4.6", Tag: "base-8"},
 			},
 		},
+		{
+			name: "promotion with accessory",
+			input: &api.ReleaseBuildConfiguration{
+				PromotionConfiguration: &api.PromotionConfiguration{
+					Namespace: "ocp",
+					Name:      "4.6",
+					AdditionalImages: map[string]string{
+						"base": "base-8",
+					},
+				},
+				AccessoryPromotionConfiguration: []api.PromotionConfiguration{{
+					Namespace: "whatever",
+					Name:      "testing",
+					AdditionalImages: map[string]string{
+						"something": "special",
+					},
+				}},
+				Metadata: api.Metadata{
+					Org:    "openshift",
+					Repo:   "images",
+					Branch: "release-4.6",
+				},
+			},
+			expected: []api.ImageStreamTagReference{
+				{Namespace: "ocp", Name: "4.6", Tag: "base"},
+				{Namespace: "whatever", Name: "testing", Tag: "something"},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -294,8 +322,9 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 		names    sets.Set[string]
 	}{
 		{
-			name:  "no promotion, no output",
-			input: &api.ReleaseBuildConfiguration{},
+			name:     "no promotion, no output",
+			input:    &api.ReleaseBuildConfiguration{},
+			expected: map[string][]api.ImageStreamTagReference{},
 		},
 		{
 			name: "promoted image means output tags",
@@ -362,7 +391,7 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					Disabled:  true,
 				},
 			},
-			expected: nil,
+			expected: map[string][]api.ImageStreamTagReference{},
 		},
 		{
 			name: "promoted image by tag means output tags",

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -316,7 +316,7 @@ func TestValidatePromotion(t *testing.T) {
 			input:                  api.PromotionConfiguration{Namespace: "foo", Tag: "bar"},
 			promotesOfficialImages: true,
 			imageTargets:           true,
-			expected:               []error{fmt.Errorf("importing the release stream is required to ensure the promoted images to the namespace foo can be integrated properly. Although it can be achieved by tag_specification or releases[\"latest\"], adding an e2e test is strongly suggested")},
+			expected:               []error{fmt.Errorf("promotion: importing the release stream is required to ensure the promoted images to the namespace foo can be integrated properly. Although it can be achieved by tag_specification or releases[\"latest\"], adding an e2e test is strongly suggested")},
 		},
 		{
 			name:                   "[release:latest] is not fulfilled because the release name is not correct",
@@ -326,7 +326,7 @@ func TestValidatePromotion(t *testing.T) {
 			releases: map[string]api.UnresolvedRelease{
 				"initial": {},
 			},
-			expected: []error{fmt.Errorf("importing the release stream is required to ensure the promoted images to the namespace foo can be integrated properly. Although it can be achieved by tag_specification or releases[\"latest\"], adding an e2e test is strongly suggested")},
+			expected: []error{fmt.Errorf("promotion: importing the release stream is required to ensure the promoted images to the namespace foo can be integrated properly. Although it can be achieved by tag_specification or releases[\"latest\"], adding an e2e test is strongly suggested")},
 		},
 		{
 			name:  "[release:latest] is fulfilled by release[latest]",
@@ -352,8 +352,9 @@ func TestValidatePromotion(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			if actual, expected := validatePromotionConfiguration("promotion", test.input, test.promotesOfficialImages, test.imageTargets, test.input.Namespace, test.releaseTagConfiguration, test.releases), test.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: got incorrect errors: %v", test.name, diff.ObjectDiff(actual, expected))
+			actual, expected := validatePromotionConfiguration(NewConfigContext().AddField("promotion"), test.input, test.promotesOfficialImages, test.imageTargets, test.input.Namespace, test.releaseTagConfiguration, test.releases), test.expected
+			if diff := cmp.Diff(actual, expected, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("%s: got incorrect errors: %v", test.name, diff)
 			}
 		})
 	}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1,6 +1,57 @@
 package webreg
 
-const ciOperatorReferenceYaml = "# The list of base images describe\n" +
+const ciOperatorReferenceYaml = "# AccessoryPromotionConfiguration determines how accessory images are\n" +
+	"# promoted by this command. This promotion follows all the same rules\n" +
+	"# as the main promotion, except that additional_images are required, as\n" +
+	"# all promotions in these stanzas are opt-in, not opt-out like the main\n" +
+	"# one. Furthermore, accessory promotion stanzas cannot be used to promote\n" +
+	"# to official streams.\n" +
+	"accessory_promotion:\n" +
+	"    - # AdditionalImages is a mapping of images to promote. The\n" +
+	"      # images will be taken from the pipeline image stream. The\n" +
+	"      # key is the name to promote as and the value is the source\n" +
+	"      # name. If you specify a tag that does not exist as the source\n" +
+	"      # the destination tag will not be created.\n" +
+	"      additional_images:\n" +
+	"        \"\": \"\"\n" +
+	"      # DisableBuildCache stops us from uploading the build cache.\n" +
+	"      # This is useful (only) for CI chat bot invocations where\n" +
+	"      # promotion does not imply output artifacts are being created\n" +
+	"      # for posterity.\n" +
+	"      disable_build_cache: true\n" +
+	"      # Disabled will no-op succeed instead of running the actual\n" +
+	"      # promotion step. This is useful when two branches need to\n" +
+	"      # promote to the same output imagestream on a cut-over but\n" +
+	"      # never concurrently, and you want to have promotion config\n" +
+	"      # in the ci-operator configuration files all the time.\n" +
+	"      disabled: true\n" +
+	"      # ExcludedImages are image names that will not be promoted.\n" +
+	"      # Exclusions are made before additional_images are included.\n" +
+	"      # Use exclusions when you want to build images for testing\n" +
+	"      # but not promote them afterwards.\n" +
+	"      excluded_images:\n" +
+	"        - \"\"\n" +
+	"      # Name is an optional image stream name to use that\n" +
+	"      # contains all component tags. If specified, tag is\n" +
+	"      # ignored.\n" +
+	"      name: ' '\n" +
+	"      # Namespace identifies the namespace to which the built\n" +
+	"      # artifacts will be published to.\n" +
+	"      namespace: ' '\n" +
+	"      # RegistryOverride is an override for the registry domain to\n" +
+	"      # which we will mirror images. This is an advanced option and\n" +
+	"      # should *not* be used in common test workflows. The CI chat\n" +
+	"      # bot uses this option to facilitate image sharing.\n" +
+	"      registry_override: ' '\n" +
+	"      # Tag is the ImageStreamTag tagged in for each\n" +
+	"      # build image's ImageStream.\n" +
+	"      tag: ' '\n" +
+	"      # TagByCommit determines if an image should be tagged by the\n" +
+	"      # git commit that was used to build it. If Tag is also set,\n" +
+	"      # this will cause both a floating tag and commit-specific tags\n" +
+	"      # to be promoted.\n" +
+	"      tag_by_commit: true\n" +
+	"# The list of base images describe\n" +
 	"# which images are going to be necessary outside\n" +
 	"# of the pipeline. The key will be the alias that other\n" +
 	"# steps use to refer to this image.\n" +


### PR DESCRIPTION
There exist repositories which promote images to the OCP payload but would also like to be able to build utility images that are promoted to some other location, since inclusion into the core payload ImageStreams is tightly regulated.

The new `accesssory_promotion` stanza in `ci-operator` configuration allows users to opt images into other promotion schemes. This field is opt-in, so no changes are expected for any current configurations.