### PR TITLE
Calm Aggregated Disruption Testing

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -85,8 +85,6 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 		// enough to attempt subtle regression detection, for that we have grafana alerts.
 		"%s disruption P70 should not be worse": checkPercentileDisruption(o.passFailCalculator, 70, 3), // for 7 attempts, this  gives us a latch on getting worse
 		"%s disruption P85 should not be worse": checkPercentileDisruption(o.passFailCalculator, 85, 7), // for 5 attempts, this gives us a latch on getting worse.
-
-		"%s zero-disruption should not be worse": checkPercentileRankDisruption(o.passFailCalculator, 0),
 	}
 
 	for _, testCaseNamePattern := range sets.StringKeySet(testCaseNamePatternToDisruptionCheckFn).List() {
@@ -123,12 +121,6 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 func checkPercentileDisruption(passFailCalculator baseline, percentile, graceSeconds int) disruptionJunitCheckFunc {
 	return func(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend, masterNodesUpdated string) (failedJobRunsIDs []string, successfulJobRunIDs []string, status testCaseStatus, message string, err error) {
 		return passFailCalculator.CheckPercentileDisruption(ctx, jobRunIDToAvailabilityResultForBackend, backend, percentile, graceSeconds, masterNodesUpdated)
-	}
-}
-
-func checkPercentileRankDisruption(passFailCalculator baseline, maxDisruptionSeconds int) disruptionJunitCheckFunc {
-	return func(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, masterNodesUpdated string) (failedJobRunsIDs []string, successfulJobRunIDs []string, status testCaseStatus, message string, err error) {
-		return passFailCalculator.CheckPercentileRankDisruption(ctx, jobRunIDToAvailabilityResultForBackend, backend, maxDisruptionSeconds, masterNodesUpdated)
 	}
 }
 

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -81,7 +81,6 @@ func (o *JobRunAggregatorAnalyzerOptions) CalculateDisruptionTestSuite(ctx conte
 		// "%s mean disruption should be less than historical plus one standard deviation":  o.passFailCalculator.CheckDisruptionMeanWithinOneStandardDeviation,
 		"%s disruption P70 should not be worse":  checkPercentileDisruption(o.passFailCalculator, 70), // for 7 attempts, this  gives us a latch on getting worse
 		"%s disruption P85 should not be worse":  checkPercentileDisruption(o.passFailCalculator, 85), // for 5 attempts, this gives us a latch on getting worse.
-		"%s disruption P95 should not be worse":  checkPercentileDisruption(o.passFailCalculator, 95),
 		"%s zero-disruption should not be worse": checkPercentileRankDisruption(o.passFailCalculator, 0),
 	}
 

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -32,7 +32,8 @@ type baseline interface {
 	CheckFailed(ctx context.Context, jobName string, suiteNames []string, testCaseDetails *jobrunaggregatorlib.TestCaseDetails) (status testCaseStatus, message string, err error)
 	CheckDisruptionMeanWithinFiveStandardDeviations(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend, masterNodesUpdated string) (failedJobRunsIDs []string, successfulJobRunIDs []string, status testCaseStatus, message string, err error)
 	CheckDisruptionMeanWithinOneStandardDeviation(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend, masterNodesUpdated string) (failedJobRunsIDs []string, successfulJobRunIDs []string, status testCaseStatus, message string, err error)
-	CheckPercentileDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, percentile int, masterNodesUpdated string) (failureJobRunIDs []string, successJobRunIDs []string, status testCaseStatus, message string, err error)
+	CheckPercentileDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult,
+		backend string, percentile int, fixedGraceSeconds int, masterNodesUpdated string) (failureJobRunIDs []string, successJobRunIDs []string, status testCaseStatus, message string, err error)
 	CheckPercentileRankDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, maxDisruptionSeconds int, masterNodesUpdated string) (failureJobRunIDs []string, successJobRunIDs []string, status testCaseStatus, message string, err error)
 }
 
@@ -421,7 +422,14 @@ func (a *weeklyAverageFromTenDays) checkDisruptionMean(ctx context.Context, jobR
 	), nil
 }
 
-func (a *weeklyAverageFromTenDays) CheckPercentileDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, percentile int, masterNodesUpdated string) ([]string, []string, testCaseStatus, string, error) {
+func (a *weeklyAverageFromTenDays) CheckPercentileDisruption(
+	ctx context.Context,
+	jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult,
+	backend string,
+	percentile int,
+	fixedGraceSeconds int,
+	masterNodesUpdated string) ([]string, []string, testCaseStatus, string, error) {
+
 	historicalDisruption, fallBackJobName, err := a.getDisruptionByBackend(ctx, masterNodesUpdated)
 	if err != nil {
 		message := fmt.Sprintf("error getting historical disruption data, skipping: %v\n", err)
@@ -442,11 +450,12 @@ func (a *weeklyAverageFromTenDays) CheckPercentileDisruption(ctx context.Context
 		return failureJobRunIDs, []string{}, testCaseSkipped, message, nil
 	}
 
-	failureJobRunIDs, successJobRunIDs, testCaseFailed, summary := a.checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, percentile)
+	failureJobRunIDs, successJobRunIDs, testCaseFailed, summary := a.checkPercentileDisruptionWithGrace(
+		jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, percentile, fixedGraceSeconds)
 	return failureJobRunIDs, successJobRunIDs, testCaseFailed, messagePrefix + summary, nil
 }
 
-func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, historicalDisruptionStatistic backendDisruptionStats, thresholdPercentile int) ([]string, []string, testCaseStatus, string) {
+func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, historicalDisruptionStatistic backendDisruptionStats, thresholdPercentile int, fixedGraceSeconds int) ([]string, []string, testCaseStatus, string) {
 	historicalThreshold := historicalDisruptionStatistic.percentileByIndex[thresholdPercentile]
 	requiredNumberOfPasses, noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary := a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalThreshold, thresholdPercentile, 0)
 	numberOfPasses := len(noGraceSuccessJobRunIDs)
@@ -454,15 +463,10 @@ func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithGrace(jobRunIDTo
 		return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
 	}
 
-	// the +1 is to have at least 1s, the 5 is arbitrary because it made forrest feel good and the denominator makes the grace smaller
-	// when there are more job runs that need to be better
-	graceSeconds := ((int(historicalThreshold) / 5) + 1) / (requiredNumberOfPasses - numberOfPasses)
-	if graceSeconds <= 0 {
-		return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
-	}
-	thresholdWithGrace := historicalThreshold + float64(graceSeconds)
+	thresholdWithGrace := historicalThreshold + float64(fixedGraceSeconds)
 
-	_, withGraceFailureJobRunIDs, withGraceSuccessJobRunIDs, withGraceTestCasePassed, withGraceSummary := a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, thresholdWithGrace, thresholdPercentile, graceSeconds)
+	_, withGraceFailureJobRunIDs, withGraceSuccessJobRunIDs, withGraceTestCasePassed, withGraceSummary :=
+		a.innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, thresholdWithGrace, thresholdPercentile, fixedGraceSeconds)
 	return withGraceFailureJobRunIDs, withGraceSuccessJobRunIDs, withGraceTestCasePassed, withGraceSummary
 }
 
@@ -472,7 +476,9 @@ func (a *weeklyAverageFromTenDays) checkPercentileDisruptionWithoutGrace(jobRunI
 	return noGraceFailureJobRunIDs, noGraceSuccessJobRunIDs, noGraceTestCasePassed, noGraceSummary
 }
 
-func (a *weeklyAverageFromTenDays) innerCheckPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, threshold float64, thresholdPercentile int, graceSeconds int) (int, []string, []string, testCaseStatus, string) {
+func (a *weeklyAverageFromTenDays) innerCheckPercentileDisruptionWithGrace(
+	jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult,
+	threshold float64, thresholdPercentile int, graceSeconds int) (int, []string, []string, testCaseStatus, string) {
 	failureJobRunIDs := []string{}
 	successJobRunIDs := []string{}
 	successRuns := []string{} // each string example: jobRunID=5s

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -34,7 +34,6 @@ type baseline interface {
 	CheckDisruptionMeanWithinOneStandardDeviation(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend, masterNodesUpdated string) (failedJobRunsIDs []string, successfulJobRunIDs []string, status testCaseStatus, message string, err error)
 	CheckPercentileDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult,
 		backend string, percentile int, fixedGraceSeconds int, masterNodesUpdated string) (failureJobRunIDs []string, successJobRunIDs []string, status testCaseStatus, message string, err error)
-	CheckPercentileRankDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, maxDisruptionSeconds int, masterNodesUpdated string) (failureJobRunIDs []string, successJobRunIDs []string, status testCaseStatus, message string, err error)
 }
 
 func assignPassFail(ctx context.Context, jobName string, combined *junit.TestSuites, baselinePassFail baseline) error {
@@ -542,45 +541,6 @@ func (a *weeklyAverageFromTenDays) innerCheckPercentileDisruptionWithGrace(
 		successRuns, failureRuns,
 	)
 	return requiredNumberOfPasses, failureJobRunIDs, successJobRunIDs, testCasePassed, summary
-}
-
-// getPercentileRank returns the maximum percentile that is at or below the disruptionThresholdSeconds
-func getPercentileRank(historicalDisruption backendDisruptionStats, disruptionThresholdSeconds int) int {
-	for i := 1; i <= 99; i++ {
-		if historicalDisruption.percentileByIndex[i] > float64(disruptionThresholdSeconds) {
-			return i - 1
-		}
-	}
-	return 99
-}
-
-func (a *weeklyAverageFromTenDays) CheckPercentileRankDisruption(ctx context.Context, jobRunIDToAvailabilityResultForBackend map[string]jobrunaggregatorlib.AvailabilityResult, backend string, maxDisruptionSeconds int, masterNodesUpdated string) ([]string, []string, testCaseStatus, string, error) {
-	historicalDisruption, fallBackJobName, err := a.getDisruptionByBackend(ctx, masterNodesUpdated)
-	if err != nil {
-		message := fmt.Sprintf("error getting historical disruption data, skipping: %v\n", err)
-		failureJobRunIDs := sets.StringKeySet(jobRunIDToAvailabilityResultForBackend).List()
-		return failureJobRunIDs, []string{}, testCaseSkipped, message, nil
-	}
-
-	messagePrefix := ""
-	if len(fallBackJobName) > 0 {
-		messagePrefix = fmt.Sprintf(fallBackMessagePrefix, fallBackJobName)
-	}
-
-	historicalDisruptionStatistic, ok := historicalDisruption[backend]
-
-	// if we have no data, then we won't have enough indexes, so we get an out of range.
-	// this happens when we add new disruption tests, so we just skip instead
-	if !ok {
-		message := "We have no historical data."
-		failureJobRunIDs := sets.StringKeySet(jobRunIDToAvailabilityResultForBackend).List()
-		return failureJobRunIDs, []string{}, testCaseSkipped, message, nil
-	}
-
-	thresholdPercentile := getPercentileRank(historicalDisruptionStatistic, maxDisruptionSeconds)
-
-	failureJobRunIDs, successJobRunIDs, testCasePassed, summary := a.checkPercentileDisruptionWithoutGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, thresholdPercentile)
-	return failureJobRunIDs, successJobRunIDs, testCasePassed, messagePrefix + summary, nil
 }
 
 func (a *weeklyAverageFromTenDays) CheckFailed(ctx context.Context, jobName string, suiteNames []string, testCaseDetails *jobrunaggregatorlib.TestCaseDetails) (testCaseStatus, string, error) {

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail_test.go
@@ -24,6 +24,7 @@ func TestCheckPercentileDisruption(t *testing.T) {
 	tests := []struct {
 		name                 string
 		disruptions          []int
+		graceSeconds         int
 		thresholdPercentile  int
 		historicalDisruption float64
 		status               testCaseStatus
@@ -58,11 +59,12 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 5 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 5) = 2
+			// graceSeconds = 2
 			// The Disruption value that == 7 gets flipped to pass
 			name:                 "Test 95th Percentile Fuzzy Pass",
 			disruptions:          []int{5, 5, 5, 6, 6, 7, 9, 9, 9, 9},
 			thresholdPercentile:  95,
+			graceSeconds:         2,
 			historicalDisruption: 6,
 			status:               testCasePassed,
 			failedCount:          4,
@@ -72,11 +74,12 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 4 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 1
+			// graceSeconds = 1
 			// The Disruption values that == 7 get flipped to passes
 			name:                 "Test 95th Percentile Multi Fuzzy Pass",
 			disruptions:          []int{5, 5, 5, 6, 7, 7, 8, 8, 8, 86},
 			thresholdPercentile:  95,
+			graceSeconds:         1,
 			historicalDisruption: 6,
 			status:               testCasePassed,
 			failedCount:          4,
@@ -86,12 +89,13 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 4 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 1
+			// graceSeconds = 1
 			// The Disruption value that == 7 gets flipped to pass
 			// But the 8s and above do not, so we don't have enough passes
 			name:                 "Test 95th Percentile Multi Fuzzy Fail",
 			disruptions:          []int{5, 5, 5, 6, 7, 8, 8, 9, 9, 86},
 			thresholdPercentile:  95,
+			graceSeconds:         1,
 			historicalDisruption: 6,
 			status:               testCaseFailed,
 			failedCount:          5,
@@ -101,12 +105,13 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 4 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 10
+			// graceSeconds = 10
 			// The Disruption values that are < 113 get flipped to pass
 			// The 113 and above does not, but we have enough passes
 			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy Pass",
 			disruptions:          []int{99, 105, 101, 102, 101, 108, 108, 112, 113, 186},
 			thresholdPercentile:  95,
+			graceSeconds:         10,
 			historicalDisruption: 102,
 			status:               testCasePassed,
 			failedCount:          2,
@@ -116,11 +121,12 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 4 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 4) = 10
+			// graceSeconds = 10
 			// The Disruption values that are < 113 get flipped to pass
 			// The 113 and above does not, so we don't have enough passes
 			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy Failed",
 			disruptions:          []int{99, 105, 101, 102, 101, 147, 113, 113, 113, 186},
+			graceSeconds:         10,
 			thresholdPercentile:  95,
 			historicalDisruption: 102,
 			status:               testCaseFailed,
@@ -131,11 +137,12 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 95th percentile is 6
 			// 4 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (6 - 2) = 5
+			// graceSeconds = 5
 			// The Disruption values that are < 108 get flipped to pass
 			// But the 108s and above do not, so we don't have enough passes
 			name:                 "Test 95th Percentile Big Disruption Multi Fuzzy High Multiplier Fail",
 			disruptions:          []int{99, 105, 101, 107, 107, 108, 108, 109, 109, 186},
+			graceSeconds:         5,
 			thresholdPercentile:  95,
 			historicalDisruption: 102,
 			status:               testCaseFailed,
@@ -155,6 +162,7 @@ func TestCheckPercentileDisruption(t *testing.T) {
 			name:                 "Test 85th Percentile Pass",
 			disruptions:          []int{1, 0, 0, 5, 5, 2, 2, 3, 4},
 			thresholdPercentile:  85,
+			graceSeconds:         1,
 			historicalDisruption: 1.30,
 			status:               testCasePassed,
 			failedCount:          4,
@@ -167,6 +175,7 @@ func TestCheckPercentileDisruption(t *testing.T) {
 			name:                 "Test 85th Percentile Fail no fuzzy matching",
 			disruptions:          []int{1, 0, 0, 5, 5, 2, 2, 3, 4},
 			thresholdPercentile:  85,
+			graceSeconds:         0,
 			historicalDisruption: 1.30,
 			status:               testCaseFailed,
 			failedCount:          6,
@@ -200,6 +209,7 @@ func TestCheckPercentileDisruption(t *testing.T) {
 			name:                 "Test 80th Percentile Pass",
 			disruptions:          []int{0, 0, 1, 1, 2, 2, 2, 2, 2, 2},
 			thresholdPercentile:  80,
+			graceSeconds:         0,
 			historicalDisruption: 1,
 			status:               testCasePassed,
 			failedCount:          6,
@@ -209,11 +219,12 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 80th percentile is 4
 			// 3 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (4 - 3) = 1
+			// graceSeconds = 1
 			// The Disruption values that == 2 get flipped to passes
 			name:                 "Test 80th Percentile Xtra Fuzzy Pass",
 			disruptions:          []int{0, 0, 1, 2, 2, 6, 3, 4, 5, 8},
 			thresholdPercentile:  80,
+			graceSeconds:         1,
 			historicalDisruption: 1,
 			status:               testCasePassed,
 			failedCount:          5,
@@ -223,12 +234,13 @@ func TestCheckPercentileDisruption(t *testing.T) {
 		{
 			// Required Passes for 80th percentile is 4
 			// 2 Natural Passes
-			// graceSeconds = ((historicalDisruption / 5) + 1) / (4 - 2) = 0
+			// graceSeconds = 0
 			// There are no disruption values that get flipped since (2-1)*2 = 2 and our Fuzz Threshold is 1
 			// But the 8s and above do not so we don't have enough passes
 			name:                 "Test 80th Percentile Fuzzy Fail",
 			disruptions:          []int{0, 0, 2, 2, 2, 2, 2, 2, 2, 2},
 			thresholdPercentile:  80,
+			graceSeconds:         0,
 			historicalDisruption: 1,
 			status:               testCaseFailed,
 			failedCount:          8,
@@ -263,15 +275,18 @@ func TestCheckPercentileDisruption(t *testing.T) {
 			var status testCaseStatus
 			var summary string
 			if test.supportsFuzziness {
-				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile)
+				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithGrace(
+					jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile, test.graceSeconds)
 			} else {
-				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithoutGrace(jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile)
+				failureJobRunIDs, successJobRunIDs, status, summary = weeklyAverageFromTenDays.checkPercentileDisruptionWithoutGrace(
+					jobRunIDToAvailabilityResultForBackend, historicalDisruptionStatistic, test.thresholdPercentile)
 			}
 
 			assert.NotNil(t, summary, "Invalid summary for: %s", test.name)
-			assert.Equal(t, test.failedCount, len(failureJobRunIDs), "Invalid failed test cont for: %s", test.name)
-			assert.Equal(t, test.successCount, len(successJobRunIDs), "Invalid success test cont for: %s", test.name)
-			assert.Equal(t, test.status, status, "Invalid success test cont for: %s", test.name)
+			t.Logf("summary = %s", summary)
+			assert.Equal(t, test.failedCount, len(failureJobRunIDs), "Invalid failed test count for: %s", test.name)
+			assert.Equal(t, test.successCount, len(successJobRunIDs), "Invalid success test count for: %s", test.name)
+			assert.Equal(t, test.status, status, "Invalid success test count for: %s", test.name)
 		})
 	}
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -712,7 +712,7 @@ FROM
                 INNER JOIN
                     DATA_SET_LOCATION.BackendDisruption_JobRuns as JobRuns on JobRuns.Name = BackendDisruption.JobRunName
                 WHERE
-                    JobRuns.StartTime BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 DAY)
+                    JobRuns.StartTime BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 17 DAY)
                 AND
                     TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
                 AND

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client.go
@@ -712,7 +712,7 @@ FROM
                 INNER JOIN
                     DATA_SET_LOCATION.BackendDisruption_JobRuns as JobRuns on JobRuns.Name = BackendDisruption.JobRunName
                 WHERE
-                    JobRuns.StartTime BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 17 DAY)
+                    JobRuns.StartTime BETWEEN TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 10 DAY)
                 AND
                     TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 DAY)
                 AND


### PR DESCRIPTION
- Drop the aggregated P95 should not get worse test
- Pass fixed graceseconds to aggregated percentile disruption tests
- Look at two weeks of disruption data instead of one for aggregated disruption percentile testing
- Remove the zero-disruption should not be worse aggregated test

More details on each commit and in the investigation doc shared with TRT.
