### PR TITLE
`autoowners`: changes the functionality of the 'ignore-repo' argument

### DIFF
--- a/cmd/autoowners/main_test.go
+++ b/cmd/autoowners/main_test.go
@@ -594,7 +594,7 @@ func TestLoadRepos(t *testing.T) {
 			ConfigSubDirs: []string{"jobs", "config", "templates"},
 			GitHubOrg:     "openshift",
 			GitHubRepo:    "release",
-			Blocklist:     blocklist{directories: sets.New[string]("testdata/test2/templates/openshift/installer")},
+			Blocklist:     blocklist{repos: sets.New[string]("openshift/installer")},
 			ExpectedRepos: []orgRepo{
 				{
 					Directories: []string{
@@ -603,15 +603,6 @@ func TestLoadRepos(t *testing.T) {
 					},
 					Organization: "kubevirt",
 					Repository:   "kubevirt",
-				},
-				{
-					Directories: []string{
-						"testdata/test2/jobs/openshift/installer",
-						"testdata/test2/config/openshift/installer",
-						// "testdata/test2/templates/openshift/installer", // not present due to blocklist
-					},
-					Organization: "openshift",
-					Repository:   "installer",
 				},
 			},
 		},


### PR DESCRIPTION
It used to be a misnomer, and actually expect a directory path to ignore. I believe this was to allow the possibility for files to be synced for some dirs, but not others. In practice, this wasn't being used this way and each of the directory paths were passed for each repo. The one exception was a 'template' path, which is irrelevant and deprecated anyway.

Follow up to https://github.com/openshift/ci-tools/pull/4199

I will change the job config file in a follow up shortly.

/cc @hongkailiu @openshift/test-platform 