### PR TITLE
Include ComplianceAsCode periodic jobs into Sippy

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -13,6 +13,7 @@ func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 		"periodic-ci-openshift-release-master-nightly-",
 		"periodic-ci-openshift-release-master-okd-",
 		"periodic-ci-shiftstack-shiftstack-ci-main-periodic-",
+		"periodic-ci-ComplianceAsCode-",
 		"promote-release-openshift-",
 		"release-openshift-",
 	}


### PR DESCRIPTION
The periodic jobs from ComplianceAsCode test different OpenShift versions
against various compliance benchmarks. Let's pull those jobs into Sippy
so we can start viewing the information in dashboards.
