### PR TITLE
promoted-image-governor: add some logs for debugging

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -256,6 +256,7 @@ func main() {
 				"--release-controller-mirror-config-dir", "./core-services/release-controller/_releases",
 				"--openshift-mapping-dir", "./core-services/image-mirroring/openshift",
 				"--openshift-mapping-config", "./core-services/image-mirroring/openshift/_config.yaml",
+				"--log-level", "debug",
 				"--dry-run=true",
 			},
 		},

--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -258,6 +258,10 @@ func generateMappings(promotedTags []api.ImageStreamTagReference, mappingConfig 
 						if mappings[filename][src].Has(dst) {
 							errs = append(errs, fmt.Errorf("cannot define the same mirroring destination %s more than once for the source %s in filename %s", dst, src, filename))
 						}
+						logrus.WithField("filename", filename).WithField("src", src).WithField("dst", dst).
+							WithField("tag.Namespace", tag.Namespace).
+							WithField("mappingConfig.SourceNamespace", mappingConfig.SourceNamespace).
+							Debug("Insert into mapping ...")
 						mappings[filename][src].Insert(dst)
 					}
 				}
@@ -285,6 +289,7 @@ func isMirroredFromOCP(tag api.ImageStreamTagReference, refs []releaseconfig.Ima
 				return false
 			}
 		}
+		logrus.WithField("tag", tag.ISTagName()).Debug("mirrored from OCP")
 		return true
 	}
 	return false


### PR DESCRIPTION
To follow up: https://redhat-internal.slack.com/archives/CHY2E1BL4/p1693342217358849?thread_ts=1693310693.926879&cid=CHY2E1BL4

Our config-auto-brancher job failed. However I cannot produce it locally.
The logs might help us identify the cause.
This PR will be reverted once we are done to reduce the log output.

/cc @openshift/test-platform 
