### PR TITLE
promotion: migrate to targets, tolerate mixed config - 3rd attempt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ update-integration:
 	go run ./cmd/determinize-ci-operator --config-dir test/integration/release-job-migrator/input/ci-operator --confirm
 	go run ./cmd/determinize-ci-operator --config-dir test/integration/repo-init/expected/ci-operator/config --confirm
 	go run ./cmd/determinize-ci-operator --config-dir test/integration/repo-init/input/ci-operator/config --confirm
+	go run ./cmd/determinize-prow-config -prow-config-dir test/integration/repo-init/input/core-services/prow/02_config -sharded-plugin-config-base-dir test/integration/repo-init/input/core-services/prow/02_config
 	go run ./cmd/determinize-prow-config -prow-config-dir test/integration/repo-init/expected/core-services/prow/02_config -sharded-plugin-config-base-dir test/integration/repo-init/expected/core-services/prow/02_config
 	UPDATE=true make integration
 .PHONY: update-integration

--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -159,6 +159,13 @@ func main() {
 		}
 
 		if rbc.PromotionConfiguration != nil {
+			rbc.PromotionConfiguration = &api.PromotionConfiguration{
+				Targets:           api.PromotionTargets(rbc.PromotionConfiguration),
+				RegistryOverride:  rbc.PromotionConfiguration.RegistryOverride,
+				DisableBuildCache: rbc.PromotionConfiguration.DisableBuildCache,
+				// All other fields are left out intentionally as they would
+				// be already there in Targets
+			}
 			if !api.BuildsAnyOfficialImages(rbc, api.WithoutOKD) && o.WhitelistConfig.IsWhitelisted(repoInfo) {
 				logger.Warn("Repo is whitelisted. Disable promotion...")
 				for i := range rbc.PromotionConfiguration.Targets {

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -200,18 +200,18 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 	}{
 		{
 			id:        "promoted by name",
-			promotion: &api.PromotionConfiguration{Name: "4.x", Namespace: "ocp"},
-			expected:  &api.PromotionConfiguration{Name: "4.x-priv", Namespace: "ocp-private"},
+			promotion: &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Name: "4.x", Namespace: "ocp"}}},
+			expected:  &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Name: "4.x-priv", Namespace: "ocp-private"}}},
 		},
 		{
 			id:        "promoted by tag",
-			promotion: &api.PromotionConfiguration{Tag: "4.x", Namespace: "ocp"},
-			expected:  &api.PromotionConfiguration{Tag: "4.x-priv", Namespace: "ocp-private"},
+			promotion: &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x", Namespace: "ocp"}}},
+			expected:  &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x-priv", Namespace: "ocp-private"}}},
 		},
 		{
 			id:        "promoted by tag, includes tag_by_commit",
-			promotion: &api.PromotionConfiguration{Tag: "4.x", Namespace: "ocp", TagByCommit: true},
-			expected:  &api.PromotionConfiguration{Tag: "4.x-priv", Namespace: "ocp-private"},
+			promotion: &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x", Namespace: "ocp", TagByCommit: true}}},
+			expected:  &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x-priv", Namespace: "ocp-private"}}},
 		},
 	}
 	for _, tc := range testCases {

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -365,12 +365,13 @@ const rawConfig = `tag_specification:
   name: '4.0'
   namespace: ocp
 promotion:
-  name: '4.0'
-  namespace: ocp
-  additional_images:
-    artifacts: artifacts
-  excluded_images:
-  - machine-os-content
+  to:
+  - name: '4.0'
+    namespace: ocp
+    additional_images:
+      artifacts: artifacts
+    excluded_images:
+    - machine-os-content
 base_images:
   base:
     name: '4.0'
@@ -740,10 +741,12 @@ var parsedConfig = &api.ReleaseBuildConfiguration{
 		},
 	}},
 	PromotionConfiguration: &api.PromotionConfiguration{
-		Namespace:        "ocp",
-		Name:             "4.0",
-		AdditionalImages: map[string]string{"artifacts": "artifacts"},
-		ExcludedImages:   []string{"machine-os-content"},
+		Targets: []api.PromotionTarget{{
+			Namespace:        "ocp",
+			Name:             "4.0",
+			AdditionalImages: map[string]string{"artifacts": "artifacts"},
+			ExcludedImages:   []string{"machine-os-content"},
+		}},
 	},
 	Resources: map[string]api.ResourceRequirements{
 		"*":           {Limits: map[string]string{"memory": "6Gi"}, Requests: map[string]string{"cpu": "100m", "memory": "200Mi"}},

--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -46,8 +46,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "custom",
-						Namespace: "custom",
+						Targets: []api.PromotionTarget{{
+							Name:      "custom",
+							Namespace: "custom",
+						}},
 					},
 				},
 				Info: config.Info{
@@ -63,8 +65,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "4.123",
-						Namespace: "ocp",
+						Targets: []api.PromotionTarget{{
+							Name:      "4.123",
+							Namespace: "ocp",
+						}},
 					},
 				},
 				Info: config.Info{
@@ -80,8 +84,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
+						Targets: []api.PromotionTarget{{
+							Name:      "current-release",
+							Namespace: "ocp",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -119,9 +125,11 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
-							Disabled:  true,
+							Targets: []api.PromotionTarget{{
+								Name:      "current-release",
+								Namespace: "ocp",
+								Disabled:  true,
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -164,8 +172,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
+						Targets: []api.PromotionTarget{{
+							Name:      "current-release",
+							Namespace: "ocp",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -193,8 +203,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 						{As: "periodic-cron-portable", Cron: &cron, Portable: true},
 					},
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
+						Targets: []api.PromotionTarget{{
+							Name:      "current-release",
+							Namespace: "ocp",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -235,9 +247,11 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							{As: "periodic-cron-portable", Cron: &cron, Portable: true},
 						},
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
-							Disabled:  true,
+							Targets: []api.PromotionTarget{{
+								Name:      "current-release",
+								Namespace: "ocp",
+								Disabled:  true,
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -277,8 +291,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							{As: "periodic-cron-portable", Cron: &cron, Portable: true},
 						},
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release-1",
-							Namespace: "ocp",
+							Targets: []api.PromotionTarget{{
+								Name:      "future-release-1",
+								Namespace: "ocp",
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -318,8 +334,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 							{As: "periodic-cron-portable", Cron: &cron, Portable: true},
 						},
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release-2",
-							Namespace: "ocp",
+							Targets: []api.PromotionTarget{{
+								Name:      "future-release-2",
+								Namespace: "ocp",
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -363,8 +381,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 			input: config.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Name:      "current-release",
-						Namespace: "ocp",
+						Targets: []api.PromotionTarget{{
+							Name:      "current-release",
+							Namespace: "ocp",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -381,8 +401,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release-1",
-							Namespace: "ocp",
+							Targets: []api.PromotionTarget{{
+								Name:      "future-release-1",
+								Namespace: "ocp",
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -398,8 +420,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "current-release",
-							Namespace: "ocp",
+							Targets: []api.PromotionTarget{{
+								Name:      "current-release",
+								Namespace: "ocp",
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -415,9 +439,11 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release-1",
-							Namespace: "ocp",
-							Disabled:  true,
+							Targets: []api.PromotionTarget{{
+								Name:      "future-release-1",
+								Namespace: "ocp",
+								Disabled:  true,
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{
@@ -433,8 +459,10 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				{
 					Configuration: api.ReleaseBuildConfiguration{
 						PromotionConfiguration: &api.PromotionConfiguration{
-							Name:      "future-release-2",
-							Namespace: "ocp",
+							Targets: []api.PromotionTarget{{
+								Name:      "future-release-2",
+								Namespace: "ocp",
+							}},
 						},
 						InputConfiguration: api.InputConfiguration{
 							ReleaseTagConfiguration: &api.ReleaseTagConfiguration{

--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -77,6 +77,26 @@ func main() {
 			return nil
 		}
 
+		if configuration.PromotionConfiguration != nil && configuration.PromotionConfiguration.Namespace != "" {
+			configuration.PromotionConfiguration.Targets = append([]api.PromotionTarget{{
+				Name:             configuration.PromotionConfiguration.Name,
+				Namespace:        configuration.PromotionConfiguration.Namespace,
+				Tag:              configuration.PromotionConfiguration.Tag,
+				TagByCommit:      configuration.PromotionConfiguration.TagByCommit,
+				ExcludedImages:   configuration.PromotionConfiguration.ExcludedImages,
+				AdditionalImages: configuration.PromotionConfiguration.AdditionalImages,
+				Disabled:         configuration.PromotionConfiguration.Disabled,
+			}}, configuration.PromotionConfiguration.Targets...)
+
+			configuration.PromotionConfiguration.Name = ""
+			configuration.PromotionConfiguration.Namespace = ""
+			configuration.PromotionConfiguration.Tag = ""
+			configuration.PromotionConfiguration.TagByCommit = false
+			configuration.PromotionConfiguration.ExcludedImages = nil
+			configuration.PromotionConfiguration.AdditionalImages = nil
+			configuration.PromotionConfiguration.Disabled = false
+		}
+
 		allowedBranches := o.templateMigrationAllowedBranches.StringSet()
 		allowedOrgs := o.templateMigrationAllowedOrgs.StringSet()
 		allowedClusterProfiles := o.templateMigrationAllowedClusterProfiles.StringSet()

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -842,7 +842,7 @@ func (r fakeCIOpConfigResolver) Config(m *api.Metadata) (*api.ReleaseBuildConfig
 	}
 	if m.Org == "openshift" {
 		return &api.ReleaseBuildConfiguration{
-			PromotionConfiguration: &api.PromotionConfiguration{Namespace: "ocp"},
+			PromotionConfiguration: &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Namespace: "ocp"}}},
 		}, nil
 	}
 	return &api.ReleaseBuildConfiguration{}, nil

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -94,12 +94,16 @@ func TestOptionsValidate(t *testing.T) {
 func TestOptionsMakeFilter(t *testing.T) {
 	official := &api.ReleaseBuildConfiguration{
 		PromotionConfiguration: &api.PromotionConfiguration{
-			Namespace: "ocp",
+			Targets: []api.PromotionTarget{{
+				Namespace: "ocp",
+			}},
 		},
 	}
 	notOfficial := &api.ReleaseBuildConfiguration{
 		PromotionConfiguration: &api.PromotionConfiguration{
-			Namespace: "not-ocp",
+			Targets: []api.PromotionTarget{{
+				Namespace: "not-ocp",
+			}},
 		},
 	}
 	// Check that our assumptions about what is an official image still holds

--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -441,7 +441,11 @@ func main() {
 			if _, ok := opts.explains[isTagRef]; ok {
 				opts.explains[isTagRef] = cfg.Metadata.AsString()
 			}
-			if cfg.PromotionConfiguration.TagByCommit {
+			var taggedByCommit bool
+			for _, target := range api.PromotionTargets(cfg.PromotionConfiguration) {
+				taggedByCommit = taggedByCommit || target.TagByCommit
+			}
+			if taggedByCommit {
 				ignoreRegex, err := regexp.Compile(fmt.Sprintf("%s/%s:[0-9a-f]{5,40}", isTagRef.Namespace, isTagRef.Name))
 				if err != nil {
 					return fmt.Errorf("could not create a regex for ignoring tagged-by-commit images for %s: %w", isTagRef.ISTagName(), err)

--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -847,14 +847,18 @@ func TestPruneOCPBuilderReplacements(t *testing.T) {
 					}},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "ocp",
-					Tag:       "4.8",
+					Targets: []api.PromotionTarget{{
+						Namespace: "ocp",
+						Tag:       "4.8",
+					}},
 				},
 			},
 			expected: &api.ReleaseBuildConfiguration{
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "ocp",
-					Tag:       "4.8",
+					Targets: []api.PromotionTarget{{
+						Namespace: "ocp",
+						Tag:       "4.8",
+					}},
 				},
 			},
 		},

--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -680,22 +680,29 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 		generated.Configuration.CanonicalGoRepository = &config.CanonicalGoRepository
 	}
 
+	basePromotionTargets := api.PromotionTargets(originConfig)
+	var basePromotionTarget api.PromotionTarget
+	if len(basePromotionTargets) > 0 {
+		basePromotionTarget = api.PromotionTargets(originConfig)[0]
+	}
 	if config.Promotes {
 		generated.Configuration.PromotionConfiguration = &api.PromotionConfiguration{
-			Namespace: originConfig.Namespace,
-			Name:      originConfig.Name,
+			Targets: []api.PromotionTarget{{
+				Namespace: basePromotionTarget.Namespace,
+				Name:      basePromotionTarget.Name,
+			}},
 		}
 		generated.Configuration.Releases = map[string]api.UnresolvedRelease{
 			api.InitialReleaseName: {
 				Integration: &api.Integration{
-					Namespace: originConfig.Namespace,
-					Name:      originConfig.Name,
+					Namespace: basePromotionTarget.Namespace,
+					Name:      basePromotionTarget.Name,
 				},
 			},
 			api.LatestReleaseName: {
 				Integration: &api.Integration{
-					Namespace:          originConfig.Namespace,
-					Name:               originConfig.Name,
+					Namespace:          basePromotionTarget.Namespace,
+					Name:               basePromotionTarget.Name,
 					IncludeBuiltImages: true,
 				},
 			},
@@ -720,8 +727,8 @@ func generateCIOperatorConfig(config initConfig, originConfig *api.PromotionConf
 
 	if config.NeedsBase {
 		generated.Configuration.BaseImages["base"] = api.ImageStreamTagReference{
-			Namespace: originConfig.Namespace,
-			Name:      originConfig.Name,
+			Namespace: basePromotionTarget.Namespace,
+			Name:      basePromotionTarget.Name,
 			Tag:       "base",
 		}
 	}

--- a/cmd/repo-init/main_test.go
+++ b/cmd/repo-init/main_test.go
@@ -216,8 +216,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				TestBuildCommands:     "make tests",
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -264,8 +266,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				Promotes:              true,
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -275,8 +279,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 						Branch: "branch",
 					},
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Namespace: "promote",
-						Name:      "version",
+						Targets: []api.PromotionTarget{{
+							Namespace: "promote",
+							Name:      "version",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						Releases: map[string]api.UnresolvedRelease{
@@ -330,8 +336,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				PromotesWithOpenShift: true,
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -341,8 +349,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 						Branch: "branch",
 					},
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Namespace: "promote",
-						Name:      "version",
+						Targets: []api.PromotionTarget{{
+							Namespace: "promote",
+							Name:      "version",
+						}},
 					},
 					InputConfiguration: api.InputConfiguration{
 						Releases: map[string]api.UnresolvedRelease{
@@ -402,8 +412,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				NeedsBase:             true,
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -467,8 +479,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				},
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -564,8 +578,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				ReleaseVersion:        "4.5",
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{
@@ -623,8 +639,10 @@ func TestGenerateCIOperatorConfig(t *testing.T) {
 				ReleaseVersion:        "4.5",
 			},
 			originConfig: &api.PromotionConfiguration{
-				Namespace: "promote",
-				Name:      "version",
+				Targets: []api.PromotionTarget{{
+					Namespace: "promote",
+					Name:      "version",
+				}},
 			},
 			expected: ciopconfig.DataWithInfo{
 				Configuration: api.ReleaseBuildConfiguration{

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -29,15 +29,18 @@ func PromotionTargets(c *PromotionConfiguration) []PromotionTarget {
 		return nil
 	}
 
-	targets := []PromotionTarget{{
-		Name:             c.Name,
-		Namespace:        c.Namespace,
-		Tag:              c.Tag,
-		TagByCommit:      c.TagByCommit,
-		ExcludedImages:   c.ExcludedImages,
-		AdditionalImages: c.AdditionalImages,
-		Disabled:         c.Disabled,
-	}}
+	var targets []PromotionTarget
+	if c.Namespace != "" {
+		targets = append(targets, PromotionTarget{
+			Name:             c.Name,
+			Namespace:        c.Namespace,
+			Tag:              c.Tag,
+			TagByCommit:      c.TagByCommit,
+			ExcludedImages:   c.ExcludedImages,
+			AdditionalImages: c.AdditionalImages,
+			Disabled:         c.Disabled,
+		})
+	}
 	targets = append(targets, c.Targets...)
 	return targets
 }
@@ -63,6 +66,17 @@ func ImageTargets(c *ReleaseBuildConfiguration) sets.Set[string] {
 func PromotesOfficialImages(configSpec *ReleaseBuildConfiguration, includeOKD OKDInclusion) bool {
 	for _, target := range PromotionTargets(configSpec.PromotionConfiguration) {
 		if !target.Disabled && BuildsOfficialImages(target, includeOKD) {
+			return true
+		}
+	}
+	return false
+}
+
+// PromotesOfficialImage determines if a configuration will promote promotionName
+// and if it belongs to any official stream.
+func PromotesOfficialImage(configSpec *ReleaseBuildConfiguration, includeOKD OKDInclusion, promotionName string) bool {
+	for _, target := range PromotionTargets(configSpec.PromotionConfiguration) {
+		if !target.Disabled && BuildsOfficialImages(target, includeOKD) && target.Name == promotionName {
 			return true
 		}
 	}

--- a/pkg/api/promotion_test.go
+++ b/pkg/api/promotion_test.go
@@ -26,7 +26,9 @@ func TestPromotesOfficialImages(t *testing.T) {
 			name: "config explicitly promoting to ocp namespace produces official images",
 			configSpec: &ReleaseBuildConfiguration{
 				PromotionConfiguration: &PromotionConfiguration{
-					Namespace: "ocp",
+					Targets: []PromotionTarget{{
+						Namespace: "ocp",
+					}},
 				},
 			},
 			expected: true,
@@ -35,8 +37,10 @@ func TestPromotesOfficialImages(t *testing.T) {
 			name: "config with disabled explicit promotion to ocp namespace does not produce official images",
 			configSpec: &ReleaseBuildConfiguration{
 				PromotionConfiguration: &PromotionConfiguration{
-					Namespace: "ocp",
-					Disabled:  true,
+					Targets: []PromotionTarget{{
+						Namespace: "ocp",
+						Disabled:  true,
+					}},
 				},
 			},
 			expected: false,
@@ -45,7 +49,9 @@ func TestPromotesOfficialImages(t *testing.T) {
 			name: "config explicitly promoting to okd namespace produces official images",
 			configSpec: &ReleaseBuildConfiguration{
 				PromotionConfiguration: &PromotionConfiguration{
-					Namespace: "origin",
+					Targets: []PromotionTarget{{
+						Namespace: "origin",
+					}},
 				},
 			},
 			expected: true,
@@ -210,6 +216,45 @@ func TestPromotionTargets(t *testing.T) {
 				ExcludedImages:   []string{"*"},
 				AdditionalImages: map[string]string{"whatever": "else"},
 				Disabled:         true,
+			},
+			output: []PromotionTarget{{
+				Namespace:        "ns",
+				Name:             "name",
+				Tag:              "tag",
+				TagByCommit:      true,
+				ExcludedImages:   []string{"*"},
+				AdditionalImages: map[string]string{"whatever": "else"},
+				Disabled:         true,
+			}, {
+				Namespace:        "new-ns",
+				Name:             "new-name",
+				Tag:              "new-tag",
+				TagByCommit:      true,
+				ExcludedImages:   []string{"new-*"},
+				AdditionalImages: map[string]string{"new-whatever": "new-else"},
+				Disabled:         true,
+			}},
+		},
+		{
+			name: "only modern config",
+			input: &PromotionConfiguration{
+				Targets: []PromotionTarget{{
+					Namespace:        "ns",
+					Name:             "name",
+					Tag:              "tag",
+					TagByCommit:      true,
+					ExcludedImages:   []string{"*"},
+					AdditionalImages: map[string]string{"whatever": "else"},
+					Disabled:         true,
+				}, {
+					Namespace:        "new-ns",
+					Name:             "new-name",
+					Tag:              "new-tag",
+					TagByCommit:      true,
+					ExcludedImages:   []string{"new-*"},
+					AdditionalImages: map[string]string{"new-whatever": "new-else"},
+					Disabled:         true,
+				}},
 			},
 			output: []PromotionTarget{{
 				Namespace:        "ns",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -499,27 +499,32 @@ type PromotionConfiguration struct {
 
 	// Namespace identifies the namespace to which the built
 	// artifacts will be published to.
-	Namespace string `json:"namespace"`
+	// Deprecated, prefer to set promotion.targets[0].namespace
+	Namespace string `json:"namespace,omitempty"`
 
 	// Name is an optional image stream name to use that
 	// contains all component tags. If specified, tag is
 	// ignored.
+	// Deprecated, prefer to set promotion.targets[0].name
 	Name string `json:"name,omitempty"`
 
 	// Tag is the ImageStreamTag tagged in for each
 	// build image's ImageStream.
+	// Deprecated, prefer to set promotion.targets[0].tag
 	Tag string `json:"tag,omitempty"`
 
 	// TagByCommit determines if an image should be tagged by the
 	// git commit that was used to build it. If Tag is also set,
 	// this will cause both a floating tag and commit-specific tags
 	// to be promoted.
+	// Deprecated, prefer to set promotion.targets[0].tag_by_commit
 	TagByCommit bool `json:"tag_by_commit,omitempty"`
 
 	// ExcludedImages are image names that will not be promoted.
 	// Exclusions are made before additional_images are included.
 	// Use exclusions when you want to build images for testing
 	// but not promote them afterwards.
+	// Deprecated, prefer to set promotion.targets[0].excluded_images
 	ExcludedImages []string `json:"excluded_images,omitempty"`
 
 	// AdditionalImages is a mapping of images to promote. The
@@ -527,6 +532,7 @@ type PromotionConfiguration struct {
 	// key is the name to promote as and the value is the source
 	// name. If you specify a tag that does not exist as the source
 	// the destination tag will not be created.
+	// Deprecated, prefer to set promotion.targets[0].additional_images
 	AdditionalImages map[string]string `json:"additional_images,omitempty"`
 
 	// Disabled will no-op succeed instead of running the actual
@@ -534,6 +540,7 @@ type PromotionConfiguration struct {
 	// promote to the same output imagestream on a cut-over but
 	// never concurrently, and you want to have promotion config
 	// in the ci-operator configuration files all the time.
+	// Deprecated, prefer to set promotion.targets[0].disabled
 	Disabled bool `json:"disabled,omitempty"`
 
 	// RegistryOverride is an override for the registry domain to

--- a/pkg/controller/promotionreconciler/reconciler_test.go
+++ b/pkg/controller/promotionreconciler/reconciler_test.go
@@ -324,10 +324,12 @@ func TestReconcile(t *testing.T) {
 							Branch: ciOpBranch,
 						},
 						PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-							Namespace:        "namespace",
-							Name:             "name",
-							AdditionalImages: map[string]string{"tag": ""},
-							Disabled:         tc.promotionDisabled,
+							Targets: []cioperatorapi.PromotionTarget{{
+								Namespace:        "namespace",
+								Name:             "name",
+								AdditionalImages: map[string]string{"tag": ""},
+								Disabled:         tc.promotionDisabled,
+							}},
 						},
 					},
 					}, nil

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1604,9 +1604,11 @@ func TestFromConfig(t *testing.T) {
 		name: "promote",
 		config: api.ReleaseBuildConfiguration{
 			PromotionConfiguration: &api.PromotionConfiguration{
-				Namespace: ns,
-				Name:      "name",
-				Tag:       "tag",
+				Targets: []api.PromotionTarget{{
+					Namespace: ns,
+					Name:      "name",
+					Tag:       "tag",
+				}},
 			},
 		},
 		promote:       true,

--- a/pkg/image-graph-generator/images.go
+++ b/pkg/image-graph-generator/images.go
@@ -22,28 +22,28 @@ type ImageRef struct {
 	Children       []ImageRef  `graphql:"children"`
 }
 
-func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfiguration, c *api.ReleaseBuildConfiguration, branchID string) error {
-	imageName := fmt.Sprintf("%s/%s:%s", c.PromotionConfiguration.Namespace, c.PromotionConfiguration.Name, string(image.To))
+func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfiguration, baseImages map[string]api.ImageStreamTagReference, c api.PromotionTarget, branchID string) error {
+	imageName := fmt.Sprintf("%s/%s:%s", c.Namespace, c.Name, string(image.To))
 
-	if c.PromotionConfiguration.Name == "" {
-		if c.PromotionConfiguration.Tag == "" {
-			imageName = fmt.Sprintf("%s/%s:latest", c.PromotionConfiguration.Namespace, string(image.To))
+	if c.Name == "" {
+		if c.Tag == "" {
+			imageName = fmt.Sprintf("%s/%s:latest", c.Namespace, string(image.To))
 		} else {
-			imageName = fmt.Sprintf("%s/%s:%s", c.PromotionConfiguration.Namespace, c.PromotionConfiguration.Tag, string(image.To))
+			imageName = fmt.Sprintf("%s/%s:%s", c.Namespace, c.Tag, string(image.To))
 		}
 	}
 
 	imageRef := &ImageRef{
 		Name:           imageName,
-		Namespace:      c.PromotionConfiguration.Namespace,
-		ImageStreamRef: c.PromotionConfiguration.Name,
+		Namespace:      c.Namespace,
+		ImageStreamRef: c.Name,
 		Branches:       []BranchRef{{ID: branchID}},
 	}
 
 	if isInternalBaseImage(string(image.From)) {
 		imageRef.FromRoot = true
 	} else if string(image.From) != "" {
-		fromImage, ok := c.BaseImages[string(image.From)]
+		fromImage, ok := baseImages[string(image.From)]
 		if ok {
 			parent := ImageRef{
 				Name:           fromImage.ISTagName(),

--- a/pkg/image-graph-generator/images_test.go
+++ b/pkg/image-graph-generator/images_test.go
@@ -31,8 +31,10 @@ func TestOperator_UpdateImage(t *testing.T) {
 				},
 				c: &api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Namespace: "test-ns",
-						Name:      "test-is",
+						Targets: []api.PromotionTarget{{
+							Namespace: "test-ns",
+							Name:      "test-is",
+						}},
 					},
 				},
 				branchID: "0x12345",
@@ -56,8 +58,10 @@ func TestOperator_UpdateImage(t *testing.T) {
 				},
 				c: &api.ReleaseBuildConfiguration{
 					PromotionConfiguration: &api.PromotionConfiguration{
-						Namespace: "test-ns",
-						Name:      "test-is",
+						Targets: []api.PromotionTarget{{
+							Namespace: "test-ns",
+							Name:      "test-is",
+						}},
 					},
 				},
 				branchID: "0x12345",
@@ -84,7 +88,7 @@ func TestOperator_UpdateImage(t *testing.T) {
 				c:      fc,
 				images: tt.images,
 			}
-			if err := o.UpdateImage(tt.args.image, tt.args.c, tt.args.branchID); (err != nil) != tt.wantErr {
+			if err := o.UpdateImage(tt.args.image, tt.args.c.BaseImages, tt.args.c.PromotionConfiguration.Targets[0], tt.args.branchID); (err != nil) != tt.wantErr {
 				t.Errorf("Operator.UpdateImage() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if diff := cmp.Diff(fc.images, tt.expected); diff != "" {

--- a/pkg/image-graph-generator/operator.go
+++ b/pkg/image-graph-generator/operator.go
@@ -80,12 +80,14 @@ func (o *Operator) callback(c *api.ReleaseBuildConfiguration, i *config.Info) er
 	}
 
 	var errs []error
-	excludedImages := sets.New[string](c.PromotionConfiguration.ExcludedImages...)
+	for _, target := range api.PromotionTargets(c.PromotionConfiguration) {
+		excludedImages := sets.New[string](target.ExcludedImages...)
 
-	for _, image := range c.Images {
-		if !excludedImages.Has(string(image.To)) {
-			if err := o.UpdateImage(image, c, branchID); err != nil {
-				errs = append(errs, err)
+		for _, image := range c.Images {
+			if !excludedImages.Has(string(image.To)) {
+				if err := o.UpdateImage(image, c.BaseImages, target, branchID); err != nil {
+					errs = append(errs, err)
+				}
 			}
 		}
 	}

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -29,9 +29,11 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "disabled",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Disabled:  true,
-					Namespace: "ns",
-					Name:      "name",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Disabled:  true,
+						Namespace: "ns",
+						Name:      "name",
+					}},
 				},
 				Images: []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{{To: cioperatorapi.PipelineImageStreamTagReferenceSource}},
 			},
@@ -40,7 +42,9 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "empty namespace",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Name: "some-stream",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name: "some-stream",
+					}},
 				},
 				Images: []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{{To: cioperatorapi.PipelineImageStreamTagReferenceSource}},
 			},
@@ -49,7 +53,9 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "empty name",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace: "some-stream",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Namespace: "some-stream",
+					}},
 				},
 				Images: []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{{To: cioperatorapi.PipelineImageStreamTagReferenceSource}},
 			},
@@ -58,8 +64,10 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "images",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace: "some-namespace",
-					Name:      "some-stream",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Namespace: "some-namespace",
+						Name:      "some-stream",
+					}},
 				},
 				Images: []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{{To: cioperatorapi.PipelineImageStreamTagReferenceSource}},
 			},
@@ -69,9 +77,11 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "additinal image",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace:        "some-namespace",
-					Name:             "some-stream",
-					AdditionalImages: map[string]string{"expected": ""},
+					Targets: []cioperatorapi.PromotionTarget{{
+						Namespace:        "some-namespace",
+						Name:             "some-stream",
+						AdditionalImages: map[string]string{"expected": ""},
+					}},
 				},
 			},
 			expected: sets.New[string]("some-namespace/some-stream:expected"),
@@ -80,9 +90,11 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 			name: "image and additional image",
 			config: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Namespace:        "some-namespace",
-					Name:             "some-stream",
-					AdditionalImages: map[string]string{"expected": ""},
+					Targets: []cioperatorapi.PromotionTarget{{
+						Namespace:        "some-namespace",
+						Name:             "some-stream",
+						AdditionalImages: map[string]string{"expected": ""},
+					}},
 				},
 				Images: []cioperatorapi.ProjectDirectoryImageBuildStepConfiguration{{To: cioperatorapi.PipelineImageStreamTagReferenceSource}},
 			},
@@ -327,9 +339,11 @@ func TestOptionsMatche(t *testing.T) {
 			},
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Disabled:  true,
-					Name:      "4.6",
-					Namespace: "ocp",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Disabled:  true,
+						Name:      "4.6",
+						Namespace: "ocp",
+					}},
 				},
 			},
 			expected: false,
@@ -341,8 +355,10 @@ func TestOptionsMatche(t *testing.T) {
 			},
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Name:      "one",
-					Namespace: "ocp",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name:      "one",
+						Namespace: "ocp",
+					}},
 				},
 			},
 			expected: true,
@@ -354,8 +370,10 @@ func TestOptionsMatche(t *testing.T) {
 			},
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Name:      "4.8",
-					Namespace: "origin",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name:      "4.8",
+						Namespace: "origin",
+					}},
 				},
 			},
 			expected: true,
@@ -368,8 +386,62 @@ func TestOptionsMatche(t *testing.T) {
 			},
 			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
 				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
-					Name:      "one",
-					Namespace: "promotionns",
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name:      "one",
+						Namespace: "promotionns",
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "at least one target matching",
+			input: []string{
+				"--current-release=release-1",
+				"--current-promotion-namespace=ns-1",
+			},
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{
+						{
+							Name:      "release-0",
+							Namespace: "ns-0",
+						},
+						{
+							Name:      "release-1",
+							Namespace: "ns-1",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "fallback to official origin namespace if it's not set",
+			input: []string{
+				"--current-release=one",
+			},
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name:      "one",
+						Namespace: "origin",
+					}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "fallback to official ocp namespace if it's not set",
+			input: []string{
+				"--current-release=one",
+			},
+			configSpec: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{{
+						Name:      "one",
+						Namespace: "ocp",
+					}},
 				},
 			},
 			expected: true,

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -280,7 +280,7 @@ func TestGeneratePostSubmitForPromotion(t *testing.T) {
 	ciopConfig := ciop.ReleaseBuildConfiguration{
 		Tests:                  []ciop.TestStepConfiguration{},
 		Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
-		PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "ci"},
+		PromotionConfiguration: &ciop.PromotionConfiguration{Targets: []ciop.PromotionTarget{{Namespace: "ci"}}},
 	}
 	generateOption := func(options *generatePostsubmitOptions) {}
 
@@ -405,7 +405,7 @@ func TestGenerateJobs(t *testing.T) {
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests:                  []ciop.TestStepConfiguration{},
 				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
-				PromotionConfiguration: &ciop.PromotionConfiguration{Namespace: "ci"},
+				PromotionConfiguration: &ciop.PromotionConfiguration{Targets: []api.PromotionTarget{{Namespace: "ci"}}},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",
@@ -422,10 +422,12 @@ func TestGenerateJobs(t *testing.T) {
 					{To: "out-2", From: "base"},
 				},
 				PromotionConfiguration: &ciop.PromotionConfiguration{
-					Namespace: "ci",
-					AdditionalImages: map[string]string{
-						"out": "out-1",
-					},
+					Targets: []api.PromotionTarget{{
+						Namespace: "ci",
+						AdditionalImages: map[string]string{
+							"out": "out-1",
+						},
+					}},
 				},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -162,8 +162,10 @@ func TestPromotedTags(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+					}},
 				},
 			},
 			expected: []api.ImageStreamTagReference{
@@ -177,9 +179,11 @@ func TestPromotedTags(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
-					Disabled:  true,
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+						Disabled:  true,
+					}},
 				},
 			},
 			expected: nil,
@@ -191,8 +195,10 @@ func TestPromotedTags(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+					}},
 				},
 			},
 			expected: []api.ImageStreamTagReference{
@@ -206,11 +212,13 @@ func TestPromotedTags(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
-					AdditionalImages: map[string]string{
-						"output": "src",
-					},
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+						AdditionalImages: map[string]string{
+							"output": "src",
+						},
+					}},
 				},
 			},
 			expected: []api.ImageStreamTagReference{
@@ -225,9 +233,11 @@ func TestPromotedTags(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace:      "roger",
-					Tag:            "fred",
-					ExcludedImages: []string{"foo"},
+					Targets: []api.PromotionTarget{{
+						Namespace:      "roger",
+						Tag:            "fred",
+						ExcludedImages: []string{"foo"},
+					}},
 				},
 			},
 			expected: nil,
@@ -238,8 +248,10 @@ func TestPromotedTags(t *testing.T) {
 				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},
 				BinaryBuildCommands: "something",
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+					}},
 				},
 				Metadata: api.Metadata{
 					Org:    "org",
@@ -255,13 +267,15 @@ func TestPromotedTags(t *testing.T) {
 			name: "promotion with AdditionalImages: many to one",
 			input: &api.ReleaseBuildConfiguration{
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "ocp",
-					Name:      "4.6",
-					AdditionalImages: map[string]string{
-						"base":   "base-8",
-						"base-7": "base-7",
-						"base-8": "base-8",
-					},
+					Targets: []api.PromotionTarget{{
+						Namespace: "ocp",
+						Name:      "4.6",
+						AdditionalImages: map[string]string{
+							"base":   "base-8",
+							"base-7": "base-7",
+							"base-8": "base-8",
+						},
+					}},
 				},
 				Metadata: api.Metadata{
 					Org:    "openshift",
@@ -307,8 +321,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+					}},
 				},
 			},
 			expected: map[string][]api.ImageStreamTagReference{
@@ -326,8 +342,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("bar"), Optional: true},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+					}},
 				},
 			},
 			expected: map[string][]api.ImageStreamTagReference{
@@ -344,8 +362,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo"), Optional: true},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+					}},
 				},
 			},
 			options: []PromotedTagsOption{WithRequiredImages(sets.New[string]("foo"))},
@@ -363,9 +383,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Name:      "fred",
-					Disabled:  true,
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Name:      "fred",
+						Disabled:  true,
+					}},
 				},
 			},
 			expected:               map[string][]api.ImageStreamTagReference{},
@@ -378,8 +400,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+					}},
 				},
 			},
 			expected: map[string][]api.ImageStreamTagReference{
@@ -396,9 +420,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace:   "roger",
-					Tag:         "fred",
-					TagByCommit: true,
+					Targets: []api.PromotionTarget{{
+						Namespace:   "roger",
+						Tag:         "fred",
+						TagByCommit: true,
+					}},
 				},
 			},
 			options: []PromotedTagsOption{WithCommitSha("sha")},
@@ -417,11 +443,13 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
-					AdditionalImages: map[string]string{
-						"output": "src",
-					},
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+						AdditionalImages: map[string]string{
+							"output": "src",
+						},
+					}},
 				},
 			},
 			expected: map[string][]api.ImageStreamTagReference{
@@ -441,9 +469,11 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 					{To: api.PipelineImageStreamTagReference("foo")},
 				},
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace:      "roger",
-					Tag:            "fred",
-					ExcludedImages: []string{"foo"},
+					Targets: []api.PromotionTarget{{
+						Namespace:      "roger",
+						Tag:            "fred",
+						ExcludedImages: []string{"foo"},
+					}},
 				},
 			},
 			expected:               map[string][]api.ImageStreamTagReference{},
@@ -455,8 +485,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},
 				BinaryBuildCommands: "something",
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "roger",
-					Tag:       "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+					}},
 				},
 				Metadata: api.Metadata{
 					Org:    "org",
@@ -475,8 +507,10 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 				Images:              []api.ProjectDirectoryImageBuildStepConfiguration{},
 				BinaryBuildCommands: "something",
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace:         "roger",
-					Tag:               "fred",
+					Targets: []api.PromotionTarget{{
+						Namespace: "roger",
+						Tag:       "fred",
+					}},
 					DisableBuildCache: true,
 				},
 				Metadata: api.Metadata{
@@ -492,13 +526,15 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 			name: "promotion with AdditionalImages: many to one",
 			input: &api.ReleaseBuildConfiguration{
 				PromotionConfiguration: &api.PromotionConfiguration{
-					Namespace: "ocp",
-					Name:      "4.6",
-					AdditionalImages: map[string]string{
-						"base":   "base-8",
-						"base-7": "base-7",
-						"base-8": "base-8",
-					},
+					Targets: []api.PromotionTarget{{
+						Namespace: "ocp",
+						Name:      "4.6",
+						AdditionalImages: map[string]string{
+							"base":   "base-8",
+							"base-7": "base-7",
+							"base-8": "base-8",
+						},
+					}},
 				},
 				Metadata: api.Metadata{
 					Org:    "openshift",
@@ -522,6 +558,14 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 			input: &api.ReleaseBuildConfiguration{
 				PromotionConfiguration: &api.PromotionConfiguration{
 					Targets: []api.PromotionTarget{{
+						Namespace: "ocp",
+						Name:      "4.6",
+						AdditionalImages: map[string]string{
+							"base":   "base-8",
+							"base-7": "base-7",
+							"base-8": "base-8",
+						},
+					}, {
 						ExcludedImages: []string{"*"},
 						AdditionalImages: map[string]string{
 							"other": "base",
@@ -529,13 +573,6 @@ func TestPromotedTagsWithRequiredImages(t *testing.T) {
 						Namespace: "extra",
 						Tag:       "latest",
 					}},
-					Namespace: "ocp",
-					Name:      "4.6",
-					AdditionalImages: map[string]string{
-						"base":   "base-8",
-						"base-7": "base-7",
-						"base-8": "base-8",
-					},
 				},
 				Metadata: api.Metadata{
 					Org:    "openshift",

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -247,6 +247,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    # key is the name to promote as and the value is the source\n" +
 	"    # name. If you specify a tag that does not exist as the source\n" +
 	"    # the destination tag will not be created.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].additional_images\n" +
 	"    additional_images:\n" +
 	"        \"\": \"\"\n" +
 	"    # DisableBuildCache stops us from uploading the build cache.\n" +
@@ -259,19 +260,23 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    # promote to the same output imagestream on a cut-over but\n" +
 	"    # never concurrently, and you want to have promotion config\n" +
 	"    # in the ci-operator configuration files all the time.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].disabled\n" +
 	"    disabled: true\n" +
 	"    # ExcludedImages are image names that will not be promoted.\n" +
 	"    # Exclusions are made before additional_images are included.\n" +
 	"    # Use exclusions when you want to build images for testing\n" +
 	"    # but not promote them afterwards.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].excluded_images\n" +
 	"    excluded_images:\n" +
 	"        - \"\"\n" +
 	"    # Name is an optional image stream name to use that\n" +
 	"    # contains all component tags. If specified, tag is\n" +
 	"    # ignored.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].name\n" +
 	"    name: ' '\n" +
 	"    # Namespace identifies the namespace to which the built\n" +
 	"    # artifacts will be published to.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].namespace\n" +
 	"    namespace: ' '\n" +
 	"    # RegistryOverride is an override for the registry domain to\n" +
 	"    # which we will mirror images. This is an advanced option and\n" +
@@ -280,11 +285,13 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"    registry_override: ' '\n" +
 	"    # Tag is the ImageStreamTag tagged in for each\n" +
 	"    # build image's ImageStream.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].tag\n" +
 	"    tag: ' '\n" +
 	"    # TagByCommit determines if an image should be tagged by the\n" +
 	"    # git commit that was used to build it. If Tag is also set,\n" +
 	"    # this will cause both a floating tag and commit-specific tags\n" +
 	"    # to be promoted.\n" +
+	"    # Deprecated, prefer to set promotion.targets[0].tag_by_commit\n" +
 	"    tag_by_commit: true\n" +
 	"    # Targets configure a set of images to be pushed to\n" +
 	"    # a registry.\n" +

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/foo/barry-white/foo-barry-white-official__releases.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -13,9 +13,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  disabled: true
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - disabled: true
+    name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: 4.5-priv
-  namespace: ocp-private
+  to:
+  - name: 4.5-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/deprecated-repo/super-priv-deprecated-repo-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/deprecated-repo/super-priv-deprecated-repo-master.yaml
@@ -17,8 +17,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/duper/super-priv-duper-master.yaml
@@ -17,8 +17,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-deprecated.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-deprecated.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super-priv/trooper/super-priv-trooper-master.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/duper/super-duper-master.yaml
@@ -16,8 +16,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/looper/super-looper-master.yaml
@@ -12,9 +12,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp
-  tag: "4.14"
-  tag_by_commit: true
+  to:
+  - namespace: ocp
+    tag: "4.14"
+    tag_by_commit: true
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input-to-clean/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input-to-clean/super/trooper/super-trooper-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-official.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/input/foo/barry-white/foo-barry-white-official__releases.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/input/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/super/duper/super-duper-master.yaml
@@ -16,8 +16,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/super/looper/super-looper-master.yaml
@@ -12,9 +12,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp
-  tag: "4.14"
-  tag_by_commit: true
+  to:
+  - namespace: ocp
+    tag: "4.14"
+    tag_by_commit: true
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/input/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/input/super/trooper/super-trooper-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/foo/barry-white/foo-barry-white-official__releases.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -13,9 +13,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  disabled: true
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - disabled: true
+    name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: 4.5-priv
-  namespace: ocp-private
+  to:
+  - name: 4.5-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/barry-white/super-priv-barry-white-official__releases.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: 4.5-priv
-  namespace: ocp-private
+  to:
+  - name: 4.5-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/duper/super-priv-duper-master.yaml
@@ -17,8 +17,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/looper/super-priv-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/looper/super-priv-looper-master.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp-private
-  tag: 4.14-priv
+  to:
+  - namespace: ocp-private
+    tag: 4.14-priv
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super-priv/trooper/super-priv-trooper-master.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/duper/super-duper-master.yaml
@@ -16,8 +16,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/looper/super-looper-master.yaml
@@ -12,9 +12,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp
-  tag: "4.14"
-  tag_by_commit: true
+  to:
+  - namespace: ocp
+    tag: "4.14"
+    tag_by_commit: true
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output-only-super/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output-only-super/super/trooper/super-trooper-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-official.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/output/foo/barry-white/foo-barry-white-official__releases.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-master.yaml
@@ -13,9 +13,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  disabled: true
-  name: satin-soul
-  namespace: non-ocp
+  to:
+  - disabled: true
+    name: satin-soul
+    namespace: non-ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: 4.5-priv
-  namespace: ocp-private
+  to:
+  - name: 4.5-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official__releases.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/barry-white/super-priv-barry-white-official__releases.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: 4.5-priv
-  namespace: ocp-private
+  to:
+  - name: 4.5-priv
+    namespace: ocp-private
 releases:
   initial:
     integration:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/duper/super-priv-duper-master.yaml
@@ -17,8 +17,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/looper/super-priv-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/looper/super-priv-looper-master.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp-private
-  tag: 4.14-priv
+  to:
+  - namespace: ocp-private
+    tag: 4.14-priv
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super-priv/trooper/super-priv-trooper-master.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other-priv
-  namespace: ocp-private
+  to:
+  - name: other-priv
+    namespace: ocp-private
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super/duper/super-duper-master.yaml
@@ -16,8 +16,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super/looper/super-looper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super/looper/super-looper-master.yaml
@@ -12,9 +12,10 @@ images:
 - from: base
   to: test-image
 promotion:
-  namespace: ocp
-  tag: "4.14"
-  tag_by_commit: true
+  to:
+  - namespace: ocp
+    tag: "4.14"
+    tag_by_commit: true
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-config-mirror/output/super/trooper/super-trooper-master.yaml
+++ b/test/integration/ci-operator-config-mirror/output/super/trooper/super-trooper-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-prowgen/input/config/private/duper/private-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/private/duper/private-duper-master.yaml
@@ -12,8 +12,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -20,8 +20,9 @@ operator:
     dockerfile_path: bundle.Dockerfile
     optional: true
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master__variant.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master__variant.yaml
@@ -13,8 +13,9 @@ images:
 - from: base
   to: test-image
 promotion:
-  name: other
-  namespace: ocp
+  to:
+  - name: other
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-release-3.11.yaml
@@ -12,10 +12,11 @@ images:
 - from: base
   to: test-image
 promotion:
-  additional_images:
-    super-duper-src: src
-  name: other
-  namespace: openshift
+  to:
+  - additional_images:
+      super-duper-src: src
+    name: other
+    namespace: openshift
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.6"
-  namespace: ocp
+  to:
+  - name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-master__releases.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-master__releases.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.6"
-  namespace: ocp
+  to:
+  - name: "4.6"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5__releases.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.5__releases.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6.yaml
@@ -14,9 +14,10 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  disabled: true
-  name: "4.6"
-  namespace: ocp
+  to:
+  - disabled: true
+    name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6__releases.yaml
+++ b/test/integration/config-brancher/expected/org/bump/org-bump-release-4.6__releases.yaml
@@ -14,9 +14,10 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  disabled: true
-  name: "4.6"
-  namespace: ocp
+  to:
+  - disabled: true
+    name: "4.6"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.6"
-  namespace: ocp
+  to:
+  - name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.5.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/existing/org-existing-release-4.6.yaml
@@ -14,9 +14,10 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  disabled: true
-  name: "4.6"
-  namespace: ocp
+  to:
+  - disabled: true
+    name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/new/org-new-master.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.5.yaml
@@ -14,9 +14,10 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  disabled: true
-  name: "4.5"
-  namespace: ocp
+  to:
+  - disabled: true
+    name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
+++ b/test/integration/config-brancher/expected/org/new/org-new-release-4.6.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.6"
-  namespace: ocp
+  to:
+  - name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/input/org/bump/org-bump-master.yaml
+++ b/test/integration/config-brancher/input/org/bump/org-bump-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/input/org/bump/org-bump-master__releases.yaml
+++ b/test/integration/config-brancher/input/org/bump/org-bump-master__releases.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/config-brancher/input/org/existing/org-existing-master.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/input/org/existing/org-existing-release-4.5.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-release-4.5.yaml
@@ -14,9 +14,10 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  disabled: true
-  name: "4.5"
-  namespace: ocp
+  to:
+  - disabled: true
+    name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/input/org/existing/org-existing-release-4.6.yaml
+++ b/test/integration/config-brancher/input/org/existing/org-existing-release-4.6.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.6"
-  namespace: ocp
+  to:
+  - name: "4.6"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/config-brancher/input/org/new/org-new-master.yaml
+++ b/test/integration/config-brancher/input/org/new/org-new-master.yaml
@@ -14,8 +14,9 @@ build_root:
     namespace: ocp
     tag: base
 promotion:
-  name: "4.5"
-  namespace: ocp
+  to:
+  - name: "4.5"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/repo-init/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -13,8 +13,9 @@ images:
         source_path: /go/bin/blocking-issue-creator
   to: blocking-issue-creator
 promotion:
-  namespace: ci
-  tag: latest
+  to:
+  - namespace: ci
+    tag: latest
 resources:
   '*':
     limits:

--- a/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -12,12 +12,13 @@ images:
       - registry.svc.ci.openshift.org/ocp/builder:golang-1.12
   to: tests
 promotion:
-  additional_images:
-    artifacts: artifacts
-  excluded_images:
-  - machine-os-content
-  name: "4.3"
-  namespace: ocp
+  to:
+  - additional_images:
+      artifacts: artifacts
+    excluded_images:
+    - machine-os-content
+    name: "4.3"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/other/org-other-nonstandard.yaml
@@ -5,8 +5,9 @@ build_root:
     tag: golang-1.15
 canonical_go_repository: k8s.io/cool
 promotion:
-  name: "4.3"
-  namespace: ocp
+  to:
+  - name: "4.3"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-master.yaml
@@ -10,8 +10,9 @@ build_root:
     namespace: openshift
     tag: golang-1.13
 promotion:
-  name: "4.3"
-  namespace: ocp
+  to:
+  - name: "4.3"
+    namespace: ocp
 releases:
   initial:
     integration:

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
@@ -3,9 +3,12 @@ deck:
   spyglass:
     gcs_browser_prefixes:
       '*': ""
+    gcs_browser_prefixes_by_bucket:
+      '*': ""
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s
@@ -45,43 +48,43 @@ tide:
   max_goroutines: 20
   queries:
   - includedBranches:
+    - openshift-4.1
     - release-4.0
     - release-4.1
     - release-4.2
     - release-4.3
     - release-4.4
-    - openshift-4.1
     labels:
-    - lgtm
     - approved
     - bugzilla/valid-bug
     - cherry-pick-approved
+    - lgtm
     missingLabels:
-    - needs-rebase
+    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
-    - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
-    - bugzilla/invalid-bug
+    - do-not-merge/work-in-progress
+    - needs-rebase
     repos:
     - openshift/unsharded-b
   - excludedBranches:
+    - openshift-4.1
     - release-4.0
     - release-4.1
     - release-4.2
     - release-4.3
     - release-4.4
-    - openshift-4.1
     labels:
-    - lgtm
     - approved
+    - lgtm
     missingLabels:
-    - needs-rebase
+    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
-    - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
-    - bugzilla/invalid-bug
+    - do-not-merge/work-in-progress
+    - needs-rebase
     repos:
     - openshift/unsharded-a
     - openshift/unsharded-b

--- a/test/integration/repo-init/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
+++ b/test/integration/repo-init/input/ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml
@@ -13,8 +13,9 @@ images:
         source_path: /go/bin/blocking-issue-creator
   to: blocking-issue-creator
 promotion:
-  namespace: ci
-  tag: latest
+  to:
+  - namespace: ci
+    tag: latest
 resources:
   '*':
     limits:

--- a/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
+++ b/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-master.yaml
@@ -12,12 +12,13 @@ images:
       - registry.svc.ci.openshift.org/ocp/builder:golang-1.12
   to: tests
 promotion:
-  additional_images:
-    artifacts: artifacts
-  excluded_images:
-  - machine-os-content
-  name: "4.3"
-  namespace: ocp
+  to:
+  - additional_images:
+      artifacts: artifacts
+    excluded_images:
+    - machine-os-content
+    name: "4.3"
+    namespace: ocp
 resources:
   '*':
     limits:

--- a/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
@@ -3,9 +3,12 @@ deck:
   spyglass:
     gcs_browser_prefixes:
       '*': ""
+    gcs_browser_prefixes_by_bucket:
+      '*': ""
     size_limit: 100000000
   tide_update_period: 10s
 default_job_timeout: 24h0m0s
+gangway: {}
 gerrit:
   ratelimit: 5
   tick_interval: 1m0s
@@ -45,43 +48,43 @@ tide:
   max_goroutines: 20
   queries:
   - includedBranches:
+    - openshift-4.1
     - release-4.0
     - release-4.1
     - release-4.2
     - release-4.3
     - release-4.4
-    - openshift-4.1
     labels:
-    - lgtm
     - approved
     - bugzilla/valid-bug
     - cherry-pick-approved
+    - lgtm
     missingLabels:
-    - needs-rebase
+    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
-    - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
-    - bugzilla/invalid-bug
+    - do-not-merge/work-in-progress
+    - needs-rebase
     repos:
     - openshift/unsharded-b
   - excludedBranches:
+    - openshift-4.1
     - release-4.0
     - release-4.1
     - release-4.2
     - release-4.3
     - release-4.4
-    - openshift-4.1
     labels:
-    - lgtm
     - approved
+    - lgtm
     missingLabels:
-    - needs-rebase
+    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
-    - do-not-merge/work-in-progress
     - do-not-merge/invalid-owners-file
-    - bugzilla/invalid-bug
+    - do-not-merge/work-in-progress
+    - needs-rebase
     repos:
     - openshift/unsharded-a
     - openshift/unsharded-b

--- a/test/integration/repo-init/input/core-services/prow/02_config/_plugins.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/_plugins.yaml
@@ -1,11 +1,6 @@
-approve:
-- commandHelpLink: ""
-  lgtm_acts_as_approve: true
-  repos:
-  - openshift
-  require_self_approval: false
 blunderbuss:
   request_count: 2
+branch_cleaner: {}
 bugzilla: {}
 cat: {}
 cherry_pick_unapproved:
@@ -40,32 +35,12 @@ config_updater:
       cluster_groups:
       - build_farm_ci
       name: cm-path
-external_plugins:
-  openshift:
-  - endpoint: http://refresh
-    events:
-    - issue_comment
-    name: refresh
-  - endpoint: http://cherrypick
-    events:
-    - issue_comment
-    - pull_request
-    name: cherrypick
-  - endpoint: http://needs-rebase
-    events:
-    - pull_request
-    name: needs-rebase
 golint: {}
 goose: {}
 heart: {}
 help:
   help_guidelines_url: https://git.k8s.io/community/contributors/guide/help-wanted.md
-label:
-  additional_labels: null
-lgtm:
-- repos:
-  - openshift
-  review_acts_as_lgtm: true
+label: {}
 override: {}
 owners:
   labels_denylist:

--- a/test/integration/repo-init/input/core-services/prow/02_config/org/other/_pluginconfig.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/org/other/_pluginconfig.yaml
@@ -1,11 +1,10 @@
 approve:
 - commandHelpLink: ""
-  lgtm_acts_as_approve: true
   repos:
-  - openshift
+  - org/other
   require_self_approval: false
 external_plugins:
-  openshift:
+  org/other:
   - endpoint: http://refresh
     events:
     - issue_comment
@@ -21,10 +20,10 @@ external_plugins:
     name: needs-rebase
 lgtm:
 - repos:
-  - openshift
+  - org/other
   review_acts_as_lgtm: true
 plugins:
-  openshift:
+  org/other:
     plugins:
     - assign
     - blunderbuss
@@ -52,3 +51,4 @@ plugins:
     - owners-label
     - wip
     - yuks
+    - approve

--- a/test/integration/repo-init/input/core-services/prow/02_config/org/repo/_pluginconfig.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/org/repo/_pluginconfig.yaml
@@ -1,11 +1,10 @@
 approve:
 - commandHelpLink: ""
-  lgtm_acts_as_approve: true
   repos:
-  - openshift
+  - org/repo
   require_self_approval: false
 external_plugins:
-  openshift:
+  org/repo:
   - endpoint: http://refresh
     events:
     - issue_comment
@@ -21,10 +20,10 @@ external_plugins:
     name: needs-rebase
 lgtm:
 - repos:
-  - openshift
+  - org/repo
   review_acts_as_lgtm: true
 plugins:
-  openshift:
+  org/repo:
     plugins:
     - assign
     - blunderbuss
@@ -52,3 +51,4 @@ plugins:
     - owners-label
     - wip
     - yuks
+    - approve

--- a/test/integration/repo-init/input/core-services/prow/02_config/org/third/_pluginconfig.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/org/third/_pluginconfig.yaml
@@ -1,11 +1,10 @@
 approve:
 - commandHelpLink: ""
-  lgtm_acts_as_approve: true
   repos:
-  - openshift
+  - org/third
   require_self_approval: false
 external_plugins:
-  openshift:
+  org/third:
   - endpoint: http://refresh
     events:
     - issue_comment
@@ -21,10 +20,10 @@ external_plugins:
     name: needs-rebase
 lgtm:
 - repos:
-  - openshift
+  - org/third
   review_acts_as_lgtm: true
 plugins:
-  openshift:
+  org/third:
     plugins:
     - assign
     - blunderbuss
@@ -52,3 +51,4 @@ plugins:
     - owners-label
     - wip
     - yuks
+    - approve


### PR DESCRIPTION
Keep trying to merge it: hopefully I haven't forgotten anything this time nor any funny edge case pops up.

At this stage it makes sense to summarize what has been done:
- 1st attempt - https://github.com/openshift/ci-tools/pull/3615
- Revert - https://github.com/openshift/ci-tools/pull/3636
- 2nd attempt - https://github.com/openshift/ci-tools/pull/3707
- Revert - https://github.com/openshift/ci-tools/pull/3853

Important note: I've spotted an edge case in `ci-operator-config-mirror` as it doesn't iterate `targets` using the `api.PromotionTargets` function but it rather performs a simply `for` loop. This might be ok once every configuration will follow the new schema but it's not safe in general.
It's true that `determinize-ci-operator` would move every configuration from the old schema to the new one but I've noticed that in the `autoconfigbrancher` it runs after `ci-operator-config-mirror`, so it (the config-mirror) won't operate on the canonicalized configuration.

I guess right after we have this merged we should run `make ci-operator-config` in [o/release](https://github.com/openshift/release) to avoid troubles for the users as it happened the [last time](https://redhat-internal.slack.com/archives/GB7NB0CUC/p1702668848031919?thread_ts=1702650091.090099&cid=GB7NB0CUC).

/cc @openshift/test-platform