### PR TITLE
`check-gh-automation`: introduce 'tide' mode 

### DIFF
--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/plugins"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -20,20 +21,38 @@ type fakeAutomationClient struct {
 	reposWithAppInstalled sets.Set[string]
 }
 
-func newFakeConfigAgent() *plugins.ConfigAgent {
-	// Create a fake Config
-	fakeConfig := &plugins.Configuration{
+func newFakePluginConfigAgent() *plugins.ConfigAgent {
+	fakePluginConfig := &plugins.Configuration{
 		ExternalPlugins: map[string][]plugins.ExternalPlugin{
 			"org-1/repo-a": {
 				{Name: "cherrypick"},
 			},
 		},
 	}
-	// Create a fake ConfigAgent
-	fakeConfigAgent := &plugins.ConfigAgent{}
-	// Set the Config
-	fakeConfigAgent.Set(fakeConfig)
-	return fakeConfigAgent
+	fakePluginConfigAgent := &plugins.ConfigAgent{}
+	fakePluginConfigAgent.Set(fakePluginConfig)
+	return fakePluginConfigAgent
+}
+
+func newFakeProwConfigAgent() *prowconfig.Agent {
+	prowConfig := &prowconfig.Config{
+		JobConfig: prowconfig.JobConfig{},
+		ProwConfig: prowconfig.ProwConfig{
+			Tide: prowconfig.Tide{
+				TideGitHubConfig: prowconfig.TideGitHubConfig{
+					Queries: prowconfig.TideQueries{
+						{
+							Orgs:  []string{"org-1", "org-3"},
+							Repos: []string{"repo-a"},
+						},
+					},
+				},
+			},
+		},
+	}
+	configAgent := &prowconfig.Agent{}
+	configAgent.Set(prowConfig)
+	return configAgent
 }
 
 func (c fakeAutomationClient) IsMember(org, user string) (bool, error) {
@@ -88,9 +107,11 @@ func TestCheckRepos(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name        string
-		repos       []string
-		bots        []string
+		name  string
+		repos []string
+		bots  []string
+		mode  appCheckMode
+
 		ignore      sets.Set[string]
 		expected    []string
 		expectedErr error
@@ -99,41 +120,48 @@ func TestCheckRepos(t *testing.T) {
 			name:     "org has bots as members",
 			repos:    []string{"org-1/repo-a"},
 			bots:     []string{"d-bot", "e-bot"},
+			mode:     standard,
 			expected: []string{},
 		},
 		{
 			name:     "org has one bot as member, and one as collaborator",
 			repos:    []string{"org-1/repo-a"},
 			bots:     []string{"a-bot", "e-bot"},
+			mode:     standard,
 			expected: []string{},
 		},
 		{
 			name:     "repo has bots as collaborators",
 			repos:    []string{"org-1/repo-a"},
 			bots:     []string{"a-bot", "b-bot"},
+			mode:     standard,
 			expected: []string{},
 		},
 		{
 			name:     "org doesn't have bots as members, and repo doesn't have bots as collaborators",
 			repos:    []string{"org-2/repo-z"},
 			bots:     []string{"a-bot", "b-bot"},
+			mode:     standard,
 			expected: []string{"org-2/repo-z"},
 		},
 		{
 			name:     "multiple repos, some passing",
 			repos:    []string{"org-1/repo-a", "org-2/repo-z"},
 			bots:     []string{"a-bot", "b-bot"},
+			mode:     standard,
 			expected: []string{"org-2/repo-z"},
 		},
 		{
 			name:     "app installed, no bots",
 			repos:    []string{"org-1/repo-a"},
+			mode:     standard,
 			expected: []string{},
 		},
 		{
 			name:     "app not installed",
 			repos:    []string{"org-3/repo-y"},
 			bots:     []string{"a-bot", "b-bot"},
+			mode:     standard,
 			expected: []string{"org-3/repo-y"},
 		},
 		{
@@ -141,6 +169,7 @@ func TestCheckRepos(t *testing.T) {
 			repos:    []string{"org-2/repo-z"},
 			bots:     []string{"a-bot", "b-bot"},
 			ignore:   sets.New[string]("org-2/repo-z"),
+			mode:     standard,
 			expected: []string{},
 		},
 		{
@@ -148,30 +177,52 @@ func TestCheckRepos(t *testing.T) {
 			repos:    []string{"org-2/repo-z"},
 			bots:     []string{"a-bot", "b-bot"},
 			ignore:   sets.New[string]("org-2"),
+			mode:     standard,
 			expected: []string{},
 		},
 		{
 			name:        "org member check returns error",
 			repos:       []string{"fake/repo"},
 			bots:        []string{"a-bot"},
+			mode:        standard,
 			expectedErr: errors.New("unable to determine if: a-bot is a member of fake: intentional error"),
 		},
 		{
 			name:        "collaborator check returns error",
 			repos:       []string{"org-1/fake"},
 			bots:        []string{"a-bot"},
+			mode:        standard,
 			expectedErr: errors.New("unable to determine if: a-bot is a collaborator on org-1/fake: intentional error"),
 		},
 		{
 			name:        "app install check returns error",
 			repos:       []string{"org-1/error"},
 			bots:        []string{"a-bot"},
+			mode:        standard,
 			expectedErr: errors.New("unable to determine if openshift-ci app is installed on org-1/error: intentional error"),
+		},
+		{
+			name:     "app install check in tide mode successful when app installed and query exists",
+			repos:    []string{"org-1/repo-a"},
+			mode:     tide,
+			expected: []string{},
+		},
+		{
+			name:     "app install check in tide mode successful when query doesn't exist",
+			repos:    []string{"org-2/repo-z"},
+			mode:     tide,
+			expected: []string{},
+		},
+		{
+			name:     "app install check fails in tide mode when app not installed, and tide query configured",
+			repos:    []string{"org-3/repo-z"},
+			mode:     tide,
+			expected: []string{"org-3/repo-z"},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			failing, err := checkRepos(tc.repos, tc.bots, tc.ignore, client, logrus.NewEntry(logrus.New()), newFakeConfigAgent())
+			failing, err := checkRepos(tc.repos, tc.bots, "openshift-ci", tc.ignore, tc.mode, client, logrus.NewEntry(logrus.New()), newFakePluginConfigAgent(), newFakeProwConfigAgent().Config().Tide.Queries.QueryMap())
 			if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("error doesn't match expected, diff: %s", diff)
 			}

--- a/hack/local-check-gh-automation.sh
+++ b/hack/local-check-gh-automation.sh
@@ -16,13 +16,16 @@ trap "cleanup" EXIT
 
 data="${BASETMPDIR}/data"
 mkdir -p "${data}"
+mkdir -p "${data}/prow"
 
 plugin_dir="${data}/plugins"
 mkdir -p "${plugin_dir}"
-OC extract configmap/plugins --to "${plugin_dir}"
+
 
 os::log::info "Extracting production data we need to run check-gh-automation..."
 OC extract secret/openshift-prow-github-app --keys appid,cert --to "${data}"
+OC extract configmap/plugins --to "${plugin_dir}"
+OC extract configmap/config --to "${data}/prow"
 
 app_id=$(cat "${data}/appid")
 
@@ -30,4 +33,5 @@ os::log::info "Running check-gh-automation"
 go run ./cmd/check-gh-automation --repo="$1" \
   --bot=openshift-merge-robot --bot=openshift-ci-robot \
   --github-app-id="$app_id" --github-app-private-key-path="${data}/cert" \
-  --plugin-config="${data}/plugins/plugins.yaml" --supplemental-plugin-config-dir="${data}/plugins" \
+  --config-path="${data}/prow/config.yaml" --supplemental-prow-config-dir="${data}/prow" \
+  --plugin-config="${data}/plugins/plugins.yaml" --supplemental-plugin-config-dir="${data}/plugins"


### PR DESCRIPTION
This mode allows bots to not be checked, but rather checking only the app installation IFF tide is configured for the repo. This will be used in a new presubmit and periodic to check `openshift-merge-bot`'s installation across our onboarded repos. There will be minimal changes needed for the existing checks. https://github.com/openshift/release/pull/45521 will update existing checks and add new ones.

/hold so I can coordinate the rollout