### PR TITLE
include the multi_arch field on images for the graph generation

### DIFF
--- a/cmd/image-graph-generator/types.graphql
+++ b/cmd/image-graph-generator/types.graphql
@@ -28,4 +28,5 @@ type Image  {
 	fromRoot: Boolean
 	branches: [Branch] @hasInverse(field:images)
 	source: String
+	multiArch: Boolean
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -75,6 +75,26 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	p.Rehearsals.DisabledRehearsals = append(p.Rehearsals.DisabledRehearsals, defaults.Rehearsals.DisabledRehearsals...)
 }
 
+func LoadProwgenConfig(folder string) (*Prowgen, error) {
+	var pConfig *Prowgen
+	path := filepath.Join(folder, ProwgenFile)
+	b, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("prowgen config found in path %s but couldn't read the file: %w", path, err)
+	}
+
+	if err == nil {
+		if err := yaml.Unmarshal(b, &pConfig); err != nil {
+			return nil, fmt.Errorf("prowgen config found in path %sbut couldn't unmarshal it: %w", path, err)
+		}
+		if err := pConfig.Validate(); err != nil {
+			return nil, fmt.Errorf("prowgen config found in path %s is not valid: %w", path, err)
+		}
+	}
+
+	return pConfig, nil
+}
+
 type Rehearsals struct {
 	// DisableAll indicates that all jobs will not have their "can-be-rehearsed" label set
 	// and therefore will not be picked up for rehearsals.

--- a/pkg/image-graph-generator/images.go
+++ b/pkg/image-graph-generator/images.go
@@ -20,9 +20,10 @@ type ImageRef struct {
 	Branches       []BranchRef `graphql:"branches"`
 	Parents        []ImageRef  `graphql:"parents"`
 	Children       []ImageRef  `graphql:"children"`
+	MultiArch      bool        `graphql:"multiArch"`
 }
 
-func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfiguration, baseImages map[string]api.ImageStreamTagReference, c api.PromotionTarget, branchID string) error {
+func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfiguration, baseImages map[string]api.ImageStreamTagReference, c api.PromotionTarget, branchID string, multiArch bool) error {
 	imageName := fmt.Sprintf("%s/%s:%s", c.Namespace, c.Name, string(image.To))
 
 	if c.Name == "" {
@@ -38,6 +39,7 @@ func (o *Operator) UpdateImage(image api.ProjectDirectoryImageBuildStepConfigura
 		Namespace:      c.Namespace,
 		ImageStreamRef: c.Name,
 		Branches:       []BranchRef{{ID: branchID}},
+		MultiArch:      multiArch,
 	}
 
 	if isInternalBaseImage(string(image.From)) {
@@ -103,6 +105,7 @@ func (o *Operator) addImageRef(image *ImageRef) error {
 		"namespace":      image.Namespace,
 		"imageStreamRef": image.ImageStreamRef,
 		"fromRoot":       image.FromRoot,
+		"multiArch":      image.MultiArch,
 	}
 
 	if image.Source != "" {
@@ -167,6 +170,7 @@ func (o *Operator) updateImageRef(newImage *ImageRef, id string) error {
 		"imageStreamRef": newImage.ImageStreamRef,
 		"namespace":      newImage.Namespace,
 		"fromRoot":       newImage.FromRoot,
+		"multiArch":      newImage.MultiArch,
 	}
 
 	if newImage.Source != "" {

--- a/pkg/image-graph-generator/images_test.go
+++ b/pkg/image-graph-generator/images_test.go
@@ -88,7 +88,7 @@ func TestOperator_UpdateImage(t *testing.T) {
 				c:      fc,
 				images: tt.images,
 			}
-			if err := o.UpdateImage(tt.args.image, tt.args.c.BaseImages, tt.args.c.PromotionConfiguration.Targets[0], tt.args.branchID); (err != nil) != tt.wantErr {
+			if err := o.UpdateImage(tt.args.image, tt.args.c.BaseImages, tt.args.c.PromotionConfiguration.Targets[0], tt.args.branchID, false); (err != nil) != tt.wantErr {
 				t.Errorf("Operator.UpdateImage() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if diff := cmp.Diff(fc.images, tt.expected); diff != "" {


### PR DESCRIPTION
Adding the multiArch field to the graph scheme. Populate the field based on the prowgen's configuration


Follow-ups: I will update the scheme after this merges.

/cc @openshift/test-platform @danilo-gemoli 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
