### PR TITLE
`pod-scaler`: update consumers and e2e tests to use v2 data

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -27,7 +27,7 @@ import (
 	buildclientv1 "github.com/openshift/client-go/build/clientset/versioned/typed/build/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	podscalerv1 "github.com/openshift/ci-tools/pkg/pod-scaler/v1"
+	podscalerv2 "github.com/openshift/ci-tools/pkg/pod-scaler/v2"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/steps"
@@ -288,7 +288,7 @@ func preventUnschedulable(resources *corev1.ResourceRequirements, cpuCap int64, 
 func mutatePodResources(pod *corev1.Pod, server *resourceServer, mutateResourceLimits bool, cpuCap int64, memoryCap string, reporter results.PodScalerReporter, logger *logrus.Entry) {
 	mutateResources := func(containers []corev1.Container) {
 		for i := range containers {
-			meta := podscalerv1.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, containers[i].Name)
+			meta := podscalerv2.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, containers[i].Name)
 			resources, recommendationExists := server.recommendedRequestFor(meta)
 			if recommendationExists {
 				logger.Debugf("recommendation exists for: %s", containers[i].Name)

--- a/cmd/pod-scaler/admission_test.go
+++ b/cmd/pod-scaler/admission_test.go
@@ -24,7 +24,7 @@ import (
 	fakebuildv1client "github.com/openshift/client-go/build/clientset/versioned/fake"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	podscalerv1 "github.com/openshift/ci-tools/pkg/pod-scaler/v1"
+	podscalerv2 "github.com/openshift/ci-tools/pkg/pod-scaler/v2"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -77,7 +77,7 @@ func TestMutatePods(t *testing.T) {
 	resources := &resourceServer{
 		logger: logger,
 		lock:   sync.RWMutex{},
-		byMetaData: map[podscalerv1.FullMetadata]corev1.ResourceRequirements{
+		byMetaData: map[podscalerv2.FullMetadata]corev1.ResourceRequirements{
 			{
 				Metadata: api.Metadata{
 					Org:     "org",
@@ -338,7 +338,7 @@ func TestMutatePodLabels(t *testing.T) {
 
 func TestMutatePodResources(t *testing.T) {
 	logger := logrus.WithField("test", t.Name())
-	metaBase := podscalerv1.FullMetadata{
+	metaBase := podscalerv2.FullMetadata{
 		Metadata: api.Metadata{
 			Org:     "org",
 			Repo:    "repo",
@@ -349,7 +349,7 @@ func TestMutatePodResources(t *testing.T) {
 		Step:   "step",
 		Pod:    "tomutate",
 	}
-	baseWithContainer := func(base *podscalerv1.FullMetadata, container string) podscalerv1.FullMetadata {
+	baseWithContainer := func(base *podscalerv2.FullMetadata, container string) podscalerv2.FullMetadata {
 		copied := *base
 		copied.Container = container
 		return copied
@@ -366,7 +366,7 @@ func TestMutatePodResources(t *testing.T) {
 			server: &resourceServer{
 				logger:     logger,
 				lock:       sync.RWMutex{},
-				byMetaData: map[podscalerv1.FullMetadata]corev1.ResourceRequirements{},
+				byMetaData: map[podscalerv2.FullMetadata]corev1.ResourceRequirements{},
 			},
 			pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				"ci.openshift.io/metadata.org":     "org",
@@ -382,7 +382,7 @@ func TestMutatePodResources(t *testing.T) {
 			server: &resourceServer{
 				logger: logger,
 				lock:   sync.RWMutex{},
-				byMetaData: map[podscalerv1.FullMetadata]corev1.ResourceRequirements{
+				byMetaData: map[podscalerv2.FullMetadata]corev1.ResourceRequirements{
 					baseWithContainer(&metaBase, "large"): {
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    *resource.NewQuantity(5, resource.DecimalSI),
@@ -476,7 +476,7 @@ func TestMutatePodResources(t *testing.T) {
 			server: &resourceServer{
 				logger: logger,
 				lock:   sync.RWMutex{},
-				byMetaData: map[podscalerv1.FullMetadata]corev1.ResourceRequirements{
+				byMetaData: map[podscalerv2.FullMetadata]corev1.ResourceRequirements{
 					baseWithContainer(&metaBase, "large"): {
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    *resource.NewQuantity(5, resource.DecimalSI),
@@ -907,7 +907,7 @@ func TestRehearsalMetadata(t *testing.T) {
   repo: REPO
   branch: BRANCH`}}}}},
 	}
-	meta := podscalerv1.FullMetadata{
+	meta := podscalerv2.FullMetadata{
 		Metadata: api.Metadata{
 			Org:    "ORG",
 			Repo:   "REPO",
@@ -919,7 +919,7 @@ func TestRehearsalMetadata(t *testing.T) {
 	if err := mutatePodMetadata(pod, logrus.WithField("test", "TestRehearsalMetadata")); err != nil {
 		t.Fatalf("failed to mutate metadata: %v", err)
 	}
-	if diff := cmp.Diff(podscalerv1.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, "test"), meta); diff != "" {
+	if diff := cmp.Diff(podscalerv2.MetadataFor(pod.ObjectMeta.Labels, pod.ObjectMeta.Name, "test"), meta); diff != "" {
 		t.Errorf("rehearsal job: got incorrect metadata: %v", diff)
 	}
 }

--- a/cmd/pod-scaler/frontend_test.go
+++ b/cmd/pod-scaler/frontend_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	podscalerv1 "github.com/openshift/ci-tools/pkg/pod-scaler/v1"
+	podscalerv2 "github.com/openshift/ci-tools/pkg/pod-scaler/v2"
 )
 
 func TestMetadataQueryMappingRoundTripping(t *testing.T) {
-	metas := []podscalerv1.FullMetadata{
+	metas := []podscalerv2.FullMetadata{
 		{
 			Metadata: api.Metadata{
 				Org:     "org",

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -134,7 +134,7 @@ func (o *options) validate() error {
 		return errors.New("--mode must be either \"producer\", \"consumer.ui\", or \"consumer.admission\"")
 	}
 	if o.cacheDir == "" {
-		if o.cacheBucket == "" {
+		if o.cacheBucket == "" && o.cacheBucketv2 == "" {
 			return errors.New("--cache-bucket is required")
 		}
 		if o.gcsCredentialsFile == "" {
@@ -187,8 +187,10 @@ func main() {
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not initialize GCS client.")
 		}
-		bucketv1 := gcsClient.Bucket(opts.cacheBucket)
-		cachev1 = &v1.BucketCache{Bucket: bucketv1}
+		if opts.cacheBucket != "" {
+			bucketv1 := gcsClient.Bucket(opts.cacheBucket)
+			cachev1 = &v1.BucketCache{Bucket: bucketv1}
+		}
 
 		if opts.cacheBucketv2 != "" {
 			bucketv2 := gcsClient.Bucket(opts.cacheBucketv2)

--- a/cmd/pod-scaler/v2/producer.go
+++ b/cmd/pod-scaler/v2/producer.go
@@ -32,9 +32,9 @@ const (
 	// Prometheus server for at once from many requests.
 	MaxSamplesPerRequest = 11000
 
-	prowjobsCachePrefix = "prowjobs"
-	podsCachePrefix     = "pods"
-	stepsCachePrefix    = "steps"
+	ProwjobsCachePrefix = "prowjobs"
+	PodsCachePrefix     = "pods"
+	StepsCachePrefix    = "steps"
 )
 
 // queriesByMetric returns a mapping of Prometheus query by metric name for all queries we want to execute
@@ -46,17 +46,17 @@ func queriesByMetric() map[string]string {
 		labels   []string
 	}{
 		{
-			prefix:   prowjobsCachePrefix,
+			prefix:   ProwjobsCachePrefix,
 			selector: `{` + string(podscalerv2.ProwLabelNameCreated) + `="true",` + string(podscalerv2.ProwLabelNameJob) + `!="",` + string(podscalerv2.LabelNameRehearsal) + `=""}`,
 			labels:   []string{string(podscalerv2.ProwLabelNameCreated), string(podscalerv2.ProwLabelNameContext), string(podscalerv2.ProwLabelNameOrg), string(podscalerv2.ProwLabelNameRepo), string(podscalerv2.ProwLabelNameBranch), string(podscalerv2.ProwLabelNameJob), string(podscalerv2.ProwLabelNameType)},
 		},
 		{
-			prefix:   podsCachePrefix,
+			prefix:   PodsCachePrefix,
 			selector: `{` + string(podscalerv2.LabelNameCreated) + `="true",` + string(podscalerv2.LabelNameStep) + `=""}`,
 			labels:   []string{string(podscalerv2.LabelNameOrg), string(podscalerv2.LabelNameRepo), string(podscalerv2.LabelNameBranch), string(podscalerv2.LabelNameVariant), string(podscalerv2.LabelNameTarget), string(podscalerv2.LabelNameBuild), string(podscalerv2.LabelNameRelease), string(podscalerv2.LabelNameApp)},
 		},
 		{
-			prefix:   stepsCachePrefix,
+			prefix:   StepsCachePrefix,
 			selector: `{` + string(podscalerv2.LabelNameCreated) + `="true",` + string(podscalerv2.LabelNameStep) + `!=""}`,
 			labels:   []string{string(podscalerv2.LabelNameOrg), string(podscalerv2.LabelNameRepo), string(podscalerv2.LabelNameBranch), string(podscalerv2.LabelNameVariant), string(podscalerv2.LabelNameTarget), string(podscalerv2.LabelNameStep)},
 		},
@@ -90,7 +90,7 @@ func Produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest
 				"version": "v2",
 				"metric":  name,
 			})
-			cache, err := loadCache(dataCache, name, logger)
+			cache, err := LoadCache(dataCache, name, logger)
 			if errors.Is(err, notExist{}) {
 				ranges := map[string][]podscalerv2.TimeRange{}
 				for cluster := range clients {

--- a/cmd/pod-scaler/v2/storage.go
+++ b/cmd/pod-scaler/v2/storage.go
@@ -119,8 +119,8 @@ func (e notExist) Unwrap() error {
 	return e.wrapped
 }
 
-// loadCache loads cached query data from the given storage loader.
-func loadCache(loader loader, metricName string, logger *logrus.Entry) (*podscalerv2.CachedQuery, error) {
+// LoadCache loads cached query data from the given storage loader.
+func LoadCache(loader loader, metricName string, logger *logrus.Entry) (*podscalerv2.CachedQuery, error) {
 	readStart := time.Now()
 	logger.Info("Reading Prometheus data from Cache.")
 	logger.Debug("Loading Prometheus data from storage.")
@@ -205,8 +205,7 @@ func storeTo(storer storer, metricName string, data []byte) error {
 	return kerrors.NewAggregate(errs)
 }
 
-//TODO(sgoeddel): this will be used once v1 is removed
-//// lastUpdated determines the time at which the Cache for this metric was last updated
-//func lastUpdated(resolver attributeResolver, metricName string) (time.Time, error) {
-//	return resolver.lastUpdated(interrupts.Context(), metricName+".json")
-//}
+// LastUpdated determines the time at which the Cache for this metric was last updated
+func LastUpdated(resolver attributeResolver, metricName string) (time.Time, error) {
+	return resolver.lastUpdated(interrupts.Context(), metricName+".json")
+}

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/prow/pkg/interrupts"
 
-	podscalerv1 "github.com/openshift/ci-tools/pkg/pod-scaler/v1"
+	podscalerv2 "github.com/openshift/ci-tools/pkg/pod-scaler/v2"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 	"github.com/openshift/ci-tools/test/e2e/pod-scaler/kubernetes"
 	"github.com/openshift/ci-tools/test/e2e/pod-scaler/prometheus"
@@ -49,13 +49,13 @@ func TestProduce(t *testing.T) {
 	sort.Slice(offsets, func(i, j int) bool {
 		return offsets[i] > offsets[j]
 	})
-	expected := prometheus.Data{ByFile: map[string]map[podscalerv1.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}}
+	expected := prometheus.Data{ByFile: map[string]map[podscalerv2.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}}
 	for _, offset := range offsets {
 		// we expect the data from this offset and all earlier ones, too
 		data := info.ByOffset[offset]
 		for filename := range data.ByFile {
 			if _, ok := expected.ByFile[filename]; !ok {
-				expected.ByFile[filename] = map[podscalerv1.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
+				expected.ByFile[filename] = map[podscalerv2.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
 			}
 			for identifier, hists := range data.ByFile[filename] {
 				expected.ByFile[filename][identifier] = append(expected.ByFile[filename][identifier], hists...)
@@ -71,7 +71,7 @@ func TestProduce(t *testing.T) {
 // - we store Prometheus data by series fingerprint, which we can't determine ahead of time
 func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
 	for filename, data := range checkAgainst.ByFile {
-		var c podscalerv1.CachedQuery
+		var c podscalerv2.CachedQuery
 		raw, err := os.ReadFile(filepath.Join(dataDir, filename))
 		if err != nil {
 			t.Fatalf("%s: failed to read cache: %v", filename, err)
@@ -79,7 +79,7 @@ func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
 		if err := json.Unmarshal(raw, &c); err != nil {
 			t.Fatalf("%s: failed to unmarshal cache: %v", filename, err)
 		}
-		actualIdentifiers, expectedIdentifiers := map[podscalerv1.FullMetadata]interface{}{}, map[podscalerv1.FullMetadata]interface{}{}
+		actualIdentifiers, expectedIdentifiers := map[podscalerv2.FullMetadata]interface{}{}, map[podscalerv2.FullMetadata]interface{}{}
 		for item := range data {
 			expectedIdentifiers[item] = nil
 		}
@@ -97,8 +97,8 @@ func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
 				// no sensible way to assert about histograms containing data using rate()
 				continue
 			}
-			for _, fingerprint := range c.DataByMetaData[identifier] {
-				hist := c.Data[fingerprint].Histogram()
+			for _, fingerprintTime := range c.DataByMetaData[identifier] {
+				hist := c.Data[fingerprintTime.Fingerprint].Histogram()
 				var found bool
 				for _, other := range data[identifier] {
 					if hist.Equals(other.Histogram()) {
@@ -113,8 +113,8 @@ func check(t *testing.T, dataDir string, checkAgainst prometheus.Data) {
 			for _, item := range data[identifier] {
 				hist := item.Histogram()
 				var found bool
-				for _, fingerprint := range c.DataByMetaData[identifier] {
-					if hist.Equals(c.Data[fingerprint].Histogram()) {
+				for _, fingerprintTime := range c.DataByMetaData[identifier] {
+					if hist.Equals(c.Data[fingerprintTime.Fingerprint].Histogram()) {
 						found = true
 						break
 					}

--- a/test/e2e/pod-scaler/prometheus/backfill.go
+++ b/test/e2e/pod-scaler/prometheus/backfill.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/openshift/ci-tools/pkg/api"
-	podscalerv1 "github.com/openshift/ci-tools/pkg/pod-scaler/v1"
+	podscalerv2 "github.com/openshift/ci-tools/pkg/pod-scaler/v2"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -41,10 +41,10 @@ type DataInStages struct {
 }
 
 type Data struct {
-	ByFile map[string]map[podscalerv1.FullMetadata][]*circonusllhist.HistogramWithoutLookups
+	ByFile map[string]map[podscalerv2.FullMetadata][]*circonusllhist.HistogramWithoutLookups
 }
 
-func (d *DataInStages) record(offset time.Duration, metric string, labels seriesLabels, identifier podscalerv1.FullMetadata, data []float64) error {
+func (d *DataInStages) record(offset time.Duration, metric string, labels seriesLabels, identifier podscalerv2.FullMetadata, data []float64) error {
 	hist := circonusllhist.New(circonusllhist.NoLookup(), circonusllhist.Size(1))
 	for _, v := range data {
 		if err := hist.RecordValue(v); err != nil {
@@ -54,7 +54,7 @@ func (d *DataInStages) record(offset time.Duration, metric string, labels series
 
 	if _, ok := d.ByOffset[offset]; !ok {
 		d.ByOffset[offset] = Data{
-			ByFile: map[string]map[podscalerv1.FullMetadata][]*circonusllhist.HistogramWithoutLookups{},
+			ByFile: map[string]map[podscalerv2.FullMetadata][]*circonusllhist.HistogramWithoutLookups{},
 		}
 	}
 	var file string
@@ -67,7 +67,7 @@ func (d *DataInStages) record(offset time.Duration, metric string, labels series
 		file = fmt.Sprintf("pods/%s.json", metric)
 	}
 	if _, ok := d.ByOffset[offset].ByFile[file]; !ok {
-		d.ByOffset[offset].ByFile[file] = map[podscalerv1.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
+		d.ByOffset[offset].ByFile[file] = map[podscalerv2.FullMetadata][]*circonusllhist.HistogramWithoutLookups{}
 	}
 	d.ByOffset[offset].ByFile[file][identifier] = append(d.ByOffset[offset].ByFile[file][identifier], circonusllhist.NewHistogramWithoutLookups(hist))
 
@@ -221,14 +221,14 @@ type seriesLabels map[string]string
 
 // seriesInfo connects a set of labels with the metadata it maps to
 type seriesInfo struct {
-	meta   podscalerv1.FullMetadata
+	meta   podscalerv2.FullMetadata
 	labels seriesLabels
 }
 
 func series() []seriesInfo {
 	return []seriesInfo{
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:     "org",
 					Repo:    "repo",
@@ -253,7 +253,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:     "org",
 					Repo:    "repo",
@@ -276,7 +276,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:     "org",
 					Repo:    "repo",
@@ -299,7 +299,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:     "org",
 					Repo:    "repo",
@@ -321,7 +321,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:    "org",
 					Repo:   "repo",
@@ -342,7 +342,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Metadata: api.Metadata{
 					Org:    "org",
 					Repo:   "repo",
@@ -364,7 +364,7 @@ func series() []seriesInfo {
 			},
 		},
 		{
-			meta: podscalerv1.FullMetadata{
+			meta: podscalerv2.FullMetadata{
 				Target:    "periodic-handwritten-prowjob",
 				Container: "container",
 			},


### PR DESCRIPTION
After some time of v2 data gathering, it will be time to utilize that data with the consumers. This is a fairly simple change as we just need to swap out `v1` for `v2` in many places. The only significant difference here is accessing the `fingerprint` within the `fingerprintTime` struct. Once we confirm this is working correctly, all `v1` logic will be removed entirely and the data will be purged. 

For: https://issues.redhat.com/browse/DPTP-4069

/hold to merge when we have sufficient v2 data available