### PR TITLE
`release`: Add observers support

### DIFF
--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -20,6 +20,7 @@ type options struct {
 	chains    registry.ChainByName
 	workflows registry.WorkflowByName
 	resolver  registry.Resolver
+	observers registry.ObserverByName
 }
 
 func NewCommand() *cobra.Command {

--- a/pkg/cmd/release/util.go
+++ b/pkg/cmd/release/util.go
@@ -38,11 +38,11 @@ func (o options) argsWithPrefixes(def, path string, args []string) []string {
 func (o *options) loadRegistry() error {
 	path := o.argsWithPrefixes(config.RegistryPath, o.registryPath, nil)[0]
 	var err error
-	o.refs, o.chains, o.workflows, _, _, _, err = load.Registry(path, load.RegistryFlag(0))
+	o.refs, o.chains, o.workflows, _, _, o.observers, err = load.Registry(path, load.RegistryFlag(0))
 	if err != nil {
 		return fmt.Errorf("failed to load registry: %w", err)
 	}
-	o.resolver = registry.NewResolver(o.refs, o.chains, o.workflows, nil)
+	o.resolver = registry.NewResolver(o.refs, o.chains, o.workflows, o.observers)
 	return nil
 }
 


### PR DESCRIPTION
Add support for the observers:
- the registry resolver gets the observers definitions
- the `registry` command is now able to properly resolve any observers

/cc @bbguimaraes 