### PR TITLE
trt-1400: replace : in branch name

### DIFF
--- a/pkg/github/prcreation/prcreation.go
+++ b/pkg/github/prcreation/prcreation.go
@@ -135,6 +135,8 @@ func (o *PRCreationOptions) UpsertPR(localSourceDir, org, repo, branch, prTitle 
 	stderr := bumper.HideSecretsWriter{Delegate: os.Stderr, Censor: secret.Censor}
 
 	sourceBranchName := strings.ReplaceAll(strings.ToLower(prArgs.matchTitle), " ", "-")
+	// Fix for NO-ISSUE: title
+	sourceBranchName = strings.ReplaceAll(strings.ToLower(sourceBranchName), ":", "-")
 	o.GithubClient.SetMax404Retries(0)
 	if _, err := o.GithubClient.GetRepo(username, repo); err != nil {
 		// Somehow github.IsNotFound doesn't recognize this?


### PR DESCRIPTION
Seeing [failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-update-origin-disruption-alert-data/1755758537033650176)  due to `couldn't find remote ref no-issue`

[PR](https://github.com/openshift/release/pull/48460/files) added `NO-ISSUE:` for automated updates not requiring JIRA.

prTitle is used for sourceBranchName, need to remove `:` as well as spaces 

Could use a regex if preferred:
```golang 
m1 := regexp.MustCompile(`[:\s]`)
sourceBranchName = m1.ReplaceAllString(prArgs.matchTitle, "-")
```

[playground](https://go.dev/play/p/TVdZE8Au1yp)