### PR TITLE
`rehearsals`: Add image mirroring to quay

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -26,6 +26,7 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 
+	quayiociimagesdistributor "github.com/openshift/ci-tools/pkg/controller/quay_io_ci_images_distributor"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 )
 
@@ -53,6 +54,7 @@ type options struct {
 	stickyLabelAuthors prowflagutil.Strings
 
 	webhookSecretFile        string
+	registryConfig           string
 	githubEventServerOptions githubeventserver.Options
 	github                   prowflagutil.GitHubOptions
 	config                   configflagutil.ConfigOptions
@@ -80,6 +82,7 @@ func gatherOptions() (options, error) {
 
 	fs.Var(&o.stickyLabelAuthors, "sticky-label-author", "PR Author for which the 'rehearsals-ack' label will not be removed upon a new push. Can be passed multiple times.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
+	fs.StringVar(&o.registryConfig, "registry-config", "", "Path to the file of registry credentials")
 
 	fs.StringVar(&o.gcsBucket, "gcs-bucket", "test-platform-results", "GCS Bucket to upload affected jobs list")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "/etc/gcs/service-account.json", "GCS Credentials file to upload affected jobs list")
@@ -187,7 +190,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 			return fmt.Errorf("%s: %w", "ERROR: pj-rehearse: failed to validate rehearsal jobs", err)
 		}
 
-		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, presubmitsToRehearse, changedTemplates, changedClusterProfiles, logger)
+		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, quayiociimagesdistributor.OCImageMirrorOptions{}, nil, presubmitsToRehearse, changedTemplates, changedClusterProfiles, logger)
 		return err
 	}
 

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	prowConfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
-	"k8s.io/test-infra/prow/flagutil"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	configflagutil "k8s.io/test-infra/prow/flagutil/config"
 	"k8s.io/test-infra/prow/github"
@@ -35,7 +34,7 @@ type options struct {
 	instrumentationOptions prowflagutil.InstrumentationOptions
 
 	prowjobKubeconfig string
-	kubernetesOptions flagutil.KubernetesOptions
+	kubernetesOptions prowflagutil.KubernetesOptions
 	noTemplates       bool
 	noRegistry        bool
 	noClusterProfiles bool
@@ -51,7 +50,7 @@ type options struct {
 	dryRun        bool
 	dryRunOptions dryRunOptions
 
-	stickyLabelAuthors flagutil.Strings
+	stickyLabelAuthors prowflagutil.Strings
 
 	webhookSecretFile        string
 	githubEventServerOptions githubeventserver.Options
@@ -60,7 +59,7 @@ type options struct {
 }
 
 func gatherOptions() (options, error) {
-	o := options{kubernetesOptions: flagutil.KubernetesOptions{NOInClusterConfigDefault: true}}
+	o := options{kubernetesOptions: prowflagutil.KubernetesOptions{NOInClusterConfigDefault: true}}
 	fs := flag.CommandLine
 
 	fs.StringVar(&o.logLevel, "log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))

--- a/images/pj-rehearse/Dockerfile
+++ b/images/pj-rehearse/Dockerfile
@@ -3,4 +3,5 @@ LABEL maintainer="nmoraiti@redhat.com"
 
 RUN yum install -y git && yum clean all
 ADD pj-rehearse /usr/bin/pj-rehearse
+ADD /usr/bin/oc /usr/bin/oc
 ENTRYPOINT ["/usr/bin/pj-rehearse"]

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -1389,9 +1389,9 @@ func (tc *tc) List(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts .
 	return nil
 }
 
-func threetimesTryingPoller(_, _ time.Duration, cf wait.ConditionFunc) error {
+func threetimesTryingPoller(ctx context.Context, _, _ time.Duration, immediate bool, cf wait.ConditionWithContextFunc) error {
 	for i := 0; i < 3; i++ {
-		success, err := cf()
+		success, err := cf(ctx)
 		if err != nil {
 			return err
 		}
@@ -1399,7 +1399,7 @@ func threetimesTryingPoller(_, _ time.Duration, cf wait.ConditionFunc) error {
 			return nil
 		}
 	}
-	return wait.ErrWaitTimeout
+	return wait.ErrorInterrupted(fmt.Errorf("polling failed"))
 }
 
 func TestUsesConfigMap(t *testing.T) {

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	pjapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
@@ -101,8 +100,8 @@ func RehearsalCandidateFromPullRequest(pullRequest *github.PullRequest, baseSHA 
 	}
 }
 
-func (rc RehearsalCandidate) createRefs() *pjapi.Refs {
-	return &pjapi.Refs{
+func (rc RehearsalCandidate) createRefs() *prowapi.Refs {
+	return &prowapi.Refs{
 		Org:     rc.org,
 		Repo:    rc.repo,
 		BaseRef: rc.base.ref,
@@ -192,7 +191,7 @@ func (r RehearsalConfig) DetermineAffectedJobs(candidate RehearsalCandidate, can
 	return filterPresubmits(presubmits, logger), filterPeriodics(periodics, logger), changedTemplates, changedClusterProfiles, nil
 }
 
-func (r RehearsalConfig) SetupJobs(candidate RehearsalCandidate, candidatePath string, presubmits config.Presubmits, periodics config.Periodics, rehearsalTemplates, rehearsalClusterProfiles *ConfigMaps, limit int, logger *logrus.Entry) (*config.ReleaseRepoConfig, *pjapi.Refs, apihelper.ImageStreamTagMap, []*prowconfig.Presubmit, error) {
+func (r RehearsalConfig) SetupJobs(candidate RehearsalCandidate, candidatePath string, presubmits config.Presubmits, periodics config.Periodics, rehearsalTemplates, rehearsalClusterProfiles *ConfigMaps, limit int, logger *logrus.Entry) (*config.ReleaseRepoConfig, *prowapi.Refs, apihelper.ImageStreamTagMap, []*prowconfig.Presubmit, error) {
 	resolver, err := r.createResolver(candidatePath)
 	if err != nil {
 		return nil, nil, nil, nil, err
@@ -270,7 +269,7 @@ func (r RehearsalConfig) AbortAllRehearsalJobs(org, repo string, number int, log
 	}
 
 	selector := labelSelectorForRehearsalJobs(org, repo, number)
-	jobs := &pjapi.ProwJobList{}
+	jobs := &prowapi.ProwJobList{}
 	err = pjclient.List(context.TODO(), jobs, selector, ctrlruntimeclient.InNamespace(r.ProwjobNamespace))
 	if err != nil {
 		logger.WithError(err).Error("failed to list prowjobs for pr")
@@ -308,7 +307,7 @@ func labelSelectorForRehearsalJobs(org, repo string, prNumber int) ctrlruntimecl
 }
 
 // RehearseJobs returns true if the jobs were triggered and succeed
-func (r RehearsalConfig) RehearseJobs(candidate RehearsalCandidate, candidatePath string, prRefs *pjapi.Refs, imageStreamTags apihelper.ImageStreamTagMap, presubmitsToRehearse []*prowconfig.Presubmit, rehearsalTemplates, rehearsalClusterProfiles *ConfigMaps, logger *logrus.Entry) (bool, error) {
+func (r RehearsalConfig) RehearseJobs(candidate RehearsalCandidate, candidatePath string, prRefs *prowapi.Refs, imageStreamTags apihelper.ImageStreamTagMap, presubmitsToRehearse []*prowconfig.Presubmit, rehearsalTemplates, rehearsalClusterProfiles *ConfigMaps, logger *logrus.Entry) (bool, error) {
 	buildClusterConfigs, prowJobConfig := r.getBuildClusterAndProwJobConfigs(logger)
 	pjclient, err := NewProwJobClient(prowJobConfig, r.DryRun)
 	if err != nil {

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -618,7 +618,7 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 			if err := istImportClient.Create(ctx, istImport); err != nil && !apierrors.IsAlreadyExists(err) {
 				return fmt.Errorf("failed to create imagestreamtag %s: %w", requiredImageStreamTag, err)
 			}
-			if err := wait.Poll(5*second, 60*second, func() (bool, error) {
+			if err := wait.PollUntilContextTimeout(ctx, 5*second, 60*second, false, func(ctx context.Context) (bool, error) {
 				if err := client.Get(ctx, requiredImageStreamTag, &imagev1.ImageStreamTag{}); err != nil {
 					if apierrors.IsNotFound(err) {
 						return false, nil

--- a/pkg/rehearse/rehearse_test.go
+++ b/pkg/rehearse/rehearse_test.go
@@ -88,7 +88,7 @@ func TestEnsureImageStreamTags(t *testing.T) {
 		},
 		{
 			name:          "app.ci cluster imports are skipped",
-			targetCluster: utilpointer.StringPtr("app.ci"),
+			targetCluster: utilpointer.String("app.ci"),
 		},
 	}
 
@@ -103,7 +103,7 @@ func TestEnsureImageStreamTags(t *testing.T) {
 				tc.istImportClient = fakectrlruntimeclient.NewClientBuilder().Build()
 			}
 			if tc.targetCluster == nil {
-				tc.targetCluster = utilpointer.StringPtr(clusterName)
+				tc.targetCluster = utilpointer.String(clusterName)
 			}
 			tc.istImportClient = &creatingClientWithCallBack{
 				Client: tc.istImportClient,


### PR DESCRIPTION
This PR implements the mirroring of images to quay.io introduced by a PR in the rehearsals. 

Resolves: [DPTP-3746](https://issues.redhat.com/browse/DPTP-3746)
Deployment change: https://github.com/openshift/release/pull/48638
/cc @hongkailiu 