### PR TITLE
TRT-1476: Exclude all network liveness backends

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -22,7 +22,7 @@ import (
 // backends for now as they run and gather more data.
 func isExcludedDisruptionBackend(name string) bool {
 	excludedNames := []string{
-		"ci-cluster-network-liveness",
+		"-network-liveness",
 		"kube-api-http1-external-lb",
 		"kube-api-http2-external-lb",
 		"openshift-api-http2-external-lb",


### PR DESCRIPTION
This allows us to exclude all network liveness backends.

For example, we will exclude the `{gcp|aws|azure}-network-liveness-{new|reused}-connections` backends.