### PR TITLE
`ci-operator`: Allow for the release of unused BYOIP leases

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -447,7 +447,7 @@ func stepForTest(
 		var ret []api.Step
 		step := multi_stage.MultiStageTestStep(*c, config, params, podClient, jobSpec, leases, nodeName, targetAdditionalSuffix, nil)
 		if ipPoolLease.ResourceType != "" {
-			step = steps.IPPoolStep(leaseClient, ipPoolLease, step, params, jobSpec.Namespace)
+			step = steps.IPPoolStep(leaseClient, podClient, ipPoolLease, step, params, jobSpec.Namespace)
 		}
 		if len(leases) != 0 {
 			step = steps.LeaseStep(leaseClient, leases, step, jobSpec.Namespace)

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -5,9 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
+	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -20,22 +23,23 @@ var NoLeaseClientForIPErr = errors.New("step needs access to an IP pool, but no 
 
 // ipPoolStep wraps another step and acquires/releases chunks of IPs.
 type ipPoolStep struct {
-	client      *lease.Client
-	ipPoolLease stepLease
-	wrapped     api.Step
-	params      api.Parameters
+	client       *lease.Client
+	secretClient ctrlruntimeclient.Client
+	ipPoolLease  stepLease
+	wrapped      api.Step
+	params       api.Parameters
 
-	// for sending heartbeats during pool acquisition
 	namespace func() string
 }
 
-func IPPoolStep(client *lease.Client, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string) api.Step {
+func IPPoolStep(client *lease.Client, secretClient ctrlruntimeclient.Client, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string) api.Step {
 	ret := ipPoolStep{
-		client:      client,
-		wrapped:     wrapped,
-		namespace:   namespace,
-		params:      params,
-		ipPoolLease: stepLease{StepLease: lease},
+		client:       client,
+		secretClient: secretClient,
+		wrapped:      wrapped,
+		namespace:    namespace,
+		params:       params,
+		ipPoolLease:  stepLease{StepLease: lease},
 	}
 	return &ret
 }
@@ -79,10 +83,11 @@ func (s *ipPoolStep) SubTests() []*junit.TestCase {
 }
 
 func (s *ipPoolStep) Run(ctx context.Context) error {
-	return results.ForReason("utilizing_ip_pool").ForError(s.run(ctx))
+	return results.ForReason("utilizing_ip_pool").ForError(s.run(ctx, time.Minute))
 }
 
-func (s *ipPoolStep) run(ctx context.Context) error {
+// minute is provided as an argument to assist with unit testing
+func (s *ipPoolStep) run(ctx context.Context, minute time.Duration) error {
 	l := &s.ipPoolLease
 	region, err := s.params.Get(api.DefaultLeaseEnv)
 	if err != nil || region == "" {
@@ -105,9 +110,68 @@ func (s *ipPoolStep) run(ctx context.Context) error {
 		s.ipPoolLease.resources = names
 	}
 
+	if len(names) > 0 {
+		go s.checkAndReleaseUnusedLeases(ctx, minute)
+	}
+
 	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
 	logrus.Infof("Releasing ip pool leases for test %s", s.Name())
 	releaseErr := results.ForReason("releasing_ip_pool_lease").ForError(releaseLeases(client, *l))
 
 	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
+}
+
+const UnusedIpCount = "UNUSED_IP_COUNT"
+
+// checkAndReleaseUnusedLeases periodically checks for a positive value in the
+// UNUSED_IP_COUNT data in the shared secret which signals that there are leases that can be released.
+// If/when this is discovered it will release that number of leases, and stop checking.
+// minute is provided as an argument to assist with unit testing.
+func (s *ipPoolStep) checkAndReleaseUnusedLeases(ctx context.Context, minute time.Duration) {
+	waitUntil := time.After(minute * 15)
+	sharedDirKey := types.NamespacedName{
+		Namespace: s.namespace(),
+		Name:      s.wrapped.Name(), // This is the name of the shared-dir secret
+	}
+	for range time.Tick(minute) {
+		logrus.Debugf("checking for unused ip-pool leases to release")
+		select {
+		case <-ctx.Done():
+			return
+		case <-waitUntil:
+			logrus.Debugf("timeout to check for unused ip-pool leases has passed, no longer waiting")
+			return
+		default:
+			sharedDirSecret := coreapi.Secret{}
+			if err := s.secretClient.Get(ctx, sharedDirKey, &sharedDirSecret); err != nil {
+				logrus.WithError(err).Warn("could not get shared dir secret")
+				continue
+			}
+			rawCount := string(sharedDirSecret.Data[UnusedIpCount])
+			if rawCount == "" {
+				continue
+			}
+			count, err := strconv.Atoi(rawCount)
+			if err != nil {
+				logrus.WithError(err).Warnf("cannot convert %s contents to int", UnusedIpCount)
+			}
+			logrus.Infof("there are %d unused ip-pool addresses to release", count)
+
+			client := *s.client
+			names := s.ipPoolLease.resources
+			if count > len(names) {
+				logrus.Warnf("requested to release %d ip-pool leases, but only %d have been leased; ignoring request", count, len(names))
+				return
+			}
+			for i := 0; i < count; i++ {
+				name := names[i]
+				logrus.Infof("releasing unused ip-pool lease: %s", name)
+				if err = client.Release(name); err != nil {
+					logrus.WithError(err).Warnf("cannot release ip-pool lease %s", name)
+				}
+			}
+			s.ipPoolLease.resources = names[count:]
+			return
+		}
+	}
 }

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -133,7 +133,9 @@ func (s *ipPoolStep) checkAndReleaseUnusedLeases(ctx context.Context, minute tim
 		Namespace: s.namespace(),
 		Name:      s.wrapped.Name(), // This is the name of the shared-dir secret
 	}
-	for range time.Tick(minute) {
+	ticker := time.NewTicker(minute)
+	defer ticker.Stop()
+	for range ticker.C {
 		logrus.Debugf("checking for unused ip-pool leases to release")
 		select {
 		case <-ctx.Done():

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -64,6 +65,7 @@ func TestProvides(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			tc.step.resourcesLock = &sync.RWMutex{}
 			result := tc.step.Provides()
 			if len(result) != len(tc.expected) {
 				t.Fatalf("resulting parameters (%d) are not the same length as expected (%d)", len(result), len(tc.expected))
@@ -318,6 +320,7 @@ func TestRun(t *testing.T) {
 			client := lease.NewFakeClient("owner", "url", 0, tc.injectFailures, &calls)
 			tc.step.client = &client
 			tc.step.secretClient = podClient
+			tc.step.resourcesLock = &sync.RWMutex{}
 			err := tc.step.run(context.Background(), time.Second)
 			if diff := cmp.Diff(err, tc.expectedError, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("unexpected error returned, diff: %s", diff)

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -3,7 +3,6 @@ package steps
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 	"time"
 
@@ -65,7 +64,6 @@ func TestProvides(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.step.resourcesLock = &sync.RWMutex{}
 			result := tc.step.Provides()
 			if len(result) != len(tc.expected) {
 				t.Fatalf("resulting parameters (%d) are not the same length as expected (%d)", len(result), len(tc.expected))
@@ -320,7 +318,6 @@ func TestRun(t *testing.T) {
 			client := lease.NewFakeClient("owner", "url", 0, tc.injectFailures, &calls)
 			tc.step.client = &client
 			tc.step.secretClient = podClient
-			tc.step.resourcesLock = &sync.RWMutex{}
 			err := tc.step.run(context.Background(), time.Second)
 			if diff := cmp.Diff(err, tc.expectedError, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("unexpected error returned, diff: %s", diff)

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -4,10 +4,17 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
+	coreapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
@@ -90,13 +97,67 @@ func (f fakeStepParams) Get(key string) (string, error) {
 	return f[key], nil
 }
 
+// blockingStep sleeps for 5 seconds to allow testing of the release of unused ip-pool leases
+type blockingStep struct{}
+
+func (blockingStep) Inputs() (api.InputDefinition, error) {
+	return api.InputDefinition{"step", "inputs"}, nil
+}
+func (blockingStep) Validate() error { return nil }
+func (s *blockingStep) Run(ctx context.Context) error {
+	time.Sleep(time.Second * 5)
+	return nil
+}
+
+func (blockingStep) Name() string        { return "blocking" }
+func (blockingStep) Description() string { return "this step needs a lease" }
+func (blockingStep) Requires() []api.StepLink {
+	return []api.StepLink{api.ReleaseImagesLink(api.LatestReleaseName)}
+}
+func (blockingStep) Creates() []api.StepLink { return []api.StepLink{api.ImagesReadyLink()} }
+
+func (blockingStep) Provides() api.ParameterMap {
+	return api.ParameterMap{
+		"parameter": func() (string, error) { return "map", nil },
+	}
+}
+
+func (blockingStep) Objects() []ctrlruntimeclient.Object {
+	return nil
+}
+
+func (blockingStep) SubTests() []*junit.TestCase {
+	ret := junit.TestCase{}
+	return []*junit.TestCase{&ret}
+}
+
 func TestRun(t *testing.T) {
+	ciOpNamespace := "ci-op-1234"
+	podClient := fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(
+		&coreapi.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ciOpNamespace,
+				Name:      "blocking", //The name of the wrapped step
+			},
+			Data: map[string][]byte{
+				UnusedIpCount: []byte("2"),
+			},
+		},
+		&coreapi.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ciOpNamespace,
+				Name:      "needs_lease", //The name of the wrapped step
+			},
+		},
+	).Build()
+
 	testCases := []struct {
 		name           string
 		step           ipPoolStep
 		injectFailures map[string]error
 		expected       []string
 		expectedError  error
+		finalResources []string // Only used to verify the release of unused leases
 	}{
 		{
 			name: "leases available in region",
@@ -110,6 +171,9 @@ func TestRun(t *testing.T) {
 				},
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				namespace: func() string {
+					return ciOpNamespace
+				},
 			},
 			expected: []string{
 				"acquire owner aws-ip-pool-us-east-1 free leased",
@@ -117,6 +181,54 @@ func TestRun(t *testing.T) {
 				"releaseone owner aws-ip-pool-us-east-1_0 free",
 				"releaseone owner aws-ip-pool-us-east-1_1 free",
 			},
+		},
+		{
+			name: "requested to release unused",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        3,
+					},
+				},
+				wrapped: &blockingStep{},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				namespace: func() string {
+					return ciOpNamespace
+				},
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"releaseone owner aws-ip-pool-us-east-1_0 free",
+				"releaseone owner aws-ip-pool-us-east-1_1 free",
+				"releaseone owner aws-ip-pool-us-east-1_2 free",
+			},
+			finalResources: []string{"aws-ip-pool-us-east-1_2"},
+		},
+		{
+			name: "requested to release too many unused",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        1,
+					},
+				},
+				wrapped: &blockingStep{},
+				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				namespace: func() string {
+					return ciOpNamespace
+				},
+			},
+			expected: []string{
+				"acquire owner aws-ip-pool-us-east-1 free leased",
+				"releaseone owner aws-ip-pool-us-east-1_0 free",
+			},
+			finalResources: []string{"aws-ip-pool-us-east-1_0"},
 		},
 		{
 			name: "leases unavailable in region, step should not error",
@@ -130,6 +242,9 @@ func TestRun(t *testing.T) {
 				},
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				namespace: func() string {
+					return ciOpNamespace
+				},
 			},
 			injectFailures: map[string]error{
 				"acquire owner aws-ip-pool-us-east-1 free leased": lease.ErrNotFound,
@@ -184,6 +299,9 @@ func TestRun(t *testing.T) {
 						Count:        1,
 					},
 				},
+				namespace: func() string {
+					return ciOpNamespace
+				},
 				wrapped: &stepNeedsLease{fail: true},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 			},
@@ -199,13 +317,23 @@ func TestRun(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.injectFailures, &calls)
 			tc.step.client = &client
-			err := tc.step.Run(context.Background())
+			tc.step.secretClient = podClient
+			err := tc.step.run(context.Background(), time.Second)
 			if diff := cmp.Diff(err, tc.expectedError, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("unexpected error returned, diff: %s", diff)
 			}
 			if diff := cmp.Diff(calls, tc.expected); diff != "" {
 				t.Fatalf("unexpected calls to the lease client: %s", diff)
 			}
+			// We can check the step's resultant resources to see which leases have been released early.
+			// This works because the final release process when the step is complete leaves the resources in the list,
+			// but the unused release process prunes them from it.
+			if len(tc.finalResources) > 0 {
+				if diff := cmp.Diff(tc.step.ipPoolLease.resources, tc.finalResources); diff != "" {
+					t.Fatalf("unexpected ipPoolLease step resources: %s", diff)
+				}
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
BYOIP automatically leases `13` ip-pool addresses in the appropriate region when using one of the (for now, hardcoded) relevant cluster profiles. In many cases, less than `13` addresses are actually needed. In order to maximize the savings from these ip pools we must provide a way to release unused leases ASAP. There aren't really many ways to do this without a significant re-architecture of `ci-operator`, but this represents the least intrusive way I could imagine. We look for the presence of an `UNUSED_IP_COUNT` item in the shared-dir secret, and if it is populated by an int, we release that number of leases immediately. If this item isn't found within fifteen minutes, then we stop checking for it. The workflow step will have to be updated to store the proper number in a file with the aforementioned name in the shared-dir.

Verified functionality with a [run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-upi-sgoeddel/1791498360352411648) of a special job using my, locally-built, `ci-operator` image.

For: https://issues.redhat.com/browse/DPTP-3929