### PR TITLE
qci-appci: get token with the scope param

### DIFF
--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -198,7 +198,7 @@ func (c *robotTokenMaintainer) renew() (ret error) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.logger.Info("Renewing token ...")
-	req, err := http.NewRequest("GET", "https://quay.io/v2/auth?service=quay.io", nil)
+	req, err := http.NewRequest("GET", "https://quay.io/v2/auth?service=quay.io&scope=repository:openshift/ci:pull", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create http request: %w", err)
 	}


### PR DESCRIPTION
When the repo is private, we need the scope when applying for the token.

/cc @openshift/test-platform 