### PR TITLE
Add build cluster and asterisks for relative duration in aggregated jobs

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatorlib/spyglass_summary.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/spyglass_summary.go
@@ -3,6 +3,7 @@ package jobrunaggregatorlib
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -46,7 +47,7 @@ body {
 				html += fmt.Sprintf(" unable to get prowjob: %v\n", err)
 			}
 			if prowJob != nil {
-				html += fmt.Sprintf(" did not finish since %v\n", prowJob.CreationTimestamp)
+				html += fmt.Sprintf("%v did not finish since %v\n", prowJob.Spec.Cluster, prowJob.CreationTimestamp)
 			}
 			html += "</li>\n"
 		}
@@ -73,7 +74,11 @@ body {
 				if prowJob.Status.CompletionTime != nil {
 					duration = prowJob.Status.CompletionTime.Sub(prowJob.Status.StartTime.Time)
 				}
-				html += fmt.Sprintf(" %v after %v\n", prowJob.Status.State, duration)
+				// Create a string of asterisks proportional to the number of seconds (scaled down by 1000)
+				// so we can visually ascertain relative job time.
+				scaleSeconds := int(duration.Seconds() / 1000.0)
+				stars := strings.Repeat("*", scaleSeconds)
+				html += fmt.Sprintf(" %v %v after %v %v\n", prowJob.Spec.Cluster, prowJob.Status.State, duration, stars)
 			}
 			html += "</li>\n"
 		}


### PR DESCRIPTION
[TRT-1428](https://issues.redhat.com//browse/TRT-1428)

job-run-summary for an aggregated job looks like this:

```
[periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade/1743954212951166976](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade/1743954212951166976) failure after 5m45s
...
[periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade/1743954219666247680](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-e2e-azure-ovn-upgrade/1743954219666247680) failure after 4h0m10s
```

This PR adds the build cluster and a little bar chart to show relative duration:

```
[periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738676454035456](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738676454035456) build01 success after 3h25m22s ************
[periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738677385170944](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738677385170944) build03 success after 3h16m38s ***********
...
[periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738683190087680](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738683190087680) build03 success after 3h17m56s ***********
[periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738684028948480](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-ci-4.16-upgrade-from-stable-4.15-e2e-gcp-ovn-rt-upgrade/1737738684028948480) build05 success after 3h15m34s ***********
```

This way you can tell if job failures are specific to a particular build cluster and visually show relative duration (to quickly identify jobs that aborted early).