### PR TITLE
[DPTP-4093] [ci-operator] introduce a configuration to control the multi arch builds for single images

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2305,6 +2305,9 @@ type ProjectDirectoryImageBuildStepConfiguration struct {
 	// are invoked only when testing certain parts of the repo.
 	Optional bool `json:"optional,omitempty"`
 
+	// MultiArch means the build step is built for multiple architectures if available. Defaults to false.
+	MultiArch bool `json:"multi_arch,omitempty"`
+
 	// Ref is an optional string linking to the extra_ref in "org.repo" format that this belongs to
 	Ref string `json:"ref,omitempty"`
 }

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -64,7 +64,13 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.config.BuildArgs,
 		s.config.Ref,
 	)
-	return handleBuilds(ctx, s.client, s.podClient, *build)
+
+	opts := []ImageBuildOptions{}
+	if s.config.MultiArch {
+		opts = append(opts, ImageBuildOptions{MultiArch: true})
+	}
+
+	return handleBuilds(ctx, s.client, s.podClient, *build, opts...)
 }
 
 type workingDir func(tag string) (string, error)

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -774,11 +774,13 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 		name              string
 		build             buildapi.Build
 		nodeArchitectures []string
+		multiArch         bool
 		want              []buildapi.Build
 	}{
 		{
 			name:              "basic case - only amd64",
 			nodeArchitectures: []string{"amd64"},
+			multiArch:         true,
 			build: buildapi.Build{
 				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
 				Spec: buildv1.BuildSpec{
@@ -817,6 +819,7 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 		{
 			name:              "basic case - multi architectures",
 			nodeArchitectures: []string{"amd64", "arm64", "ppc64"},
+			multiArch:         true,
 			build: buildapi.Build{
 				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
 				Spec: buildv1.BuildSpec{
@@ -888,11 +891,50 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:              "basic case - multi architectures - multi arch image disabled",
+			nodeArchitectures: []string{"amd64", "arm64", "ppc64"},
+			multiArch:         false,
+			build: buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
+				Spec: buildv1.BuildSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							ImageLabels: []buildapi.ImageLabel{
+								{Name: "io.openshift.build.namespace", Value: "namespace"},
+								{Name: "io.openshift.build.commit.id", Value: "commit-id"},
+								{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
+							},
+						},
+					},
+				},
+			},
+			want: []buildapi.Build{
+				{
+					ObjectMeta: meta.ObjectMeta{Name: "test-build-amd64"},
+					Spec: buildapi.BuildSpec{
+						CommonSpec: buildapi.CommonSpec{
+							NodeSelector: map[string]string{
+								"kubernetes.io/arch": "amd64",
+							},
+							Output: buildv1.BuildOutput{
+								ImageLabels: []buildapi.ImageLabel{
+									{Name: "io.openshift.build.namespace", Value: "namespace"},
+									{Name: "io.openshift.build.commit.id", Value: "commit-id"},
+									{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
+								},
+								To: &coreapi.ObjectReference{Name: "pipeline:test-build-amd64"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := cmp.Diff(constructMultiArchBuilds(tt.build, tt.nodeArchitectures), tt.want, cmpopts.IgnoreFields(coreapi.ObjectReference{}, "Kind")); diff != "" {
+			if diff := cmp.Diff(constructMultiArchBuilds(tt.build, tt.nodeArchitectures, tt.multiArch), tt.want, cmpopts.IgnoreFields(coreapi.ObjectReference{}, "Kind")); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -202,6 +202,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                  destination_dir: ' '\n" +
 	"                  # SourcePath is a file or directory in the source image to copy from.\n" +
 	"                  source_path: ' '\n" +
+	"      # MultiArch means the build step is built for multiple architectures if available. Defaults to false.\n" +
+	"      multi_arch: true\n" +
 	"      # Optional means the build step is not built, published, or\n" +
 	"      # promoted unless explicitly targeted. Use for builds which\n" +
 	"      # are invoked only when testing certain parts of the repo.\n" +
@@ -418,6 +420,8 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"                      destination_dir: ' '\n" +
 	"                      # SourcePath is a file or directory in the source image to copy from.\n" +
 	"                      source_path: ' '\n" +
+	"        # MultiArch means the build step is built for multiple architectures if available. Defaults to false.\n" +
+	"        multi_arch: true\n" +
 	"        # Optional means the build step is not built, published, or\n" +
 	"        # promoted unless explicitly targeted. Use for builds which\n" +
 	"        # are invoked only when testing certain parts of the repo.\n" +


### PR DESCRIPTION
Add the `multi_arch` configuration to the `images` stanza. It defaults to false which is a breaking change.



[DPTP-4093](https://issues.redhat.com/browse/DPTP-4093)

/cc @openshift/test-platform @smg247 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
