### PR TITLE
`payload-testing-ui`: properly display pull requests list

### DIFF
--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -87,6 +87,7 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
 
 {{ with .Spec }}
 
+{{ if .PullRequest.Org }}
 <h2>Pull request</h2>
 
 {{ with .PullRequest }}
@@ -99,6 +100,23 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
 	</li>
 </ul>
 {{ end }}{{/* with .PullRequest */}}
+{{ else }}
+<h2>Pull requests</h2>
+<ul>
+  {{ range $i, $pullRequest := .PullRequests }}
+	{{ prLink . }} by {{ authorLink .PullRequest.Author }}
+	<li>
+      <ul>
+		<li>Repository: {{ repoLink .Org .Repo }}</li>
+		<li>SHA: <tt>{{ shaLink . .PullRequest.SHA }}</tt></li>
+		<li>
+			Base: <tt>{{ refLink . .BaseRef }}</tt> (<tt>{{ shaLink . .BaseSHA }}</tt>)
+		</li>
+	  </ul>
+    </li>
+  {{ end }}
+</ul>
+{{ end }}{{/* if .PullRequest.Org */}}
 
 {{ with .Jobs }}
 

--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -105,7 +105,7 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
 <ul>
   {{ range $i, $pullRequest := .PullRequests }}
 	{{ prLink . }} by {{ authorLink .PullRequest.Author }}
-	<li>
+	<li style="list-style:none; padding:">
       <ul>
 		<li>Repository: {{ repoLink .Org .Repo }}</li>
 		<li>SHA: <tt>{{ shaLink . .PullRequest.SHA }}</tt></li>


### PR DESCRIPTION
This allows the `payload-testing-ui` to display both the singular and multiple pullRequests. This will only apply in the ~6 week period that both of these options are present. Eventually, we will only display the list.

The result looks like the the following screenshot:

![Screenshot 2023-11-20 at 3 50 46 PM](https://github.com/openshift/ci-tools/assets/1794300/2dc9d698-7f0f-4df2-b4c2-c5658ea44eb3)

