### PR TITLE
PowerVS: Add missing PowerVS3

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1344,6 +1344,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileIBMCloudMultiS390x,
 		ClusterProfilePOWERVS1,
 		ClusterProfilePOWERVS2,
+		ClusterProfilePOWERVS3,
 		ClusterProfileKubevirt,
 		ClusterProfileLibvirtPpc64le,
 		ClusterProfileLibvirtS390x,


### PR DESCRIPTION
It looks like one section for adding the new cluster type PowerVS-3 was missing. :(