### PR TITLE
OCPNODE-1888: Increase timeouts for payload jobs to land k8s 1.29

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -49,9 +49,10 @@ const (
 	conditionAllJobsTriggered = "AllJobsTriggered"
 	conditionWithErrors       = "WithErrors"
 
-	aggregationIDLabel          = "release.openshift.io/aggregation-id"
-	defaultAggregatorJobTimeout = 6 * time.Hour
-	defaultMultiRefJobTimeout   = 6 * time.Hour
+	aggregationIDLabel = "release.openshift.io/aggregation-id"
+	// TODO: Bumping this to 8 hours to hopefully allow more time for the k8s bump.  Will revert once the bump is complete.
+	defaultAggregatorJobTimeout = 8 * time.Hour
+	defaultMultiRefJobTimeout   = 8 * time.Hour
 )
 
 type injectingResolverClient interface {
@@ -533,6 +534,11 @@ func generateProwjob(ciopConfig *api.ReleaseBuildConfiguration, defaulter period
 			options.Cron = "@yearly"
 		})
 		periodic.Name = generateJobNameToSubmit(inject, prs)
+		// TODO: Temporarily bumping the timeout to 6 hours to allow extra time for the Kube rebase.  We'll remove this once the rebase lands...
+		if periodic.DecorationConfig == nil {
+			periodic.DecorationConfig = &prowv1.DecorationConfig{}
+		}
+		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
 		break
 	}
 	// We did not find the injected test: this is a bug

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -21,7 +21,7 @@
     cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
-      timeout: 6h0m0s
+      timeout: 8h0m0s
     job: aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
     pod_spec:
       containers:
@@ -120,6 +120,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"
@@ -205,6 +206,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-overwritten
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -105,8 +105,9 @@ func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute
-	if durationToWait > (5*time.Hour + 15*time.Minute) {
-		durationToWait = 5*time.Hour + 15*time.Minute
+	// TODO: drop back to 5:15, this was temporary due to slow jobs on azure going over 5h timeout
+	if durationToWait > (7*time.Hour + 15*time.Minute) {
+		durationToWait = 7*time.Hour + 15*time.Minute
 	}
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)
 	alog := logrus.WithFields(logrus.Fields{


### PR DESCRIPTION
This reverts commit 642090c9ea047b63cddfac8471618d6cb498efad.

cc: @soltysh 