### PR TITLE
DPTP-4147 fix resolving multi-arch for all steps nodes in the graph

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -901,9 +901,6 @@ func (o *options) Run() []error {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}
 
-	// Resolve which of the steps should enable multi arch based on the graph build steps.
-	buildSteps = api.ResolveMultiArch(buildSteps)
-
 	// Before we create the namespace, we need to ensure all inputs to the graph
 	// have been resolved. We must run this step before we resolve the partial
 	// graph or otherwise two jobs with different targets would create different
@@ -920,6 +917,10 @@ func (o *options) Run() []error {
 	if err != nil {
 		return []error{results.ForReason("building_graph").WithError(err).Errorf("could not build execution graph: %v", err)}
 	}
+
+	// Resolve which of the steps should enable multi arch based on the graph build steps.
+	api.ResolveMultiArch(nodes)
+
 	stepList, errs := nodes.TopologicalSort()
 	if errs != nil {
 		return append([]error{results.ForReason("building_graph").ForError(errors.New("could not sort nodes"))}, errs...)

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1046,6 +1046,9 @@ func (*fakeValidationStep) Provides() api.ParameterMap           { return nil }
 func (f *fakeValidationStep) Validate() error                    { return f.err }
 func (*fakeValidationStep) Objects() []ctrlruntimeclient.Object  { return nil }
 
+func (*fakeValidationStep) IsMultiArch() bool { return false }
+func (*fakeValidationStep) SetMultiArch(bool) {}
+
 func TestValidateSteps(t *testing.T) {
 	valid0 := fakeValidationStep{name: "valid0"}
 	valid1 := fakeValidationStep{name: "valid1"}

--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -35,59 +35,38 @@ type Step interface {
 	Provides() ParameterMap
 	// Objects returns all objects the client for this step has seen
 	Objects() []ctrlruntimeclient.Object
-}
-
-// MultiArchStep is a step that holds multi-arch information
-// +k8s:deepcopy-gen=false
-type MultiArchStep interface {
-	Step
 
 	IsMultiArch() bool
-	SetMultiArch(multiArch bool)
+	SetMultiArch(bool)
 }
 
-func ResolveMultiArch(steps []Step) []Step {
-	stepsMap := make(map[string]Step)
-	for _, step := range steps {
-		stepsMap[step.Name()] = step
+// ResolveMultiArch traverses the graph of StepNodes and updates the multiArch field of each node.
+// If a node has a child that is multi-arch, the node itself is marked as multi-arch.
+// This function is used to propagate the multi-arch property up the graph, ensuring that any step
+// that depends on a multi-arch step is also considered multi-arch.
+func ResolveMultiArch(nodes []*StepNode) {
+	for _, node := range nodes {
+		setMultiArchForChildren(node)
+		ResolveMultiArch(node.Children)
 	}
-	for _, step := range stepsMap {
-		if multiArchStep, ok := step.(MultiArchStep); ok {
-			if multiArchStep.IsMultiArch() {
-				setMultiArchForParents(logrus.WithField("step_parent", multiArchStep.Name()), multiArchStep, stepsMap)
-			}
+
+	for _, node := range nodes {
+		if len(node.MultiArchReasons) == 0 {
+			continue
 		}
+		reasons := sets.New[string]()
+		for _, r := range node.MultiArchReasons {
+			reasons.Insert(r)
+		}
+		logrus.WithField("reasons", strings.Join(reasons.UnsortedList(), ", ")).Infof("Setting multi-arch for %s", node.Step.Name())
 	}
-
-	for i, step := range steps {
-		steps[i] = stepsMap[step.Name()]
-	}
-
-	return steps
 }
 
-func setMultiArchForParents(l *logrus.Entry, step Step, stepsMap map[string]Step) {
-	if step == nil {
-		return
-	}
-
-	for _, link := range step.Requires() {
-		if internalLink, ok := link.(*internalImageStreamTagLink); ok {
-			parentStepName := internalLink.tag
-			parentStep := stepsMap[parentStepName]
-			if parentStep != nil {
-				if multiArchStep, ok := parentStep.(MultiArchStep); ok {
-
-					if multiArchStep.IsMultiArch() {
-						continue
-					}
-
-					l.Infof("Setting multi-arch for %s:%s", internalLink.name, internalLink.tag)
-					multiArchStep.SetMultiArch(true)
-
-					setMultiArchForParents(logrus.WithField("step_parent", multiArchStep.Name()), multiArchStep, stepsMap)
-				}
-			}
+func setMultiArchForChildren(node *StepNode) {
+	for _, child := range node.Children {
+		if child.Step.IsMultiArch() {
+			node.MultiArchReasons = append(node.MultiArchReasons, child.Step.Name())
+			node.Step.SetMultiArch(true)
 		}
 	}
 }
@@ -331,8 +310,9 @@ func IsReleasePayloadStream(stream string) bool {
 
 // +k8s:deepcopy-gen=false
 type StepNode struct {
-	Step     Step
-	Children []*StepNode
+	Step             Step
+	Children         []*StepNode
+	MultiArchReasons []string
 }
 
 // GraphConfiguration contains step data used to build the execution graph.

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -305,6 +305,9 @@ func (s *clusterClaimStep) saveObjectAsArtifact(ctx context.Context, key ctrlrun
 	return api.SaveArtifact(s.censor, path, data)
 }
 
+func (s *clusterClaimStep) IsMultiArch() bool           { return false }
+func (s *clusterClaimStep) SetMultiArch(multiArch bool) {}
+
 func ClusterClaimStep(as string, clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.WithWatch, client loggingclient.LoggingClient, jobSpec *api.JobSpec, wrapped api.Step, censor *secrets.DynamicCensor) api.Step {
 	return &clusterClaimStep{
 		as:           as,

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -160,3 +160,6 @@ func (s *e2eTestStep) Description() string {
 func (s *e2eTestStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
+
+func (s *e2eTestStep) IsMultiArch() bool           { return false }
+func (s *e2eTestStep) SetMultiArch(multiArch bool) {}

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -42,6 +42,9 @@ func (s *imagesReadyStep) Objects() []ctrlruntimeclient.Object {
 
 func (s *imagesReadyStep) Description() string { return "All images are built and tagged into stable" }
 
+func (s *imagesReadyStep) IsMultiArch() bool           { return false }
+func (s *imagesReadyStep) SetMultiArch(multiArch bool) {}
+
 func ImagesReadyStep(links []api.StepLink) api.Step {
 	return &imagesReadyStep{
 		links: links,

--- a/pkg/steps/input_env.go
+++ b/pkg/steps/input_env.go
@@ -66,3 +66,6 @@ func (s *inputEnvironmentStep) Provides() api.ParameterMap {
 func (s *inputEnvironmentStep) Objects() []ctrlruntimeclient.Object {
 	return nil
 }
+
+func (s *inputEnvironmentStep) IsMultiArch() bool           { return false }
+func (s *inputEnvironmentStep) SetMultiArch(multiArch bool) {}

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -167,6 +167,11 @@ func (s *inputImageTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *inputImageTagStep) IsMultiArch() bool { return false }
+func (s *inputImageTagStep) SetMultiArch(multiArch bool) {
+	logrus.WithField("step", s.Name()).Warnf("Assuming image %q is multi-arch", s.imageName)
+}
+
 func InputImageTagStep(
 	config *api.InputImageTagStepConfiguration,
 	client loggingclient.LoggingClient,

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -62,6 +62,9 @@ func (s *ipPoolStep) Requires() []api.StepLink            { return s.wrapped.Req
 func (s *ipPoolStep) Creates() []api.StepLink             { return s.wrapped.Creates() }
 func (s *ipPoolStep) Objects() []ctrlruntimeclient.Object { return s.wrapped.Objects() }
 
+func (s *ipPoolStep) IsMultiArch() bool           { return false }
+func (s *ipPoolStep) SetMultiArch(multiArch bool) {}
+
 func (s *ipPoolStep) Provides() api.ParameterMap {
 	parameters := s.wrapped.Provides()
 	if parameters == nil {

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -130,6 +130,9 @@ func (blockingStep) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
+func (s *blockingStep) IsMultiArch() bool           { return false }
+func (s *blockingStep) SetMultiArch(multiArch bool) {}
+
 func TestRun(t *testing.T) {
 	ciOpNamespace := "ci-op-1234"
 

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -123,6 +123,9 @@ func (s *leaseStep) run(ctx context.Context) error {
 	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
 }
 
+func (s *leaseStep) IsMultiArch() bool           { return false }
+func (s *leaseStep) SetMultiArch(multiArch bool) {}
+
 func aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr error) error {
 	// we want a sensible output error for reporting, so we bubble up these individually if we can
 	if wrappedErr != nil && releaseErr == nil {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -54,6 +54,9 @@ func (stepNeedsLease) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
+func (s *stepNeedsLease) IsMultiArch() bool           { return false }
+func (s *stepNeedsLease) SetMultiArch(multiArch bool) {}
+
 func emptyNamespace() string { return "" }
 
 func TestLeaseStepForward(t *testing.T) {

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -165,6 +165,9 @@ func (s *outputImageTagStep) imageStreamTag(fromImage string) *imagev1.ImageStre
 	}
 }
 
+func (s *outputImageTagStep) IsMultiArch() bool           { return false }
+func (s *outputImageTagStep) SetMultiArch(multiArch bool) {}
+
 func OutputImageTagStep(config api.OutputImageTagStepConfiguration, client loggingclient.LoggingClient, jobSpec *api.JobSpec) api.Step {
 	return &outputImageTagStep{
 		config:  config,

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -161,6 +161,11 @@ func (s *podStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *podStep) IsMultiArch() bool {
+	return s.config.NodeArchitecture != "" && s.config.NodeArchitecture != api.NodeArchitectureAMD64
+}
+func (s *podStep) SetMultiArch(multiArch bool) {}
+
 func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, client kubernetes.PodClient, jobSpec *api.JobSpec, nodeName string) api.Step {
 	return PodStep(
 		"test",

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -190,6 +190,7 @@ func (s *projectDirectoryImageBuildStep) Objects() []ctrlruntimeclient.Object {
 }
 
 func (s *projectDirectoryImageBuildStep) IsMultiArch() bool {
+	// fmt.Printf("config: %s -- %v\n", s.config.To, s.config.MultiArch)
 	return s.config.MultiArch
 }
 

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -242,6 +242,9 @@ func (s *assembleReleaseStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *assembleReleaseStep) IsMultiArch() bool           { return false }
+func (s *assembleReleaseStep) SetMultiArch(multiArch bool) {}
+
 // AssembleReleaseStep builds a new update payload image based on the cluster version operator
 // and the operators defined in the release configuration.
 func AssembleReleaseStep(name, nodeName string, config *api.ReleaseTagConfiguration, resources api.ResourceConfiguration,

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -301,6 +301,9 @@ func (s *importReleaseStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *importReleaseStep) IsMultiArch() bool           { return false }
+func (s *importReleaseStep) SetMultiArch(multiArch bool) {}
+
 // ImportReleaseStep imports an existing update payload image
 func ImportReleaseStep(
 	name, nodeName, target string,

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -450,6 +450,9 @@ func (s *promotionStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *promotionStep) IsMultiArch() bool           { return false }
+func (s *promotionStep) SetMultiArch(multiArch bool) {}
+
 // PromotionStep copies tags from the pipeline image stream to the destination defined in the promotion config.
 // If the source tag does not exist it is silently skipped.
 func PromotionStep(

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -87,6 +87,9 @@ func (s *stableImagesTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *stableImagesTagStep) IsMultiArch() bool           { return false }
+func (s *stableImagesTagStep) SetMultiArch(multiArch bool) {}
+
 // releaseImagesTagStep will tag a full release suite
 // of images in from the configured namespace. It is
 // expected that builds will overwrite these tags at
@@ -203,6 +206,9 @@ func (s *releaseImagesTagStep) Description() string {
 func (s *releaseImagesTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
+
+func (s *releaseImagesTagStep) IsMultiArch() bool           { return false }
+func (s *releaseImagesTagStep) SetMultiArch(multiArch bool) {}
 
 func ReleaseImagesTagStep(config api.ReleaseTagConfiguration, client loggingclient.LoggingClient, params *api.DeferredParameters, jobSpec *api.JobSpec, integratedStream *configresolver.IntegratedStream) api.Step {
 	return &releaseImagesTagStep{

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -144,6 +144,9 @@ func (r *releaseSnapshotStep) Objects() []ctrlruntimeclient.Object {
 	return r.client.Objects()
 }
 
+func (s *releaseSnapshotStep) IsMultiArch() bool           { return false }
+func (s *releaseSnapshotStep) SetMultiArch(multiArch bool) {}
+
 func ReleaseSnapshotStep(release string, config api.Integration, client loggingclient.LoggingClient, jobSpec *api.JobSpec, integratedStream *configresolver.IntegratedStream) api.Step {
 	return &releaseSnapshotStep{
 		name:             release,

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -410,6 +410,9 @@ func (s *rpmServerStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *rpmServerStep) IsMultiArch() bool           { return false }
+func (s *rpmServerStep) SetMultiArch(multiArch bool) {}
+
 func admittedHostForRoute(client ctrlruntimeclient.Client, namespace, name string, timeout time.Duration) (string, error) {
 	var repoHost string
 	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -43,8 +43,9 @@ func (f *fakeStep) Creates() []api.StepLink           { return f.creates }
 func (f *fakeStep) Name() string                      { return f.name }
 func (f *fakeStep) Description() string               { return f.name }
 func (*fakeStep) Objects() []ctrlruntimeclient.Object { return nil }
-
-func (f *fakeStep) Provides() api.ParameterMap { return nil }
+func (f *fakeStep) Provides() api.ParameterMap        { return nil }
+func (f *fakeStep) IsMultiArch() bool                 { return false }
+func (f *fakeStep) SetMultiArch(multiArch bool)       {}
 
 func TestStepsRun(t *testing.T) {
 	testCases := []struct {

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -278,6 +278,9 @@ func (s *templateExecutionStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
+func (s *templateExecutionStep) IsMultiArch() bool           { return false }
+func (s *templateExecutionStep) SetMultiArch(multiArch bool) {}
+
 func TemplateExecutionStep(template *templateapi.Template, params api.Parameters, podClient kubernetes.PodClient, templateClient TemplateClient, jobSpec *api.JobSpec, resources api.ResourceConfiguration) api.Step {
 	return &templateExecutionStep{
 		template:  template,

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -75,6 +75,9 @@ func (s *writeParametersStep) Objects() []ctrlruntimeclient.Object {
 	return nil
 }
 
+func (s *writeParametersStep) IsMultiArch() bool           { return false }
+func (s *writeParametersStep) SetMultiArch(multiArch bool) {}
+
 func WriteParametersStep(params *api.DeferredParameters, paramFile string) api.Step {
 	return &writeParametersStep{
 		params:    params,


### PR DESCRIPTION
- Remove the MultiArchStep wrapper to avoid refactoring the whole StepNode graph resolution.
- Add the necessary methods to all steps for multi-arch.
- Change the multi-arch resolution to the partial graph instead
- Update the tests
- For the test steps, we treat them as multi-arch if their `nodeArchitecture` is non AMD64



/cc @openshift/test-platform @deepsm007 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>
