### PR TITLE
`rehearsal`: add supplemental images config

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -55,6 +55,7 @@ type options struct {
 
 	webhookSecretFile        string
 	registryConfig           string
+	ciImagesMirrorConfigPath string
 	githubEventServerOptions githubeventserver.Options
 	github                   prowflagutil.GitHubOptions
 	config                   configflagutil.ConfigOptions
@@ -83,6 +84,7 @@ func gatherOptions() (options, error) {
 	fs.Var(&o.stickyLabelAuthors, "sticky-label-author", "PR Author for which the 'rehearsals-ack' label will not be removed upon a new push. Can be passed multiple times.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 	fs.StringVar(&o.registryConfig, "registry-config", "", "Path to the file of registry credentials")
+	fs.StringVar(&o.ciImagesMirrorConfigPath, "ci-images-mirror-config-path", "", "Path to ci-image-mirror config path file")
 
 	fs.StringVar(&o.gcsBucket, "gcs-bucket", "test-platform-results", "GCS Bucket to upload affected jobs list")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "/etc/gcs/service-account.json", "GCS Credentials file to upload affected jobs list")
@@ -190,7 +192,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 			return fmt.Errorf("%s: %w", "ERROR: pj-rehearse: failed to validate rehearsal jobs", err)
 		}
 
-		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, quayiociimagesdistributor.OCImageMirrorOptions{}, nil, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, logger)
+		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, quayiociimagesdistributor.OCImageMirrorOptions{}, nil, nil, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, logger)
 		return err
 	}
 

--- a/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
+++ b/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
@@ -1,0 +1,65 @@
+package quay_io_ci_images_distributor
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/util/gzip"
+)
+
+func LoadConfig(file string) (*CIImagesMirrorConfig, error) {
+	bytes, err := gzip.ReadFileMaybeGZIP(file)
+	if err != nil {
+		return nil, err
+	}
+	c := &CIImagesMirrorConfig{}
+	if err := yaml.UnmarshalStrict(bytes, c); err != nil {
+		return nil, err
+	}
+	var errs []error
+	for k, v := range c.SupplementalCIImages {
+		splits := strings.Split(k, "/")
+		if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
+			errs = append(errs, fmt.Errorf("invalid target: %s", k))
+		} else {
+			splits = strings.Split(splits[1], ":")
+			if len(splits) != 2 || splits[0] == "" || splits[1] == "" {
+				errs = append(errs, fmt.Errorf("invalid target: %s", k))
+			}
+		}
+		if v.As != "" {
+			errs = append(errs, errors.New("as cannot be set"))
+		}
+		if v.Image == "" {
+			if v.Namespace == "" {
+				errs = append(errs, errors.New("namespace for the source must be set"))
+			}
+			if v.Name == "" {
+				errs = append(errs, errors.New("name for the source must be set"))
+			}
+			if v.Tag == "" {
+				errs = append(errs, errors.New("tag for the source must be set"))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return nil, utilerrors.NewAggregate(errs)
+	}
+	return c, nil
+}
+
+type CIImagesMirrorConfig struct {
+	SupplementalCIImages map[string]Source `json:"supplementalCIImages"`
+}
+
+type Source struct {
+	api.ImageStreamTagReference `json:",inline"`
+	// Image is an image that can be pulled in either form of tag or digest.
+	// When image is set, Tag will be ignored.
+	Image string `json:"image"`
+}


### PR DESCRIPTION
Add the option to supplemental images config: https://github.com/openshift/release/blob/master/core-services/image-mirroring/_config.yaml and ignore the targeting images defined there.

/cc @hongkailiu 