### PR TITLE
`ci-operator`: add labels for specific ref to the build when provided

### DIFF
--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -76,6 +76,7 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 		s.resources,
 		s.pullSecret,
 		nil,
+		"",
 	)
 	return handleBuilds(ctx, s.client, s.podClient, *build)
 }

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -57,7 +57,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 				URI: cloneURI,
 				Ref: refs.BaseRef,
 			},
-		}, "", s.config.DockerfilePath, s.resources, s.pullSecret, nil))
+		}, "", s.config.DockerfilePath, s.resources, s.pullSecret, nil, s.config.Ref))
 	}
 
 	return fmt.Errorf("nothing to build source image from, no refs")

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -120,6 +120,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 		s.resources,
 		s.pullSecret,
 		nil,
+		"",
 	)
 	err = handleBuilds(ctx, s.client, s.podClient, *build)
 	if err != nil && strings.Contains(err.Error(), "error checking provided apis") {

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -57,6 +57,7 @@ func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 		s.resources,
 		s.pullSecret,
 		nil,
+		s.config.Ref,
 	))
 }
 

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -213,7 +213,7 @@ func GenerateBasePod(
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
 			Name:      name,
-			Labels:    labelsFor(jobSpec, baseLabels),
+			Labels:    labelsFor(jobSpec, baseLabels, ""),
 			Annotations: map[string]string{
 				JobSpecAnnotation:                     jobSpec.RawSpec(),
 				annotationContainersForSubTestResults: containerName,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -62,6 +62,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.resources,
 		s.pullSecret,
 		s.config.BuildArgs,
+		s.config.Ref,
 	)
 	return handleBuilds(ctx, s.client, s.podClient, *build)
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -61,6 +61,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 		s.resources,
 		s.pullSecret,
 		nil,
+		"",
 	))
 }
 

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -60,7 +60,7 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 		return fmt.Errorf("could not find source ImageStreamTag for RPM repo deployment: %w", err)
 	}
 
-	labelSet := labelsFor(s.jobSpec, map[string]string{AppLabel: RPMRepoName, TTLIgnoreLabel: "true"})
+	labelSet := labelsFor(s.jobSpec, map[string]string{AppLabel: RPMRepoName, TTLIgnoreLabel: "true"}, s.config.Ref)
 	selectorSet := map[string]string{
 		AppLabel: RPMRepoName,
 	}

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_specified.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_specified.yaml
@@ -1,0 +1,52 @@
+metadata:
+  annotations:
+    ci.openshift.io/job-spec: ""
+  creationTimestamp: null
+  labels:
+    OPENSHIFT_CI: "true"
+    ci.openshift.io/metadata.branch: master
+    ci.openshift.io/metadata.org: org
+    ci.openshift.io/metadata.repo: other-repo
+    ci.openshift.io/metadata.target: ""
+    ci.openshift.io/metadata.variant: ""
+    created-by-ci: "true"
+    creates: ""
+  namespace: test-namespace
+spec:
+  nodeSelector: null
+  output:
+    imageLabels:
+    - name: io.openshift.build.commit.author
+    - name: io.openshift.build.commit.date
+    - name: io.openshift.build.commit.id
+    - name: io.openshift.build.commit.message
+    - name: io.openshift.build.commit.ref
+    - name: io.openshift.build.name
+    - name: io.openshift.build.namespace
+    - name: io.openshift.build.source-context-dir
+    - name: io.openshift.build.source-location
+    - name: vcs-ref
+    - name: vcs-type
+    - name: vcs-url
+    to:
+      kind: ImageStreamTag
+      name: 'pipeline:'
+      namespace: test-namespace
+  postCommit: {}
+  resources: {}
+  source: {}
+  strategy:
+    dockerStrategy:
+      buildArgs:
+      - name: TAGS
+        value: release
+      env:
+      - name: BUILD_LOGLEVEL
+        value: "0"
+      forcePull: true
+      imageOptimizationPolicy: SkipLayers
+      noCache: true
+    type: Docker
+status:
+  output: {}
+  phase: ""


### PR DESCRIPTION
The generated `build` should contain the proper labels for: `org`, `repo`, and `branch` when a `ref` is defined. Not having this doesn't cause anything to break, but it doesn't allow `pod-scaler` to properly determine the resource requests, and it adds to confusion when viewing the `build` itself on the cluster.

For: https://issues.redhat.com/browse/DPTP-3519