### PR TITLE
`checkconfig`: Update unmarshalling error to be more descriptive

### DIFF
--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -243,7 +243,7 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 
 	var profileOwnersList api.ClusterProfilesList
 	if err = yaml.Unmarshal(configContents, &profileOwnersList); err != nil {
-		return nil, fmt.Errorf("failed to unmarshall cluster profiles config: %w", err)
+		return nil, fmt.Errorf("failed to unmarshall file %v. Please check that the formatting in the file is correct. Full error: %w", configPath, err)
 	}
 
 	// TODO: The following code can be erased once profiles are completely moved


### PR DESCRIPTION
Making the unmarshalling error clearer when there's something wrong with the formatting of the [cluster profiles config file](https://github.com/openshift/release/blob/master/core-services/cluster-profiles/_config.yaml).

/cc @smg247 