### PR TITLE
jobdisruption: exclude internal-lb

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_disruption.go
@@ -33,6 +33,7 @@ func isExcludedDisruptionBackend(name string) bool {
 		"pod-to-pod",
 		"pod-to-service",
 		"-localhost-",
+		"-internal-lb-",
 	}
 
 	for _, excludedName := range excludedNames {


### PR DESCRIPTION
There is no way for us to differentiate between "real" internal LB in the cloud or fake one in SNO, so this disruption is not being alerted upon.

Ref: https://github.com/openshift/origin/pull/28982