### PR TITLE
OCPBUGS-20097: Use RHEL8 oc explicitly

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -498,9 +498,16 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 	})
 	pod.Spec.InitContainers = append(pod.Spec.InitContainers, coreapi.Container{
 		Name:    "inject-cli",
-		Image:   fmt.Sprintf("%s:cli", imagestream),
-		Command: []string{"/bin/cp"},
-		Args:    []string{"/usr/bin/oc", CliMountPath},
+		Image:   fmt.Sprintf("%s:cli-artifacts", imagestream),
+		Command: []string{"/bin/sh"},
+		// to allow the oc team to freely upgrade RHEL version shipped in the release,
+		// We will explicitly request rhel8 version used in CI and
+		// if we decide to update to newer rhel in CI, you'll need to update
+		// this line to pick appropriate oc version (i.e. oc.rhel9).
+		// Additionally, we need to check the existence of path because releases < 4.15 does not have oc.rhel8,
+		// and we fall back to old path due to backwards compatibility.
+		// In order to support multi arch oc, just change the arch path (i.e. /usr/share/openshift/linux_arm64/oc.rhel8).
+		Args: []string{"-c", fmt.Sprintf("if [[ -e /usr/share/openshift/linux_amd64/oc.rhel8 ]]; then /bin/cp /usr/share/openshift/linux_amd64/oc.rhel8 %s ; echo \"oc.rhel8 is used\"; else /bin/cp /usr/bin/oc %s; echo \"default oc is used\"; fi", filepath.Join(CliMountPath, "oc"), CliMountPath)},
 		VolumeMounts: []coreapi.VolumeMount{{
 			Name:      volumeName,
 			MountPath: CliMountPath,

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -507,7 +507,7 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 		// Additionally, we need to check the existence of path because releases < 4.15 does not have oc.rhel8,
 		// and we fall back to old path due to backwards compatibility.
 		// In order to support multi arch oc, just change the arch path (i.e. /usr/share/openshift/linux_arm64/oc.rhel8).
-		Args: []string{"-c", fmt.Sprintf("if [[ -e /usr/share/openshift/linux_amd64/oc.rhel8 ]]; then /bin/cp /usr/share/openshift/linux_amd64/oc.rhel8 %s ; echo \"oc.rhel8 is used\"; else /bin/cp /usr/bin/oc %s; echo \"default oc is used\"; fi", filepath.Join(CliMountPath, "oc"), CliMountPath)},
+		Args: []string{"-c", fmt.Sprintf("if [[ -e /usr/share/openshift/linux_amd64/oc.rhel8 ]]; then /bin/cp /usr/share/openshift/linux_amd64/oc.rhel8 %s; else /bin/cp /usr/bin/oc %s; fi", filepath.Join(CliMountPath, "oc"), CliMountPath)},
 		VolumeMounts: []coreapi.VolumeMount{{
 			Name:      volumeName,
 			MountPath: CliMountPath,

--- a/test/e2e/multi-stage/assembled-release-no-injection.yaml
+++ b/test/e2e/multi-stage/assembled-release-no-injection.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.13"
+    name: "4.15"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.13"
+      name: "4.15"
 resources:
   '*':
     requests:

--- a/test/e2e/multi-stage/assembled-release.yaml
+++ b/test/e2e/multi-stage/assembled-release.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.13"
+    name: "4.15"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.13"
+      name: "4.15"
       include_built_images: true
 resources:
   '*':

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -14,12 +14,12 @@ resources:
       cpu: 10m
 tag_specification:
   namespace: ocp
-  name: "4.13"
+  name: "4.15"
 releases:
   custom:
     candidate:
       product: okd
-      version: "4.13"
+      version: "4.15"
 tests:
   - as: with-dependencies
     steps:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -192,7 +192,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.13.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},
@@ -202,7 +202,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.13.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},


### PR DESCRIPTION
Previous PR https://github.com/openshift/ci-tools/pull/4000 was reverted in https://github.com/openshift/ci-tools/pull/4002 because changes were not backwards compatible and caused cascading failures.

This PR reintroduces same approach additionally supporting backwards compatibility. Firstly, it checks the path of `oc.rhel8`. If binary is found, it will copy. If binary is not found like releases older than 4.15, it falls back to current behavior.

Thanks to this change, maintainers of this repository can change rhel version of oc and also supports multiple architecture versions (i.e. linux_arm64).

Edited: I'd like to note the reason of this change is that we are going to change the base image of oc from RHEL8 to RHEL9 and oc compiled in RHEL9 does not work on RHEL8 clusters. Therefore, we have to explicitly use oc RHEL8 binary in ci-tools, until ci-tools is decided to bumped to RHEL9.