### PR TITLE
testgrid-config-generator: allow OLM tests

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -174,8 +174,8 @@ func getAllowList(data []byte) (map[string]string, error) {
 	for jobName, releaseType := range allowList {
 		if releaseType == "blocking" {
 			errs = append(errs, fmt.Errorf("release_type 'blocking' not permitted in the allow-list for %s, blocking jobs must be in the release controller configuration", jobName))
-		} else if releaseType != "informing" && releaseType != "broken" && releaseType != "generic-informing" && releaseType != "osde2e" {
-			errs = append(errs, fmt.Errorf("%s: release_type must be one of 'informing', 'broken' or 'generic-informing'", jobName))
+		} else if releaseType != "informing" && releaseType != "broken" && releaseType != "generic-informing" && releaseType != "osde2e" && releaseType != "olm" {
+			errs = append(errs, fmt.Errorf("%s: release_type must be one of 'informing', 'broken', 'generic-informing', 'osde2e' or 'olm'", jobName))
 		}
 	}
 	return allowList, utilerrors.NewAggregate(errs)
@@ -202,9 +202,9 @@ func addDashboardTab(p prowConfig.Periodic,
 	}
 
 	switch label {
-	case "informing", "blocking", "broken", "generic-informing", "osde2e":
+	case "informing", "blocking", "broken", "generic-informing", "osde2e", "olm":
 		dashboardType = label
-		if (label == "informing" || label == "osde2e") && (aggregateJobName != nil || configuredJobs[p.Name] == "blocking") {
+		if (label == "informing" || label == "osde2e" || label == "olm") && (aggregateJobName != nil || configuredJobs[p.Name] == "blocking") {
 			dashboardType = "blocking"
 		}
 	default:
@@ -240,6 +240,8 @@ func addDashboardTab(p prowConfig.Periodic,
 		current = genericDashboardFor("informing")
 	case "osde2e":
 		current = genericDashboardFor("osd")
+	case "olm":
+		current = genericDashboardFor("olm")
 	default:
 		var stream string
 		switch {

--- a/cmd/testgrid-config-generator/main_test.go
+++ b/cmd/testgrid-config-generator/main_test.go
@@ -44,7 +44,7 @@ key2: informing
 key1: 
 key2: informing
 `,
-			expectedError: fmt.Errorf("key1: release_type must be one of 'informing', 'broken' or 'generic-informing'"),
+			expectedError: fmt.Errorf("key1: release_type must be one of 'informing', 'broken', 'generic-informing', 'osde2e' or 'olm'"),
 			expectedOut: map[string]string{
 				"key1": "",
 				"key2": "informing",


### PR DESCRIPTION
RedHat manages quite a large list of TestGrid configurations that are *not* derived from the release controller configuration. It's a shame that every single one of those folks need to manually configure TestGrid for their use-case and cannot take advantage of this tool and the automatic PR updates.

This is a small commit that mirrors the OSD additions added last year; in the process of working through the wrinkles for this new TestGrid config we will know how to factor the code such that other config could also be added here.