### PR TITLE
`ci-operator`: trim whitespace from the unused address count

### DIFF
--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -161,6 +162,7 @@ func checkAndReleaseUnusedLeases(ctx context.Context, namespace, testName string
 			if rawCount == "" {
 				continue
 			}
+			rawCount = strings.TrimSpace(rawCount)
 			count, err := strconv.Atoi(rawCount)
 			if err != nil {
 				logrus.WithError(err).Warnf("cannot convert %s contents to int", UnusedIpCount)


### PR DESCRIPTION
Follow up to https://github.com/openshift/ci-tools/pull/4130. This was noticed in the [rehearsal](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52178/rehearse-52178-periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-upi/1792881337972035584)