### PR TITLE
secret-bootstrap: ignore user secrets on disabled clusters

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1653,7 +1653,7 @@ func TestUpdateSecrets(t *testing.T) {
 				"build01": fkcBuild01.CoreV1(),
 			}
 
-			actual := updateSecrets(clients, tc.secretsMap, tc.force, true, nil)
+			actual := updateSecrets(clients, tc.secretsMap, tc.force, true, nil, nil)
 			equalError(t, tc.expected, actual)
 
 			actualSecretsOnDefault, err := fkcDefault.CoreV1().Secrets("").List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
Previously, it ignored the dptp-defined secrets.
The tool handles the user-defined secrets too. 
We need to ignore them as well.

/cc @openshift/test-platform 