### PR TITLE
ci-scheduling-webhook: don't overwrite `.spec.nodeSelector`

### DIFF
--- a/cmd/ci-scheduling-webhook/mutation.go
+++ b/cmd/ci-scheduling-webhook/mutation.go
@@ -260,7 +260,10 @@ func mutatePod(w http.ResponseWriter, r *http.Request) {
 		addPatchEntry("add", "/spec/runtimeClassName", "ci-scheduler-runtime-"+podClass)
 
 		// Set a nodeSelector to ensure this finds our desired machineset nodes
-		nodeSelector := make(map[string]string)
+		nodeSelector := pod.Spec.NodeSelector
+		if nodeSelector == nil {
+			nodeSelector = make(map[string]string)
+		}
 		nodeSelector[CiWorkloadLabelName] = string(podClass)
 		addPatchEntry("add", "/spec/nodeSelector", nodeSelector)
 


### PR DESCRIPTION
`ci-scheduling-webhook` should be gentle and add only its own stuff into the map instead of replacing it entirely.

/cc @bear-redhat @droslean 