### PR TITLE
`config-brancher`: skip promotion targets when branching

### DIFF
--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -449,6 +449,63 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "remove additional targets that don't promote to the current release",
+			currentRelease: "current-release",
+			futureReleases: []string{"future-release"},
+			input: config.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Name:      "current-release",
+						Namespace: "ocp",
+						Targets: []api.PromotionTarget{
+							{
+								Tag:       "target-1-tag",
+								Namespace: "target-1-namespace",
+							},
+							{
+								Name:      "current-release",
+								Namespace: "target-2-namespace",
+							},
+						},
+					},
+					InputConfiguration: api.InputConfiguration{
+						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+							Name:      "current-release",
+							Namespace: "ocp",
+						},
+					},
+				},
+				Info: config.Info{
+					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "master"},
+				},
+			},
+			output: []config.DataWithInfo{
+				{
+					Configuration: api.ReleaseBuildConfiguration{
+						PromotionConfiguration: &api.PromotionConfiguration{
+							Name:      "future-release",
+							Namespace: "ocp",
+							Targets: []api.PromotionTarget{
+								{
+									Name:      "future-release",
+									Namespace: "target-2-namespace",
+								},
+							},
+						},
+						InputConfiguration: api.InputConfiguration{
+							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
+								Name:      "future-release",
+								Namespace: "ocp",
+							},
+						},
+					},
+					Info: config.Info{
+						Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "release-future-release"},
+					},
+				},
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Skip `.promotion.to[]` targets when branching a configuration. 
As an example, the following configuration on the dev branch `$ORG-$REPO-master.yaml`:
```yaml
promotion:
  excluded_images:
  - ci-image
  - olm-bumper
  name: "4.15"
  namespace: ocp
  to:
  - additional_images:
      ci-image: ci-image
      olm-bumper: olm-bumper
    excluded_images:
    - '*'
    namespace: operator-lifecycle-manager
    tag: latest
```
gets two new branched configurations when `config-brancher --current-release=4.15 --future-release=4.16` is run:
```yaml
promotion:
  excluded_images:
  - ci-image
  - olm-bumper
  name: "4.15"
  namespace: ocp
  disabled: true
```
targeting current release `$ORG-$REPO-release-4.15.yaml` and:
```yaml
promotion:
  excluded_images:
  - ci-image
  - olm-bumper
  name: "4.16"
  namespace: ocp
```
targeting the next release `$ORG-$REPO-release-4.16.yaml`.
In both cases `.promotion.to[]` has been deleted.

/cc @stevekuznetsov @bbguimaraes 