### PR TITLE
cluster-display: no resolving image registry host on hosted-mgmt

### DIFF
--- a/cmd/cluster-display/main.go
+++ b/cmd/cluster-display/main.go
@@ -136,9 +136,14 @@ func (g *clusterInfoGetter) GetClusterDetails(ctx context.Context, cluster strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve the console host for cluster %s: %w", cluster, err)
 	}
-	registryHost, err := api.ResolveImageRegistryHost(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve the image registry host for cluster %s: %w", cluster, err)
+	registryHost := "unset"
+	if cluster != string(api.ClusterHive) {
+		host, err := api.ResolveImageRegistryHost(ctx, client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve the image registry host for cluster %s: %w", cluster, err)
+		} else {
+			registryHost = host
+		}
 	}
 	cv := &configv1.ClusterVersion{}
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: "version"}, cv); err != nil {


### PR DESCRIPTION
One difference between hive and hosted-mgmt is that OSD vs OCP.
The former has route for image registry out of the box but the former does not.

Tested locally:

```console
$ curl -s http://localhost:8090/api/v1/clusters | jq '.data[]|select(.cluster=="hosted-mgmt")'
{
  "cloud": "AWS",
  "cluster": "hosted-mgmt",
  "consoleHost": "console-openshift-console.apps.hosted-mgmt.ci.devcluster.openshift.com",
  "hypershiftSupportedVersions": "[\"4.16\",\"4.15\",\"4.14\",\"4.13\"]",
  "product": "OCP",
  "registryHost": "unset",
  "version":
```

/cc @openshift/test-platform 