### PR TITLE
`multi-arch-builder-controller`: Improve logs and add deep copy

### DIFF
--- a/pkg/api/multiarchbuildconfig/v1/types.go
+++ b/pkg/api/multiarchbuildconfig/v1/types.go
@@ -64,16 +64,17 @@ const (
 
 func UpdateMultiArchBuildConfig(ctx context.Context, logger *logrus.Entry, client ctrlruntimeclient.Client, namespacedName types.NamespacedName, mutateFn func(mabcToMutate *MultiArchBuildConfig)) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		multiArchBuildConfig := &MultiArchBuildConfig{}
-		if err := client.Get(ctx, namespacedName, multiArchBuildConfig); err != nil {
+		mabc := &MultiArchBuildConfig{}
+		if err := client.Get(ctx, namespacedName, mabc); err != nil {
 			return fmt.Errorf("failed to get the MultiArchBuildConfig: %w", err)
 		}
 
-		mutateFn(multiArchBuildConfig)
+		mabc = mabc.DeepCopy()
+		mutateFn(mabc)
 
 		logger.WithField("namespace", namespacedName.Namespace).WithField("name", namespacedName.Name).Info("Updating MultiArchBuildConfig...")
-		if err := client.Update(ctx, multiArchBuildConfig); err != nil {
-			return fmt.Errorf("failed to update MultiArchBuildConfig %s: %w", multiArchBuildConfig.Name, err)
+		if err := client.Update(ctx, mabc); err != nil {
+			return fmt.Errorf("failed to update MultiArchBuildConfig %s: %w", mabc.Name, err)
 		}
 		return nil
 	})

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
@@ -109,6 +109,8 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 		return fmt.Errorf("failed to get the MultiArchBuildConfig: %w", err)
 	}
 
+	mabc = mabc.DeepCopy()
+
 	// Deletion is being processed, do nothing
 	if mabc.ObjectMeta.DeletionTimestamp != nil {
 		return nil

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
@@ -146,6 +146,7 @@ func (r *reconciler) handleMultiArchBuildConfig(ctx context.Context, mabc *v1.Mu
 	}
 
 	if !checkAllBuildsFinished(builds) {
+		r.logger.Info("Waiting for the builds to finish")
 		return nil
 	}
 
@@ -201,7 +202,7 @@ func (r *reconciler) createBuilds(ctx context.Context, mabc *v1.MultiArchBuildCo
 
 		r.logger.WithField("build_namespace", build.Namespace).WithField("build_name", build.Name).Info("Creating build")
 		if err := r.client.Create(ctx, build); err != nil {
-			return fmt.Errorf("coudldn't create build %s/%s: %w", build.Namespace, build.Name, err)
+			return fmt.Errorf("couldn't create build %s/%s: %w", build.Namespace, build.Name, err)
 		}
 	}
 	return nil
@@ -268,6 +269,7 @@ func (r *reconciler) handleMirrorImage(ctx context.Context, targetImageRef strin
 		}
 	}
 
+	r.logger.WithField("registries", strings.Join(mabc.Spec.ExternalRegistries, ",")).Info("Mirroring image")
 	if err := v1.UpdateMultiArchBuildConfig(ctx, r.logger, r.client, ctrlruntimeclient.ObjectKey{Namespace: mabc.Namespace, Name: mabc.Name}, mutateFn); err != nil {
 		return fmt.Errorf("failed to update the MultiArchBuildConfig %s/%s: %w", mabc.Namespace, mabc.Name, err)
 	}

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 			manifestPusher: &mockManifestPusher{},
 		},
 		{
-			name:              "Fails it isn't able to spawn builds",
+			name:              "Fails if it isn't able to spawn builds",
 			builds:            &buildv1.BuildList{},
 			failOnBuildCreate: true,
 			inputMabc: &v1.MultiArchBuildConfig{
@@ -561,7 +561,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: v1.MultiArchBuildConfigStatus{State: v1.FailureState},
 			},
-			expectedErr: errors.New("couldn't create builds for architectures: amd64,arm64: coudldn't create build test-ns/test-mabc-amd64: planned failure"),
+			expectedErr: errors.New("couldn't create builds for architectures: amd64,arm64: couldn't create build test-ns/test-mabc-amd64: planned failure"),
 		},
 	}
 


### PR DESCRIPTION
Add some logs for clarity and perform a deep copy every type a `mabc` is retrieved.
Objects are pulled by the client from a shared internal cache, the controllers documentation [here](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/controllers.md#:~:text=Never%20mutate%20original%20objects!) states that we are supposed to modify those only after a deep copy. 

/cc @droslean 
/label tide/merge-method-squash