### PR TITLE
`prowgen`: allow the ability to configure the slack reporter config

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -130,9 +130,9 @@ func validateProwgenConfig(pConfig *Prowgen) error {
 			for _, job := range sc.JobNames {
 				if jobsSeen.Has(job) {
 					errs = append(errs, fmt.Errorf("job: %s exists in multiple slack_reporter_configs, it should only be in one", job))
-				} else {
-					jobsSeen.Insert(job)
+					continue
 				}
+				jobsSeen.Insert(job)
 			}
 		}
 	}

--- a/pkg/jobconfig/files.go
+++ b/pkg/jobconfig/files.go
@@ -527,7 +527,11 @@ func mergePeriodics(old, new *prowconfig.Periodic) prowconfig.Periodic {
 	merged := *new
 
 	merged.MaxConcurrency = old.MaxConcurrency
-	merged.ReporterConfig = old.ReporterConfig
+	//TODO(sgoeddel): We will keep this functionality for backwards-compatibility.
+	// Eventually, we should only allow the reporter_config to be set through prowgen configuration
+	if old.ReporterConfig != nil && merged.ReporterConfig == nil {
+		merged.ReporterConfig = old.ReporterConfig
+	}
 	if old.Cluster != "" {
 		merged.Cluster = old.Cluster
 	}

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -139,6 +139,17 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	if testContainsLease(&test) {
 		p.PodSpec.Add(LeaseClient())
 	}
+	if slackReporter := info.Config.GetSlackReporterConfigForTest(test.As); slackReporter != nil {
+		if p.base.ReporterConfig == nil {
+			p.base.ReporterConfig = &prowv1.ReporterConfig{}
+		}
+		p.base.ReporterConfig.Slack = &prowv1.SlackReporterConfig{
+			Channel:           slackReporter.Channel,
+			JobStatesToReport: slackReporter.JobStatesToReport,
+			ReportTemplate:    slackReporter.ReportTemplate,
+		}
+
+	}
 
 	switch {
 	case test.MultiStageTestConfigurationLiteral != nil:

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_with_slack_reporter_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_with_slack_reporter_config.yaml
@@ -1,0 +1,50 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-unit
+reporter_config:
+  slack:
+    channel: some-channel
+    job_states_to_report:
+    - error
+    report_template: some template
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=unit
+    command:
+    - ci-operator
+    image: ci-operator:latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/input/config/slack-report/duper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/slack-report/duper/.config.prowgen
@@ -1,0 +1,14 @@
+slack_reporter:
+- channel: "#slack-channel"
+  job_states_to_report:
+  - success
+  - failure
+  - error
+  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+                           ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+                           :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+                           logs> :volcano: {{end}}'
+  job_names:
+  - unit
+  - upload-results
+  - lint

--- a/test/integration/ci-operator-prowgen/input/config/slack-report/duper/slack-report-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/slack-report/duper/slack-report-duper-master.yaml
@@ -1,0 +1,42 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+- as: e2e
+  commands: make test-e2e
+  container:
+    from: src
+- as: upload-results
+  commands: make upload-results
+  container:
+    from: src
+  postsubmit: true
+- as: lint
+  commands: make test-lint
+  container:
+    from: src
+  interval: 2h
+zz_generated_metadata:
+  branch: master
+  org: norehearsals
+  repo: duper

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
@@ -1,0 +1,64 @@
+periodics:
+- agent: kubernetes
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: slack-report
+    repo: duper
+  interval: 2h
+  labels:
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-slack-report-duper-master-lint
+  reporter_config:
+    slack:
+      channel: '#slack-channel'
+      job_states_to_report:
+      - success
+      - failure
+      - error
+      report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+        ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+        :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+        logs> :volcano: {{end}}'
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=lint
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
@@ -1,0 +1,63 @@
+postsubmits:
+  slack-report/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-slack-report-duper-master-upload-results
+    reporter_config:
+      slack:
+        channel: '#slack-channel'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upload-results
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
@@ -1,0 +1,121 @@
+presubmits:
+  slack-report/duper:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-slack-report-duper-master-e2e
+    rerun_command: /test e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=e2e
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-slack-report-duper-master-unit
+    reporter_config:
+      slack:
+        channel: '#slack-channel'
+        job_states_to_report:
+        - success
+        - failure
+        - error
+        report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
+          ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
+          :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
+          logs> :volcano: {{end}}'
+    rerun_command: /test unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )unit,?($|\s.*)


### PR DESCRIPTION
This also allows the ability to use the slack reporter functionality for postsubmits and periodics. It leaves the possibility for existing slack reporter configs in periodics to behave as they currently do, with the option to remove that later once configs are migrated.

The new integration test case showcases an example of how this can be used, but I will be following this up with a change to the docs and an announcement.
Example usage in `.prowgen.config`, this would generate slack_reporter configs in the `unit`, `upload-results`, and `lint` jobs.
```
slack_reporter:
- channel: "#slack-channel"
  job_states_to_report:
  - success
  - failure
  - error
  report_template: '{{if eq .Status.State "success"}} :rainbow: Job *{{.Spec.Job}}*
                           ended with *{{.Status.State}}*. <{{.Status.URL}}|View logs> :rainbow: {{else}}
                           :volcano: Job *{{.Spec.Job}}* ended with *{{.Status.State}}*. <{{.Status.URL}}|View
                           logs> :volcano: {{end}}'
  job_names:
  - unit
  - upload-results
  - lint
```

Fixes https://issues.redhat.com/browse/DPTP-3366, and completes the enhancement in https://issues.redhat.com/browse/DPTP-2875