### PR TITLE
TRT-1662: jobruntestcaseanalyzer: add test group to verify upgrade success

### DIFF
--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -33,10 +33,17 @@ var (
 	installTest           = "install should succeed: overall"
 	installTestIdentifier = testIdentifier{testSuites: installTestSuites, testName: installTest}
 
+	// Checking the step graph that the "test" phase succeeded is a proxy for "all tests passed"
 	overallTestGroup      = "overall"
 	overallTestsSuite     = []string{"step graph"}
 	overallTestsTest      = "Run multi-stage test test phase"
 	overallTestIdentifier = testIdentifier{testSuites: overallTestsSuite, testName: overallTestsTest}
+
+	// This test verifies that the cluster upgraded, and that the upgrade finished with the cluster in a good state.
+	upgradeTestGroup      = "upgrade"
+	upgradeTestSuite      = []string{"openshift-tests-upgrade"}
+	upgradeTest           = "[sig-arch][Feature:ClusterUpgrade] Cluster should be upgradeable after finishing upgrade [Late][Suite:upgrade]"
+	upgradeTestIdentifier = testIdentifier{testSuites: upgradeTestSuite, testName: upgradeTest}
 )
 
 // JobGetter gets related jobs for further analysis

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/cmd.go
@@ -350,6 +350,8 @@ func (f *JobRunsTestCaseAnalyzerFlags) ToOptions(ctx context.Context) (*JobRunTe
 		testIdentifierOpt = installTestIdentifier
 	case overallTestGroup:
 		testIdentifierOpt = overallTestIdentifier
+	case upgradeTestGroup:
+		testIdentifierOpt = upgradeTestIdentifier
 	default:
 		return nil, fmt.Errorf("unknown test group: %s", f.TestGroup)
 	}


### PR DESCRIPTION
Adds a test group to the job analyzer that verifies an upgrade completes cleanly.