### PR TITLE
`ci-operator`: simplify observer pods unit test

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -407,7 +407,7 @@ func stepForTest(
 			params = api.NewDeferredParameters(params)
 		}
 		var ret []api.Step
-		step := multi_stage.MultiStageTestStep(*c, config, params, podClient, jobSpec, leases, nodeName, targetAdditionalSuffix)
+		step := multi_stage.MultiStageTestStep(*c, config, params, podClient, jobSpec, leases, nodeName, targetAdditionalSuffix, nil)
 		if len(leases) != 0 {
 			step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace)
 		}

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -77,7 +77,7 @@ func TestGeneratePods(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil)
 	step.test[0].Resources = api.ResourceRequirements{
 		Requests: api.ResourceList{api.ShmResource: "2G"},
 		Limits:   api.ResourceList{api.ShmResource: "2G"}}
@@ -155,7 +155,7 @@ func TestGenerateObservers(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil)
 	ret, err := step.generateObservers(observers, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -229,7 +229,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Test:        test,
 					Environment: tc.env,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "")
+			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "", nil)
 			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -297,7 +297,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "")
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil)
 	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -80,7 +80,7 @@ func TestRequires(t *testing.T) {
 				As:                                 "some-e2e",
 				ClusterClaim:                       tc.clusterClaim,
 				MultiStageTestConfigurationLiteral: &tc.steps,
-			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "")
+			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "", nil)
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true


### PR DESCRIPTION
Natural consequence of https://github.com/openshift/ci-tools/pull/3895, this approach is way simpler than what I proposed with https://github.com/openshift/ci-tools/pull/3465.

The main source of pain, as well as the lines of code I had to write to unit test the thing, was due the observers being concurrently executed and torn down alongside a regular step. That was also the cause of sporadic deadlocks.

In this PR I give a test the faculty not to abruptly terminate an observer but therefore wait for it to complete, regardless of the result. By doing so the code requires no other synchronization than what there is already existing [here](https://github.com/openshift/ci-tools/blob/230178ef7f7e15dcc835314f7fde578ad88cb46d/pkg/steps/multi_stage/multi_stage.go#L235).

What follow is an example of how the code would execute **when run from a unit test**:
1. the unit test inject its own `cancelObservers` function that does nothing
1. steps and observers start
1. steps terminate
1. `ci-operator` invokes `cancelObservers` but the observers keep going
1. `ci-operator` waits for all the observers to terminate as it would regularly do 
 
When the code executes outside a unit test context the `ci-operator` does instead cancel the observer context, therefore preserving its normal behavior.