### PR TITLE
Add default secret logic for cluster profiles

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1997,6 +1997,11 @@ func (p ClusterProfile) Secret() string {
 	return fmt.Sprintf("cluster-secrets-%s", name)
 }
 
+// GetClusterProfileSecret returns the default secret name for the profile
+func GetClusterProfileSecret(profile ClusterProfile) string {
+	return fmt.Sprintf("cluster-secrets-%s", string(profile))
+}
+
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1997,8 +1997,8 @@ func (p ClusterProfile) Secret() string {
 	return fmt.Sprintf("cluster-secrets-%s", name)
 }
 
-// GetClusterProfileSecret returns the default secret name for the profile
-func GetClusterProfileSecret(profile ClusterProfile) string {
+// GetDefaultClusterProfileSecretName returns the default secret name for the profile
+func GetDefaultClusterProfileSecretName(profile ClusterProfile) string {
 	return fmt.Sprintf("cluster-secrets-%s", string(profile))
 }
 

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -286,7 +286,7 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 	return mergedMap, nil
 }
 
-// ClusterClaimOwnersConfig ClusterClaimsOwnersConfig loads cluster claim owners information from its config in the release repository
+// ClusterClaimOwnersConfig loads cluster claim owners information from its config in the release repository
 func ClusterClaimOwnersConfig(configPath string) (api.ClusterClaimOwnersMap, error) {
 	configContents, err := os.ReadFile(configPath)
 	if err != nil {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -255,32 +255,38 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 		return nil, fmt.Errorf("failed to read cluster profiles config: %w", err)
 	}
 
-	var profileOwnersList api.ClusterProfilesList
-	if err = yaml.Unmarshal(configContents, &profileOwnersList); err != nil {
+	var profilesFromConfig api.ClusterProfilesList
+	if err = yaml.Unmarshal(configContents, &profilesFromConfig); err != nil {
 		return nil, fmt.Errorf("failed to unmarshall file %v. Please check that the formatting in the file is correct. Full error: %w", configPath, err)
 	}
 
 	// TODO: The following code can be erased once profiles are completely moved
 	// from code in ci-tools to the config file in openshift/release
-	profileOwnersMap := make(api.ClusterProfilesMap)
-	for _, p := range profileOwnersList {
-		profileOwnersMap[p.Profile] = p
+	profilesFromConfigMap := make(api.ClusterProfilesMap)
+	for _, p := range profilesFromConfig {
+		profilesFromConfigMap[p.Profile] = p
 	}
 
 	mergedMap := make(api.ClusterProfilesMap)
 	for _, profileName := range api.ClusterProfiles() {
-		profile, found := profileOwnersMap[profileName]
+		profile, found := profilesFromConfigMap[profileName]
 		if found {
+			if profile.Secret == "" {
+				profile.Secret = api.GetClusterProfileSecret(profileName) // get the default secret name
+			}
 			mergedMap[profileName] = profile
 		} else {
-			mergedMap[profileName] = api.ClusterProfileDetails{Profile: profileName}
+			mergedMap[profileName] = api.ClusterProfileDetails{
+				Profile: profileName,
+				Secret:  api.GetClusterProfileSecret(profileName),
+			}
 		}
 	}
 
 	return mergedMap, nil
 }
 
-// ClusterClaimsOwnersConfig loads cluster claim owners information from its config in the release repository
+// ClusterClaimOwnersConfig ClusterClaimsOwnersConfig loads cluster claim owners information from its config in the release repository
 func ClusterClaimOwnersConfig(configPath string) (api.ClusterClaimOwnersMap, error) {
 	configContents, err := os.ReadFile(configPath)
 	if err != nil {

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -272,13 +272,13 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 		profile, found := profilesFromConfigMap[profileName]
 		if found {
 			if profile.Secret == "" {
-				profile.Secret = api.GetClusterProfileSecret(profileName) // get the default secret name
+				profile.Secret = api.GetDefaultClusterProfileSecretName(profileName)
 			}
 			mergedMap[profileName] = profile
 		} else {
 			mergedMap[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
-				Secret:  api.GetClusterProfileSecret(profileName),
+				Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -271,6 +271,7 @@ func TestClusterProfilesConfig(t *testing.T) {
 	for _, profileName := range api.ClusterProfiles() {
 		existingProfiles[profileName] = api.ClusterProfileDetails{
 			Profile: profileName,
+			Secret:  api.GetClusterProfileSecret(profileName),
 		}
 	}
 
@@ -280,15 +281,39 @@ func TestClusterProfilesConfig(t *testing.T) {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
 				Owners:  []api.ClusterProfileOwners{{Org: "org1"}},
+				Secret:  api.GetClusterProfileSecret(profileName),
 			}
 		} else if profileName == "aws-2" {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
 				Owners:  []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				Secret:  api.GetClusterProfileSecret(profileName),
 			}
 		} else {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
+				Secret:  api.GetClusterProfileSecret(profileName),
+			}
+		}
+	}
+
+	profilesWithSecrets := make(api.ClusterProfilesMap)
+	for _, profileName := range api.ClusterProfiles() {
+		if profileName == "aws-2" {
+			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
+				Profile: profileName,
+				Owners:  []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
+				Secret:  "non-default-secret-name-aws",
+			}
+		} else if profileName == "vsphere-connected-2" {
+			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
+				Profile: profileName,
+				Secret:  "non-default-secret-name-vsphere",
+			}
+		} else {
+			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
+				Profile: profileName,
+				Secret:  api.GetClusterProfileSecret(profileName),
 			}
 		}
 	}
@@ -325,6 +350,22 @@ func TestClusterProfilesConfig(t *testing.T) {
         - profile: aws-2
     `,
 			expected: existingProfiles,
+		},
+		{
+			name: "profiles with owners and secrets",
+			testYaml: `
+        - profile: aws
+        - profile: aws-2
+          owners:
+            - org: org2
+              repos:
+                - repo1
+                - repo2
+          secret: non-default-secret-name-aws
+        - profile: vsphere-connected-2
+          secret: non-default-secret-name-vsphere
+    `,
+			expected: profilesWithSecrets,
 		},
 	}
 

--- a/pkg/load/load_test.go
+++ b/pkg/load/load_test.go
@@ -271,7 +271,7 @@ func TestClusterProfilesConfig(t *testing.T) {
 	for _, profileName := range api.ClusterProfiles() {
 		existingProfiles[profileName] = api.ClusterProfileDetails{
 			Profile: profileName,
-			Secret:  api.GetClusterProfileSecret(profileName),
+			Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 		}
 	}
 
@@ -281,18 +281,18 @@ func TestClusterProfilesConfig(t *testing.T) {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
 				Owners:  []api.ClusterProfileOwners{{Org: "org1"}},
-				Secret:  api.GetClusterProfileSecret(profileName),
+				Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		} else if profileName == "aws-2" {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
 				Owners:  []api.ClusterProfileOwners{{Org: "org2", Repos: []string{"repo1", "repo2"}}},
-				Secret:  api.GetClusterProfileSecret(profileName),
+				Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		} else {
 			profilesWithOwners[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
-				Secret:  api.GetClusterProfileSecret(profileName),
+				Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}
@@ -313,7 +313,7 @@ func TestClusterProfilesConfig(t *testing.T) {
 		} else {
 			profilesWithSecrets[profileName] = api.ClusterProfileDetails{
 				Profile: profileName,
-				Secret:  api.GetClusterProfileSecret(profileName),
+				Secret:  api.GetDefaultClusterProfileSecretName(profileName),
 			}
 		}
 	}


### PR DESCRIPTION
Implemented new logic; when loading cluster profiles from their [config file](https://github.com/openshift/release/blob/master/ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml), we autogenerate the secret name for each cluster profile. If a profile had the secret field defined in the config, we will use that one (this is mainly for keeping backwards compatibility with a few  derivative cluster profiles that don't follow the naming convention; I added those to the config file in https://github.com/openshift/release/pull/53787). 

The result of this is that `config-resolver` will be able to provide the secret for each cluster profile. 
Now:
```
$ curl "https://config.ci.openshift.org/clusterProfile?name=packet"
{
  "profile": "packet"
}
```
After this PR merges:
```
$ curl "https://config.ci.openshift.org/clusterProfile?name=packet"
{
  "profile": "packet",
  "secret": "cluster-secrets-packet"
}
```
/cc @droslean @smg247 