### PR TITLE
SPLAT-1175: enable vsphere02 as a target for vSphere CI jobs

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1443,7 +1443,6 @@ func (p ClusterProfile) ClusterType() string {
 	case
 		ClusterProfileVSphere,
 		ClusterProfileVSphere8,
-		ClusterProfileVSphere8Vpn,
 		ClusterProfileVSphereDis,
 		ClusterProfileVSphereClusterbot,
 		ClusterProfileVSphereIBM7,
@@ -1451,6 +1450,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileVSphereConnected,
 		ClusterProfileVSphereMultizone:
 		return "vsphere"
+	case ClusterProfileVSphere8Vpn:
+		return "vsphere02"
 	case ClusterProfileOvirt:
 		return "ovirt"
 	case

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -114,6 +114,11 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 		return "", false, nil
 	}
 	if strings.Contains(jobBase.Name, "vsphere") && !isApplyConfigJob(jobBase) {
+		if cluster, ok := jobBase.Labels[api.ClusterLabel]; ok {
+			if cluster == string(api.ClusterVSphere02) {
+				return api.Cluster(cluster), false, nil
+			}
+		}
 		return api.ClusterVSphere, false, nil
 	}
 	if isSSHBastionJob(jobBase) && config.SSHBastion != "" {

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -430,6 +430,14 @@ func TestDetermineClusterForJob(t *testing.T) {
 			expected: "vsphere",
 		},
 		{
+			name:   "Vsphere job on vsphere02",
+			config: &configWithBuildFarmWithJobs,
+			jobBase: config.JobBase{Agent: "kubernetes", Name: "yalayala-vsphere", Labels: map[string]string{
+				api.ClusterLabel: string(api.ClusterVSphere02),
+			}},
+			expected: "vsphere02",
+		},
+		{
 			name:   "applyconfig job for vsphere",
 			config: &configWithBuildFarmWithJobs,
 			jobBase: config.JobBase{Agent: "kubernetes", Name: "pull-ci-openshift-release-master-vsphere-dry", Spec: &v1.PodSpec{


### PR DESCRIPTION
The intention of this PR is to enable the transition of jobs from vSphere build01 to vSphere build02.  At present, all vSphere jobs are mapped to the current vSphere build01 cluster.