### PR TITLE
`payload-testing-prow-plugin`: add the ability to support multiple PRs

### DIFF
--- a/pkg/release/config/config.go
+++ b/pkg/release/config/config.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"fmt"
+	"regexp"
+	"strconv"
+
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
@@ -25,12 +29,34 @@ type ImageStreamRef struct {
 	ExcludeTags []string `json:"excludeTags,omitempty"`
 }
 
+// AdditionalPR is a formatted string that takes the form "org/repo#number"
+type AdditionalPR string
+
+const additionalPRPattern = `^([\w-]+)/([\w-]+)#(\d+)$`
+
+func (pr AdditionalPR) GetOrgRepoAndNumber() (string, string, int, error) {
+	re := regexp.MustCompile(additionalPRPattern)
+	matches := re.FindStringSubmatch(string(pr))
+	if len(matches) == 4 {
+		org := matches[1]
+		repo := matches[2]
+		number, err := strconv.Atoi(matches[3])
+		if err != nil {
+			return "", "", 0, fmt.Errorf("unable to get additional pr number from string: %s: %w", pr, err)
+		}
+		return org, repo, number, nil
+	} else {
+		return "", "", 0, fmt.Errorf("string: %s doesn't match expected format: org/repo#number", pr)
+	}
+}
+
 type Job struct {
 	Name                 string            `json:"name"`
 	Annotations          map[string]string `json:"annotations"`
 	api.MetadataWithTest `json:",inline"`
 
-	AggregatedCount int `json:"-"`
+	WithPRs         []AdditionalPR `json:"with-prs"`
+	AggregatedCount int            `json:"-"`
 }
 
 type AggregatedJob struct {

--- a/pkg/release/config/config_test.go
+++ b/pkg/release/config/config_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestGetOrgRepoAndNumber(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          AdditionalPR
+		expectedOrg    string
+		expectedRepo   string
+		expectedNumber int
+		expectedError  error
+	}{
+		{
+			name:           "valid string",
+			input:          "openshift/kubernetes#1234",
+			expectedOrg:    "openshift",
+			expectedRepo:   "kubernetes",
+			expectedNumber: 1234,
+		},
+		{
+			name:          "improperly formatted string",
+			input:         "opens/hift/kubernetes#1234",
+			expectedError: errors.New("string: opens/hift/kubernetes#1234 doesn't match expected format: org/repo#number"),
+		},
+		{
+			name:          "number is not a number",
+			input:         "openshift/kubernetes#somestring",
+			expectedError: errors.New("string: openshift/kubernetes#somestring doesn't match expected format: org/repo#number"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			org, repo, number, err := tc.input.GetOrgRepoAndNumber()
+			if diff := cmp.Diff(org, tc.expectedOrg); diff != "" {
+				t.Fatalf("expectedOrg differs from actual: %s", diff)
+			}
+			if diff := cmp.Diff(repo, tc.expectedRepo); diff != "" {
+				t.Fatalf("expectedRepo differs from actual: %s", diff)
+			}
+			if diff := cmp.Diff(number, tc.expectedNumber); diff != "" {
+				t.Fatalf("expectedNumber differs from actual: %s", diff)
+			}
+			if diff := cmp.Diff(err, tc.expectedError, testhelper.EquateErrorMessage); diff != "" {
+				t.Fatalf("expectedErr differs from actual: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a new command to the plugin to support triggering a payload job with additional PRs built into the payload: `payload-job-with-prs`. As an example, the command `/payload-job-with-prs some-job-name openshift/kubernetes#1234 openshift/installer#999` would include the PR that the command was issued on as well as the 2 mentioned PRs in the generated `PRPQR` CR. I will follow this up with an update to the documentation.


For: https://issues.redhat.com/browse/DPTP-3689