### PR TITLE
stop getting the manifest-tool binary from the official image in ci-operator

### DIFF
--- a/images/ci-operator/Dockerfile
+++ b/images/ci-operator/Dockerfile
@@ -1,9 +1,8 @@
-FROM mplatform/manifest-tool as builder
 FROM quay.io/centos/centos:stream8
-
-COPY --from=builder /manifest-tool /usr/bin/manifest-tool
 
 RUN yum install -y git python2
 RUN alternatives --set python /usr/bin/python2
+
+ADD manifest-tool /usr/bin/manifest-tool
 ADD ci-operator /usr/bin/ci-operator
 ENTRYPOINT ["/usr/bin/ci-operator"]


### PR DESCRIPTION
/cc @danilo-gemoli 