### PR TITLE
Name check in pr payload aggregate run is incorrect

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -52,11 +52,6 @@ type JobRunAggregatorAnalyzerOptions struct {
 func (o *JobRunAggregatorAnalyzerOptions) loadStaticJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRuns []jobrunaggregatorapi.JobRunInfo
 	for _, job := range o.staticJobRunIdentifiers {
-		// in this context passing the job name is optional for the
-		// static job runs but if it is present then check to make sure it matches
-		if len(job.JobName) > 0 && strings.Compare(job.JobName, o.jobName) != 0 {
-			continue
-		}
 		jobRun, err := o.jobRunLocator.FindJob(ctx, job.JobRunID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In PR payload-aggregate case, job names are created by ci-operator and are not the same as the periodic name. 