### PR TITLE
releaseSnapshotStep: no dependencies on isTags of the local cluster

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -30,6 +30,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/html"
 	"github.com/openshift/ci-tools/pkg/load/agents"
@@ -187,12 +188,7 @@ func validateStream(ns string, name string) error {
 	return fmt.Errorf("not a valid integrated stream: %s", is)
 }
 
-type IntegratedStream struct {
-	Tags                        []string `json:"tags,omitempty"`
-	ReleaseControllerConfigName string   `json:"releaseControllerConfigName"`
-}
-
-func integratedStream(ctx context.Context, client ctrlruntimeclient.Client, ns, name string) (*IntegratedStream, error) {
+func integratedStream(ctx context.Context, client ctrlruntimeclient.Client, ns, name string) (*configresolver.IntegratedStream, error) {
 	is := &imagev1.ImageStream{}
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, is); err != nil {
 		return nil, fmt.Errorf("failed to get image stream %s/%s: %w", ns, name, err)
@@ -211,7 +207,7 @@ func integratedStream(ctx context.Context, client ctrlruntimeclient.Client, ns, 
 		}
 		releaseControllerConfigName = releaseConfig.Name
 	}
-	return &IntegratedStream{Tags: tags, ReleaseControllerConfigName: releaseControllerConfigName}, nil
+	return &configresolver.IntegratedStream{Tags: tags, ReleaseControllerConfigName: releaseControllerConfigName}, nil
 }
 
 // l and v keep the tree legible

--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -29,7 +29,6 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/html"
@@ -153,7 +152,7 @@ func getIntegratedStream(ctx context.Context, client ctrlruntimeclient.Client) h
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		stream, err := integratedStream(ctx, client, ns, name)
+		stream, err := configresolver.LocalIntegratedStream(ctx, client, ns, name)
 		if err != nil {
 			logrus.WithError(err).WithField("namespace", ns).WithField("name", name).Error("failed to get information of integrated stream")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -186,28 +185,6 @@ func validateStream(ns string, name string) error {
 		}
 	}
 	return fmt.Errorf("not a valid integrated stream: %s", is)
-}
-
-func integratedStream(ctx context.Context, client ctrlruntimeclient.Client, ns, name string) (*configresolver.IntegratedStream, error) {
-	is := &imagev1.ImageStream{}
-	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, is); err != nil {
-		return nil, fmt.Errorf("failed to get image stream %s/%s: %w", ns, name, err)
-	}
-	var tags []string
-	for _, tag := range is.Status.Tags {
-		tags = append(tags, tag.Tag)
-	}
-	var releaseControllerConfigName string
-	if raw, ok := is.ObjectMeta.Annotations[api.ReleaseConfigAnnotation]; ok {
-		var releaseConfig struct {
-			Name string `json:"name"`
-		}
-		if err := json.Unmarshal([]byte(raw), &releaseConfig); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal release controller's config on image stream %s/%s: %w", ns, name, err)
-		}
-		releaseControllerConfigName = releaseConfig.Name
-	}
-	return &configresolver.IntegratedStream{Tags: tags, ReleaseControllerConfigName: releaseControllerConfigName}, nil
 }
 
 // l and v keep the tree legible

--- a/cmd/ci-operator-configresolver/main_test.go
+++ b/cmd/ci-operator-configresolver/main_test.go
@@ -17,6 +17,7 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 
+	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -127,7 +128,7 @@ func TestIntegratedStream(t *testing.T) {
 		client      ctrlruntimeclient.Client
 		isNS        string
 		isName      string
-		expected    *IntegratedStream
+		expected    *configresolver.IntegratedStream
 		expectedErr error
 	}{
 		{
@@ -135,7 +136,7 @@ func TestIntegratedStream(t *testing.T) {
 			isNS:     "ocp",
 			isName:   "4.15",
 			client:   fakeclient.NewClientBuilder().WithRuntimeObjects(ocp415Stream.DeepCopy()).Build(),
-			expected: &IntegratedStream{Tags: []string{"bar", "foo"}, ReleaseControllerConfigName: "4.15.0-0.ci"},
+			expected: &configresolver.IntegratedStream{Tags: []string{"bar", "foo"}, ReleaseControllerConfigName: "4.15.0-0.ci"},
 		},
 		{
 			name:        "not found",
@@ -149,7 +150,7 @@ func TestIntegratedStream(t *testing.T) {
 			isNS:     "ocp",
 			isName:   "5.1",
 			client:   fakeclient.NewClientBuilder().WithRuntimeObjects(ocp51Stream.DeepCopy()).Build(),
-			expected: &IntegratedStream{Tags: []string{"bar", "foo"}, ReleaseControllerConfigName: ""},
+			expected: &configresolver.IntegratedStream{Tags: []string{"bar", "foo"}, ReleaseControllerConfigName: ""},
 		},
 	}
 

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -70,6 +70,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	"github.com/openshift/ci-tools/pkg/api/nsttl"
 	"github.com/openshift/ci-tools/pkg/defaults"
 	"github.com/openshift/ci-tools/pkg/interrupt"
@@ -871,6 +872,11 @@ func (o *options) Run() []error {
 
 	o.resolveConsoleHost()
 
+	streams, err := integratedStreams(o.configSpec, o.resolverClient)
+	if err != nil {
+		return []error{results.ForReason("config_resolver").WithError(err).Errorf("failed to generate integrated streams: %v", err)}
+	}
+
 	client, err := coreclientset.NewForConfig(o.clusterConfig)
 	if err != nil {
 		return []error{fmt.Errorf("could not get core client for cluster config: %w", err)}
@@ -885,7 +891,7 @@ func (o *options) Run() []error {
 	// load the graph from the configuration
 	buildSteps, postSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig,
 		o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig,
-		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, mergedConfig)
+		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, mergedConfig, streams)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}
@@ -984,6 +990,33 @@ func (o *options) Run() []error {
 		eventRecorder.Event(runtimeObject, coreapi.EventTypeNormal, "CiJobSucceeded", eventJobDescription(o.jobSpec, o.namespace))
 		return nil
 	})
+}
+
+func integratedStreams(config *api.ReleaseBuildConfiguration, client server.ResolverClient) (map[string]*configresolver.IntegratedStream, error) {
+	if config == nil {
+		return nil, errors.New("unable to get integrated stream for nil config")
+	}
+	if client == nil {
+		return nil, errors.New("unable to get integrated stream with nil client")
+	}
+	ret := map[string]*configresolver.IntegratedStream{}
+	var objectKeys []ctrlruntimeclient.ObjectKey
+	if config.ReleaseTagConfiguration != nil {
+		objectKeys = append(objectKeys, ctrlruntimeclient.ObjectKey{Namespace: config.ReleaseTagConfiguration.Namespace, Name: config.ReleaseTagConfiguration.Name})
+	}
+	for _, release := range config.Releases {
+		if release.Integration != nil {
+			objectKeys = append(objectKeys, ctrlruntimeclient.ObjectKey{Namespace: release.Integration.Namespace, Name: release.Integration.Name})
+		}
+	}
+	for _, key := range objectKeys {
+		integratedStream, err := client.IntegratedStream(key.Namespace, key.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get integrated stream %s/%s: %w", key.Namespace, key.Name, err)
+		}
+		ret[fmt.Sprintf("%s/%s", key.Namespace, key.Name)] = integratedStream
+	}
+	return ret, nil
 }
 
 // runStep mostly duplicates steps.runStep. The latter uses an *api.StepNode though and we only have an api.Step for the PostSteps

--- a/pkg/api/configresolver/configresolver.go
+++ b/pkg/api/configresolver/configresolver.go
@@ -1,0 +1,34 @@
+package configresolver
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type IntegratedStream struct {
+	Tags                        []string `json:"tags,omitempty"`
+	ReleaseControllerConfigName string   `json:"releaseControllerConfigName"`
+}
+
+type releaseConfig struct {
+	Name string `json:"name"`
+}
+
+// ReleaseControllerConfigNameToAnnotationValue converts a config name to the annotation value
+func ReleaseControllerConfigNameToAnnotationValue(configName string) (string, error) {
+	rc := releaseConfig{Name: configName}
+	bytes, err := json.Marshal(rc)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal release configuration: %w", err)
+	}
+	return string(bytes), nil
+}
+
+// ReleaseControllerAnnotationValueToConfigName converts a annotation value to the config name
+func ReleaseControllerAnnotationValueToConfigName(annotationValue string) (string, error) {
+	var rc releaseConfig
+	if err := json.Unmarshal([]byte(annotationValue), &rc); err != nil {
+		return "", fmt.Errorf("failed to unmarshal release configuration: %w", err)
+	}
+	return rc.Name, nil
+}

--- a/pkg/api/configresolver/configresolver.go
+++ b/pkg/api/configresolver/configresolver.go
@@ -1,8 +1,15 @@
 package configresolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	imagev1 "github.com/openshift/api/image/v1"
+
+	"github.com/openshift/ci-tools/pkg/api"
 )
 
 type IntegratedStream struct {
@@ -31,4 +38,25 @@ func ReleaseControllerAnnotationValueToConfigName(annotationValue string) (strin
 		return "", fmt.Errorf("failed to unmarshal release configuration: %w", err)
 	}
 	return rc.Name, nil
+}
+
+// LocalIntegratedStream return the information of the given integrated stream
+func LocalIntegratedStream(ctx context.Context, client ctrlruntimeclient.Client, ns, name string) (*IntegratedStream, error) {
+	is := &imagev1.ImageStream{}
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, is); err != nil {
+		return nil, fmt.Errorf("failed to get image stream %s/%s: %w", ns, name, err)
+	}
+	var tags []string
+	for _, tag := range is.Status.Tags {
+		tags = append(tags, tag.Tag)
+	}
+	var releaseControllerConfigName string
+	if raw, ok := is.ObjectMeta.Annotations[api.ReleaseConfigAnnotation]; ok {
+		configName, err := ReleaseControllerAnnotationValueToConfigName(raw)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve release configuration on imagestream %s/%s: %w", ns, name, err)
+		}
+		releaseControllerConfigName = configName
+	}
+	return &IntegratedStream{Tags: tags, ReleaseControllerConfigName: releaseControllerConfigName}, nil
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -33,6 +33,7 @@ import (
 	templateclientset "github.com/openshift/client-go/template/clientset/versioned/typed/template/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
 	"github.com/openshift/ci-tools/pkg/lease"
@@ -79,6 +80,7 @@ func FromConfig(
 	manifestToolDockerCfg string,
 	localRegistryDNS string,
 	mergedConfig bool,
+	integratedStreams map[string]*configresolver.IntegratedStream,
 ) ([]api.Step, []api.Step, error) {
 	crclient, err := ctrlruntimeclient.NewWithWatch(clusterConfig, ctrlruntimeclient.Options{})
 	crclient = secretrecordingclient.Wrap(crclient, censor)
@@ -115,7 +117,7 @@ func FromConfig(
 	httpClient := retryablehttp.NewClient()
 	httpClient.Logger = nil
 
-	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient.StandardClient(), requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost, nodeName, targetAdditionalSuffix, nodeArchitectures, mergedConfig)
+	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient.StandardClient(), requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost, nodeName, targetAdditionalSuffix, nodeArchitectures, mergedConfig, integratedStreams)
 }
 
 func fromConfig(
@@ -143,6 +145,7 @@ func fromConfig(
 	targetAdditionalSuffix string,
 	nodeArchitectures []string,
 	mergedConfig bool,
+	integratedStreams map[string]*configresolver.IntegratedStream,
 ) ([]api.Step, []api.Step, error) {
 	requiredNames := sets.New[string]()
 	for _, target := range requiredTargets {
@@ -213,7 +216,7 @@ func fromConfig(
 				case resolveConfig.Integration != nil:
 					logrus.Infof("Building release %s from a snapshot of %s/%s", resolveConfig.Name, resolveConfig.Integration.Namespace, resolveConfig.Integration.Name)
 					// this is the one case where we're not importing a payload, we need to get the images and build one
-					snapshot := releasesteps.ReleaseSnapshotStep(resolveConfig.Name, *resolveConfig.Integration, podClient, jobSpec)
+					snapshot := releasesteps.ReleaseSnapshotStep(resolveConfig.Name, *resolveConfig.Integration, podClient, jobSpec, integratedStreams[fmt.Sprintf("%s/%s", resolveConfig.Integration.Namespace, resolveConfig.Integration.Name)])
 					assemble := releasesteps.AssembleReleaseStep(resolveConfig.Name, nodeName, &api.ReleaseTagConfiguration{
 						Namespace:          resolveConfig.Integration.Namespace,
 						Name:               resolveConfig.Integration.Name,
@@ -269,7 +272,7 @@ func fromConfig(
 		} else if rawStep.ReleaseImagesTagStepConfiguration != nil {
 			// if the user has specified a tag_specification we always
 			// will import those images to the stable stream
-			step = releasesteps.ReleaseImagesTagStep(*rawStep.ReleaseImagesTagStepConfiguration, client, params, jobSpec)
+			step = releasesteps.ReleaseImagesTagStep(*rawStep.ReleaseImagesTagStepConfiguration, client, params, jobSpec, integratedStreams[fmt.Sprintf("%s/%s", rawStep.ReleaseImagesTagStepConfiguration.Namespace, rawStep.ReleaseImagesTagStepConfiguration.Name)])
 			stepLinks = append(stepLinks, step.Creates()...)
 
 			hasReleaseStep = true

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -25,6 +25,7 @@ import (
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
 	"github.com/openshift/ci-tools/pkg/lease"
@@ -1722,7 +1723,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, tc.mergedConfig)
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, tc.mergedConfig, map[string]*configresolver.IntegratedStream{})
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CHY2E1BL4/p1714644855129709?thread_ts=1714643460.138379&cid=CHY2E1BL4

For the cluster-bot jobs, we get the tags from the stream in the local cluster, as we did before.

/cc @openshift/test-platform 

/hold

Will verify with the built image