### PR TITLE
Revert #3581 "TRT-1204: Support static list of JobRuns"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -45,41 +45,10 @@ type JobRunAggregatorAnalyzerOptions struct {
 	prowJobClient       *prowjobclientset.Clientset
 	jobStateQuerySource string
 	prowJobMatcherFunc  jobrunaggregatorlib.ProwJobMatcherFunc
-
-	staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
-}
-
-func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
-	var jobRuns []jobrunaggregatorapi.JobRunInfo
-	for _, job := range o.staticJobRunIdentifiers {
-		// in this context passing the job name is optional for the
-		// static job runs but if it is present then check to make sure it matches
-		if len(job.JobName) > 0 && strings.Compare(job.JobName, o.jobName) != 0 {
-			continue
-		}
-		jobRun, err := o.jobRunLocator.FindJob(ctx, job.JobRunID)
-		if err != nil {
-			return nil, err
-		}
-		if jobRun != nil {
-			jobRuns = append(jobRuns, jobRun)
-		}
-	}
-	return jobRuns, nil
-}
-
-func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRunsFromIdentifiers(ctx context.Context, jobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier) ([]jobrunaggregatorapi.JobRunInfo, error) {
-	o.staticJobRunIdentifiers = jobRunIdentifiers
-	return o.GetRelatedJobRuns(ctx)
 }
 
 // GetRelatedJobRuns gets all related job runs for analysis
 func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
-	// allow for the list of ids to be passed in
-	if len(o.staticJobRunIdentifiers) > 0 {
-		return o.loadStaticJobRuns(ctx)
-	}
-
 	errorsInARow := 0
 	for {
 		jobsToAggregate, err := o.jobRunLocator.FindRelatedJobs(ctx)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -23,16 +23,6 @@ const (
 	testPayloadtag = "4.14.0-0.ci-2023-06-18-131345"
 )
 
-func TestParseStaticJobRunInfo(t *testing.T) {
-	// example json and validation we can unmarshal
-	staticJSON := `[{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762997483114496"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762998317780992"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676762999165030400"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000020668416"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763000834363392"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763001673224192"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763002516279296"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763003355140096"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763004194000896"},{"JobName": "periodic-ci-openshift-release-master-ci-4.14-e2e-azure-ovn-upgrade","JobRunId":"1676763005460680704"}]`
-	jobRunInfo, err := jobrunaggregatorlib.GetStaticJobRunInfo(staticJSON, "")
-	if err != nil {
-		t.Fatalf("Failed to parse static JobRunInfo json: %v", err)
-	}
-	assert.Equal(t, 10, len(jobRunInfo), "Invalid JobRunInfo length")
-}
-
 func TestAnalyzer(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -74,8 +64,8 @@ func TestAnalyzer(t *testing.T) {
 			endPayloadJobRunWindow := payloadStartTime.Add(jobrunaggregatorlib.JobSearchWindowEndOffset)
 
 			mockDataClient := jobrunaggregatorlib.NewMockCIDataClient(mockCtrl)
-			mockDataClient.EXPECT().GetJobRunForJobNameBeforeTime(gomock.Any(), testJobName, startPayloadJobRunWindow).Return("1000", nil).Times(1)
-			mockDataClient.EXPECT().GetJobRunForJobNameAfterTime(gomock.Any(), testJobName, endPayloadJobRunWindow).Return("2000", nil).Times(1)
+			mockDataClient.EXPECT().GetJobRunForJobNameBeforeTime(gomock.Any(), testJobName, startPayloadJobRunWindow).Return("1000", nil).Times(2)
+			mockDataClient.EXPECT().GetJobRunForJobNameAfterTime(gomock.Any(), testJobName, endPayloadJobRunWindow).Return("2000", nil).Times(2)
 
 			mockGCSClient := jobrunaggregatorlib.NewMockCIGCSClient(mockCtrl)
 			mockGCSClient.EXPECT().ReadRelatedJobRuns(
@@ -84,11 +74,7 @@ func TestAnalyzer(t *testing.T) {
 				fmt.Sprintf("logs/%s", testJobName),
 				"1000",
 				"2000",
-				gomock.Any()).Return(tc.jobRunInfos, nil).Times(1)
-
-			for _, ri := range tc.jobRunInfos {
-				mockGCSClient.EXPECT().ReadJobRunFromGCS(gomock.Any(), gomock.Any(), testJobName, ri.GetJobRunID(), gomock.Any()).Return(ri, nil)
-			}
+				gomock.Any()).Return(tc.jobRunInfos, nil).Times(2)
 
 			analyzer := JobRunAggregatorAnalyzerOptions{
 				jobRunLocator: jobrunaggregatorlib.NewPayloadAnalysisJobLocatorForReleaseController(

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/cmd.go
@@ -28,9 +28,6 @@ type JobRunsAnalyzerFlags struct {
 	Timeout                     time.Duration
 	EstimatedJobStartTimeString string
 	JobStateQuerySource         string
-
-	StaticJobRunIdentifierPath string
-	StaticJobRunIdentifierJSON string
 }
 
 func NewJobRunsAnalyzerFlags() *JobRunsAnalyzerFlags {
@@ -58,11 +55,6 @@ func (f *JobRunsAnalyzerFlags) BindFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&f.Timeout, "timeout", f.Timeout, "Time to wait for aggregation to complete.")
 	fs.StringVar(&f.EstimatedJobStartTimeString, "job-start-time", f.EstimatedJobStartTimeString, fmt.Sprintf("Start time in RFC822Z: %s", kubeTimeSerializationLayout))
 	fs.StringVar(&f.JobStateQuerySource, "query-source", jobrunaggregatorlib.JobStateQuerySourceBigQuery, "The source from which job states are found. It is either bigquery or cluster")
-
-	// optional for local use or potentially gangway results
-	fs.StringVar(&f.StaticJobRunIdentifierPath, "static-run-info-path", f.StaticJobRunIdentifierPath, "The optional path to a file containing JSON formatted JobRunIdentifier array used for aggregated analysis")
-	fs.StringVar(&f.StaticJobRunIdentifierJSON, "static-run-info-json", f.StaticJobRunIdentifierJSON, "The optional JSON formatted string of JobRunIdentifier array used for aggregated analysis")
-
 }
 
 func NewJobRunsAnalyzerCommand() *cobra.Command {
@@ -155,14 +147,6 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 		return nil, err
 	}
 
-	var staticJobRunIdentifiers []jobrunaggregatorlib.JobRunIdentifier
-	if len(f.StaticJobRunIdentifierJSON) > 0 || len(f.StaticJobRunIdentifierPath) > 0 {
-		staticJobRunIdentifiers, err = jobrunaggregatorlib.GetStaticJobRunInfo(f.StaticJobRunIdentifierJSON, f.StaticJobRunIdentifierPath)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	var jobRunLocator jobrunaggregatorlib.JobRunLocator
 	var prowJobMatcherFunc jobrunaggregatorlib.ProwJobMatcherFunc
 	if len(f.PayloadTag) > 0 {
@@ -199,18 +183,17 @@ func (f *JobRunsAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunAggregator
 	}
 
 	return &JobRunAggregatorAnalyzerOptions{
-		explicitGCSPrefix:       f.ExplicitGCSPrefix,
-		jobRunLocator:           jobRunLocator,
-		passFailCalculator:      newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 6, ciDataClient),
-		jobName:                 f.JobName,
-		payloadTag:              f.PayloadTag,
-		workingDir:              f.WorkingDir,
-		jobRunStartEstimate:     estimatedStartTime,
-		clock:                   clock.RealClock{},
-		timeout:                 f.Timeout,
-		prowJobClient:           prowJobClient,
-		jobStateQuerySource:     f.JobStateQuerySource,
-		prowJobMatcherFunc:      prowJobMatcherFunc,
-		staticJobRunIdentifiers: staticJobRunIdentifiers,
+		explicitGCSPrefix:   f.ExplicitGCSPrefix,
+		jobRunLocator:       jobRunLocator,
+		passFailCalculator:  newWeeklyAverageFromTenDaysAgo(f.JobName, estimatedStartTime, 6, ciDataClient),
+		jobName:             f.JobName,
+		payloadTag:          f.PayloadTag,
+		workingDir:          f.WorkingDir,
+		jobRunStartEstimate: estimatedStartTime,
+		clock:               clock.RealClock{},
+		timeout:             f.Timeout,
+		prowJobClient:       prowJobClient,
+		jobStateQuerySource: f.JobStateQuerySource,
+		prowJobMatcherFunc:  prowJobMatcherFunc,
 	}, nil
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/jobrun_locator.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -20,7 +18,6 @@ var (
 
 type JobRunLocator interface {
 	FindRelatedJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
-	FindJob(ctx context.Context, jobRunID string) (jobrunaggregatorapi.JobRunInfo, error)
 }
 
 // ProwJobMatcherFunc defines a function signature for matching prow jobs. The function is
@@ -83,8 +80,4 @@ func (a *analysisJobAggregator) FindRelatedJobs(ctx context.Context) ([]jobrunag
 	}
 
 	return a.ciGCSClient.ReadRelatedJobRuns(ctx, a.jobName, a.gcsPrefix, startingJobRunID, endingJobRunID, a.prowJobMatcher)
-}
-
-func (a *analysisJobAggregator) FindJob(ctx context.Context, jobRunID string) (jobrunaggregatorapi.JobRunInfo, error) {
-	return a.ciGCSClient.ReadJobRunFromGCS(ctx, a.gcsPrefix, a.jobName, jobRunID, logrus.New())
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util.go
@@ -2,7 +2,6 @@ package jobrunaggregatorlib
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,7 +18,6 @@ import (
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobclientset "k8s.io/test-infra/prow/client/clientset/versioned"
 	prowjobinformers "k8s.io/test-infra/prow/client/informers/externalversions"
-	v1 "k8s.io/test-infra/prow/client/informers/externalversions/prowjobs/v1"
 	"k8s.io/utils/clock"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -40,43 +38,14 @@ var (
 	KnownQuerySources = sets.Set[string]{JobStateQuerySourceBigQuery: sets.Empty{}, JobStateQuerySourceCluster: sets.Empty{}}
 )
 
-type JobRunIdentifier struct {
-	JobName  string
-	JobRunID string
-}
-
-func GetStaticJobRunInfo(staticRunInfoJSON, staticRunInfoPath string) ([]JobRunIdentifier, error) {
-	var jsonBytes []byte
-	var jobRuns []JobRunIdentifier
-	var err error
-	if len(staticRunInfoJSON) == 0 {
-		jsonBytes, err = os.ReadFile(staticRunInfoPath)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		jsonBytes = []byte(staticRunInfoJSON)
-	}
-
-	if err = json.Unmarshal(jsonBytes, &jobRuns); err != nil {
-		return nil, err
-	}
-
-	return jobRuns, nil
-}
-
 type JobRunGetter interface {
 	// GetRelatedJobRuns gets all related job runs for analysis
 	GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error)
-
-	// GetRelatedJobRunsFromIdentifiers passes along minimal information known about the jobs already so that we can skip
-	// querying and go directly to fetching the full job details when GetRelatedJobRuns is called
-	GetRelatedJobRunsFromIdentifiers(ctx context.Context, jobRunIdentifiers []JobRunIdentifier) ([]jobrunaggregatorapi.JobRunInfo, error)
 }
 
 type JobRunWaiter interface {
 	// Wait waits until all job runs finish, or time out
-	Wait(ctx context.Context) ([]JobRunIdentifier, error)
+	Wait(ctx context.Context) error
 }
 
 // WaitUntilTime waits until readAt time has passed
@@ -141,20 +110,17 @@ type BigQueryJobRunWaiter struct {
 	TimeToStopWaiting time.Time
 }
 
-func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, error) {
+func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) error {
 	clock := clock.RealClock{}
 	relatedJobRuns, err := w.JobRunGetter.GetRelatedJobRuns(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	var finishedJobRuns, unfinishedJobRuns []jobrunaggregatorapi.JobRunInfo
-	var unfinishedJobRunNames []string
 
 	for {
 		fmt.Println() // for prettier logs
 
-		finishedJobRuns, unfinishedJobRuns, _, unfinishedJobRunNames = getAllFinishedJobRuns(ctx, relatedJobRuns)
+		_, _, _, unfinishedJobRunNames := getAllFinishedJobRuns(ctx, relatedJobRuns)
 
 		// ready or not, it's time to check
 		if clock.Now().After(w.TimeToStopWaiting) {
@@ -168,26 +134,13 @@ func (w *BigQueryJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, er
 			case <-time.After(10 * time.Minute):
 				continue
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return ctx.Err()
 			}
 		}
 
 		break
 	}
-
-	// Optional if we don't want to change the BigQuery path we can remove
-	// This will save us from making an additional lookup immediately
-	// after this call returns
-	jobRunIdentifiers := make([]JobRunIdentifier, 0)
-	for _, jobRunInfo := range finishedJobRuns {
-		jobRunIdentifiers = append(jobRunIdentifiers, JobRunIdentifier{JobRunID: jobRunInfo.GetJobRunID(), JobName: jobRunInfo.GetJobName()})
-	}
-
-	for _, jobRunInfo := range unfinishedJobRuns {
-		jobRunIdentifiers = append(jobRunIdentifiers, JobRunIdentifier{JobRunID: jobRunInfo.GetJobRunID(), JobName: jobRunInfo.GetJobName()})
-	}
-
-	return jobRunIdentifiers, nil
+	return nil
 }
 
 // ClusterJobRunWaiter implements a waiter that will wait for job completion based on live stats for prow jobs
@@ -204,43 +157,32 @@ type ClusterJobRunWaiter struct {
 	ProwJobMatcherFunc ProwJobMatcherFunc
 }
 
-func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) (bool, map[string]*prowv1.ProwJob) {
+func (w *ClusterJobRunWaiter) allProwJobsFinished(allItems []*prowv1.ProwJob) bool {
 	uncompletedJobMap := map[string]*prowv1.ProwJob{}
-	matchedJobMap := map[string]*prowv1.ProwJob{}
-
+	totalMatchedJobs := 0
 	for _, prowJob := range allItems {
 		if !w.ProwJobMatcherFunc(prowJob) {
 			continue
 		}
-		jobRunID := prowJob.Labels[prowJobJobRunIDLabel]
-		matchedJobMap[jobRunID] = prowJob
+		totalMatchedJobs++
 		if prowJob.Status.CompletionTime != nil {
 			continue
 		}
 
+		jobRunID := prowJob.Labels[prowJobJobRunIDLabel]
 		uncompletedJobMap[jobRunID] = prowJob
 	}
 	if len(uncompletedJobMap) == 0 {
 		logrus.Info("all jobs completed")
-		return true, matchedJobMap
+		return true
 	}
-	logrus.Infof("%d/%d jobs completed, waiting for: [%v]", len(matchedJobMap)-len(uncompletedJobMap), len(matchedJobMap), strings.Join(sets.StringKeySet(uncompletedJobMap).List(), ", "))
-	return false, matchedJobMap
+	logrus.Infof("%d/%d jobs completed, waiting for: [%v]", totalMatchedJobs-len(uncompletedJobMap), totalMatchedJobs, strings.Join(sets.StringKeySet(uncompletedJobMap).List(), ", "))
+	return false
 }
 
-func (w *ClusterJobRunWaiter) checkMatchedJobsForCompletion(prowJobInformer v1.ProwJobInformer) (bool, map[string]*prowv1.ProwJob, error) {
-	allItems, err := prowJobInformer.Lister().List(labels.Everything())
-	if err != nil {
-		return false, nil, err
-	}
-
-	allDone, matchedJobs := w.allProwJobsFinished(allItems)
-	return allDone, matchedJobs, nil
-}
-
-func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, error) {
+func (w *ClusterJobRunWaiter) Wait(ctx context.Context) error {
 	if w.ProwJobClient == nil {
-		return nil, fmt.Errorf("prowjob client is missing")
+		return fmt.Errorf("prowjob client is missing")
 	}
 
 	prowJobInformerFactory := prowjobinformers.NewSharedInformerFactory(w.ProwJobClient, 24*time.Hour)
@@ -251,7 +193,7 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, err
 	hasSynced := prowJobInformer.Informer().HasSynced
 	go prowJobInformerFactory.Start(ctx.Done())
 	if !cache.WaitForCacheSync(ctx.Done(), hasSynced) {
-		return nil, fmt.Errorf("prowjob informer sync error")
+		return fmt.Errorf("prowjob informer sync error")
 	}
 	timeout := time.Until(w.TimeToStopWaiting)
 	if timeout < 0 {
@@ -266,36 +208,22 @@ func (w *ClusterJobRunWaiter) Wait(ctx context.Context) ([]JobRunIdentifier, err
 		timeout,
 		true,
 		func(ctx context.Context) (bool, error) {
-			allDone, _, err := w.checkMatchedJobsForCompletion(prowJobInformer)
-
+			allItems, err := prowJobInformer.Lister().List(labels.Everything())
 			if err != nil {
-				// log and suppress the error
 				logrus.Infof("Error listing prow jobs: %v", err)
 				return false, nil
 			}
 
-			return allDone, err
+			if w.allProwJobsFinished(allItems) {
+				return true, nil
+			}
+			return false, nil
 		},
 	)
 	if err != nil && err != context.DeadlineExceeded {
-		return nil, fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
+		return fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
 	}
-
-	// one more time to get the matched jobs
-	_, matchedJobs, err := w.checkMatchedJobsForCompletion(prowJobInformer)
-
-	if err != nil && err != context.DeadlineExceeded {
-		return nil, fmt.Errorf("failed waiting for prowjobs to complete: %w", err)
-	}
-
-	jobRuns := make([]JobRunIdentifier, len(matchedJobs))
-	count := 0
-	for _, value := range matchedJobs {
-		jobRuns[count] = JobRunIdentifier{JobName: value.Spec.Job, JobRunID: value.Status.BuildID}
-		count += 1
-	}
-
-	return jobRuns, nil
+	return nil
 }
 
 // WaitAndGetAllFinishedJobRuns waits for all job runs to finish until timeToStopWaiting. It returns all finished and unfinished job runs
@@ -309,21 +237,15 @@ func WaitAndGetAllFinishedJobRuns(ctx context.Context,
 	finishedJobRunNames := []string{}
 	unfinishedJobRunNames := []string{}
 
-	var err error
-	matchedJobs, err := waiter.Wait(ctx)
+	err := waiter.Wait(ctx)
 	if err != nil {
 		logrus.Errorf("finished waiting with error %+v", err)
 		return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 	}
 	logrus.Infof("finished waiting")
 
-	var relatedJobRuns []jobrunaggregatorapi.JobRunInfo
-	if len(matchedJobs) > 0 {
-		relatedJobRuns, err = jobRunGetter.GetRelatedJobRunsFromIdentifiers(ctx, matchedJobs)
-	} else {
-		// Refresh the job runs content one last time
-		relatedJobRuns, err = jobRunGetter.GetRelatedJobRuns(ctx)
-	}
+	// Refresh the job runs content one last time
+	relatedJobRuns, err := jobRunGetter.GetRelatedJobRuns(ctx)
 	if err != nil {
 		return finishedJobRuns, unfinishedJobRuns, finishedJobRunNames, unfinishedJobRunNames, err
 	}

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/util_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/util_test.go
@@ -193,7 +193,7 @@ func TestAllProwJobFinished(t *testing.T) {
 				TimeToStopWaiting:  time.Now(),
 				ProwJobMatcherFunc: tt.ProwJobMatcherFunc,
 			}
-			result, _ := waiter.allProwJobsFinished(tt.allItems)
+			result := waiter.allProwJobsFinished(tt.allItems)
 			assert.Equal(t, tt.result, result, "Test %s expecting %v, got %v", tt.name, tt.result, result)
 		})
 	}


### PR DESCRIPTION

Reverts #3581 ; tracked by TRT-666

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Again, check your work

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Next time check your work
```

CC: @neisw

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
