### PR TITLE
`slack-bot`: fix review request workflow response

### DIFF
--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -59,6 +59,7 @@ type options struct {
 	keywordsConfigPath      string
 	helpdeskAlias           string
 	forumChannelId          string
+	reviewRequestWorkflowID string
 	namespace               string
 	requireWorkflowsInForum bool
 }
@@ -104,6 +105,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.keywordsConfigPath, "keywords-config-path", "", "Path to the slack-bot keywords config file.")
 	fs.StringVar(&o.helpdeskAlias, "helpdesk-alias", "@dptp-helpdesk", "Alias for helpdesk user(s) beginning with '@'")
 	fs.StringVar(&o.forumChannelId, "forum-channel-id", "CBN38N3MW", "Channel ID for #forum-ocp-testplatform")
+	fs.StringVar(&o.reviewRequestWorkflowID, "review-request-workflow-id", "B06T46F374N", "ID for the 'Review Request' slack workflow")
 	fs.StringVar(&o.namespace, "namespace", "ci", "Namespace to store helpdesk-faq items")
 	fs.BoolVar(&o.requireWorkflowsInForum, "require-workflows-in-forum", true, "Require the use of workflows in the designated forum channel")
 
@@ -200,7 +202,7 @@ func main() {
 	// handle the root to allow for a simple uptime probe
 	mux.Handle("/", handler(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusOK) })))
 	mux.Handle("/slack/interactive-endpoint", handler(handleInteraction(secret.GetTokenGenerator(o.slackSigningSecretPath), interactionrouter.ForModals(issueFiler, slackClient))))
-	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.namespace, o.requireWorkflowsInForum))))
+	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.reviewRequestWorkflowID, o.namespace, o.requireWorkflowsInForum))))
 	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
 
 	health.ServeReady()

--- a/pkg/slack/events/helpdesk/helpdesk-message_test.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message_test.go
@@ -86,6 +86,7 @@ func TestGetPresentKeywords(t *testing.T) {
 }
 
 func TestGetContactedHelpdeskResponse(t *testing.T) {
+	reviewRequestWorkflow := "1234"
 	testCases := []struct {
 		name  string
 		botId string
@@ -106,7 +107,7 @@ func TestGetContactedHelpdeskResponse(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual := getContactedHelpdeskResponse(testCase.botId)
+			actual := getContactedHelpdeskResponse(testCase.botId, reviewRequestWorkflow)
 			testhelper.CompareWithFixture(t, actual)
 		})
 	}

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -15,9 +15,9 @@ import (
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId, namespace string, requireWorkflowsInForum bool) events.Handler {
+func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId, reviewRequestWorkflowID, namespace string, requireWorkflowsInForum bool) events.Handler {
 	return events.MultiHandler(
-		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, requireWorkflowsInForum),
+		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, reviewRequestWorkflowID, requireWorkflowsInForum),
 		helpdesk.FAQHandler(client, kubeClient, forumChannelId, namespace),
 		mention.Handler(client),
 		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),


### PR DESCRIPTION
The bot ID changed recently. Since this can change, we should make it configurable while updating the default to the new ID.