### PR TITLE
increase default timeout for multi-pr payload tests

### DIFF
--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_multiple_PRs_from_different_repositories.yaml
@@ -25,6 +25,7 @@
     cluster: cluster-name-defaulted
     decoration_config:
       skip_cloning: true
+      timeout: 6h0m0s
     extra_refs:
     - base_ref: test-branch
       base_sha: "123456"


### PR DESCRIPTION
I have noticed a few instances in my testing where 4 hours isn't enough to build from multiple sources **and** complete the tests and post steps prior to hitting the timeout. We can increase it to 6 hours for these as a first try, I think it should be enough.