### PR TITLE
`multi-arch-builder-controller`: Better logging and tests

### DIFF
--- a/pkg/api/multiarchbuildconfig/v1/types.go
+++ b/pkg/api/multiarchbuildconfig/v1/types.go
@@ -66,13 +66,13 @@ func UpdateMultiArchBuildConfig(ctx context.Context, logger *logrus.Entry, clien
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		mabc := &MultiArchBuildConfig{}
 		if err := client.Get(ctx, namespacedName, mabc); err != nil {
-			return fmt.Errorf("failed to get the MultiArchBuildConfig: %w", err)
+			return fmt.Errorf("failed to get the MultiArchBuildConfig during update: %w", err)
 		}
 
 		mabc = mabc.DeepCopy()
 		mutateFn(mabc)
 
-		logger.WithField("namespace", namespacedName.Namespace).WithField("name", namespacedName.Name).Info("Updating MultiArchBuildConfig...")
+		logger.Info("Updating MultiArchBuildConfig...")
 		if err := client.Update(ctx, mabc); err != nil {
 			return fmt.Errorf("failed to update MultiArchBuildConfig %s: %w", mabc.Name, err)
 		}

--- a/pkg/controller/multiarchbuildconfig/mirror_test.go
+++ b/pkg/controller/multiarchbuildconfig/mirror_test.go
@@ -208,7 +208,7 @@ func TestHandleMirrorImage(t *testing.T) {
 				imageMirrorer: newFakeOCImage(imageMirrorCmdFactory(testCase.imageMirrorErr)),
 			}
 
-			if err := r.handleMirrorImage(context.TODO(), "fake-image", &testCase.mabc); err != nil {
+			if _, err := r.handleMirrorImage(context.TODO(), logrus.NewEntry(logrus.StandardLogger()), "fake-image", &testCase.mabc); err != nil {
 				t.Fatalf("Failed to mirror %v", err)
 			}
 


### PR DESCRIPTION
I had hard time trying to understand what was going wrong with a failing build and I have realized we could have done much better with logs.

/cc @droslean 