### PR TITLE
clear profile aws-perfscale

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1274,7 +1274,6 @@ const (
 	ClusterProfileAWSAutoreleaseQE      ClusterProfile = "aws-autorelease-qe"
 	ClusterProfileAWSSdQE               ClusterProfile = "aws-sd-qe"
 	ClusterProfileAWSPerfScale          ClusterProfile = "aws-perfscale"
-	ClusterProfileAWSPerfQE             ClusterProfile = "aws-perf-qe"
 	ClusterProfileAWSPerfScaleQE        ClusterProfile = "aws-perfscale-qe"
 	ClusterProfileAWSPerfScaleLRCQE     ClusterProfile = "aws-perfscale-lrc-qe"
 	ClusterProfileAWSOutpostQE          ClusterProfile = "aws-outpost-qe"
@@ -1421,7 +1420,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWSCSPIQE,
 		ClusterProfileAWSPerfScale,
-		ClusterProfileAWSPerfQE,
 		ClusterProfileAWSPerfScaleQE,
 		ClusterProfileAWSPerfScaleLRCQE,
 		ClusterProfileAWSChaos,
@@ -1587,7 +1585,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSVirtualization,
 		ClusterProfileFleetManagerQE,
 		ClusterProfileAWSPerfScale,
-		ClusterProfileAWSPerfQE,
 		ClusterProfileAWSPerfScaleQE,
 		ClusterProfileAWSPerfScaleLRCQE,
 		ClusterProfileAWSServerless,
@@ -1818,8 +1815,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-china-qe-quota-slice"
 	case ClusterProfileAWSCSPIQE:
 		return "aws-cspi-qe-quota-slice"
-	case ClusterProfileAWSPerfQE:
-		return "aws-perf-qe-quota-slice"
 	case ClusterProfileAWSChaos:
 		return "aws-chaos-quota-slice"
 	case ClusterProfileAWSPerfScale:


### PR DESCRIPTION
This pr clear the profile aws-perf-qe created by https://github.com/openshift/ci-tools/pull/3541, which is replaced by aws-perfscale-lrc-qe created by https://github.com/openshift/ci-tools/pull/3537.
Related PR in release repo: https://github.com/openshift/release/pull/50779