### PR TITLE
prowgen: introduce the multi-arch branch filtering configuration

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -33,7 +33,24 @@ type Prowgen struct {
 	// Rehearsals declares any disabled rehearsals for jobs
 	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
 	// If true build images targeting multiple architectures
-	MultiArch bool `json:"multi_arch"`
+	MultiArch bool `json:"multi_arch,omitempty"`
+	// MultiArchBranchFilter is a filter of branches that will be built for multiple architectures.
+	// If empty, all branches will be included.
+	MultiArchBranchFilter []string `json:"multi_arch_branch_filter,omitempty"`
+}
+
+func (p *Prowgen) HasMultiArchBranchFilter(branch string) bool {
+	// We assume that if the filter is empty, we should build for all branches.
+	if len(p.MultiArchBranchFilter) == 0 {
+		return true
+	}
+
+	for _, b := range p.MultiArchBranchFilter {
+		if b == branch {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
@@ -49,6 +66,10 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	if defaults.MultiArch {
 		p.MultiArch = true
 	}
+	if defaults.MultiArchBranchFilter != nil {
+		p.MultiArchBranchFilter = defaults.MultiArchBranchFilter
+	}
+
 	p.Rehearsals.DisabledRehearsals = append(p.Rehearsals.DisabledRehearsals, defaults.Rehearsals.DisabledRehearsals...)
 }
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -99,7 +99,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 			presubmitTargets = append(presubmitTargets, "[release:latest]")
 		}
 		jobBaseGen := newJobBaseBuilder().TestName("images")
-		if info.Config.MultiArch {
+		if info.Config.MultiArch && info.Config.HasMultiArchBranchFilter(info.Branch) {
 			jobBaseGen.Cluster(api.ClusterBuild10).WithLabel(api.ClusterLabel, string(api.ClusterBuild10))
 		}
 		jobBaseGen.PodSpec.Add(Targets(presubmitTargets...))
@@ -107,7 +107,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 
 		if configSpec.PromotionConfiguration != nil {
 			jobBaseGen = newJobBaseBuilder().TestName("images")
-			if info.Config.MultiArch {
+			if info.Config.MultiArch && info.Config.HasMultiArchBranchFilter(info.Branch) {
 				jobBaseGen.Cluster(api.ClusterBuild10).WithLabel(api.ClusterLabel, string(api.ClusterBuild10))
 			}
 			jobBaseGen.PodSpec.Add(Promotion(), Targets(imageTargets.UnsortedList()...))

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -566,6 +566,46 @@ func TestGenerateJobs(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: "multiarch branch filtered, cluster change",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{
+						From: "os",
+						To:   "ci-tools",
+					},
+				},
+				PromotionConfiguration: &ciop.PromotionConfiguration{},
+			},
+			repoInfo: &ProwgenInfo{
+				Config: config.Prowgen{MultiArch: true, MultiArchBranchFilter: []string{"branch"}},
+				Metadata: ciop.Metadata{
+					Org:    "organization",
+					Repo:   "repository",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			id: "multiarch branch filtered, no cluster change",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{
+						From: "os",
+						To:   "ci-tools",
+					},
+				},
+				PromotionConfiguration: &ciop.PromotionConfiguration{},
+			},
+			repoInfo: &ProwgenInfo{
+				Config: config.Prowgen{MultiArch: true, MultiArchBranchFilter: []string{"another-branch"}},
+				Metadata: ciop.Metadata{
+					Org:    "organization",
+					Repo:   "repository",
+					Branch: "branch",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_branch_filtered__cluster_change.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_branch_filtered__cluster_change.yaml
@@ -1,0 +1,17 @@
+postsubmits:
+  organization/repository:
+  - always_run: true
+    cluster: build10
+    labels:
+      ci-operator.openshift.io/cluster: build10
+      ci-operator.openshift.io/is-promotion: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+presubmits:
+  organization/repository:
+  - always_run: false
+    cluster: build10
+    labels:
+      ci-operator.openshift.io/cluster: build10
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_branch_filtered__no_cluster_change.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_branch_filtered__no_cluster_change.yaml
@@ -1,0 +1,13 @@
+postsubmits:
+  organization/repository:
+  - always_run: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images


### PR DESCRIPTION
Introduces the `multi_arch_branch_filter` field that if exists, only the specified branches will be included in the multi-arch image builds.

Example config
```yaml
multi_arch: true
multi_arch_branch_filter:
- main
- release-4.15
- release-4.14
```

https://issues.redhat.com/browse/DPTP-3958

/cc @deepsm007 @danilo-gemoli @openshift/test-platform 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
