### PR TITLE
Add cluster-profiles-config arg to README

### DIFF
--- a/cmd/ci-operator-checkconfig/README.md
+++ b/cmd/ci-operator-checkconfig/README.md
@@ -28,6 +28,7 @@ To validate a local copy of `openshift/release`, simply execute:
 ci-operator-checkconfig \
     --config-dir path/to/release/ci-operator/config \
     --registry path/to/release/ci-operator/step-registry \
+    --cluster-profiles-config path/to/release/core-services/cluster-profiles/_config.yaml 
     …
 ```
 


### PR DESCRIPTION
Since implementing the private cluster profile feature, the script needs a new arg to be run, as now it is also checking the cluster profiles config file to validate the configs in the release repository.