### PR TITLE
`BYOIP`: simplify configurations for other cluster-profiles to utilize

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -23,13 +23,18 @@ func LeasesForTest(s *MultiStageTestConfigurationLiteral) (ret []StepLease) {
 	return
 }
 
+const maxAddressesRequired = 13
+
 func IPPoolLeaseForTest(s *MultiStageTestConfigurationLiteral, metadata Metadata) (ret StepLease) {
-	if p := s.ClusterProfile; p == "aws" { //TODO(sgoeddel): Hardcoded to only work on aws, eventually this will be available as a configuration
-		if branchValidForIPPoolLease(metadata.Branch) {
-			ret = StepLease{
-				ResourceType: p.IPPoolLeaseType(),
-				Env:          DefaultIPPoolLeaseEnv,
-				Count:        13,
+	p := s.ClusterProfile
+	if p != "" {
+		if lt := p.IPPoolLeaseType(); lt != "" {
+			if !p.IPPoolLeaseShouldValidateBranch() || branchValidForIPPoolLease(metadata.Branch) {
+				ret = StepLease{
+					ResourceType: lt,
+					Env:          DefaultIPPoolLeaseEnv,
+					Count:        maxAddressesRequired,
+				}
 			}
 		}
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1946,6 +1946,16 @@ func (p ClusterProfile) IPPoolLeaseType() string {
 	}
 }
 
+// IPPoolLeaseShouldValidateBranch declares whether the ip-pool leases should only be applied to branches matching a
+// specific OpenShift validation model. returns true by default, but should return false for any cluster-profiles
+// that don't want this validation
+func (p ClusterProfile) IPPoolLeaseShouldValidateBranch() bool {
+	switch p {
+	default:
+		return true
+	}
+}
+
 // ConfigMap maps profiles to the ConfigMap they require (if applicable).
 func (p ClusterProfile) ConfigMap() string {
 	switch p {

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/steps/loggingclient"
 )
 
 var NoLeaseClientForIPErr = errors.New("step needs access to an IP pool, but no lease client provided")
@@ -24,7 +25,7 @@ var NoLeaseClientForIPErr = errors.New("step needs access to an IP pool, but no 
 // ipPoolStep wraps another step and acquires/releases chunks of IPs.
 type ipPoolStep struct {
 	client       *lease.Client
-	secretClient ctrlruntimeclient.Client
+	secretClient loggingclient.LoggingClient
 	ipPoolLease  stepLease
 	wrapped      api.Step
 	params       api.Parameters
@@ -32,7 +33,7 @@ type ipPoolStep struct {
 	namespace func() string
 }
 
-func IPPoolStep(client *lease.Client, secretClient ctrlruntimeclient.Client, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string) api.Step {
+func IPPoolStep(client *lease.Client, secretClient loggingclient.LoggingClient, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string) api.Step {
 	ret := ipPoolStep{
 		client:       client,
 		secretClient: secretClient,


### PR DESCRIPTION
Originally, this was hardcoded to only work on the `aws` cluster-profile. This configuration change will make it possible for others to be added as desired. I will be working on adding documentation for this in the cluster-profile area. There is an, in progress, change to cluster-profile configuration that we will be reworking these configs into once it lands.

Also fixed a flaky race condition with the, previously added, unit tests.