### PR TITLE
`pj-rehearse`: acknowledge that a request is being processed

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -300,6 +300,11 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 		repo := pullRequest.Base.Repo.Name
 		number := pullRequest.Number
 
+		// Sometimes, hooks or requests are dropped causing confusion to the command issuer. We can acknowledge that the request has been received
+		if err := s.ghc.CreateComment(org, repo, number, fmt.Sprintf("@%s: now processing your pj-rehearse request. Please allow up to 10 minutes for jobs to trigger or cancel.", user)); err != nil {
+			logger.WithError(err).Error("failed to create acknowledgement comment")
+		}
+
 		// We shouldn't allow rehearsals to run (or be ack'd) on untrusted PRs
 		for _, label := range pullRequest.Labels {
 			if needsOkToTestLabel == label.Name {


### PR DESCRIPTION
It is increasingly confusing users with the time it takes to process requests. add an acknowledgment of the request to let them know we are processing.