### PR TITLE
`check-gh-automation`: add org/repo to failing list when branch-protection reqs are not met

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -213,6 +213,7 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 			}
 			if !hasAdminAccess {
 				logger.Errorf("Bot %s does not have admin access in %s/%s with branch protection enabled", bot, org, repo)
+				failing.Insert(orgRepo)
 			} else {
 				logger.Infof("Bot %s has admin access in %s/%s", bot, org, repo)
 			}


### PR DESCRIPTION
Follow up to https://github.com/openshift/ci-tools/pull/4018, we need to add this to the failing list in order to get the correct output for our users to know how to fix the problem.