### PR TITLE
Remove gcp-40 cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1272,7 +1272,6 @@ const (
 	ClusterProfileGCPArm64              ClusterProfile = "gcp-arm64"
 	ClusterProfileGCP                   ClusterProfile = "gcp"
 	ClusterProfileGCP3                  ClusterProfile = "gcp-3"
-	ClusterProfileGCP40                 ClusterProfile = "gcp-40"
 	ClusterProfileGCPHA                 ClusterProfile = "gcp-ha"
 	ClusterProfileGCPCRIO               ClusterProfile = "gcp-crio"
 	ClusterProfileGCPLogging            ClusterProfile = "gcp-logging"
@@ -1414,7 +1413,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileGCP,
 		ClusterProfileGCP2,
 		ClusterProfileGCP3,
-		ClusterProfileGCP40,
 		ClusterProfileGCPCRIO,
 		ClusterProfileGCPHA,
 		ClusterProfileGCPLogging,
@@ -1596,7 +1594,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileGCPArm64,
 		ClusterProfileGCP,
 		ClusterProfileGCP3,
-		ClusterProfileGCP40,
 		ClusterProfileGCPHA,
 		ClusterProfileGCPCRIO,
 		ClusterProfileGCPLogging,
@@ -1825,7 +1822,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "gcp-arm64-quota-slice"
 	case
 		ClusterProfileGCP,
-		ClusterProfileGCP40,
 		ClusterProfileGCPHA,
 		ClusterProfileGCPCRIO,
 		ClusterProfileGCPLogging,
@@ -2008,7 +2004,6 @@ func (p ClusterProfile) ConfigMap() string {
 		ClusterProfileGCP,
 		ClusterProfileGCP2,
 		ClusterProfileGCP3,
-		ClusterProfileGCP40,
 		ClusterProfileGCPCRIO,
 		ClusterProfileGCPHA,
 		ClusterProfileGCPLogging,
@@ -2033,7 +2028,6 @@ func (p ClusterProfile) Secret() string {
 		ClusterProfileAWSCentos40,
 		ClusterProfileAWSGluster,
 		ClusterProfileAWSOutpost,
-		ClusterProfileGCP40,
 		ClusterProfileGCPCRIO,
 		ClusterProfileGCPHA,
 		ClusterProfileGCPLogging,


### PR DESCRIPTION
Removing possibly deprecated gcp-40 cluster profile.
/cc @droslean @vrutkovs 

/hold
Associated config map in relese repo is being removed in: https://github.com/openshift/release/pull/53299
