### PR TITLE
Revert "TRT-1627: Use variant registry for disruption and remove some outdated half implemented view management"

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -240,7 +240,7 @@ func (a *weeklyAverageFromTenDays) getNormalizedFallBackJobName(ctx context.Cont
 		return jobName, err
 	}
 	var targetFromRelease, targetToRelease string
-	var job *jobrunaggregatorapi.JobRowWithVariants
+	var job *jobrunaggregatorapi.JobRow
 	for _, j := range allJobs {
 		if j.JobName == jobName {
 			job = &j
@@ -248,9 +248,9 @@ func (a *weeklyAverageFromTenDays) getNormalizedFallBackJobName(ctx context.Cont
 		}
 	}
 	if job != nil {
-		if len(job.FromRelease.StringVal) > 0 {
-			fromReleaseMajor, err1 := getMajor(job.FromRelease.StringVal)
-			fromReleaseMinor, err2 := getMinor(job.FromRelease.StringVal)
+		if len(job.FromRelease) > 0 {
+			fromReleaseMajor, err1 := getMajor(job.FromRelease)
+			fromReleaseMinor, err2 := getMinor(job.FromRelease)
 			if err1 != nil || err2 != nil {
 				fmt.Printf("Error parsing from release %s. Will not fall back to previous release data.\n", job.FromRelease)
 				return jobName, nil
@@ -267,16 +267,16 @@ func (a *weeklyAverageFromTenDays) getNormalizedFallBackJobName(ctx context.Cont
 			targetToRelease = fmt.Sprintf("%d.%d", toReleaseMajor, toReleaseMinor-1)
 		}
 
-		normalizedJobName := normalizeJobName(job.JobName, job.FromRelease.StringVal, job.Release)
+		normalizedJobName := normalizeJobName(job.JobName, job.FromRelease, job.Release)
 		for _, j := range allJobs {
 			if j.Architecture == job.Architecture &&
 				j.Topology == job.Topology &&
 				j.Network == job.Network &&
 				j.Platform == job.Platform &&
-				j.FromRelease.StringVal == targetFromRelease &&
+				j.FromRelease == targetFromRelease &&
 				j.Release == targetToRelease &&
 				j.IPMode == job.IPMode &&
-				normalizeJobName(j.JobName, j.FromRelease.StringVal, j.Release) == normalizedJobName {
+				normalizeJobName(j.JobName, j.FromRelease, j.Release) == normalizedJobName {
 				return j.JobName, nil
 			}
 		}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/bypass_linter.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/bypass_linter.go
@@ -1,0 +1,25 @@
+package jobrunaggregatorapi
+
+import "fmt"
+
+func init() {
+	// Some variables exist as documentation of how various tables and views are built.  The linter complains about dead code.
+	// This creates fake references.
+	rand := fairDiceRoll()
+	if rand == -1 {
+		fmt.Print(unifiedBackendDisruptionSchema)
+		fmt.Print(testRunsUnifiedLast200JobRunsSchema)
+		fmt.Print(testRunsUnifiedTestRunsForLast200JobRunsSchema)
+		fmt.Print(testRunsUnifiedTestRunsSingleResultForLast200JobRunsSchema)
+		fmt.Print(testRunsSummaryLast200RunsSchema)
+		fmt.Print(testRunsUnifiedTestRunsSingleResultForAllJobRunsSchema)
+		fmt.Print(testRunsSummaryAllJobRunsSchema)
+		fmt.Print(alertSchema)
+		fmt.Print(unifiedAlertSchema)
+		fmt.Print(testRunsUnifiedJobRunsSchema)
+	}
+}
+
+func fairDiceRoll() int {
+	return 4 // chosen by fair dice roll.  guaranteed to be random
+}

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_aggregatedtestrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_aggregatedtestrun.go
@@ -6,6 +6,172 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
+const (
+	// used to create TestRuns_Unified_Last200JobRuns
+	// A query to pull the historical jobruns we will use to represent aggregated history
+	testRunsUnifiedLast200JobRunsSchema = `
+select 
+    * 
+from (
+    SELECT 
+        row_number() over (PARTITION BY Jobs.Jobname ORDER BY JobRuns.name DESC) JobRunIndex,
+        JobRuns.name as JobRunName,
+        Jobs.Jobname as JobName,
+        JobRuns.StartTime as JobRunStartTime,
+        JobRuns.ReleaseTag as ReleaseTag,
+        JobRuns.Cluster as Cluster,
+        Jobs.Platform as Platform,
+        Jobs.Architecture as Architecture,
+        Jobs.Network as Network,
+        Jobs.IPMode as IPMode,
+        Jobs.Topology as Topology,
+        Jobs.Release as Release,
+        Jobs.FromRelease as FromRelease,
+        if(Jobs.FromRelease="",false,true) as IsUpgrade,
+    FROM openshift-ci-data-analysis.ci_data.JobRuns as JobRuns
+    INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.JobName
+    order by jobruns.name
+)
+where
+    JobRunIndex <= 200 AND 
+    JobRunStartTime >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 21 DAY)
+`
+
+	// used to create TestRuns_Unified_TestRunsForLast200JobRuns and TestRuns_Scheduled_Unified_TestRunsForLast200JobRuns
+	// A query to find all the testruns to include in the historical data
+	testRunsUnifiedTestRunsForLast200JobRunsSchema = `
+select 
+  testRuns.name as TestName,
+  testRuns.TestSuite as TestSuiteName,
+  jobRuns.JobRunName as JobRunName,
+  jobRuns.JobName as JobName,
+  testRuns.Status as TestStatus,
+  jobRuns.JobRunStartTime as JobRunStartTime,
+  jobRuns.ReleaseTag as ReleaseTag,
+  jobRuns.cluster as Cluster,
+  jobRuns.platform as Platform,
+  jobRuns.architecture as Architecture,
+  jobRuns.network as NetworkPlugin,
+  jobRuns.release as Release,
+  jobRuns.fromrelease as FromRelease,
+  if(TestRuns.Status="Passed", 1, 0) as Passed,
+  if(TestRuns.Status="Failed", 1, 0) as Failed,
+from openshift-ci-data-analysis.ci_data.TestRuns
+inner join openshift-ci-data-analysis.ci_data.TestRuns_Unified_Last200JobRuns as JobRuns on TestRuns.JobRunName = jobRuns.JobRunName
+`
+
+	// used to create TestRuns_Unified_TestRunsSingleResultForLast200JobRuns
+	// A query to that sets a pass, fail, flake bit for every jobrun,test tuple.  This is logically correct *only*
+	// if the testsuite is included.  When testsuite is added, this is one spot that is impacted
+	testRunsUnifiedTestRunsSingleResultForLast200JobRunsSchema = `
+select 
+    JobRunName,
+    TestName,
+    TestSuiteName,
+    if(sum(UnifiedTestRuns.Passed)>0 AND sum(UnifiedTestRuns.Failed)>0, 1, 0) as Flaked,
+    if(sum(UnifiedTestRuns.Passed)>0 AND sum(UnifiedTestRuns.Failed)=0, 1, 0) as Passed,
+    if(sum(UnifiedTestRuns.Passed)=0 AND sum(UnifiedTestRuns.Failed)>0, 1, 0) as Failed,
+    min(UnifiedTestRuns.JobRunStartTime) as AggregationStartDate,
+from openshift-ci-data-analysis.ci_data.TestRuns_Scheduled_Unified_TestRunsForLast200JobRuns as UnifiedTestRuns
+group by JobRunName, TestSuiteName, TestName
+`
+
+	// used to create TestRuns_Summary_Last200Runs
+	// This conforms to the AggregatedTestRunRow schema.  It sums the pass, fail, flake counts and pre-calculates
+	// percentages for aggregated analysis.
+	testRunsSummaryLast200RunsSchema = `
+select 
+  min(TestRuns.AggregationStartDate) as AggregationStartDate,
+  testRuns.TestName as TestName,
+  testRuns.TestSuiteName as TestSuiteName,
+  jobRuns.JobName as JobName,
+  sum(TestRuns.Passed) as PassCount,
+  sum(TestRuns.Failed) as FailCount,
+  sum(TestRuns.Flaked) as FlakeCount,
+  (sum(TestRuns.Passed)/(sum(TestRuns.Passed)+sum(TestRuns.Failed)+sum(TestRuns.Flaked)))*100 as PassPercentage,
+  ((sum(TestRuns.Passed)+sum(TestRuns.Flaked))/(sum(TestRuns.Passed)+sum(TestRuns.Failed)+sum(TestRuns.Flaked)))*100 as WorkingPercentage,
+  "" as DominantCluster,
+from openshift-ci-data-analysis.ci_data.TestRuns_Unified_TestRunsSingleResultForLast200JobRuns as TestRuns
+inner join openshift-ci-data-analysis.ci_data.TestRuns_Unified_Last200JobRuns as JobRuns on TestRuns.JobRunName = jobRuns.JobRunName
+group by jobRuns.JobName, TestRuns.TestSuiteName, TestRuns.TestName
+`
+
+	// used to create TestRuns_Unified_TestRunsSingleResultForAllJobRuns
+	// A query to that sets a pass, fail, flake bit for every jobrun,test tuple.  This is logically correct *only*
+	// if the testsuite is included.  When testsuite is added, this is one spot that is impacted
+	testRunsUnifiedTestRunsSingleResultForAllJobRunsSchema = `
+select 
+    JobName,
+    JobRunName,
+    TestName,
+    TestSuiteName,
+    if(sum(Passed)>0 AND sum(Failed)>0, 1, 0) as Flaked,
+    if(sum(Passed)>0 AND sum(Failed)=0, 1, 0) as Passed,
+    if(sum(Passed)=0 AND sum(Failed)>0, 1, 0) as Failed,
+    JobRunStartDate,
+from (
+    select 
+        testRuns.name as TestName,
+        testRuns.TestSuite as TestSuiteName,
+        jobRuns.JobRunName as JobRunName,
+        jobRuns.JobName as JobName,
+        testRuns.Status as TestStatus,
+        extract(date from jobRuns.JobRunStartTime) as JobRunStartDate,
+        jobRuns.ReleaseTag as ReleaseTag,
+        jobRuns.cluster as Cluster,
+        jobRuns.platform as Platform,
+        jobRuns.architecture as Architecture,
+        jobRuns.network as NetworkPlugin,
+        jobRuns.release as Release,
+        jobRuns.fromrelease as FromRelease,
+        if(TestRuns.Status="Passed", 1, 0) as Passed,
+        if(TestRuns.Status="Failed", 1, 0) as Failed,
+    from openshift-ci-data-analysis.ci_data.TestRuns
+    inner join openshift-ci-data-analysis.ci_data.TestRuns_Unified_AllJobRuns as JobRuns on TestRuns.JobRunName = jobRuns.JobRunName
+)
+group by JobName, JobRunName, JobRunStartDate, TestSuiteName, TestName
+`
+
+	// used to create TestRuns_Summary_PerDayPassCountForAllJobs
+	testRunsSummaryAllJobRunsSchema = `
+select
+  TestRunSummary.TestName,
+  TestRunSummary.TestSuiteName,
+    TestRunSummary.JobName,
+    TestRunSummary.JobRunStartDate, 
+    TestRunSummary.PassCount,
+    TestRunSummary.FailCount,
+    TestRunSummary.FlakeCount,
+    TestRunSummary.PassPercentage,
+    TestRunSummary.WorkingPercentage,
+    TestRunSummary.TotalRuns,
+    Jobs.Platform as Platform,
+    Jobs.Architecture as Architecture,
+  Jobs.Network as Network,
+  Jobs.IPMode as IPMode,
+  Jobs.Topology as Topology,
+  Jobs.Release as Release,
+  Jobs.FromRelease as FromRelease,
+  if(Jobs.FromRelease="",false,true) as IsUpgrade,
+from (
+  select 
+    TestName,
+    TestSuiteName,
+    JobName,
+    JobRunStartDate, 
+    sum(TestRuns.Passed) as PassCount,
+    sum(TestRuns.Failed) as FailCount,
+    sum(TestRuns.Flaked) as FlakeCount,
+    (sum(TestRuns.Passed)/(sum(TestRuns.Passed)+sum(TestRuns.Failed)+sum(TestRuns.Flaked)))*100 as PassPercentage,
+    ((sum(TestRuns.Passed)+sum(TestRuns.Flaked))/(sum(TestRuns.Passed)+sum(TestRuns.Failed)+sum(TestRuns.Flaked)))*100 as WorkingPercentage,
+    (sum(TestRuns.Passed)+sum(TestRuns.Failed)+sum(TestRuns.Flaked)) as TotalRuns,
+  from openshift-ci-data-analysis.ci_data.TestRuns_Unified_TestRunsSingleResultForAllJobRuns as TestRuns
+  group by JobName, TestRuns.TestSuiteName, TestRuns.TestName, JobRunStartDate
+) as TestRunSummary
+INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on TestRunSummary.JobName = Jobs.JobName
+`
+)
+
 type AggregatedTestRunRow struct {
 	AggregationStartDate time.Time
 	TestName             string

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_alert.go
@@ -6,6 +6,65 @@ import (
 
 const (
 	AlertsTableName = "Alerts"
+
+	alertSchema = `
+[
+  {
+    "name": "JobRunName",
+    "description": "name of the jobrun (the long number)",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Name",
+    "description": "name of the alert",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Namespace",
+    "description": "namespace the alert fires in",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "Level",
+    "description": "Info, Warning, Critical",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "AlertSeconds",
+    "description": "number of seconds the alert was firing",
+    "type": "INTEGER",
+    "mode": "REQUIRED"
+  }
+]
+`
+
+	unifiedAlertSchema = `
+SELECT 
+  Alerts.Name as AlertName,
+  Alerts.Namespace as AlertNamespace,
+  Alerts.Level as AlertLevel,
+  JobRuns.name as JobRunName,
+  Jobs.Jobname as JobName,
+  Alerts.AlertSeconds as AlertSeconds,
+  JobRuns.StartTime as JobRunStartTime,
+  JobRuns.ReleaseTag as ReleaseTag,
+  JobRuns.Cluster as Cluster,
+  Jobs.Platform as Platform,
+  Jobs.Architecture as Architecture,
+  Jobs.Network as Network,
+  Jobs.IPMode as IPMode,
+  Jobs.Topology as Topology,
+  Jobs.Release as Release,
+  Jobs.FromRelease as FromRelease,
+  if(Jobs.FromRelease="",false,true) as IsUpgrade,
+FROM openshift-ci-data-analysis.ci_data.Alerts
+INNER JOIN openshift-ci-data-analysis.ci_data.Alerts_JobRuns as JobRuns on Alerts.JobRunName = JobRuns.Name
+INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.JobName
+`
 )
 
 type AlertRow struct {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_backenddisruption.go
@@ -4,6 +4,30 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
+const (
+	unifiedBackendDisruptionSchema = `
+SELECT 
+  BackendDisruption.BackendName as BackendName,
+  JobRuns.name as JobRunName,
+  Jobs.Jobname as JobName,
+  BackendDisruption.DisruptionSeconds as DisruptionSeconds,
+  JobRuns.StartTime as JobRunStartTime,
+  JobRuns.ReleaseTag as ReleaseTag,
+  JobRuns.Cluster as Cluster,
+  Jobs.Platform as Platform,
+  Jobs.Architecture as Architecture,
+  Jobs.Network as Network,
+  Jobs.IPMode as IPMode,
+  Jobs.Topology as Topology,
+  Jobs.Release as Release,
+  Jobs.FromRelease as FromRelease,
+  if(Jobs.FromRelease="",false,true) as IsUpgrade,
+FROM openshift-ci-data-analysis.ci_data.BackendDisruption
+INNER JOIN openshift-ci-data-analysis.ci_data.BackendDisruption_JobRuns as JobRuns on BackendDisruption.JobRunName = JobRuns.Name
+INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.JobName
+`
+)
+
 const BackendDisruptionTableName = "BackendDisruption"
 
 type BackendDisruptionRow struct {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_job.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_job.go
@@ -1,20 +1,105 @@
 package jobrunaggregatorapi
 
-import "cloud.google.com/go/bigquery"
-
+// The jobSchema below is used to build the "Jobs" table.
 const (
 	JobsTableName = "Jobs"
+	JobSchema     = `
+[
+  {
+    "name": "JobName",
+    "description": "name of the job from CI",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "GCSBucketName",
+    "description": "name of the GCS bucket we store jobrun artifacts in",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "GCSJobHistoryLocationPrefix",
+    "description": "spot in the GCS bucket to look.  like logs/<jobName>",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "CollectDisruption",
+    "description": "should we collect disruption data from the job runs",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "CollectTestRuns",
+    "description": "should we collect test run data from the job runs",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Platform",
+    "description": "gcp, aws, vsphere, metal, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+    {
+    "name": "Architecture",
+    "description": "amd64, arm64, ppc64le, s390x",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Network",
+    "description": "ovn, sdn, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "IPMode",
+    "description": "ipv4, ipv6, dual, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Topology",
+    "description": "Single, HA, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Release",
+    "description": "4.8, 4.9, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "FromRelease",
+    "description": "4.8, 4.9, etc",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "RunsUpgrade",
+    "description": "true if the job run an upgrade",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "RunsE2EParallel",
+    "description": "true if the job runs e2e parallel",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "RunsE2ESerial",
+    "description": "true if the job runs e2e serial",
+    "type": "BOOLEAN",
+    "mode": "REQUIRED"
+  }
+]
+`
 )
 
 type JobRow struct {
-	JobName                     string
-	GCSBucketName               string
-	GCSJobHistoryLocationPrefix string
-	CollectDisruption           bool
-	CollectTestRuns             bool
-}
-
-type JobRowWithVariants struct {
 	JobName                     string
 	GCSBucketName               string
 	GCSJobHistoryLocationPrefix string
@@ -26,5 +111,8 @@ type JobRowWithVariants struct {
 	IPMode                      string
 	Topology                    string
 	Release                     string
-	FromRelease                 bigquery.NullString
+	FromRelease                 string
+	RunsUpgrade                 bool
+	RunsE2EParallel             bool
+	RunsE2ESerial               bool
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_jobrun.go
@@ -9,10 +9,80 @@ import (
 const (
 	LegacyJobRunTableName     = "JobRuns"
 	DisruptionJobRunTableName = "BackendDisruption_JobRuns"
+	AlertJobRunTableName      = "Alerts_JobRuns"
 
-	// TODO: Remove population of this table, I don't think it's used anywhere in ci-tools or the views in bigquery.
-	// Instead used the data embedded in each Alerts row, or the jobs table in openshift-gce-devel.ci_analysis_us
-	AlertJobRunTableName = "Alerts_JobRuns"
+	JobRunSchema = `
+[
+  {
+    "name": "Name",
+    "description": "name of the jobrun (the long number)",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "JobName",
+    "description": "name of the job from CI",
+    "type": "STRING",
+    "mode": "REQUIRED"
+  },
+  {
+    "name": "Status",
+    "description": "error, failure, success",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "StartTime",
+    "description": "time the jobrun started",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "EndTime",
+    "description": "time the jobrun started",
+    "type": "TIMESTAMP",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "ReleaseTag",
+    "description": "",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "Cluster",
+    "description": "the build farm cluster that the CI job ran on: build01, build02, build03, vsphere, etc",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "MasterNodesUpdated",
+    "description": "indicator if master nodes restarted during the jobrun",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  }
+]
+`
+
+	// used for TestRuns_Unified_AllJobRuns
+	testRunsUnifiedJobRunsSchema = `
+SELECT 
+  JobRuns.name as JobRunName,
+  Jobs.Jobname as JobName,
+  JobRuns.StartTime as JobRunStartTime,
+  JobRuns.ReleaseTag as ReleaseTag,
+  JobRuns.Cluster as Cluster,
+  Jobs.Platform as Platform,
+  Jobs.Architecture as Architecture,
+  Jobs.Network as Network,
+  Jobs.IPMode as IPMode,
+  Jobs.Topology as Topology,
+  Jobs.Release as Release,
+  Jobs.FromRelease as FromRelease,
+  if(Jobs.FromRelease="",false,true) as IsUpgrade,
+FROM openshift-ci-data-analysis.ci_data.JobRuns
+INNER JOIN openshift-ci-data-analysis.ci_data.Jobs on JobRuns.JobName = Jobs.JobName
+`
 )
 
 type JobRunRow struct {

--- a/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorapi/types_row_testrun.go
@@ -4,6 +4,47 @@ import (
 	"cloud.google.com/go/bigquery"
 )
 
+const (
+	TestRunTableName = "TestRuns"
+
+	// The TestRunsSchema below is used to build the "TestRuns" table.
+	//
+	TestRunsSchema = `
+[
+  {
+    "mode": "REQUIRED",
+    "name": "Name",
+    "description" : "Name of the test run",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "JobRunName",
+    "description" : "Name of the JobRun (big number) that ran this test (e.g., 1389486541524439040)",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "JobName",
+    "description" : "Name of the Job that as this test in it",
+    "type": "STRING"
+  },
+  {
+    "mode": "REQUIRED",
+    "name": "Status",
+    "description" : "Status of the test (e.g., pass, fail)",
+    "type": "STRING"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "TestSuite",
+    "description" : "Testsuite that this test belongs to",
+    "type": "STRING"
+  }
+]
+`
+)
+
 // Move here from jobrunbigqueryloader/types.go
 type TestRunRow struct {
 	Name               string

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/big_query.go
@@ -17,6 +17,8 @@ import (
 const (
 	BigQueryProjectID = "openshift-ci-data-analysis"
 	CIDataSetID       = "ci_data"
+	JobsTableName     = "Jobs"
+	JobRunTableName   = "JobRuns"
 	TestRunTableName  = "TestRuns"
 
 	ReleaseTableName             = "ReleaseTags"

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client_mock.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/ci_data_client_mock.go
@@ -160,10 +160,10 @@ func (mr *MockCIDataClientMockRecorder) ListAlertHistoricalData(arg0 interface{}
 }
 
 // ListAllJobs mocks base method.
-func (m *MockCIDataClient) ListAllJobs(arg0 context.Context) ([]jobrunaggregatorapi.JobRowWithVariants, error) {
+func (m *MockCIDataClient) ListAllJobs(arg0 context.Context) ([]jobrunaggregatorapi.JobRow, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllJobs", arg0)
-	ret0, _ := ret[0].([]jobrunaggregatorapi.JobRowWithVariants)
+	ret0, _ := ret[0].([]jobrunaggregatorapi.JobRow)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
+++ b/pkg/jobrunaggregator/jobrunaggregatorlib/retrying_ci_data_client.go
@@ -46,8 +46,8 @@ func (c *retryingCIDataClient) GetBackendDisruptionStatisticsByJob(ctx context.C
 	return ret, err
 }
 
-func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRowWithVariants, error) {
-	var ret []jobrunaggregatorapi.JobRowWithVariants
+func (c *retryingCIDataClient) ListAllJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error) {
+	var ret []jobrunaggregatorapi.JobRow
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.ListAllJobs(ctx)
@@ -81,6 +81,26 @@ func (c *retryingCIDataClient) ListUploadedJobRunIDsSinceFromTable(ctx context.C
 	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
 		var innerErr error
 		ret, innerErr = c.delegate.ListUploadedJobRunIDsSinceFromTable(ctx, table, since)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) GetLastAggregationForJob(ctx context.Context, frequency, jobName string) (*jobrunaggregatorapi.AggregatedTestRunRow, error) {
+	var ret *jobrunaggregatorapi.AggregatedTestRunRow
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.GetLastAggregationForJob(ctx, frequency, jobName)
+		return innerErr
+	})
+	return ret, err
+}
+
+func (c *retryingCIDataClient) ListUnifiedTestRunsForJobAfterDay(ctx context.Context, jobName string, startDay time.Time) (*UnifiedTestRunRowIterator, error) {
+	var ret *UnifiedTestRunRowIterator
+	err := retry.OnError(slowBackoff, isReadQuotaError, func() error {
+		var innerErr error
+		ret, innerErr = c.delegate.ListUnifiedTestRunsForJobAfterDay(ctx, jobName, startDay)
 		return innerErr
 	})
 	return ret, err

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/alert.go
@@ -132,7 +132,7 @@ func (f *BigQueryAlertUploadFlags) ToOptions(ctx context.Context) (*allJobsLoade
 		gcsClient:    gcsClient,
 
 		jobRunInserter: jobRunTableInserter,
-		shouldCollectedDataForJobFn: func(job jobrunaggregatorapi.JobRowWithVariants) bool {
+		shouldCollectedDataForJobFn: func(job jobrunaggregatorapi.JobRow) bool {
 			return true
 		},
 		jobRunUploaderRegistry:  jobRunUploaderRegistry,

--- a/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
+++ b/pkg/jobrunaggregator/jobrunbigqueryloader/uploader.go
@@ -21,12 +21,12 @@ const (
 	workerCount = 10
 )
 
-type shouldCollectDataForJobFunc func(job jobrunaggregatorapi.JobRowWithVariants) bool
+type shouldCollectDataForJobFunc func(job jobrunaggregatorapi.JobRow) bool
 
-func wantsTestRunData(job jobrunaggregatorapi.JobRowWithVariants) bool {
+func wantsTestRunData(job jobrunaggregatorapi.JobRow) bool {
 	return job.CollectTestRuns
 }
-func wantsDisruptionData(job jobrunaggregatorapi.JobRowWithVariants) bool {
+func wantsDisruptionData(job jobrunaggregatorapi.JobRow) bool {
 	return job.CollectDisruption
 }
 
@@ -77,7 +77,7 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 	}
 
 	// Convert list of JobRows to a map by job name, we're going to want quick lookups
-	jobRowsMap := map[string]jobrunaggregatorapi.JobRowWithVariants{}
+	jobRowsMap := map[string]jobrunaggregatorapi.JobRow{}
 	for _, job := range jobs {
 		jobRowsMap[job.JobName] = job
 	}
@@ -177,7 +177,7 @@ func (o *allJobsLoaderOptions) Run(ctx context.Context) error {
 
 // processJobRuns is started in several concurrent goroutines to pull job runs to process from the channel. Errors are sent
 // to the errChan for aggregation in the main thread.
-func (o *allJobsLoaderOptions) processJobRuns(ctx context.Context, jobsMap map[string]jobrunaggregatorapi.JobRowWithVariants, wg *sync.WaitGroup, workerThread, origRunsToImportCount int, jobRunsToImportCh <-chan *jobrunaggregatorapi.TestPlatformProwJobRow, errChan chan<- error) {
+func (o *allJobsLoaderOptions) processJobRuns(ctx context.Context, jobsMap map[string]jobrunaggregatorapi.JobRow, wg *sync.WaitGroup, workerThread, origRunsToImportCount int, jobRunsToImportCh <-chan *jobrunaggregatorapi.TestPlatformProwJobRow, errChan chan<- error) {
 	defer wg.Done()
 	for job := range jobRunsToImportCh {
 		jrLogger := logrus.WithFields(logrus.Fields{

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer.go
@@ -48,7 +48,7 @@ var (
 
 // JobGetter gets related jobs for further analysis
 type JobGetter interface {
-	GetJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRowWithVariants, error)
+	GetJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error)
 }
 
 func NewTestCaseAnalyzerJobGetter(platform, infrastructure, network, testNameSuffix string,
@@ -133,7 +133,7 @@ func (s *testCaseAnalyzerJobGetter) shouldAggregateJob(prowJob *prowjobv1.ProwJo
 // For PR payload, this contains jobs correspond to the list of jobGCSPreix passed
 // For release-controller generated payload, this contains all jobs meeting selection criteria
 // from command args.
-func (s *testCaseAnalyzerJobGetter) GetJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRowWithVariants, error) {
+func (s *testCaseAnalyzerJobGetter) GetJobs(ctx context.Context) ([]jobrunaggregatorapi.JobRow, error) {
 	jobs, err := s.ciDataClient.ListAllJobs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list all jobs: %w", err)
@@ -156,8 +156,8 @@ func getJobInfrastructure(name string) string {
 	return "ipi"
 }
 
-func (s *testCaseAnalyzerJobGetter) filterJobsForPayload(allJobs []jobrunaggregatorapi.JobRowWithVariants) []jobrunaggregatorapi.JobRowWithVariants {
-	jobs := []jobrunaggregatorapi.JobRowWithVariants{}
+func (s *testCaseAnalyzerJobGetter) filterJobsForPayload(allJobs []jobrunaggregatorapi.JobRow) []jobrunaggregatorapi.JobRow {
+	jobs := []jobrunaggregatorapi.JobRow{}
 	for i := range allJobs {
 		job := allJobs[i]
 		if (len(s.platform) != 0 && job.Platform != s.platform) ||
@@ -210,8 +210,8 @@ func (s *testCaseAnalyzerJobGetter) isJobNameExcluded(jobName string) bool {
 	return false
 }
 
-func (s *testCaseAnalyzerJobGetter) filterJobsByNames(jobNames sets.Set[string], allJobs []jobrunaggregatorapi.JobRowWithVariants) []jobrunaggregatorapi.JobRowWithVariants {
-	ret := []jobrunaggregatorapi.JobRowWithVariants{}
+func (s *testCaseAnalyzerJobGetter) filterJobsByNames(jobNames sets.Set[string], allJobs []jobrunaggregatorapi.JobRow) []jobrunaggregatorapi.JobRow {
+	ret := []jobrunaggregatorapi.JobRow{}
 	for i := range allJobs {
 		curr := allJobs[i]
 		if jobNames.Has(curr.JobName) {
@@ -494,15 +494,15 @@ func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobRuns(ctx context.Context, j
 	return outputRuns, nil
 }
 
-func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobs() []jobrunaggregatorapi.JobRowWithVariants {
-	rows := make([]jobrunaggregatorapi.JobRowWithVariants, 0)
+func (o *JobRunTestCaseAnalyzerOptions) loadStaticJobs() []jobrunaggregatorapi.JobRow {
+	rows := make([]jobrunaggregatorapi.JobRow, 0)
 	uniqueNames := sets.Set[string]{}
 
 	for _, r := range o.staticJobRunIdentifiers {
 		// only one row per unique job name
 		if !uniqueNames.Has(r.JobName) {
 			// we only care about returning JobName
-			rows = append(rows, jobrunaggregatorapi.JobRowWithVariants{JobName: r.JobName})
+			rows = append(rows, jobrunaggregatorapi.JobRow{JobName: r.JobName})
 			uniqueNames.Insert(r.JobName)
 		}
 	}
@@ -518,7 +518,7 @@ func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRunsFromIdentifiers(ctx con
 // GetRelatedJobRuns gets all related job runs for analysis
 func (o *JobRunTestCaseAnalyzerOptions) GetRelatedJobRuns(ctx context.Context) ([]jobrunaggregatorapi.JobRunInfo, error) {
 	var jobRunsToReturn []jobrunaggregatorapi.JobRunInfo
-	var jobs []jobrunaggregatorapi.JobRowWithVariants
+	var jobs []jobrunaggregatorapi.JobRow
 	var err error
 
 	// allow for the list of ids to be passed in

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer_test.go
@@ -101,11 +101,11 @@ func TestGetJobs(t *testing.T) {
 
 }
 
-func createJobs() []jobrunaggregatorapi.JobRowWithVariants {
-	jobs := make([]jobrunaggregatorapi.JobRowWithVariants, 3)
-	jobs[0] = jobrunaggregatorapi.JobRowWithVariants{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-sdn-upgrade", Platform: "metal", Network: "sdn"}
-	jobs[1] = jobrunaggregatorapi.JobRowWithVariants{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-sdn-serial-ipv4", Platform: "metal", Network: "sdn"}
-	jobs[2] = jobrunaggregatorapi.JobRowWithVariants{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ovn-ipv6", Platform: "metal", Network: "sdn"}
+func createJobs() []jobrunaggregatorapi.JobRow {
+	jobs := make([]jobrunaggregatorapi.JobRow, 3)
+	jobs[0] = jobrunaggregatorapi.JobRow{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-sdn-upgrade", Platform: "metal", Network: "sdn"}
+	jobs[1] = jobrunaggregatorapi.JobRow{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-sdn-serial-ipv4", Platform: "metal", Network: "sdn"}
+	jobs[2] = jobrunaggregatorapi.JobRow{JobName: "periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ipi-serial-ovn-ipv6", Platform: "metal", Network: "sdn"}
 
 	return jobs
 }

--- a/pkg/jobrunaggregator/jobtableprimer/job_typer.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_typer.go
@@ -1,6 +1,9 @@
 package jobtableprimer
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
 )
 
@@ -8,13 +11,112 @@ type jobRowBuilder struct {
 	job *jobrunaggregatorapi.JobRow
 }
 
-func newJob(name string) *jobRowBuilder {
+func newJob(name string, reverseOrderedVersions []string) *jobRowBuilder {
+	platform := ""
+	switch {
+	case strings.Contains(name, "gcp"):
+		platform = gcp
+	case strings.Contains(name, "aws"):
+		platform = aws
+	case strings.Contains(name, "azure"):
+		platform = azure
+	case strings.Contains(name, "metal"):
+		platform = metal
+	case strings.Contains(name, "vsphere"):
+		platform = vsphere
+	case strings.Contains(name, "ovirt"):
+		platform = ovirt
+	case strings.Contains(name, "openstack"):
+		platform = openstack
+	case strings.Contains(name, "libvirt"):
+		platform = libvirt
+	case strings.Contains(name, "alibaba"):
+		platform = alibaba
+	case strings.Contains(name, "ibmcloud"):
+		platform = ibmcloud
+	}
+
+	architecture := ""
+	switch {
+	case strings.Contains(name, "arm64"):
+		architecture = arm64
+	case strings.Contains(name, "ppc64le"):
+		architecture = ppc64le
+	case strings.Contains(name, "s390x"):
+		architecture = s390x
+	default:
+		architecture = amd64
+	}
+
+	runsUpgrade := false
+	if strings.Contains(name, "upgrade") {
+		runsUpgrade = true
+	}
+
+	network := sdn
+	if strings.Contains(name, "ovn") {
+		network = ovn
+	}
+
+	topology := ""
+	switch {
+	case strings.Contains(name, "single"):
+		topology = single
+	case strings.Contains(name, "hypershift"):
+		topology = external
+	default:
+		topology = ha
+	}
+
+	// figure out some way to do the ip mode
+	ipMode := ipv4
+
+	versions := []string{}
+	for _, curr := range reverseOrderedVersions {
+		if strings.Contains(name, curr) {
+			versions = append(versions, curr)
+		}
+	}
+	currRelease := "unknown"
+	if len(versions) >= 1 {
+		currRelease = versions[0]
+	} else {
+		// If this job doesn't have one of the known releases, panic to avoid silently missing data for it.
+		panic(fmt.Sprintf("Unable to determine the release from job %s, please update the release list: %v", name, reverseOrderedVersions))
+	}
+	fromRelease := ""
+	if runsUpgrade {
+		if len(versions) > 0 {
+			fromRelease = versions[len(versions)-1]
+		}
+	}
+
+	runsSerial := false
+	if strings.Contains(name, "serial") {
+		runsSerial = true
+	}
+
+	runsE2E := false
+	if !runsUpgrade && !runsSerial {
+		runsE2E = true
+	}
+
 	return &jobRowBuilder{
 		job: &jobrunaggregatorapi.JobRow{
 			JobName:                     name,
 			GCSJobHistoryLocationPrefix: "logs/" + name,
+			Platform:                    platform,
+			Architecture:                architecture,
+			Network:                     network,
+			IPMode:                      ipMode,
+			Topology:                    topology,
+			Release:                     currRelease,
+			FromRelease:                 fromRelease,
 			CollectDisruption:           true, // by default we collect disruption
 			CollectTestRuns:             true, // by default we collect disruption
+			RunsUpgrade:                 runsUpgrade,
+			RunsE2EParallel:             runsE2E,
+			RunsE2ESerial:               runsSerial,
 		},
 	}
 }
@@ -26,6 +128,11 @@ func (b *jobRowBuilder) WithoutDisruption() *jobRowBuilder {
 
 func (b *jobRowBuilder) WithoutTestRuns() *jobRowBuilder {
 	b.job.CollectTestRuns = true
+	return b
+}
+
+func (b *jobRowBuilder) WithE2EParallel() *jobRowBuilder {
+	b.job.RunsE2EParallel = true
 	return b
 }
 

--- a/pkg/jobrunaggregator/jobtableprimer/jobs.go
+++ b/pkg/jobrunaggregator/jobtableprimer/jobs.go
@@ -2,9 +2,40 @@ package jobtableprimer
 
 import (
 	_ "embed"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
+)
+
+const (
+	gcp       = "gcp"
+	aws       = "aws"
+	azure     = "azure"
+	metal     = "metal"
+	vsphere   = "vsphere"
+	ovirt     = "ovirt"
+	openstack = "openstack"
+	libvirt   = "libvirt"
+	alibaba   = "alibaba"
+	ibmcloud  = "ibmcloud"
+
+	amd64   = "amd64"
+	arm64   = "arm64"
+	ppc64le = "ppc64le"
+	s390x   = "s390x"
+
+	sdn = "sdn"
+	ovn = "ovn"
+
+	ha       = "ha"
+	single   = "single"
+	external = "external"
+
+	ipv4 = "ipv4"
+	//ipv6 = "ipv6"
+	//dual = "dual"
 )
 
 // jobRowListBuilder builds the list of job rows used to prime the job table
@@ -18,7 +49,44 @@ func newJobRowListBuilder(releases []jobrunaggregatorapi.ReleaseRow) *jobRowList
 	}
 }
 
+func (j *jobRowListBuilder) getReverseOrderedVersions(releases []jobrunaggregatorapi.ReleaseRow) []string {
+	reverseOrderedVersions := []string{}
+	for _, release := range releases {
+		reverseOrderedVersions = append(reverseOrderedVersions, release.Release)
+	}
+	sort.Slice(reverseOrderedVersions, func(i, j int) bool {
+		iVersionStrs := strings.Split(reverseOrderedVersions[i], ".")
+		if len(iVersionStrs) < 2 {
+			return false
+		}
+		iMajor, err := strconv.ParseInt(iVersionStrs[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		iMinor, err := strconv.ParseInt(iVersionStrs[1], 10, 64)
+		if err != nil {
+			return false
+		}
+		jVersionStrs := strings.Split(reverseOrderedVersions[j], ".")
+		if len(jVersionStrs) < 2 {
+			return false
+		}
+		jMajor, err := strconv.ParseInt(jVersionStrs[0], 10, 64)
+		if err != nil {
+			return false
+		}
+		jMinor, err := strconv.ParseInt(jVersionStrs[1], 10, 64)
+		if err != nil {
+			return false
+		}
+
+		return iMajor > jMajor || iMinor > jMinor
+	})
+	return reverseOrderedVersions
+}
+
 func (j *jobRowListBuilder) CreateAllJobRows(jobNames []string) []jobrunaggregatorapi.JobRow {
+	reverseOrderedVersions := j.getReverseOrderedVersions(j.releases)
 	jobsRowToCreate := []jobrunaggregatorapi.JobRow{}
 
 	for _, jobName := range jobNames {
@@ -45,7 +113,7 @@ func (j *jobRowListBuilder) CreateAllJobRows(jobNames []string) []jobrunaggregat
 			continue
 		}
 
-		jobsRowToCreate = append(jobsRowToCreate, newJob(jobName).ToJob())
+		jobsRowToCreate = append(jobsRowToCreate, newJob(jobName, reverseOrderedVersions).ToJob())
 	}
 	return jobsRowToCreate
 }

--- a/pkg/jobrunaggregator/jobtableprimer/jobs_test.go
+++ b/pkg/jobrunaggregator/jobtableprimer/jobs_test.go
@@ -1,0 +1,89 @@
+package jobtableprimer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	v408 = "4.8"
+	v409 = "4.9"
+	v410 = "4.10"
+	v411 = "4.11"
+	v412 = "4.12"
+	v413 = "4.13"
+	v414 = "4.14"
+	v415 = "4.15"
+	v416 = "4.16"
+)
+
+func TestJobVersions(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		jobName     string
+		fromVersion string
+		toVersion   string
+		shouldPanic bool
+	}{
+		{
+			name:        "multi-version-upgrade",
+			jobName:     "release-openshift-origin-installer-e2e-aws-upgrade-4.11-to-4.12-to-4.13-to-4.14-ci",
+			fromVersion: "4.11",
+			toVersion:   "4.14",
+		},
+		{
+			name:        "non-upgrade",
+			jobName:     "release-openshift-origin-installer-e2e-aws-4.11-to-4.12-to-4.13-to-4.14-ci",
+			fromVersion: "",
+			toVersion:   "4.14",
+		},
+		{
+			name:        "non-upgrade-mixed-version-order",
+			jobName:     "release-openshift-origin-installer-e2e-aws-4.11-to-4.12-to-4.14-to-4.13-ci",
+			fromVersion: "",
+			toVersion:   "4.14",
+		},
+		{
+			name:        "micro-version-upgrade",
+			jobName:     "release-openshift-origin-installer-e2e-aws-upgrade-4.14-ci",
+			fromVersion: "4.14",
+			toVersion:   "4.14",
+		},
+		{
+			name:        "minor-version-upgrade",
+			jobName:     "release-openshift-origin-installer-e2e-aws-upgrade-4.13-to-4.14-ci",
+			fromVersion: "4.13",
+			toVersion:   "4.14",
+		},
+		{
+			name:        "missing-version-upgrade",
+			jobName:     "release-openshift-origin-installer-e2e-aws-upgrade-ci",
+			fromVersion: "",
+			toVersion:   "unknown",
+			shouldPanic: true,
+		},
+	}
+
+	reverseOrderedVersions := []string{
+		v416, v415, v414, v413, v412, v411, v410, v409, v408,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					newJob(tc.jobName, reverseOrderedVersions)
+				}, "Expected panic for unknown release")
+			} else {
+				j := newJob(tc.jobName, reverseOrderedVersions)
+
+				assert.NotNil(t, j, "Unexpected nil builder")
+				assert.NotNil(t, j.job, "Unexpected nil job")
+				assert.Equal(t, tc.toVersion, j.job.Release, "Invalid toVersion")
+				assert.Equal(t, tc.fromVersion, j.job.FromRelease, "Invalid fromVersion")
+			}
+		})
+	}
+
+}

--- a/pkg/jobrunaggregator/tablescreator/table_creator.go
+++ b/pkg/jobrunaggregator/tablescreator/table_creator.go
@@ -1,0 +1,45 @@
+package tablescreator
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/bigquery"
+
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
+	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorlib"
+)
+
+type allJobsTableCreatorOptions struct {
+	ciDataClient jobrunaggregatorlib.CIDataClient
+	ciDataSet    *bigquery.Dataset
+}
+
+func (r *allJobsTableCreatorOptions) Run(ctx context.Context) error {
+
+	tableNamesToSchemas := map[string]string{
+		jobrunaggregatorlib.JobsTableName:    jobrunaggregatorapi.JobSchema,
+		jobrunaggregatorlib.TestRunTableName: jobrunaggregatorapi.TestRunsSchema,
+		jobrunaggregatorlib.JobRunTableName:  jobrunaggregatorapi.JobRunSchema,
+	}
+
+	for tableName, tableSchema := range tableNamesToSchemas {
+
+		// Create the table
+		bqTable := r.ciDataSet.Table(tableName)
+		_, err := bqTable.Metadata(ctx)
+		if err != nil {
+			schema, err := bigquery.SchemaFromJSON([]byte(tableSchema))
+			if err != nil {
+				return err
+			}
+			if err := bqTable.Create(ctx, &bigquery.TableMetadata{Schema: schema}); err != nil {
+				return err
+			}
+		} else {
+			fmt.Fprintf(os.Stdout, "table already exists: %s\n", tableName)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Reverts openshift/ci-tools#4096

Seeing errors from job-table-updater

```
Creating jobs from releases
Priming jobs
Inserting 54 jobs
time="2024-05-16T18:30:06.673Z" level=fatal msg="Command failed" error="54 row insertions failed (insertion of row [insertID: \"zRq7MrrxXwJCZAY6gKhNxXx8aha\"; insertIndex: 0] failed with error: {Location: \"\"; Message: \"Missing required fields: Msg_0_CLOUD_QUERY_TABLE.architecture, Msg_0_CLOUD_QUERY_TABLE.fromrelease, Msg_0_CLOUD_QUERY_TABLE.ipmode, Msg_0_CLOUD_QUERY_TABLE.network, Msg_0_CLOUD_QUERY_TABLE.platform, Msg_0_CLOUD_QUERY_TABLE.release, Msg_0_CLOUD_QUERY_TABLE.runse2eparallel, Msg_0_CLOUD_QUERY_TABLE.runse2eserial, Msg_0_CLOUD_QUERY_TABLE.runsupgrade, Msg_0_CLOUD_QUERY_TABLE.topology.\"; Reason: \"invalid\"}, insertion of row [insertID: \"rdnOEFAiHAD0V6IkZI25IAjd8ua\"; insertIndex: 1] failed with error: {Location: \"\"; Message: \"Missing required fields: Msg_0_CLOUD_QUERY_TABLE.architecture, Msg_0_CLOUD_QUERY_TABLE.fromrelease, Msg_0_CLOUD_QUERY_TABLE.ipmode, Msg_0_CLOUD_QUERY_TABLE.network, Msg_0_CLOUD_QUERY_TABLE.platform, Msg_0_CLOUD_QUERY_TABLE.release, Msg_0_CLOUD_QUERY_TABLE.runse2eparallel, Msg_0_CLOUD_QUERY_TABLE.runse2eserial, Msg_0_CLOUD_QUERY_TABLE.runsupgrade, Msg_0_CLOUD_QUERY_TABLE.topology.\"; Reason: \"invalid\"}, insertion of row [insertID: \"8oRswDfSS6YwrMmAt5oZGVUiye0\"; insertIndex: 2] failed with error: {Location: \"\"; Message: \"Missing required fields: Msg_0_CLOUD_QUERY_TABLE.architecture, Msg_0_CLOUD_QUERY_TABLE.fromrelease, Msg_0_CLOUD_QUERY_TABLE.ipmode, Msg_0_CLOUD_QUERY_TABLE.network, Msg_0_CLOUD_QUERY_TABLE.platform, Msg_0_CLOUD_QUERY_TABLE.release, Msg_0_CLOUD_QUERY_TABLE.runse2eparallel, Msg_0_CLOUD_QUERY_TABLE.runse2eserial, Msg_0_CLOUD_QUERY_TABLE.runsupgrade, Msg_0_CLOUD_QUERY_TABLE.topology.\"; Reason: \"invalid\"}, ...)"
```