### PR TITLE
Chaos profile for aws cluster type

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1471,6 +1471,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSPerfQE,
 		ClusterProfileAWSPerfScaleQE,
 		ClusterProfileAWSPerfScaleLRCQE,
+		ClusterProfileAWSChaos,
 		ClusterProfileAWSTerraformQE,
 		ClusterProfileAWSRHTAPQE,
 		ClusterProfileAWSRHTAPPerformance,


### PR DESCRIPTION
Missed chaos profile for aws cluster type 

Missed this section in previous PR: https://github.com/openshift/release/pull/41590
CC: @chaitanyaenr 