### PR TITLE
AutoConfigBrancher: disable debug logging

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -257,7 +257,6 @@ func main() {
 				"--release-controller-mirror-config-dir", "./core-services/release-controller/_releases",
 				"--openshift-mapping-dir", "./core-services/image-mirroring/openshift",
 				"--openshift-mapping-config", "./core-services/image-mirroring/openshift/_config.yaml",
-				"--log-level", "debug",
 				"--dry-run=true",
 			},
 		},


### PR DESCRIPTION
Introduced by https://github.com/openshift/ci-tools/pull/3591

We've identified the issue and the fix is on the way.

/cc @openshift/test-platform 

/hold

Let us verify if https://github.com/openshift/release/pull/42869 fixed it.