### PR TITLE
Update how ci-operator gets cluster profile secrets

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -2324,26 +2324,15 @@ func getClusterProfileSecret(clusterProfile string, client ctrlruntimeclient.Cli
 	// Use config-resolver to get details about the cluster profile (which includes the secret's name)
 	cpDetails, err := resolverClient.ClusterProfile(clusterProfile)
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to retrieve details from config resolver for '%s' cluster profile", clusterProfile)
 		return nil, fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile", clusterProfile)
 	}
-
 	// Get the secret from the ci namespace. We expect it exists
-	cpSecret, err := getSecretFromCiNamespace(cpDetails.Secret, client, ctx)
-	if err != nil {
-		return nil, err
-	}
-	return cpSecret, nil
-}
-
-// getSecretFromCiNamespace retrieves a secret from the ci namespace
-func getSecretFromCiNamespace(secretName string, client ctrlruntimeclient.Client, ctx context.Context) (*coreapi.Secret, error) {
 	ciSecret := &coreapi.Secret{}
-	err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: secretName}, ciSecret)
+	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: cpDetails.Secret}, ciSecret)
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to get secret '%s' from ci namespace", secretName)
-		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace", secretName)
+		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace", cpDetails.Secret)
 	}
+
 	return ciSecret, nil
 }
 

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -633,6 +633,11 @@ func (o *options) Complete() error {
 	}
 
 	for _, path := range o.secretDirectories.values {
+		// TODO: Delete this after regenerating all jobs with the new cluster profile system.
+		if strings.HasSuffix(path, "-cluster-profile") {
+			continue
+		}
+
 		secret, err := util.SecretFromDir(path)
 		name := filepath.Base(path)
 		if err != nil {

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -2341,7 +2341,12 @@ func (o *options) getClusterProfileNamesFromTargets() {
 	for _, targetName := range o.targets.values {
 		for _, test := range o.configSpec.Tests {
 			if targetName == test.As && test.MultiStageTestConfigurationLiteral != nil {
-				o.clusterProfileNames = append(o.clusterProfileNames, test.MultiStageTestConfigurationLiteral.ClusterProfile.Name())
+				//TODO delete - adding logs for debugging
+				logrus.Infof("target: %v, test.As: %v", targetName, test.As)
+				logrus.Infof("test.MultiStageTestConfigurationLiteral.ClusterProfile: %v", test.MultiStageTestConfigurationLiteral.ClusterProfile)
+				if test.MultiStageTestConfigurationLiteral.ClusterProfile.Name() != "" {
+					o.clusterProfileNames = append(o.clusterProfileNames, test.MultiStageTestConfigurationLiteral.ClusterProfile.Name())
+				}
 				break
 			}
 		}

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -2349,14 +2349,12 @@ func getClusterProfileSecret(clusterProfile string, client ctrlruntimeclient.Cli
 func (o *options) getClusterProfileNamesFromTargets() {
 	for _, targetName := range o.targets.values {
 		for _, test := range o.configSpec.Tests {
-			if targetName == test.As && test.MultiStageTestConfigurationLiteral != nil {
-				//TODO delete - adding logs for debugging
-				logrus.Infof("target: %v, test.As: %v", targetName, test.As)
-				logrus.Infof("test.MultiStageTestConfigurationLiteral.ClusterProfile: %v", test.MultiStageTestConfigurationLiteral.ClusterProfile)
-				if test.MultiStageTestConfigurationLiteral.ClusterProfile.Name() != "" {
-					o.clusterProfileNames = append(o.clusterProfileNames, test.MultiStageTestConfigurationLiteral.ClusterProfile.Name())
-				}
-				break
+			if targetName != test.As {
+				continue
+			}
+			profile := test.GetClusterProfileName()
+			if profile != "" {
+				o.clusterProfileNames = append(o.clusterProfileNames, profile)
 			}
 		}
 	}

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1454,7 +1454,7 @@ func (o *options) initializeNamespace() error {
 	// adds the appropriate cluster profile secrets to o.secrets,
 	// so they can be created by ctrlruntime client in the for cycle below this one
 	for _, cp := range o.clusterProfiles {
-		cpSecret, err := getClusterProfileSecret(cp, ctrlClient, o.resolverClient, ctx)
+		cpSecret, err := getClusterProfileSecret(cp, labeledclient.Wrap(ctrlClient, o.jobSpec), o.resolverClient, ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create cluster profile secret %s: %w", cp, err)
 		}
@@ -2337,7 +2337,7 @@ func getClusterProfileSecret(cp clusterProfileForTarget, client ctrlruntimeclien
 	newSecret := &coreapi.Secret{
 		Data: ciSecret.Data,
 		Type: ciSecret.Type,
-		ObjectMeta: meta.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-cluster-profile", cp.target),
 		},
 	}

--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -2330,7 +2330,7 @@ func getClusterProfileSecret(clusterProfile string, client ctrlruntimeclient.Cli
 	ciSecret := &coreapi.Secret{}
 	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: cpDetails.Secret}, ciSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace", cpDetails.Secret)
+		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace: %w", cpDetails.Secret, err)
 	}
 
 	return ciSecret, nil

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	corev1 "k8s.io/api/core/v1"
 	rbacapi "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -1611,6 +1612,162 @@ func TestHandleTargetAdditionalSuffix(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expectedJobSpec.Target, o.jobSpec.Target); diff != "" {
 				t.Fatalf("expectedJobSpec Target differs from actual, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestGetSecretFromCiNamespace(t *testing.T) {
+	namespace, secretName := "ci", "ci-secret-name"
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      secretName,
+			}},
+	).Build()
+
+	testCases := []struct {
+		name          string
+		secretName    string
+		expected      *corev1.Secret
+		expectedErr   error
+		clusterClient ctrlruntimeclient.Client
+	}{
+		{
+			name:          "getting secret works as expected",
+			secretName:    secretName,
+			clusterClient: fakeClient,
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      secretName,
+				}},
+		},
+		{
+			name:          "getting secret that doesn't exist in ci ns fails with error",
+			secretName:    "nonexistent-secret",
+			clusterClient: fakeClient,
+			expectedErr:   fmt.Errorf("failed to get secret '%s' from ci namespace", "nonexistent-secret"),
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := getSecretFromCiNamespace(tc.secretName, tc.clusterClient, ctx)
+			if tc.expected != nil && tc.expectedErr == nil {
+				if diff := cmp.Diff(actual, tc.expected, testhelper.RuntimeObjectIgnoreRvTypeMeta); diff != "" {
+					t.Errorf("secret differs from expected:\n%v", diff)
+				}
+			}
+			if tc.expectedErr != nil {
+				if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
+					t.Errorf("error differs from expected:\n%v", diff)
+				}
+			}
+		})
+	}
+}
+
+type mockResolverClient struct {
+	ClusterProfileFunc func(profileName string) (*api.ClusterProfileDetails, error)
+}
+
+func (m *mockResolverClient) ClusterProfile(profileName string) (*api.ClusterProfileDetails, error) {
+	if m.ClusterProfileFunc != nil {
+		return m.ClusterProfileFunc(profileName)
+	}
+	return nil, nil
+}
+
+func (m *mockResolverClient) Config(metadata *api.Metadata) (*api.ReleaseBuildConfiguration, error) {
+	return nil, nil
+}
+
+func (m *mockResolverClient) ConfigWithTest(base *api.Metadata, testSource *api.MetadataWithTest) (*api.ReleaseBuildConfiguration, error) {
+	return nil, nil
+}
+
+func (m *mockResolverClient) Resolve(data []byte) (*api.ReleaseBuildConfiguration, error) {
+	return nil, nil
+}
+
+func TestgetClusterProfileSecret(t *testing.T) {
+	namespace, secretName := "ci", "profile-name-cluster-secret"
+	okClient := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      secretName,
+			}},
+	).Build()
+
+	testCases := []struct {
+		name           string
+		clusterProfile string
+		client         ctrlruntimeclient.Client
+		resolverFunc   func(profileName string) (*api.ClusterProfileDetails, error)
+		expected       *corev1.Secret
+		expectedErr    error
+	}{
+		{
+			name:           "ok path",
+			clusterProfile: "profile-name",
+			client:         okClient,
+			resolverFunc: func(profileName string) (*api.ClusterProfileDetails, error) {
+				return &api.ClusterProfileDetails{
+					Profile: "profile-name",
+					Secret:  "profile-name-cluster-secret",
+				}, nil
+			},
+			expected: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      secretName,
+				}},
+		},
+		{
+			name:           "resolver error path",
+			clusterProfile: "wrong-profile-name",
+			client:         okClient,
+			resolverFunc: func(profileName string) (*api.ClusterProfileDetails, error) {
+				return nil, fmt.Errorf("some config resolver error occurred")
+			},
+			expectedErr: fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster profile", "wrong-profile-name"),
+		},
+		{
+			name:           "error while getting secret from ci namespace path",
+			clusterProfile: "nonexistent-profile-name",
+			client:         fakectrlruntimeclient.NewClientBuilder().Build(),
+			resolverFunc: func(profileName string) (*api.ClusterProfileDetails, error) {
+				return &api.ClusterProfileDetails{
+					Profile: "profile-name",
+					Secret:  "profile-name-cluster-secret",
+				}, nil
+			},
+			expectedErr: fmt.Errorf("failed to get secret '%s' from ci namespace", secretName),
+		},
+	}
+
+	ctx := context.Background()
+	mockResolverClient := &mockResolverClient{}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockResolverClient.ClusterProfileFunc = tc.resolverFunc
+			actual, err := getClusterProfileSecret(tc.clusterProfile, tc.client, mockResolverClient, ctx)
+
+			if tc.expected != nil && tc.expectedErr == nil {
+				if diff := cmp.Diff(actual, tc.expected, testhelper.RuntimeObjectIgnoreRvTypeMeta); diff != "" {
+					t.Errorf("secret differs from expected:\n%v", diff)
+				}
+			}
+			if tc.expectedErr != nil {
+				if diff := cmp.Diff(tc.expectedErr, err, testhelper.EquateErrorMessage); diff != "" {
+					t.Errorf("error differs from expected:\n%v", diff)
+				}
 			}
 		})
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1685,7 +1685,7 @@ func TestGetClusterProfileNamesFromTargets(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.options.getClusterProfileNamesFromTargets()
-			reflect.DeepEqual(tc.expectedProfileNames, tc.options.clusterProfileNames)
+			reflect.DeepEqual(tc.expectedProfileNames, tc.options.clusterProfiles)
 		})
 	}
 }

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1698,7 +1698,7 @@ func TestGetClusterProfileSecret(t *testing.T) {
 					Secret:  "profile-name-cluster-secret",
 				}, nil
 			},
-			expectedErr: fmt.Errorf("failed to get secret '%s' from ci namespace", secretName),
+			expectedErr: fmt.Errorf("failed to get secret '%s' from ci namespace: secrets \"%s\" not found", secretName, secretName),
 		},
 	}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -805,6 +805,14 @@ func (config TestStepConfiguration) IsPeriodic() bool {
 	return config.Interval != nil || config.MinimumInterval != nil || config.Cron != nil || config.ReleaseController
 }
 
+// GetClusterProfileName returns the cluster profile name if it's set
+func (config TestStepConfiguration) GetClusterProfileName() string {
+	if config.MultiStageTestConfigurationLiteral != nil {
+		return config.MultiStageTestConfigurationLiteral.ClusterProfile.Name()
+	}
+	return ""
+}
+
 // Cloud is the name of a cloud provider, e.g., aws cluster topology, etc.
 type Cloud string
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -807,10 +807,16 @@ func (config TestStepConfiguration) IsPeriodic() bool {
 
 // GetClusterProfileName returns the cluster profile name if it's set
 func (config TestStepConfiguration) GetClusterProfileName() string {
-	if config.MultiStageTestConfigurationLiteral != nil {
+	switch {
+	case config.MultiStageTestConfigurationLiteral != nil:
 		return config.MultiStageTestConfigurationLiteral.ClusterProfile.Name()
+	case config.MultiStageTestConfiguration != nil:
+		return config.MultiStageTestConfiguration.ClusterProfile.Name()
+	case config.OpenshiftInstallerClusterTestConfiguration != nil:
+		return config.OpenshiftInstallerClusterTestConfiguration.ClusterProfile.Name()
+	default:
+		return ""
 	}
-	return ""
 }
 
 // Cloud is the name of a cloud provider, e.g., aws cluster topology, etc.


### PR DESCRIPTION
Use config-resolver to get the name of cluster profile secret we need, instead of mounting it to the job and then reading it locally along with the other user-defined secrets.

Next steps:
- create a presubmit job to check the cluster profile secret (defined in the test config) exists in the ci namespace
- edit prowgen so it doesn't add the cluster profile volume to the job yaml, as it won't be needed anymore & regenerate all jobs

/cc @droslean 