### PR TITLE
multi01: fix registry url

### DIFF
--- a/cmd/cluster-init/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/update_bootstrap_secrets.go
@@ -349,6 +349,8 @@ func registryUrlFor(cluster string) string {
 		return api.ServiceDomainAPPCIRegistry
 	case string(api.ClusterARM01):
 		return "registry.arm-build01.arm-build.devcluster.openshift.com"
+	case string(api.ClusterMulti01):
+		return "registry.multi-build01.arm-build.devcluster.openshift.com"
 	default:
 		return fmt.Sprintf("registry.%s.ci.openshift.org", cluster)
 	}


### PR DESCRIPTION
The registry url for the multi01 cluster is different than the others. This PR fixes the validation and is depended upon by openshift/release#46574