### PR TITLE
`ci-opeartor-configresolver`: remove deprecated `configWithTest` endpoint

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -220,8 +220,6 @@ func main() {
 	// add handler func for incorrect paths as well; can help with identifying errors/404s caused by incorrect paths
 	http.HandleFunc("/", handler(http.HandlerFunc(http.NotFound)).ServeHTTP)
 	http.HandleFunc("/config", handler(registryserver.ResolveConfig(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
-	//TODO(sgoeddel): this is deprecated, mergeConfigsWithInjectedTest should be used instead
-	http.HandleFunc("/configWithInjectedTest", handler(registryserver.ResolveConfigWithInjectedTest(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/mergeConfigsWithInjectedTest", handler(registryserver.ResolveAndMergeConfigsAndInjectTest(configAgent, registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/resolve", handler(registryserver.ResolveLiteralConfig(registryAgent, configresolverMetrics)).ServeHTTP)
 	http.HandleFunc("/configGeneration", handler(getConfigGeneration(configAgent)).ServeHTTP)

--- a/test/integration/ci-operator-configresolver.sh
+++ b/test/integration/ci-operator-configresolver.sh
@@ -25,9 +25,6 @@ os::integration::configresolver::check_log
 os::cmd::expect_success "curl -X POST -H 'Content-Type: application/json' --data @${BASETMPDIR}/unresolved-config.json 'http://127.0.0.1:8080/resolve' >${actual}/resolved-config.json"
 os::integration::compare "${actual}/resolved-config.json" "${expected}/resolved-config.json"
 os::integration::configresolver::check_log
-os::cmd::expect_success "curl 'http://127.0.0.1:8080/configWithInjectedTest?org=openshift&repo=installer&branch=release-4.2&injectTestFromOrg=openshift&injectTestFromRepo=release&injectTestFromBranch=master&injectTestFromVariant=ci-4.9&injectTest=e2e' >${actual}/openshift-installer-release-4.2-injected.json"
-os::integration::compare "${actual}/openshift-installer-release-4.2-injected.json" "${expected}/openshift-installer-release-4.2-injected.json"
-os::integration::configresolver::check_log
 os::cmd::expect_success "curl 'http://127.0.0.1:8080/mergeConfigsWithInjectedTest?org=openshift,openshift&repo=installer,console&branch=release-4.2,master&injectTestFromOrg=openshift&injectTestFromRepo=release&injectTestFromBranch=master&injectTestFromVariant=ci-4.9&injectTest=e2e' >${actual}/openshift-installer-console-merged-release-4.2-injected.json"
 os::integration::compare "${actual}/openshift-installer-console-merged-release-4.2-injected.json" "${expected}/openshift-installer-console-merged-release-4.2-injected.json"
 os::integration::configresolver::check_log


### PR DESCRIPTION
This has been deprecated for awhile, and is no longer in use.