### PR TITLE
handle multiple pullRequests in the `PRPQR` spec

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -6,7 +6,7 @@ go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen object \
     paths=./pkg/api/testimagestreamtagimport/v1 \
     output:dir=./pkg/api/testimagestreamtagimport/v1
 
-go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen object \
+go run ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen crd:crdVersions=v1 object \
     paths=./pkg/api/pullrequestpayloadqualification/v1 \
     output:dir=./pkg/api/pullrequestpayloadqualification/v1
 

--- a/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
+++ b/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.3-0.20210827222652-7b3a8699fa04
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: pullrequestpayloadqualificationruns.ci.openshift.io
 spec:
@@ -117,8 +116,9 @@ spec:
                 - releaseJobSpec
                 type: object
               pullRequest:
-                description: PullRequest specifies the code to be tested. Immutable
-                  and required.
+                description: 'PullRequest specifies the code to be tested. Immutable
+                  and required. Deprecated: use PullRequests instead. TODO(sgoeddel):
+                  this is only here during the transitional period'
                 properties:
                   baseRef:
                     description: BaseRef identifies the target branch for the PR
@@ -156,9 +156,55 @@ spec:
                 - pr
                 - repo
                 type: object
+              pullRequests:
+                description: PullRequests specifies the code to be tested. Immutable
+                  and required.
+                items:
+                  description: PullRequestUnderTest describes the state of the repo
+                    that will be under test This is a combination of the PR revision
+                    and base ref revision. Tested code is the specific revision of
+                    the PR merged into the base branch with a specific branch as a
+                    HEAD
+                  properties:
+                    baseRef:
+                      description: BaseRef identifies the target branch for the PR
+                      type: string
+                    baseSHA:
+                      description: BaseSHA identifies the HEAD of BaseRef at the time
+                      type: string
+                    org:
+                      description: Org is something like "openshift" in github.com/openshift/kubernetes
+                      type: string
+                    pr:
+                      description: PullRequest identifies a pull request in a repository
+                      properties:
+                        author:
+                          type: string
+                        number:
+                          type: integer
+                        sha:
+                          type: string
+                        title:
+                          type: string
+                      required:
+                      - author
+                      - number
+                      - sha
+                      - title
+                      type: object
+                    repo:
+                      description: Repo is something like "kubernetes" in github.com/openshift/kubernetes
+                      type: string
+                  required:
+                  - baseRef
+                  - baseSHA
+                  - org
+                  - pr
+                  - repo
+                  type: object
+                type: array
             required:
             - jobs
-            - pullRequest
             type: object
           status:
             description: PullRequestPayloadTestStatus provides runtime data, such
@@ -170,13 +216,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition
@@ -321,9 +366,3 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/api/pullrequestpayloadqualification/v1/types.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/types.go
@@ -29,7 +29,11 @@ type PullRequestPayloadQualificationRun struct {
 // and the list of individual jobs that should be executed.
 type PullRequestPayloadTestSpec struct {
 	// PullRequest specifies the code to be tested. Immutable and required.
-	PullRequest PullRequestUnderTest `json:"pullRequest"`
+	// Deprecated: use PullRequests instead.
+	//TODO(sgoeddel): this is only here during the transitional period
+	PullRequest PullRequestUnderTest `json:"pullRequest,omitempty"`
+	// PullRequests specifies the code to be tested. Immutable and required.
+	PullRequests []PullRequestUnderTest `json:"pullRequests,omitempty"`
 	// Jobs specifies the jobs to be executed. Immutable.
 	Jobs PullRequestPayloadJobSpec `json:"jobs"`
 }

--- a/pkg/api/pullrequestpayloadqualification/v1/zz_generated.deepcopy.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/zz_generated.deepcopy.go
@@ -140,6 +140,11 @@ func (in *PullRequestPayloadQualificationRunList) DeepCopyObject() runtime.Objec
 func (in *PullRequestPayloadTestSpec) DeepCopyInto(out *PullRequestPayloadTestSpec) {
 	*out = *in
 	out.PullRequest = in.PullRequest
+	if in.PullRequests != nil {
+		in, out := &in.PullRequests, &out.PullRequests
+		*out = make([]PullRequestUnderTest, len(*in))
+		copy(*out, *in)
+	}
 	in.Jobs.DeepCopyInto(&out.Jobs)
 }
 

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -164,7 +166,30 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 		statusByJobName[jobName] = &prpqr.Status.Jobs[i]
 	}
 
-	baseMetadata := metadataFromPullRequestUnderTest(prpqr.Spec.PullRequest)
+	var pullRequests []v1.PullRequestUnderTest
+	if len(prpqr.Spec.PullRequests) > 0 {
+		logger.Debugf("There are %d pullRequests supplied", len(prpqr.Spec.PullRequests))
+		pullRequests = prpqr.Spec.PullRequests
+	} else {
+		//TODO(sgoeddel): this logic will only apply during the transitional period
+		pullRequests = []v1.PullRequestUnderTest{prpqr.Spec.PullRequest}
+	}
+
+	if len(pullRequests) == 0 { //TODO(sgoeddel): this only applies during the transitional period, eventually the pullRequests will be required in the spec and this validation can be removed
+		return errors.New("no pull requests supplied for this PullRequestPayloadQualifiactionRun. must supply either a single pullRequest or an entry in the pullRequests list")
+	}
+
+	//TODO(sgoeddel): phase 3 will support this
+	reposSeen := sets.Set[string]{}
+	for _, pullRequest := range pullRequests {
+		orgRepo := fmt.Sprintf("%s/%s", pullRequest.Org, pullRequest.Repo)
+		if reposSeen.Has(orgRepo) {
+			return fmt.Errorf("multiple pullRequests reference the %s repo. this is not currently supported", orgRepo)
+		}
+		reposSeen.Insert(orgRepo)
+	}
+
+	baseMetadata := metadataFromPullRequestsUnderTest(pullRequests)
 	for _, jobSpec := range prpqr.Spec.Jobs.Jobs {
 		var prowjobsToCreate []*prowv1.ProwJob
 		mimickedJob := jobSpec.JobName(jobconfig.PeriodicPrefix)
@@ -201,7 +226,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			Test: jobSpec.Test,
 		}
 
-		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, inject)
+		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, inject, len(prpqr.Spec.PullRequests) > 1)
 		if err != nil {
 			logger.WithError(err).Error("Failed to resolve the ci-operator configuration")
 			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -216,7 +241,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 
 		if jobSpec.AggregatedCount > 0 {
 			uid := jobNameHash(req.Name + mimickedJob)
-			aggregatedProwjobs, err := generateAggregatedProwjobs(uid, ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &jobSpec, &prpqr.Spec.PullRequest, inject)
+			aggregatedProwjobs, err := generateAggregatedProwjobs(uid, ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &jobSpec, pullRequests, inject)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate the aggregated prowjobs")
 				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -230,7 +255,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			}
 			prowjobsToCreate = append(prowjobsToCreate, aggregatedProwjobs...)
 
-			submitted := generateJobNameToSubmit(baseMetadata, inject, &prpqr.Spec.PullRequest)
+			submitted := generateJobNameToSubmit(inject, pullRequests)
 			aggregatorJob, err := generateAggregatorJob(baseMetadata, uid, mimickedJob, jobSpec.JobName(jobconfig.PeriodicPrefix), req.Name, req.Namespace, r.prowConfigGetter.Config(), time.Now(), submitted)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate an aggregator prowjob")
@@ -251,7 +276,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			prowjobsToCreate = append(prowjobsToCreate, aggregatorJob)
 
 		} else {
-			prowjob, err := generateProwjob(ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, &prpqr.Spec.PullRequest, mimickedJob, inject, nil)
+			prowjob, err := generateProwjob(ciopConfig, r.prowConfigGetter.Config(), baseMetadata, req.Name, req.Namespace, pullRequests, mimickedJob, inject, nil)
 			if err != nil {
 				logger.WithError(err).Error("Failed to generate prowjob")
 				statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -426,8 +451,8 @@ func jobNameHash(name string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
-	ciopConfig, err := rc.ConfigWithTest(baseCiop, inject, false)
+func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error) {
+	ciopConfig, err := rc.ConfigWithTest(baseCiop, inject, multipleSources)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config from resolver: %w", err)
 	}
@@ -441,7 +466,7 @@ type aggregatedOptions struct {
 	releaseJobName  string
 }
 
-func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, pr *v1.PullRequestUnderTest, mimickedJob string, inject *api.MetadataWithTest, aggregatedOptions *aggregatedOptions) (*prowv1.ProwJob, error) {
+func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, prs []v1.PullRequestUnderTest, mimickedJob string, inject *api.MetadataWithTest, aggregatedOptions *aggregatedOptions) (*prowv1.ProwJob, error) {
 	fakeProwgenInfo := &prowgen.ProwgenInfo{Metadata: *baseCiop}
 
 	annotations := map[string]string{
@@ -498,7 +523,7 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		periodic = prowgen.GeneratePeriodicForTest(jobBaseGen, fakeProwgenInfo, prowgen.FromConfigSpec(ciopConfig), func(options *prowgen.GeneratePeriodicOptions) {
 			options.Cron = "@yearly"
 		})
-		periodic.Name = generateJobNameToSubmit(baseCiop, inject, pr)
+		periodic.Name = generateJobNameToSubmit(inject, prs)
 		break
 	}
 	// We did not find the injected test: this is a bug
@@ -506,18 +531,19 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 		return nil, fmt.Errorf("BUG: test '%s' not found in injected config", inject.Test)
 	}
 
-	extraRefs := prowv1.Refs{
-		Org:  baseCiop.Org,
-		Repo: baseCiop.Repo,
-		// TODO(muller): All these commented-out fields need to be propagated via the PRPQR spec
-		// We do not need them now but we should eventually wire them through
-		// RepoLink:  pr.Base.Repo.HTMLURL,
-		BaseRef: pr.BaseRef,
-		BaseSHA: pr.BaseSHA,
-		// BaseLink:  fmt.Sprintf("%s/commit/%s", pr.Base.Repo.HTMLURL, pr.BaseSHA),
-		PathAlias: periodic.ExtraRefs[0].PathAlias,
-		Pulls: []prowv1.Pull{
-			{
+	var refs []prowv1.Refs
+	for _, pr := range prs {
+		refs = append(refs, prowv1.Refs{
+			Org:  pr.Org,
+			Repo: pr.Repo,
+			// TODO(muller): All these commented-out fields need to be propagated via the PRPQR spec
+			// We do not need them now but we should eventually wire them through
+			// RepoLink:  pr.Base.Repo.HTMLURL,
+			BaseRef: pr.BaseRef,
+			BaseSHA: pr.BaseSHA,
+			// BaseLink:  fmt.Sprintf("%s/commit/%s", pr.Base.Repo.HTMLURL, pr.BaseSHA),
+			PathAlias: determinePathAlias(ciopConfig, pr),
+			Pulls: []prowv1.Pull{{
 				Number: pr.PullRequest.Number,
 				Author: pr.PullRequest.Author,
 				SHA:    pr.PullRequest.SHA,
@@ -525,10 +551,10 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 				// Link:       pr.HTMLURL,
 				// AuthorLink: pr.User.HTMLURL,
 				// CommitLink: fmt.Sprintf("%s/pull/%d/commits/%s", pr.Base.Repo.HTMLURL, pr.Number, pr.Head.SHA),
-			},
-		},
+			}},
+		})
 	}
-	periodic.ExtraRefs = []prowv1.Refs{extraRefs}
+	periodic.ExtraRefs = refs
 
 	if err := defaulter.DefaultPeriodic(periodic); err != nil {
 		return nil, fmt.Errorf("failed to default the ProwJob: %w", err)
@@ -540,11 +566,35 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 	return &pj, nil
 }
 
-func metadataFromPullRequestUnderTest(pr v1.PullRequestUnderTest) *api.Metadata {
-	return &api.Metadata{Org: pr.Org, Repo: pr.Repo, Branch: pr.BaseRef}
+func determinePathAlias(ciopConfig *api.ReleaseBuildConfiguration, pr v1.PullRequestUnderTest) string {
+	if ciopConfig.CanonicalGoRepository != nil {
+		return *ciopConfig.CanonicalGoRepository
+	}
+
+	orgRepo := fmt.Sprintf("%s.%s", pr.Org, pr.Repo)
+	for _, cgr := range ciopConfig.CanonicalGoRepositoryList {
+		if cgr.Ref == orgRepo {
+			return cgr.Repository
+		}
+	}
+	return ""
 }
 
-func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, spec *v1.ReleaseJobSpec, pr *v1.PullRequestUnderTest, inject *api.MetadataWithTest) ([]*prowv1.ProwJob, error) {
+func metadataFromPullRequestsUnderTest(prs []v1.PullRequestUnderTest) *api.Metadata {
+	var orgs, repos, branches []string
+	for _, pr := range prs {
+		orgs = append(orgs, pr.Org)
+		repos = append(repos, pr.Repo)
+		branches = append(branches, pr.BaseRef)
+	}
+	return &api.Metadata{
+		Org:    strings.Join(orgs, ","),
+		Repo:   strings.Join(repos, ","),
+		Branch: strings.Join(branches, ","),
+	}
+}
+
+func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfiguration, defaulter periodicDefaulter, baseCiop *api.Metadata, prpqrName, prpqrNamespace string, spec *v1.ReleaseJobSpec, prs []v1.PullRequestUnderTest, inject *api.MetadataWithTest) ([]*prowv1.ProwJob, error) {
 	var ret []*prowv1.ProwJob
 
 	for i := 0; i < spec.AggregatedCount; i++ {
@@ -555,7 +605,7 @@ func generateAggregatedProwjobs(uid string, ciopConfig *api.ReleaseBuildConfigur
 		}
 		jobName := fmt.Sprintf("%s-%d", spec.JobName(jobconfig.PeriodicPrefix), i)
 
-		pj, err := generateProwjob(ciopConfig, defaulter, baseCiop, prpqrName, prpqrNamespace, pr, jobName, inject, opts)
+		pj, err := generateProwjob(ciopConfig, defaulter, baseCiop, prpqrName, prpqrNamespace, prs, jobName, inject, opts)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create prowjob: %w", err)
 		}
@@ -630,10 +680,19 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 	return &pj, nil
 }
 
-func generateJobNameToSubmit(baseCiop *api.Metadata, inject *api.MetadataWithTest, pr *v1.PullRequestUnderTest) string {
+func generateJobNameToSubmit(inject *api.MetadataWithTest, prs []v1.PullRequestUnderTest) string {
+	var refs string
+	for i, pr := range prs {
+		if i > 0 {
+			refs += "-"
+		}
+		refs += fmt.Sprintf("%s-%s-%d", pr.Org, pr.Repo, pr.PullRequest.Number)
+	}
+
 	var variant string
 	if inject.Variant != "" {
 		variant = fmt.Sprintf("-%s", inject.Variant)
 	}
-	return fmt.Sprintf("%s-%s-%d%s-%s", baseCiop.Org, baseCiop.Repo, pr.PullRequest.Number, variant, inject.Test)
+
+	return fmt.Sprintf("%s%s-%s", refs, variant, inject.Test)
 }

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -30,6 +30,7 @@ func TestReconcile(t *testing.T) {
 		prowJobs []ctrlruntimeclient.Object
 		prpqr    []ctrlruntimeclient.Object
 	}{
+		//TODO(sgoeddel): Once the transitional period is over, all of these cases will be updated to use the PullRequests slice rather than the singular PullRequest
 		{
 			name: "basic case",
 			prpqr: []ctrlruntimeclient.Object{
@@ -126,6 +127,24 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 					Status: prowv1.ProwJobStatus{State: "triggered"},
+				},
+			},
+		},
+		{
+			name: "basic case with multiple PRs from different repositories",
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Spec: v1.PullRequestPayloadTestSpec{
+						PullRequests: []v1.PullRequestUnderTest{
+							{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}},
+							{Org: "test-org", Repo: "another-test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: v1.PullRequest{Number: 101, Author: "test", SHA: "123452", Title: "test-pr"}},
+						},
+						Jobs: v1.PullRequestPayloadJobSpec{
+							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
@@ -1,0 +1,93 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-org-another-test-repo-101-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-org-another-test-repo-101-test-name
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.pull: "100"
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: cluster-name-defaulted
+    decoration_config:
+      skip_cloning: true
+    extra_refs:
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 101
+        sha: "123452"
+        title: test-pr
+      repo: another-test-repo
+    job: test-org-test-repo-100-test-org-another-test-repo-101-test-name
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
@@ -1,0 +1,61 @@
+- apiVersion: ci.openshift.io/v1
+  kind: PullRequestPayloadQualificationRun
+  metadata:
+    creationTimestamp: null
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    pullRequest:
+      baseRef: ""
+      baseSHA: ""
+      org: ""
+      pr:
+        author: ""
+        number: 0
+        sha: ""
+        title: ""
+      repo: ""
+    pullRequests:
+    - baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    - baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 101
+        sha: "123452"
+        title: test-pr
+      repo: another-test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -28,8 +28,22 @@ func jobRelease(configSpec *cioperatorapi.ReleaseBuildConfiguration) string {
 	return ""
 }
 
+// If any included buildRoot uses from_repository we must not skip cloning
 func skipCloning(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
-	return configSpec.BuildRootImage == nil || !configSpec.BuildRootImage.FromRepository
+	buildRoots := configSpec.BuildRootImages
+	if buildRoots == nil {
+		buildRoots = make(map[string]cioperatorapi.BuildRootImageConfiguration)
+	}
+	if configSpec.BuildRootImage != nil {
+		buildRoots[""] = *configSpec.BuildRootImage
+	}
+	for _, buildRoot := range buildRoots {
+		if buildRoot.FromRepository {
+			return false
+		}
+	}
+
+	return true
 }
 
 func hasNoBuilds(c *cioperatorapi.ReleaseBuildConfiguration, info *ProwgenInfo) bool {


### PR DESCRIPTION
`ci-operator` has been given the ability to assemble the release payload from multiple refs in: https://github.com/openshift/ci-tools/pull/3749. We can now support multiple pull requests (from different repos) in the PRPQR spec and reconciller. There will be a transitional period of ~6 weeks where the spec accepts both the singular and multiple pullRequest definitions. After that time the singular will be removed, and the code can be simplified.

For: https://issues.redhat.com/browse/DPTP-3685