### PR TITLE
quay_io_ci_images_distributor: fix the isNotFound function

### DIFF
--- a/pkg/controller/quay_io_ci_images_distributor/oc_quay_io_image_helper.go
+++ b/pkg/controller/quay_io_ci_images_distributor/oc_quay_io_image_helper.go
@@ -166,5 +166,6 @@ func (c *client) ImageInfo(image string, options OCImageInfoOptions) (ImageInfo,
 }
 
 func isNotFound(output []byte) bool {
-	return strings.Contains(string(output), "not found:")
+	o := string(output)
+	return strings.Contains(o, "not found:") || strings.Contains(o, "was deleted or has expired")
 }


### PR DESCRIPTION
```json

{
    "args": "image info quay.io/openshift/ci:ocp-private_4.7-priv_tools --filter-by-os=linux/amd64 --registry-config=/etc/push/.dockerconfigjson --output=json",
    "client": "/usr/bin/oc",
    "component": "ci-images-mirror",
    "error": "exit status 1",
    "file": "/go/src/github.com/openshift/ci-tools/pkg/controller/quay_io_ci_images_distributor/oc_quay_io_image_helper.go:49",
    "func": "github.com/openshift/ci-tools/pkg/controller/quay_io_ci_images_distributor.(*ocExecutor).Run",
    "kubernetes": {
        "container_id": "cri-o://39abd267e18e7ca6905a2bfdf328e076b73862ca0f3300246a5de2feed19cc0c",
        "container_image": "image-registry.openshift-image-registry.svc:5000/ci/ci-images-mirror@sha256:f5f78246a759d4ac4acd956b15beefb3cf9fa2df24c70e6fb1322a51131f6aec",
        "container_name": "ci-images-mirror",
        "namespace_labels": {
            "ci.openshift.io/scale-pods": "true",
            "kubernetes.io/metadata.name": "ci",
            "name": "ci",
            "pod-security.kubernetes.io/audit": "privileged",
            "pod-security.kubernetes.io/audit-version": "v1.24",
            "pod-security.kubernetes.io/warn": "privileged",
            "pod-security.kubernetes.io/warn-version": "v1.24"
        },
        "pod_annotations": {
            "k8s.v1.cni.cncf.io/network-status": "[{\n    \"name\": \"openshift-sdn\",\n    \"interface\": \"eth0\",\n    \"ips\": [\n        \"10.128.2.104\"\n    ],\n    \"default\": true,\n    \"dns\": {}\n}]",
            "openshift.io/scc": "restricted-v2",
            "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
        },
        "pod_ip": "10.128.2.104",
        "pod_ips": [
            "10.128.2.104"
        ],
        "pod_labels": {
            "app": "ci-images-mirror",
            "pod-template-hash": "745b6dcb84"
        },
        "pod_name": "ci-images-mirror-745b6dcb84-g46rh",
        "pod_namespace": "ci",
        "pod_node_name": "ip-10-0-132-76.ec2.internal",
        "pod_owner": "ReplicaSet/ci-images-mirror-745b6dcb84",
        "pod_uid": "098c367b-b85a-4423-aa98-87dfd8d034f4"
    },
    "level": "debug",
    "msg": "Running command failed.",
    "output": "error: unable to read image quay.io/openshift/ci:ocp-private_4.7-priv_tools: unknown: Tag ocp-private_4.7-priv_tools was deleted or has expired. To pull, revive via time machine\n",
    "severity": "debug",
    "source_type": "kubernetes_logs",
    "stream": "stderr",
    "time": "2024-06-04T12:11:40Z"
}
```

Need to handle the case above properly.

/cc @openshift/test-platform 
