### PR TITLE
`cluster-init`: update format of `token-*` items in ci-secret-generator config

### DIFF
--- a/cmd/cluster-init/cmd/onboard/update_secret_generator.go
+++ b/cmd/cluster-init/cmd/onboard/update_secret_generator.go
@@ -49,7 +49,7 @@ func updateSecretGeneratorConfig(o options, c *SecretGenConfig) error {
 	if err := appendToSecretItem(buildUFarm, serviceAccountConfigPath, o, c); err != nil {
 		return err
 	}
-	if err := appendToSecretItem(buildUFarm, fmt.Sprintf("token_image-puller_%s_reg_auth_value.txt", clusterWildcard), o, c); err != nil {
+	if err := appendToSecretItem(buildUFarm, fmt.Sprintf("token_%s_%s_reg_auth_value.txt", serviceAccountWildcard, clusterWildcard), o, c); err != nil {
 		return err
 	}
 	if err := appendToSecretItem("ci-chat-bot", serviceAccountConfigPath, o, c); err != nil {

--- a/cmd/cluster-init/cmd/onboard/update_secret_generator_test.go
+++ b/cmd/cluster-init/cmd/onboard/update_secret_generator_test.go
@@ -125,13 +125,17 @@ func TestUpdateSecretGeneratorConfig(t *testing.T) {
 				{
 					ItemName: buildUFarm,
 					Fields: []secretgenerator.FieldGenerator{{
-						Name: fmt.Sprintf("token_image-puller_%s_reg_auth_value.txt", clusterWildcard),
+						Name: fmt.Sprintf("token_%s_%s_reg_auth_value.txt", serviceAccountWildcard, clusterWildcard),
 						Cmd:  "oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account) | sed \"s/$(service_account)/$(cluster)/g\"",
 					}},
 					Params: map[string][]string{
 						"cluster": {
 							string(api.ClusterAPPCI),
-							string(api.ClusterBuild01)}},
+							string(api.ClusterBuild01)},
+						"service_account": {
+							"image-puller",
+						},
+					},
 				},
 				{
 					ItemName: "ci-chat-bot",
@@ -172,14 +176,19 @@ func TestUpdateSecretGeneratorConfig(t *testing.T) {
 				{
 					ItemName: buildUFarm,
 					Fields: []secretgenerator.FieldGenerator{{
-						Name: fmt.Sprintf("token_image-puller_%s_reg_auth_value.txt", clusterWildcard),
+						Name: fmt.Sprintf("token_%s_%s_reg_auth_value.txt", serviceAccountWildcard, clusterWildcard),
 						Cmd:  "oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account) | sed \"s/$(service_account)/$(cluster)/g\"",
 					}},
 					Params: map[string][]string{
 						"cluster": {
 							string(api.ClusterAPPCI),
 							string(api.ClusterBuild01),
-							"newcluster"}},
+							"newcluster",
+						},
+						"service_account": {
+							"image-puller",
+						},
+					},
 				},
 				{
 					ItemName: "ci-chat-bot",

--- a/test/integration/cluster-init/create/expected/core-services/ci-secret-generator/_config.yaml
+++ b/test/integration/cluster-init/create/expected/core-services/ci-secret-generator/_config.yaml
@@ -29,13 +29,15 @@
       jq --slurp '.[-1] | .data[".dockercfg"]' --raw-output | base64 --decode | jq
       '.["image-registry.openshift-image-registry.svc:5000"].auth' --raw-output |
       tr -d '\n'
-    name: token_image-puller_$(cluster)_reg_auth_value.txt
+    name: token_$(service_account)_$(cluster)_reg_auth_value.txt
   item_name: build_farm
   params:
     cluster:
     - app.ci
     - build01
     - newCluster
+    service_account:
+    - image-puller
 - fields:
   - cmd: oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account)
       | sed "s/$(service_account)/$(cluster)/g"

--- a/test/integration/cluster-init/create/input/core-services/ci-secret-generator/_config.yaml
+++ b/test/integration/cluster-init/create/input/core-services/ci-secret-generator/_config.yaml
@@ -28,12 +28,14 @@
       jq --slurp '.[-1] | .data[".dockercfg"]' --raw-output | base64 --decode | jq
       '.["image-registry.openshift-image-registry.svc:5000"].auth' --raw-output |
       tr -d '\n'
-    name: token_image-puller_$(cluster)_reg_auth_value.txt
+    name: token_$(service_account)_$(cluster)_reg_auth_value.txt
   item_name: build_farm
   params:
     cluster:
     - app.ci
     - build01
+    service_account:
+    - image-puller
 - fields:
   - cmd: oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account)
       | sed "s/$(service_account)/$(cluster)/g"

--- a/test/integration/cluster-init/update/expected/core-services/ci-secret-generator/_config.yaml
+++ b/test/integration/cluster-init/update/expected/core-services/ci-secret-generator/_config.yaml
@@ -29,13 +29,15 @@
       jq --slurp '.[-1] | .data[".dockercfg"]' --raw-output | base64 --decode | jq
       '.["image-registry.openshift-image-registry.svc:5000"].auth' --raw-output |
       tr -d '\n'
-    name: token_image-puller_$(cluster)_reg_auth_value.txt
+    name: token_$(service_account)_$(cluster)_reg_auth_value.txt
   item_name: build_farm
   params:
     cluster:
     - app.ci
     - build01
     - existingCluster
+    service_account:
+    - image-puller
 - fields:
   - cmd: oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account)
       | sed "s/$(service_account)/$(cluster)/g"

--- a/test/integration/cluster-init/update/input/core-services/ci-secret-generator/_config.yaml
+++ b/test/integration/cluster-init/update/input/core-services/ci-secret-generator/_config.yaml
@@ -29,12 +29,14 @@
       jq --slurp '.[-1] | .data[".dockercfg"]' --raw-output | base64 --decode | jq
       '.["image-registry.openshift-image-registry.svc:5000"].auth' --raw-output |
       tr -d '\n'
-    name: token_image-puller_$(cluster)_reg_auth_value.txt
+    name: token_$(service_account)_$(cluster)_reg_auth_value.txt
   item_name: build_farm
   params:
     cluster:
     - app.ci
     - build01
+    service_account:
+    - image-puller
 - fields:
   - cmd: oc --context $(cluster) sa create-kubeconfig --namespace ci $(service_account)
       | sed "s/$(service_account)/$(cluster)/g"


### PR DESCRIPTION
Upcoming changes to the `ci-secret-generator` config necessitate this update.

Supersedes: https://github.com/openshift/ci-tools/pull/4279