### PR TITLE
`ci-operator`: fix potential goroutine leak when one of the promotion steps fails

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -983,12 +983,13 @@ func (o *options) Run() []error {
 		}
 
 		// Run each of the promotion steps concurrently
-		detailsChan := make(chan api.CIOperatorStepDetails)
-		errChan := make(chan error)
+		lenOfPromotionSteps := len(promotionSteps)
+		detailsChan := make(chan api.CIOperatorStepDetails, lenOfPromotionSteps)
+		errChan := make(chan error, lenOfPromotionSteps)
 		for _, step := range promotionSteps {
 			go runPromotionStep(ctx, step, detailsChan, errChan)
 		}
-		for i := 0; i < len(promotionSteps); i++ {
+		for i := 0; i < lenOfPromotionSteps; i++ {
 			select {
 			case details := <-detailsChan:
 				graph.MergeFrom(details)


### PR DESCRIPTION
Follows up on https://github.com/openshift/ci-tools/pull/4220
Uses buffered channels to make sure that we don't have a goroutine leak. In practice, this would not be a big deal as this is the end of the process anyways, but we should fix this bug.