### PR TITLE
ci-images-mirror: set version.Name

### DIFF
--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/prow/pkg/flagutil"
 	"sigs.k8s.io/prow/pkg/interrupts"
 	"sigs.k8s.io/prow/pkg/logrusutil"
+	"sigs.k8s.io/prow/pkg/version"
 
 	imagev1 "github.com/openshift/api/image/v1"
 
@@ -173,6 +174,7 @@ func newSupplementalCIImagesServiceWithMirrorStore(mirrorStore quayiociimagesdis
 }
 
 func main() {
+	version.Name = "ci-images-mirror"
 	logrusutil.ComponentInit()
 	controllerruntime.SetLogger(logrusr.New(logrus.StandardLogger()))
 	logrus.SetLevel(logrus.TraceLevel)


### PR DESCRIPTION
We do this for logging.
It used to work (at least for the logs uploaded to CloudWatch) without it but not any more.

Tested the PR locally, it does the job:

```
{"component":"ci-images-mirror","file":"/Users/hongkliu/repo/openshift/ci-tools/cmd/ci-images-mirror/main.go:322","func":"main.main","level":"info","msg":"Process ended gracefully","severity":"info","time":"2024-07-31T10:14:13-04:00"}
```

/cc @openshift/test-platform 