### PR TITLE
dptp-cm: disable test_images_distributor by default

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -74,7 +74,7 @@ type options struct {
 }
 
 func (o *options) addDefaults() {
-	o.enabledControllers = flagutil.NewStrings(promotionreconciler.ControllerName, testimagesdistributor.ControllerName)
+	o.enabledControllers = flagutil.NewStrings(promotionreconciler.ControllerName)
 }
 
 type testImagesDistributorOptions struct {


### PR DESCRIPTION
https://issues.redhat.com/browse/DPTP-3998

/cc @openshift/test-platform 

/hold

Will watch the rolling.