### PR TITLE
`ci-operator`: limit ip pool leases on the aws profile to "master"/"main" or greater than "4.16"

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -1,5 +1,10 @@
 package api
 
+import (
+	"strconv"
+	"strings"
+)
+
 // LeasesForTest aggregates all the lease configurations in a test.
 // It is assumed that they have been validated and contain only valid and
 // unique values.
@@ -18,13 +23,42 @@ func LeasesForTest(s *MultiStageTestConfigurationLiteral) (ret []StepLease) {
 	return
 }
 
-func IPPoolLeaseForTest(s *MultiStageTestConfigurationLiteral) (ret StepLease) {
+func IPPoolLeaseForTest(s *MultiStageTestConfigurationLiteral, metadata Metadata) (ret StepLease) {
 	if p := s.ClusterProfile; p == "aws" { //TODO(sgoeddel): Hardcoded to only work on aws, eventually this will be available as a configuration
-		ret = StepLease{
-			ResourceType: p.IPPoolLeaseType(),
-			Env:          DefaultIPPoolLeaseEnv,
-			Count:        13,
+		if branchValidForIPPoolLease(metadata.Branch) {
+			ret = StepLease{
+				ResourceType: p.IPPoolLeaseType(),
+				Env:          DefaultIPPoolLeaseEnv,
+				Count:        13,
+			}
 		}
 	}
 	return
+}
+
+const (
+	openshiftBranch = "openshift-4."
+	releaseBranch   = "release-4."
+	minimumVersion  = 16
+)
+
+// Currently, we only have the ability to utilize IP pools in 4.16 and later, we want to make sure not to allocate them
+// on earlier versions
+func branchValidForIPPoolLease(branch string) bool {
+	if branch == "master" || branch == "main" {
+		return true
+	}
+	var version string
+	if strings.HasPrefix(branch, openshiftBranch) {
+		version = strings.TrimPrefix(branch, openshiftBranch)
+	}
+	if strings.HasPrefix(branch, releaseBranch) {
+		version = strings.TrimPrefix(branch, releaseBranch)
+	}
+	number, err := strconv.Atoi(version)
+	if err != nil {
+		return false
+	}
+
+	return number >= minimumVersion
 }

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -52,11 +52,13 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 	testCases := []struct {
 		name     string
 		tests    MultiStageTestConfigurationLiteral
+		metadata Metadata
 		expected StepLease
 	}{
 		{
-			name:  "aws",
-			tests: MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			name:     "aws",
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			metadata: Metadata{Branch: "master"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",
 				Env:          DefaultIPPoolLeaseEnv,
@@ -67,10 +69,25 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 			name:  "other cluster profile",
 			tests: MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS2},
 		},
+		{
+			name:     "aws, with 4.16 branch",
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			metadata: Metadata{Branch: "release-4.16"},
+			expected: StepLease{
+				ResourceType: "aws-ip-pools",
+				Env:          DefaultIPPoolLeaseEnv,
+				Count:        13,
+			},
+		},
+		{
+			name:     "aws, but older release branch",
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			metadata: Metadata{Branch: "release-4.10"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := IPPoolLeaseForTest(&tc.tests)
+			ret := IPPoolLeaseForTest(&tc.tests, tc.metadata)
 			if diff := cmp.Diff(tc.expected, ret); diff != "" {
 				t.Errorf("incorrect lease returned, diff: %s", diff)
 			}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -440,7 +440,7 @@ func stepForTest(
 ) ([]api.Step, error) {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		leases := api.LeasesForTest(test)
-		ipPoolLease := api.IPPoolLeaseForTest(test)
+		ipPoolLease := api.IPPoolLeaseForTest(test, config.Metadata)
 		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
 			params = api.NewDeferredParameters(params)
 		}


### PR DESCRIPTION
We can't take advantage of these on versions older than 4.16. We shouldn't lease them out if they won't be used.