### PR TITLE
pj-rehearse: remove flags for image mirroring

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -53,8 +53,6 @@ type options struct {
 	stickyLabelAuthors prowflagutil.Strings
 
 	webhookSecretFile        string
-	registryConfig           string
-	ciImagesMirrorConfigPath string
 	githubEventServerOptions githubeventserver.Options
 	github                   prowflagutil.GitHubOptions
 	config                   configflagutil.ConfigOptions
@@ -82,8 +80,6 @@ func gatherOptions() (options, error) {
 
 	fs.Var(&o.stickyLabelAuthors, "sticky-label-author", "PR Author for which the 'rehearsals-ack' label will not be removed upon a new push. Can be passed multiple times.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
-	fs.StringVar(&o.registryConfig, "registry-config", "", "Path to the file of registry credentials")
-	fs.StringVar(&o.ciImagesMirrorConfigPath, "ci-images-mirror-config-path", "", "Path to ci-image-mirror config path file")
 
 	fs.StringVar(&o.gcsBucket, "gcs-bucket", "test-platform-results", "GCS Bucket to upload affected jobs list")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "/etc/gcs/service-account.json", "GCS Credentials file to upload affected jobs list")


### PR DESCRIPTION
Follow up https://github.com/openshift/ci-tools/pull/4108

/hold

Require https://github.com/openshift/release/pull/51888

and

Let it soak in production for a whole.