### PR TITLE
Revert "add the sanitize-prow-jobs binary in the ci-operator-prowgen image"

### DIFF
--- a/images/ci-operator-prowgen/Dockerfile
+++ b/images/ci-operator-prowgen/Dockerfile
@@ -1,9 +1,8 @@
 FROM quay.io/centos/centos:stream8
+LABEL maintainer="skuznets@redhat.com"
 
 RUN dnf install --nogpg -y diffutils git && \
       dnf clean all
 
-ADD sanitize-prow-jobs /usr/bin/sanitize-prow-jobs
 ADD ci-operator-prowgen /usr/bin/ci-operator-prowgen
-
 ENTRYPOINT ["/usr/bin/ci-operator-prowgen"]


### PR DESCRIPTION
/cc @openshift/test-platform @danilo-gemoli 

follow-up of https://github.com/openshift/release/pull/43485

Reverts openshift/ci-tools#3619