### PR TITLE
Fix issue DPTP-4032 Delete firewall when RH intranet access is desired

### DIFF
--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -1,7 +1,6 @@
 package prowgen
 
 import (
-	"strconv"
 	"time"
 
 	utilpointer "k8s.io/utils/pointer"
@@ -149,10 +148,6 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 			JobStatesToReport: slackReporter.JobStatesToReport,
 			ReportTemplate:    slackReporter.ReportTemplate,
 		}
-	}
-
-	if test.RestrictNetworkAccess != nil {
-		p.PodSpec.Add(Arg("--restrict-network-access", strconv.FormatBool(*test.RestrictNetworkAccess)))
 	}
 
 	switch {


### PR DESCRIPTION
We will use template to create the firewall object when NS creates. `ci-operator` just need to delete those created object on-demand.