### PR TITLE
Changes in dispatching algorithm

### DIFF
--- a/cmd/prow-job-dispatcher/prometheus_volumes.go
+++ b/cmd/prow-job-dispatcher/prometheus_volumes.go
@@ -56,3 +56,12 @@ func (pv *prometheusVolumes) GetJobVolumes() (map[string]float64, error) {
 	logrus.Info("Fetched new job volumes")
 	return pv.jobVolumes, nil
 }
+
+func (pv *prometheusVolumes) getTotalVolume() float64 {
+	var totalVolume float64
+	for _, volume := range pv.jobVolumes {
+		totalVolume += volume
+	}
+
+	return totalVolume
+}

--- a/cmd/prow-job-dispatcher/prowjobs.go
+++ b/cmd/prow-job-dispatcher/prowjobs.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type prowjobs struct {
@@ -43,4 +44,15 @@ func (pjs *prowjobs) get(pj string) string {
 		return cluster
 	}
 	return ""
+}
+
+func (pjs *prowjobs) hasAnyOfClusters(clusters sets.Set[string]) bool {
+	pjs.mu.Lock()
+	defer pjs.mu.Unlock()
+	for _, cluster := range pjs.data {
+		if clusters.Has(cluster) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/prow-job-dispatcher/prowjobs.go
+++ b/cmd/prow-job-dispatcher/prowjobs.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/xyz-operator-presubmits.yaml
+++ b/cmd/prow-job-dispatcher/testdata/TestDispatchJobs/basic_case/xyz-operator-presubmits.yaml
@@ -1,0 +1,55 @@
+postsubmits:
+  xyz/xyz-operator:
+  - agent: kubernetes
+    branches:
+    - ^master$
+    cluster: api.ci
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+      ci-operator.openshift.io/prowgen-controlled: "true"
+    max_concurrency: 1
+    name: branch-ci-xyz-xyz-operator-master-images
+    spec:
+      containers:
+      - args:
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --kubeconfig=/etc/apici/kubeconfig
+        - --promote
+        - --report-password-file=/etc/report/password.txt
+        - --report-username=ci
+        - --target=[images]
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/apici
+          name: apici-ci-operator-credentials
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: apici-ci-operator-credentials
+        secret:
+          items:
+          - key: sa.ci-operator.apici.config
+            path: kubeconfig
+          secretName: apici-ci-operator-credentials
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator

--- a/cmd/sanitize-prow-jobs/main.go
+++ b/cmd/sanitize-prow-jobs/main.go
@@ -2,27 +2,13 @@ package main
 
 import (
 	"flag"
-	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-	prowconfig "sigs.k8s.io/prow/pkg/config"
-	"sigs.k8s.io/yaml"
-
-	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/dispatcher"
-	"github.com/openshift/ci-tools/pkg/jobconfig"
-	"github.com/openshift/ci-tools/pkg/util"
-	"github.com/openshift/ci-tools/pkg/util/gzip"
-)
-
-const (
-	cioperatorLatestImage = "ci-operator:latest"
+	"github.com/openshift/ci-tools/pkg/sanitizer"
 )
 
 type options struct {
@@ -40,115 +26,6 @@ func bindOptions(flag *flag.FlagSet) *options {
 	flag.BoolVar(&opt.help, "h", false, "Show help for ci-operator-prowgen")
 
 	return opt
-}
-
-func determinizeJobs(prowJobConfigDir string, config *dispatcher.Config) error {
-	ch := make(chan string)
-	errCh := make(chan error)
-	produce := func() error {
-		defer close(ch)
-		return filepath.WalkDir(prowJobConfigDir, func(path string, info fs.DirEntry, err error) error {
-			if err != nil {
-				errCh <- fmt.Errorf("failed to walk file/directory %q: %w", path, err)
-				return nil
-			}
-			if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
-				return nil
-			}
-			ch <- path
-			return nil
-		})
-	}
-	map_ := func() error {
-		for path := range ch {
-			data, err := gzip.ReadFileMaybeGZIP(path)
-			if err != nil {
-				errCh <- fmt.Errorf("failed to read file %q: %w", path, err)
-				continue
-			}
-
-			jobConfig := &prowconfig.JobConfig{}
-			if err := yaml.Unmarshal(data, jobConfig); err != nil {
-				errCh <- fmt.Errorf("failed to unmarshal file %q: %w", path, err)
-				continue
-			}
-
-			if err := defaultJobConfig(jobConfig, path, config); err != nil {
-				errCh <- fmt.Errorf("failed to default job config %q: %w", path, err)
-			}
-
-			serialized, err := yaml.Marshal(jobConfig)
-			if err != nil {
-				errCh <- fmt.Errorf("failed to marshal file %q: %w", path, err)
-				continue
-			}
-
-			if err := os.WriteFile(path, serialized, 0644); err != nil {
-				errCh <- fmt.Errorf("failed to write file %q: %w", path, err)
-				continue
-			}
-		}
-		return nil
-	}
-	if err := util.ProduceMap(0, produce, map_, errCh); err != nil {
-		return fmt.Errorf("failed to determinize all Prow jobs: %w", err)
-	}
-	return nil
-}
-
-func defaultJobConfig(jc *prowconfig.JobConfig, path string, config *dispatcher.Config) error {
-	for k := range jc.PresubmitsStatic {
-		for idx := range jc.PresubmitsStatic[k] {
-			cluster, err := config.GetClusterForJob(jc.PresubmitsStatic[k][idx].JobBase, path)
-			if err != nil {
-				return err
-			}
-			jc.PresubmitsStatic[k][idx].JobBase.Cluster = string(cluster)
-
-			if string(cluster) == string(api.ClusterARM01) && isCIOperatorLatest(jc.PresubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image) {
-				jc.PresubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image = "ci-operator-arm64:latest"
-			}
-
-			// Enforce that even hand-crafted jobs have explicit branch regexes
-			// Presubmits are generally expected to hit also on "feature branches",
-			// so we generate regexes for both exact match and feature branch patterns
-			featureBranches := sets.New[string]()
-			for _, branch := range jc.PresubmitsStatic[k][idx].Branches {
-				featureBranches.Insert(jobconfig.FeatureBranch(branch))
-				featureBranches.Insert(jobconfig.ExactlyBranch(branch))
-			}
-			jc.PresubmitsStatic[k][idx].Branches = sets.List(featureBranches)
-		}
-	}
-	for k := range jc.PostsubmitsStatic {
-		for idx := range jc.PostsubmitsStatic[k] {
-			cluster, err := config.GetClusterForJob(jc.PostsubmitsStatic[k][idx].JobBase, path)
-			if err != nil {
-				return err
-			}
-			jc.PostsubmitsStatic[k][idx].JobBase.Cluster = string(cluster)
-
-			if string(cluster) == string(api.ClusterARM01) && isCIOperatorLatest(jc.PostsubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image) {
-				jc.PostsubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image = "ci-operator-arm64:latest"
-			}
-
-			// Enforce that even hand-crafted jobs have explicit branch regexes
-			// Postsubmits are generally expected to only hit on exact match branches
-			// so we do not generate a regex for feature branch pattern like we do
-			// for presubmits above
-			for item := range jc.PostsubmitsStatic[k][idx].Branches {
-				jc.PostsubmitsStatic[k][idx].Branches[item] = jobconfig.ExactlyBranch(jc.PostsubmitsStatic[k][idx].Branches[item])
-			}
-		}
-	}
-	for idx := range jc.Periodics {
-		cluster, err := config.GetClusterForJob(jc.Periodics[idx].JobBase, path)
-		if err != nil {
-			return err
-		}
-		jc.Periodics[idx].JobBase.Cluster = string(cluster)
-	}
-	return nil
 }
 
 func main() {
@@ -183,15 +60,8 @@ func main() {
 	}
 	for _, subDir := range args {
 		subDir = filepath.Join(opt.prowJobConfigDir, subDir)
-		if err := determinizeJobs(subDir, config); err != nil {
+		if err := sanitizer.DeterminizeJobs(subDir, config, nil); err != nil {
 			logrus.WithError(err).Fatal("Failed to determinize")
 		}
 	}
-}
-
-func isCIOperatorLatest(image string) bool {
-	parts := strings.Split(image, "/")
-	lastPart := parts[len(parts)-1]
-
-	return lastPart == cioperatorLatestImage
 }

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/fgprof v0.9.1 // indirect
-	github.com/fsnotify/fsnotify v1.7.0
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fsouza/go-dockerclient v1.11.0 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
 	github.com/go-logr/logr v1.4.1

--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -318,3 +318,18 @@ func SaveConfig(config *Config, configPath string) error {
 	}
 	return nil
 }
+
+// GetBuildFarmSize returns build farm size
+func (config *Config) GetBuildFarmSize() int {
+	size := 0
+
+	if config == nil || config.BuildFarm == nil {
+		return size
+	}
+	for cloud := range config.BuildFarm {
+		for range config.BuildFarm[cloud] {
+			size++
+		}
+	}
+	return size
+}

--- a/pkg/sanitizer/determinize.go
+++ b/pkg/sanitizer/determinize.go
@@ -1,0 +1,151 @@
+package sanitizer
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/dispatcher"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
+	"github.com/openshift/ci-tools/pkg/util"
+	"github.com/openshift/ci-tools/pkg/util/gzip"
+)
+
+const (
+	cioperatorLatestImage = "ci-operator:latest"
+)
+
+func DeterminizeJobs(prowJobConfigDir string, config *dispatcher.Config, pjs map[string]string) error {
+	ch := make(chan string)
+	errCh := make(chan error)
+	produce := func() error {
+		defer close(ch)
+		return filepath.WalkDir(prowJobConfigDir, func(path string, info fs.DirEntry, err error) error {
+			if err != nil {
+				errCh <- fmt.Errorf("failed to walk file/directory %q: %w", path, err)
+				return nil
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
+				return nil
+			}
+			ch <- path
+			return nil
+		})
+	}
+	map_ := func() error {
+		for path := range ch {
+			data, err := gzip.ReadFileMaybeGZIP(path)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to read file %q: %w", path, err)
+				continue
+			}
+
+			jobConfig := &prowconfig.JobConfig{}
+			if err := yaml.Unmarshal(data, jobConfig); err != nil {
+				errCh <- fmt.Errorf("failed to unmarshal file %q: %w", path, err)
+				continue
+			}
+
+			if err := defaultJobConfig(jobConfig, path, config, pjs); err != nil {
+				errCh <- fmt.Errorf("failed to default job config %q: %w", path, err)
+			}
+
+			serialized, err := yaml.Marshal(jobConfig)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to marshal file %q: %w", path, err)
+				continue
+			}
+
+			if err := os.WriteFile(path, serialized, 0644); err != nil {
+				errCh <- fmt.Errorf("failed to write file %q: %w", path, err)
+				continue
+			}
+		}
+		return nil
+	}
+	if err := util.ProduceMap(0, produce, map_, errCh); err != nil {
+		return fmt.Errorf("failed to determinize all Prow jobs: %w", err)
+	}
+	return nil
+}
+
+func defaultJobConfig(jc *prowconfig.JobConfig, path string, config *dispatcher.Config, pjs map[string]string) error {
+	for k := range jc.PresubmitsStatic {
+		for idx := range jc.PresubmitsStatic[k] {
+			cluster, err := determineCluster(jc.PresubmitsStatic[k][idx].JobBase, config, pjs, path)
+			if err != nil {
+				return err
+			}
+			jc.PresubmitsStatic[k][idx].JobBase.Cluster = cluster
+
+			if cluster == string(api.ClusterARM01) && isCIOperatorLatest(jc.PresubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image) {
+				jc.PresubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image = "ci-operator-arm64:latest"
+			}
+
+			// Enforce that even hand-crafted jobs have explicit branch regexes
+			// Presubmits are generally expected to hit also on "feature branches",
+			// so we generate regexes for both exact match and feature branch patterns
+			featureBranches := sets.New[string]()
+			for _, branch := range jc.PresubmitsStatic[k][idx].Branches {
+				featureBranches.Insert(jobconfig.FeatureBranch(branch))
+				featureBranches.Insert(jobconfig.ExactlyBranch(branch))
+			}
+			jc.PresubmitsStatic[k][idx].Branches = sets.List(featureBranches)
+		}
+	}
+	for k := range jc.PostsubmitsStatic {
+		for idx := range jc.PostsubmitsStatic[k] {
+			cluster, err := determineCluster(jc.PostsubmitsStatic[k][idx].JobBase, config, pjs, path)
+			if err != nil {
+				return err
+			}
+			jc.PostsubmitsStatic[k][idx].JobBase.Cluster = cluster
+
+			if cluster == string(api.ClusterARM01) && isCIOperatorLatest(jc.PostsubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image) {
+				jc.PostsubmitsStatic[k][idx].JobBase.Spec.Containers[0].Image = "ci-operator-arm64:latest"
+			}
+
+			// Enforce that even hand-crafted jobs have explicit branch regexes
+			// Postsubmits are generally expected to only hit on exact match branches
+			// so we do not generate a regex for feature branch pattern like we do
+			// for presubmits above
+			for item := range jc.PostsubmitsStatic[k][idx].Branches {
+				jc.PostsubmitsStatic[k][idx].Branches[item] = jobconfig.ExactlyBranch(jc.PostsubmitsStatic[k][idx].Branches[item])
+			}
+		}
+	}
+	for idx := range jc.Periodics {
+		cluster, err := determineCluster(jc.Periodics[idx].JobBase, config, pjs, path)
+		if err != nil {
+			return err
+		}
+		jc.Periodics[idx].JobBase.Cluster = cluster
+	}
+	return nil
+}
+
+func isCIOperatorLatest(image string) bool {
+	parts := strings.Split(image, "/")
+	lastPart := parts[len(parts)-1]
+
+	return lastPart == cioperatorLatestImage
+}
+
+func determineCluster(jb prowconfig.JobBase, config *dispatcher.Config, pjs map[string]string, path string) (string, error) {
+	if pjs == nil {
+		c, err := config.GetClusterForJob(jb, path)
+		if err != nil {
+			return "", err
+		}
+		return string(c), nil
+	}
+	return pjs[jb.Name], nil
+
+}

--- a/pkg/sanitizer/determinize_test.go
+++ b/pkg/sanitizer/determinize_test.go
@@ -1,4 +1,4 @@
-package main
+package sanitizer
 
 import (
 	"testing"
@@ -22,7 +22,7 @@ func TestDefaultJobConfig(t *testing.T) {
 	}
 
 	config := &dispatcher.Config{Default: "api.ci"}
-	if err := defaultJobConfig(jc, "", config); err != nil {
+	if err := defaultJobConfig(jc, "", config, nil); err != nil {
 		t.Errorf("failed default job config: %v", err)
 	}
 


### PR DESCRIPTION
- remove multithreading to boost determinism of the algorithm
- until 75% of per cluster capacity try to assign to previous cluster (if existing)
- above 75% or if cluster disabled/blocked, take cluster with lowest amount of volumes (as it was before)
- take files to process from largest to smallest (assumption: it will allow larger test groups to be reassigned to the same cluster as before)
- honor exceptions and e2e colocation per test

Signed-off-by: Jakub Guzik <jguzik@redhat.com>

**Note**: https://github.com/openshift/ci-tools/pull/4275 has to be merged.