### PR TITLE
Remove list of missing data from origin synthetic test update PRs

### DIFF
--- a/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/pr_message_template.md
+++ b/pkg/jobrunaggregator/jobrunhistoricaldataanalyzer/pr_message_template.md
@@ -15,17 +15,3 @@ Note: For P99, {{.DataType}} had `{{.IncreasedCount}}` jobs increased and `{{.De
 
 </details>
 {{ end }}
-
-{{- if .MissingJobs }}
-
-### Missing Data
-
-Note: Jobs that are missing from the new data set but were present in the previous dataset.
-
-<details>
-  <summary>Click To Show Table</summary>
-
-{{formatTableOutput .MissingJobs false}}
-
-</details>
-{{ end }}


### PR DESCRIPTION
This job has been broken for several weeks because the PR message being
generated is now too big for bash to cat in a command. We also need to
watch the Github comment limit of 64K chars.

With the inclusion of alert data, and the 4.13 rolling out due to 4.15
coming online, the list of missing data (i.e. jobs removed) has blown
up, the file was coming out 400K chars, even if we fixed reading it,
Github likely would reject.

I have removed the list of missing jobs, we can now see it can generate
too much data at boundaries of releases and it's of questionable value
regardless, we can still see the count of missing data at the top of the
template.

This allows us to continue generating the comparison table.

[TRT-1312](https://issues.redhat.com//browse/TRT-1312)