### PR TITLE
Improve logging for promotion

### DIFF
--- a/pkg/release/candidate/client.go
+++ b/pkg/release/candidate/client.go
@@ -66,11 +66,11 @@ func ResolvePullSpec(client release.HTTPClient, candidate api.Candidate) (string
 }
 
 func ResolvePullSpecCommon(client release.HTTPClient, endpoint string, bounds *api.VersionBounds, relative int) (string, error) {
-	rel, err := ResolveReleaseCommon(client, endpoint, bounds, relative)
+	rel, err := ResolveReleaseCommon(client, endpoint, bounds, relative, false)
 	return rel.PullSpec, err
 }
 
-func ResolveReleaseCommon(client release.HTTPClient, endpoint string, bounds *api.VersionBounds, relative int) (Release, error) {
+func ResolveReleaseCommon(client release.HTTPClient, endpoint string, bounds *api.VersionBounds, relative int, silent bool) (Release, error) {
 	ret := Release{}
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
@@ -87,7 +87,9 @@ func ResolveReleaseCommon(client release.HTTPClient, endpoint string, bounds *ap
 	if s := q.Encode(); s != "" {
 		req.URL.RawQuery = s
 	}
-	logrus.Infof("Requesting a release from %s", req.URL.String())
+	if !silent {
+		logrus.Infof("Requesting a release from %s", req.URL.String())
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return ret, fmt.Errorf("failed to request latest release: %w", err)

--- a/pkg/release/prerelease/client.go
+++ b/pkg/release/prerelease/client.go
@@ -37,7 +37,7 @@ func resolvePullSpec(client release.HTTPClient, endpoint string, bounds api.Vers
 
 func stable4Latest(client release.HTTPClient) (string, error) {
 	endpoint := endpoint(api.Prerelease{ReleaseDescriptor: api.ReleaseDescriptor{Product: api.ReleaseProductOCP, Architecture: api.ReleaseArchitectureAMD64}})
-	rel, err := candidate.ResolveReleaseCommon(client, endpoint, nil, 0)
+	rel, err := candidate.ResolveReleaseCommon(client, endpoint, nil, 0, true)
 	return rel.Name, err
 }
 


### PR DESCRIPTION
```
INFO[2024-06-13T09:47:26Z] Promoting tags to registry.ci.openshift.org/ocp/4.17:${component}: openshift-controller-manager  name=promotion
INFO[2024-06-13T09:47:26Z] Requesting a release from https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest 
INFO[2024-06-13T09:47:31Z] Promoting tags to quay.io/openshift/ci:ocp_4.17_${component}: openshift-controller-manager  name=promotion-quay
INFO[2024-06-13T09:47:[31](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/branch-ci-openshift-openshift-controller-manager-master-images/1801189505684738048#1:build-log.txt%3A31)Z] Requesting a release from https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/4-stable/latest 
INFO[2024-06-13T09:48:22Z] Ran for 57s                                  
INFO[2024-06-13T09:48:22Z] Reporting job state 'succeeded'
```

This PR will remove the log likes with "Requesting a release from ..." for promotion.

/cc @openshift/test-platform 