### PR TITLE
TRT-1243: add release-ocp-4.15.json to include control-plane-machine-…

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -54,6 +54,8 @@ func newGenerateJobNamesFlags() *generateJobNamesFlags {
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-ppc64le.json",
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12-s390x.json",
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.12.json",
+
+			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.15.json",
 		},
 	}
 }


### PR DESCRIPTION
Minimal update to add release-ocp-4.15.json.

Specifically so we start uploading jobs for 

periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-aws
periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-azure
periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-gcp

Which are causing failures in periodic-ci-openshift-release-master-nightly-4.15-overall-analysis-all due to not having any job runs.

generated_job_names.txt will be updated to include

// begin https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.15.json
periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-aws
periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-azure
periodic-ci-openshift-cluster-control-plane-machine-set-operator-release-4.15-periodics-e2e-gcp
periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-conformance
periodic-ci-openshift-osde2e-main-nightly-4.15-osd-aws
periodic-ci-openshift-osde2e-main-nightly-4.15-osd-gcp
periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts
periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn
periodic-ci-openshift-release-master-ci-4.15-e2e-aws-ovn-upgrade
periodic-ci-openshift-release-master-ci-4.15-e2e-aws-sdn-techpreview
periodic-ci-openshift-release-master-ci-4.15-e2e-aws-sdn-techpreview-serial
periodic-ci-openshift-release-master-ci-4.15-e2e-azure-ovn
periodic-ci-openshift-release-master-ci-4.15-e2e-azure-ovn-upgrade
periodic-ci-openshift-release-master-ci-4.15-e2e-azure-sdn-techpreview
periodic-ci-openshift-release-master-ci-4.15-e2e-azure-sdn-techpreview-serial
periodic-ci-openshift-release-master-ci-4.15-e2e-azure-sdn-upgrade
periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-ovn
periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn-techpreview
periodic-ci-openshift-release-master-ci-4.15-e2e-gcp-sdn-techpreview-serial
periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-gcp-ovn-rt-upgrade
periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-gcp-ovn-upgrade
periodic-ci-openshift-release-master-ci-4.15-upgrade-from-stable-4.14-e2e-gcp-sdn-upgrade
periodic-ci-openshift-release-master-nightly-4.15-console-aws
periodic-ci-openshift-release-master-nightly-4.15-e2e-agent-compact-ipv4
periodic-ci-openshift-release-master-nightly-4.15-e2e-agent-ha-dualstack
periodic-ci-openshift-release-master-nightly-4.15-e2e-agent-sno-ipv6
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-csi
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-driver-toolkit
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-fips
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-proxy
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-single-node
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-single-node-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-upi
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-sdn
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-sdn-cgroupsv2
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-sdn-upgrade
periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-sdn-upgrade
periodic-ci-openshift-release-master-nightly-4.15-e2e-azure-csi
periodic-ci-openshift-release-master-nightly-4.15-e2e-azure-deploy-cnv
periodic-ci-openshift-release-master-nightly-4.15-e2e-azure-sdn
periodic-ci-openshift-release-master-nightly-4.15-e2e-azure-upgrade-cnv
periodic-ci-openshift-release-master-nightly-4.15-e2e-gcp-ovn-csi
periodic-ci-openshift-release-master-nightly-4.15-e2e-gcp-ovn-rt
periodic-ci-openshift-release-master-nightly-4.15-e2e-gcp-sdn
periodic-ci-openshift-release-master-nightly-4.15-e2e-gcp-sdn-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-gcp-sdn-upgrade
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-ovn-dualstack
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-ovn-ipv6
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-sdn-bm
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-sdn-bm-upgrade
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-sdn-serial-ipv4
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-sdn-serial-virtualmedia-bond
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-serial-ovn-dualstack
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-serial-ovn-ipv6
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ipi-upgrade-ovn-ipv6
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ovn-assisted
periodic-ci-openshift-release-master-nightly-4.15-e2e-metal-ovn-single-node-live-iso
periodic-ci-openshift-release-master-nightly-4.15-e2e-telco5g
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-csi
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-techpreview
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-techpreview-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-upi
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-ovn-upi-serial
periodic-ci-openshift-release-master-nightly-4.15-e2e-vsphere-sdn
periodic-ci-openshift-release-master-nightly-4.15-install-analysis-all
periodic-ci-openshift-release-master-nightly-4.15-overall-analysis-all
periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-aws-sdn-upgrade
periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-metal-ipi-sdn-bm-upgrade
periodic-ci-openshift-release-master-nightly-4.15-upgrade-from-stable-4.14-e2e-metal-ipi-upgrade-ovn-ipv6
release-openshift-ocp-installer-e2e-azure-serial-4.15
// end https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.15.json
