### PR TITLE
import_release: add more debug logs

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -548,7 +548,17 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 			}
 			return false, err
 		}
-		return streamTag.Tag != nil && streamTag.Tag.Generation != nil && *streamTag.Tag.Generation == streamTag.Generation, nil
+		populated := streamTag.Tag != nil && streamTag.Tag.Generation != nil && *streamTag.Tag.Generation == streamTag.Generation
+		if streamTag.Tag == nil {
+			logrus.Debug("The 'cli' image in the stable stream is not populated: streamTag.Tag is nil")
+			return false, nil
+		}
+		if !populated {
+			logrus.WithField("streamTag.Tag.Generation", streamTag.Tag.Generation).
+				WithField("streamTag.Generation", streamTag.Generation).
+				Debug("The 'cli' image in the stable stream is not populated")
+		}
+		return populated, nil
 	}); err != nil {
 		duration := time.Since(startedWaiting)
 		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate (waited for %s): %w", duration, err)


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CBN38N3MW/p1712580650489229?thread_ts=1712481700.619319&cid=CBN38N3MW

[This job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-assisted-installer-agent-release-ocm-2.10-subsystem-test-periodic/1777124438580400128) ends up with

```
ERRO[2024-04-08T00:16:06Z] 
  * could not run steps: step [release:latest] failed: failed to get CLI image: unable to wait for the 'cli' image in the stable stream to populate (waited for 5m5.027192371s): timed out waiting for the condition 
```

and the stream.json in artifacts does not have the values at the time of checking.
So we add the logs for debugging.

/cc @openshift/test-platform 