### PR TITLE
Add CAPI CI periodics to sippy

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -8,6 +8,7 @@ func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 		"periodic-ci-openshift-cluster-control-plane-machine-set-operator-",
 		"periodic-ci-openshift-cluster-etcd-operator-",
 		"periodic-ci-openshift-hypershift-main-periodics-",
+		"periodic-ci-openshift-installer-master-altinfra-periodics-",
 		"periodic-ci-openshift-multiarch",
 		"periodic-ci-openshift-release-master-ci-",
 		"periodic-ci-openshift-release-master-nightly-",


### PR DESCRIPTION
openshift/release#50438 added initial capi periodics for aws & vsphere. This updates sippy so that the jobs will be visible.

Note that these periodics are currently ci-only. We're still working on resolving rhel9 issues in order to get the capi-installer buildable by ART.