### PR TITLE
`ci-operator`: increase timeout waiting for pull-secrets to be available in the NS

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1348,7 +1348,7 @@ func (o *options) initializeNamespace() error {
 
 	pullStart := time.Now()
 	var imagePullSecretsMinted bool
-	for i := 0; i < 119; i++ {
+	for i := 0; i < 299; i++ {
 		imagePullSecretsMinted = true
 		serviceAccounts := map[string]*coreapi.ServiceAccount{
 			"builder": {},
@@ -1363,7 +1363,7 @@ func (o *options) initializeNamespace() error {
 		if imagePullSecretsMinted {
 			break
 		}
-		logrus.Debugf("[%d/120] Image pull secrets in namespace not yet ready, sleeping for a second...", i)
+		logrus.Debugf("[%d/300] Image pull secrets in namespace not yet ready, sleeping for a second...", i)
 		time.Sleep(time.Second)
 	}
 	logrus.Debugf("Spent %v waiting for image pull secrets to initialize in the new namespace.", time.Since(pullStart))


### PR DESCRIPTION
We are noticing issues with this timing out in `build01`. This was previously increased in https://github.com/openshift/ci-tools/pull/2415. Our hunch is that general cluster slowness is causing this timeout to be hit now, and we would like to see if an increase to 5min resolves this.