### PR TITLE
cluster-init: add the image-pusher credentials for the local registry dns

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -126,6 +126,11 @@ func generateRegistryPushCredentialsSecret(o options) secretbootstrap.SecretConf
 					RegistryURL: api.ServiceDomainAPPCIRegistry,
 				},
 				{
+					AuthField:   registryCommandTokenField(o.clusterName, push),
+					Item:        buildUFarm,
+					RegistryURL: "image-registry.openshift-image-registry.svc.cluster.local:5000",
+				},
+				{
 					AuthField:   "auth",
 					Item:        "quay-io-push-credentials",
 					RegistryURL: "quay.io/openshift/ci",

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -273,6 +273,9 @@ secret_configs:
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
+      - auth_field: token_image-pusher_newCluster_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
       - auth_field: auth
         item: quay-io-push-credentials
         registry_url: quay.io/openshift/ci

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -283,6 +283,9 @@ secret_configs:
       - auth_field: token_image-pusher_app.ci_reg_auth_value.txt
         item: build_farm
         registry_url: registry.ci.openshift.org
+      - auth_field: token_image-pusher_existingCluster_reg_auth_value.txt
+        item: build_farm
+        registry_url: image-registry.openshift-image-registry.svc.cluster.local:5000
       - auth_field: auth
         item: quay-io-push-credentials
         registry_url: quay.io/openshift/ci


### PR DESCRIPTION
/cc @openshift/test-platform @hongkailiu 

Needed for https://github.com/openshift/release/pull/43026

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
