### PR TITLE
Fix validation for ocp-build-data from.builder.image

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -17,6 +17,7 @@ import (
 )
 
 type OCPImageConfig struct {
+	Mode           *Mode                  `json:"mode"`
 	Content        *OCPImageConfigContent `json:"content"`
 	From           OCPImageConfigFrom     `json:"from"`
 	Push           OCPImageConfigPush     `json:"push"`
@@ -35,6 +36,9 @@ func (o OCPImageConfig) validate() error {
 		errs = append(errs, fmt.Errorf(".from failed validation: %w", err))
 	}
 	for idx, cfg := range o.From.Builder {
+		if o.Mode.ModeDisabled != "" && cfg.Image != "" {
+			continue
+		}
 		if err := cfg.validate(); err != nil {
 			errs = append(errs, fmt.Errorf(".from.%d failed validation: %w", idx, err))
 		}
@@ -45,6 +49,14 @@ func (o OCPImageConfig) validate() error {
 
 func (o OCPImageConfig) PromotesTo() string {
 	return fmt.Sprintf("registry.ci.openshift.org/ocp/%s.%s:%s", o.Version.Major, o.Version.Minor, strings.TrimPrefix(o.Name, "openshift/ose-"))
+}
+
+// Config mode: enabled | disabled | wip
+// Leaving this out entirely means `enable` which is normal operation
+type Mode struct {
+	ModeEnabled  string `json:"enabled"`
+	ModeDisabled string `json:"disabled"`
+	ModeWip      string `json:"wip"`
 }
 
 type OCPImageConfigContent struct {
@@ -85,11 +97,16 @@ type OCPImageConfigFrom struct {
 type OCPImageConfigFromStream struct {
 	Stream string `json:"stream"`
 	Member string `json:"member"`
+	Image  string `json:"image"`
 }
 
 func (icfs OCPImageConfigFromStream) validate() error {
 	if icfs.Stream == "" && icfs.Member == "" {
 		return errors.New("both stream and member were unset")
+	}
+	if icfs.Image == "" {
+		// skip validation for image
+		return nil
 	}
 	if icfs.Stream != "" && icfs.Member != "" {
 		return fmt.Errorf("both stream(%s) and member(%s) were set", icfs.Stream, icfs.Member)


### PR DESCRIPTION
/cc @openshift/test-platform 

`image configs from ocp-build-data: error validating images/okd-only-upi-installer.yml: [.from.5 failed validation: both stream and member were unset, .from.6 failed validation: both stream and member were unset, .from.7 failed validation: both stream and member were unset, .from.8 failed validation: both stream and member were unset]"
`