### PR TITLE
`ci-operator-configresolver`: base output off of config that requested test is injected from

### DIFF
--- a/test/integration/ci-operator-configresolver.sh
+++ b/test/integration/ci-operator-configresolver.sh
@@ -28,6 +28,9 @@ os::integration::configresolver::check_log
 os::cmd::expect_success "curl 'http://127.0.0.1:8080/mergeConfigsWithInjectedTest?org=openshift,openshift&repo=installer,console&branch=release-4.2,master&injectTestFromOrg=openshift&injectTestFromRepo=release&injectTestFromBranch=master&injectTestFromVariant=ci-4.9&injectTest=e2e' >${actual}/openshift-installer-console-merged-release-4.2-injected.json"
 os::integration::compare "${actual}/openshift-installer-console-merged-release-4.2-injected.json" "${expected}/openshift-installer-console-merged-release-4.2-injected.json"
 os::integration::configresolver::check_log
+os::cmd::expect_success "curl 'http://127.0.0.1:8080/mergeConfigsWithInjectedTest?org=openshift,openshift&repo=installer,console&branch=release-4.2,master&injectTestFromOrg=openshift&injectTestFromRepo=installer&injectTestFromBranch=release-4.2&injectTest=unit' >${actual}/openshift-installer-console-merged-release-4.2-installer-as-base.json"
+os::integration::compare "${actual}/openshift-installer-console-merged-release-4.2-installer-as-base.json" "${expected}/openshift-installer-console-merged-release-4.2-installer-as-base.json"
+os::integration::configresolver::check_log
 
 generation="$( os::integration::configresolver::generation::config )"
 mv "${BASETMPDIR}/configs2/release-4.2/openshift-installer-release-4.2-golang111.yaml" "${BASETMPDIR}/configs/release-4.2/openshift-installer-release-4.2.yaml"

--- a/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-installer-as-base.json
+++ b/test/integration/ci-operator-configresolver/expected/openshift-installer-console-merged-release-4.2-installer-as-base.json
@@ -1,0 +1,350 @@
+{
+  "zz_generated_metadata": {
+    "org": "openshift",
+    "repo": "installer",
+    "branch": "release-4.2"
+  },
+  "base_images": {
+    "base": {
+      "namespace": "ocp",
+      "name": "4.2",
+      "tag": "base"
+    },
+    "base-openshift.console": {
+      "namespace": "ocp",
+      "name": "4.2",
+      "tag": "base"
+    }
+  },
+  "build_root": {
+    "image_stream_tag": {
+      "namespace": "openshift",
+      "name": "release",
+      "tag": "golang-1.10"
+    }
+  },
+  "build_roots": {
+    "openshift.console": {
+      "image_stream_tag": {
+        "namespace": "openshift",
+        "name": "release",
+        "tag": "golang-1.20"
+      }
+    }
+  },
+  "images": [
+    {
+      "from": "base",
+      "to": "installer"
+    },
+    {
+      "from": "base-openshift.console",
+      "to": "console-openshift.console",
+      "ref": "openshift.console"
+    }
+  ],
+  "tests": [
+    {
+      "as": "unit",
+      "commands": "go test ./pkg/...",
+      "container": {
+        "from": "src"
+      }
+    },
+    {
+      "as": "e2e-aws",
+      "commands": "TEST_SUITE=openshift/conformance/parallel run-tests",
+      "openshift_installer": {
+        "cluster_profile": "aws"
+      }
+    },
+    {
+      "as": "e2e-azure",
+      "literal_steps": {
+        "cluster_profile": "azure4",
+        "pre": [
+          {
+            "as": "ipi-install-rbac",
+            "from": "installer",
+            "commands": "setup-rbac\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-install-install",
+            "from": "installer",
+            "commands": "openshift-cluster install\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "env": [
+              {
+                "name": "TEST_PARAMETER",
+                "default": "test parameter default"
+              }
+            ],
+            "observers": [
+              "resourcewatcher"
+            ],
+            "node_architecture": "amd64"
+          }
+        ],
+        "test": [
+          {
+            "as": "e2e",
+            "from": "my-image",
+            "commands": "make azure-e2e",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ],
+        "post": [
+          {
+            "as": "ipi-deprovision-must-gather",
+            "from": "installer",
+            "commands": "gather\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-deprovision-deprovision",
+            "from": "installer",
+            "commands": "openshift-cluster destroy\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ]
+      }
+    },
+    {
+      "as": "e2e-azure-with-watcher",
+      "literal_steps": {
+        "cluster_profile": "azure4",
+        "pre": [
+          {
+            "as": "ipi-install-rbac",
+            "from": "installer",
+            "commands": "setup-rbac\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-install-install",
+            "from": "installer",
+            "commands": "openshift-cluster install\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "env": [
+              {
+                "name": "TEST_PARAMETER",
+                "default": "test parameter default"
+              }
+            ],
+            "observers": [
+              "resourcewatcher"
+            ],
+            "node_architecture": "amd64"
+          }
+        ],
+        "test": [
+          {
+            "as": "e2e",
+            "from": "my-image",
+            "commands": "make azure-e2e",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ],
+        "post": [
+          {
+            "as": "ipi-deprovision-must-gather",
+            "from": "installer",
+            "commands": "gather\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-deprovision-deprovision",
+            "from": "installer",
+            "commands": "openshift-cluster destroy\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ],
+        "observers": [
+          {
+            "name": "resourcewatcher",
+            "from_image": {
+              "namespace": "ocp",
+              "name": "resourcewatcher",
+              "tag": "latest"
+            },
+            "commands": "#!/bin/bash\n\nsleep 300",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "as": "e2e-gcp",
+      "literal_steps": {
+        "cluster_profile": "gcp",
+        "pre": [
+          {
+            "as": "ipi-install-rbac",
+            "from": "installer",
+            "commands": "setup-rbac\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-install-install",
+            "from": "installer",
+            "commands": "openshift-cluster install\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "env": [
+              {
+                "name": "TEST_PARAMETER",
+                "default": "test parameter default"
+              }
+            ],
+            "observers": [
+              "resourcewatcher"
+            ],
+            "node_architecture": "amd64"
+          }
+        ],
+        "test": [
+          {
+            "as": "e2e",
+            "from": "my-image",
+            "commands": "make custom-e2e",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ],
+        "post": [
+          {
+            "as": "ipi-deprovision-must-gather",
+            "from": "installer",
+            "commands": "gather\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          },
+          {
+            "as": "ipi-deprovision-deprovision",
+            "from": "installer",
+            "commands": "openshift-cluster destroy\n",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            },
+            "node_architecture": "amd64"
+          }
+        ],
+        "observers": [
+          {
+            "name": "resourcewatcher",
+            "from_image": {
+              "namespace": "ocp",
+              "name": "resourcewatcher",
+              "tag": "latest"
+            },
+            "commands": "#!/bin/bash\n\nsleep 300",
+            "resources": {
+              "requests": {
+                "cpu": "1000m",
+                "memory": "2Gi"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "resources": {
+    "*": {
+      "requests": {
+        "cpu": "110m",
+        "memory": "300Mi"
+      },
+      "limits": {
+        "memory": "4Gi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This only applies when the requested injected test belongs to a config that is being merged. This allows for the entire config containing the injected test to be trivially included in the output without the need for the refs. It simplifies the logic for multi-pr presubmit testing in ci-operator without compromising functionality from payload testing.

For: https://issues.redhat.com/browse/DPTP-2894