### PR TITLE
add aws-stackrox cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1333,6 +1333,7 @@ const (
 	ClusterProfileODFAWS                ClusterProfile = "odf-aws"
 	ClusterProfileKonfluxWorkspacesAWS  ClusterProfile = "konfluxworkspaces-aws"
 	ClusterProfileAWSObservabiltity     ClusterProfile = "aws-observability"
+	ClusterProfileAWSStackrox           ClusterProfile = "aws-stackrox"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1373,6 +1374,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
 		ClusterProfileAWSServerless,
+		ClusterProfileAWSStackrox,
 		ClusterProfileAWSTelco,
 		ClusterProfileAWSOpendatahub,
 		ClusterProfileAWSDevfile,
@@ -1505,6 +1507,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSPerfScaleQE,
 		ClusterProfileAWSPerfScaleLRCQE,
 		ClusterProfileAWSServerless,
+		ClusterProfileAWSStackrox,
 		ClusterProfileAWSOutpostQE,
 		ClusterProfileAWSChaos,
 		ClusterProfileAWSTerraformQE,
@@ -1742,6 +1745,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-rhdh-performance-quota-slice"
 	case ClusterProfileAWSServerless:
 		return "aws-serverless-quota-slice"
+	case ClusterProfileAWSStackrox:
+		return "aws-stackrox-quota-slice"
 	case ClusterProfileAWSTelco:
 		return "aws-telco-quota-slice"
 	case ClusterProfileAWSOpendatahub:


### PR DESCRIPTION
https://docs.ci.openshift.org/docs/how-tos/adding-a-cluster-profile/

I added the aws credentials to vault under `selfservice/stackrox-cluster-profile/credentials`
as `aws_access_key_id` and `aws_secret_access_key` alongside the key: `  "secretsync/target-name": "cluster-secrets-aws-stackrox",`