### PR TITLE
`helpdesk-faq`: slack handler to add FAQ items

### DIFF
--- a/cmd/helpdesk-faq/main.go
+++ b/cmd/helpdesk-faq/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -11,11 +10,9 @@ import (
 	"strconv"
 	"time"
 
+	helpdeskfaq "github.com/openshift/ci-tools/pkg/helpdesk-faq"
 	"github.com/sirupsen/logrus"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
@@ -25,50 +22,7 @@ import (
 
 const (
 	appCIContextName = string(api.ClusterAPPCI)
-	faqConfigMap     = "helpdesk-faq"
-	ci               = "ci"
 )
-
-type faqItemClient interface {
-	GetFAQItems() ([]string, error)
-}
-
-type configMapClient struct {
-	kubeClient  kubernetes.Interface
-	cachedItems []string
-	lastReload  time.Time
-}
-
-func (c *configMapClient) GetFAQItems() ([]string, error) {
-	fifteenMinutesFromLastCacheReload := c.lastReload.Add(time.Minute * 15)
-	if len(c.cachedItems) > 0 && time.Now().Before(fifteenMinutesFromLastCacheReload) {
-		logrus.Debugf("returning faq items from cache")
-		return c.cachedItems, nil
-	}
-	logrus.Debugf("reloading faq items from configmap")
-	configMap, err := c.getConfigMap()
-	if err != nil {
-		return nil, err
-	}
-	if configMap.Data == nil {
-		return nil, nil
-	}
-	var items []string
-	for _, item := range configMap.Data {
-		items = append(items, item)
-	}
-	c.cachedItems = items
-	c.lastReload = time.Now()
-	return items, nil
-}
-
-func (c *configMapClient) getConfigMap() (*v1.ConfigMap, error) {
-	configMap, err := c.kubeClient.CoreV1().ConfigMaps(ci).Get(context.TODO(), faqConfigMap, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get configMap %s: %w", faqConfigMap, err)
-	}
-	return configMap, nil
-}
 
 type options struct {
 	logLevel          string
@@ -78,21 +32,7 @@ type options struct {
 }
 
 type Page struct {
-	Data []FaqItem `json:"data"`
-}
-
-// TODO(sgoeddel): these structs will be placed in a common package somewhere so slack-bot can use them too
-type FaqItem struct {
-	Question  string   `json:"question"`
-	Timestamp string   `json:"timestamp"`
-	Author    string   `json:"author"`
-	Answers   []Answer `json:"answers"`
-}
-
-type Answer struct {
-	Author    string `json:"author"`
-	Timestamp string `json:"timestamp"`
-	Body      string `json:"body"`
+	Data []helpdeskfaq.FaqItem `json:"data"`
 }
 
 func gatherOptions() (options, error) {
@@ -116,7 +56,7 @@ func validateOptions(o options) error {
 	return o.kubernetesOptions.Validate(false)
 }
 
-func router(client faqItemClient) *http.ServeMux {
+func router(client helpdeskfaq.FaqItemClient) *http.ServeMux {
 	handler := http.NewServeMux()
 
 	handler.HandleFunc("/api/health", func(w http.ResponseWriter, r *http.Request) {
@@ -130,7 +70,7 @@ func router(client faqItemClient) *http.ServeMux {
 	handler.HandleFunc("/api/v1/faq-items", func(w http.ResponseWriter, r *http.Request) {
 		logrus.WithField("path", "/api/v1/faq-items").Info("serving")
 
-		items, err := client.GetFAQItems()
+		items, err := client.GetSerializedFAQItems()
 		if err != nil {
 			logrus.WithError(err).Fatal("unable to get helpdesk-faq items")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -139,7 +79,7 @@ func router(client faqItemClient) *http.ServeMux {
 
 		page := Page{}
 		for _, item := range items {
-			faqItem := &FaqItem{}
+			faqItem := &helpdeskfaq.FaqItem{}
 			if err := json.Unmarshal([]byte(item), faqItem); err != nil {
 				logrus.WithError(err).Fatal("unable to unmarshall faq item")
 				http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -186,7 +126,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("could not load kube config")
 	}
-	client := configMapClient{kubeClient: kubeClient}
+	client := helpdeskfaq.NewCMClient(kubeClient)
 	server := &http.Server{
 		Addr:    ":" + strconv.Itoa(o.port),
 		Handler: router(&client),

--- a/hack/local-slack-bot.sh
+++ b/hack/local-slack-bot.sh
@@ -63,12 +63,13 @@ sleep 5
 os::log::info "Sending production traffic from Slack to the reverse proxy..."
 ssh -N -T root@127.0.0.1 -p 2222 -R "8888:127.0.0.1:8888" &
 
+export KUBECONFIG="${data}/sa.config-updater.app.ci.config"
+
 os::log::info "Running the slack-bot server..."
 helpdesk_alias="U032D8MQZR6" # Update this to your slack userid in the dptp-robot-testing-space
 require_workflows=false # Set to true to test out the auto-reply when not using a workflow
 http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 \
  --slack-token-path="${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" \
- --kubeconfig="${data}/sa.config-updater.app.ci.config" \
  --jira-bearer-token-file="${data}/token" --jira-endpoint https://issues.redhat.com \
  --log-level=trace \
  --prow-config-path="${RELEASE_REPO_DIR}/core-services/prow/02_config/_config.yaml" --prow-job-config-path="${RELEASE_REPO_DIR}/ci-operator/jobs" \

--- a/hack/local-slack-bot.sh
+++ b/hack/local-slack-bot.sh
@@ -29,6 +29,7 @@ function OC() {
 
 os::log::info "Extracting production data we need to run the server..."
 OC extract secret/slack-credentials-dptp-bot-alpha --keys oauth_token,signing_secret --to "${data}"
+OC extract secret/config-updater --keys sa.config-updater.app.ci.config --to "${data}"
 OC extract secret/jira-token-dptp-bot --keys token --to "${data}"
 OC extract configmap/slack-bot-keyword-list --keys config.yaml --to "${data}"
 
@@ -65,4 +66,10 @@ ssh -N -T root@127.0.0.1 -p 2222 -R "8888:127.0.0.1:8888" &
 os::log::info "Running the slack-bot server..."
 helpdesk_alias="U032D8MQZR6" # Update this to your slack userid in the dptp-robot-testing-space
 require_workflows=false # Set to true to test out the auto-reply when not using a workflow
-http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 --slack-token-path "${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" --jira-bearer-token-file="${data}/token" --jira-endpoint https://issues.redhat.com --log-level=trace --prow-config-path="${RELEASE_REPO_DIR}/core-services/prow/02_config/_config.yaml" --prow-job-config-path="${RELEASE_REPO_DIR}/ci-operator/jobs" --keywords-config-path="${data}/config.yaml" --helpdesk-alias="${helpdesk_alias}" --forum-channel-id=C01CQ3MA5NX --require-workflows-in-forum="${require_workflows}"
+http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 \
+ --slack-token-path="${data}/oauth_token" --slack-signing-secret-path="${data}/signing_secret" \
+ --kubeconfig="${data}/sa.config-updater.app.ci.config" \
+ --jira-bearer-token-file="${data}/token" --jira-endpoint https://issues.redhat.com \
+ --log-level=trace \
+ --prow-config-path="${RELEASE_REPO_DIR}/core-services/prow/02_config/_config.yaml" --prow-job-config-path="${RELEASE_REPO_DIR}/ci-operator/jobs" \
+ --keywords-config-path="${data}/config.yaml" --helpdesk-alias="${helpdesk_alias}" --forum-channel-id=C01CQ3MA5NX --require-workflows-in-forum="${require_workflows}"

--- a/pkg/helpdesk-faq/client.go
+++ b/pkg/helpdesk-faq/client.go
@@ -1,0 +1,115 @@
+package helpdesk_faq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	faqConfigMap = "helpdesk-faq"
+	ci           = "ci"
+)
+
+type FaqItemClient interface {
+	GetSerializedFAQItems() ([]string, error)
+	GetFAQItemIfExists(timestamp string) (*FaqItem, error)
+	UpsertItem(item FaqItem) error
+	RemoveItem(timestamp string) error
+}
+
+func NewCMClient(kubeClient kubernetes.Interface) ConfigMapClient {
+	return ConfigMapClient{kubeClient: kubeClient}
+}
+
+type ConfigMapClient struct {
+	kubeClient  kubernetes.Interface
+	cachedItems []string
+	lastReload  time.Time
+}
+
+func (c *ConfigMapClient) GetSerializedFAQItems() ([]string, error) {
+	fifteenMinutesFromLastCacheReload := c.lastReload.Add(time.Minute * 15)
+	if len(c.cachedItems) > 0 && time.Now().Before(fifteenMinutesFromLastCacheReload) {
+		logrus.Debug("returning faq items from cache")
+		return c.cachedItems, nil
+	}
+	logrus.Debug("reloading faq items from configmap")
+	configMap, err := c.getConfigMap()
+	if err != nil {
+		return nil, err
+	}
+	if configMap.Data == nil {
+		return nil, nil
+	}
+	var items []string
+	for _, item := range configMap.Data {
+		items = append(items, item)
+	}
+	c.cachedItems = items
+	c.lastReload = time.Now()
+	return items, nil
+}
+
+func (c *ConfigMapClient) GetFAQItemIfExists(timestamp string) (*FaqItem, error) {
+	configMap, err := c.getConfigMap()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get configmap: %w", err)
+	}
+	rawFaqItem := configMap.Data[timestamp]
+	if rawFaqItem == "" {
+		return nil, nil
+	}
+	faqItem := &FaqItem{}
+	if err = json.Unmarshal([]byte(rawFaqItem), faqItem); err != nil {
+		return nil, fmt.Errorf("unable to unmarshall faqItem: %w", err)
+	}
+	return faqItem, nil
+}
+
+func (c *ConfigMapClient) UpsertItem(item FaqItem) error {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return fmt.Errorf("unable to marshal faqItem to json: %w", err)
+	}
+	configMap, err := c.getConfigMap()
+	if err != nil {
+		return fmt.Errorf("unable to get configmap: %w", err)
+	}
+	configMap.Data[item.Timestamp] = string(data)
+	_, err = c.kubeClient.CoreV1().ConfigMaps(ci).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to update helpdesk-faq config map: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigMapClient) RemoveItem(timestamp string) error {
+	configMap, err := c.getConfigMap()
+	if err != nil {
+		return fmt.Errorf("unable to get configmap: %w", err)
+	}
+	delete(configMap.Data, timestamp)
+	_, err = c.kubeClient.CoreV1().ConfigMaps(ci).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("unable to update helpdesk-faq config map: %w", err)
+	}
+
+	return nil
+}
+
+func (c *ConfigMapClient) getConfigMap() (*v1.ConfigMap, error) {
+	configMap, err := c.kubeClient.CoreV1().ConfigMaps(ci).Get(context.TODO(), faqConfigMap, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configMap %s: %w", faqConfigMap, err)
+	}
+	return configMap, nil
+}

--- a/pkg/helpdesk-faq/types.go
+++ b/pkg/helpdesk-faq/types.go
@@ -1,0 +1,17 @@
+package helpdesk_faq
+
+type FaqItem struct {
+	Question  string   `json:"question"`
+	Timestamp string   `json:"timestamp"`
+	Author    string   `json:"author"`
+	Answers   []Answer `json:"answers"`
+}
+
+type Answer struct {
+	Author    string `json:"author"`
+	Timestamp string `json:"timestamp"`
+	Body      string `json:"body"`
+}
+
+//TODO(sgoeddel): We probably need a "contributing info" emoji and section as well for when the question isn't entirely summarized in one prompt
+//TODO(sgoeddel): It would also be good to link to the original full thread for additional context

--- a/pkg/slack/events/helpdesk/helpdesk-faq.go
+++ b/pkg/slack/events/helpdesk/helpdesk-faq.go
@@ -1,0 +1,245 @@
+package helpdesk
+
+import (
+	helpdeskfaq "github.com/openshift/ci-tools/pkg/helpdesk-faq"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/openshift/ci-tools/pkg/slack/events"
+)
+
+const (
+	questionReaction = "channel_faq"
+	answerReaction   = "faq_answer"
+)
+
+type slackClient interface {
+	GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
+	GetConversationReplies(params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
+}
+
+func FAQHandler(client slackClient, kubeClient kubernetes.Interface, forumChannelId string) events.PartialHandler {
+	return events.PartialHandlerFunc("helpdesk",
+		func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
+			log := logger.WithField("handler", "helpdesk-faq")
+			log.Debug("checking event payload")
+
+			if callback.Type != slackevents.CallbackEvent {
+				return false, nil
+			}
+
+			cmClient := helpdeskfaq.NewCMClient(kubeClient)
+			event, added := callback.InnerEvent.Data.(*slackevents.ReactionAddedEvent)
+			if added {
+				if event.Item.Channel != forumChannelId {
+					log.Debugf("not in correct channel. wanted: %s, reaction was in: %s", forumChannelId, event.Item.Channel)
+					return false, nil
+				}
+				return handleReactionAdded(event, client, kubeClient, &cmClient, forumChannelId, log)
+
+			} else {
+				event, removed := callback.InnerEvent.Data.(*slackevents.ReactionRemovedEvent)
+				if removed {
+					if event.Item.Channel != forumChannelId {
+						log.Debugf("not in correct channel. wanted: %s, reaction was in: %s", forumChannelId, event.Item.Channel)
+						return false, nil
+					}
+					return handleReactionRemoved(event, client, &cmClient, forumChannelId, log)
+				} else {
+					return false, nil
+				}
+			}
+		})
+}
+
+func handleReactionRemoved(event *slackevents.ReactionRemovedEvent, client slackClient, faqItemClient helpdeskfaq.FaqItemClient, forumChannelId string, logger *logrus.Entry) (bool, error) {
+	logger.Debugf("%s emoji removed from message", event.Reaction)
+	switch event.Reaction {
+	case questionReaction:
+		questionLog := logger.WithField("type", "remove-question")
+		if err := faqItemClient.RemoveItem(event.Item.Timestamp); err != nil {
+			questionLog.WithError(err).Error("unable to update helpdesk-faq config map")
+			return false, err
+		}
+	case answerReaction:
+		answerLog := logger.WithField("type", "remove-answer")
+		messageTs := event.Item.Timestamp
+		replies, _, _, err := client.GetConversationReplies(&slack.GetConversationRepliesParameters{
+			ChannelID: forumChannelId,
+			Timestamp: messageTs,
+			Inclusive: true,
+		})
+		if err != nil {
+			answerLog.WithError(err).Error("unable to retrieve message that reaction was added for")
+			return false, err
+		}
+		if len(replies) == 1 {
+			reply := replies[0]
+			questionTs := reply.Msg.ThreadTimestamp
+			faqItem, err := faqItemClient.GetFAQItemIfExists(questionTs)
+			if err != nil {
+				answerLog.WithError(err).Warn("unable to get faqItem")
+				return false, nil //Don't return the error, because this is due to the question not having been added
+			}
+
+			index := -1
+			for i, answer := range faqItem.Answers {
+				if answer.Timestamp == messageTs {
+					index = i
+					break
+				}
+			}
+			if index >= 0 {
+				faqItem.Answers = append(faqItem.Answers[:index], faqItem.Answers[index+1:]...)
+			}
+			if err := faqItemClient.UpsertItem(*faqItem); err != nil {
+				answerLog.WithError(err).Error("unable to update helpdesk-faq config map")
+				return false, err
+			}
+		}
+	default:
+		logger.Debugf("emoji we do not care about: %s", event.Reaction)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func handleReactionAdded(event *slackevents.ReactionAddedEvent, client slackClient, kubeClient kubernetes.Interface, faqItemClient helpdeskfaq.FaqItemClient, forumChannelId string, logger *logrus.Entry) (bool, error) {
+	logger.Debugf("%s emoji added to message", event.Reaction)
+	//TODO: we will need a list of users whom reactions we actually care about, everyone else will be ignored
+	switch event.Reaction {
+	case questionReaction:
+		questionLog := logger.WithField("type", "add-question")
+		messageTs := event.Item.Timestamp
+		item, err := faqItemClient.GetFAQItemIfExists(messageTs)
+		if err != nil {
+			questionLog.WithError(err).Error("unable to get faq item")
+			return false, err
+		}
+		if item != nil {
+			questionLog.Info("we already have a question for this faqItem, ignoring")
+			return false, nil
+		}
+
+		message, err := getTopLevelMessage(client, forumChannelId, messageTs, questionLog)
+		if err != nil {
+			questionLog.WithError(err).Error("unable to get top-level message")
+			return false, err
+		}
+		if message != nil {
+			faqItem := helpdeskfaq.FaqItem{
+				Question:  message.Text,
+				Timestamp: messageTs,
+				Author:    message.User,
+			}
+
+			var cursor string
+			var hasMore bool
+			var replies []slack.Message
+			for {
+				replies, hasMore, cursor, err = client.GetConversationReplies(&slack.GetConversationRepliesParameters{
+					ChannelID: forumChannelId,
+					Timestamp: messageTs,
+					Inclusive: true,
+					Cursor:    cursor,
+				})
+				if err != nil {
+					questionLog.WithError(err).Error("unable to get replies for top-level message")
+					return false, err
+				}
+
+				for _, reply := range replies {
+					for _, reaction := range reply.Reactions {
+						if reaction.Name == answerReaction {
+							questionLog.Debugf("adding pre-marked answer with timestamp: %s", reply.Timestamp)
+							faqItem.Answers = append(faqItem.Answers, helpdeskfaq.Answer{
+								Author:    reply.User,
+								Timestamp: reply.Timestamp,
+								Body:      reply.Msg.Text,
+							})
+						}
+					}
+				}
+
+				if !hasMore {
+					break
+				}
+			}
+
+			if err := faqItemClient.UpsertItem(faqItem); err != nil {
+				questionLog.WithError(err).Error("unable to create helpdesk-faq item")
+				return false, err
+			}
+		}
+	case answerReaction:
+		answerLog := logger.WithField("type", "add-answer")
+		messageTs := event.Item.Timestamp
+		replies, _, _, err := client.GetConversationReplies(&slack.GetConversationRepliesParameters{
+			ChannelID: forumChannelId,
+			Timestamp: messageTs,
+			Inclusive: true,
+		})
+		if err != nil {
+			answerLog.WithError(err).Error("unable to retrieve message that reaction was added for")
+			return false, err
+		}
+		if len(replies) == 1 {
+			reply := replies[0]
+			questionTs := reply.Msg.ThreadTimestamp
+			faqItem, err := faqItemClient.GetFAQItemIfExists(questionTs)
+			if err != nil {
+				answerLog.WithError(err).Error("unable to get faq item")
+				return false, err
+			}
+			if faqItem == nil {
+				answerLog.Info("requested answer doesn't belong to an existing question, ignoring")
+				return false, nil
+			}
+
+			for _, answer := range faqItem.Answers {
+				if answer.Timestamp == messageTs {
+					answerLog.Debug("answer already exists, ignoring")
+					return false, nil
+				}
+			}
+			faqItem.Answers = append(faqItem.Answers, helpdeskfaq.Answer{
+				Author:    reply.User,
+				Timestamp: messageTs,
+				Body:      reply.Msg.Text,
+			})
+			if err := faqItemClient.UpsertItem(*faqItem); err != nil {
+				answerLog.WithError(err).Error("unable to update helpdesk-faq item")
+				return false, err
+			}
+
+		}
+	default:
+		logger.Debugf("emoji we do not care about: %s", event.Reaction)
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func getTopLevelMessage(client slackClient, forumChannelId string, messageTs string, logger *logrus.Entry) (*slack.Message, error) {
+	conversationHistory, err := client.GetConversationHistory(&slack.GetConversationHistoryParameters{
+		ChannelID: forumChannelId,
+		Inclusive: true,
+		Latest:    messageTs,
+		Limit:     1,
+		Oldest:    messageTs,
+	})
+	if err != nil || len(conversationHistory.Messages) == 0 {
+		if err != nil {
+			logger.WithError(err).Error("unable to retrieve message that reaction was added for")
+		} else {
+			logger.Warn("unable to retrieve message, it is likely the reaction was not on a top-level thread")
+		}
+		return nil, err
+	}
+	return &conversationHistory.Messages[0], nil
+}

--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -27,9 +27,9 @@ type KeywordsListItem struct {
 
 const reviewRequestWorkflow = "B03KCKGCBC7"
 
-// Handler returns a handler that knows how to respond to new messages
+// MessageHandler returns a handler that knows how to respond to new messages
 // in forum-ocp-testplatform channel that mention @dptp-helpdesk.
-func Handler(client messagePoster, keywordsConfig KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.PartialHandler {
+func MessageHandler(client messagePoster, keywordsConfig KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.PartialHandler {
 	return events.PartialHandlerFunc("helpdesk",
 		func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (handled bool, err error) {
 			log := logger.WithField("handler", "helpdesk-message")

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -6,6 +6,8 @@ import (
 
 	"k8s.io/test-infra/prow/config"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/openshift/ci-tools/pkg/slack/events"
 	"github.com/openshift/ci-tools/pkg/slack/events/helpdesk"
 	"github.com/openshift/ci-tools/pkg/slack/events/joblink"
@@ -14,9 +16,10 @@ import (
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.Handler {
+func ForEvents(client *slack.Client, kubeClient kubernetes.Interface, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.Handler {
 	return events.MultiHandler(
-		helpdesk.Handler(client, keywordsConfig, helpdeskAlias, forumChannelId, requireWorkflowsInForum),
+		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, requireWorkflowsInForum),
+		helpdesk.FAQHandler(client, kubeClient, forumChannelId),
 		mention.Handler(client),
 		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),
 	)

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -5,8 +5,7 @@ import (
 	"github.com/slack-go/slack"
 
 	"k8s.io/test-infra/prow/config"
-
-	"k8s.io/client-go/kubernetes"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/slack/events"
 	"github.com/openshift/ci-tools/pkg/slack/events/helpdesk"
@@ -16,7 +15,7 @@ import (
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client, kubeClient kubernetes.Interface, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.Handler {
+func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.Handler {
 	return events.MultiHandler(
 		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, requireWorkflowsInForum),
 		helpdesk.FAQHandler(client, kubeClient, forumChannelId),


### PR DESCRIPTION
Adds the ability for `slack-bot` to add and remove items from the `helpdesk-faq` (currently a ConfigMap on app.ci) based on emoji reactions on messages in `#forum-ocp-testplatform`

For: https://issues.redhat.com/browse/DPTP-3521