### PR TITLE
Enable pipeline_run_if_changed for optional jobs

### DIFF
--- a/cmd/pipeline-controller/config_data_provider.go
+++ b/cmd/pipeline-controller/config_data_provider.go
@@ -61,17 +61,17 @@ func (c *ConfigDataProvider) gatherData() {
 	for _, orgRepo := range orgRepos {
 		presubmits := cfg.GetPresubmitsStatic(orgRepo)
 		for _, p := range presubmits {
-			if !p.Optional {
-				if !p.AlwaysRun && p.RunIfChanged == "" && p.SkipIfOnlyChanged == "" {
-					if val, ok := p.Annotations["pipeline_run_if_changed"]; ok && val != "" {
-						if pre, ok := updatedPresubmits[orgRepo]; !ok {
-							updatedPresubmits[orgRepo] = presubmitTests{pipelineConditionallyRequired: []config.Presubmit{p}}
-						} else {
-							pre.pipelineConditionallyRequired = append(pre.pipelineConditionallyRequired, p)
-							updatedPresubmits[orgRepo] = pre
-						}
-						continue
+			if !p.AlwaysRun && p.RunIfChanged == "" && p.SkipIfOnlyChanged == "" {
+				if val, ok := p.Annotations["pipeline_run_if_changed"]; ok && val != "" {
+					if pre, ok := updatedPresubmits[orgRepo]; !ok {
+						updatedPresubmits[orgRepo] = presubmitTests{pipelineConditionallyRequired: []config.Presubmit{p}}
+					} else {
+						pre.pipelineConditionallyRequired = append(pre.pipelineConditionallyRequired, p)
+						updatedPresubmits[orgRepo] = pre
 					}
+					continue
+				}
+				if !p.Optional {
 					if pre, ok := updatedPresubmits[orgRepo]; !ok {
 						updatedPresubmits[orgRepo] = presubmitTests{protected: []string{p.Name}}
 					} else {
@@ -80,24 +80,24 @@ func (c *ConfigDataProvider) gatherData() {
 					}
 					continue
 				}
-				if p.AlwaysRun {
-					if pre, ok := updatedPresubmits[orgRepo]; !ok {
-						updatedPresubmits[orgRepo] = presubmitTests{alwaysRequired: []string{p.Name}}
-					} else {
-						pre.alwaysRequired = append(pre.alwaysRequired, p.Name)
-						updatedPresubmits[orgRepo] = pre
-					}
-					continue
+			}
+			if !p.Optional && p.AlwaysRun {
+				if pre, ok := updatedPresubmits[orgRepo]; !ok {
+					updatedPresubmits[orgRepo] = presubmitTests{alwaysRequired: []string{p.Name}}
+				} else {
+					pre.alwaysRequired = append(pre.alwaysRequired, p.Name)
+					updatedPresubmits[orgRepo] = pre
 				}
-				if p.RunIfChanged != "" || p.SkipIfOnlyChanged != "" {
-					if pre, ok := updatedPresubmits[orgRepo]; !ok {
-						updatedPresubmits[orgRepo] = presubmitTests{conditionallyRequired: []string{p.Name}}
-					} else {
-						pre.conditionallyRequired = append(pre.conditionallyRequired, p.Name)
-						updatedPresubmits[orgRepo] = pre
-					}
-					continue
+				continue
+			}
+			if !p.Optional && (p.RunIfChanged != "" || p.SkipIfOnlyChanged != "") {
+				if pre, ok := updatedPresubmits[orgRepo]; !ok {
+					updatedPresubmits[orgRepo] = presubmitTests{conditionallyRequired: []string{p.Name}}
+				} else {
+					pre.conditionallyRequired = append(pre.conditionallyRequired, p.Name)
+					updatedPresubmits[orgRepo] = pre
 				}
+				continue
 			}
 		}
 	}

--- a/cmd/pipeline-controller/reconciler.go
+++ b/cmd/pipeline-controller/reconciler.go
@@ -225,7 +225,9 @@ func (r *reconciler) acquireConditionalContexts(pj *v1.ProwJob, pipelineConditio
 					testCommands += "\n" + presubmit.RerunCommand
 					continue
 				}
-				overrideCommands += " " + presubmit.Context
+				if !presubmit.Optional {
+					overrideCommands += " " + presubmit.Context
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is enabling `pipeline_run_if_changed` setting for optional jobs and not adding them to override list. Mostly to further optimize costs.