### PR TITLE
`ci-operator`: ensure ist is available on the build cluster for image tag override

### DIFF
--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1720,7 +1720,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, "", "", "", nil, tc.mergedConfig)
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, tc.mergedConfig)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}


### PR DESCRIPTION
My testing with this was all done on `app.ci`, but the real payload tests are largely run on `build01` so when verifying the functionality I ran into an issue with the `ist` not being available. I borrowed this idea from https://github.com/openshift/ci-tools/blob/d0b031bfd62188d3064639354f77fdd55474f1de/pkg/defaults/defaults.go#L993-L997

For: https://issues.redhat.com/browse/DPTP-3688

/cc @danilo-gemoli @openshift/test-platform