### PR TITLE
`ci-operator`: Add env var `OVERRIDE_IMAGE_*` to override component images with provided name

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -164,7 +164,7 @@ func fromConfig(
 		return nil, nil, fmt.Errorf("failed to get steps from configuration: %w", err)
 	}
 	rawSteps = append(graphConf.Steps, rawSteps...)
-	rawSteps = append(rawSteps, stepsForImageOverrides()...)
+	rawSteps = append(rawSteps, stepsForImageOverrides(utils.GetOverriddenImages())...)
 
 	for _, rawStep := range rawSteps {
 		if testStep := rawStep.TestStepConfiguration; testStep != nil {
@@ -372,9 +372,9 @@ func fromConfig(
 	return append(overridableSteps, buildSteps...), postSteps, nil
 }
 
-func stepsForImageOverrides() []api.StepConfiguration {
+func stepsForImageOverrides(overriddenImages map[string]string) []api.StepConfiguration {
 	var overrideSteps []api.StepConfiguration
-	for tag, value := range utils.GetOverriddenImages() {
+	for tag, value := range overriddenImages {
 		inputStep := api.StepConfiguration{InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 			InputImage: api.InputImage{
 				BaseImage: api.ImageStreamTagReference{

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -164,6 +164,7 @@ func fromConfig(
 		return nil, nil, fmt.Errorf("failed to get steps from configuration: %w", err)
 	}
 	rawSteps = append(graphConf.Steps, rawSteps...)
+	rawSteps = append(rawSteps, stepsForImageOverrides()...)
 
 	for _, rawStep := range rawSteps {
 		if testStep := rawStep.TestStepConfiguration; testStep != nil {
@@ -369,6 +370,32 @@ func fromConfig(
 	}
 
 	return append(overridableSteps, buildSteps...), postSteps, nil
+}
+
+func stepsForImageOverrides() []api.StepConfiguration {
+	var overrideSteps []api.StepConfiguration
+	for tag, value := range utils.GetOverriddenImages() {
+		inputStep := api.StepConfiguration{InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+			InputImage: api.InputImage{
+				BaseImage: api.ImageStreamTagReference{
+					Namespace: "ocp",
+					Name:      value,
+					Tag:       tag,
+				},
+				To: api.PipelineImageStreamTagReference(tag),
+			},
+		}}
+		overrideSteps = append(overrideSteps, inputStep)
+		outputStep := api.StepConfiguration{OutputImageTagStepConfiguration: &api.OutputImageTagStepConfiguration{
+			From: api.PipelineImageStreamTagReference(tag),
+			To: api.ImageStreamTagReference{
+				Name: api.StableImageStream,
+				Tag:  tag,
+			},
+		}}
+		overrideSteps = append(overrideSteps, outputStep)
+	}
+	return overrideSteps
 }
 
 // registryDomain determines the domain of the registry we promote to


### PR DESCRIPTION
This adds a new pattern for env vars to `ci-operator`: `OVERRIDE_IMAGE_*`. The remaining part of the var name relates to the image name, and the value is the tag to override it with in the `ocp` namespace. This will be used for payload-testing in a follow up PR.

For: https://issues.redhat.com/browse/DPTP-3688