### PR TITLE
`payload-testing-prow-plugin`: handle errors from config reload

### DIFF
--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -142,8 +142,9 @@ func main() {
 		logger.WithError(err).WithField("context", appCIContextName).Fatal("could not get client for kube config")
 	}
 
-	// TODO: add error handling
-	configAgent, err := agents.NewConfigAgent(o.ciOpConfigDir, nil)
+	errChan := make(chan error)
+	go func() { logrus.Fatal(<-errChan) }()
+	configAgent, err := agents.NewConfigAgent(o.ciOpConfigDir, errChan)
 	if err != nil {
 		logger.WithError(err).Fatal("could not get config agent")
 	}


### PR DESCRIPTION
> The logs show that the config agent is constantly reloading configs. As soon as the reload is complete, it starts another. I believe this may be due to improper error handling. It also seems that the plugin is behaving non-deterministically in finding matching jobs, and I think this might have something to do with it.

Tested this out, and no errors popped up. Everything seemed to be working properly. Once this change lands we will monitor it, and if something goes wrong, we will notice the restarts and can investigate the error.

For: https://issues.redhat.com/browse/DPTP-4172