### PR TITLE
Add the requester label to TestImageStreamTagImport

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1095,6 +1095,7 @@ func ensureImageStreamTag(ctx context.Context, client ctrlruntimeclient.Client, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isTagRef.Name + "-" + isTagRef.Tag,
 			Namespace: "ci",
+			Labels:    map[string]string{api.DPTPRequesterLabel: "ci-operator"},
 		},
 		Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{
 			Namespace: isTagRef.Namespace,

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -200,8 +200,9 @@ func TestStepConfigsForBuild(t *testing.T) {
 					Namespace: "ci",
 					Name:      "stream-name-stream-tag",
 					Labels: map[string]string{
-						"imagestreamtag-namespace": "stream-namespace",
-						"imagestreamtag-name":      "stream-name_stream-tag",
+						"dptp.openshift.io/requester": "ci-operator",
+						"imagestreamtag-namespace":    "stream-namespace",
+						"imagestreamtag-name":         "stream-name_stream-tag",
 					},
 				},
 				Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{
@@ -268,8 +269,9 @@ func TestStepConfigsForBuild(t *testing.T) {
 					Namespace: "ci",
 					Name:      "org-repo-branch",
 					Labels: map[string]string{
-						"imagestreamtag-namespace": "build-cache",
-						"imagestreamtag-name":      "org-repo_branch",
+						"dptp.openshift.io/requester": "ci-operator",
+						"imagestreamtag-namespace":    "build-cache",
+						"imagestreamtag-name":         "org-repo_branch",
 					},
 				},
 				Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -606,7 +606,7 @@ func ensureImageStreamTags(ctx context.Context, client ctrlruntimeclient.Client,
 				return fmt.Errorf("failed to check if imagestreamtag %s exists: %w", requiredImageStreamTag, err)
 			}
 			istImport := &testimagestreamtagimportv1.TestImageStreamTagImport{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Labels: map[string]string{api.DPTPRequesterLabel: "pj-rehearse"}},
 				Spec: testimagestreamtagimportv1.TestImageStreamTagImportSpec{
 					ClusterName: clusterName,
 					Namespace:   requiredImageStreamTag.Namespace,


### PR DESCRIPTION
Useful when we figure out which component created the CR. I found only two components uses it at the moment.

```console
oc get TestImageStreamTagImport --context app.ci -n ci --show-labels
NAME                                                     AGE     LABELS
build01-ocp-builder.rhel-8-golang-1.19-openshift-4.16    28h     imagestreamtag-name=builder_rhel-8-golang-1.19-openshift-4.16,imagestreamtag-namespace=ocp
...

oc get TestImageStreamTagImport --context build01 -n ci --show-labels
NAME                                                AGE     LABELS
builder-go1.21-linux                                2d1h    imagestreamtag-name=builder_go1.21-linux,imagestreamtag-namespace=stolostron
...
```

They look quite different on app.ci and b0n.

/cc @openshift/test-platform 