### PR TITLE
Add etcd_rhel9_golang to streams to ignore mirror=false from

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -282,7 +282,7 @@ func replaceStream(streamName string, streamMap StreamMap) (string, error) {
 	}
 	//TODO: this is a temporary workaround until https://github.com/openshift-eng/ocp-build-data/commit/155694be74cb2f020f6fafeaf6e4b3fba89646a2 is reverted/changed
 	// We need to allow the: 'golang', 'rhel-9-golang', and 'etcd_golang' streams through in the meantime
-	if streamName != "golang" && streamName != "golang-1.19" && streamName != "rhel-9-golang" && streamName != "etcd_golang" && streamName != "etcd_golang-1.19" && streamName != "rhel-9-golang-1.19" {
+	if streamName != "golang" && streamName != "golang-1.19" && streamName != "rhel-9-golang" && streamName != "etcd_golang" && streamName != "etcd_golang-1.19" && streamName != "rhel-9-golang-1.19" && streamName != "etcd_rhel9_golang" {
 		if replacement.Mirror == nil || !*replacement.Mirror {
 			return "", fmt.Errorf("stream.yaml.%s.mirror is set to false, can not dereference", streamName)
 		}


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CHY2E1BL4/p1693584498466689?thread_ts=1693584203.856869&cid=CHY2E1BL4

```
time="2023-09-01T16:01:28Z" level=fatal msg="failed to read ocp build data" error="failed to load ocp build data configs: failed dereferencing config for images/ose-etcd.yml: [failed to replace .from.0.stream: stream.yaml.etcd_rhel9_golang.mirror is set to false, can not dereference, failed to dereference from.builder.0]"
```

Similar to https://github.com/openshift/ci-tools/pull/3531

/cc @openshift/test-platform @jupierce 

