### PR TITLE
[ci-operator] resolve the multi-arch dependencies in the image tree graph

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -900,6 +900,10 @@ func (o *options) Run() []error {
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}
+
+	// Resolve which of the steps should enable multi arch based on the graph build steps.
+	buildSteps = api.ResolveMultiArch(buildSteps)
+
 	// Before we create the namespace, we need to ensure all inputs to the graph
 	// have been resolved. We must run this step before we resolve the partial
 	// graph or otherwise two jobs with different targets would create different

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -169,7 +169,8 @@ func fromConfig(
 		}
 	}
 	inputImages := make(inputImageSet)
-	var overridableSteps, buildSteps []api.Step
+	var overridableSteps []api.Step
+	var buildSteps []api.Step
 	var imageStepLinks []api.StepLink
 	var hasReleaseStep bool
 	resolver := rootImageResolver(client, ctx, promote)

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -26,6 +26,7 @@ type bundleSourceStep struct {
 	podClient          kubernetes.PodClient
 	jobSpec            *api.JobSpec
 	pullSecret         *coreapi.Secret
+	multiArch          bool
 }
 
 func (s *bundleSourceStep) Inputs() (api.InputDefinition, error) {
@@ -78,7 +79,8 @@ func (s *bundleSourceStep) run(ctx context.Context) error {
 		nil,
 		"",
 	)
-	return handleBuilds(ctx, s.client, s.podClient, *build)
+
+	return handleBuilds(ctx, s.client, s.podClient, *build, newImageBuildOptions(s.multiArch))
 }
 
 func replaceCommand(pullSpec, with string) string {
@@ -131,6 +133,9 @@ func (s *bundleSourceStep) Name() string { return s.config.TargetName() }
 func (s *bundleSourceStep) Description() string {
 	return fmt.Sprintf("Build image %s from the repository", api.PipelineImageStreamTagReferenceBundleSource)
 }
+
+func (s *bundleSourceStep) IsMultiArch() bool           { return s.multiArch }
+func (s *bundleSourceStep) SetMultiArch(multiArch bool) { s.multiArch = multiArch }
 
 func BundleSourceStep(
 	config api.BundleSourceStepConfiguration,

--- a/pkg/steps/git_source.go
+++ b/pkg/steps/git_source.go
@@ -23,6 +23,7 @@ type gitSourceStep struct {
 	jobSpec         *api.JobSpec
 	cloneAuthConfig *CloneAuthConfig
 	pullSecret      *coreapi.Secret
+	multiArch       bool
 }
 
 func (s *gitSourceStep) Inputs() (api.InputDefinition, error) {
@@ -57,7 +58,7 @@ func (s *gitSourceStep) run(ctx context.Context) error {
 				URI: cloneURI,
 				Ref: refs.BaseRef,
 			},
-		}, "", s.config.DockerfilePath, s.resources, s.pullSecret, nil, s.config.Ref))
+		}, "", s.config.DockerfilePath, s.resources, s.pullSecret, nil, s.config.Ref), newImageBuildOptions(s.multiArch))
 	}
 
 	return fmt.Errorf("nothing to build source image from, no refs")
@@ -119,6 +120,9 @@ func (s *gitSourceStep) determineRefsWorkdir(refs *prowapi.Refs, extraRefs []pro
 
 	return matchingRef
 }
+
+func (s *gitSourceStep) IsMultiArch() bool           { return s.multiArch }
+func (s *gitSourceStep) SetMultiArch(multiArch bool) { s.multiArch = multiArch }
 
 // GitSourceStep returns gitSourceStep that holds all the required information to create a build from a git source.
 func GitSourceStep(

--- a/pkg/steps/index_generator.go
+++ b/pkg/steps/index_generator.go
@@ -28,6 +28,7 @@ type indexGeneratorStep struct {
 	podClient          kubernetes.PodClient
 	jobSpec            *api.JobSpec
 	pullSecret         *coreapi.Secret
+	multiArch          bool
 }
 
 const IndexDataDirectory = "/index-data"
@@ -122,7 +123,7 @@ func (s *indexGeneratorStep) run(ctx context.Context) error {
 		nil,
 		"",
 	)
-	err = handleBuilds(ctx, s.client, s.podClient, *build)
+	err = handleBuilds(ctx, s.client, s.podClient, *build, newImageBuildOptions(s.multiArch))
 	if err != nil && strings.Contains(err.Error(), "error checking provided apis") {
 		return results.ForReason("generating_index").WithError(err).Errorf("failed to generate operator index due to invalid bundle info: %v", err)
 	}
@@ -195,6 +196,9 @@ func (s *indexGeneratorStep) Description() string {
 func (s *indexGeneratorStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
+
+func (s *indexGeneratorStep) IsMultiArch() bool           { return s.multiArch }
+func (s *indexGeneratorStep) SetMultiArch(multiArch bool) { s.multiArch = multiArch }
 
 func IndexGeneratorStep(
 	config api.IndexGeneratorStepConfiguration,

--- a/pkg/steps/pipeline_image_cache.go
+++ b/pkg/steps/pipeline_image_cache.go
@@ -28,6 +28,7 @@ type pipelineImageCacheStep struct {
 	podClient  kubernetes.PodClient
 	jobSpec    *api.JobSpec
 	pullSecret *coreapi.Secret
+	multiArch  bool
 }
 
 func (s *pipelineImageCacheStep) Inputs() (api.InputDefinition, error) {
@@ -58,7 +59,7 @@ func (s *pipelineImageCacheStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 		s.config.Ref,
-	))
+	), newImageBuildOptions(s.multiArch))
 }
 
 func (s *pipelineImageCacheStep) Requires() []api.StepLink {
@@ -87,6 +88,9 @@ func (s *pipelineImageCacheStep) Description() string {
 func (s *pipelineImageCacheStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
+
+func (s *pipelineImageCacheStep) IsMultiArch() bool           { return s.multiArch }
+func (s *pipelineImageCacheStep) SetMultiArch(multiArch bool) { s.multiArch = multiArch }
 
 func PipelineImageCacheStep(
 	config api.PipelineImageCacheStepConfiguration,

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -27,6 +27,7 @@ type projectDirectoryImageBuildStep struct {
 	podClient          kubernetes.PodClient
 	jobSpec            *api.JobSpec
 	pullSecret         *coreapi.Secret
+	multiArch          bool
 }
 
 func (s *projectDirectoryImageBuildStep) Inputs() (api.InputDefinition, error) {
@@ -65,7 +66,7 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.config.Ref,
 	)
 
-	return handleBuilds(ctx, s.client, s.podClient, *build, ImageBuildOptions{MultiArch: s.config.MultiArch})
+	return handleBuilds(ctx, s.client, s.podClient, *build, newImageBuildOptions(s.multiArch))
 }
 
 type workingDir func(tag string) (string, error)
@@ -188,6 +189,14 @@ func (s *projectDirectoryImageBuildStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *projectDirectoryImageBuildStep) IsMultiArch() bool {
+	return s.config.MultiArch
+}
+
+func (s *projectDirectoryImageBuildStep) SetMultiArch(m bool) {
+	s.multiArch = m
+}
+
 func ProjectDirectoryImageBuildStep(
 	config api.ProjectDirectoryImageBuildStepConfiguration,
 	releaseBuildConfig *api.ReleaseBuildConfiguration,
@@ -205,5 +214,6 @@ func ProjectDirectoryImageBuildStep(
 		podClient:          podClient,
 		jobSpec:            jobSpec,
 		pullSecret:         pullSecret,
+		multiArch:          config.MultiArch,
 	}
 }

--- a/pkg/steps/rpm_injection.go
+++ b/pkg/steps/rpm_injection.go
@@ -27,6 +27,7 @@ type rpmImageInjectionStep struct {
 	podClient  kubernetes.PodClient
 	jobSpec    *api.JobSpec
 	pullSecret *coreapi.Secret
+	multiArch  bool
 }
 
 func (s *rpmImageInjectionStep) Inputs() (api.InputDefinition, error) {
@@ -62,7 +63,7 @@ func (s *rpmImageInjectionStep) run(ctx context.Context) error {
 		s.pullSecret,
 		nil,
 		"",
-	))
+	), newImageBuildOptions(s.multiArch))
 }
 
 func (s *rpmImageInjectionStep) Requires() []api.StepLink {
@@ -86,6 +87,9 @@ func (s *rpmImageInjectionStep) Description() string {
 func (s *rpmImageInjectionStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
+
+func (s *rpmImageInjectionStep) IsMultiArch() bool           { return s.multiArch }
+func (s *rpmImageInjectionStep) SetMultiArch(multiArch bool) { s.multiArch = multiArch }
 
 func RPMImageInjectionStep(
 	config api.RPMImageInjectionStepConfiguration,

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
 	imagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"


### PR DESCRIPTION
These changes introduce the multi-arch property in the step graph. The steps that are building images will include all architecture if the image is needed by another step that is marked as multi-arch. 
Currently, the only step the user controls is the `ProjectDirectoryImageBuildStep`, which is the images stanza in the ci-operator configuration. If the user marks a specific image as multi-arch, all image build steps that are dependencies will also be built for multi-arch.  


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
