### PR TITLE
`autoowners`: prune '@' from OWNERS file contents

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -191,6 +191,8 @@ func getOwnersHTTP(fg FileGetter, orgRepo orgRepo, filenames ownersconfig.Filena
 			}
 			return httpResult, err
 		}
+		// some OWNERS files (especially upstream ones) can have the '@' symbol in front of usernames, this will not load properly and should be pruned
+		data = []byte(strings.ReplaceAll(string(data), "@", ""))
 
 		switch filename {
 		case filenames.Owners:


### PR DESCRIPTION
Some upstream files include this in front of usernames. It makes it so that the file cannot be loaded as yaml as there are no quotes around the names. We can just remove the symbol to make the files valid.

Note: the ignore-repo logic still attempts to load the file in one confusing case even if it is set to ignore all 3 directories for the repo. I am going to look into fixing and simplifying this logic in a follow up.

For: https://issues.redhat.com/browse/DPTP-4061