### PR TITLE
Add openshift-cherrypick-robot org membership verification for cherrypick plugin

### DIFF
--- a/cmd/check-gh-automation/README.md
+++ b/cmd/check-gh-automation/README.md
@@ -1,6 +1,6 @@
 # Check GH Automation
-A tool to check that our bots (`openshift-merge-robot` and `openshift-ci-robot`) have access to repositories that have CI configured.
-It also checks that the app used to run it is installed in the repositories.
+A tool to check that our bots (`openshift-merge-robot`, `openshift-ci-robot`, and `openshift-cherrypick-robot`) have access to repositories that have CI configured. It also checks that the app used to run it is installed in the repositories. This tool also verifies if `openshift-cherrypick-robot` is an organization member for repos that have the `cherrypick` external prow plugin configured. 
+
 This can be run in multiple modes:
 
 ## Pass Prow Config Options
@@ -12,6 +12,7 @@ check-gh-automation \
 --config-path=/release/core-services/prow/02_config/_config.yaml \
 --supplemental-prow-config-dir=/release/core-services/prow/02_config \
 --job-config-path=/release/ci-operator/jobs/ \
+--plugin-config=/release/core-services/prow/02_config/ViaQ/_pluginconfig.yaml \
 --github-app-id={APP_ID} \
 --github-app-private-key-path={CERT_PATH}
 ```
@@ -20,21 +21,21 @@ check-gh-automation \
 If a `candidate-path` to the modified `openshift/release` repo is provided, then the tool will determine which repos have modified/added configurations and _only_ check those.
 It is able to determine this by utilizing the `$JOB_SPEC` environment variable that is available in the test pods.
 ```bash
-check-gh-automation
+check-gh-automation \
 --bot=openshift-merge-robot \
 --bot=openshift-ci-robot \
 --candidate-path=/release \
+--plugin-config=/path/to/plugin/config.yaml \
 --github-app-id={APP_ID} \
 --github-app-private-key-path={CERT_PATH}
 ```
 
 ## Pass specific Repo(s) to check
-The `--repo` parameter can be used to pass one or more repos in to be checked.
-When using this mode do not supply the prow config options or the `candidate-path`
+Use the `--repo` parameter for specific repos. Do not supply prow config options or `candidate-path` when using this mode.
 
 ## Local Development
-A `hack/local-check-gh-automation.sh` script exists to test out the tool locally. Usage is simple:
+Test out the tool locally using the provided script:
 ```bash
 hack/local-check-gh-automation.sh some-org/repo
 ```
-The script will pull the necessary secrets from the `app.ci` cluster and run the tool locally, checking the provided repo.
+This script will pull necessary secrets from the `app.ci` cluster and run the tool locally, checking the provided repo.


### PR DESCRIPTION
This PR adds functionality to verify that `openshift-cherrypick-robot` is an organization member for repositories that have the `cherrypick` external prow plugin configured. This ensures that the bot has the necessary permissions to operate correctly, aligning with the requirements outlined in JIRA TICKET.

### Changes
- Added a new flag `--plugin-config` for specifying the plugin configuration file.
- Extended the `options` struct to include `PluginConfigPath`.
- Modified `checkRepos` function to check for `cherrypick` plugin and verify `openshift-cherrypick-robot` org membership.
- Adjusted `main_test.go` to include a fake ConfigAgent for testing and added `openshift-cherrypick-robot` to the test organization members.
- Updated README to reflect the new changes.

This PR aims to resolve the issue of incorrect messages being posted when `openshift-cherrypick-robot` lacks the necessary permissions to view hidden members of an organization.
