### PR TITLE
github-ldap-user-group-creator: include a group with all rover usernames

### DIFF
--- a/cmd/github-ldap-user-group-creator/main.go
+++ b/cmd/github-ldap-user-group-creator/main.go
@@ -418,7 +418,9 @@ func makeGroups(openshiftPrivAdmins sets.Set[string], peribolosConfig string, ma
 		}
 	}
 
+	roverUsers := sets.New[string]()
 	for k, v := range roverGroups {
+		roverUsers.Insert(v...)
 		oldGroupName := k
 		groupName := k
 		clustersForRoverGroup := clusters
@@ -449,6 +451,14 @@ func makeGroups(openshiftPrivAdmins sets.Set[string], peribolosConfig string, ma
 				Users:      sets.List(sets.New[string](v...).Delete("")),
 			},
 		}
+	}
+
+	groups[api.AllRoverUsersGroupName] = GroupClusters{
+		Clusters: clusters,
+		Group: &userv1.Group{
+			ObjectMeta: metav1.ObjectMeta{Name: api.AllRoverUsersGroupName, Labels: map[string]string{api.DPTPRequesterLabel: toolName}},
+			Users:      sets.List(roverUsers),
+		},
 	}
 	return groups, kerrors.NewAggregate(errs)
 }

--- a/cmd/github-ldap-user-group-creator/main_test.go
+++ b/cmd/github-ldap-user-group-creator/main_test.go
@@ -108,6 +108,16 @@ func TestMakeGroups(t *testing.T) {
 						Users: userv1.OptionalNames{"y"},
 					},
 				},
+				"redhat-rover-users": {
+					Clusters: sets.New[string]("app.ci", "build01", "build02", "hosted-mgmt"),
+					Group: &userv1.Group{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "redhat-rover-users",
+							Labels: map[string]string{"dptp.openshift.io/requester": "github-ldap-user-group-creator"},
+						},
+						Users: userv1.OptionalNames{"b", "c", "y"},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
This change will allow the tool to create the group `redhat-rover-users` to all clusters that will hold ALL rover users. 

/cc @openshift/test-platform @hongkailiu 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
