### PR TITLE
`gpu-scheduling-webhook`: First implementation

### DIFF
--- a/cmd/gpu-scheduling-webhook/README.md
+++ b/cmd/gpu-scheduling-webhook/README.md
@@ -1,0 +1,41 @@
+# gpu-scheduling-webhook
+
+## Motivation
+Our clusters host some nodes that feature an Nvidia GPU. They are expensive to run workload on so
+by using this mutating webhook we ensure that only the pods requesting a GPU actually run on those
+nodes, leaving out everything else.
+
+## How it works
+A node that features an Nvida GPU holds the following taint:
+
+```yaml
+taints:
+- effect: NoSchedule
+  key: nvidia.com/gpu
+  value: "true"
+```
+
+The webhook inspects a pod's container requests, both form the init containers and regular ones, and apply
+this toleration:
+
+```yaml
+tolerations:
+- key: nvidia.com/gpu
+  operator: Equal
+  value: "true"
+  effect: NoSchedule
+```
+
+when it finds either such a request:
+
+```yaml
+requests:
+  nvidia.com/gpu: <SOME_VALUE_HERE>
+```
+
+or the following limit:
+
+```yaml
+limits:
+  nvidia.com/gpu: <SOME_VALUE_HERE>
+```

--- a/cmd/gpu-scheduling-webhook/main.go
+++ b/cmd/gpu-scheduling-webhook/main.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bombsimon/logrusr/v3"
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const nvidiaGPU = "nvidia.com/gpu"
+
+var (
+	nvidiaGPUToleration = corev1.Toleration{
+		Key:      nvidiaGPU,
+		Operator: corev1.TolerationOpEqual,
+		Value:    "true",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
+	opts = options{}
+
+	rootCmd = &cobra.Command{
+		Use:   "gpu-scheduling-webhook",
+		Short: "Controls where pods will be scheduled when they request a GPU",
+		Long: `Controls where pods will be scheduled when they request a GPU.
+
+Example:
+$ gpu-scheduling-webhook --cert-dir=<cert-dir> --port=443`,
+		RunE: RunE,
+	}
+)
+
+func init() {
+	rootCmd.Flags().StringVar(&opts.certDir, "cert-dir", "", "A folder holding the server private key and and certicate for TLS")
+	rootCmd.Flags().IntVar(&opts.port, "port", 0, "Port the server will listen on")
+}
+
+func setupLogger() logr.Logger {
+	innerLogger := logrus.New()
+	innerLogger.Formatter = &logrus.JSONFormatter{}
+	log.SetLogger(logrusr.New(innerLogger))
+	return log.Log
+}
+
+type options struct {
+	certDir string
+	port    int
+}
+
+type gpuTolerator struct{}
+
+func (*gpuTolerator) Default(ctx context.Context, obj runtime.Object) error {
+	logger := log.FromContext(ctx)
+
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("expected a Pod but got a %T", obj)
+	}
+
+	logger = logger.WithValues("pod", fmt.Sprintf("%s/%s", pod.Namespace, pod.Name))
+
+	// Check if a GPU required on resources from containers and init containers.
+	var gpuNeeded bool
+	gpuNeeded = hasNvidaGPURequest(logger, pod.Spec.InitContainers)
+
+	if !gpuNeeded {
+		gpuNeeded = hasNvidaGPURequest(logger, pod.Spec.Containers)
+	}
+
+	if gpuNeeded {
+		addToleration(logger, pod)
+	}
+
+	return nil
+}
+
+func hasNvidaGPURequest(logger logr.Logger, containers []corev1.Container) bool {
+	for i := range containers {
+		c := &containers[i]
+		if needNvidiaGPU(c.Resources) {
+			logger.Info("Request Nvidia GPU", "container", c.Name)
+			return true
+		}
+	}
+	return false
+}
+
+// Allow a pod to be scheduled on the GPU featured node by adding a toleration.
+// Do nothing if the toleration has already been added.
+func addToleration(logger logr.Logger, pod *corev1.Pod) {
+	var tolerationExists bool
+	for _, t := range pod.Spec.Tolerations {
+		if t == nvidiaGPUToleration {
+			tolerationExists = true
+			break
+		}
+	}
+
+	if !tolerationExists {
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, nvidiaGPUToleration)
+		logger.Info("Add toleration")
+	} else {
+		logger.Info("Toleration exists already")
+	}
+}
+
+func needNvidiaGPU(requirement corev1.ResourceRequirements) bool {
+	_, requestExists := requirement.Requests[nvidiaGPU]
+	_, limitExists := requirement.Limits[nvidiaGPU]
+	return requestExists || limitExists
+}
+
+func startWebhookServer(ctx context.Context, logger *logr.Logger, o *options, cfg *rest.Config) error {
+	logger.Info("Setting up manager")
+	mgr, err := manager.New(cfg, manager.Options{
+		WebhookServer: webhook.NewServer(webhook.Options{
+			CertDir: o.certDir,
+			Port:    o.port,
+		}),
+	})
+	if err != nil {
+		logger.Error(err, "Unable to set up manager")
+		return err
+	}
+
+	if err := builder.WebhookManagedBy(mgr).
+		For(&corev1.Pod{}).
+		WithDefaulter(&gpuTolerator{}).
+		Complete(); err != nil {
+		logger.Error(err, "Unable to build webhook")
+		return err
+	}
+
+	logger.Info("Starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		logger.Error(err, "Unable to start manager")
+		return err
+	}
+
+	return nil
+}
+
+func RunE(cmd *cobra.Command, args []string) error {
+	logger := setupLogger().WithName("gpu-scheduling")
+
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return fmt.Errorf("get cluster config: %w", err)
+	}
+
+	return startWebhookServer(cmd.Context(), &logger, &opts, cfg)
+}
+
+func main() {
+	cobra.CheckErr(rootCmd.ExecuteContext(signals.SetupSignalHandler()))
+}

--- a/cmd/gpu-scheduling-webhook/main_test.go
+++ b/cmd/gpu-scheduling-webhook/main_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestMutatePod(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		pod     runtime.Object
+		wantPod corev1.Pod
+		wantErr error
+	}{
+		{
+			name: "Request a GPU therefore add toleration",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "c1",
+							Command: []string{"cmd"},
+							Image:   "img",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "c1",
+							Command: []string{"cmd"},
+							Image:   "img",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{nvidiaGPUToleration},
+				},
+			},
+		},
+		{
+			name: "No GPU request a GPU, leave pod untouched",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:    "c1",
+					Command: []string{"cmd"},
+					Image:   "img",
+				}}},
+			},
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:    "c1",
+					Command: []string{"cmd"},
+					Image:   "img",
+				}}},
+			},
+		},
+		{
+			name: "Do not add the same toleration again",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "c1",
+							Command: []string{"cmd"},
+							Image:   "img",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{nvidiaGPUToleration},
+				},
+			},
+			wantPod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:    "c1",
+							Command: []string{"cmd"},
+							Image:   "img",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									nvidiaGPU: resource.MustParse("1"),
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{nvidiaGPUToleration},
+				},
+			},
+		},
+		{
+			name:    "Not a pod, return an error",
+			pod:     &corev1.Node{},
+			wantErr: errors.New("expected a Pod but got a *v1.Node"),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			pgs := gpuTolerator{}
+			err := pgs.Default(context.TODO(), testCase.pod)
+
+			if err != nil && testCase.wantErr == nil {
+				t.Fatalf("want err nil but got: %v", err)
+			}
+			if err == nil && testCase.wantErr != nil {
+				t.Fatalf("want err %v but nil", testCase.wantErr)
+			}
+			if err != nil && testCase.wantErr != nil {
+				if diff := cmp.Diff(testCase.wantErr.Error(), err.Error()); diff != "" {
+					t.Fatalf("unexpected error: %s", diff)
+				}
+				return
+			}
+
+			pod, _ := testCase.pod.(*corev1.Pod)
+			if diff := cmp.Diff(testCase.wantPod, *pod); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/images/gpu-scheduling-webhook/Dockerfile
+++ b/images/gpu-scheduling-webhook/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/centos/centos:stream8
+LABEL maintainer="dgemoli@redhat.com"
+
+ADD gpu-scheduling-webhook /usr/bin/gpu-scheduling-webhook
+ENTRYPOINT ["/usr/bin/gpu-scheduling-webhook"]


### PR DESCRIPTION
Add a mutating admission controller that adds a toleration on pods that request an Nvidia GPU.

Our clusters host some nodes that feature an Nvidia GPU. They are expensive to run workload on so
by using a mutating webhook we ensure that only the pods requesting a GPU actually run on those
nodes, leaving out everything else.

Check out `README.md` for a more detailed description.

/cc @bear-redhat @openshift/test-platform