### PR TITLE
Fix TestInputImageStreamTagsFromResolvedConfig function

### DIFF
--- a/pkg/api/helper/imageextraction_test.go
+++ b/pkg/api/helper/imageextraction_test.go
@@ -96,7 +96,7 @@ func TestTestInputImageStreamTagsFromConfigParsing(t *testing.T) {
 			expectedResult: "foo/Baz:Bar",
 		},
 		{
-			name: "boot image from repo",
+			name: "root image from repo",
 			config: api.ReleaseBuildConfiguration{
 				InputConfiguration: api.InputConfiguration{
 					BuildRootImage: &api.BuildRootImageConfiguration{FromRepository: true}},

--- a/pkg/api/helper/imageextraction_test.go
+++ b/pkg/api/helper/imageextraction_test.go
@@ -10,6 +10,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/github"
 )
 
 func TestTestInputImageStreamTagsFromResolvedConfigReturnsAllImageStreamTags(t *testing.T) {
@@ -52,7 +53,7 @@ func TestTestInputImageStreamTagsFromResolvedConfigReturnsAllImageStreamTags(t *
 				numberInsertedElements++
 			}
 
-			res, err := TestInputImageStreamTagsFromResolvedConfig(cfg)
+			res, err := TestInputImageStreamTagsFromResolvedConfig(cfg, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -71,26 +72,42 @@ func TestTestInputImageStreamTagsFromResolvedConfigReturnsAllImageStreamTags(t *
 	}
 }
 
+func fakeRepoFileGetter(org, repo, branch string, _ ...github.Opt) github.FileGetter {
+	return func(path string) ([]byte, error) {
+		return []byte(`build_root_image:
+  name: boilerplate
+  namespace: openshift
+  tag: image-v3.0.2`), nil
+	}
+}
+
 func TestTestInputImageStreamTagsFromConfigParsing(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name           string
-		istr           api.ImageStreamTagReference
+		config         api.ReleaseBuildConfiguration
 		expectedResult string
 	}{
 		{
-			name:           "happy path",
-			istr:           api.ImageStreamTagReference{Namespace: "foo", Name: "Baz", Tag: "Bar"},
+			name: "happy path",
+			config: api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{BaseImages: map[string]api.ImageStreamTagReference{"": {Namespace: "foo", Name: "Baz", Tag: "Bar"}}},
+			},
 			expectedResult: "foo/Baz:Bar",
+		},
+		{
+			name: "boot image from repo",
+			config: api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					BuildRootImage: &api.BuildRootImageConfiguration{FromRepository: true}},
+			},
+			expectedResult: "openshift/boilerplate:image-v3.0.2",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := api.ReleaseBuildConfiguration{
-				InputConfiguration: api.InputConfiguration{BaseImages: map[string]api.ImageStreamTagReference{"": tc.istr}},
-			}
-			result, err := TestInputImageStreamTagsFromResolvedConfig(config)
+			result, err := TestInputImageStreamTagsFromResolvedConfig(tc.config, fakeRepoFileGetter)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -131,7 +148,7 @@ func TestTestInputImageStreamTagsFromResolvedConfigErrorsOnUnresolvedConfig(t *t
 		t.Run(tc.name, func(t *testing.T) {
 
 			var errStr string
-			_, err := TestInputImageStreamTagsFromResolvedConfig(tc.config)
+			_, err := TestInputImageStreamTagsFromResolvedConfig(tc.config, nil)
 			if err != nil {
 				errStr = err.Error()
 			}

--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -25,6 +25,7 @@ import (
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	apihelper "github.com/openshift/ci-tools/pkg/api/helper"
 	controllerutil "github.com/openshift/ci-tools/pkg/controller/util"
+	"github.com/openshift/ci-tools/pkg/github"
 	"github.com/openshift/ci-tools/pkg/load/agents"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagmapper"
 	"github.com/openshift/ci-tools/pkg/util/imagestreamtagwrapper"
@@ -295,7 +296,7 @@ func indexConfigsByTestInputImageStreamTag(resolver registryResolver) agents.Ind
 			log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
 			return nil
 		}
-		m, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(cfg)
+		m, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(cfg, github.FileGetterFactory)
 		if err != nil {
 			// Should never happen as we set it to nil above
 			log.WithError(err).Error("Got error from TestInputImageStreamTagsFromResolvedConfig. This is a software bug.")

--- a/pkg/controller/test-images-distributor/test_images_distributor.go
+++ b/pkg/controller/test-images-distributor/test_images_distributor.go
@@ -605,7 +605,7 @@ func indexConfigsByTestInputImageStreamTag(resolver registryResolver) agents.Ind
 			log.WithError(err).Error("Failed to resolve MultiStageTestConfiguration")
 			return nil
 		}
-		m, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(cfg)
+		m, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(cfg, nil)
 		if err != nil {
 			// Should never happen as we set it to nil above
 			log.WithError(err).Error("Got error from TestInputImageStreamTagsFromResolvedConfig. This is a software bug.")

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -277,7 +277,7 @@ func getResolvedConfigForTest(ciopConfig config.DataWithInfo, resolver registry.
 		return "", nil, fmt.Errorf("failed to marshal ci-operator config file: %w", err)
 	}
 
-	imageStreamTags, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(ciopConfigResolved)
+	imageStreamTags, err := apihelper.TestInputImageStreamTagsFromResolvedConfig(ciopConfigResolved, nil)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to resolve test imagestreamtags: %w", err)
 	}


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CBN38N3MW/p1710169725703149?thread_ts=1710168229.675879&cid=CBN38N3MW

I believe this bug has been there since the beginning.
As it shown in the PR, `TestInputImageStreamTagsFromResolvedConfig` is used by other tools too.

However, it is not outstanding in other tools is because of the difference on `testInputImageStreamTagFilterFactory`.
https://github.com/openshift/ci-tools/blob/0a9b4d7a2992f110a4569f92a9c5690e9e3d7406/pkg/controller/test-images-distributor/test_images_distributor.go#L583
For example, the tag `openshift/release:rhel-8-release-golang-1.20-openshift-4.16` is not mirrored to QCI.
But the dptp-controller still distritubtes the image to build farms (the component has logs on the request).

/cc @openshift/test-platform 