### PR TITLE
`payload-testing-prow-plugin`: use new `PullRequests` list

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -463,7 +463,7 @@ func (b *prpqrBuilder) build(releaseJobSpecs []prpqv1.ReleaseJobSpec) *prpqv1.Pu
 					Specifier: string(b.spec.jobs),
 				},
 			},
-			PullRequest: prpqv1.PullRequestUnderTest{
+			PullRequests: []prpqv1.PullRequestUnderTest{{
 				Org:     b.org,
 				Repo:    b.repo,
 				BaseRef: b.pr.Base.Ref,
@@ -473,7 +473,7 @@ func (b *prpqrBuilder) build(releaseJobSpecs []prpqv1.ReleaseJobSpec) *prpqv1.Pu
 					Author: b.pr.User.Login,
 					SHA:    b.pr.Head.SHA,
 					Title:  b.pr.Title,
-				},
+				}},
 			},
 		},
 	}

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -358,11 +358,11 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Spec: prpqv1.PullRequestPayloadTestSpec{
-					PullRequest: prpqv1.PullRequestUnderTest{Org: "org",
+					PullRequests: []prpqv1.PullRequestUnderTest{{Org: "org",
 						Repo:        "repo",
 						BaseRef:     "ref",
 						BaseSHA:     "sha",
-						PullRequest: prpqv1.PullRequest{Number: 123, Author: "login", SHA: "head-sha", Title: "title"}},
+						PullRequest: prpqv1.PullRequest{Number: 123, Author: "login", SHA: "head-sha", Title: "title"}}},
 					Jobs: prpqv1.PullRequestPayloadJobSpec{
 						ReleaseControllerConfig: prpqv1.ReleaseControllerConfig{OCP: "4.10", Release: "nightly", Specifier: "ci"},
 						Jobs: []prpqv1.ReleaseJobSpec{
@@ -418,11 +418,11 @@ func TestBuild(t *testing.T) {
 					},
 				},
 				Spec: prpqv1.PullRequestPayloadTestSpec{
-					PullRequest: prpqv1.PullRequestUnderTest{Org: "org",
+					PullRequests: []prpqv1.PullRequestUnderTest{{Org: "org",
 						Repo:        "repo",
 						BaseRef:     "ref",
 						BaseSHA:     "sha",
-						PullRequest: prpqv1.PullRequest{Number: 123, Author: "login", SHA: "head-sha", Title: "title"}},
+						PullRequest: prpqv1.PullRequest{Number: 123, Author: "login", SHA: "head-sha", Title: "title"}}},
 					Jobs: prpqv1.PullRequestPayloadJobSpec{
 						Jobs: []prpqv1.ReleaseJobSpec{
 							{


### PR DESCRIPTION
Update the plugin to use the new list to provide the singular PR in the spec. Eventually, it will be possible to supply additional PRs here, but for now we will simply use the new list to make it easier to remove the, now deprecated, `PullRequest` singular field.