### PR TITLE
TRT-1440: Allow prcreator to have comma separated assignee list

### DIFF
--- a/cmd/prcreator/main.go
+++ b/cmd/prcreator/main.go
@@ -28,7 +28,7 @@ func gatherOptions() (*options, error) {
 	flag.StringVar(&opts.prTitle, "pr-title", "", "The title of the PR to create")
 	flag.StringVar(&opts.prMessage, "pr-message", "", "The message of the PR to create")
 	flag.StringVar(&opts.gitCommitMessage, "git-message", "", "The git commit message of the PR to create. If not set, then its value will be composed of other flags")
-	flag.StringVar(&opts.prAssignee, "pr-assignee", "", "The assignee of the PR to create")
+	flag.StringVar(&opts.prAssignee, "pr-assignee", "", "Comma separated list of assignees for the PR to create")
 	flag.StringVar(&opts.organization, "organization", "openshift", "The GitHub organization in which the PR should be created")
 	flag.StringVar(&opts.repo, "repo", "release", "The name of the repo in which the PR should be created")
 	flag.StringVar(&opts.branch, "branch", "master", "The branch for which the PR should be created")

--- a/pkg/github/prcreation/prcreation.go
+++ b/pkg/github/prcreation/prcreation.go
@@ -196,12 +196,18 @@ func (o *PRCreationOptions) UpsertPR(localSourceDir, org, repo, branch, prTitle 
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)
 	}
 
+	assignees := strings.Split(prArgs.prAssignee, ",")
+	for i, assignee := range assignees {
+		assignees[i] = "@" + assignee
+	}
+	assigneeList := strings.Join(assignees, ", ")
+
 	if err := bumper.UpdatePullRequestWithLabels(
 		o.GithubClient,
 		org,
 		repo,
 		prTitle,
-		prArgs.prBody+"\n/cc @"+prArgs.prAssignee,
+		prArgs.prBody+"\n/cc "+assigneeList,
 		username+":"+sourceBranchName,
 		branch,
 		sourceBranchName,


### PR DESCRIPTION
We want certain automated PRs to get assigned to multiple people instead of just one.  This allows the assignee to be a comma separated list; one assignee should still work.

TODO:

- [ ] Do some due diligence on this to avoid breaking automated PRs.