### PR TITLE
`pj-rehearse`: surface specific error that caused changes to not rebase

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -472,8 +471,8 @@ func (s *server) prepareCandidate(repoClient git.RepoClient, pullRequest *github
 
 	// In order to determine *only* the affected jobs from the changes in the PR, we need to rebase onto master
 	baseRef := pullRequest.Base.Ref
-	if rebased, _ := repoClient.MergeWithStrategy(baseRef, "rebase"); !rebased {
-		return rehearse.RehearsalCandidate{}, errors.New("couldn't rebase repo client")
+	if rebased, err := repoClient.MergeWithStrategy(baseRef, "rebase"); !rebased {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rebase candidate onto master: %w", err)
 	}
 
 	return candidate, nil


### PR DESCRIPTION
We shouldn't eat this error. This came up in https://github.com/openshift/release/pull/44172#issuecomment-1755825288