### PR TITLE
`ci-operator-configresolver`: guarantee unique metadata when merging configs from multiple sources

### DIFF
--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/metrics"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -451,7 +452,7 @@ func MetadataEntriesFromQuery(w http.ResponseWriter, r *http.Request) ([]api.Met
 		fmt.Fprint(w, "If any variants are passed, there must be one for each ref. Blank variants are allowed.")
 	}
 
-	var metadata []api.Metadata
+	metadata := make(sets.Set[api.Metadata])
 	for i, org := range orgs {
 		element := api.Metadata{
 			Org:    org,
@@ -461,8 +462,8 @@ func MetadataEntriesFromQuery(w http.ResponseWriter, r *http.Request) ([]api.Met
 		if variantsExist {
 			element.Variant = variants[i]
 		}
-		metadata = append(metadata, element)
+		metadata.Insert(element)
 	}
 
-	return metadata, nil
+	return metadata.UnsortedList(), nil
 }

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -465,5 +466,20 @@ func MetadataEntriesFromQuery(w http.ResponseWriter, r *http.Request) ([]api.Met
 		metadata.Insert(element)
 	}
 
-	return metadata.UnsortedList(), nil
+	result := metadata.UnsortedList()
+	sort.SliceStable(result, func(i, j int) bool {
+		one := result[i]
+		two := result[j]
+		if one.Org != two.Org {
+			return one.Org < two.Org
+		}
+		if one.Repo != two.Repo {
+			return one.Repo < two.Repo
+		}
+		if one.Branch != two.Branch {
+			return one.Branch < two.Branch
+		}
+		return one.Variant < two.Variant
+	})
+	return result, nil
 }

--- a/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-injected.json
+++ b/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-injected.json
@@ -39,14 +39,14 @@
   },
   "images": [
     {
-      "from": "base-openshift.installer",
-      "to": "installer-openshift.installer",
-      "ref": "openshift.installer"
-    },
-    {
       "from": "base-openshift.console",
       "to": "console-openshift.console",
       "ref": "openshift.console"
+    },
+    {
+      "from": "base-openshift.installer",
+      "to": "installer-openshift.installer",
+      "ref": "openshift.installer"
     }
   ],
   "tests": [


### PR DESCRIPTION
Now that we allow PRs from the same repo to be tested together, we have situations where we are merging multiple of the same configs together. In practice, this appears to be okay with `ci-operator`, but it is a waste of time and resources. Instead, we should not merge duplicated metadata.

For: https://issues.redhat.com/browse/DPTP-3691