### PR TITLE
autoconfigbrancher: ignore openshift/linuxptp-daemon

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -175,6 +175,7 @@ func main() {
 				"--current-release-minor=" + versionSplit[1],
 				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/origin-aggregated-logging",
 				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/console",
+				"--ensure-correct-promotion-dockerfile-ignored-repos", "openshift/linuxptp-daemon",
 			},
 		},
 		{


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CHY2E1BL4/p1693418057541059?thread_ts=1693336376.195279&cid=CHY2E1BL4

/cc @openshift/test-platform @jupierce @nishant-parekh 