### PR TITLE
MULTIARCH-4510: Updated dnsConfig to always overwrite from highest order set value (job > workflow > step).

### DIFF
--- a/pkg/registry/resolver.go
+++ b/pkg/registry/resolver.go
@@ -334,9 +334,11 @@ func (r *registry) processStep(step *api.TestStep, seen sets.Set[string], stack 
 		ret.Dependencies = deps
 	}
 
-	if ret.DNSConfig != nil {
-		ret.DNSConfig = stack.resolveDNS(ret.DNSConfig)
-	}
+	// We always resolve dnsConfig to the highest-level object (job > workflow > step)
+	// This pushes the responsibility of handling steps that need custom dnsConfigs to workflow
+	// and job authors. This implementation allows for steps to be shared between teams.
+	ret.DNSConfig = stack.resolveDNS(ret.DNSConfig)
+
 	return ret, errs
 }
 


### PR DESCRIPTION
We've discovered that overriding only when declared is disruptive if teams want to share steps but only one team is setting an override. This change makes it the responsibility of workflow and job authors to set dnsConfig only when they're sure they want to override all steps contained by those higher-order objects.

https://redhat-internal.slack.com/archives/CBN38N3MW/p1709743581114759?thread_ts=1709667080.103889&cid=CBN38N3MW