### PR TITLE
`helpdesk-faq`: add: topic, subject, and body fields to question

### DIFF
--- a/pkg/helpdesk-faq/types.go
+++ b/pkg/helpdesk-faq/types.go
@@ -1,10 +1,16 @@
 package helpdesk_faq
 
 type FaqItem struct {
-	Question  string   `json:"question"`
+	Question  Question `json:"question"`
 	Timestamp string   `json:"timestamp"`
-	Author    string   `json:"author"`
 	Answers   []Answer `json:"answers"`
+}
+
+type Question struct {
+	Author  string `json:"author"`
+	Topic   string `json:"topic"`
+	Subject string `json:"subject"`
+	Body    string `json:"body"`
 }
 
 type Answer struct {


### PR DESCRIPTION
This couples us to the formatting of our workflow in Slack, but it also provides a much better user experience for viewing the FAQ items. The workflow changes very infrequently, so it is worth the coupling.

For: https://issues.redhat.com/browse/DPTP-3521