### PR TITLE
OSASINFRA-3477: openstack: Remove legacy location for OpenStack periodics from Sippy

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -13,8 +13,6 @@ func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 		"periodic-ci-openshift-release-master-ci-",
 		"periodic-ci-openshift-release-master-nightly-",
 		"periodic-ci-openshift-release-master-okd-",
-		"periodic-ci-shiftstack-shiftstack-ci-main-periodic-",
-		"periodic-ci-shiftstack-shiftstack-ci-main-techpreview-",
 		"periodic-ci-shiftstack-ci-release-",
 		"promote-release-openshift-",
 		"release-openshift-",


### PR DESCRIPTION
A follow-up to https://github.com/openshift/ci-tools/pull/4182

Depends on https://github.com/openshift/release/pull/53236