### PR TITLE
Add Unit Tests for replacement.go in registery-replacer

### DIFF
--- a/cmd/registry-replacer/replacement_test.go
+++ b/cmd/registry-replacer/replacement_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/imagebuilder"
+	"github.com/openshift/imagebuilder/dockerfile/parser"
+)
+
+func TestReplaceLastFrom(t *testing.T) {
+	testCases := []struct {
+		testName           string
+		inputDockerFile    string
+		expectedDockerFile string
+		newBaseImage       string
+		alias              string
+	}{
+		{
+			testName: "Replace golang base image with feodra",
+			inputDockerFile: `FROM golang:1.21
+				COPY test.go /app/main.go
+				RUN go build -o /bin/hello ./main.go`,
+			expectedDockerFile: `From fedora:latest
+				COPY test.go /app/main.go
+				RUN go build -o /bin/hello ./main.go`,
+		},
+		{
+			testName: "Replace only the last FROM in a multi-stage Dockerfile",
+			inputDockerFile: `FROM golang:1.21 as builder
+				COPY . /app
+				RUN go build -o /bin/app
+
+				FROM alpine:3.10
+				COPY --from=builder /bin/app /bin/app
+				CMD ["/bin/app"]`,
+			expectedDockerFile: `FROM golang:1.21 as builder
+				COPY . /app
+				RUN go build -o /bin/app
+
+				FROM fedora:latest
+				COPY --from=builder /bin/app /bin/app
+				CMD ["/bin/app"]`,
+		},
+		{
+			testName:           "Handle nil node input",
+			inputDockerFile:    "",
+			expectedDockerFile: "",
+		},
+		{
+			testName: "Dockerfile with no FROM instruction",
+			inputDockerFile: `COPY test.go /app/main.go
+				RUN go build -o /bin/hello ./main.go`,
+			expectedDockerFile: `COPY test.go /app/main.go
+				RUN go build -o /bin/hello ./main.go`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			node, err := imagebuilder.ParseDockerfile(bytes.NewBufferString(testCase.inputDockerFile))
+			if err != nil {
+				t.Fatalf("error parsing dockerfile: %v", err)
+			}
+
+			replaceLastFrom(node, "fedora:latest", "")
+
+			wantNode, err := imagebuilder.ParseDockerfile(bytes.NewBufferString(testCase.expectedDockerFile))
+			if err != nil {
+				t.Fatalf("error parsing dockerfile: %v", err)
+			}
+
+			nodeDump := node.Dump()
+			wantNodeDump := wantNode.Dump()
+
+			if diff := cmp.Diff(wantNodeDump, nodeDump); diff != "" {
+				t.Fatalf("unexpected node difference: %q\n", diff)
+			}
+		})
+	}
+}
+
+func TestNodeHasFromRef(t *testing.T) {
+	testCases := []struct {
+		testName      string
+		nodeFlags     []string
+		expectedFrom  string
+		expectedFound bool
+	}{
+		{
+			testName:      "Node with --from flag",
+			nodeFlags:     []string{"--from=builder"},
+			expectedFrom:  "builder",
+			expectedFound: true,
+		},
+		{
+			testName:      "Node without --from flag",
+			nodeFlags:     []string{"--other-flag=value"},
+			expectedFrom:  "",
+			expectedFound: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			node := &parser.Node{Flags: testCase.nodeFlags}
+			from, found := nodeHasFromRef(node)
+
+			if from != testCase.expectedFrom || found != testCase.expectedFound {
+				t.Fatalf("TestNodeHasFromRef %s failed: expected (%q, %v), got (%q, %v)",
+					testCase.testName, testCase.expectedFrom, testCase.expectedFound, from, found)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces comprehensive unit tests for the `replacement.go` file in the `/cmd/registery-replacer/` directory.

## Overview of Changes

- Implemented unit tests for the functions in `replacement.go`.
- The tests cover crucial functionalities and scenarios, including:
  - **Replace Last FROM Image**: 
    - Tests that the last `FROM` instruction in a Dockerfile is correctly replaced with a specified base image.
  - **Multi-Stage Dockerfile Handling**: 
    - Ensures that only the last `FROM` instruction is replaced in a multi-stage Dockerfile, leaving earlier stages unaltered.
  - **Handling of Dockerfiles Without FROM Instructions**: 
    - Verifies that Dockerfiles without any `FROM` instructions remain unchanged.
  - **Node Reference Extraction in Dockerfile**: 
    - Tests the ability to correctly identify and extract the `--from` reference in Dockerfile nodes.
    
    https://issues.redhat.com/browse/DPTP-3846