### PR TITLE
Revert "Skip periodics for the future and current releases"

### DIFF
--- a/cmd/autoconfigbrancher/main.go
+++ b/cmd/autoconfigbrancher/main.go
@@ -168,7 +168,7 @@ func main() {
 		{
 			command: "/usr/bin/config-brancher",
 			arguments: func() []string {
-				args := []string{"--config-dir", "./ci-operator/config", "--current-release", o.CurrentRelease, "--skip-periodics"}
+				args := []string{"--config-dir", "./ci-operator/config", "--current-release", o.CurrentRelease}
 				for _, fr := range o.FutureReleases.Strings() {
 					args = append(args, "--future-release", fr)
 				}


### PR DESCRIPTION
Reverts openshift/ci-tools#3208

not sure if we want to revert this or if we have a different way to prevent jobs intentionally configured as periodics to not be
removed.