### PR TITLE
`ci-operator`: treat building the primary ref differently from the extra_refs

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -892,11 +892,10 @@ func (o *options) Run() []error {
 		return []error{fmt.Errorf("could not resolve the node architectures: %w", err)}
 	}
 
-	mergedConfig := o.injectTest != "" || len(o.jobSpec.ExtraRefs) > 1
 	// load the graph from the configuration
 	buildSteps, promotionSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig,
 		o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig,
-		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, mergedConfig, streams)
+		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, streams)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -58,7 +58,6 @@ func TestStepConfigsForBuild(t *testing.T) {
 		output        []api.StepConfiguration
 		readFile      readFile
 		resolver      resolveRoot
-		mergedConfig  bool
 		expectedError error
 	}{
 		{
@@ -862,6 +861,153 @@ func TestStepConfigsForBuild(t *testing.T) {
 			expectedError: fmt.Errorf("failed to read buildRootImageStream from repository: %w", fmt.Errorf("failed to read .ci-operator.yaml file: %w", fmt.Errorf("fail to read file: reason"))),
 		},
 		{
+			name: "from a primary ref with an additional ref",
+			input: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					BuildRootImage: &api.BuildRootImageConfiguration{
+						ImageStreamTagReference: &api.ImageStreamTagReference{
+							Namespace: "root-ns",
+							Name:      "root-name",
+							Tag:       "manual",
+						},
+					},
+					BuildRootImages: map[string]api.BuildRootImageConfiguration{
+						"org.other-repo": {
+							ImageStreamTagReference: &api.ImageStreamTagReference{Tag: "manual"},
+							UseBuildCache:           true,
+						},
+					},
+				},
+				BinaryBuildCommands: "binbuild",
+				BinaryBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build",
+						Ref:      "org.other-repo",
+					},
+				},
+				TestBinaryBuildCommands: "build test-bin",
+				TestBinaryBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build tb",
+						Ref:      "org.other-repo",
+					},
+				},
+				RpmBuildCommands: "build rpm",
+				RpmBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build this-rpm",
+						Ref:      "org.other-repo",
+					},
+				},
+				RpmBuildLocation: "here",
+				RpmBuildLocationList: []api.RefLocation{
+					{
+						Location: "there",
+						Ref:      "org.other-repo",
+					},
+				},
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Refs: &prowapi.Refs{
+						Org:  "org",
+						Repo: "repo",
+					},
+					ExtraRefs: []prowapi.Refs{
+						{
+							Org:  "org",
+							Repo: "other-repo",
+						},
+					},
+				},
+			},
+			resolver: noopResolver,
+			output: []api.StepConfiguration{
+				{
+					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceRoot,
+						To:   api.PipelineImageStreamTagReferenceSource,
+					}),
+				}, {
+					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
+						From: api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRoot)),
+						To:   api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						Ref:  "org.other-repo",
+					}),
+				}, {
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						InputImage: api.InputImage{
+							BaseImage: api.ImageStreamTagReference{
+								Namespace: "root-ns",
+								Name:      "root-name",
+								Tag:       "manual",
+							},
+							To: api.PipelineImageStreamTagReferenceRoot,
+						},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceType(api.ImageStreamSourceRoot)}},
+					},
+				}, {
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						InputImage: api.InputImage{
+							BaseImage: api.ImageStreamTagReference{
+								Tag: "manual",
+							},
+							To:  api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRoot)),
+							Ref: "org.other-repo",
+						},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceType(fmt.Sprintf("%s-org.other-repo", api.ImageStreamSourceRoot))}},
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceSource,
+						To:       api.PipelineImageStreamTagReferenceBinaries,
+						Commands: "binbuild",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceBinaries)),
+						Commands: "build",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceSource,
+						To:       api.PipelineImageStreamTagReferenceTestBinaries,
+						Commands: "build test-bin",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceTestBinaries)),
+						Commands: "build tb",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceBinaries,
+						To:       api.PipelineImageStreamTagReferenceRPMs,
+						Commands: "build rpm; ln -s $( pwd )/here /srv/repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceBinaries)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRPMs)),
+						Commands: "build this-rpm; ln -s $( pwd )/there /srv/repo",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					RPMServeStepConfiguration: &api.RPMServeStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceRPMs,
+					},
+				}, {
+					RPMServeStepConfiguration: &api.RPMServeStepConfiguration{
+						From: api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRPMs)),
+						Ref:  "org.other-repo",
+					},
+				}},
+		},
+		{
 			name: "from multiple repo references",
 			input: &api.ReleaseBuildConfiguration{
 				InputConfiguration: api.InputConfiguration{
@@ -934,8 +1080,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 			},
-			resolver:     noopResolver,
-			mergedConfig: true,
+			resolver: noopResolver,
 			output: []api.StepConfiguration{
 				{
 					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
@@ -1032,7 +1177,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			graphConf := FromConfigStatic(testCase.input)
-			runtimeSteps, actualError := runtimeStepConfigsForBuild(testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages(), testCase.mergedConfig)
+			runtimeSteps, actualError := runtimeStepConfigsForBuild(testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages())
 			graphConf.Steps = append(graphConf.Steps, runtimeSteps...)
 			if diff := cmp.Diff(testCase.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("actualError does not match expectedError, diff: %s", diff)
@@ -1184,7 +1329,6 @@ func TestFromConfig(t *testing.T) {
 		env                 api.Parameters
 		params              map[string]string
 		overriddenImagesEnv map[string]string
-		mergedConfig        bool
 		expectedSteps       []string
 		expectedPost        []string
 		expectedParams      map[string]string
@@ -1284,7 +1428,6 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig:  true,
 		expectedSteps: []string{"root-org.repo1", "root-org.repo2", "[output-images]", "[images]"},
 	}, {
 		name: "base RPM images",
@@ -1326,7 +1469,6 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig: true,
 		expectedSteps: []string{
 			"[input:base_rpm_image-org.repo1-without-rpms]",
 			"base_rpm_image-org.repo1",
@@ -1367,7 +1509,6 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig: true,
 		expectedSteps: []string{
 			"rpms-org.repo1",
 			"[serve:rpms-org.repo1]",
@@ -1703,7 +1844,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, tc.mergedConfig, map[string]*configresolver.IntegratedStream{})
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, map[string]*configresolver.IntegratedStream{})
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -944,7 +944,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 							},
 							To: api.PipelineImageStreamTagReferenceRoot,
 						},
-						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceType(api.ImageStreamSourceRoot)}},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceRoot}},
 					},
 				}, {
 					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{


### PR DESCRIPTION
Since https://github.com/openshift/ci-tools/pull/4311 has merged, the `ci-operator-configresolver` now will not include the ref information for the primary ref. That is due to it being the ref that the requested test comes from. In order to support multi-pr presubmit testing, `ci-operator` needs to be slightly modified to generate build steps for the primary ref that don't include the ref suffixes, etc..

For: https://issues.redhat.com/browse/DPTP-2894