### PR TITLE
ci-operator: validate `nvidia.com/gpu` resource

### DIFF
--- a/cmd/gpu-scheduling-webhook/main.go
+++ b/cmd/gpu-scheduling-webhook/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/go-logr/logr"
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -21,11 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
-const nvidiaGPU = "nvidia.com/gpu"
-
 var (
 	nvidiaGPUToleration = corev1.Toleration{
-		Key:      nvidiaGPU,
+		Key:      api.NvidiaGPUResource,
 		Operator: corev1.TolerationOpEqual,
 		Value:    "true",
 		Effect:   corev1.TaintEffectNoSchedule,
@@ -121,8 +120,8 @@ func addToleration(logger logr.Logger, pod *corev1.Pod) {
 }
 
 func needNvidiaGPU(requirement corev1.ResourceRequirements) bool {
-	_, requestExists := requirement.Requests[nvidiaGPU]
-	_, limitExists := requirement.Limits[nvidiaGPU]
+	_, requestExists := requirement.Requests[api.NvidiaGPUResource]
+	_, limitExists := requirement.Limits[api.NvidiaGPUResource]
 	return requestExists || limitExists
 }
 

--- a/cmd/gpu-scheduling-webhook/main.go
+++ b/cmd/gpu-scheduling-webhook/main.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/bombsimon/logrusr/v3"
 	"github.com/go-logr/logr"
-	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -20,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/openshift/ci-tools/pkg/api"
 )
 
 var (

--- a/cmd/gpu-scheduling-webhook/main_test.go
+++ b/cmd/gpu-scheduling-webhook/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/ci-tools/pkg/api"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -35,10 +36,10 @@ func TestMutatePod(t *testing.T) {
 							Image:   "img",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 								Limits: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -58,10 +59,10 @@ func TestMutatePod(t *testing.T) {
 							Image:   "img",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 								Limits: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -110,10 +111,10 @@ func TestMutatePod(t *testing.T) {
 							Image:   "img",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 								Limits: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 							},
 						},
@@ -134,10 +135,10 @@ func TestMutatePod(t *testing.T) {
 							Image:   "img",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 								Limits: corev1.ResourceList{
-									nvidiaGPU: resource.MustParse("1"),
+									api.NvidiaGPUResource: resource.MustParse("1"),
 								},
 							},
 						},

--- a/cmd/gpu-scheduling-webhook/main_test.go
+++ b/cmd/gpu-scheduling-webhook/main_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/openshift/ci-tools/pkg/api"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openshift/ci-tools/pkg/api"
 )
 
 func TestMutatePod(t *testing.T) {

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -70,7 +70,8 @@ const (
 
 	CIAdminsGroupName = "test-platform-ci-admins"
 
-	ShmResource = "ci-operator.openshift.io/shm"
+	ShmResource       = "ci-operator.openshift.io/shm"
+	NvidiaGPUResource = "nvidia.com/gpu"
 
 	// ReleaseConfigAnnotation is the name of annotation created by the release controller.
 	// ci-operator uses the release controller configuration to determine

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -552,7 +552,7 @@ func validateResourceList(fieldRoot string, list api.ResourceList) []error {
 	var numInvalid int
 	for key := range list {
 		switch key {
-		case "cpu", "memory", api.ShmResource:
+		case "cpu", "memory", api.ShmResource, api.NvidiaGPUResource:
 			quantity, err := resource.ParseQuantity(list[key])
 			if err != nil {
 				validationErrors = append(validationErrors, fmt.Errorf("%s.%s: invalid quantity: %w", fieldRoot, key, err))

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -271,6 +271,33 @@ func TestValidateResources(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		{
+			name: "valid nvidia gpu value passes",
+			input: api.ResourceConfiguration{
+				"*": api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.NvidiaGPUResource: "1",
+					},
+					Limits: api.ResourceList{
+						api.NvidiaGPUResource: "1",
+					},
+				},
+			},
+		},
+		{
+			name: "invalid nvidia gpu value passes",
+			input: api.ResourceConfiguration{
+				"*": api.ResourceRequirements{
+					Requests: api.ResourceList{
+						api.NvidiaGPUResource: "foo",
+					},
+					Limits: api.ResourceList{
+						api.NvidiaGPUResource: "bar",
+					},
+				},
+			},
+			expectedErr: true,
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			err := validateResources("", testCase.input)


### PR DESCRIPTION
This is a follow up of https://github.com/openshift/ci-tools/pull/3927
Allow `nvidia.com/gpu` to be specified in both `requests:` and `limits:` stanzas.