### PR TITLE
qci-appci: fix SubjectAccessReviewSpec for human users

### DIFF
--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -413,6 +413,7 @@ func (s *SimpleClusterTokenService) Validate(token string) (bool, error) {
 			User:   username,
 			Groups: tr.Status.User.Groups,
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace:   "ocp",
 				Group:       "image.openshift.io",
 				Version:     "v1",
 				Resource:    "imagestreams",


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/CBN38N3MW/p1717668160958539?thread_ts=1717430173.655359&cid=CBN38N3MW

The user `dmanor ` from `group/infrastructure-operator` cannot access QCI.
The group is on the cluster and the user is included.

I think this is the cause:
https://github.com/openshift/release/blob/master/clusters/app.ci/assets/admin_qci-image-puller_rbac.yaml

The reference role is namespaced (`ocp`) and 

```console
$ oc adm policy who-can get imagestreams -n ocp --as system:admin --subresource layers | grep infrastructure-operator
        infrastructure-operator

$ oc adm policy who-can get imagestreams --as system:admin --subresource layers | grep infrastructure-operator
### returns nothing
```

/cc @openshift/test-platform 