### PR TITLE
Mirror CI supplemental images

### DIFF
--- a/hack/run-ci-images-mirror.sh
+++ b/hack/run-ci-images-mirror.sh
@@ -16,5 +16,6 @@ KUBECONFIG="${TMP_DIR}/sa.ci-images-mirror.app.ci.config" go run  ./cmd/ci-image
   --leader-election-namespace=ci \
   --leader-election-suffix="-${USER}" \
   --release-repo-git-sync-path="${release}"  \
+  --config="${release}/core-services/image-mirroring/supplemental-ci-images/_config.yaml" \
   --quayIOCIImagesDistributorOptions.additional-image-stream-namespace=ci \
   --dry-run=true

--- a/pkg/controller/quay_io_ci_images_distributor/mirror.go
+++ b/pkg/controller/quay_io_ci_images_distributor/mirror.go
@@ -20,6 +20,7 @@ type MirrorTask struct {
 	CurrentQuayDigest string                                `json:"current_quay_digest"`
 	CreatedAt         time.Time                             `json:"created_at"`
 	Stale             bool                                  `json:"stale"`
+	Owner             string                                `json:"owner"`
 }
 
 type MirrorStore interface {
@@ -38,6 +39,10 @@ func (s *memoryMirrorStore) Put(tasks ...MirrorTask) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, t := range tasks {
+		if t.Source == "" || t.Destination == "" {
+			logrus.WithField("source", t.Source).WithField("destination", t.Destination).Warn("Skipped an invalid mirror task: both source and destination must be set")
+			continue
+		}
 		t.CreatedAt = time.Now()
 		s.mirrors[t.Destination] = t
 	}

--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -190,6 +190,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 			Destination:       quayImage,
 			CurrentQuayDigest: imageInfo.Digest,
 			Stale:             stale,
+			Owner:             ControllerName,
 		},
 			MirrorTask{
 				SourceTagRef:      tagRef,
@@ -197,6 +198,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, log *
 				Destination:       targetImageWithDateAndDigest,
 				CurrentQuayDigest: imageInfo.Digest,
 				Stale:             stale,
+				Owner:             ControllerName,
 			}); err != nil {
 			return fmt.Errorf("failed to put the mirror into store: %w", err)
 		}
@@ -243,7 +245,7 @@ func testInputImageStreamTagFilterFactory(
 	l = logrus.WithField("subcomponent", "test-input-image-stream-tag-filter")
 	return func(nn types.NamespacedName) bool {
 		if ignoreImageStreamTags.Has(nn.String()) {
-			logrus.WithField("tag", nn.String()).Debug("Ignored events of image stream tag")
+			logrus.WithField("tag", nn.String()).Fatal("Ignored events of image stream tag")
 			return false
 		}
 		if additionalImageStreamTags.Has(nn.String()) {


### PR DESCRIPTION
We will start to migrate mirroring external images to CI with this tool.
https://docs.ci.openshift.org/docs/how-tos/external-images/ will be updated accordingly after this PR.

Note that this PR does not impact how the images are mirrored out of CI: We may do it later in this tool too if needed.
https://docs.ci.openshift.org/docs/how-tos/mirroring-to-quay/

The user will fill in the config file of this tool such as

```yaml
supplementalCIImages:
  openshift/boilerplate:image-v0.1.1:
    image: quay.io/app-sre/boilerplate:image-v0.1.1
  openshift/boilerplate:image-v5.0.0:
    image: quay.io/app-sre/boilerplate:image-v5.0.0
  ci/hongkliu-test:supplemental-ci-images-test:
    namespace: ci
    name: hongkliu-test
    tag: speical-tag-for-proxy-testing
```

The keys such as `openshift/boilerplate:image-v0.1.1` are the targets in QCI and the values are the sources of the images which are represented either by `image` or `namespace/name:tag`.

The above configuration file will generate the mirror cmd:

> oc --continue-on-error=true --max-per-registry=20 --dry-run=true registry.ci.openshift.org/ci/hongkliu-test:speical-tag-for-proxy-testing=quay.io/openshift/ci:ci_hongkliu-test_supplemental-ci-images-test quay.io/app-sre/boilerplate:image-v0.1.1=quay.io/openshift/ci:openshift_boilerplate_image-v0.1.1 quay.io/app-sre/boilerplate:image-v5.0.0=quay.io/openshift/ci:openshift_boilerplate_image-v5.0.0"

In order to avoid mirror conflicts, i.e. the same tag are mirrored by different sources, the targets will be ignored to mirror by `quay_io_ci_images_distributor` that mirrors from `app.ci` to `QCI`.
@droslean 
It is convenient to implement this feature in the tool, but not necessarily. We may factor it out if needed in the future.

/cc @openshift/test-platform 

