### PR TITLE
fix linter issue

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  timeout: 10m
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,6 @@ run:
 linters:
   enable:
     - unused
-    - deadcode
     - gosimple
     - gofmt
     - govet

--- a/cmd/qci-appci/main.go
+++ b/cmd/qci-appci/main.go
@@ -390,7 +390,10 @@ func (s *SimpleClusterTokenService) Validate(token string) (bool, error) {
 	t := time.Now()
 	var username string
 	var ret bool
-	defer s.logger.WithField("username", username).WithField("validated", ret).WithField("duration", time.Since(t)).Debug("Validated token")
+	defer func() {
+		duration := time.Since(t)
+		s.logger.WithField("username", username).WithField("validated", ret).WithField("duration", duration).Debug("Validated token")
+	}()
 	tr := &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{
 			Token: token,


### PR DESCRIPTION
It looks like the linter isn't sophisticated enough to handle this one as is:
```
cmd/qci-appci/main.go:393:99: defers: call to time.Since is not deferred (govet)
	defer s.logger.WithField("username", username).WithField("validated", ret).WithField("duration", time.Since(t)).Debug("Validated token")
```

Also, removes the deprecated 'deadcode' linter whose existence is throwing an error message, and updates to use the new 'timeout' param