### PR TITLE
dptp-cm: add flag promotionReconcilerOptions.since

### DIFF
--- a/hack/run-dptp-controller-manager.sh
+++ b/hack/run-dptp-controller-manager.sh
@@ -86,7 +86,10 @@ go run ./cmd/dptp-controller-manager \
   --leader-election-namespace=dptp-controller-manager-testing \
   --leader-election-suffix="-$USER" \
   --release-repo-git-sync-path="${release}" \
-  --enable-controller=test_images_distributor \
+  --enable-controller=promotionreconciler \
+  --promotionReconcilerOptions.since=360h \
   --kubeconfig-dir="${tmpdir}" \
   --kubeconfig-suffix=config \
+  --github-hourly-tokens=4000 \
+  --github-allowed-burst=2000 \
   --dry-run=true


### PR DESCRIPTION
The controller `promotionreconciler` is a best-effort to trigger the promotion job in case the merge-triggered post-submit  did not go thro for any reason.
`dptp-cm` got restarted too often and as a result of slow consumption of the work queue, some request might be starved forever.

With this PR, we give an flag, opting in istags within certain age. It results in that old tags are staled which seems more acceptable than random tags are.

https://issues.redhat.com/browse/DPTP-3780

/cc @openshift/test-platform 