### PR TITLE
`ci-operator`: only determine the absolute path to `.ci-operator.yaml` when a ref has been defined

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -911,13 +911,16 @@ func runtimeStepConfigsForBuild(
 		if target != nil {
 			istTagRef := &target.InputImage.BaseImage
 			if root.FromRepository {
-				var matchingRefs []prowapi.Refs
-				for _, r := range refs {
-					if ref == "" || ref == fmt.Sprintf("%s.%s", r.Org, r.Repo) {
-						matchingRefs = append(matchingRefs, r)
+				path := "."    // By default, the path will be the working directory
+				if ref != "" { // If we are getting the build root image for a specific ref we must determine the absolute path
+					var matchingRefs []prowapi.Refs
+					for _, r := range refs {
+						if ref == fmt.Sprintf("%s.%s", r.Org, r.Repo) {
+							matchingRefs = append(matchingRefs, r)
+						}
 					}
+					path = decorate.DetermineWorkDir(codeMountPath, matchingRefs)
 				}
-				path := decorate.DetermineWorkDir(codeMountPath, matchingRefs)
 				var err error
 				istTagRef, err = buildRootImageStreamFromRepository(path, readFile)
 				if err != nil {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -186,7 +186,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			}},
 			readFile: func(filename string) ([]byte, error) {
-				if filename != "/home/prow/go/src/github.com/org/repo/.ci-operator.yaml" {
+				if filename != "./.ci-operator.yaml" {
 					return nil, fmt.Errorf("expected '.ci-operator.yaml' as file for the build_root_image, got %s", filename)
 				}
 				return []byte(`build_root_image:
@@ -254,7 +254,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 				},
 			}},
 			readFile: func(filename string) ([]byte, error) {
-				if filename != "/home/prow/go/src/github.com/org/repo/.ci-operator.yaml" {
+				if filename != "./.ci-operator.yaml" {
 					return nil, fmt.Errorf("expected '.ci-operator.yaml' as file for the build_root_image, got %s", filename)
 				}
 				return []byte(`build_root_image:


### PR DESCRIPTION
`cluster-bot` sets the `path_alias` [here](https://github.com/openshift/ci-chat-bot/blob/af9a327dc8ceaef8cf17654894322eb5542159dc/pkg/manager/prow.go#L788), and it doesn't interact well with the standard codeMountPath that is defined. We don't need to generate an absolute path when we are only cloning one ref anyways, so there is no need to run through this logic in those scenarios.