### PR TITLE
ci-images-mirror: ignore tags

### DIFF
--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -59,6 +59,8 @@ type quayIOCIImagesDistributorOptions struct {
 	additionalImageStreamTagsRaw       flagutil.Strings
 	additionalImageStreamsRaw          flagutil.Strings
 	additionalImageStreamNamespacesRaw flagutil.Strings
+
+	ignoreImageStreamTagsRaw flagutil.Strings
 }
 
 func newOpts() *options {
@@ -74,6 +76,7 @@ func newOpts() *options {
 	fs.Var(&opts.quayIOCIImagesDistributorOptions.additionalImageStreamTagsRaw, "quayIOCIImagesDistributorOptions.additional-image-stream-tag", "An imagestreamtag that will be distributed even if no test explicitly references it. It must be in namespace/name:tag format (e.G `ci/clonerefs:latest`). Can be passed multiple times.")
 	fs.Var(&opts.quayIOCIImagesDistributorOptions.additionalImageStreamsRaw, "quayIOCIImagesDistributorOptions.additional-image-stream", "An imagestream that will be distributed even if no test explicitly references it. It must be in namespace/name format (e.G `ci/clonerefs`). Can be passed multiple times.")
 	fs.Var(&opts.quayIOCIImagesDistributorOptions.additionalImageStreamNamespacesRaw, "quayIOCIImagesDistributorOptions.additional-image-stream-namespace", "A namespace in which imagestreams will be distributed even if no test explicitly references them (e.G `ci`). Can be passed multiple times.")
+	fs.Var(&opts.quayIOCIImagesDistributorOptions.ignoreImageStreamTagsRaw, "quayIOCIImagesDistributorOptions.ignore-image-stream-tag", "An imagestreamtag that will be ignored to mirror. It overrides --addition-* flags. It must be in namespace/name:tag format (e.G `ci/clonerefs:latest`). Can be passed multiple times.")
 	fs.IntVar(&opts.port, "port", 8090, "Port to run the server on")
 	fs.DurationVar(&opts.gracePeriod, "gracePeriod", time.Second*10, "Grace period for server shutdown")
 	fs.BoolVar(&opts.onlyValidManifestV2Images, "only-valid-manifest-v2-images", true, "If set, source images with invalidate manifests of v2 will not be mirrored")
@@ -197,6 +200,7 @@ func main() {
 			sets.New[string](opts.quayIOCIImagesDistributorOptions.additionalImageStreamTagsRaw.Strings()...),
 			sets.New[string](opts.quayIOCIImagesDistributorOptions.additionalImageStreamsRaw.Strings()...),
 			sets.New[string](opts.quayIOCIImagesDistributorOptions.additionalImageStreamNamespacesRaw.Strings()...),
+			sets.New[string](opts.quayIOCIImagesDistributorOptions.ignoreImageStreamTagsRaw.Strings()...),
 			quayIOImageHelper,
 			mirrorStore,
 			opts.registryConfig,

--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -41,7 +41,7 @@ type registryResolver interface {
 func AddToManager(manager manager.Manager,
 	configAgent agents.ConfigAgent,
 	resolver registryResolver,
-	additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces sets.Set[string],
+	additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces, ignoreImageStreamTags sets.Set[string],
 	quayIOImageHelper QuayIOImageHelper,
 	mirrorStore MirrorStore,
 	registryConfig string,
@@ -75,7 +75,7 @@ func AddToManager(manager manager.Manager,
 		return fmt.Errorf("failed to construct controller: %w", err)
 	}
 
-	objectFilter, err := testInputImageStreamTagFilterFactory(log, configAgent, resolver, additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces)
+	objectFilter, err := testInputImageStreamTagFilterFactory(log, configAgent, resolver, additionalImageStreamTags, additionalImageStreams, additionalImageStreamNamespaces, ignoreImageStreamTags)
 	if err != nil {
 		return fmt.Errorf("failed to get filter for ImageStreamTags: %w", err)
 	}
@@ -227,13 +227,17 @@ func testInputImageStreamTagFilterFactory(
 	resolver registryResolver,
 	additionalImageStreamTags,
 	additionalImageStreams,
-	additionalImageStreamNamespaces sets.Set[string],
+	additionalImageStreamNamespaces,
+	ignoreImageStreamTags sets.Set[string],
 ) (objectFilter, error) {
 	if err := ca.AddIndex(configIndexName, indexConfigsByTestInputImageStreamTag(resolver)); err != nil {
 		return nil, fmt.Errorf("failed to add %s index to configAgent: %w", configIndexName, err)
 	}
 	l = logrus.WithField("subcomponent", "test-input-image-stream-tag-filter")
 	return func(nn types.NamespacedName) bool {
+		if ignoreImageStreamTags.Has(nn.String()) {
+			return false
+		}
 		if additionalImageStreamTags.Has(nn.String()) {
 			return true
 		}


### PR DESCRIPTION
All kinds of broken images are on app.ci.
Fixed some of them but there are too many.
Let us grow a list of ignored images.

/cc @openshift/test-platform @jupierce 