### PR TITLE
`check-gh-automation`: fix branch-protection determination logic

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -191,7 +191,11 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 		orgConfig := prowAgent.Config().BranchProtection.GetOrg(org)
 		var branchProtectionEnabled bool
 		if orgConfig != nil {
-			_, branchProtectionEnabled = orgConfig.Repos[repo]
+			branchProtection, exists := orgConfig.Repos[repo]
+			if exists {
+				// if "unmanaged" is set to "true" we don't care. If it is "nil" or "false" we consider it enabled
+				branchProtectionEnabled = branchProtection.Unmanaged == nil || !*branchProtection.Unmanaged
+			}
 		}
 
 		// If branch protection is configured, verify admin access for the hardcoded admin bot

--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -189,11 +189,11 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 		}
 
 		orgConfig := prowAgent.Config().BranchProtection.GetOrg(org)
-		var branchProtectionEnabled bool
+		branchProtectionEnabled := true // By default, it is turned on in absence of configuration stating otherwise
 		if orgConfig != nil {
 			branchProtection, exists := orgConfig.Repos[repo]
 			if exists {
-				// if "unmanaged" is set to "true" we don't care. If it is "nil" or "false" we consider it enabled
+				// if "unmanaged" is set to "true" it is disabled. If it is "nil" or "false" we consider it enabled
 				branchProtectionEnabled = branchProtection.Unmanaged == nil || !*branchProtection.Unmanaged
 			}
 		}

--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -191,10 +191,13 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 		orgConfig := prowAgent.Config().BranchProtection.GetOrg(org)
 		branchProtectionEnabled := true // By default, it is turned on in absence of configuration stating otherwise
 		if orgConfig != nil {
-			branchProtection, exists := orgConfig.Repos[repo]
+			unmanagedOrgLevel := orgConfig.Policy.Unmanaged
+			branchProtectionEnabled = unmanagedOrgLevel == nil || !*unmanagedOrgLevel
+
+			repoLevel, exists := orgConfig.Repos[repo]
 			if exists {
 				// if "unmanaged" is set to "true" it is disabled. If it is "nil" or "false" we consider it enabled
-				branchProtectionEnabled = branchProtection.Unmanaged == nil || !*branchProtection.Unmanaged
+				branchProtectionEnabled = repoLevel.Unmanaged == nil || !*repoLevel.Unmanaged
 			}
 		}
 

--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -52,6 +52,21 @@ func newFakeProwConfigAgent() *prowconfig.Agent {
 			},
 			BranchProtection: prowconfig.BranchProtection{
 				Orgs: map[string]prowconfig.Org{
+					"org-1": {
+						Policy: prowconfig.Policy{
+							Unmanaged: &t,
+						},
+					},
+					"org-2": {
+						Policy: prowconfig.Policy{
+							Unmanaged: &t,
+						},
+					},
+					"org-3": {
+						Policy: prowconfig.Policy{
+							Unmanaged: &t,
+						},
+					},
 					"org-5": {
 						Repos: map[string]prowconfig.Repo{
 							"repo-a": {
@@ -65,6 +80,11 @@ func newFakeProwConfigAgent() *prowconfig.Agent {
 							"repo-c": {
 								Policy: prowconfig.Policy{},
 							},
+						},
+					},
+					"org-6": {
+						Policy: prowconfig.Policy{
+							Unmanaged: &t,
 						},
 					},
 				},
@@ -141,8 +161,9 @@ func TestCheckRepos(t *testing.T) {
 			"org-2": {"some-user", "z-bot"},
 			"org-3": {"a-user"},
 			"org-5": {"openshift-merge-robot"},
+			"org-6": {"openshift-merge-robot"},
 		},
-		reposWithAppInstalled: sets.New[string]("org-1/repo-a", "org-2/repo-z", "org-5/repo-a", "org-5/repo-b"),
+		reposWithAppInstalled: sets.New[string]("org-1/repo-a", "org-2/repo-z", "org-5/repo-a", "org-5/repo-b", "org-6/repo-a"),
 		permissionsByRepo: map[string]map[string][]string{
 			"org-1/repo-a": {
 				"a-bot":                      []string{"write"},
@@ -299,6 +320,14 @@ func TestCheckRepos(t *testing.T) {
 			adminBots: []string{},
 			mode:      standard,
 			expected:  []string{"org-5/repo-c"},
+		},
+		{
+			name:      "openshift-merge-robot without admin access and branch protection set to unmanaged at org level",
+			repos:     []string{"org-6/repo-a"},
+			bots:      []string{"openshift-merge-robot"},
+			adminBots: []string{},
+			mode:      standard,
+			expected:  []string{},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Lots of failures in this [run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-check-gh-automation/1764485958339661824) due to this case.

Branch protection is enabled by default unless there is configuration stating unmanaged=true.

The unit tests were also incorrectly passing without actually looking at branch protection. I fixed those as well.