### PR TITLE
`multi-arch-builder-controller`: Handle optional mirroring

### DIFF
--- a/pkg/controller/multiarchbuildconfig/mirror_test.go
+++ b/pkg/controller/multiarchbuildconfig/mirror_test.go
@@ -136,7 +136,7 @@ func TestHandleMirrorImage(t *testing.T) {
 			},
 		},
 		{
-			name: "Mirror completed successfully, set status to success",
+			name: "Mirror completed successfully, add condition",
 			mabc: v1.MultiArchBuildConfig{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mabc-1",
@@ -162,7 +162,6 @@ func TestHandleMirrorImage(t *testing.T) {
 						Reason:             ImageMirrorSuccessReason,
 					},
 				},
-				State: v1.SuccessState,
 			},
 		},
 		{

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go
@@ -173,6 +173,12 @@ func (r *reconciler) handleMultiArchBuildConfig(ctx context.Context, mabc *v1.Mu
 		}
 	}
 
+	// So far everything went well, the mabc status can be set to success
+	mutateFn := func(mabcToMutate *v1.MultiArchBuildConfig) { mabcToMutate.Status.State = v1.SuccessState }
+	if err := v1.UpdateMultiArchBuildConfig(ctx, r.logger, r.client, ctrlruntimeclient.ObjectKey{Namespace: mabc.Namespace, Name: mabc.Name}, mutateFn); err != nil {
+		return fmt.Errorf("failed to update the MultiArchBuildConfig %s/%s: %w", mabc.Namespace, mabc.Name, err)
+	}
+
 	return nil
 }
 
@@ -252,7 +258,6 @@ func (r *reconciler) handleMirrorImage(ctx context.Context, targetImageRef strin
 			LastTransitionTime: metav1.Time{Time: time.Now()},
 			Reason:             ImageMirrorSuccessReason,
 		})
-		mabcToMutate.Status.State = v1.SuccessState
 	}
 
 	imageMirrorArgs := ocImageMirrorArgs(targetImageRef, mabc.Spec.ExternalRegistries)

--- a/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
+++ b/pkg/controller/multiarchbuildconfig/multiarchbuildconfig_test.go
@@ -563,6 +563,106 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedErr: errors.New("couldn't create builds for architectures: amd64,arm64: couldn't create build test-ns/test-mabc-amd64: planned failure"),
 		},
+		{
+			name: "Push and mirror done, set status to success",
+			inputMabc: &v1.MultiArchBuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mabc",
+					Namespace: "test-ns",
+				},
+				Spec: v1.MultiArchBuildConfigSpec{
+					BuildSpec: buildv1.BuildConfigSpec{
+						CommonSpec: buildv1.CommonSpec{Output: buildv1.BuildOutput{To: &corev1.ObjectReference{Namespace: "test-ns", Name: "test-image"}}},
+					},
+					ExternalRegistries: []string{"foo-registry.com/foo/bar:latest"},
+				},
+				Status: v1.MultiArchBuildConfigStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   PushImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: PushManifestSuccessReason,
+						},
+						{
+							Type:   MirrorImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: ImageMirrorSuccessReason,
+						},
+					},
+				},
+			},
+			expectedMabc: &v1.MultiArchBuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mabc",
+					Namespace: "test-ns",
+				},
+				Spec: v1.MultiArchBuildConfigSpec{
+					BuildSpec: buildv1.BuildConfigSpec{
+						CommonSpec: buildv1.CommonSpec{Output: buildv1.BuildOutput{To: &corev1.ObjectReference{Namespace: "test-ns", Name: "test-image"}}},
+					},
+					ExternalRegistries: []string{"foo-registry.com/foo/bar:latest"},
+				},
+				Status: v1.MultiArchBuildConfigStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   PushImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: PushManifestSuccessReason,
+						},
+						{
+							Type:   MirrorImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: ImageMirrorSuccessReason,
+						},
+					},
+					State: v1.SuccessState,
+				},
+			},
+		},
+		{
+			name: "Push done but no mirror required, set status to success",
+			inputMabc: &v1.MultiArchBuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mabc",
+					Namespace: "test-ns",
+				},
+				Spec: v1.MultiArchBuildConfigSpec{
+					BuildSpec: buildv1.BuildConfigSpec{
+						CommonSpec: buildv1.CommonSpec{Output: buildv1.BuildOutput{To: &corev1.ObjectReference{Namespace: "test-ns", Name: "test-image"}}},
+					},
+				},
+				Status: v1.MultiArchBuildConfigStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   PushImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: PushManifestSuccessReason,
+						},
+					},
+				},
+			},
+			expectedMabc: &v1.MultiArchBuildConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-mabc",
+					Namespace: "test-ns",
+				},
+				Spec: v1.MultiArchBuildConfigSpec{
+					BuildSpec: buildv1.BuildConfigSpec{
+						CommonSpec: buildv1.CommonSpec{Output: buildv1.BuildOutput{To: &corev1.ObjectReference{Namespace: "test-ns", Name: "test-image"}}},
+					},
+				},
+				Status: v1.MultiArchBuildConfigStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   PushImageManifestDone,
+							Status: metav1.ConditionTrue,
+							Reason: PushManifestSuccessReason,
+						},
+					},
+					State: v1.SuccessState,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
When a `mabc` is configured not to mirror images to any external registries, the controller never sets `.status.state` to success.
This changeset make sure the controller marks a `mabc` to `success` at the end of the reconcile function, and only after everything (push and mirror so far) has been completed successfully.

/cc @droslean   