### PR TITLE
adds a new script to help build and push a ci-tools cmd image to the requested quay account

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,3 +489,7 @@ analyse-code:
 	@echo Full vulnerabilities report is available at ${ARTIFACTS}/snyk.sarif.json
 
 .PHONY: analyse-code
+
+build-and-push-image:
+	hack/build-and-push.sh "${TOOL}" "${QUAY_ACCOUNT}"
+.PHONY: build-and-push-image

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -1,0 +1,15 @@
+TOOL=$1
+QUAY_ACCOUNT=$2
+TMPDIR=${TMPDIR:-/tmp}
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-podman}
+
+echo "Building linux binary of ${TOOL}"
+GOOS=linux go build -v -o "${TMPDIR}/bin/linux/${TOOL}" "./cmd/${TOOL}"
+echo "Building ${CONTAINER_ENGINE} image quay.io/${QUAY_ACCOUNT}/${TOOL}:latest"
+if "${CONTAINER_ENGINE}" build -f "images/${TOOL}/Dockerfile" "${TMPDIR}/bin/linux" -t "quay.io/${QUAY_ACCOUNT}/${TOOL}:latest"; then
+  echo build succeeded
+else
+  echo "build failed; make sure the images/${TOOL} DOCKERFILE exists"
+fi
+echo "Pushing ${CONTAINER_ENGINE} image quay.io/${QUAY_ACCOUNT}/${TOOL}:latest"
+"${CONTAINER_ENGINE}" push "quay.io/${QUAY_ACCOUNT}/${TOOL}:latest"


### PR DESCRIPTION
I have been using a less generic version of this script for awhile. It's usage is as follows:
```
TOOL=autoowners QUAY_ACCOUNT=sgoeddel make build-and-push-image
```
This will build the `autoowners` cmd and publish it to my quay account. It can build any cmd that has a DOCKERFILE in the `/images` directory (most of the complex ones). DOCKERFILES can be added there when needed. Useful for trying out WIP changes.