### PR TITLE
Enable retries on image mirroring

### DIFF
--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -186,7 +186,7 @@ func main() {
 	}
 
 	mirrorConsumerController := quayiociimagesdistributor.NewMirrorConsumer(mirrorStore, quayIOImageHelper, opts.registryConfig, opts.dryRun)
-	interrupts.Run(func(_ context.Context) { execute(mirrorConsumerController) })
+	interrupts.Run(func(ctx context.Context) { execute(ctx, mirrorConsumerController) })
 
 	if opts.enabledControllersSet.Has(quayiociimagesdistributor.ControllerName) {
 		if err := quayiociimagesdistributor.AddToManager(mgr,
@@ -279,8 +279,8 @@ func mirrors(action string, n int, ms quayiociimagesdistributor.MirrorStore) (an
 	}
 }
 
-func execute(c *quayiociimagesdistributor.MirrorConsumerController) {
-	if err := c.Run(); err != nil {
+func execute(ctx context.Context, c *quayiociimagesdistributor.MirrorConsumerController) {
+	if err := c.Run(ctx); err != nil {
 		logrus.WithError(err).Error("Error running")
 	}
 }

--- a/pkg/controller/quay_io_ci_images_distributor/oc_quay_io_image_helper.go
+++ b/pkg/controller/quay_io_ci_images_distributor/oc_quay_io_image_helper.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -127,10 +128,14 @@ func (c *client) ImageMirror(pairs []string, options OCImageMirrorOptions) error
 	args := []string{"image", "mirror", "--keep-manifest-list", fmt.Sprintf("--registry-config=%s", options.RegistryConfig),
 		fmt.Sprintf("--continue-on-error=%t", options.ContinueOnError), fmt.Sprintf("--max-per-registry=%d", options.MaxPerRegistry),
 		fmt.Sprintf("--dry-run=%t", options.DryRun)}
-	if _, err := c.executor.Run(append(args, pairs...)...); err != nil {
+	t := time.Now()
+	_, err := c.executor.Run(append(args, pairs...)...)
+	d := time.Since(t)
+	if err != nil {
+		logger.WithError(err).WithField("duration", d).Warn("Failed to mirror")
 		return err
 	}
-	logger.Info("Mirrored successfully")
+	logger.WithField("duration", d).Info("Mirrored successfully")
 	return nil
 }
 


### PR DESCRIPTION
Found some error in the log like

```
error: unable to push manifest to quay.io/openshift/ci:edge-infrastructure_ocm-2.10_assisted-service-scripts: manifest invalid: manifest invalid
```

When I rerun it on my laptop, it succeeded.

The retries will help in those transit errors.

In addition, this PR also adds the duration for executing the mirror cmd in the log to help tune the timeout parameter if needed.

/cc @openshift/test-platform 