### PR TITLE
ci-operator-config-mirror: disable non ocp promotions

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -255,6 +255,9 @@ func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
 			}
 			promotion.Targets[i].TagByCommit = false // Never use tag_by_commit for mirrored repos
 			promotion.Targets[i].Namespace = privatePromotionNamespace
+		} else {
+			// Disable this target or it will conflict with its non `-priv` counterpart
+			promotion.Targets[i].Disabled = true
 		}
 	}
 }

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -213,6 +213,17 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 			promotion: &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x", Namespace: "ocp", TagByCommit: true}}},
 			expected:  &api.PromotionConfiguration{Targets: []api.PromotionTarget{{Tag: "4.x-priv", Namespace: "ocp-private"}}},
 		},
+		{
+			id: "disable non ocp targets",
+			promotion: &api.PromotionConfiguration{Targets: []api.PromotionTarget{
+				{Tag: "4.x", Namespace: "ocp"},
+				{Tag: "4.x", Namespace: "hypershift"},
+			}},
+			expected: &api.PromotionConfiguration{Targets: []api.PromotionTarget{
+				{Tag: "4.x-priv", Namespace: "ocp-private"},
+				{Tag: "4.x", Namespace: "hypershift", Disabled: true},
+			}},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.id, func(t *testing.T) {


### PR DESCRIPTION
Follow up of https://github.com/openshift/ci-tools/pull/3858. I have lost count how many times I have been reworking it.

`Automate config brancher` ([here](https://github.com/openshift/release/pull/52309)) is failing because of two duplicate promotion targets.
The test `pull-ci-openshift-release-master-ci-operator-config` fails with the following error (check [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52309/pull-ci-openshift-release-master-ci-operator-config/1793251806369812480)):
```
time="2024-05-22T12:06:51Z" level=info msg="Configs reloaded" duration=937.032692ms
time="2024-05-22T12:06:53Z" level=error error="output tag hypershift/hypershift:latest is promoted from more than one place: openshift-priv/hypershift@main, openshift/hypershift@main"
time="2024-05-22T12:06:53Z" level=error error="output tag hypershift/hypershift-operator:latest is promoted from more than one place: openshift-priv/hypershift@main, openshift/hypershift@main"
time="2024-05-22T12:06:53Z" level=fatal msg="error validating configuration files"
```

If we analyze `ci-operator/config/openshift/hypershift/openshift-hypershift-main.yaml` we notice the promotion stanza consists of:
```yaml
promotion:
  to:
  - additional_images:
      hypershift-tests: test-bin
    name: "4.17"
    namespace: ocp
  - additional_images:
      hypershift-operator: hypershift-operator
    excluded_images:
    - '*'
    namespace: hypershift
    tag: latest
```

It then gets mirrored to `ci-operator/config/openshift-priv/hypershift/openshift-priv-hypershift-main.yaml`:
```yaml
promotion:
  to:
  - additional_images:
      hypershift-tests: test-bin
    name: 4.17-priv
    namespace: ocp-private
  - additional_images:
      hypershift-operator: hypershift-operator
    excluded_images:
    - '*'
    namespace: hypershift
    tag: latest
```

The second target is conflicting as those two configurations are promoting images to the same stream `hypershift/*:latest`.

I guess we can solve the problem by disabling any target that doesn't promote to `ocp` stream:
```diff
promotion:
  to:
  - additional_images:
      hypershift-tests: test-bin
    name: 4.17-priv
    namespace: ocp-private
  - additional_images:
      hypershift-operator: hypershift-operator
    excluded_images:
    - '*'
    namespace: hypershift
    tag: latest
+   disabled: true
```