### PR TITLE
install git for job-run-aggregator for weekly disruption PR

### DIFF
--- a/images/job-run-aggregator/Dockerfile
+++ b/images/job-run-aggregator/Dockerfile
@@ -3,4 +3,5 @@ LABEL maintainer="deads@redhat.com"
 
 ADD job-run-aggregator /usr/bin/job-run-aggregator
 ADD prcreator /usr/bin/prcreator
+RUN dnf install -y git
 ENTRYPOINT ["/usr/bin/job-run-aggregator"]


### PR DESCRIPTION
The latest [weekly PR run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-update-origin-disruption-alert-data/1801419585887408128) shows:

```
failed to check for changes: running command git [status --porcelain]: exec: \"git\": executable file not found in $PATH
```

indicating the `git` executable needs to be installed.