### PR TITLE
add tools to `pr-reminder` image

### DIFF
--- a/images/pr-reminder/Dockerfile
+++ b/images/pr-reminder/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL maintainer="sgoeddel@redhat.com"
 
+RUN microdnf install -y tar gzip
+
 ADD pr-reminder /usr/bin/pr-reminder
 ENTRYPOINT ["/usr/bin/pr-reminder"]


### PR DESCRIPTION
`ubi-minimal` doesn't contain tar or gzip. I tested this by using a locally built image to run the job.