### PR TITLE
`payload-testing-prow-plugin`: add blanket response when user has mis-formatted payload command

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	prPayloadTestsUIURL = "https://pr-payload-tests.ci.openshift.org/runs"
+	prPayloadTestsUIURL    = "https://pr-payload-tests.ci.openshift.org/runs"
+	unknownCommandResponse = "it appears that you have attempted to use some version of the payload command, but your comment was incorrectly formatted and cannot be acted upon. See the [docs](https://docs.ci.openshift.org/docs/release-oversight/payload-testing/#usage) for usage info."
 )
 
 type githubClient interface {
@@ -290,6 +291,10 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) (string, [
 
 	abortRequested := ocpPayloadAbortPattern.MatchString(strings.TrimSpace(ic.Comment.Body))
 	if len(specs) == 0 && !abortRequested {
+		if strings.HasPrefix(ic.Comment.Body, "/payload") {
+			// Someone was probably attempting to use the command, but due to a formatting error, nothing was picked up
+			return unknownCommandResponse, nil
+		}
 		return "", nil
 	}
 

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -943,6 +943,27 @@ trigger 0 job(s) of type all for the ci release of OCP 4.8
 			},
 			expectedMessage: `aborted active payload jobs for pull request org/repo#123`,
 		},
+		{
+			name: "incorrectly formatted command",
+			s: &server{
+				ghc:            ghc,
+				ctx:            context.TODO(),
+				namespace:      "ci",
+				trustedChecker: &fakeTrustedChecker{},
+			},
+			ic: github.IssueCommentEvent{
+				GUID: "guid",
+				Repo: github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				Issue: github.Issue{
+					Number:      123,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/payload-something-that-doesnt-exist 4.10 nightly informing",
+				},
+			},
+			expectedMessage: `it appears that you have attempted to use some version of the payload command, but your comment was incorrectly formatted and cannot be acted upon. See the [docs](https://docs.ci.openshift.org/docs/release-oversight/payload-testing/#usage) for usage info.`,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Due to the various, complex, regexs that this command acts upon, it is difficult to inform users when they have made a mistake in the command. This will catch any comments that start with "/payload", but we don't find any actionable command for, and provide a blanket response asking them to see the docs.

For: https://issues.redhat.com/browse/DPTP-3868