### PR TITLE
Use aws as the CLUSTER_TYPE

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1654,7 +1654,7 @@ func (p ClusterProfile) ClusterType() string {
 	case ClusterProfileHypershiftPowerVSCB:
 		return "hypershift-powervs-cb"
 	case ClusterProfileRHOpenShiftEcosystem:
-		return "rh-openshift-ecosystem"
+		return string(CloudAWS)
 	default:
 		return ""
 	}


### PR DESCRIPTION
https://steps.ci.openshift.org/reference/ipi-install-install step fails for preflight tests using rh-openshift-ecosystem as the CLUSTER_TYPE when building the install-config.yaml and attempting to create find the cloud credentials. It is my understanding that resources will still be created using the rh-openshift-ecosystem-quota-slice