### PR TITLE
TRT-1621: Reduce initial aggregator wait 

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer.go
@@ -104,7 +104,7 @@ func (o *JobRunAggregatorAnalyzerOptions) GetRelatedJobRuns(ctx context.Context)
 
 func (o *JobRunAggregatorAnalyzerOptions) Run(ctx context.Context) error {
 	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
+	readyAt := o.jobRunStartEstimate.Add(10 * time.Minute)
 
 	// the aggregator has a long time.  The jobs it aggregates only have 4h (we think).
 	durationToWait := o.timeout - 20*time.Minute

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -625,7 +625,7 @@ func (o *JobRunTestCaseAnalyzerOptions) Run(ctx context.Context) error {
 	}
 
 	// if it hasn't been more than two hours since the jobRuns started, the list isn't complete.
-	readyAt := o.jobRunStartEstimate.Add(2 * time.Hour)
+	readyAt := o.jobRunStartEstimate.Add(10 * time.Minute)
 
 	durationToWait := o.timeout - 20*time.Minute
 	timeToStopWaiting := o.jobRunStartEstimate.Add(durationToWait)


### PR DESCRIPTION
Aggregator retry mechanism depends on release-controller to set the job start time each time it is retried. release-controller sets the start time to the current time when the job is started. When aggregator is retried the third time, most of the sub jobs already finished. But aggregator still wait for two hours before it event tries to check on sub jobs.

I am reducing the initial wait from 2h to 10m. This means the maximum time we wait is 10m. Since we are using incluster prowjob watch mechanism now, this should not increase any resource usage. One can even argue that we can remove initial wait. I am leaving the implementation as it is since we still keep the fallback gcs based wait mechanism. 