### PR TITLE
local-e2e: specify context when getting LOCAL_REGISTRY_DNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ local-e2e: \
 	$(eval export REMOTE_REGISTRY_SECRET_DIR=$(TMPDIR)/remote-secret)
 	$(eval export GCS_CREDENTIALS_FILE=$(TMPDIR)/gcs/service-account.json)
 	$(eval export MANIFEST_TOOL_SECRET=$(TMPDIR)/manifest-tool-secret/.dockerconfigjson)
-	$(eval export LOCAL_REGISTRY_DNS=$(shell oc get route -n openshift-image-registry -o jsonpath='{.items[0].spec.host}'))
+	$(eval export LOCAL_REGISTRY_DNS=$(shell oc --context $(CLUSTER) get route -n openshift-image-registry -o jsonpath='{.items[0].spec.host}'))
 	$(eval export PATH=${PATH}:$(TMPDIR))
 	@$(MAKE) e2e
 .PHONY: local-e2e


### PR DESCRIPTION
/cc @openshift/test-platform 