### PR TITLE
merge ci-operator configs for all payload tests

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -220,6 +220,7 @@ func main() {
 	// add handler func for incorrect paths as well; can help with identifying errors/404s caused by incorrect paths
 	http.HandleFunc("/", handler(http.HandlerFunc(http.NotFound)).ServeHTTP)
 	http.HandleFunc("/config", handler(registryserver.ResolveConfig(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
+	//TODO(sgoeddel): this is deprecated, mergeConfigsWithInjectedTest should be used instead
 	http.HandleFunc("/configWithInjectedTest", handler(registryserver.ResolveConfigWithInjectedTest(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/mergeConfigsWithInjectedTest", handler(registryserver.ResolveAndMergeConfigsAndInjectTest(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/resolve", handler(registryserver.ResolveLiteralConfig(registryAgent, configresolverMetrics)).ServeHTTP)

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -552,7 +552,7 @@ func (o *options) Complete() error {
 		if o.unresolvedConfigPath != "" || o.configSpecPath != "" {
 			return errors.New("cannot request injecting test into locally provided config")
 		}
-		config, err = o.resolverClient.ConfigWithTest(info, injectTest, len(jobSpec.ExtraRefs) > 1)
+		config, err = o.resolverClient.ConfigWithTest(info, injectTest)
 	} else {
 		config, err = o.loadConfig(info)
 	}
@@ -881,10 +881,11 @@ func (o *options) Run() []error {
 		return []error{fmt.Errorf("could not resolve the node architectures: %w", err)}
 	}
 
+	mergedConfig := o.injectTest != "" || len(o.jobSpec.ExtraRefs) > 1
 	// load the graph from the configuration
 	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig,
 		o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig,
-		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS)
+		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, mergedConfig)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -55,7 +55,7 @@ const (
 )
 
 type injectingResolverClient interface {
-	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error)
+	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error)
 }
 
 type prowConfigGetter interface {
@@ -227,7 +227,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 			Test: jobSpec.Test,
 		}
 
-		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, inject, len(prpqr.Spec.PullRequests) > 1)
+		ciopConfig, err := resolveCiopConfig(r.configResolverClient, baseMetadata, inject)
 		if err != nil {
 			logger.WithError(err).Error("Failed to resolve the ci-operator configuration")
 			statuses[mimickedJob] = &v1.PullRequestPayloadJobStatus{
@@ -452,8 +452,8 @@ func jobNameHash(name string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error) {
-	ciopConfig, err := rc.ConfigWithTest(baseCiop, inject, multipleSources)
+func resolveCiopConfig(rc injectingResolverClient, baseCiop *api.Metadata, inject *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
+	ciopConfig, err := rc.ConfigWithTest(baseCiop, inject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get config from resolver: %w", err)
 	}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -288,7 +288,7 @@ func pruneProwjobsForTests(t *testing.T, items []prowv1.ProwJob) {
 
 type fakeResolverClient struct{}
 
-func (f *fakeResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error) {
+func (f *fakeResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
 	return &api.ReleaseBuildConfiguration{
 		Metadata: *base,
 		Tests: []api.TestStepConfiguration{

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -60,6 +60,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 		output          []api.StepConfiguration
 		readFile        readFile
 		resolver        resolveRoot
+		mergedConfig    bool
 		expectedError   error
 		expectedImports []testimagestreamtagimportv1.TestImageStreamTagImport
 	}{
@@ -965,7 +966,8 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 			},
-			resolver: noopResolver,
+			resolver:     noopResolver,
+			mergedConfig: true,
 			output: []api.StepConfiguration{
 				{
 					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
@@ -1063,7 +1065,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			client := fakectrlruntimeclient.NewClientBuilder().Build()
 			graphConf := FromConfigStatic(testCase.input)
-			runtimeSteps, actualError := runtimeStepConfigsForBuild(context.Background(), client, testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages(), time.Nanosecond, testCase.consoleHost)
+			runtimeSteps, actualError := runtimeStepConfigsForBuild(context.Background(), client, testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages(), time.Nanosecond, testCase.consoleHost, testCase.mergedConfig)
 			graphConf.Steps = append(graphConf.Steps, runtimeSteps...)
 			if diff := cmp.Diff(testCase.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("actualError does not match expectedError, diff: %s", diff)
@@ -1221,6 +1223,7 @@ func TestFromConfig(t *testing.T) {
 		templates      []*templateapi.Template
 		env            api.Parameters
 		params         map[string]string
+		mergedConfig   bool
 		expectedSteps  []string
 		expectedPost   []string
 		expectedParams map[string]string
@@ -1320,6 +1323,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
+		mergedConfig:  true,
 		expectedSteps: []string{"root-org.repo1", "root-org.repo2", "[output-images]", "[images]"},
 	}, {
 		name: "base RPM images",
@@ -1361,6 +1365,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
+		mergedConfig: true,
 		expectedSteps: []string{
 			"[input:base_rpm_image-org.repo1-without-rpms]",
 			"base_rpm_image-org.repo1",
@@ -1401,6 +1406,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
+		mergedConfig: true,
 		expectedSteps: []string{
 			"rpms-org.repo1",
 			"[serve:rpms-org.repo1]",
@@ -1693,7 +1699,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "", nil)
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "", nil, tc.mergedConfig)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/registry/server/client.go
+++ b/pkg/registry/server/client.go
@@ -19,7 +19,7 @@ import (
 
 type ResolverClient interface {
 	Config(*api.Metadata) (*api.ReleaseBuildConfiguration, error)
-	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error)
+	ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error)
 	Resolve([]byte) (*api.ReleaseBuildConfiguration, error)
 }
 
@@ -48,12 +48,9 @@ func (r *resolverClient) Config(info *api.Metadata) (*api.ReleaseBuildConfigurat
 	return configFromResolverRequest(req)
 }
 
-func (r *resolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest, multipleSources bool) (*api.ReleaseBuildConfiguration, error) {
+func (r *resolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
 	logrus.Infof("Loading configuration from %s for %s", r.Address, base.AsString())
-	endpoint := fmt.Sprintf("%s/configWithInjectedTest", r.Address)
-	if multipleSources {
-		endpoint = fmt.Sprintf("%s/mergeConfigsWithInjectedTest", r.Address)
-	}
+	endpoint := fmt.Sprintf("%s/mergeConfigsWithInjectedTest", r.Address)
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for configresolver: %w", err)

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -127,6 +127,8 @@ func getInjectTestFromQuery(w http.ResponseWriter, r *http.Request) (*api.Metada
 	return &ret, nil
 }
 
+// Deprecated, use ResolveAndMergeConfigsAndInjectTest instead
+// TODO(sgoeddel): this should be removed in the future once it is confirmed that it is no longer used
 func ResolveConfigWithInjectedTest(configs Getter, resolver Resolver, resolverMetrics *metrics.Metrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {


### PR DESCRIPTION
This solves issues where multiple images share the same name as the endpoint to merge configs appends a suffix to each of them. With this change we will be able to run payload tests with `hypershift` and in the `installer` repo, which currently fail during graph resolution due to duplicate image names.

For: https://issues.redhat.com/browse/DPTP-3751