### PR TITLE
Revert "`multi-arch-builder-controller`: remove manifest-tool from dockerfile"

### DIFF
--- a/images/multi-arch-builder-controller/Dockerfile
+++ b/images/multi-arch-builder-controller/Dockerfile
@@ -1,4 +1,7 @@
+FROM mplatform/manifest-tool as builder
 FROM quay.io/centos/centos:stream8
+
+COPY --from=builder /manifest-tool /usr/bin/manifest-tool
 
 ADD multi-arch-builder-controller /usr/bin/multi-arch-builder-controller
 ENTRYPOINT ["/usr/bin/multi-arch-builder-controller"]


### PR DESCRIPTION
Reverts openshift/ci-tools#3592