### PR TITLE
Override cluster allocation for agent jobs

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -489,7 +489,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		switch {
 		case strings.Contains(inject.Test, "vsphere"):
 			jobBaseGen.Cluster("vsphere02")
-		case strings.Contains(inject.Test, "metal") || strings.Contains(inject.Test, "telco5g"):
+		case strings.Contains(inject.Test, "metal") || strings.Contains(inject.Test, "telco5g") || strings.Contains(inject.Test, "e2e-agent"):
 			jobBaseGen.Cluster("build05")
 		default:
 			jobBaseGen.Cluster("build01")


### PR DESCRIPTION
Following the patch https://github.com/openshift/release-controller/pull/564, the current one is required to ensure that the agent-based installer jobs will be executed on `build05` cluster, since they are using ofcir