### PR TITLE
OSASINFRA-3477: openstack: Add new location for OpenStack periodics to Sippy

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -15,6 +15,7 @@ func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 		"periodic-ci-openshift-release-master-okd-",
 		"periodic-ci-shiftstack-shiftstack-ci-main-periodic-",
 		"periodic-ci-shiftstack-shiftstack-ci-main-techpreview-",
+		"periodic-ci-shiftstack-ci-release-",
 		"promote-release-openshift-",
 		"release-openshift-",
 	}


### PR DESCRIPTION
Jobs will be added in https://github.com/openshift/release/pull/53236

We will remove the old locations as a follow-up.