### PR TITLE
github-ldap-user-group-creator: recognize a new rebot Id

### DIFF
--- a/cmd/github-ldap-user-group-creator/main.go
+++ b/cmd/github-ldap-user-group-creator/main.go
@@ -306,7 +306,7 @@ type GroupClusters struct {
 	Group    *userv1.Group
 }
 
-var githubRobotIds = sets.New[string]("RH-Cachito", "openshift-bot", "openshift-ci-robot", "openshift-merge-robot")
+var githubRobotIds = sets.New[string]("RH-Cachito", "openshift-bot", "openshift-ci-robot", "openshift-merge-robot", "openshift-cherrypick-robot")
 
 func deleteInvalidUsers(ctx context.Context, clients map[string]ctrlruntimeclient.Client,
 	kerberosIDs sets.Set[string], ciAdmins sets.Set[string], dryRun bool) error {


### PR DESCRIPTION
```
{"component":"github-ldap-user-group-creator","file":"/go/src/github.com/openshift/ci-tools/cmd/github-ldap-user-group-creator/main.go:406","func":"main.makeGroups","ignoredOpenshiftPrivAdminNames":["openshift-cherrypick-robot"],"level":"error","msg":"These logins are members of openshift-priv but have no mapping to RH login.","severity":"error","time":"2024-01-03T19:46:14Z"}
```

Found it in the log above.

/cc @openshift/test-platform 