### PR TITLE
TRT-1243: Minimal changes to get 4.15 in sync

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
+++ b/pkg/jobrunaggregator/jobtableprimer/generate_jobnames.go
@@ -26,12 +26,15 @@ func newGenerateJobNamesFlags() *generateJobNamesFlags {
 	return &generateJobNamesFlags{
 		periodicURLs: []string{
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-master-periodics.yaml",
+			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/multiarch/openshift-multiarch-master-periodics.yaml",
+
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.10-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.11-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/release/openshift-release-release-4.12-periodics.yaml",
-			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/multiarch/openshift-multiarch-master-periodics.yaml",
+
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.13-periodics.yaml",
 			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.14-periodics.yaml",
+			"https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.15-periodics.yaml",
 		},
 		releaseConfigURLs: []string{
 			"https://raw.githubusercontent.com/openshift/release/master/core-services/release-controller/_releases/release-ocp-4.10-arm64.json",

--- a/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
+++ b/pkg/jobrunaggregator/jobtableprimer/generated_job_names.txt
@@ -398,6 +398,20 @@ periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-mce-power-conformanc
 periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-powervs
 // end https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.14-periodics.yaml
 
+// begin https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.15-periodics.yaml
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-agent-ovn-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-conformance-serial
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-mce-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn-proxy-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-ibmcloud-iks
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-ibmcloud-roks
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-kubevirt-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-kubevirt-mce-baremetalds-conformance
+periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-kubevirt-mce-conformance
+// end https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-4.15-periodics.yaml
+
 // begin https://raw.githubusercontent.com/openshift/release/master/ci-operator/jobs/openshift/multiarch/openshift-multiarch-master-periodics.yaml
 periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-aws-arm64
 periodic-ci-openshift-multiarch-master-nightly-4.10-ocp-e2e-aws-arm64-techpreview


### PR DESCRIPTION
For comparison against https://github.com/openshift/ci-tools/pull/3630

If we don't want the 'all' change we at a minimum need to update hypershift for 4.15