### PR TITLE
NO-JIRA: Use RHEL8 oc explicitly

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -498,9 +498,13 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 	})
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coreapi.Container{
 		Name:    "inject-cli",
-		Image:   fmt.Sprintf("%s:cli", imagestream),
+		Image:   fmt.Sprintf("%s:cli-artifacts", imagestream),
 		Command: []string{"/bin/cp"},
-		Args:    []string{"/usr/bin/oc", CliMountPath},
+		// to allow the oc team to freely upgrade RHEL version shipped in the realese
+		// we will explicitly request rhel8 version used in CI
+		// if we decide to update to newer rhel in CI, you'll need to update
+		// this line to pick appropriate oc version
+		Args: []string{"/usr/share/openshift/linux_amd64/oc.rhel8", filepath.Join(CliMountPath, "oc")},
 		VolumeMounts: []coreapi.VolumeMount{{
 			Name:      volumeName,
 			MountPath: CliMountPath,

--- a/test/e2e/multi-stage/assembled-release-no-injection.yaml
+++ b/test/e2e/multi-stage/assembled-release-no-injection.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.13"
+    name: "4.15"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.13"
+      name: "4.15"
 resources:
   '*':
     requests:

--- a/test/e2e/multi-stage/assembled-release.yaml
+++ b/test/e2e/multi-stage/assembled-release.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.13"
+    name: "4.15"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.13"
+      name: "4.15"
       include_built_images: true
 resources:
   '*':

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -14,12 +14,12 @@ resources:
       cpu: 10m
 tag_specification:
   namespace: ocp
-  name: "4.13"
+  name: "4.15"
 releases:
   custom:
     candidate:
       product: okd
-      version: "4.13"
+      version: "4.15"
 tests:
   - as: with-dependencies
     steps:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -192,7 +192,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.13.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},
@@ -202,7 +202,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.13.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},


### PR DESCRIPTION
This PR basically mimics the same approach done in https://github.com/openshift/ci-tools/pull/3535 to bump release version from 4.13 to 4.15 to achieve what is being tried in https://github.com/openshift/ci-tools/pull/3914