### PR TITLE
Don't fail aggregation if junit isn't parseable

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/gcs_jobrun.go
@@ -242,12 +242,10 @@ func (j *gcsJobRun) GetCombinedJUnitTestSuites(ctx context.Context) (*junit.Test
 
 		currTestSuite := &junit.TestSuite{}
 		if testSuiteErr := xml.Unmarshal(junitContent, currTestSuite); testSuiteErr != nil {
-			if isParseFloatError(testSuiteErr) {
-				// this was a testsuite, but we cannot read the file.  There is no choice to ignore errors so we suppress here
-				fmt.Fprintf(os.Stderr, "error parsing testsuite: %v", testSuiteErr)
-				continue
-			}
-			return nil, fmt.Errorf("error parsing junit for jobrun/%v/%v %q: testsuiteError=%w  testsuitesError=%v", j.GetJobName(), j.GetJobRunID(), junitFile, testSuiteErr, testSuitesErr.Error() /*tricking invalid/wrong linter*/)
+			// If we get an error reading from just one of the junits, don't end the world, just log it.
+			fmt.Printf("error parsing junit for jobrun/%v/%v %q: testsuiteError=%v  testsuitesError=%v",
+				j.GetJobName(), j.GetJobRunID(), junitFile, testSuiteErr.Error(), testSuitesErr.Error())
+			continue
 		}
 		testSuites.Suites = append(testSuites.Suites, currTestSuite)
 	}


### PR DESCRIPTION
If any junit file isn't valid XML then it fails the entire aggregation, even if it's a small number. We should just log it, but still try to do the aggregation.

If too many fail, the aggregator will fail at a higher level informing us it doesn't have enough results.