### PR TITLE
`ci-operator`: add step for `aws` ip pool lease

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -59,8 +59,9 @@ const (
 	// `podStartTimeout`.
 	ReasonPending = "pod_pending"
 	// CliEnv if the env we use to expose the path to the cli
-	CliEnv          = "CLI_DIR"
-	DefaultLeaseEnv = "LEASED_RESOURCE"
+	CliEnv                = "CLI_DIR"
+	DefaultLeaseEnv       = "LEASED_RESOURCE"
+	DefaultIPPoolLeaseEnv = "IP_POOL_AVAILABLE"
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"
 

--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -17,3 +17,14 @@ func LeasesForTest(s *MultiStageTestConfigurationLiteral) (ret []StepLease) {
 	ret = append(ret, s.Leases...)
 	return
 }
+
+func IPPoolLeaseForTest(s *MultiStageTestConfigurationLiteral) (ret StepLease) {
+	if p := s.ClusterProfile; p == "aws" { //TODO(sgoeddel): Hardcoded to only work on aws, eventually this will be available as a configuration
+		ret = StepLease{
+			ResourceType: p.IPPoolLeaseType(),
+			Env:          DefaultIPPoolLeaseEnv,
+			Count:        13,
+		}
+	}
+	return
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1905,6 +1905,15 @@ func (p ClusterProfile) LeaseType() string {
 	}
 }
 
+func (p ClusterProfile) IPPoolLeaseType() string {
+	switch p {
+	case ClusterProfileAWS:
+		return "aws-ip-pools"
+	default:
+		return ""
+	}
+}
+
 // ConfigMap maps profiles to the ConfigMap they require (if applicable).
 func (p ClusterProfile) ConfigMap() string {
 	switch p {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -437,11 +437,15 @@ func stepForTest(
 ) ([]api.Step, error) {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		leases := api.LeasesForTest(test)
-		if len(leases) != 0 {
+		ipPoolLease := api.IPPoolLeaseForTest(test)
+		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
 			params = api.NewDeferredParameters(params)
 		}
 		var ret []api.Step
 		step := multi_stage.MultiStageTestStep(*c, config, params, podClient, jobSpec, leases, nodeName, targetAdditionalSuffix, nil)
+		if ipPoolLease.ResourceType != "" {
+			step = steps.IPPoolStep(leaseClient, ipPoolLease, step, params, jobSpec.Namespace)
+		}
 		if len(leases) != 0 {
 			step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace)
 		}

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -1,0 +1,111 @@
+package steps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/lease"
+	"github.com/openshift/ci-tools/pkg/results"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var NoLeaseClientForIPErr = errors.New("step needs access to an IP pool, but no lease client provided")
+
+// ipPoolStep wraps another step and acquires/releases chunks of IPs.
+type ipPoolStep struct {
+	client      *lease.Client
+	ipPoolLease stepLease
+	wrapped     api.Step
+	params      api.Parameters
+
+	// for sending heartbeats during pool acquisition
+	namespace func() string
+}
+
+func IPPoolStep(client *lease.Client, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string) api.Step {
+	ret := ipPoolStep{
+		client:      client,
+		wrapped:     wrapped,
+		namespace:   namespace,
+		params:      params,
+		ipPoolLease: stepLease{StepLease: lease},
+	}
+	return &ret
+}
+
+func (s *ipPoolStep) Inputs() (api.InputDefinition, error) {
+	return s.wrapped.Inputs()
+}
+
+func (s *ipPoolStep) Validate() error {
+	if s.client == nil {
+		return NoLeaseClientForIPErr
+	}
+	return nil
+}
+
+func (s *ipPoolStep) Name() string                        { return s.wrapped.Name() }
+func (s *ipPoolStep) Description() string                 { return s.wrapped.Description() }
+func (s *ipPoolStep) Requires() []api.StepLink            { return s.wrapped.Requires() }
+func (s *ipPoolStep) Creates() []api.StepLink             { return s.wrapped.Creates() }
+func (s *ipPoolStep) Objects() []ctrlruntimeclient.Object { return s.wrapped.Objects() }
+
+func (s *ipPoolStep) Provides() api.ParameterMap {
+	parameters := s.wrapped.Provides()
+	if parameters == nil {
+		parameters = api.ParameterMap{}
+	}
+	l := &s.ipPoolLease
+	parameters[l.Env] = func() (string, error) {
+		return strconv.Itoa(len(l.resources)), nil
+	}
+	return parameters
+}
+
+func (s *ipPoolStep) SubTests() []*junit.TestCase {
+	if subTests, ok := s.wrapped.(SubtestReporter); ok {
+		return subTests.SubTests()
+	}
+	return nil
+}
+
+func (s *ipPoolStep) Run(ctx context.Context) error {
+	return results.ForReason("utilizing_ip_pool").ForError(s.run(ctx))
+}
+
+func (s *ipPoolStep) run(ctx context.Context) error {
+	l := &s.ipPoolLease
+	region, err := s.params.Get(api.DefaultLeaseEnv)
+	if err != nil || region == "" {
+		return results.ForReason("acquiring_ip_pool_lease").WithError(err).Errorf("failed to determine region to acquire lease for %s", l.ResourceType)
+	}
+	l.ResourceType = fmt.Sprintf("%s-%s", l.ResourceType, region)
+	logrus.Infof("Acquiring IP Pool leases for test %s: %v", s.Name(), l.ResourceType)
+	client := *s.client
+	ctx, cancel := context.WithCancel(ctx)
+
+	names, err := client.AcquireIfAvailableImmediately(l.ResourceType, l.Count, cancel)
+	if err != nil {
+		if err == lease.ErrNotFound {
+			logrus.Infof("no leases of type: %s available", l.ResourceType)
+		} else {
+			return results.ForReason("acquiring_ip_pool_lease").WithError(err).Errorf("failed to acquire lease for %s: %v", l.ResourceType, err)
+		}
+	} else {
+		logrus.Infof("Acquired %d ip pool lease(s) for %s: %v", l.Count, l.ResourceType, names)
+		s.ipPoolLease.resources = names
+	}
+
+	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
+	logrus.Infof("Releasing ip pool leases for test %s", s.Name())
+	releaseErr := results.ForReason("releasing_ip_pool_lease").ForError(releaseLeases(client, *l))
+
+	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
+}

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -1,0 +1,210 @@
+package steps
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/lease"
+	"github.com/openshift/ci-tools/pkg/testhelper"
+)
+
+func TestProvides(t *testing.T) {
+	testCases := []struct {
+		name     string
+		step     ipPoolStep
+		expected map[string]string
+	}{
+		{
+			name: "leases acquired",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        2,
+					},
+					resources: []string{"some-resource", "some-other-resource"},
+				},
+				wrapped: &stepNeedsLease{},
+			},
+			expected: map[string]string{
+				"parameter":               "map",
+				api.DefaultIPPoolLeaseEnv: "2",
+			},
+		},
+		{
+			name: "no leases acquired",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        2,
+					},
+					resources: []string{},
+				},
+				wrapped: &stepNeedsLease{},
+			},
+			expected: map[string]string{
+				"parameter":               "map",
+				api.DefaultIPPoolLeaseEnv: "0",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.step.Provides()
+			if len(result) != len(tc.expected) {
+				t.Fatalf("resulting parameters (%d) are not the same length as expected (%d)", len(result), len(tc.expected))
+			}
+			for key, value := range tc.expected {
+				match, exists := result[key]
+				if !exists {
+					t.Errorf("expected parameter: %s doesn't exist in result", key)
+				}
+				resultValue, _ := match()
+				if diff := cmp.Diff(value, resultValue); diff != "" {
+					t.Errorf("expected doesn't match result, diff: %s", diff)
+				}
+			}
+		})
+	}
+}
+
+type fakeStepParams map[string]string
+
+func (f fakeStepParams) Has(key string) bool {
+	_, ok := f[key]
+	return ok
+}
+
+func (f fakeStepParams) HasInput(_ string) bool {
+	panic("This should not be used")
+}
+
+func (f fakeStepParams) Get(key string) (string, error) {
+	return f[key], nil
+}
+
+func TestRun(t *testing.T) {
+	testCases := []struct {
+		name           string
+		step           ipPoolStep
+		injectFailures map[string]error
+		expected       []string
+		expectedError  error
+	}{
+		{
+			name: "leases available in region",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        2,
+					},
+				},
+				wrapped: &stepNeedsLease{},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"releaseone owner aws-ip-pool-us-east-1_0 free",
+				"releaseone owner aws-ip-pool-us-east-1_1 free",
+			},
+		},
+		{
+			name: "leases unavailable in region, step should not error",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        1,
+					},
+				},
+				wrapped: &stepNeedsLease{},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+			},
+			injectFailures: map[string]error{
+				"acquire owner aws-ip-pool-us-east-1 free leased": lease.ErrNotFound,
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+			},
+		},
+		{
+			name: "region not provided, errors",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        2,
+					},
+				},
+				wrapped: &stepNeedsLease{},
+				params:  fakeStepParams{},
+			},
+			expectedError: errors.New("failed to determine region to acquire lease for aws-ip-pool"),
+		},
+		{
+			name: "unknown lease client error",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        1,
+					},
+				},
+				wrapped: &stepNeedsLease{},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+			},
+			injectFailures: map[string]error{
+				"acquire owner aws-ip-pool-us-east-1 free leased": errors.New("some client error"),
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+			},
+			expectedError: errors.New("failed to acquire lease for aws-ip-pool-us-east-1: some client error"),
+		},
+		{
+			name: "wrapped step fails",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        1,
+					},
+				},
+				wrapped: &stepNeedsLease{fail: true},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"releaseone owner aws-ip-pool-us-east-1_0 free",
+			},
+			expectedError: errors.New("injected failure"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls []string
+			client := lease.NewFakeClient("owner", "url", 0, tc.injectFailures, &calls)
+			tc.step.client = &client
+			err := tc.step.Run(context.Background())
+			if diff := cmp.Diff(err, tc.expectedError, testhelper.EquateErrorMessage); diff != "" {
+				t.Fatalf("unexpected error returned, diff: %s", diff)
+			}
+			if diff := cmp.Diff(calls, tc.expected); diff != "" {
+				t.Fatalf("unexpected calls to the lease client: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -118,7 +118,7 @@ func (s *leaseStep) run(ctx context.Context) error {
 	}
 	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
 	logrus.Infof("Releasing leases for test %s", s.Name())
-	releaseErr := results.ForReason("releasing_lease").ForError(releaseLeases(client, s.leases))
+	releaseErr := results.ForReason("releasing_lease").ForError(releaseLeases(client, s.leases...))
 
 	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
 }
@@ -164,14 +164,14 @@ func acquireLeases(
 		l.resources = names
 	}
 	if errs != nil {
-		if err := releaseLeases(client, leases); err != nil {
+		if err := releaseLeases(client, leases...); err != nil {
 			errs = append(errs, fmt.Errorf("failed to release leases after acquisition failure: %w", err))
 		}
 	}
 	return utilerrors.NewAggregate(errs)
 }
 
-func releaseLeases(client lease.Client, leases []stepLease) error {
+func releaseLeases(client lease.Client, leases ...stepLease) error {
 	var errs []error
 	for _, l := range leases {
 		for _, r := range l.resources {

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -376,6 +376,13 @@ func (s *multiStageTestStep) environment() ([]coreapi.EnvVar, error) {
 			}
 			ret = append(ret, coreapi.EnvVar{Name: e, Value: val})
 		}
+		if s.profile == "aws" { //TODO(sgoeddel): only enabled for aws for now, later this will be configurable
+			val, err := s.params.Get(api.DefaultIPPoolLeaseEnv)
+			if err != nil {
+				return nil, err
+			}
+			ret = append(ret, coreapi.EnvVar{Name: api.DefaultIPPoolLeaseEnv, Value: val})
+		}
 	}
 	return ret, nil
 }


### PR DESCRIPTION
This, short-term, solution allows all jobs using the `aws` cluster-profile to lease 13 ip pool addresses.

For: https://issues.redhat.com/browse/DPTP-3901