### PR TITLE
ci-operator-configresolver: fix simplifypath

### DIFF
--- a/cmd/ci-operator-configresolver/main.go
+++ b/cmd/ci-operator-configresolver/main.go
@@ -317,6 +317,7 @@ func main() {
 		l("clusterProfile"),
 		l("configGeneration"),
 		l("registryGeneration"),
+		l("integratedStream"),
 	))
 
 	uisimplifier := simplifypath.NewSimplifier(l("", // shadow element mimicing the root


### PR DESCRIPTION
Found log in the compoment:

```json
{
    "component": "ci-operator-configresolver",
    "file": "/go/src/github.com/openshift/ci-tools/vendor/k8s.io/test-infra/prow/simplifypath/simplify.go:48",
    "func": "k8s.io/test-infra/prow/simplifypath.(*simplifier).Simplify",
    "level": "debug",
    "msg": "Path not handled. This is a bug, please open an issue against the kubernetes/test-infra repository with this error message.",
    "path": "/integratedStream",
    "severity": "debug",
    "time": "2024-05-06T12:44:40Z"
}

```

/cc @openshift/test-platform 