### PR TITLE
Increase aggregator timeout from 4h15m to 5h15m

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -79,8 +79,8 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute
-	if durationToWait > (4*time.Hour + 15*time.Minute) {
-		durationToWait = 4*time.Hour + 15*time.Minute
+	if durationToWait > (5*time.Hour + 15*time.Minute) {
+		durationToWait = 5*time.Hour + 15*time.Minute
 	}
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)
 	alog := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
Sub-jobs (especially gcp rt upgrade) are running close to the current threshold of 4h15m. We also noticed that sub-jobs are not all starting the same time as the aggregator. Some jobs start 30m later. 