### PR TITLE
[testgrid-config-generator] Allow arbitrary testgrid dashboards and multiple allow lists

### DIFF
--- a/cmd/testgrid-config-generator/main_test.go
+++ b/cmd/testgrid-config-generator/main_test.go
@@ -44,7 +44,7 @@ key2: informing
 key1: 
 key2: informing
 `,
-			expectedError: fmt.Errorf("key1: release_type must be one of 'informing', 'broken', 'generic-informing', 'osde2e' or 'olm'"),
+			expectedError: fmt.Errorf("key1: release_type must be non-empty"),
 			expectedOut: map[string]string{
 				"key1": "",
 				"key2": "informing",

--- a/test/integration/testgrid-config-generator.sh
+++ b/test/integration/testgrid-config-generator.sh
@@ -15,7 +15,7 @@ cp -a "${suite_dir}/config/testgrid/"* "${workdir}"
 os::test::junit::declare_suite_start "integration/testgrid-config-generator"
 # This test validates the testgrid-config-generator tool
 
-os::cmd::expect_success "testgrid-config-generator --release-config ${suite_dir}/config/release --testgrid-config ${workdir} --prow-jobs-dir ${suite_dir}/config/jobs --allow-list ${suite_dir}/config/_allow-list.yaml"
+os::cmd::expect_success "testgrid-config-generator --release-config ${suite_dir}/config/release --testgrid-config ${workdir} --prow-jobs-dir ${suite_dir}/config/jobs --allow-list ${suite_dir}/config/_allow-list.yaml --allow-list ${suite_dir}/config/_allow-list2.yaml"
 os::integration::compare "${workdir}" "${suite_dir}/expected"
 
 os::cmd::expect_failure_and_text "testgrid-config-generator --release-config ${suite_dir}/config/release --allow-list ${suite_dir}/config/_allow-list-broken.yaml --validate" "The following jobs are blocking by virtue of being in the release-controller configuration, but are also in the allow-list. Their entries in the allow-list are disallowed and should be removed: release-openshift-ocp-installer-e2e-aws-4.2"

--- a/test/integration/testgrid-config-generator/config/_allow-list.yaml
+++ b/test/integration/testgrid-config-generator/config/_allow-list.yaml
@@ -1,5 +1,3 @@
 release-openshift-origin-job-from-allow-list: informing
 release-openshift-origin-job: informing
 release-openshift-origin-job-without-release-label-broken: broken
-release-openshift-ocp-job: informing
-aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator: informing

--- a/test/integration/testgrid-config-generator/config/_allow-list2.yaml
+++ b/test/integration/testgrid-config-generator/config/_allow-list2.yaml
@@ -1,0 +1,2 @@
+release-openshift-ocp-job: informing
+aggregated-aws-ovn-upgrade-4.10-minor-release-openshift-release-analysis-aggregator: informing


### PR DESCRIPTION
- Allow arbitrary testgrid dashboard roles
- Allow specifying multiple allow list files so that teams can manage their own allow list files without requiring core team reviews 