### PR TITLE
Be more specific on importing

### DIFF
--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -105,11 +105,11 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 		return fmt.Errorf("failed to create imagestreamtag for input image: %w", err)
 	}
 
-	logrus.Debugf("Waiting to import tags on imagestream (after creating pipeline) %s/%s ...", s.jobSpec.Namespace(), api.PipelineImageStream)
-	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), api.PipelineImageStream, nil, sets.New[string](), utils.DefaultImageImportTimeout); err != nil {
-		return fmt.Errorf("failed to wait for importing imagestreamtags on %s/%s: %w", s.jobSpec.Namespace(), api.PipelineImageStream, err)
+	logrus.Debugf("Waiting to import tags on imagestream (after creating pipeline) %s/%s:%s ...", s.jobSpec.Namespace(), api.PipelineImageStream, s.config.To)
+	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), api.PipelineImageStream, nil, sets.New[string](string(s.config.To)), utils.DefaultImageImportTimeout); err != nil {
+		return fmt.Errorf("failed to wait for importing imagestreamtags on %s/%s:%s: %w", s.jobSpec.Namespace(), api.PipelineImageStream, s.config.To, err)
 	}
-	logrus.Debugf("Imported tags on imagestream (after creating pipeline) %s/%s", s.jobSpec.Namespace(), api.PipelineImageStream)
+	logrus.Debugf("Imported tags on imagestream (after creating pipeline) %s/%s:%s", s.jobSpec.Namespace(), api.PipelineImageStream, s.config.To)
 	return nil
 }
 

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -42,6 +42,9 @@ func TestInputImageTagStep(t *testing.T) {
 			Spec: imagev1.ImageStreamSpec{
 				// pipeline:* will now be directly referenceable
 				LookupPolicy: imagev1.ImageLookupPolicy{Local: true},
+				Tags: []imagev1.TagReference{
+					{Name: "TO"},
+				},
 			},
 			Status: imagev1.ImageStreamStatus{
 				PublicDockerImageRepository: "some-reg/target-namespace/pipeline",

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -150,13 +150,13 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 	stable := &imageapi.ImageStream{}
 	logrus.Debugf("Waiting to import tags on imagestream (before creating release) %s/%s ...", s.jobSpec.Namespace(), streamName)
 	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, stable, sets.New("cluster-version-operator", "cli"), utils.DefaultImageImportTimeout); err != nil {
-		return fmt.Errorf("failed to wait for importing imagestreamtags on %s/%s: %w", s.jobSpec.Namespace(), streamName, err)
+		return fmt.Errorf("failed to wait for importing imagestreamtags [cluster-version-operator, cli] on %s/%s: %w", s.jobSpec.Namespace(), streamName, err)
 	}
 	logrus.Debugf("Imported tags on imagestream (before creating release) %s/%s", s.jobSpec.Namespace(), streamName)
 	cvo, _, _ := util.ResolvePullSpec(stable, "cluster-version-operator", true)
 	if cvo == "" {
 		// should never happen
-		return fmt.Errorf("failed to resolve for importing imagestreamtags on %s/%s: %w", s.jobSpec.Namespace(), streamName, err)
+		return fmt.Errorf("failed to resolve for importing imagestreamtags on %s/%s:%s: %w", s.jobSpec.Namespace(), streamName, "cluster-version-operator", err)
 	}
 
 	// we want to expose the release payload as a CI version that looks just like


### PR DESCRIPTION
Improve the error msg like the from [this job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ptp-operator/477/pull-ci-openshift-ptp-operator-master-e2e-aws-ovn/1799749266361552896).

A minor improvement on `input_image_tag` sneaks into this PR: Each run of this step imports only one tag.

/cc @openshift/test-platform 
/assign @deepsm007 