### PR TITLE
`payload-testing-prow-plugin`: only add each distinct pr to the PRPQR once

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -58,6 +58,12 @@ func helpProvider(_ []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 		Examples:    []string{"/payload 4.10 nightly informing", "/payload 4.8 ci all"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/payload-with-prs",
+		Description: "The payload-testing plugin triggers a run of specified release qualification jobs against a payload also including the other mentioned PRs",
+		WhoCanUse:   "Members of the trusted organization for the repo.",
+		Examples:    []string{"/payload 4.10 nightly informing openshift/kubernetes#1234 openshift/installer#999", "/payload 4.8 ci all openshift/kubernetes#1234"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
 		Usage:       "/payload-job",
 		Description: "The payload-testing plugin triggers a run of specified job or jobs delimited by spaces",
 		WhoCanUse:   "Members of the trusted organization for the repo.",


### PR DESCRIPTION
Fixes a bug discovered in https://github.com/openshift/ci-tools/pull/3912 where the additional PRs would be duplicated when building the `PRPQR` CR. Each `job` had the same `WithPRs` set, by design. The list would then get duplicated values and create a CR that was invalid. Since all jobs triggered by one `*-with-prs` command must include the same PRs, we can resolve them after the jobs loop.

Also, adds plugin help for this command.