### PR TITLE
DPTP 3481 - Enhance check-gh-automation with Admin Bot Access Verification

### DIFF
--- a/hack/local-check-gh-automation.sh
+++ b/hack/local-check-gh-automation.sh
@@ -34,4 +34,4 @@ go run ./cmd/check-gh-automation --repo="$1" \
   --bot=openshift-merge-robot --bot=openshift-ci-robot \
   --github-app-id="$app_id" --github-app-private-key-path="${data}/cert" \
   --config-path="${data}/prow/config.yaml" --supplemental-prow-config-dir="${data}/prow" \
-  --plugin-config="${data}/plugins/plugins.yaml" --supplemental-plugin-config-dir="${data}/plugins"
+  --plugin-config="${data}/plugins/plugins.yaml" --supplemental-plugin-config-dir="${data}/plugins" \


### PR DESCRIPTION
## Overview
This PR addresses [DPTP-3481](https://issues.redhat.com/browse/DPTP-3481), enhancing the `check-gh-automation` tool. The primary focus is to ensure that the `openshift-merge-robot` has proper admin access to repositories when branch-protection is configured.

### Key Changes
- **Hardcoded Admin Bot**: The `openshift-merge-robot` is now hardcoded in the tool for admin access checks in repositories with branch protection.
- **Branch Protection Verification**: Updated logic in `checkRepos` to verify if branch protection is enabled for a repository.
- **Admin Access Check**: Implemented a check within `checkRepos` to ensure `openshift-merge-robot` has admin access in repositories with branch protection.
- **Logging Enhancements**: Updated logging for better clarity on the branch protection status and bot permissions in each repository.

### How to Test the Changes
Run the following command from the command line in your forked `~/ci-tools` repository:
```
./hack/local-check-gh-automation.sh openshift/ci-tools
```
This command tests the changes with the hardcoded `openshift-merge-robot`.

## Enhanced Unit Testing in `main_test.go`
- **Comprehensive Test Coverage**: Enhanced unit tests in `main_test.go` to cover the new admin access checks for `openshift-merge-robot`, particularly in the context of branch-protection.
- **Refactored Test Setup**: Improved test setup for better modularity and readability.
- **Regression Testing**: Confirmed no regression in current functionalities.
- **Running the Tests**: Execute `go test ./...` in the `~/ci-tools` repository to verify both new and existing test scenarios.

### Testing the Unit Tests in `main_test.go`
Follow these steps to verify the unit tests:

1. **Navigate to the Test Directory**:
   Change to the directory containing `main_test.go`:
   ```bash
   cd ~/ci-tools/cmd/check-gh-automation
   ```

2. **Run the Unit Tests**:
   Execute the tests using the `go test` command:
   ```bash
   go test
   ```
