### PR TITLE
ci-images-mirror: fix Take function of memoryMirrorStore

### DIFF
--- a/pkg/controller/quay_io_ci_images_distributor/mirror.go
+++ b/pkg/controller/quay_io_ci_images_distributor/mirror.go
@@ -45,32 +45,26 @@ func (s *memoryMirrorStore) Put(tasks ...MirrorTask) error {
 }
 
 func (s *memoryMirrorStore) Take(n int) ([]MirrorTask, error) {
-	var ret []MirrorTask
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	c := 0
-	for k, v := range s.mirrors {
-		if c < n {
-			ret = append(ret, v)
-			c = c + 1
-			delete(s.mirrors, k)
-		} else {
-			break
-		}
-	}
+	ret, _, nil := s.get(n, false)
 	return ret, nil
 }
 
 func (s *memoryMirrorStore) Show(n int) ([]MirrorTask, int, error) {
+	return s.get(n, false)
+}
+func (s *memoryMirrorStore) get(n int, del bool) ([]MirrorTask, int, error) {
 	var ret []MirrorTask
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	l := len(s.mirrors)
 	c := 0
-	for _, v := range s.mirrors {
+	for k, v := range s.mirrors {
 		if c < n {
 			ret = append(ret, v)
 			c = c + 1
+			if del {
+				delete(s.mirrors, k)
+			}
 		} else {
 			break
 		}

--- a/pkg/controller/quay_io_ci_images_distributor/mirror.go
+++ b/pkg/controller/quay_io_ci_images_distributor/mirror.go
@@ -53,8 +53,9 @@ func (s *memoryMirrorStore) Take(n int) ([]MirrorTask, error) {
 		if c < n {
 			ret = append(ret, v)
 			c = c + 1
-		} else {
 			delete(s.mirrors, k)
+		} else {
+			break
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
Found in log that more mirror tasks were executed than it is supposed to and it is caused by Not deleting the task when taking it out of the store.

/cc @openshift/test-platform 