### PR TITLE
`pr-reminder`: escape text in slack message

### DIFF
--- a/cmd/pr-reminder/README.md
+++ b/cmd/pr-reminder/README.md
@@ -13,6 +13,6 @@ Finally, a slack message will be sent to each of the `teamMember's` containing i
 
 ## Local Development
 A script, `hack/local-pr-reminder.sh`, exists for running the tool locally. This script takes no arguments, but the user must be logged into the `app.ci` cluster.
-You will want to run the script as `USR="my-kerberos-id" hack/pr-reminder-config.yaml` to include your own kerberos ID to receive the message in the testing space.
+You will want to run the script as `USR="my-kerberos-id" hack/local-pr-reminder.sh` to include your own kerberos ID to receive the message in the testing space.
 The cluster is utilized to obtain the production `github-users-file` file and the `slack-token` for the alpha slack instance.
 The script will run the tool, and message corresponding slack users in the `dptp-robot-testing` space.

--- a/cmd/pr-reminder/main.go
+++ b/cmd/pr-reminder/main.go
@@ -472,7 +472,7 @@ func messageUser(user user, slackClient slackClient) error {
 	}
 
 	responseChannel, responseTimestamp, err := slackClient.PostMessage(user.SlackId,
-		slack.MsgOptionText("PR Review Reminders.", false),
+		slack.MsgOptionText("PR Review Reminders.", true),
 		slack.MsgOptionBlocks(message...))
 	if err != nil {
 		logrus.WithError(err).WithField("kerberosId", user.KerberosId).WithField("message", message).Debug("Failed to message user about PR review reminder")


### PR DESCRIPTION
Attempting to fix the error in logs like [this](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-pr-reminder/1717813475989786624) where there are invalid blocks. Set `escape` to true, because there is no good reason that it was false.