### PR TITLE
Adding missing commands

### DIFF
--- a/images/ci-operator/Dockerfile
+++ b/images/ci-operator/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-RUN microdnf install -y git python3
+RUN microdnf install -y git python3 findutils tar jq
 
 ADD manifest-tool /usr/bin/manifest-tool
 ADD ci-operator /usr/bin/ci-operator


### PR DESCRIPTION
The clusterbot runs custom `ci-operator` scripts that utilize a handful of commands that were lost with: https://github.com/openshift/ci-tools/pull/4160.  
For reference:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1804072048717205504
This PR adds the commands that should allow our scripts to run again.