### PR TITLE
Revert "add cluster profile for konflux workspaces"

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1329,7 +1329,6 @@ const (
 	ClusterProfileAWSEdgeInfra          ClusterProfile = "aws-edge-infra"
 	ClusterProfileRHOpenShiftEcosystem  ClusterProfile = "rh-openshift-ecosystem"
 	ClusterProfileODFAWS                ClusterProfile = "odf-aws"
-	ClusterProfileKonfluxWorkspacesAWS  ClusterProfile = "konfluxworkspaces-aws"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1463,7 +1462,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSEdgeInfra,
 		ClusterProfileRHOpenShiftEcosystem,
 		ClusterProfileODFAWS,
-		ClusterProfileKonfluxWorkspacesAWS,
 	}
 }
 
@@ -1516,8 +1514,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileDevSandboxCIAWS,
 		ClusterProfileQuayAWS,
 		ClusterProfileAWSEdgeInfra,
-		ClusterProfileODFAWS,
-		ClusterProfileKonfluxWorkspacesAWS:
+		ClusterProfileODFAWS:
 		return string(CloudAWS)
 	case
 		ClusterProfileAlibabaCloud,
@@ -1914,8 +1911,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "rh-openshift-ecosystem-quota-slice"
 	case ClusterProfileODFAWS:
 		return "odf-aws-quota-slice"
-	case ClusterProfileKonfluxWorkspacesAWS:
-		return "konfluxworkspaces-aws-quota-slice"
 	default:
 		return ""
 	}


### PR DESCRIPTION
This cluster profile is no longer needed.  It has no current users, and it will not be used in the future.

This reverts commit 18b957af294ec2cf4a532188131ae6658c581f0c.