### PR TITLE
enable multi-arch builds by default but respect the configuration from the images stanza

### DIFF
--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -65,12 +65,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.config.Ref,
 	)
 
-	opts := []ImageBuildOptions{}
-	if s.config.MultiArch {
-		opts = append(opts, ImageBuildOptions{MultiArch: true})
-	}
-
-	return handleBuilds(ctx, s.client, s.podClient, *build, opts...)
+	return handleBuilds(ctx, s.client, s.podClient, *build, ImageBuildOptions{MultiArch: s.config.MultiArch})
 }
 
 type workingDir func(tag string) (string, error)

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -447,9 +447,9 @@ type ImageBuildOptions struct {
 func handleBuilds(ctx context.Context, buildClient BuildClient, podClient kubernetes.PodClient, build buildapi.Build, opts ...ImageBuildOptions) error {
 	var wg sync.WaitGroup
 
-	multiArch := false
-	if len(opts) > 0 && opts[0].MultiArch {
-		multiArch = true
+	multiArch := true
+	if len(opts) > 0 {
+		multiArch = opts[0].MultiArch
 	}
 
 	builds := constructMultiArchBuilds(build, buildClient.NodeArchitectures(), multiArch)


### PR DESCRIPTION
Follow-up of https://github.com/openshift/ci-tools/pull/4231

All base ci-operator image builds should be multi-arch. This change respects the images stanza configuration to allow the user to choose which images should be built for multi arch.  


/cc @openshift/test-platform @deepsm007 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
