### PR TITLE
`ci-operator-configresolver`: merge '*' resources when merging configs, and remove limits

### DIFF
--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -335,10 +335,12 @@ func ResolveAndMergeConfigsAndInjectTest(configs Getter, resolver Resolver, reso
 							existingValue, err := resource.ParseQuantity(existing.Requests[resourceType])
 							if err != nil {
 								logger.WithError(err).Warnf("couldn't parse existing '%s' resource quantity", resourceType)
+								return
 							}
 							value, err := resource.ParseQuantity(resources.Requests[resourceType])
 							if err != nil {
 								logger.WithError(err).Warnf("couldn't parse '%s' resource quantity", resourceType)
+								return
 							}
 							if existingValue.Cmp(value) < 0 { // This value is higher than existing
 								mergedConfig.Resources["*"].Requests[resourceType] = resources.Requests[resourceType]

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/test-infra/prow/metrics"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -328,8 +329,29 @@ func ResolveAndMergeConfigsAndInjectTest(configs Getter, resolver Resolver, reso
 				})
 			}
 			for step, resources := range config.Resources {
-				if step == "*" { // * is special, and we will only pull from one config to merge, this is "last in wins" we may need to do better in the future
-					mergedConfig.Resources[step] = resources
+				if step == "*" { // * is special, and the ref should not be appended, it will be merged to use the greatest value instead
+					if existing, ok := mergedConfig.Resources["*"]; ok {
+						replaceIfGreater := func(resourceType string) {
+							existingValue, err := resource.ParseQuantity(existing.Requests[resourceType])
+							if err != nil {
+								logger.WithError(err).Warnf("couldn't parse existing '%s' resource quantity", resourceType)
+							}
+							value, err := resource.ParseQuantity(resources.Requests[resourceType])
+							if err != nil {
+								logger.WithError(err).Warnf("couldn't parse '%s' resource quantity", resourceType)
+							}
+							if existingValue.Cmp(value) < 0 { // This value is higher than existing
+								mergedConfig.Resources["*"].Requests[resourceType] = resources.Requests[resourceType]
+							}
+						}
+						replaceIfGreater("memory")
+						replaceIfGreater("cpu")
+					} else {
+						mergedConfig.Resources["*"] = api.ResourceRequirements{
+							Requests: resources.Requests,
+							// We cannot set Limits for * because other configs may not be able to fall under them
+						}
+					}
 				} else {
 					stepWithRef := fmt.Sprintf("%s-%s", step, ref)
 					mergedConfig.Resources[stepWithRef] = resources

--- a/test/integration/ci-operator-configresolver/configs/master/openshift-console-master.yaml
+++ b/test/integration/ci-operator-configresolver/configs/master/openshift-console-master.yaml
@@ -20,8 +20,8 @@ resources:
     limits:
       memory: 4Gi
     requests:
-      cpu: 100m
-      memory: 200Mi
+      cpu: 110m
+      memory: 300Mi
 tests:
 - as: unit
   commands: go test ./pkg/...

--- a/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-injected.json
+++ b/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-injected.json
@@ -147,11 +147,8 @@
   "resources": {
     "*": {
       "requests": {
-        "cpu": "100m",
-        "memory": "200Mi"
-      },
-      "limits": {
-        "memory": "4Gi"
+        "cpu": "110m",
+        "memory": "300Mi"
       }
     }
   }


### PR DESCRIPTION
The naive way we were handling the '*' entry in the merged resources map was causing issues in certain scenarios. We cannot have `limits` set when merging as this can result in a configuration where the request is lower than the limit. We should also use the higher of the request values in order to always request enough of the resource.