### PR TITLE
Determine the cli version in the promotion pod

### DIFF
--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -702,7 +702,7 @@ func TestGetPromotionPod(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			testhelper.CompareWithFixture(t, getPromotionPod(testCase.imageMirror, testCase.namespace, "promotion", testCase.nodeArchitectures))
+			testhelper.CompareWithFixture(t, getPromotionPod(testCase.imageMirror, testCase.namespace, "promotion", "4.14", testCase.nodeArchitectures))
 		})
 	}
 }


### PR DESCRIPTION
We use the service provided by the release controller to determine the version so that we do not need to manually bump the hardcoded version.
It is the latest Y-stream for 4-stable.
https://amd64.ocp.releases.ci.openshift.org/#4-stable
Currently it is 4.15.

/cc @openshift/test-platform 
