### PR TITLE
ci-images-mirror: add --validate-config-only option

### DIFF
--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -375,15 +375,9 @@ func sourceForConfigChangeChannel(registryClient ctrlruntimeclient.Client, chang
 }
 
 func LoadConfigFromReleaseRepo(configPath string) ([]byte, error) {
-	metadata := cioperatorapi.Metadata{
-		Org:    "openshift",
-		Repo:   "release",
-		Branch: "master",
-	}
-	fileGetter := repoFileGetterWithIgnore(metadata)
-	file, err := fileGetter(metadata.Org, metadata.Repo, metadata.Branch)(configPath)
+	file, err := repoFileGetterWithIgnore(cioperatorapi.Metadata{})("openshift", "release", "master")(configPath)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("failed to get the file %s in repo openshift/release for branch master: %w", configPath, err)
 	}
 	return file, nil
 }

--- a/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
+++ b/pkg/controller/quay_io_ci_images_distributor/quay_io_ci_images_distributor.go
@@ -374,6 +374,20 @@ func sourceForConfigChangeChannel(registryClient ctrlruntimeclient.Client, chang
 	return channelSource
 }
 
+func LoadConfigFromReleaseRepo(configPath string) ([]byte, error) {
+	metadata := cioperatorapi.Metadata{
+		Org:    "openshift",
+		Repo:   "release",
+		Branch: "master",
+	}
+	fileGetter := repoFileGetterWithIgnore(metadata)
+	file, err := fileGetter(metadata.Org, metadata.Repo, metadata.Branch)(configPath)
+	if err != nil {
+		return []byte{}, err
+	}
+	return file, nil
+}
+
 type ImageInfo struct {
 	Name string `json:"name"`
 	// Digest is the digest of the image, e.g., sha256:b24f782bee7dfddcc36b962f663aeabb16d6fa56a64a7cd0639ebfb1e5fa73f4

--- a/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
+++ b/pkg/controller/quay_io_ci_images_distributor/supplemental_images.go
@@ -19,11 +19,19 @@ import (
 	"github.com/openshift/ci-tools/pkg/util/gzip"
 )
 
-func LoadConfig(file string) (*CIImagesMirrorConfig, error) {
-	bytes, err := gzip.ReadFileMaybeGZIP(file)
+func LoadConfigFromFile(path string) (*CIImagesMirrorConfig, error) {
+	bytes, err := gzip.ReadFileMaybeGZIP(path)
 	if err != nil {
 		return nil, err
 	}
+	c, err := LoadConfig(bytes)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func LoadConfig(bytes []byte) (*CIImagesMirrorConfig, error) {
 	c := &CIImagesMirrorConfig{}
 	if err := yaml.UnmarshalStrict(bytes, c); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR adds the option to validate the ci-images-mirror config: [core-services/image-mirroring/_config.yaml](https://github.com/openshift/release/blob/master/core-services/image-mirroring/_config.yaml)
Issue: [DPTP-3915](https://issues.redhat.com/browse/DPTP-3915)
/cc @hongkailiu 