### PR TITLE
Replace vsphere with vsphere02 completely.

### DIFF
--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -597,7 +597,7 @@ tests:
 - as: e2e-upi-src-vsphere
   commands: make tests
   openshift_installer_upi_src:
-    cluster_profile: vsphere
+    cluster_profile: vsphere-2
 `
 
 var parsedConfig = &api.ReleaseBuildConfiguration{
@@ -837,7 +837,7 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 		As:       "e2e-upi-src-vsphere",
 		Commands: `make tests`,
 		OpenshiftInstallerUPISrcClusterTestConfiguration: &api.OpenshiftInstallerUPISrcClusterTestConfiguration{
-			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "vsphere"},
+			ClusterTestConfiguration: api.ClusterTestConfiguration{ClusterProfile: "vsphere-2"},
 		},
 	}},
 }

--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -343,8 +343,8 @@ func updateSecretItemContext(c *secretbootstrap.Config, name, cluster, key strin
 
 func registryUrlFor(cluster string) string {
 	switch cluster {
-	case string(api.ClusterVSphere):
-		return "registry.apps.build01-us-west-2.vmc.ci.openshift.org"
+	case string(api.ClusterVSphere02):
+		return "registry.apps.build02.vmc.ci.openshift.org"
 	case string(api.ClusterAPPCI):
 		return api.ServiceDomainAPPCIRegistry
 	case string(api.ClusterARM01):
@@ -355,7 +355,7 @@ func registryUrlFor(cluster string) string {
 }
 
 func updateBuildFarmSecrets(c *secretbootstrap.Config, o options) error {
-	if o.clusterName == string(api.ClusterVSphere) {
+	if o.clusterName == string(api.ClusterVSphere02) {
 		_, buildFarmCredentials, err := findSecretConfig(fmt.Sprintf("%s-%s", buildFarm, credentials), string(api.ClusterAPPCI), c.Secrets)
 		if err != nil {
 			return err

--- a/cmd/cluster-init/update_jobs.go
+++ b/cmd/cluster-init/update_jobs.go
@@ -107,7 +107,7 @@ func generatePostsubmit(clusterName string) prowconfig.Postsubmit {
 
 func generatePresubmit(clusterName string) prowconfig.Presubmit {
 	var optional bool
-	if clusterName == string(api.ClusterVSphere) {
+	if clusterName == string(api.ClusterVSphere02) {
 		optional = true
 	}
 	return prowconfig.Presubmit{
@@ -201,7 +201,7 @@ func generateContainer(image, clusterName string, extraArgs []string, extraVolum
 			},
 		}...)
 	}
-	if clusterName == string(api.ClusterVSphere) {
+	if clusterName == string(api.ClusterVSphere02) {
 		env = append(env, v1.EnvVar{
 			Name: "github_client_id",
 			ValueFrom: &v1.EnvVarSource{

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -79,7 +79,7 @@ var (
 		string(ClusterBuild01),
 		string(ClusterBuild02),
 		string(ClusterBuild03),
-		string(ClusterVSphere),
+		string(ClusterVSphere02),
 	)
 )
 

--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -19,7 +19,6 @@ const (
 	ServiceDomainGCS   = "googleapis.com"
 
 	ServiceDomainAPPCIRegistry     = "registry.ci.openshift.org"
-	ServiceDomainVSphereRegistry   = "registry.apps.build01-us-west-2.vmc.ci.openshift.org"
 	ServiceDomainVSphere02Registry = "registry.apps.build02.vmc.ci.openshift.org"
 	ServiceDomainArm01Registry     = "registry.arm-build01.arm-build.devcluster.openshift.com"
 	ServiceDomainMulti01Registry   = "registry.multi-build01.arm-build.devcluster.openshift.com"
@@ -67,9 +66,6 @@ var (
 func RegistryDomainForClusterName(clusterName string) (string, error) {
 	if clusterName == string(ClusterAPPCI) {
 		return ServiceDomainAPPCIRegistry, nil
-	}
-	if clusterName == string(ClusterVSphere) {
-		return ServiceDomainVSphereRegistry, nil
 	}
 	if clusterName == string(ClusterVSphere02) {
 		return ServiceDomainVSphere02Registry, nil

--- a/pkg/api/domain_test.go
+++ b/pkg/api/domain_test.go
@@ -65,8 +65,8 @@ func TestRegistryDomainForClusterName(t *testing.T) {
 		},
 		{
 			name:        "vsphere",
-			clusterName: "vsphere",
-			expected:    "registry.apps.build01-us-west-2.vmc.ci.openshift.org",
+			clusterName: "vsphere02",
+			expected:    "registry.apps.build02.vmc.ci.openshift.org",
 		},
 		{
 			name:        "arm01",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -724,7 +724,6 @@ const (
 	ClusterBuild02   Cluster = "build02"
 	ClusterBuild03   Cluster = "build03"
 	ClusterBuild09   Cluster = "build09"
-	ClusterVSphere   Cluster = "vsphere"
 	ClusterVSphere02 Cluster = "vsphere02"
 	ClusterARM01     Cluster = "arm01"
 	ClusterHive      Cluster = "hive"

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -114,22 +114,7 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 		return "", false, nil
 	}
 	if strings.Contains(jobBase.Name, "vsphere") && !isApplyConfigJob(jobBase) {
-		cluster := api.ClusterVSphere
-		// once the vsphere build cluster is removed, this logic will also be removed and the vsphere02 cluster will be
-		// the only vsphere cluster used.
-
-		if clusterProfile, ok := jobBase.Labels[api.CloudClusterProfileLabel]; ok {
-			switch clusterProfile {
-			case string(api.ClusterProfileVSphere8Vpn),
-				string(api.ClusterProfileVSphere2),
-				string(api.ClusterProfileVSphereMultizone2),
-				string(api.ClusterProfileVSphereConnected2),
-				string(api.ClusterProfileVSphereDis2):
-
-				cluster = api.ClusterVSphere02
-			}
-		}
-		return cluster, false, nil
+		return api.ClusterVSphere02, false, nil
 	}
 	if isSSHBastionJob(jobBase) && config.SSHBastion != "" {
 		return config.SSHBastion, false, nil

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -424,13 +424,13 @@ func TestDetermineClusterForJob(t *testing.T) {
 			expectedCanBeRelocated: true,
 		},
 		{
-			name:     "Vsphere job",
+			name:     "Vsphere job on vsphere02",
 			config:   &configWithBuildFarmWithJobs,
 			jobBase:  config.JobBase{Agent: "kubernetes", Name: "yalayala-vsphere"},
-			expected: "vsphere",
+			expected: "vsphere02",
 		},
 		{
-			name:   "Vsphere job on vsphere02",
+			name:   "Vsphere job on vsphere02 with profile",
 			config: &configWithBuildFarmWithJobs,
 			jobBase: config.JobBase{Agent: "kubernetes", Name: "yalayala-vsphere", Labels: map[string]string{
 				api.CloudClusterProfileLabel: string(api.ClusterProfileVSphere8Vpn),


### PR DESCRIPTION
This PR removes all references to `vsphere`
and replaces it with vsphere02. The
only cluster that should be used for vsphere
ci jobs now is `vsphere02`.