### PR TITLE
Use the cli image from QCI

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1148,5 +1148,5 @@ func resolveCLIOverrideImage(architecture api.ReleaseArchitecture, version strin
 		Tag:       "cli",
 	}
 
-	return &coreapi.ObjectReference{Kind: "ImageStreamTag", Namespace: isTagRef.Namespace, Name: fmt.Sprintf("%s:%s", isTagRef.Name, isTagRef.Tag)}, nil
+	return &coreapi.ObjectReference{Kind: "DockerImage", Name: api.QuayImageReference(isTagRef)}, nil
 }


### PR DESCRIPTION
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-upgrade-gcp-ovn-arm64/1800834849221644288
The above job has log

```
ERRO[2024-06-12T11:17:56Z] Some steps failed:                           
ERRO[2024-06-12T11:17:56Z] 
  * could not run steps: step [release:arm64-initial] failed: release "release-images-arm64-initial" failed: pod pending for more than 1h0m0s: containers have not started in 1h0m0.000995278s: release: 
* Container release is not ready with reason ImagePullBackOff and message Back-off pulling image "image-registry.openshift-image-registry.svc:5000/ci-op-wgq4blit/amd64-cli@sha256:8c31318e4269077e1d17ef48e2ee6f7ec965abbcf8da26b2b0e43007f2[86](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-upgrade-gcp-ovn-arm64/1800834849221644288#1:build-log.txt%3A86)e021"

...
* 2024-06-12T10:18:38Z 3x kubelet: Pulling image "image-registry.openshift-image-registry.svc:5000/ci-op-wgq4blit/amd64-cli@sha256:8c31318e4269077e1d17ef48e2ee6f7ec965abbcf8da26b2b0e43007f286e021"
* 2024-06-12T10:18:39Z 3x kubelet: Failed to pull image "image-registry.openshift-image-registry.svc:5000/ci-op-wgq4blit/amd64-cli@sha256:8c31318e4269077e1d17ef48e2ee6f7ec965abbcf8da26b2b0e43007f286e021": reading manifest sha256:8c31318e4269077e1d17ef48e2ee6f7ec965abbcf8da26b2b0e43007f286e021 in image-registry.openshift-image-registry.svc:5000/ci-op-wgq4blit/amd64-cli: unknown: unable to pull manifest from registry.ci.openshift.org/ocp/4.17@sha256:8c31318e4269077e1d17ef48e2ee6f7ec965abbcf8da26b2b0e43007f286e021: manifest unknown: manifest unknown
```

and 

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.17-ocp-e2e-upgrade-gcp-ovn-arm64/1800834849221644288/artifacts/build-resources/imagestreams.json | yq -y '.items[]|select(.metadata.name=="amd64-cli")|.spec.tags[]|select(.name=="latest")|.from'
kind: ImageStreamTag
namespace: ocp
name: 4.17:cli
```

And it is caused by the `cli` image coming from the local cluster which points to an image that does not exists any more on app.ci as we disabled the controller that syncs images from app.ci to build farms.

To fix this issue, we import the image from QCI as we do for other tags, instead of the tag in the local cluster.

/cc @openshift/test-platform 
/assign @deepsm007 
