### PR TITLE
Disable ci-operator-yaml-creator

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -149,20 +149,6 @@ func main() {
 
 	steps := []step{
 		{
-			// Will check if repos that are part of the OCP payload
-			// have an up-to-date .ci-operator.yaml and if yes, update
-			// their config to set .build_root.from_repository: true
-			command: "/usr/bin/ci-operator-yaml-creator",
-			arguments: []string{
-				"--max-concurrency", "1",
-				"--github-token-path", "/etc/github/oauth",
-				"--github-endpoint", "http://ghproxy",
-				"--ci-operator-config-dir=ci-operator/config",
-				// Only update o/release
-				"--create-prs=false",
-			},
-		},
-		{
 			command: "/usr/bin/registry-replacer",
 			arguments: []string{
 				"--github-token-path", "/etc/github/oauth",


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CHY2E1BL4/p1707428803154829?thread_ts=1707422678.970149&cid=CHY2E1BL4

A uncovered case of this tool showed up.
Instead of fixing the tool, we stop running it because we might not need it any more as "most repos contributing to OCP would already be using `build_root.from_repository: true` ".

/cc @openshift/test-platform 
/assign @jupierce 