### PR TITLE
`manifest-pusher`: fix push args

### DIFF
--- a/pkg/manifestpusher/manifestpusher.go
+++ b/pkg/manifestpusher/manifestpusher.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -35,13 +36,13 @@ type manifestPusher struct {
 	dockercfgPath string
 }
 
-// pushOutputImageWithManifest constructs a manifest-tool command to create and push a new image with all images that we built
+// PushImageWithManifest constructs a manifest-tool command to create and push a new image with all images that we built
 // in the manifest list based on their architecture.
 //
 // Example command:
 // /usr/bin/manifest-tool push from-args \
-// --platforms linux/amd64 --template registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-amd64 \
-// --platforms linux/arm64 --template registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-arm64 \
+// --platforms linux/amd64,linux/arm64 \
+// --template registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-ARCH \
 // --target registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest
 func (m manifestPusher) PushImageWithManifest(builds []buildv1.Build, targetImageRef string) error {
 	return wait.ExponentialBackoff(wait.Backoff{
@@ -50,27 +51,7 @@ func (m manifestPusher) PushImageWithManifest(builds []buildv1.Build, targetImag
 		Factor:   2.0,
 		Jitter:   0.1,
 	}, func() (bool, error) {
-		args := []string{
-			"--debug",
-			"--insecure",
-			"--docker-cfg", m.dockercfgPath,
-			"push", "from-args",
-		}
-		for i := range builds {
-			build := &builds[i]
-			args = append(args, []string{
-				"--platforms",
-				fmt.Sprintf("linux/%s", build.Spec.NodeSelector[nodeArchitectureLabel]),
-				"--template",
-				fmt.Sprintf("%s/%s/%s", m.registryURL, build.Spec.Output.To.Namespace, build.Spec.Output.To.Name),
-			}...)
-		}
-
-		args = append(args, []string{
-			"--target",
-			fmt.Sprintf("%s/%s", m.registryURL, targetImageRef),
-		}...)
-
+		args := m.args(builds, targetImageRef)
 		cmd := exec.Command("manifest-tool", args...)
 
 		cmdOutput := &bytes.Buffer{}
@@ -89,4 +70,27 @@ func (m manifestPusher) PushImageWithManifest(builds []buildv1.Build, targetImag
 		m.logger.Infof("Image %s created", targetImageRef)
 		return true, nil
 	})
+}
+
+func (m manifestPusher) args(builds []buildv1.Build, targetImageRef string) []string {
+	var template string
+	platforms := make([]string, 0, len(builds))
+	args := []string{
+		"--debug",
+		"--insecure",
+		"--docker-cfg", m.dockercfgPath,
+		"push", "from-args",
+	}
+
+	for i := range builds {
+		build := &builds[i]
+		arch := build.Spec.NodeSelector[nodeArchitectureLabel]
+		platforms = append(platforms, fmt.Sprintf("linux/%s", arch))
+		nameWithPlaceholder := strings.Replace(build.Spec.Output.To.Name, arch, "ARCH", 1)
+		template = fmt.Sprintf("%s/%s/%s", m.registryURL, build.Spec.Output.To.Namespace, nameWithPlaceholder)
+	}
+
+	args = append(args, "--platforms", strings.Join(platforms, ","))
+	args = append(args, "--template", template)
+	return append(args, "--target", fmt.Sprintf("%s/%s", m.registryURL, targetImageRef))
 }

--- a/pkg/manifestpusher/manifestpusher_test.go
+++ b/pkg/manifestpusher/manifestpusher_test.go
@@ -1,0 +1,85 @@
+package manifestpusher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus/hooks/test"
+
+	corev1 "k8s.io/api/core/v1"
+
+	buildv1 "github.com/openshift/api/build/v1"
+)
+
+func TestArgs(t *testing.T) {
+	for _, testCase := range []struct {
+		name           string
+		builds         []buildv1.Build
+		targetImageRef string
+		dockercfgPath  string
+		registryUrl    string
+		wantArgs       []string
+	}{
+		{
+			name: "Bundle amd64 and arm64 images into a manifest list",
+			builds: []buildv1.Build{
+				{
+					Spec: buildv1.BuildSpec{
+						CommonSpec: buildv1.CommonSpec{
+							NodeSelector: buildv1.OptionalNodeSelector{
+								nodeArchitectureLabel: "amd64",
+							},
+							Output: buildv1.BuildOutput{
+								To: &corev1.ObjectReference{
+									Name:      "managed-clonerefs:latest-amd64",
+									Namespace: "ci",
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: buildv1.BuildSpec{
+						CommonSpec: buildv1.CommonSpec{
+							NodeSelector: buildv1.OptionalNodeSelector{
+								nodeArchitectureLabel: "arm64",
+							},
+							Output: buildv1.BuildOutput{
+								To: &corev1.ObjectReference{
+									Name:      "managed-clonerefs:latest-arm64",
+									Namespace: "ci",
+								},
+							},
+						},
+					},
+				},
+			},
+			targetImageRef: "ci/managed-clonerefs:latest",
+			dockercfgPath:  ".dockercfgjson",
+			registryUrl:    "foo-registry.com",
+			wantArgs: []string{
+				"--debug", "--insecure",
+				"--docker-cfg", ".dockercfgjson",
+				"push", "from-args",
+				"--platforms", "linux/amd64,linux/arm64",
+				"--template", "foo-registry.com/ci/managed-clonerefs:latest-ARCH",
+				"--target", "foo-registry.com/ci/managed-clonerefs:latest",
+			},
+		},
+	} {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			m := manifestPusher{
+				logger:        logger.WithContext(context.TODO()),
+				dockercfgPath: testCase.dockercfgPath,
+				registryURL:   testCase.registryUrl,
+			}
+			args := m.args(testCase.builds, testCase.targetImageRef)
+			if diff := cmp.Diff(testCase.wantArgs, args); diff != "" {
+				t.Fatalf("args differs: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `manifest-tools` gets invoked with the wrong arguments so it ends up bundling a manifest-list in which every manifest refers to the same image, regardless of the architecture (notice the same `.manifests[].digest` value):
```bash
skopeo inspect --raw 'docker://registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest' | jq
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1240,
      "digest": "sha256:d67dc219cd8ea0e51c5f9e855b8d4963a693e996141b9a5e401a8eaf4c327e5d",
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 1240,
      "digest": "sha256:d67dc219cd8ea0e51c5f9e855b8d4963a693e996141b9a5e401a8eaf4c327e5d",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```

The previous image has been created by:
```bash
manifest-tool \
  --debug \
  --insecure \
  --docker-cfg="/.docker/config.json" \
  push from-args \
  --platforms="linux/arm64" \
  --template="registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-arm64" \
  --platforms="linux/amd64" \
  --template="registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-amd64" \
  --target="registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest"
```

`--template` is not treated as a slice and it cannot be passed multiple times, so the last value wins (check [here](https://github.com/estesp/manifest-tool/blob/d6688c1fe2a6bec6c48deabb000b26d0b9b364ff/v2/cmd/manifest-tool/push.go#L98C9-L98C9)).

The proper way to run `manifest-tool` should be:
```bash
manifest-tool \
  --debug \
  --insecure \
  --docker-cfg="/.docker/config.json" \
  push from-args \
  --platforms="linux/amd64,linux/arm64" \
  --template="registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest-ARCH" \
  --target="registry.multi-build01.arm-build.devcluster.openshift.com/ci/managed-clonerefs:latest"
```

/cc @droslean 