### PR TITLE
mount the manifest-tool-local-pusher secret when generating jobs with prowgen

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -52,6 +52,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -63,6 +66,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -52,6 +52,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -63,6 +66,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -56,6 +56,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -67,6 +70,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -33,6 +33,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -44,6 +47,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -82,6 +88,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -90,6 +99,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -81,6 +87,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -89,6 +98,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -35,6 +35,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -43,6 +46,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -85,6 +91,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -93,6 +102,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -81,6 +87,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -89,6 +98,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -15,6 +15,9 @@ const (
 	GCSUploadCredentialsSecret          = "gce-sa-credentials-gcs-publisher"
 	GCSUploadCredentialsSecretMountPath = "/secrets/gcs"
 
+	ManifestToolLocalPusherSecret          = "manifest-tool-local-pusher"
+	ManifestToolLocalPusherSecretMountPath = "/secrets/manifest-tool"
+
 	ReleaseAnnotationSoftDelete = "release.openshift.io/soft-delete"
 
 	// DPTPRequesterLabel is the label on a Kubernates CR whose value indicates the automated tool that requests the CR

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -68,6 +68,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -76,6 +79,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -148,6 +154,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -156,6 +165,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -228,6 +240,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -236,6 +251,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -58,6 +58,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -66,6 +69,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -58,6 +58,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -66,6 +69,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -58,6 +58,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -66,6 +69,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -58,6 +58,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -66,6 +69,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -58,6 +58,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -66,6 +69,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -45,6 +45,11 @@ var defaultPodSpec = corev1.PodSpec{
 					MountPath: cioperatorapi.GCSUploadCredentialsSecretMountPath,
 					ReadOnly:  true,
 				},
+				{
+					Name:      "manifest-tool-local-pusher",
+					MountPath: cioperatorapi.ManifestToolLocalPusherSecretMountPath,
+					ReadOnly:  true,
+				},
 			},
 		},
 	},
@@ -59,6 +64,12 @@ var defaultPodSpec = corev1.PodSpec{
 			Name: "result-aggregator",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{SecretName: "result-aggregator"},
+			},
+		},
+		{
+			Name: "manifest-tool-local-pusher",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: cioperatorapi.ManifestToolLocalPusherSecret},
 			},
 		},
 	},

--- a/pkg/prowgen/testdata/zz_fixture_TestCIPullSecret_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCIPullSecret_secret_is_added.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -30,6 +33,9 @@ volumes:
 - name: ci-pull-credentials
   secret:
     secretName: ci-pull-credentials
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClaims_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClaims_secret_is_added.yaml
@@ -23,6 +23,9 @@ containers:
   - mountPath: /secrets/hive-hive-credentials
     name: hive-hive-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -37,6 +40,9 @@ volumes:
 - name: hive-hive-credentials
   secret:
     secretName: hive-hive-credentials
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -30,6 +33,9 @@ volumes:
 - name: cluster-profile
   secret:
     secretName: cluster-secrets-aws
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws_cpaas.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_aws_cpaas.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -30,6 +33,9 @@ volumes:
 - name: cluster-profile
   secret:
     secretName: cluster-secrets-aws-cpaas
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_gcp.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_gcp.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -34,6 +37,9 @@ volumes:
         name: cluster-secrets-gcp
     - configMap:
         name: cluster-profile-gcp
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_openstack.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClusterProfile_openstack.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -30,6 +33,9 @@ volumes:
 - name: cluster-profile
   secret:
     secretName: cluster-secrets-openstack
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
@@ -16,6 +16,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -24,6 +27,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
@@ -17,6 +17,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -25,6 +28,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -33,6 +33,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -44,6 +47,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -88,6 +94,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -96,6 +105,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_periodic.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_periodic.yaml
@@ -32,6 +32,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -40,6 +43,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
@@ -28,6 +28,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -36,6 +39,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials
@@ -73,6 +79,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -81,6 +90,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
@@ -28,6 +28,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -36,6 +39,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_my_bundle_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_my_bundle_presubmit_job.yaml
@@ -32,6 +32,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -40,6 +43,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
@@ -32,6 +32,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -40,6 +43,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo__reusing_Prow_s_volume_with_credentials.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo__reusing_Prow_s_volume_with_credentials.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /usr/local/github-credentials
     name: github-credentials-openshift-ci-robot-private-git-cloner
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -27,6 +30,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo_without_reusing_Prow_s_volume_with_credentials.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo_without_reusing_Prow_s_volume_with_credentials.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /usr/local/github-credentials
     name: github-credentials-openshift-ci-robot-private-git-cloner
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -30,6 +33,9 @@ volumes:
 - name: github-credentials-openshift-ci-robot-private-git-cloner
   secret:
     secretName: github-credentials-openshift-ci-robot-private-git-cloner
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
@@ -17,6 +17,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -25,6 +28,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
@@ -17,6 +17,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -25,6 +28,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestLeaseClient_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestLeaseClient_secret_is_added.yaml
@@ -19,6 +19,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -33,6 +36,9 @@ volumes:
     - key: credentials
       path: credentials
     secretName: boskos-credentials
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_defaults_repo.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_defaults_repo.yaml
@@ -15,6 +15,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -23,6 +26,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_no_parameter_is_added_when_variant_is_empty.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_no_parameter_is_added_when_variant_is_empty.yaml
@@ -15,6 +15,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -23,6 +26,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_parameter_is_added_for_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_parameter_is_added_for_variant.yaml
@@ -16,6 +16,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -24,6 +27,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleClusterTestConfiguration.yaml
@@ -37,6 +37,9 @@ spec:
     - mountPath: /usr/local/template1
       name: job-definition
       subPath: cluster-launch-e2e.yaml
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -51,6 +54,9 @@ spec:
   - configMap:
       name: prow-job-cluster-launch-e2e
     name: job-definition
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftAnsibleCustomClusterTestConfiguration.yaml
@@ -37,6 +37,9 @@ spec:
     - mountPath: /usr/local/template1
       name: job-definition
       subPath: cluster-launch-e2e-openshift-ansible.yaml
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -51,6 +54,9 @@ spec:
   - configMap:
       name: prow-job-cluster-launch-e2e-openshift-ansible
     name: job-definition
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerClusterTestConfiguration.yaml
@@ -39,6 +39,9 @@ spec:
     - mountPath: /usr/local/template1
       name: job-definition
       subPath: cluster-launch-installer-e2e.yaml
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -59,6 +62,9 @@ spec:
   - configMap:
       name: prow-job-cluster-launch-installer-e2e
     name: job-definition
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerCustomTestImageClusterTestConfiguration.yaml
@@ -41,6 +41,9 @@ spec:
     - mountPath: /usr/local/template1
       name: job-definition
       subPath: cluster-launch-installer-custom-test-image.yaml
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -61,6 +64,9 @@ spec:
   - configMap:
       name: prow-job-cluster-launch-installer-custom-test-image
     name: job-definition
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_OpenshiftInstallerUPIClusterTestConfiguration.yaml
@@ -39,6 +39,9 @@ spec:
     - mountPath: /usr/local/template1
       name: job-definition
       subPath: cluster-launch-installer-upi-e2e.yaml
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -59,6 +62,9 @@ spec:
   - configMap:
       name: prow-job-cluster-launch-installer-upi-e2e
     name: job-definition
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_literal_multi_stage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_literal_multi_stage_test.yaml
@@ -22,6 +22,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -30,6 +33,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test.yaml
@@ -22,6 +22,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -30,6 +33,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_claim.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_claim.yaml
@@ -30,6 +30,9 @@ spec:
     - mountPath: /secrets/hive-hive-credentials
       name: hive-hive-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -44,6 +47,9 @@ spec:
   - name: hive-hive-credentials
     secret:
       secretName: hive-hive-credentials
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
@@ -32,6 +32,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -49,6 +52,9 @@ spec:
   - name: cluster-profile
     secret:
       secretName: cluster-secrets-alibabacloud
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_releases.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_releases.yaml
@@ -26,6 +26,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -37,6 +40,9 @@ spec:
   - name: ci-pull-credentials
     secret:
       secretName: ci-pull-credentials
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test.yaml
@@ -22,6 +22,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -30,6 +33,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_arm01_cluster.yaml
@@ -25,6 +25,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -33,6 +36,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_cluster.yaml
@@ -25,6 +25,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -33,6 +36,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secret.yaml
@@ -23,6 +23,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -34,6 +37,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secrets.yaml
@@ -24,6 +24,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -38,6 +41,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout.yaml
@@ -23,6 +23,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -31,6 +34,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
@@ -22,6 +22,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -30,6 +33,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestPromotion_secret_and_parameters_are_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestPromotion_secret_and_parameters_are_added.yaml
@@ -17,6 +17,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -28,6 +31,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration__including_podspec.yaml
@@ -21,6 +21,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -29,6 +32,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant__including_podspec.yaml
@@ -24,6 +24,9 @@ spec:
     - mountPath: /secrets/gcs
       name: gcs-credentials
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -32,6 +35,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
@@ -28,6 +28,9 @@ spec:
     - mountPath: /usr/local/github-credentials
       name: github-credentials-openshift-ci-robot-private-git-cloner
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -36,6 +39,9 @@ spec:
       readOnly: true
   serviceAccountName: ci-operator
   volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
@@ -26,6 +26,9 @@ spec:
     - mountPath: /usr/local/github-credentials
       name: github-credentials-openshift-ci-robot-private-git-cloner
       readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
     - mountPath: /etc/pull-secret
       name: pull-secret
       readOnly: true
@@ -37,6 +40,9 @@ spec:
   - name: github-credentials-openshift-ci-robot-private-git-cloner
     secret:
       secretName: github-credentials-openshift-ci-robot-private-git-cloner
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
   - name: pull-secret
     secret:
       secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_additional_envvar_generated_for_template.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_additional_envvar_generated_for_template.yaml
@@ -32,6 +32,9 @@ containers:
   - mountPath: /usr/local/tgt
     name: job-definition
     subPath: template.yaml
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -46,6 +49,9 @@ volumes:
 - configMap:
     name: prow-job-template
   name: job-definition
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_empty_list_is_a_nop.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_empty_list_is_a_nop.yaml
@@ -15,6 +15,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -23,6 +26,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_multiple_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_multiple_secrets.yaml
@@ -20,6 +20,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -34,6 +37,9 @@ volumes:
 - name: another
   secret:
     secretName: another
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_one_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_one_secret.yaml
@@ -16,6 +16,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -27,6 +30,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
@@ -16,6 +16,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -24,6 +27,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTargets_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargets_multiple_targets.yaml
@@ -17,6 +17,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -25,6 +28,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTargets_single_target.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargets_single_target.yaml
@@ -16,6 +16,9 @@ containers:
   - mountPath: /secrets/gcs
     name: gcs-credentials
     readOnly: true
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -24,6 +27,9 @@ containers:
     readOnly: true
 serviceAccountName: ci-operator
 volumes:
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_different_template_with_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_different_template_with_command.yaml
@@ -29,6 +29,9 @@ containers:
   - mountPath: /usr/local/t
     name: job-definition
     subPath: cluster-launch-installer-libvirt-e2e.yaml
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -43,6 +46,9 @@ volumes:
 - configMap:
     name: prow-job-cluster-launch-installer-libvirt-e2e
   name: job-definition
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_a_custom_test_image.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_a_custom_test_image.yaml
@@ -32,6 +32,9 @@ containers:
   - mountPath: /usr/local/t
     name: job-definition
     subPath: cluster-launch-installer-upi-e2e.yaml
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -46,6 +49,9 @@ volumes:
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_command.yaml
@@ -30,6 +30,9 @@ containers:
   - mountPath: /usr/local/t
     name: job-definition
     subPath: cluster-launch-installer-upi-e2e.yaml
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -44,6 +47,9 @@ volumes:
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_different_command.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTemplate_template_with_different_command.yaml
@@ -30,6 +30,9 @@ containers:
   - mountPath: /usr/local/t
     name: job-definition
     subPath: cluster-launch-installer-upi-e2e.yaml
+  - mountPath: /secrets/manifest-tool
+    name: manifest-tool-local-pusher
+    readOnly: true
   - mountPath: /etc/pull-secret
     name: pull-secret
     readOnly: true
@@ -44,6 +47,9 @@ volumes:
 - configMap:
     name: prow-job-cluster-launch-installer-upi-e2e
   name: job-definition
+- name: manifest-tool-local-pusher
+  secret:
+    secretName: manifest-tool-local-pusher
 - name: pull-secret
   secret:
     secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-branch-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-branch-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/random-file/legacy-random-file-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/random-file/legacy-random-file-master-periodics.yaml
@@ -31,6 +31,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -39,6 +42,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
@@ -30,6 +30,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -38,6 +41,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
@@ -32,6 +32,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -40,6 +43,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -79,6 +85,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -87,6 +96,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
@@ -30,6 +30,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -38,6 +41,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -80,6 +86,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -88,6 +97,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -38,6 +38,9 @@ presubmits:
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -49,6 +52,9 @@ presubmits:
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
@@ -40,6 +40,9 @@ presubmits:
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -48,6 +51,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -52,6 +52,9 @@ periodics:
       - mountPath: /usr/local/e2e-nightly
         name: job-definition
         subPath: cluster-launch-e2e.yaml
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -73,6 +76,9 @@ periodics:
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -38,6 +38,9 @@ postsubmits:
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -52,6 +55,9 @@ postsubmits:
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -54,6 +54,9 @@ presubmits:
         - mountPath: /usr/local/e2e
           name: job-definition
           subPath: cluster-launch-e2e.yaml
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -75,6 +78,9 @@ presubmits:
       - configMap:
           name: prow-job-cluster-launch-e2e
         name: job-definition
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -121,6 +127,9 @@ presubmits:
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -132,6 +141,9 @@ presubmits:
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -177,6 +189,9 @@ presubmits:
         - mountPath: /usr/local/github-credentials
           name: github-credentials-openshift-ci-robot-private-git-cloner
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -188,6 +203,9 @@ presubmits:
       - name: github-credentials-openshift-ci-robot-private-git-cloner
         secret:
           secretName: github-credentials-openshift-ci-robot-private-git-cloner
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
@@ -32,6 +32,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -40,6 +43,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -47,6 +47,9 @@ periodics:
       - mountPath: /usr/local/e2e-aws-nightly
         name: job-definition
         subPath: cluster-launch-e2e.yaml
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -61,6 +64,9 @@ periodics:
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials
@@ -115,6 +121,9 @@ periodics:
       - mountPath: /usr/local/e2e-aws-nightly-interval
         name: job-definition
         subPath: cluster-launch-e2e.yaml
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -129,6 +138,9 @@ periodics:
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials
@@ -183,6 +195,9 @@ periodics:
       - mountPath: /usr/local/e2e-nightly
         name: job-definition
         subPath: cluster-launch-e2e.yaml
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -201,6 +216,9 @@ periodics:
     - configMap:
         name: prow-job-cluster-launch-e2e
       name: job-definition
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials
@@ -240,6 +258,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -248,6 +269,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -33,6 +33,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -44,6 +47,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -90,6 +96,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -98,6 +107,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -140,6 +152,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -151,6 +166,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -81,6 +87,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -89,6 +98,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -145,6 +157,9 @@ presubmits:
         - mountPath: /usr/local/e2e
           name: job-definition
           subPath: cluster-launch-e2e.yaml
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -163,6 +178,9 @@ presubmits:
       - configMap:
           name: prow-job-cluster-launch-e2e
         name: job-definition
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -208,6 +226,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -216,6 +237,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -266,6 +290,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -274,6 +301,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -324,6 +354,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -341,6 +374,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-aws
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -381,6 +417,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -389,6 +428,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -438,6 +480,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -455,6 +500,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-aws
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -495,6 +543,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -503,6 +554,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -543,6 +597,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -551,6 +608,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -595,6 +655,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -603,6 +666,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -646,6 +712,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -654,6 +723,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -34,6 +34,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -45,6 +48,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -34,6 +34,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,6 +45,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -92,6 +98,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -100,6 +109,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -140,6 +152,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -148,6 +163,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -66,6 +66,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -74,6 +77,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -116,6 +116,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -124,6 +127,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -77,6 +77,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -85,6 +88,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -115,6 +115,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -123,6 +126,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -192,6 +198,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -200,6 +209,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -240,6 +252,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -248,6 +263,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -297,6 +315,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -314,6 +335,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-azure4
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -354,6 +378,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -362,6 +389,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -402,6 +432,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -410,6 +443,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -450,6 +486,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -458,6 +497,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -81,6 +87,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -89,6 +98,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -129,6 +141,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -137,6 +152,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -177,6 +195,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -185,6 +206,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -225,6 +249,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -233,6 +260,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -273,6 +303,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -281,6 +314,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -674,6 +674,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -682,6 +685,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -868,6 +874,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -876,6 +885,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1385,6 +1397,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1393,6 +1408,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1489,6 +1507,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1497,6 +1518,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1602,6 +1626,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1619,6 +1646,9 @@
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-azure4
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1715,6 +1745,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1723,6 +1756,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1819,6 +1855,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1827,6 +1866,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -1923,6 +1965,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -1931,6 +1976,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -2027,6 +2075,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -2035,6 +2086,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -2131,6 +2185,9 @@
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -2139,6 +2196,9 @@
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -66,6 +66,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -74,6 +77,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -111,6 +111,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -119,6 +122,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -76,6 +76,9 @@ periodics:
       - mountPath: /secrets/gcs
         name: gcs-credentials
         readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
       - mountPath: /etc/pull-secret
         name: pull-secret
         readOnly: true
@@ -84,6 +87,9 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
     - name: pull-secret
       secret:
         secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -115,6 +115,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -123,6 +126,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -192,6 +198,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -200,6 +209,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -240,6 +252,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -248,6 +263,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -297,6 +315,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -314,6 +335,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-azure4
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -354,6 +378,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -362,6 +389,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -402,6 +432,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -410,6 +443,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
@@ -33,6 +33,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -41,6 +44,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -81,6 +87,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -89,6 +98,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -129,6 +141,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -137,6 +152,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -177,6 +195,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -185,6 +206,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -225,6 +249,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -233,6 +260,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -273,6 +303,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -281,6 +314,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -34,6 +34,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -45,6 +48,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -34,6 +34,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,6 +45,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -83,6 +89,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -91,6 +100,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-postsubmits.yaml
@@ -35,6 +35,9 @@ postsubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -46,6 +49,9 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-master-presubmits.yaml
@@ -36,6 +36,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -44,6 +47,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -85,6 +91,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -93,6 +102,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -35,6 +35,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -43,6 +46,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-master-presubmits.yaml
@@ -34,6 +34,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -42,6 +45,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -96,6 +102,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -116,6 +125,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-aws
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -170,6 +182,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -190,6 +205,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-aws
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -231,6 +249,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -239,6 +260,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials
@@ -280,6 +304,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -288,6 +315,9 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -49,6 +49,9 @@ presubmits:
         - mountPath: /secrets/gcs
           name: gcs-credentials
           readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
         - mountPath: /etc/pull-secret
           name: pull-secret
           readOnly: true
@@ -69,6 +72,9 @@ presubmits:
       - name: cluster-profile
         secret:
           secretName: cluster-secrets-aws
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
       - name: pull-secret
         secret:
           secretName: registry-pull-credentials


### PR DESCRIPTION
/cc @openshift/test-platform @danilo-gemoli @deepsm007 

is needed for https://github.com/openshift/ci-tools/pull/3587

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
