### PR TITLE
`ClusterProfiles`: add Name() method

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1445,6 +1445,10 @@ func ClusterProfiles() []ClusterProfile {
 	}
 }
 
+func (p ClusterProfile) Name() string {
+	return string(p)
+}
+
 // ClusterType maps profiles to the type string used by tests.
 func (p ClusterProfile) ClusterType() string {
 	switch p {

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -477,6 +477,9 @@ func addProfile(name string, profile api.ClusterProfile, pod *coreapi.Pod) {
 		MountPath: ClusterProfileMountPath,
 	})
 	container.Env = append(container.Env, []coreapi.EnvVar{{
+		Name:  "CLUSTER_PROFILE_NAME",
+		Value: profile.Name(),
+	}, {
 		Name:  "CLUSTER_TYPE",
 		Value: profile.ClusterType(),
 	}, {

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -74,6 +74,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR
@@ -226,6 +228,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -80,6 +80,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR
@@ -249,6 +251,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR
@@ -411,6 +415,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR
@@ -579,6 +585,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig-minimal
       - name: KUBEADMIN_PASSWORD_FILE
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
+      - name: CLUSTER_PROFILE_NAME
+        value: aws
       - name: CLUSTER_TYPE
         value: aws
       - name: CLUSTER_PROFILE_DIR


### PR DESCRIPTION
When creating a `hypershift-hostedcluster` we want to know, what `ClusterProfile` it was created with and add it to the [annotations](https://github.com/openshift/release/blob/master/ci-operator/step-registry/hypershift/hostedcluster/create/hostedcluster/hypershift-hostedcluster-create-hostedcluster-commands.sh#L82), so it can be properly deleted with the [cleaner](https://github.com/openshift/ci-tools/blob/master/images/dptp-3312-hypershift-leaks-cleaner/cleanup-hypershift-leaks.sh).