### PR TITLE
publicize: construct the user credentials while reloving the external remote

### DIFF
--- a/cmd/publicize/server.go
+++ b/cmd/publicize/server.go
@@ -89,6 +89,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 	sourceRemoteResolver := func() (string, error) {
 		remote := &url.URL{Scheme: "https", Host: s.githubHost, Path: fmt.Sprintf("%s/%s", org, repo)}
+		remote.User = url.UserPassword(s.githubLogin, string(s.githubTokenGenerator()))
 		return remote.String(), nil
 	}
 


### PR DESCRIPTION
/cc @openshift/test-platform @smg247 


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
