### PR TITLE
qci-appci: ensure to get a valid token

### DIFF
--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -142,7 +142,10 @@ func execute(c *robotTokenMaintainer) {
 }
 
 func (c *robotTokenMaintainer) GetRobotToken() (string, error) {
-	if c.token == "" {
+	if valid, err := c.isValid(); !valid || err != nil {
+		if err != nil {
+			c.logger.WithError(err).Error("Failed to validate the robot's token")
+		}
 		if err := c.renew(); err != nil {
 			return "", fmt.Errorf("failed to renew token: %w", err)
 		}


### PR DESCRIPTION
Before this PR, we check the validity of the token periodically.
There is a chance that a client gets an invalid token between the interval.

Now, we ensure the returned token is always valid by checking it more diligently.

Consulting the quay team https://redhat-internal.slack.com/archives/C7WH69HCY/p1700487847591749 about the token validity.
We might revert this PR if a better solution comes out the discussion.
