### PR TITLE
Support Network-edge-testing repo for pull token

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -645,7 +645,7 @@ func mutateGlobalPullSecret(original, secret *coreapi.Secret) (bool, error) {
 		return false, fmt.Errorf("failed to parse the original secret: %w", err)
 	}
 	mutatedSecret := false
-	domains := []string{api.DomainForService(api.ServiceRegistry), api.QCIAPPCIDomain, api.QuayOpenShiftRepo, api.QCICacheDomain}
+	domains := []string{api.DomainForService(api.ServiceRegistry), api.QCIAPPCIDomain, api.QuayOpenShiftCIRepo, api.QuayOpenShiftNetworkEdgeRepo, api.QCICacheDomain}
 	for _, domain := range domains {
 		if dockerConfig.Auths[domain].Auth == "" {
 			return false, fmt.Errorf("failed to get token for %s", domain)

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -3193,7 +3193,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3221,9 +3224,13 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
 			"auth": "supercool"
 		},
+		"quay.io/openshift/network-edge-testing": {
+			"auth": "supercool"
+		},
+		
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
 			"auth": "supercool"
 		}
@@ -3235,7 +3242,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},
@@ -3256,7 +3263,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3284,7 +3294,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3312,7 +3325,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3337,7 +3353,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3351,7 +3370,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},
@@ -3372,7 +3391,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3405,7 +3427,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},
@@ -3426,7 +3448,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3456,7 +3481,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},
@@ -3477,7 +3502,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3505,8 +3533,11 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
 			"auth": "expired"
+		},
+		"quay.io/openshift/network-edge-testing": {
+			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
 			"auth": "supercool"
@@ -3519,7 +3550,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},
@@ -3540,7 +3571,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "supercool"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "supercool"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "supercool"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3568,7 +3602,10 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 		"quay-proxy.ci.openshift.org": {
 			"auth": "expired"
 		},
-		"quay.io/openshift/": {
+		"quay.io/openshift/ci": {
+			"auth": "expired"
+		},
+		"quay.io/openshift/network-edge-testing": {
 			"auth": "expired"
 		},
 		"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com": {
@@ -3582,7 +3619,7 @@ func TestMutateGlobalPullSecret(t *testing.T) {
 			expected: true,
 			mutatedSecret: &coreapi.Secret{
 				Data: map[string][]byte{
-					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
+					".dockerconfigjson": []byte("{\"auths\":{\"osd\":{\"auth\":\"foo\",\"email\":\"e\"},\"qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com\":{\"auth\":\"supercool\"},\"quay-proxy.ci.openshift.org\":{\"auth\":\"supercool\"},\"quay.io/openshift/ci\":{\"auth\":\"supercool\"},\"quay.io/openshift/network-edge-testing\":{\"auth\":\"supercool\"},\"registry.ci.openshift.org\":{\"auth\":\"cool\"}}}"),
 				},
 				Type: coreapi.SecretTypeDockerConfigJson,
 			},

--- a/cmd/cluster-init/cmd/onboard/update_bootstrap_secrets.go
+++ b/cmd/cluster-init/cmd/onboard/update_bootstrap_secrets.go
@@ -173,7 +173,12 @@ func generateRegistryPullCredentialsSecret(o options) secretbootstrap.SecretConf
 				{
 					AuthField:   "auth",
 					Item:        "quayio-ci-read-only-robot",
-					RegistryURL: "quay.io/openshift/",
+					RegistryURL: "quay.io/openshift/ci",
+				},
+				{
+					AuthField:   "auth",
+					Item:        "quayio-ci-read-only-robot",
+					RegistryURL: "quay.io/openshift/network-edge-testing",
 				},
 				{
 					AuthField:   "auth",

--- a/pkg/api/domain.go
+++ b/pkg/api/domain.go
@@ -23,8 +23,8 @@ const (
 	ServiceDomainArm01Registry     = "registry.arm-build01.arm-build.devcluster.openshift.com"
 	ServiceDomainMulti01Registry   = "registry.multi-build01.arm-build.devcluster.openshift.com"
 
-	QuayOpenShiftCIRepo = "quay.io/openshift/ci"
-	QuayOpenShiftRepo   = "quay.io/openshift/"
+	QuayOpenShiftCIRepo          = "quay.io/openshift/ci"
+	QuayOpenShiftNetworkEdgeRepo = "quay.io/openshift/network-edge-testing"
 
 	QCIAPPCIDomain = "quay-proxy.ci.openshift.org"
 

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -309,7 +309,10 @@ secret_configs:
         registry_url: quay-proxy.ci.openshift.org
       - auth_field: auth
         item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/
+        registry_url: quay.io/openshift/ci
+      - auth_field: auth
+        item: quayio-ci-read-only-robot
+        registry_url: quay.io/openshift/network-edge-testing
       - auth_field: auth
         item: quayio-ci-read-only-robot
         registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -319,7 +319,10 @@ secret_configs:
         registry_url: quay-proxy.ci.openshift.org
       - auth_field: auth
         item: quayio-ci-read-only-robot
-        registry_url: quay.io/openshift/
+        registry_url: quay.io/openshift/ci
+      - auth_field: auth
+        item: quayio-ci-read-only-robot
+        registry_url: quay.io/openshift/network-edge-testing
       - auth_field: auth
         item: quayio-ci-read-only-robot
         registry_url: qci-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com


### PR DESCRIPTION
Until https://issues.redhat.com/browse/OCPBUGS-38737 is fixed, there is no way we can make both happy unless we fully qualify both repos under openshift/ that the bot needs access to. That is, '[quay.io/openshift/ci](http://quay.io/openshift/ci)' and '[quay.io/openshift/network-edge-testing](http://quay.io/openshift/network-edge-testing)' explicitly in the pull-secret

/cc @openshift/test-platform 