### PR TITLE
ci-op: waitForTagInSpec

### DIFF
--- a/pkg/steps/utils/image.go
+++ b/pkg/steps/utils/image.go
@@ -88,9 +88,9 @@ const DefaultImageImportTimeout = 45 * time.Minute
 
 func getEvaluator(ctx context.Context, client ctrlruntimeclient.Client, ns, name string, tags sets.Set[string]) func(obj runtime.Object) (bool, error) {
 	return func(obj runtime.Object) (bool, error) {
-		checkedTags := sets.New[string]()
 		switch stream := obj.(type) {
 		case *imagev1.ImageStream:
+			checkedTags := sets.New[string]()
 			for i, tag := range stream.Spec.Tags {
 				if tags.Len() > 0 {
 					if tags.Has(tag.Name) {


### PR DESCRIPTION
Saw the error in [this job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/53047/rehearse-53047-pull-ci-openshift-hypershift-main-e2e-aws/1800525084801110016).

```
{"level":"info","msg":"Running [input:root], [input:ocp_4.16_base-rhel9], [input:ocp_builder_rhel-9-golang-1.22-openshift-4.17], [input:openshift_release_rhel-9-release-golang-1.22-openshift-4.17], [input:cli], [input:ocp-4.16-hypershift-operator], [input:ocp-4.14-hypershift-operator], [release:initial], [release-inputs:latest], src, hypershift, hypershift-operator, [output:stable:hypershift-operator], [output:stable:hypershift], [images], test-bin, [release:latest], e2e-aws","time":"2024-06-11T13:48:09Z"}
...
{"level":"info","msg":"Tagging ocp/4.14:hypershift-operator into pipeline:ocp-4.14-hypershift-operator.","time":"2024-06-11T13:48:10Z"}
...
{"level":"debug","msg":"Waiting to import tags on imagestream (after creating pipeline) ci-op-q67k6ndl/pipeline:ocp-4.14-hypershift-operator ...","time":"2024-06-11T13:48:10Z"}
...
"level":"error","msg":"Some steps failed:","time":"2024-06-11T14:11:54Z"}
{"level":"error","msg":"\n  * could not run steps: step [input:ocp-4.14-hypershift-operator] failed: failed to wait for importing imagestreamtags on ci-op-q67k6ndl/pipeline:ocp-4.14-hypershift-operator: failed to import tag(s) [ocp-4.14-hypershift-operator] on image stream ci-op-q67k6ndl/pipeline because of missing definition in the spec","time":"2024-06-11T14:11:54Z"}
{"level":"info","msg":"Reporting job state 'failed' with reason 'executing_graph:step_failed:tagging_input_image'","time":"2024-06-11T14:11:54Z"}
```

Occasionally, it happens that the tag is not in the imagestream's spec after the istag is created.
This PR checks the spec until it does, or timeout on 3 min's of waiting.