### PR TITLE
`prowgen`: add the option to exclude variants from having a slack reporter config added

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -52,13 +52,13 @@ type SlackReporterConfig struct {
 	JobStatesToReport []prowv1.ProwJobState `json:"job_states_to_report,omitempty"`
 	ReportTemplate    string                `json:"report_template,omitempty"`
 	JobNames          []string              `json:"job_names,omitempty"`
-	//TODO(sgoeddel): if desired, we could add a list of excluded or included variants here to limit which jobs
-	// have the config added
+	// ExcludedVariants lists job variants that this config will not apply to
+	ExcludedVariants []string `json:"excluded_variants,omitempty"`
 }
 
-func (p *Prowgen) GetSlackReporterConfigForTest(test string) *SlackReporterConfig {
+func (p *Prowgen) GetSlackReporterConfigForTest(test, variant string) *SlackReporterConfig {
 	for _, s := range p.SlackReporterConfigs {
-		if slices.Contains(s.JobNames, test) {
+		if !slices.Contains(s.ExcludedVariants, variant) && slices.Contains(s.JobNames, test) {
 			return &s
 		}
 	}

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -139,7 +139,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 	if testContainsLease(&test) {
 		p.PodSpec.Add(LeaseClient())
 	}
-	if slackReporter := info.Config.GetSlackReporterConfigForTest(test.As); slackReporter != nil {
+	if slackReporter := info.Config.GetSlackReporterConfigForTest(test.As, configSpec.Metadata.Variant); slackReporter != nil {
 		if p.base.ReporterConfig == nil {
 			p.base.ReporterConfig = &prowv1.ReporterConfig{}
 		}

--- a/test/integration/ci-operator-prowgen/input/config/slack-report/duper/.config.prowgen
+++ b/test/integration/ci-operator-prowgen/input/config/slack-report/duper/.config.prowgen
@@ -12,3 +12,5 @@ slack_reporter:
   - unit
   - upload-results
   - lint
+  excluded_variants:
+  - exclude

--- a/test/integration/ci-operator-prowgen/input/config/slack-report/duper/slack-report-duper-master__exclude.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/slack-report/duper/slack-report-duper-master__exclude.yaml
@@ -1,0 +1,43 @@
+base_images:
+  base:
+    name: origin-v4.0
+    namespace: openshift
+    tag: base
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tag_specification:
+  name: origin-v4.0
+  namespace: openshift
+tests:
+- as: unit
+  commands: make test-unit
+  container:
+    from: src
+- as: e2e
+  commands: make test-e2e
+  container:
+    from: src
+- as: upload-results
+  commands: make upload-results
+  container:
+    from: src
+  postsubmit: true
+- as: lint
+  commands: make test-lint
+  container:
+    from: src
+  interval: 2h
+zz_generated_metadata:
+  branch: master
+  org: norehearsals
+  repo: duper
+  variant: exclude

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
@@ -9,6 +9,60 @@ periodics:
     repo: duper
   interval: 2h
   labels:
+    ci-operator.openshift.io/variant: exclude
+    ci.openshift.io/generator: prowgen
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-slack-report-duper-master-exclude-lint
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=lint
+      - --variant=exclude
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator
+- agent: kubernetes
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: master
+    org: slack-report
+    repo: duper
+  interval: 2h
+  labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-slack-report-duper-master-lint

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
@@ -8,6 +8,58 @@ postsubmits:
     decoration_config:
       skip_cloning: true
     labels:
+      ci-operator.openshift.io/variant: exclude
+      ci.openshift.io/generator: prowgen
+    max_concurrency: 1
+    name: branch-ci-slack-report-duper-master-exclude-upload-results
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=upload-results
+        - --variant=exclude
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
     name: branch-ci-slack-report-duper-master-upload-results

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
@@ -59,6 +59,118 @@ presubmits:
     branches:
     - ^master$
     - ^master-
+    context: ci/prow/exclude-e2e
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: exclude
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-slack-report-duper-master-exclude-e2e
+    rerun_command: /test exclude-e2e
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=e2e
+        - --variant=exclude
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )exclude-e2e,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
+    context: ci/prow/exclude-unit
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/variant: exclude
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-slack-report-duper-master-exclude-unit
+    rerun_command: /test exclude-unit
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --report-credentials-file=/etc/report/credentials
+        - --target=unit
+        - --variant=exclude
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )exclude-unit,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^master$
+    - ^master-
     context: ci/prow/unit
     decorate: true
     decoration_config:


### PR DESCRIPTION
The intention here is that specific variants can be excluded from having the config added, despite sharing the same test name. This will be useful for having older release jobs no longer report, for instance.

Follows up on: https://github.com/openshift/ci-tools/pull/4217
For: https://issues.redhat.com/browse/DPTP-3366