### PR TITLE
Fix issue DPTP-3621 Add unmanaged flag to cluster-init

### DIFF
--- a/cmd/cluster-init/build_clusters.go
+++ b/cmd/cluster-init/build_clusters.go
@@ -15,6 +15,10 @@ type BuildClusters struct {
 }
 
 func updateBuildClusters(o options) error {
+	if o.unmanaged {
+		logrus.Infof("skipping build clusters config update for unmanaged cluster: %s", o.clusterName)
+		return nil
+	}
 	logrus.Infof("updating build clusters config to add: %s", o.clusterName)
 	buildClusters, err := loadBuildClusters(o)
 	if err != nil {

--- a/cmd/cluster-init/main.go
+++ b/cmd/cluster-init/main.go
@@ -39,7 +39,8 @@ type options struct {
 
 	useTokenFileInKubeconfig bool
 
-	hosted bool
+	hosted    bool
+	unmanaged bool
 }
 
 func (o options) String() string {
@@ -57,6 +58,7 @@ func parseOptions() (options, error) {
 	fs.StringVar(&o.assign, "assign", githubTeam, "The github username or group name to assign the created pull request to. Set to Test Platform by default")
 	fs.BoolVar(&o.useTokenFileInKubeconfig, "use-token-file-in-kubeconfig", true, "Set true if the token files are used in kubeconfigs. Set to true by default")
 	fs.BoolVar(&o.hosted, "hosted", false, "Set true if the cluster is hosted (i.e., HyperShift hosted cluster). Set to false by default")
+	fs.BoolVar(&o.unmanaged, "unmanaged", false, "Set true if the cluster is unmanaged (i.e., not managed by DPTP). Set to false by default")
 
 	o.GitAuthorOptions.AddFlags(fs)
 	o.PRCreationOptions.AddFlags(fs)

--- a/cmd/cluster-init/main_test.go
+++ b/cmd/cluster-init/main_test.go
@@ -92,7 +92,7 @@ func TestValidateOptions(t *testing.T) {
 		{
 			name: "valid with hosted true",
 			options: options{
-				clusterName: "newcluster",
+				clusterName: "newCluster",
 				releaseRepo: testdata,
 				hosted:      true,
 			},
@@ -104,6 +104,14 @@ func TestValidateOptions(t *testing.T) {
 				releaseRepo: testdata,
 				update:      true,
 				hosted:      true,
+			},
+		},
+		{
+			name: "valid with unmanaged true",
+			options: options{
+				clusterName: "newUnmanagedCluster",
+				releaseRepo: testdata,
+				unmanaged:   true,
 			},
 		},
 	}

--- a/cmd/cluster-init/update_secret_generator.go
+++ b/cmd/cluster-init/update_secret_generator.go
@@ -55,7 +55,12 @@ func updateSecretGeneratorConfig(o options, c *SecretGenConfig) error {
 	if err := appendToSecretItem("ci-chat-bot", serviceAccountConfigPath, o, c); err != nil {
 		return err
 	}
-	return appendToSecretItem(podScaler, serviceAccountConfigPath, o, c)
+	if !o.unmanaged {
+		if err := appendToSecretItem(podScaler, serviceAccountConfigPath, o, c); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func appendToSecretItem(itemName string, name string, o options, c *SecretGenConfig) error {


### PR DESCRIPTION
Add support for creating unmanaged clusters with `cluster-init`

The unmanaged clusters will:
1. not be included in `_cluster_init.yaml`
2. not update certain configs, e.g., PodScalar
