### PR TITLE
`registry-replacer`: Don't use disabled configs

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -338,6 +338,10 @@ func gatherAllOCPImageConfigs(ocpBuildDataDir string, majorMinor MajorMinor) (ma
 		if info.IsDir() {
 			return nil
 		}
+		// We only want to operate on "yaml" ("yml") files, so we don't load disabled configs
+		if !strings.HasSuffix(info.Name(), "yaml") && !strings.HasSuffix(info.Name(), "yml") {
+			return nil
+		}
 		errGroup.Go(func() error {
 			config := OCPImageConfig{}
 			if err := readYAML(path, &config, majorMinor); err != nil {


### PR DESCRIPTION
We only want to operate on "yaml" ("yml") files, so we don't load disabled configs

To fix errors like:
```
time="2024-02-12T12:01:57Z" level=fatal msg="Failed to construct promotion target to dockerfile mapping" error="failed to read image configs from ocp-build-data: [failed dereferencing config for images/ci-openshift-golang-builder-extra.rhel9.disabled: [failed to replace .from.stream: streamMap has no replacement for stream rhel-9-golang-{GO_EXTRA}, failed to find replacement for .from.stream], failed dereferencing config for images/ci-openshift-build-root-extra.rhel9.disabled: [failed to replace .from.member: no config images/ci-openshift-golang-builder-extra.rhel9.yml found, failed to find replacement for .from.stream]]"
```

For: https://issues.redhat.com/browse/DPTP-3871