### PR TITLE
ci-op: pipeline imports images from QCI-APPCI

### DIFF
--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -24,6 +24,8 @@ const (
 	ServiceDomainMulti01Registry   = "registry.multi-build01.arm-build.devcluster.openshift.com"
 
 	QuayOpenShiftCIRepo = "quay.io/openshift/ci"
+
+	QCIAPPCIDomain = "quay-proxy.ci.openshift.org"
 )
 
 type Service string

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -110,6 +110,11 @@ func QuayImage(tag ImageStreamTagReference) string {
 	return fmt.Sprintf("%s:%s_%s_%s", QuayOpenShiftCIRepo, tag.Namespace, tag.Name, tag.Tag)
 }
 
+// QCIAPPCIImage returns the image in quay.io for an image stream tag
+func QCIAPPCIImage(tag ImageStreamTagReference) string {
+	return strings.Replace(fmt.Sprintf("%s:%s_%s_%s", QuayOpenShiftCIRepo, tag.Namespace, tag.Name, tag.Tag), "quay.io", QCIAPPCIDomain, 1)
+}
+
 // QuayImageFromDateAndDigest returns the image in quay.io for a date and an image digest
 func QuayImageFromDateAndDigest(date, digest string) string {
 	return fmt.Sprintf("%s:%s_sha256_%s", QuayOpenShiftCIRepo, date, digest)

--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -110,9 +110,10 @@ func QuayImage(tag ImageStreamTagReference) string {
 	return fmt.Sprintf("%s:%s_%s_%s", QuayOpenShiftCIRepo, tag.Namespace, tag.Name, tag.Tag)
 }
 
-// QCIAPPCIImage returns the image in quay.io for an image stream tag
-func QCIAPPCIImage(tag ImageStreamTagReference) string {
-	return strings.Replace(fmt.Sprintf("%s:%s_%s_%s", QuayOpenShiftCIRepo, tag.Namespace, tag.Name, tag.Tag), "quay.io", QCIAPPCIDomain, 1)
+// QuayImageReference returns the image in quay.io for an image stream tag
+func QuayImageReference(tag ImageStreamTagReference) string {
+	// TODO replace quay.io with the hostname of the image registry cache
+	return QuayImage(tag)
 }
 
 // QuayImageFromDateAndDigest returns the image in quay.io for a date and an image digest

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -79,9 +79,8 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 				Type: imagev1.LocalTagReferencePolicy,
 			},
 			From: &coreapi.ObjectReference{
-				Kind:      "ImageStreamImage",
-				Name:      fmt.Sprintf("%s@%s", s.config.BaseImage.Name, s.imageName),
-				Namespace: s.config.BaseImage.Namespace,
+				Kind: "DockerImage",
+				Name: api.QCIAPPCIImage(s.config.BaseImage),
 			},
 			ImportPolicy: imagev1.TagImportPolicy{
 				ImportMode: imagev1.ImportModePreserveOriginal,

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -80,7 +80,7 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 			},
 			From: &coreapi.ObjectReference{
 				Kind: "DockerImage",
-				Name: api.QCIAPPCIImage(s.config.BaseImage),
+				Name: api.QuayImageReference(s.config.BaseImage),
 			},
 			ImportPolicy: imagev1.TagImportPolicy{
 				ImportMode: imagev1.ImportModePreserveOriginal,

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -100,7 +100,7 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 		if err := s.client.Get(importCtx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: api.PipelineImageStream}, pipeline); err != nil {
 			return false, err
 		}
-		_, exists := util.ResolvePullSpec(pipeline, string(s.config.To), true)
+		_, exists, _ := util.ResolvePullSpec(pipeline, string(s.config.To), true)
 		if !exists {
 			logrus.Debugf("Waiting to import %s ...", ist.ObjectMeta.Name)
 		}

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -112,7 +112,7 @@ func TestInputImageTagStep(t *testing.T) {
 		Tag: &imagev1.TagReference{
 			From: &corev1.ObjectReference{
 				Kind: "DockerImage",
-				Name: "quay-proxy.ci.openshift.org/openshift/ci:source-namespace_BASE_BASETAG",
+				Name: "quay.io/openshift/ci:source-namespace_BASE_BASETAG",
 			},
 			ImportPolicy: imagev1.TagImportPolicy{
 				ImportMode: imagev1.ImportModePreserveOriginal,

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -111,9 +111,8 @@ func TestInputImageTagStep(t *testing.T) {
 		TypeMeta: metav1.TypeMeta{Kind: "ImageStreamTag", APIVersion: "image.openshift.io/v1"},
 		Tag: &imagev1.TagReference{
 			From: &corev1.ObjectReference{
-				Kind:      "ImageStreamImage",
-				Namespace: baseImage.Namespace,
-				Name:      "BASE@ddc0de",
+				Kind: "DockerImage",
+				Name: "quay-proxy.ci.openshift.org/openshift/ci:source-namespace_BASE_BASETAG",
 			},
 			ImportPolicy: imagev1.TagImportPolicy{
 				ImportMode: imagev1.ImportModePreserveOriginal,

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -159,8 +159,8 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: streamName}, stable); err != nil {
 			return false, err
 		}
-		cvo, cvoExists = util.ResolvePullSpec(stable, "cluster-version-operator", true)
-		_, cliExists = util.ResolvePullSpec(stable, "cli", true)
+		cvo, cvoExists, _ = util.ResolvePullSpec(stable, "cluster-version-operator", true)
+		_, cliExists, _ = util.ResolvePullSpec(stable, "cli", true)
 		ret := cvoExists && cliExists
 		if !ret {
 			logrus.Infof("Waiting to import cluster-version-operator and cli ...")

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -136,7 +136,7 @@ func (s *releaseImagesTagStep) run(ctx context.Context) error {
 	}
 
 	for _, tag := range is.Spec.Tags {
-		spec, ok := util.ResolvePullSpec(is, tag.Name, false)
+		spec, ok, _ := util.ResolvePullSpec(is, tag.Name, false)
 		if !ok {
 			continue
 		}

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -3,11 +3,16 @@ package release
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imagev1 "github.com/openshift/api/image/v1"
@@ -15,6 +20,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
+	"github.com/openshift/ci-tools/pkg/util"
 )
 
 // releaseSnapshotStep snapshots the state of an integration ImageStream
@@ -73,22 +79,92 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 		snapshot.ObjectMeta.Annotations[releaseConfigAnnotation] = raw
 	}
 	for _, tag := range source.Status.Tags {
-		if !ignoredTags.Has(tag.Tag) {
-			snapshot.Spec.Tags = append(snapshot.Spec.Tags, imagev1.TagReference{
-				Name: tag.Tag,
-				From: &coreapi.ObjectReference{
-					Kind: "DockerImage",
-					Name: api.QCIAPPCIImage(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Tag}),
-				},
-				ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
-			})
-		}
+		snapshot.Spec.Tags = append(snapshot.Spec.Tags, imagev1.TagReference{
+			Name: tag.Tag,
+			From: &coreapi.ObjectReference{
+				Kind: "DockerImage",
+				Name: api.QCIAPPCIImage(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Tag}),
+			},
+			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+		})
 	}
 	// the Create call mutates the input object, so we need to copy it before returning
 	created := snapshot.DeepCopy()
 	if err := client.Create(ctx, created); err != nil && !kerrors.IsAlreadyExists(err) {
 		return nil, nil, fmt.Errorf("could not create snapshot imagestream %s/%s for release %s: %w", sourceNamespace, sourceName, targetRelease, err)
 	}
+	begin := time.Now()
+	logrus.Infof("Waiting to import tags on imagestream %s/%s ...", created.Namespace, created.Name)
+	for i, tag := range created.Spec.Tags {
+		stable := &imagev1.ImageStream{}
+		if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 40*time.Minute, true, func(ctx context.Context) (bool, error) {
+			if time.Now().After(begin.Add(45 * time.Minute)) {
+				return false, fmt.Errorf("timed out importing tags[%d] %s on imagestream %s/%s", i, tag.Name, created.Namespace, created.Name)
+			}
+			if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: created.Namespace, Name: created.Name}, stable); err != nil {
+				return false, fmt.Errorf("falied to get image stream %s/%s: %w", created.Namespace, created.Name, err)
+			}
+			_, exist, condition := util.ResolvePullSpec(stable, tag.Name, true)
+			if !exist {
+				logrus.WithField("conditionMessage", condition.Message).Debugf("Waiting to import tags on imagestream %s/%s:%s ...", created.Namespace, created.Name, tag.Name)
+				if strings.Contains(condition.Message, "Internal error occurred") {
+					streamImport := &imagev1.ImageStreamImport{
+						ObjectMeta: meta.ObjectMeta{
+							Namespace: created.Namespace,
+							Name:      created.Name,
+						},
+						Spec: imagev1.ImageStreamImportSpec{
+							Import: true,
+							Images: []imagev1.ImageImportSpec{
+								{
+									To: &coreapi.LocalObjectReference{
+										Name: tag.Name,
+									},
+									From: coreapi.ObjectReference{
+										Kind: "DockerImage",
+										Name: api.QCIAPPCIImage(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Name}),
+									},
+									ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
+									ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
+								},
+							},
+						},
+					}
+					if err := wait.ExponentialBackoff(wait.Backoff{Steps: 3, Duration: 1 * time.Second, Factor: 2}, func() (bool, error) {
+						logrus.Debugf("Retrying importing tag %s/%s@%s because %s", created.Namespace, created.Name, tag.Name, condition.Message)
+						if err := client.Create(ctx, streamImport); err != nil {
+							if kerrors.IsConflict(err) {
+								return false, nil
+							}
+							if kerrors.IsForbidden(err) {
+								// the ci-operator expects to have POST /imagestreamimports in the namespace of the job
+								logrus.Warnf("Unable to lock %s/%s@%s to an image digest pull spec, you don't have permission to access the necessary API.",
+									created.Namespace, created.Name, tag.Name)
+								return false, nil
+							}
+							return false, err
+						}
+						if len(streamImport.Status.Images) == 0 {
+							return false, nil
+						}
+						image := streamImport.Status.Images[0]
+						if image.Image == nil {
+							return false, nil
+						}
+						logrus.Debugf("Imported tag %s/%s@%s", created.Namespace, created.Name, tag.Name)
+						return true, nil
+					}); err != nil {
+						return false, fmt.Errorf("unable to import tag %s/%s@%s: %w even with retries", created.Namespace, created.Name, tag.Name, err)
+					}
+				}
+			}
+			return exist, nil
+		}); err != nil {
+			return nil, nil, fmt.Errorf("failed to import tags on imagestream %s/%s: %w", created.Namespace, created.Name, err)
+		}
+	}
+	logrus.Infof("Imported tags on imagestream %s/%s", created.Namespace, created.Name)
 	return source, snapshot, nil
 }
 

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -74,7 +74,7 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 			Name: tag.Tag,
 			From: &coreapi.ObjectReference{
 				Kind: "DockerImage",
-				Name: api.QCIAPPCIImage(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Tag}),
+				Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Tag}),
 			},
 			ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 			ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},
@@ -114,7 +114,7 @@ func snapshotStream(ctx context.Context, client loggingclient.LoggingClient, sou
 									},
 									From: coreapi.ObjectReference{
 										Kind: "DockerImage",
-										Name: api.QCIAPPCIImage(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Name}),
+										Name: api.QuayImageReference(api.ImageStreamTagReference{Namespace: sourceNamespace, Name: sourceName, Tag: tag.Name}),
 									},
 									ImportPolicy:    imagev1.TagImportPolicy{ImportMode: imagev1.ImportModePreserveOriginal},
 									ReferencePolicy: imagev1.TagReferencePolicy{Type: imagev1.LocalTagReferencePolicy},

--- a/pkg/util/imagestream.go
+++ b/pkg/util/imagestream.go
@@ -25,32 +25,36 @@ func ParseImageStreamTagReference(s string) (api.ImageStreamTagReference, error)
 }
 
 // ResolvePullSpec if a tag of an imagestream is resolved
-func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (string, bool) {
+func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (string, bool, imageapi.TagEventCondition) {
+	var condition imageapi.TagEventCondition
 	for _, tags := range is.Status.Tags {
 		if tags.Tag != tag {
 			continue
+		}
+		if conditions := tags.Conditions; len(conditions) > 0 {
+			condition = conditions[0]
 		}
 		if len(tags.Items) == 0 {
 			break
 		}
 		if image := tags.Items[0].Image; len(image) > 0 {
 			if len(is.Status.PublicDockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image), true
+				return fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image), true, condition
 			}
 			if len(is.Status.DockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image), true
+				return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image), true, condition
 			}
 		}
 		break
 	}
 	if requireExact {
-		return "", false
+		return "", false, condition
 	}
 	if len(is.Status.PublicDockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag), true
+		return fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag), true, condition
 	}
 	if len(is.Status.DockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag), true
+		return fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag), true, condition
 	}
-	return "", false
+	return "", false, condition
 }

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -43,7 +43,7 @@ tests:
             if [[ -z $COMMAND ]]; then
               echo "ERROR: COMMAND unset!"
               exit 1
-            elif [[ ! $COMMAND =~ /${NAMESPACE}/stable-initial@sha256: ]]; then
+            elif [[ ! $COMMAND =~ /${NAMESPACE}/stable-initial@sha256: ]] && [[ $COMMAND != */${NAMESPACE}/stable-initial:cli ]]; then
               echo "ERROR: COMMAND set to something unexpected: $COMMAND!"
               exit 1
             fi

--- a/test/e2e/observer/e2e_test.go
+++ b/test/e2e/observer/e2e_test.go
@@ -76,6 +76,7 @@ func TestObservers(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
+			cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 			cmd.AddArgs(testCase.args...)
 			cmd.AddEnv(testCase.env...)
 			output, err := cmd.Run()

--- a/test/e2e/simple/e2e_test.go
+++ b/test/e2e/simple/e2e_test.go
@@ -70,6 +70,7 @@ func TestSimpleExitCodes(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
+			cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 			cmd.AddArgs(append(testCase.args, "--config=config.yaml")...)
 			if testCase.jobSpec == "" {
 				testCase.jobSpec = defaultJobSpec
@@ -119,6 +120,7 @@ func TestCompressed(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		framework.Run(t, testCase.name, func(t *framework.T, cmd *framework.CiOperatorCommand) {
+			cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 			cmd.AddArgs(testCase.args...)
 			cmd.AddEnv(fmt.Sprintf("CONFIG_SPEC=%s", string(configFile)))
 			cmd.AddEnv(`JOB_SPEC={"type":"postsubmit","job":"branch-ci-openshift-ci-tools-master-ci-operator-e2e-compressed","buildid":"0","prowjobid":"uuid","refs":{"org":"openshift","repo":"ci-tools","base_ref":"master","base_sha":"6d231cc37652e85e0f0e25c21088b73d644d89ad","pulls":[]},"decoration_config":{"timeout":"4h0m0s","grace_period":"30m0s","utility_images":{"clonerefs":"registry.ci.openshift.org/ci/clonerefs:latest","initupload":"registry.ci.openshift.org/ci/initupload:latest","entrypoint":"registry.ci.openshift.org/ci/entrypoint:latest","sidecar":"registry.ci.openshift.org/ci/sidecar:latest"},"resources":{"clonerefs":{"limits":{"memory":"3Gi"},"requests":{"cpu":"100m","memory":"500Mi"}},"initupload":{"limits":{"memory":"200Mi"},"requests":{"cpu":"100m","memory":"50Mi"}},"place_entrypoint":{"limits":{"memory":"100Mi"},"requests":{"cpu":"100m","memory":"25Mi"}},"sidecar":{"limits":{"memory":"2Gi"},"requests":{"cpu":"100m","memory":"250Mi"}}},"gcs_configuration":{"bucket":"test-platform-results","path_strategy":"single","default_org":"openshift","default_repo":"origin","mediaTypes":{"log":"text/plain"}},"gcs_credentials_secret":"gce-sa-credentials-gcs-publisher"}}`)
@@ -142,6 +144,7 @@ func TestTemplate(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(clusterProfileDir, "data"), []byte("nothing"), 0644); err != nil {
 			t.Fatalf("failed to create dummy secret data: %v", err)
 		}
+		cmd.AddArgs(framework.LocalPullSecretFlag(t), framework.RemotePullSecretFlag(t))
 		cmd.AddArgs(
 			"--template=template.yaml",
 			"--target=template",


### PR DESCRIPTION
This PR handles two cases (probably the only two?) where a CI job imports images from a local cluster.

- the images from a ref on a tag in ci-op's config, such as base_images,
- the images from a release that snapshots the integration streams, i.e., there is `tag_specification` or `releases.integration` as described in https://docs.ci.openshift.org/docs/internals/steps/#releaseimagestagstep

Those images are distributed by the controller `test-images-distributor` in `dptp-controller-manager` https://github.com/openshift/ci-tools/tree/master/pkg/controller/test-images-distributor from app.ci to build-farms.

As planed, we want the Job imports those images from QCI-APPCI, instead of the one cluster that the job is running on.

There is a commit for each of the case above. ~The 3rd commit is about bumping the waiting time on import images which can be done with another PR. It would help the success rate of the job because there are rehearsals (e.g., [job-27m](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/48891/rehearse-48891-pull-ci-openshift-csi-external-attacher-master-e2e-aws-csi/1759423804687257600) and [job2-timeout](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/48891/rehearse-48891-pull-ci-openshift-cluster-nfd-operator-master-e2e-aws/1758686460812201984).
I believe this is because importing from local tags is much faster than quay.io.~




https://issues.redhat.com/browse/DPTP-3878

/cc @openshift/test-platform 


/hold

Let us see if any test breaks.