### PR TITLE
ci-images-mirror: sync images with schema version 1 only once

### DIFF
--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -149,6 +149,12 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 		return fmt.Errorf("failed to get imageStreamTag %s from registry cluster: %w", req.String(), err)
 	}
 
+	// sync only when the target image does not exist because "Digests are not preserved with schema version 1 images."
+	if strings.HasSuffix(sourceImageStreamTag.Image.DockerImageManifestMediaType, "manifest.v1+prettyjws") && imageInfo.Digest != "" {
+		log.WithField("currentQuayDigest", imageInfo.Digest).Info("Skip mirroring image with manifest v1")
+		return nil
+	}
+
 	if r.onlyValidManifestV2Images && invalidManifestV2(sourceImageStreamTag) {
 		log.Info("Skip mirroring image with invalid manifest v2")
 		return nil


### PR DESCRIPTION
```console
$ oc image mirror --keep-manifest-list --registry-config=/tmp/p.c --continue-on-error=true --max-per-registry=20 --dry-run=false registry.ci.openshift.org/openshift/release@sha256:09e51ff46de9707cab1d34b1c0d3ee40388f610de21ce30b51153a26c70473b7=quay.io/openshift/ci:openshift_release_tectonic-console-builder-v19 
...
I1030 18:22:12.293011   72990 manifest.go:550] warning: Digests are not preserved with schema version 1 images. Support for schema version 1 images will be removed in a future release
...

$ oc image info registry.ci.openshift.org/openshift/release@sha256:09e51ff46de9707cab1d34b1c0d3ee40388f610de21ce30b51153a26c70473b7 -o json -a /tmp/p.c | jq -r '.mediaType'
application/vnd.docker.distribution.manifest.v1+prettyjws

$ oc image info registry.ci.openshift.org/openshift/release@sha256:09e51ff46de9707cab1d34b1c0d3ee40388f610de21ce30b51153a26c70473b7 -o json -a /tmp/p.c | jq -r '.digest'
sha256:09e51ff46de9707cab1d34b1c0d3ee40388f610de21ce30b51153a26c70473b7
$ oc image info quay.io/openshift/ci:openshift_release_tectonic-console-builder-v19 -o json -a /tmp/p.c | jq -r '.digest'
sha256:a97051f6ee6c5372c7bee11f6eda922d01351028c24f90273e4662b9dbb87ad3
```

/cc @openshift/test-platform @jupierce 