### PR TITLE
registry-replacer: consider image aliases when pruning ci-operator replacements

### DIFF
--- a/cmd/registry-replacer/main.go
+++ b/cmd/registry-replacer/main.go
@@ -551,9 +551,12 @@ func extractReplacementCandidatesFromDockerfile(dockerfile []byte) (sets.Set[str
 		for _, child := range stage.Node.Children {
 			switch {
 			case child.Value == "from" && child.Next != nil:
-				image := child.Next.Value
-				replacementCandidates.Insert(image)
-				names[stage.Name] = image
+				image := child.Next
+				replacementCandidates.Insert(image.Value)
+				names[stage.Name] = image.Value
+				if alias := image.Next; alias != nil && alias.Value == "AS" && alias.Next != nil {
+					replacementCandidates.Insert(alias.Next.Value)
+				}
 			case child.Value == "copy":
 				if ref, ok := nodeHasFromRef(child); ok {
 					if len(ref) > 0 {

--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -596,7 +596,17 @@ RUN yum update -y && \
     yum clean all && rm -rf /var/cache/yum/*
 COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /usr/bin/
 ENTRYPOINT ["/usr/bin/aws-ebs-csi-driver"]`,
-			expectedResult: sets.New[string]("registry.svc.ci.openshift.org/openshift/release:golang-1.13", "registry.svc.ci.openshift.org/openshift/origin-v4.0:base"),
+			expectedResult: sets.New[string]("registry.svc.ci.openshift.org/openshift/release:golang-1.13", "builder", "registry.svc.ci.openshift.org/openshift/origin-v4.0:base"),
+		},
+		{
+			name:           "Missing image alias name",
+			in:             "FROM centos:8 AS",
+			expectedResult: sets.New("centos:8"),
+		},
+		{
+			name:           "Lowercase image alias",
+			in:             "FROM centos:8 as useless",
+			expectedResult: sets.New("centos:8"),
 		},
 		{
 			name: "Unrelated directives",


### PR DESCRIPTION
Slack [thread](https://redhat-internal.slack.com/archives/GB7NB0CUC/p1714674628936099) that backs this decision up .