### PR TITLE
Ignore known infra-files in `prowgen` warnings

### DIFF
--- a/cmd/ci-operator-prowgen/main.go
+++ b/cmd/ci-operator-prowgen/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	prowconfig "k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
@@ -20,7 +21,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/prowgen"
 	"github.com/openshift/ci-tools/pkg/registry"
 	"github.com/openshift/ci-tools/pkg/util"
-	"k8s.io/test-infra/prow/flagutil"
 )
 
 type options struct {

--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -13,6 +13,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
@@ -23,7 +24,6 @@ import (
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/util"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type options struct {

--- a/cmd/config-shard-validator/main.go
+++ b/cmd/config-shard-validator/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/util"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type options struct {
@@ -97,7 +98,7 @@ func main() {
 	}
 
 	var foundFailures bool
-	if err := jobconfig.OperateOnJobConfigDir(path.Join(o.releaseRepoDir, config.JobConfigInRepoPath), func(jobConfig *prowconfig.JobConfig, info *jobconfig.Info) error {
+	if err := jobconfig.OperateOnJobConfigDir(path.Join(o.releaseRepoDir, config.JobConfigInRepoPath), make(sets.Set[string]), func(jobConfig *prowconfig.JobConfig, info *jobconfig.Info) error {
 		// we know the path is relative, but there is no API to declare that
 		relPath, _ := filepath.Rel(o.releaseRepoDir, info.Filename)
 		pathsToCheck = append(pathsToCheck, pathWithConfig{path: relPath, configMap: info.ConfigMapName()})

--- a/pkg/cmd/release/jobs.go
+++ b/pkg/cmd/release/jobs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func newJobCommand(o *options) *cobra.Command {
@@ -37,7 +38,7 @@ func cmdJob(o *options, list bool, args []string) error {
 
 func cmdJobList(args []string) error {
 	for _, p := range args {
-		if err := jobconfig.OperateOnJobConfigSubdirPaths("", p, func(
+		if err := jobconfig.OperateOnJobConfigSubdirPaths("", p, make(sets.Set[string]), func(
 			info *jobconfig.Info,
 		) error {
 			fmt.Println(info.Filename)
@@ -51,7 +52,7 @@ func cmdJobList(args []string) error {
 
 func cmdJobPrint(args []string) error {
 	for _, p := range args {
-		if err := jobconfig.OperateOnJobConfigDir(p, func(
+		if err := jobconfig.OperateOnJobConfigDir(p, make(sets.Set[string]), func(
 			job *prowconfig.JobConfig,
 			_ *jobconfig.Info,
 		) error {

--- a/pkg/cmd/release/jobs.go
+++ b/pkg/cmd/release/jobs.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "k8s.io/test-infra/prow/config"
 
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func newJobCommand(o *options) *cobra.Command {

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -128,8 +128,8 @@ func (o *Options) OperateOnCIOperatorConfigDir(configDir string, callback func(*
 
 // OperateOnJobConfigSubdirPaths filters the full set of configurations
 // down to those that were selected by the user with --{org|repo}
-func (o *Options) OperateOnJobConfigSubdirPaths(dir, subDir string, callback func(info *jc.Info) error) error {
-	return jc.OperateOnJobConfigSubdirPaths(dir, subDir, func(info *jc.Info) error {
+func (o *Options) OperateOnJobConfigSubdirPaths(dir, subDir string, knownInfraJobFiles sets.Set[string], callback func(info *jc.Info) error) error {
+	return jc.OperateOnJobConfigSubdirPaths(dir, subDir, knownInfraJobFiles, func(info *jc.Info) error {
 		if !o.matches(info.Org, info.Repo) {
 			return nil
 		}

--- a/pkg/config/options_test.go
+++ b/pkg/config/options_test.go
@@ -414,7 +414,7 @@ func TestOperateOnJobConfigSubdirPaths(t *testing.T) {
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
 			var ret []string
-			if err := tc.opt.OperateOnJobConfigSubdirPaths(dir, tc.sub, func(info *jc.Info) error {
+			if err := tc.opt.OperateOnJobConfigSubdirPaths(dir, tc.sub, make(sets.Set[string]), func(info *jc.Info) error {
 				ret = append(ret, strings.TrimPrefix(info.Filename, dir))
 				return nil
 			}); err != nil {

--- a/test/integration/ci-operator-prowgen.sh
+++ b/test/integration/ci-operator-prowgen.sh
@@ -16,7 +16,7 @@ cp -a "${suite_dir}/input/jobs/." "${actual}"
 os::test::junit::declare_suite_start "integration/ci-operator-prowgen"
 # This test validates the ci-operator-prowgen tool
 
-os::cmd::expect_success "ci-operator-prowgen --registry ${suite_dir}/input/registry --from-dir ${suite_dir}/input/config --to-dir ${actual}"
+os::cmd::expect_success "ci-operator-prowgen --registry ${suite_dir}/input/registry --known-infra-file infra-periodics.yaml --from-dir ${suite_dir}/input/config --to-dir ${actual}"
 os::integration::compare "${actual}" "${suite_dir}/output/jobs"
 
 os::test::junit::declare_suite_end

--- a/test/integration/ci-operator-prowgen/input/jobs/infra-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/input/jobs/infra-periodics.yaml
@@ -1,0 +1,3 @@
+# This job should stay in this file.
+periodics:
+- name: some-infra-job

--- a/test/integration/ci-operator-prowgen/output/jobs/infra-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/infra-periodics.yaml
@@ -1,0 +1,3 @@
+# This job should stay in this file.
+periodics:
+- name: some-infra-job


### PR DESCRIPTION
We shouldn't output warnings for these files, as it confuses users and they think something is broken.

For: https://issues.redhat.com/browse/DPTP-3376

I will follow this up by adding the arguments to the call for `make jobs` in `openshift/release`