### PR TITLE
jobaggregator: exclude disruption if backend is localhost

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -32,6 +32,7 @@ func isExcludedDisruptionBackend(name string) bool {
 		"pod-to-host",
 		"pod-to-pod",
 		"pod-to-service",
+		"-localhost-",
 	}
 
 	for _, excludedName := range excludedNames {


### PR DESCRIPTION
Kubeapiserver in-cluster monitors now watch external/internal lb, service network and localhost. Localhost disruptions are informational only, so they should not cause tests to fail