### PR TITLE
`pj-rehearse`: don't wait for job success on standard rehearsal runs

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -192,7 +192,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 			return fmt.Errorf("%s: %w", "ERROR: pj-rehearse: failed to validate rehearsal jobs", err)
 		}
 
-		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, quayiociimagesdistributor.OCImageMirrorOptions{}, nil, nil, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, logger)
+		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, quayiociimagesdistributor.OCImageMirrorOptions{}, nil, nil, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, true, logger)
 		return err
 	}
 

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -415,14 +415,13 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 						continue
 					}
 
-					success, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, s.rehearsalConfig.MirrorOptions, s.rehearsalConfig.QuayIOImageHelper, s.rehearsalConfig.IgnoredTargets, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, logger)
+					autoAckMode := rehearseAutoAck == command
+					success, err := rc.RehearseJobs(candidate, candidatePath, prRefs, imageStreamTags, s.rehearsalConfig.MirrorOptions, s.rehearsalConfig.QuayIOImageHelper, s.rehearsalConfig.IgnoredTargets, presubmitsToRehearse, changedTemplates, changedClusterProfiles, prConfig.Prow, autoAckMode, logger)
 					if err != nil {
 						logger.WithError(err).Error("couldn't rehearse jobs")
 						s.reportFailure("failed to create rehearsal jobs", err, org, repo, user, number, true, false, logger)
 						continue
 					}
-
-					autoAckMode := rehearseAutoAck == command
 					if autoAckMode && success {
 						s.acknowledgeRehearsals(org, repo, number, logger)
 					}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -579,7 +579,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 			if err != nil {
 				t.Errorf("Expected to get no error, but got one: %v", err)
 			}
-			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, true, logger, client, testNamespace, &prowconfig.Config{})
+			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, true, logger, client, testNamespace, &prowconfig.Config{}, true)
 			executor.pollFunc = threetimesTryingPoller
 			_, err = executor.ExecuteJobs()
 
@@ -645,7 +645,7 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 			if err != nil {
 				t.Errorf("Expected to get no error, but got one: %v", err)
 			}
-			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, false, logger, client, testNamespace, &prowconfig.Config{})
+			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, false, logger, client, testNamespace, &prowconfig.Config{}, true)
 			executor.pollFunc = threetimesTryingPoller
 			success, _ := executor.ExecuteJobs()
 
@@ -769,7 +769,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 			if diff := cmp.Diff(imageStreamTags, tc.expectedImageStreamTagMap, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("returned imageStreamTags do not match expected: %s", diff)
 			}
-			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, true, logger, client, testNamespace, &prowconfig.Config{})
+			executor := NewExecutor(presubmits, testPrNumber, testRepoPath, testRefs, true, logger, client, testNamespace, &prowconfig.Config{}, true)
 			success, err := executor.ExecuteJobs()
 
 			if err != nil {
@@ -873,7 +873,7 @@ func TestWaitForJobs(t *testing.T) {
 		t.Run(tc.id, func(t *testing.T) {
 			client := newTC(tc.events...)
 
-			executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logger, client, "", &prowconfig.Config{})
+			executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logger, client, "", &prowconfig.Config{}, true)
 			executor.pollFunc = threetimesTryingPoller
 			success, err := executor.waitForJobs(tc.pjs, &ctrlruntimeclient.ListOptions{})
 			if err != tc.err {
@@ -902,7 +902,7 @@ func TestWaitForJobsRetries(t *testing.T) {
 		return nil
 	})
 
-	executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logrus.NewEntry(logrus.New()), client, "", &prowconfig.Config{})
+	executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logrus.NewEntry(logrus.New()), client, "", &prowconfig.Config{}, true)
 	executor.pollFunc = threetimesTryingPoller
 	success, err := executor.waitForJobs(sets.Set[string]{"j": {}}, &ctrlruntimeclient.ListOptions{})
 	if err != nil {
@@ -924,7 +924,7 @@ func TestWaitForJobsLog(t *testing.T) {
 			Status:     pjapi.ProwJobStatus{State: pjapi.FailureState}},
 	).Build()
 
-	executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logger.WithFields(nil), client, "", &prowconfig.Config{})
+	executor := NewExecutor(nil, 0, "", &pjapi.Refs{}, true, logger.WithFields(nil), client, "", &prowconfig.Config{}, true)
 	executor.pollFunc = threetimesTryingPoller
 	_, err := executor.waitForJobs(sets.New[string]("success", "failure"), &ctrlruntimeclient.ListOptions{})
 	if err != nil {
@@ -1758,7 +1758,7 @@ func TestSubmitPresubmit(t *testing.T) {
 			t.Parallel()
 			client := newTC()
 			logger := logrus.NewEntry(logrus.New())
-			extor := NewExecutor([]*prowconfig.Presubmit{}, 0, "", &tc.refs, false, logger, client, tc.namespace, &tc.prowConfig)
+			extor := NewExecutor([]*prowconfig.Presubmit{}, 0, "", &tc.refs, false, logger, client, tc.namespace, &tc.prowConfig, true)
 			actualJob, err := extor.submitPresubmit(&tc.presubmit)
 
 			if err != nil {


### PR DESCRIPTION
There is no reason to wait and constantly poll for job success in standard workflows. It appears that doing so makes it so the temporary git repo checkout doesn't get pruned until all jobs are complete. This causes the `inactive_anon` memory space to be filled up, and results in the plugin using significantly more memory than necessary. We still need to wait in `auto-ack` mode in order to ack when jobs succeed only.

For: https://issues.redhat.com/browse/DPTP-3933