### PR TITLE
Disable aggregated testing for new disruption backends

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -26,6 +26,12 @@ func isExcludedDisruptionBackend(name string) bool {
 		"kube-api-http1-external-lb",
 		"kube-api-http2-external-lb",
 		"openshift-api-http2-external-lb",
+		"host-to-service",
+		"host-to-host",
+		"host-to-pod",
+		"pod-to-host",
+		"pod-to-pod",
+		"pod-to-service",
 	}
 
 	for _, excludedName := range excludedNames {


### PR DESCRIPTION
The situation with these backends is not yet fully known, and the
aggregation is tripping frequently. We're not confident in the data yet
and need the payloads to keep flowing. We will investigate this new
signal separately.
