### PR TITLE
ci-images-mirror: add a log when mirroring supplemental CI images

### DIFF
--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -188,6 +188,7 @@ type supplementalCIImagesServiceWithMirrorStore struct {
 }
 
 func (s *supplementalCIImagesServiceWithMirrorStore) Mirror(m map[string]Source) error {
+	s.logger.Info("Mirroring supplemental CI images ...")
 	for k, v := range m {
 		source := v.Image
 		if source == "" {


### PR DESCRIPTION
/cc @openshift/test-platform 