### PR TITLE
configresolver: allow the integrated steams for private jobs

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -169,6 +169,7 @@ var validStreams = []*regexp.Regexp{
 	regexp.MustCompile(`^ocp/4.([6-9]|\d\d+)`),
 	regexp.MustCompile(`^origin/4.([6-9]|\d\d+)`),
 	regexp.MustCompile(`^origin/scos-4.([6-9]|\d\d+)`),
+	regexp.MustCompile(`^ocp-private/4.([6-9]|\d\d+)-priv`),
 }
 
 func validateStream(ns string, name string) error {

--- a/cmd/ci-operator-configresolver/main_test.go
+++ b/cmd/ci-operator-configresolver/main_test.go
@@ -69,6 +69,11 @@ func TestValidateStream(t *testing.T) {
 			isName: "scos-4.15",
 		},
 		{
+			name:   "ocp-private/4.16-priv is valid",
+			isNS:   "ocp-private",
+			isName: "4.16-priv",
+		},
+		{
 			name:     "origin/bar-4.15 is invalid",
 			isNS:     "origin",
 			isName:   "bar-4.15",


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CHY2E1BL4/p1714643460138379

Allow the integrated steams for private jobs, such as `ocp-private/4.16-priv`.

/cc @openshift/test-platform 