### PR TITLE
`ci-operator-prowgen`: fix image definition

### DIFF
--- a/images/ci-operator-prowgen/Dockerfile
+++ b/images/ci-operator-prowgen/Dockerfile
@@ -3,7 +3,6 @@ FROM quay.io/centos/centos:stream8
 RUN dnf install --nogpg -y diffutils git && \
       dnf clean all
 
-ADD sanitize-prow-jobs /usr/bin/sanitize-prow-jobs
 ADD ci-operator-prowgen /usr/bin/ci-operator-prowgen
 
 ENTRYPOINT ["/usr/bin/ci-operator-prowgen"]


### PR DESCRIPTION
This is a follow up of https://github.com/openshift/release/pull/43485, `sanitize-prow-jobs` was removed:
```diff
      paths:
      - destination_dir: .
        source_path: /go/bin/ci-operator-prowgen
-      - destination_dir: .
-        source_path: /go/bin/sanitize-prow-jobs
  to: ci-operator-prowgen
```
