### PR TITLE
Use oc from cli-artifacts picking the appropriate oc binary

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -498,9 +498,13 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 	})
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coreapi.Container{
 		Name:    "inject-cli",
-		Image:   fmt.Sprintf("%s:cli", imagestream),
+		Image:   fmt.Sprintf("%s:cli-artifacts", imagestream),
 		Command: []string{"/bin/cp"},
-		Args:    []string{"/usr/bin/oc", CliMountPath},
+		// to allow the oc team to freely upgrade RHEL version shipped in the realese
+		// we will explicitly request rhel8 version used in CI
+		// if we decide to update to newer rhel in CI, you'll need to update
+		// this line to pick appropriate oc version
+		Args: []string{"/usr/share/openshift/linux_amd64/oc.rhel8", filepath.Join(CliMountPath, "oc")},
 		VolumeMounts: []coreapi.VolumeMount{{
 			Name:      volumeName,
 			MountPath: CliMountPath,


### PR DESCRIPTION
While working on bumping oc to ship by default with rhel9 (https://github.com/openshift/oc/pull/1652) I've run into an issue where our CI still relies on rhel8, which can be seen in this run https://prow.ci.openshift.org/log?container=test&id=1750485685850083328&job=pull-ci-openshift-oc-master-e2e-aws-ovn, for example, specifically these lines:
```
oc: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by oc)
oc: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by oc)
```
This indicates a mismatch between the glibs version of the host operating system (OS), and the OS where the binary was built (ie. the linked above PR changes from rhel8 -> rhel9). 

To alleviate the problem, we need to be explicit about which binary we need in CI, this is achieved by picking oc binary from `cli-artifacts` image which provides multiple versions of oc binary, including rhel8.

/assign @deepsm007 @ardaguclu 