### PR TITLE
Panic if we unable to determine Release from a job name

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/job_typer.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_typer.go
@@ -1,6 +1,7 @@
 package jobtableprimer
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -79,8 +80,10 @@ func newJob(name string) *jobRowBuilder {
 	currRelease := "unknown"
 	if len(versions) >= 1 {
 		currRelease = versions[0]
+	} else {
+		// If this job doesn't have one of the known releases, panic to avoid silently missing data for it.
+		panic(fmt.Sprintf("Unable to determine the release from job %s, please update the release list: %v", name, reverseOrderedVersions))
 	}
-
 	fromRelease := ""
 	if runsUpgrade {
 		if len(versions) > 0 {

--- a/pkg/jobrunaggregator/jobtableprimer/jobs.go
+++ b/pkg/jobrunaggregator/jobtableprimer/jobs.go
@@ -43,11 +43,13 @@ const (
 	v413 = "4.13"
 	v414 = "4.14"
 	v415 = "4.15"
+	v416 = "4.16"
 )
 
 var (
+	// Update this for every new release of Openshift.
 	reverseOrderedVersions = []string{
-		v415, v414, v413, v412, v411, v410, v409, v408,
+		v416, v415, v414, v413, v412, v411, v410, v409, v408,
 	}
 )
 

--- a/pkg/jobrunaggregator/jobtableprimer/jobs_test.go
+++ b/pkg/jobrunaggregator/jobtableprimer/jobs_test.go
@@ -24,6 +24,7 @@ func TestJobVersions(t *testing.T) {
 		jobName     string
 		fromVersion string
 		toVersion   string
+		shouldPanic bool
 	}{
 		{
 			name:        "multi-version-upgrade",
@@ -60,17 +61,24 @@ func TestJobVersions(t *testing.T) {
 			jobName:     "release-openshift-origin-installer-e2e-aws-upgrade-ci",
 			fromVersion: "",
 			toVersion:   "unknown",
+			shouldPanic: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			j := newJob(tc.jobName)
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					newJob(tc.jobName)
+				}, "Expected panic for unknown release")
+			} else {
+				j := newJob(tc.jobName)
 
-			assert.NotNil(t, j, "Unexpected nil builder")
-			assert.NotNil(t, j.job, "Unexpected nil job")
-			assert.Equal(t, tc.toVersion, j.job.Release, "Invalid toVersion")
-			assert.Equal(t, tc.fromVersion, j.job.FromRelease, "Invalid fromVersion")
+				assert.NotNil(t, j, "Unexpected nil builder")
+				assert.NotNil(t, j.job, "Unexpected nil job")
+				assert.Equal(t, tc.toVersion, j.job.Release, "Invalid toVersion")
+				assert.Equal(t, tc.fromVersion, j.job.FromRelease, "Invalid fromVersion")
+			}
 		})
 	}
 


### PR DESCRIPTION
[TRT-1414](https://issues.redhat.com//browse/TRT-1414)

Because of this, we didn't get 4.16 Job data which prevented us from getting 4.16 disruption/alerting data (as the Release was set to 'unknown'.  This PR makes it so that we panic to avoid this happening in the future in case we forgot to update the code with the branch after a new 4.n release is created.