### PR TITLE
`check-gh-automation`: create an option to skip the branch protection access check. 

### DIFF
--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -333,7 +333,7 @@ func TestCheckRepos(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			logrus.Infof("Testing %s", tc.name)
-			failing, err := checkRepos(tc.repos, tc.bots, "openshift-ci", tc.ignore, tc.mode, client, logrus.NewEntry(logrus.New()), newFakePluginConfigAgent(), newFakeProwConfigAgent().Config().Tide.Queries.QueryMap(), newFakeProwConfigAgent())
+			failing, err := checkRepos(tc.repos, tc.bots, "openshift-ci", tc.ignore, tc.mode, true, client, logrus.NewEntry(logrus.New()), newFakePluginConfigAgent(), newFakeProwConfigAgent().Config().Tide.Queries.QueryMap(), newFakeProwConfigAgent())
 			if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("error doesn't match expected, diff: %s", diff)
 			}


### PR DESCRIPTION
this check is too heavy handed to use in the periodic version. we will only use this one on the presubmit. We have [dozens](https://redhat-internal.slack.com/archives/CHY2E1BL4/p1710756614008279?thread_ts=1710749128.779799&cid=CHY2E1BL4) of currently onboarded repos that are failing this check, despite the branch protection job passing just fine. The reasons vary, but are not worth making the repo owners grant us access, for example:
- “konveyor/tackle-ui-tests” it seems that the branch protection matches the policy. So there is no need to have admin rights as nothing is changing.
- Others, like “kiegroup/kie-cloud-operator” have “protect=false”, and it also matches the settings, so no admin required there either.

This check will only be used in the presubmit version of the tool. This will result in new onboarding attempts following our standards, but existing exceptions will remain. A PR will follow to set this new option to false for the periodic.
