### PR TITLE
Removing unused cluster-profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1204,7 +1204,6 @@ type ClusterProfile string
 
 const (
 	ClusterProfileAWS                   ClusterProfile = "aws"
-	ClusterProfileAWSArm64              ClusterProfile = "aws-arm64"
 	ClusterProfileAWSAtomic             ClusterProfile = "aws-atomic"
 	ClusterProfileAWSCentos             ClusterProfile = "aws-centos"
 	ClusterProfileAWSCentos40           ClusterProfile = "aws-centos-40"
@@ -1336,7 +1335,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWS,
 		ClusterProfileAWS2,
 		ClusterProfileAWS3,
-		ClusterProfileAWSArm64,
 		ClusterProfileAWSAtomic,
 		ClusterProfileAWSC2SQE,
 		ClusterProfileAWSCPaaS,
@@ -1517,8 +1515,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAlibabaCloudQE,
 		ClusterProfileAlibabaCloudCNQE:
 		return "alibabacloud"
-	case ClusterProfileAWSArm64:
-		return "aws-arm64"
 	case ClusterProfileAWSC2SQE:
 		return "aws-c2s"
 	case ClusterProfileAWSChinaQE:
@@ -1670,8 +1666,6 @@ func (p ClusterProfile) LeaseType() string {
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSGluster:
 		return "aws-quota-slice"
-	case ClusterProfileAWSArm64:
-		return "aws-arm64-quota-slice"
 	case ClusterProfileAWSQE:
 		return "aws-qe-quota-slice"
 	case ClusterProfileAWS1QE:
@@ -1968,7 +1962,7 @@ func (p ClusterProfile) Secret() string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-arm64", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "aws-opendatahub", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-s390x", "libvirt-s390x-amd64", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb":
+	case "aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-outpost", "aws-local-zones", "aws-opendatahub", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-s390x", "libvirt-s390x-amd64", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
All the aws arm64 jobs are using aws-2 cluster profile.