### PR TITLE
`helpdesk-faq`: sort replies on upload

### DIFF
--- a/cmd/helpdesk-faq/main.go
+++ b/cmd/helpdesk-faq/main.go
@@ -21,6 +21,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
+const (
+	ci = "ci"
+)
+
 type options struct {
 	logLevel          string
 	port              int
@@ -127,7 +131,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create client")
 	}
-	client := helpdeskfaq.NewCMClient(kubeClient)
+	client := helpdeskfaq.NewCMClient(kubeClient, ci)
 	server := &http.Server{
 		Addr:    ":" + strconv.Itoa(o.port),
 		Handler: router(&client),

--- a/cmd/helpdesk-faq/main.go
+++ b/cmd/helpdesk-faq/main.go
@@ -131,7 +131,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to create client")
 	}
-	client := helpdeskfaq.NewCMClient(kubeClient, ci)
+	client := helpdeskfaq.NewCMClient(kubeClient, ci, logrus.WithField("client", "cm-client"))
 	server := &http.Server{
 		Addr:    ":" + strconv.Itoa(o.port),
 		Handler: router(&client),

--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -59,6 +59,7 @@ type options struct {
 	keywordsConfigPath      string
 	helpdeskAlias           string
 	forumChannelId          string
+	namespace               string
 	requireWorkflowsInForum bool
 }
 
@@ -103,6 +104,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.keywordsConfigPath, "keywords-config-path", "", "Path to the slack-bot keywords config file.")
 	fs.StringVar(&o.helpdeskAlias, "helpdesk-alias", "@dptp-helpdesk", "Alias for helpdesk user(s) beginning with '@'")
 	fs.StringVar(&o.forumChannelId, "forum-channel-id", "CBN38N3MW", "Channel ID for #forum-ocp-testplatform")
+	fs.StringVar(&o.namespace, "namespace", "ci", "Namespace to store helpdesk-faq items")
 	fs.BoolVar(&o.requireWorkflowsInForum, "require-workflows-in-forum", true, "Require the use of workflows in the designated forum channel")
 
 	if err := fs.Parse(args); err != nil {
@@ -198,7 +200,7 @@ func main() {
 	// handle the root to allow for a simple uptime probe
 	mux.Handle("/", handler(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusOK) })))
 	mux.Handle("/slack/interactive-endpoint", handler(handleInteraction(secret.GetTokenGenerator(o.slackSigningSecretPath), interactionrouter.ForModals(issueFiler, slackClient))))
-	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.requireWorkflowsInForum))))
+	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.namespace, o.requireWorkflowsInForum))))
 	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
 
 	health.ServeReady()

--- a/hack/local-slack-bot.sh
+++ b/hack/local-slack-bot.sh
@@ -73,4 +73,4 @@ http_proxy=localhost:7777 https_proxy=localhost:7777 slack-bot --port 6666 \
  --jira-bearer-token-file="${data}/token" --jira-endpoint https://issues.redhat.com \
  --log-level=trace \
  --prow-config-path="${RELEASE_REPO_DIR}/core-services/prow/02_config/_config.yaml" --prow-job-config-path="${RELEASE_REPO_DIR}/ci-operator/jobs" \
- --keywords-config-path="${data}/config.yaml" --helpdesk-alias="${helpdesk_alias}" --forum-channel-id=C01CQ3MA5NX --require-workflows-in-forum="${require_workflows}"
+ --keywords-config-path="${data}/config.yaml" --helpdesk-alias="${helpdesk_alias}" --forum-channel-id=C01CQ3MA5NX --namespace=ci-staging --require-workflows-in-forum="${require_workflows}"

--- a/pkg/helpdesk-faq/client.go
+++ b/pkg/helpdesk-faq/client.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	faqConfigMap = "helpdesk-faq"
-	ci           = "ci"
 )
 
 type FaqItemClient interface {
@@ -25,12 +24,13 @@ type FaqItemClient interface {
 	RemoveItem(timestamp string) error
 }
 
-func NewCMClient(kubeClient ctrlruntimeclient.Client) ConfigMapClient {
-	return ConfigMapClient{kubeClient: kubeClient}
+func NewCMClient(kubeClient ctrlruntimeclient.Client, namespace string) ConfigMapClient {
+	return ConfigMapClient{kubeClient: kubeClient, namespace: namespace}
 }
 
 type ConfigMapClient struct {
 	kubeClient  ctrlruntimeclient.Client
+	namespace   string
 	cachedItems []string
 	lastReload  time.Time
 }
@@ -108,7 +108,7 @@ func (c *ConfigMapClient) RemoveItem(timestamp string) error {
 
 func (c *ConfigMapClient) getConfigMap() (*v1.ConfigMap, error) {
 	configMap := &v1.ConfigMap{}
-	if err := c.kubeClient.Get(context.TODO(), types.NamespacedName{Namespace: ci, Name: faqConfigMap}, configMap); err != nil {
+	if err := c.kubeClient.Get(context.TODO(), types.NamespacedName{Namespace: c.namespace, Name: faqConfigMap}, configMap); err != nil {
 		return nil, fmt.Errorf("failed to get configMap %s: %w", faqConfigMap, err)
 	}
 	return configMap, nil

--- a/pkg/helpdesk-faq/client_test.go
+++ b/pkg/helpdesk-faq/client_test.go
@@ -1,0 +1,52 @@
+package helpdesk_faq
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSortReplies(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		item     FaqItem
+		expected FaqItem
+	}{
+		{
+			name:     "one answer",
+			item:     FaqItem{Answers: []Reply{{Timestamp: "1718288128.952979"}}},
+			expected: FaqItem{Answers: []Reply{{Timestamp: "1718288128.952979"}}},
+		},
+		{
+			name:     "multiple answers out of order",
+			item:     FaqItem{Answers: []Reply{{Timestamp: "1718288129.952979"}, {Timestamp: "1718288118.234567"}, {Timestamp: "1718288112.952976"}}},
+			expected: FaqItem{Answers: []Reply{{Timestamp: "1718288112.952976"}, {Timestamp: "1718288118.234567"}, {Timestamp: "1718288129.952979"}}},
+		},
+		{
+			name:     "multiple contributing info out of order",
+			item:     FaqItem{ContributingInfo: []Reply{{Timestamp: "1718288199.952979"}, {Timestamp: "1718288180.952979"}, {Timestamp: "1718288192.952979"}}},
+			expected: FaqItem{ContributingInfo: []Reply{{Timestamp: "1718288180.952979"}, {Timestamp: "1718288192.952979"}, {Timestamp: "1718288199.952979"}}},
+		},
+		{
+			name: "both out of order",
+			item: FaqItem{
+				ContributingInfo: []Reply{{Timestamp: "1718288199.952979"}, {Timestamp: "1718288180.952979"}, {Timestamp: "1718288192.952979"}},
+				Answers:          []Reply{{Timestamp: "1718288129.952979"}, {Timestamp: "1718288118.234567"}, {Timestamp: "1718288112.952976"}},
+			},
+			expected: FaqItem{
+				ContributingInfo: []Reply{{Timestamp: "1718288180.952979"}, {Timestamp: "1718288192.952979"}, {Timestamp: "1718288199.952979"}},
+				Answers:          []Reply{{Timestamp: "1718288112.952976"}, {Timestamp: "1718288118.234567"}, {Timestamp: "1718288129.952979"}},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := ConfigMapClient{}
+			client.sortReplies(&tc.item)
+			if diff := cmp.Diff(tc.item, tc.expected); diff != "" {
+				t.Fatalf("item doesn't match expected, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/helpdesk-faq/types.go
+++ b/pkg/helpdesk-faq/types.go
@@ -1,9 +1,27 @@
 package helpdesk_faq
 
 type FaqItem struct {
-	Question  Question `json:"question"`
-	Timestamp string   `json:"timestamp"`
-	Answers   []Answer `json:"answers"`
+	Question         Question `json:"question"`
+	Timestamp        string   `json:"timestamp"`
+	ContributingInfo []Reply  `json:"contributing_info"`
+	Answers          []Reply  `json:"answers"`
+}
+
+// ReplyExists takes a timestamp and returns true if the reply at that timestamp is included
+// in the Answers or ContributingInfo on this FaqItem
+func (f FaqItem) ReplyExists(timestamp string) bool {
+	for _, answer := range f.Answers {
+		if answer.Timestamp == timestamp {
+			return true
+		}
+	}
+	for _, contributingInfo := range f.ContributingInfo {
+		if contributingInfo.Timestamp == timestamp {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Question struct {
@@ -13,11 +31,10 @@ type Question struct {
 	Body    string `json:"body"`
 }
 
-type Answer struct {
+type Reply struct {
 	Author    string `json:"author"`
 	Timestamp string `json:"timestamp"`
 	Body      string `json:"body"`
 }
 
-//TODO(sgoeddel): We probably need a "contributing info" emoji and section as well for when the question isn't entirely summarized in one prompt
 //TODO(sgoeddel): It would also be good to link to the original full thread for additional context

--- a/pkg/helpdesk-faq/types_test.go
+++ b/pkg/helpdesk-faq/types_test.go
@@ -1,0 +1,67 @@
+package helpdesk_faq
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReplyExists(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		timestamp string
+		faqItem   FaqItem
+		expected  bool
+	}{
+		{
+			name:      "doesn't exist",
+			timestamp: "2024-06-13T14:00:00Z",
+			faqItem: FaqItem{
+				Answers: []Reply{
+					{
+						Timestamp: "2024-05-13T14:00:00Z",
+					},
+				},
+				ContributingInfo: []Reply{
+					{
+						Timestamp: "2024-05-14T14:00:00Z",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:      "exists as answer",
+			timestamp: "2024-06-13T14:00:00Z",
+			faqItem: FaqItem{
+				Answers: []Reply{
+					{
+						Timestamp: "2024-06-13T14:00:00Z",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:      "exists as contributing info",
+			timestamp: "2024-06-13T14:00:00Z",
+			faqItem: FaqItem{
+				ContributingInfo: []Reply{
+					{
+						Timestamp: "2024-06-13T14:00:00Z",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.faqItem.ReplyExists(tc.timestamp)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Fatalf("expected doesn't match result, diff: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/slack/events/helpdesk/helpdesk-faq.go
+++ b/pkg/slack/events/helpdesk/helpdesk-faq.go
@@ -53,7 +53,7 @@ func FAQHandler(client slackClient, kubeClient ctrlruntimeclient.Client, forumCh
 				return false, nil
 			}
 
-			cmClient := helpdeskfaq.NewCMClient(kubeClient, namespace)
+			cmClient := helpdeskfaq.NewCMClient(kubeClient, namespace, log)
 			event, added := callback.InnerEvent.Data.(*slackevents.ReactionAddedEvent)
 			if added {
 				if event.Item.Channel != forumChannelId {

--- a/pkg/slack/events/helpdesk/helpdesk-faq_test.go
+++ b/pkg/slack/events/helpdesk/helpdesk-faq_test.go
@@ -4,9 +4,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	helpdeskfaq "github.com/openshift/ci-tools/pkg/helpdesk-faq"
 )
 
 func TestFormatItemField(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		input    string
@@ -31,6 +35,70 @@ func TestFormatItemField(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := formatItemField(tc.input)
+			if diff := cmp.Diff(result, tc.expected); diff != "" {
+				t.Fatalf("result doesn't match expected, diff: %s", diff)
+			}
+		})
+	}
+}
+
+func TestRemoveReply(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name      string
+		messageTs string
+		replies   []helpdeskfaq.Reply
+		expected  []helpdeskfaq.Reply
+	}{
+		{
+			name:      "reply doesn't exist",
+			messageTs: "2024-06-13T14:00:00Z",
+			replies: []helpdeskfaq.Reply{
+				{
+					Author:    "U1234",
+					Timestamp: "2024-06-14T14:00:00Z",
+					Body:      "this is the only reply",
+				},
+			},
+			expected: []helpdeskfaq.Reply{
+				{
+					Author:    "U1234",
+					Timestamp: "2024-06-14T14:00:00Z",
+					Body:      "this is the only reply",
+				},
+			},
+		},
+		{
+			name:      "reply exists",
+			messageTs: "2024-06-13T14:00:00Z",
+			replies: []helpdeskfaq.Reply{
+				{
+					Author:    "U1234",
+					Timestamp: "2024-06-13T14:00:00Z",
+					Body:      "this is a reply",
+				},
+				{
+					Author:    "U1234",
+					Timestamp: "2024-06-14T14:00:00Z",
+					Body:      "and another one",
+				},
+			},
+			expected: []helpdeskfaq.Reply{
+				{
+					Author:    "U1234",
+					Timestamp: "2024-06-14T14:00:00Z",
+					Body:      "and another one",
+				},
+			},
+		},
+		{
+			name:      "no replies",
+			messageTs: "2024-06-13T14:00:00Z",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := removeReply(tc.messageTs, tc.replies, logrus.NewEntry(logrus.New()))
 			if diff := cmp.Diff(result, tc.expected); diff != "" {
 				t.Fatalf("result doesn't match expected, diff: %s", diff)
 			}

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -15,10 +15,10 @@ import (
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId string, requireWorkflowsInForum bool) events.Handler {
+func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId, namespace string, requireWorkflowsInForum bool) events.Handler {
 	return events.MultiHandler(
 		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, requireWorkflowsInForum),
-		helpdesk.FAQHandler(client, kubeClient, forumChannelId),
+		helpdesk.FAQHandler(client, kubeClient, forumChannelId, namespace),
 		mention.Handler(client),
 		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),
 	)


### PR DESCRIPTION
Answers and Contributing Info should be sorted ascending by timestamp. I took the approach of sorting them when the faq-item is added or modified.

For: https://issues.redhat.com/browse/DPTP-3521

/hold Builds on https://github.com/openshift/ci-tools/pull/4180, merge this after