### PR TITLE
`payload-testing-prow-plugin`: use correct field for author on additional PRs

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -321,7 +321,7 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) string {
 					BaseSHA: pullRequest.Base.SHA,
 					PullRequest: prpqv1.PullRequest{
 						Number: number,
-						Author: pullRequest.AuthorAssociation,
+						Author: pullRequest.User.Login,
 						SHA:    pullRequest.Head.SHA,
 						Title:  pullRequest.Title,
 					},


### PR DESCRIPTION
You can see the issue with the current field [here](https://pr-payload-tests.ci.openshift.org/runs/ci/04b4f1b0-b6e4-11ee-9042-a34fde72eb6c-0)