### PR TITLE
`ci-operator`: pass `ORIGINAL_*` env vars to the multi-stage steps

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -156,6 +156,18 @@ func fromConfig(
 	params.Add("JOB_NAME_SAFE", func() (string, error) { return strings.Replace(jobSpec.Job, "_", "-", -1), nil })
 	params.Add("UNIQUE_HASH", func() (string, error) { return jobSpec.UniqueHash(), nil })
 	params.Add("NAMESPACE", func() (string, error) { return jobSpec.Namespace(), nil })
+	// when provided, RELEASE_IMAGE_INITIAL and RELASE_IMAGE_LATEST will be overwritten when resolving the respective releases.
+	// some multi-stage steps need the original values of these env vars, so we set them on respective ORIGINAL_* vars
+	for _, name := range []string{api.InitialReleaseName, api.LatestReleaseName} {
+		envVar := utils.ReleaseImageEnv(name)
+		val, err := params.Get(envVar)
+		if err != nil {
+			logrus.WithError(err).Warnf("couldn't get env var for: %s", name)
+		} else if val != "" {
+			logrus.Debugf("setting original value of overridden release image to env var for: %s", name)
+			params.Add(fmt.Sprintf("ORIGINAL_%s", envVar), func() (string, error) { return val, nil })
+		}
+	}
 	inputImages := make(inputImageSet)
 	var overridableSteps, buildSteps, postSteps []api.Step
 	var imageStepLinks []api.StepLink

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1423,9 +1423,10 @@ func TestFromConfig(t *testing.T) {
 			"[images]",
 		},
 		expectedParams: map[string]string{
-			"IMAGE_FORMAT":          "public_docker_image_repository/ns/stable:${component}",
-			"RELEASE_IMAGE_INITIAL": "public_docker_image_repository:initial",
-			"RELEASE_IMAGE_LATEST":  "public_docker_image_repository:latest",
+			"IMAGE_FORMAT":                  "public_docker_image_repository/ns/stable:${component}",
+			"RELEASE_IMAGE_INITIAL":         "public_docker_image_repository:initial",
+			"RELEASE_IMAGE_LATEST":          "public_docker_image_repository:latest",
+			"ORIGINAL_RELEASE_IMAGE_LATEST": "latest",
 		},
 	}, {
 		name: "resolve release",
@@ -1457,6 +1458,29 @@ func TestFromConfig(t *testing.T) {
 		expectedSteps: []string{"[release:release]", "[images]"},
 		expectedParams: map[string]string{
 			utils.ReleaseImageEnv("release"): "public_docker_image_repository:release",
+		},
+	}, {
+		name: "resolve initial and latest with input, original vals are set",
+		config: api.ReleaseBuildConfiguration{
+			InputConfiguration: api.InputConfiguration{
+				Releases: map[string]api.UnresolvedRelease{
+					"initial": {Release: &api.Release{Version: "4.0.9"}},
+					"latest":  {Release: &api.Release{Version: "4.1.0"}},
+				},
+			},
+		},
+		env: environmentOverride{
+			m: map[string]string{
+				utils.ReleaseImageEnv("initial"): "initial",
+				utils.ReleaseImageEnv("latest"):  "latest",
+			},
+		},
+		expectedSteps: []string{"[release:initial]", "[release:latest]", "[images]"},
+		expectedParams: map[string]string{
+			utils.ReleaseImageEnv("initial"): "public_docker_image_repository:initial",
+			utils.ReleaseImageEnv("latest"):  "public_docker_image_repository:latest",
+			"ORIGINAL_RELEASE_IMAGE_INITIAL": "initial",
+			"ORIGINAL_RELEASE_IMAGE_LATEST":  "latest",
 		},
 	}, {
 		name: "container test",

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -228,6 +228,17 @@ func TestEnvironment(t *testing.T) {
 				"IM_A_POWERUSER": "nope you are not",
 			},
 		},
+		{
+			name: "ORIGINAL_* variables are exposed in environment",
+			params: fakeStepParams{
+				"ORIGINAL_RELEASE_IMAGE_INITIAL": "initial",
+				"ORIGINAL_RELEASE_IMAGE_LATEST":  "latest",
+			},
+			expected: []coreapi.EnvVar{
+				{Name: "ORIGINAL_RELEASE_IMAGE_INITIAL", Value: "initial"},
+				{Name: "ORIGINAL_RELEASE_IMAGE_LATEST", Value: "latest"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This is necessary so steps can use the original values when `RELEASE_IMAGE_INITIAL` and/or `RELEASE_IMAGE_LATEST` env vars are provided. These values get overwritten when resolving the release, so we must provide alternatives to use in the steps.

For: https://issues.redhat.com/browse/DPTP-4070