### PR TITLE
add cluster-profiles-config to validate-checkconfig.sh

### DIFF
--- a/test/validate-checkconfig.sh
+++ b/test/validate-checkconfig.sh
@@ -30,6 +30,7 @@ for org in openshift; do
 
   if ! ci-operator-checkconfig \
     --config-dir ci-operator/config \
+    --cluster-profiles-config core-services/cluster-profiles/_config.yaml \
     --registry "${registry}"
   then
     echo "ERROR: Errors in $org/release"


### PR DESCRIPTION
Fixes the broken [checkconfig](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_ci-tools/3757/pull-ci-openshift-ci-tools-master-checkconfig/1722677415177621504) test.