### PR TITLE
Adding new image for ci-operator with ubi base image

### DIFF
--- a/images/ci-operator-minimal/Dockerfile
+++ b/images/ci-operator-minimal/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf install -y git python3
+RUN alternatives --install /usr/bin/python python /usr/bin/python3.9 1
+
+ADD manifest-tool /usr/bin/manifest-tool
+ADD ci-operator /usr/bin/ci-operator
+ENTRYPOINT ["/usr/bin/ci-operator"]


### PR DESCRIPTION
Adding a new image for smooth transition from centos:stream9 to ubi-minimal

/cc @danilo-gemoli @openshift/test-platform 