### PR TITLE
`payload-testing-ui`: handle base commits rather than assume PRs

### DIFF
--- a/cmd/payload-testing-ui/server.go
+++ b/cmd/payload-testing-ui/server.go
@@ -91,19 +91,31 @@ Created: {{ .ObjectMeta.CreationTimestamp }}
 
 {{ with .Spec }}
 
-<h2>Pull requests</h2>
+<h2>Sources</h2>
 <ul>
   {{ range $i, $pullRequest := .PullRequests }}
-	{{ prLink . }} by {{ authorLink .PullRequest.Author }}
-	<li style="list-style:none; padding:">
-      <ul>
-		<li>Repository: {{ repoLink .Org .Repo }}</li>
-		<li>SHA: <tt>{{ shaLink . .PullRequest.SHA }}</tt></li>
-		<li>
-			Base: <tt>{{ refLink . .BaseRef }}</tt> (<tt>{{ shaLink . .BaseSHA }}</tt>)
+    {{ if .PullRequest }}
+		{{ prLink . }} by {{ authorLink .PullRequest.Author }}
+		<li style="list-style:none; padding:">
+		  <ul>
+			<li>Repository: {{ repoLink .Org .Repo }}</li>
+			<li>SHA: <tt>{{ shaLink . .PullRequest.SHA }}</tt></li>
+			<li>
+				Base: <tt>{{ refLink . .BaseRef }}</tt> (<tt>{{ shaLink . .BaseSHA }}</tt>)
+			</li>
+		  </ul>
 		</li>
-	  </ul>
-    </li>
+    {{ else }}
+		Sourced From:
+		<li style="list-style:none; padding:">
+		  <ul>
+			<li>Repository: {{ repoLink .Org .Repo }}</li>
+			<li>
+				Base: <tt>{{ refLink . .BaseRef }}</tt> (<tt>{{ shaLink . .BaseSHA }}</tt>)
+			</li>
+		  </ul>
+		</li>
+    {{ end }}
   {{ end }}
 </ul>
 


### PR DESCRIPTION
Now that we don't require an actual PR to be passed for each `pullRequest` in the `PRPQR` spec, we need to display something reasonable in the UI when this is utilized.

This results in the following when a `PRPQR` is created using one base without a PR, and a couple with them:
![Screenshot 2024-02-16 at 3 03 47 PM](https://github.com/openshift/ci-tools/assets/1794300/f5000b61-7136-492f-bd15-6980de9695c9)

For: https://issues.redhat.com/browse/DPTP-3686