### PR TITLE
resolve the step graph dependencies for specific architectures

### DIFF
--- a/pkg/api/graph.go
+++ b/pkg/api/graph.go
@@ -16,10 +16,27 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Step is a self-contained bit of work that the
-// build pipeline needs to do.
+// Step holds a common step
 // +k8s:deepcopy-gen=false
 type Step interface {
+	CommonStep
+}
+
+// MultiArchStep is a step that can be executed for multiple architectures.
+// It is used to propagate the multi-arch property up the graph, ensuring that any step
+// that depends on a multi-arch step is also considered multi-arch.
+// +k8s:deepcopy-gen=false
+type MultiArchStep interface {
+	CommonStep
+
+	ResolveMultiArch() sets.Set[string]
+	AddArchitectures([]string)
+}
+
+// CommonStep is a self-contained bit of work that the
+// build pipeline needs to do.
+// +k8s:deepcopy-gen=false
+type CommonStep interface {
 	Inputs() (InputDefinition, error)
 	// Validate checks inputs of steps that are part of the execution graph.
 	Validate() error
@@ -35,13 +52,11 @@ type Step interface {
 	Provides() ParameterMap
 	// Objects returns all objects the client for this step has seen
 	Objects() []ctrlruntimeclient.Object
-
-	IsMultiArch() bool
-	SetMultiArch(bool)
 }
 
 // ResolveMultiArch traverses the graph of StepNodes and updates the multiArch field of each node.
-// If a node has a child that is multi-arch, the node itself is marked as multi-arch.
+// If a node has a child that is multi-arch, the node itself is marked as multi-arch by
+// adding the child's architecture to the node.
 // This function is used to propagate the multi-arch property up the graph, ensuring that any step
 // that depends on a multi-arch step is also considered multi-arch.
 func ResolveMultiArch(nodes []*StepNode) {
@@ -54,21 +69,36 @@ func ResolveMultiArch(nodes []*StepNode) {
 		if len(node.MultiArchReasons) == 0 {
 			continue
 		}
-		reasons := sets.New[string]()
-		for _, r := range node.MultiArchReasons {
-			reasons.Insert(r)
+
+		if multiArchStep, ok := node.Step.(MultiArchStep); ok {
+			for arch, reasons := range node.MultiArchReasons {
+				logrus.WithField("reasons", strings.Join(reasons.UnsortedList(), ", ")).
+					WithField("arch", arch).
+					Infof("Setting arch for %s", multiArchStep.Name())
+			}
 		}
-		logrus.WithField("reasons", strings.Join(reasons.UnsortedList(), ", ")).Infof("Setting multi-arch for %s", node.Step.Name())
 	}
 }
 
 func setMultiArchForChildren(node *StepNode) {
 	for _, child := range node.Children {
-		if child.Step.IsMultiArch() {
-			node.MultiArchReasons = append(node.MultiArchReasons, child.Step.Name())
-			node.Step.SetMultiArch(true)
-		}
 		setMultiArchForChildren(child)
+
+		if multiArchStep, ok := child.Step.(MultiArchStep); ok {
+			childArchs := multiArchStep.ResolveMultiArch()
+			for _, arch := range childArchs.UnsortedList() {
+				if node.MultiArchReasons == nil {
+					node.MultiArchReasons = make(map[string]sets.Set[string])
+				}
+				if _, ok := node.MultiArchReasons[arch]; !ok {
+					node.MultiArchReasons[arch] = sets.New[string]()
+				}
+				node.MultiArchReasons[arch].Insert(multiArchStep.Name())
+				if nodeMultiArchStep, ok := node.Step.(MultiArchStep); ok {
+					nodeMultiArchStep.AddArchitectures([]string{arch})
+				}
+			}
+		}
 	}
 }
 
@@ -313,7 +343,7 @@ func IsReleasePayloadStream(stream string) bool {
 type StepNode struct {
 	Step             Step
 	Children         []*StepNode
-	MultiArchReasons []string
+	MultiArchReasons map[string]sets.Set[string]
 }
 
 // GraphConfiguration contains step data used to build the execution graph.

--- a/pkg/api/graph_test.go
+++ b/pkg/api/graph_test.go
@@ -15,6 +15,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -113,10 +114,10 @@ func TestMatches(t *testing.T) {
 }
 
 type fakeStep struct {
-	requires  []StepLink
-	creates   []StepLink
-	name      string
-	multiArch bool
+	requires      []StepLink
+	creates       []StepLink
+	name          string
+	architectures sets.Set[string]
 }
 
 func (f *fakeStep) Inputs() (InputDefinition, error) { return nil, nil }
@@ -131,8 +132,15 @@ func (f *fakeStep) Objects() []ctrlruntimeclient.Object { return nil }
 
 func (f *fakeStep) Provides() ParameterMap { return nil }
 
-func (f *fakeStep) IsMultiArch() bool           { return f.multiArch }
-func (f *fakeStep) SetMultiArch(multiArch bool) { f.multiArch = multiArch }
+func (f *fakeStep) ResolveMultiArch() sets.Set[string] {
+	return f.architectures
+}
+func (f *fakeStep) AddArchitectures(archs []string) {
+	if f.architectures == nil {
+		f.architectures = sets.New[string]()
+	}
+	f.architectures.Insert(archs...)
+}
 
 func TestBuildGraph(t *testing.T) {
 	root := &fakeStep{
@@ -263,8 +271,6 @@ func (*fakeSortStep) Description() string                 { return "" }
 func (*fakeSortStep) Provides() ParameterMap              { return nil }
 func (f *fakeSortStep) Validate() error                   { return f.err }
 func (*fakeSortStep) Objects() []ctrlruntimeclient.Object { return nil }
-func (f *fakeSortStep) IsMultiArch() bool                 { return false }
-func (f *fakeSortStep) SetMultiArch(multiArch bool)       {}
 
 func (f *fakeSortStep) Creates() []StepLink {
 	return []StepLink{fakeSortLink{name: f.name}}
@@ -518,19 +524,19 @@ func TestResolveMultiArch(t *testing.T) {
 				{
 					Step: &fakeStep{name: "step1"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
-						{Step: &fakeStep{name: "step4", multiArch: false}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
+						{Step: &fakeStep{name: "step4"}},
 					},
 				},
 			},
 			expected: []*StepNode{
 				{
-					Step: &fakeStep{name: "step1", multiArch: false},
+					Step: &fakeStep{name: "step1"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
-						{Step: &fakeStep{name: "step4", multiArch: false}}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
+						{Step: &fakeStep{name: "step4"}}},
 				},
 			},
 		},
@@ -540,75 +546,109 @@ func TestResolveMultiArch(t *testing.T) {
 				{
 					Step: &fakeStep{name: "step1"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step2", multiArch: true}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
-						{Step: &fakeStep{name: "step4", multiArch: true}},
+						{Step: &fakeStep{name: "step2", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step3"}},
+						{Step: &fakeStep{name: "step4", architectures: sets.New[string]("arm64")}},
 					},
 				},
 			},
 			expected: []*StepNode{
 				{
-					Step: &fakeStep{name: "step1", multiArch: true},
+					Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step2", multiArch: true}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
-						{Step: &fakeStep{name: "step4", multiArch: true}}},
-					MultiArchReasons: []string{"step2", "step4"},
+						{Step: &fakeStep{name: "step2", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step3"}},
+						{Step: &fakeStep{name: "step4", architectures: sets.New[string]("arm64")}}},
+					MultiArchReasons: map[string]sets.Set[string]{
+						"arm64": sets.New[string]("step2", "step4"),
+					},
 				},
 			},
 		},
+		{
+			name: "multiple children with different architectures",
+			nodes: []*StepNode{
+				{
+					Step: &fakeStep{name: "parent"},
+					Children: []*StepNode{
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("amd64")}},
+						{Step: &fakeStep{name: "step2", architectures: sets.New[string]("arm64")}},
+					},
+				},
+			},
+			expected: []*StepNode{
+				{
+					Step: &fakeStep{name: "parent", architectures: sets.New[string]("amd64", "arm64")},
+					Children: []*StepNode{
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("amd64")}},
+						{Step: &fakeStep{name: "step2", architectures: sets.New[string]("arm64")}},
+					},
+					MultiArchReasons: map[string]sets.Set[string]{
+						"arm64": sets.New[string]("step2"),
+						"amd64": sets.New[string]("step1"),
+					}},
+			},
+		},
+
 		{
 			name: "multiple nodes - one or more children are multi-arch",
 			nodes: []*StepNode{
 				{
 					Step: &fakeStep{name: "step10"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: false}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
 					},
 				},
 				{
 					Step: &fakeStep{name: "step20"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: true}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: true}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
 					},
 				},
 				{
 					Step: &fakeStep{name: "step30"},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: true}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
 					},
 				},
 			},
 			expected: []*StepNode{
 				{
-					Step: &fakeStep{name: "step10"},
+					Step: &fakeStep{name: "step10", architectures: sets.New[string]("arm64")},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: false}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
+					},
+					MultiArchReasons: map[string]sets.Set[string]{
+						"arm64": sets.New[string]("step1"),
 					},
 				},
 				{
-					Step: &fakeStep{name: "step20", multiArch: true},
+					Step: &fakeStep{name: "step20", architectures: sets.New[string]("arm64")},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: true}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: true}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
 					},
-					MultiArchReasons: []string{"step1", "step3"},
+					MultiArchReasons: map[string]sets.Set[string]{
+						"arm64": sets.New[string]("step1"),
+					},
 				},
 				{
-					Step: &fakeStep{name: "step30", multiArch: true},
+					Step: &fakeStep{name: "step30", architectures: sets.New[string]("arm64")},
 					Children: []*StepNode{
-						{Step: &fakeStep{name: "step1", multiArch: true}},
-						{Step: &fakeStep{name: "step2", multiArch: false}},
-						{Step: &fakeStep{name: "step3", multiArch: false}},
+						{Step: &fakeStep{name: "step1", architectures: sets.New[string]("arm64")}},
+						{Step: &fakeStep{name: "step2"}},
+						{Step: &fakeStep{name: "step3"}},
 					},
-					MultiArchReasons: []string{"step1"},
+					MultiArchReasons: map[string]sets.Set[string]{
+						"arm64": sets.New[string]("step1"),
+					},
 				},
 			},
 		},

--- a/pkg/steps/bundle_source.go
+++ b/pkg/steps/bundle_source.go
@@ -136,11 +136,6 @@ func (s *bundleSourceStep) Description() string {
 	return fmt.Sprintf("Build image %s from the repository", api.PipelineImageStreamTagReferenceBundleSource)
 }
 
-func (s *bundleSourceStep) IsMultiArch() bool { return false }
-func (s *bundleSourceStep) SetMultiArch(multiArch bool) {
-	logrus.Warnf("Not setting %s as multi-arch since bundle images are not multi-arch by design", s.Name())
-}
-
 func BundleSourceStep(
 	config api.BundleSourceStepConfiguration,
 	releaseBuildConfig *api.ReleaseBuildConfiguration,

--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -305,9 +305,6 @@ func (s *clusterClaimStep) saveObjectAsArtifact(ctx context.Context, key ctrlrun
 	return api.SaveArtifact(s.censor, path, data)
 }
 
-func (s *clusterClaimStep) IsMultiArch() bool           { return false }
-func (s *clusterClaimStep) SetMultiArch(multiArch bool) {}
-
 func ClusterClaimStep(as string, clusterClaim *api.ClusterClaim, hiveClient ctrlruntimeclient.WithWatch, client loggingclient.LoggingClient, jobSpec *api.JobSpec, wrapped api.Step, censor *secrets.DynamicCensor) api.Step {
 	return &clusterClaimStep{
 		as:           as,

--- a/pkg/steps/clusterinstall/clusterinstall.go
+++ b/pkg/steps/clusterinstall/clusterinstall.go
@@ -160,6 +160,3 @@ func (s *e2eTestStep) Description() string {
 func (s *e2eTestStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
-
-func (s *e2eTestStep) IsMultiArch() bool           { return false }
-func (s *e2eTestStep) SetMultiArch(multiArch bool) {}

--- a/pkg/steps/images_ready.go
+++ b/pkg/steps/images_ready.go
@@ -42,9 +42,6 @@ func (s *imagesReadyStep) Objects() []ctrlruntimeclient.Object {
 
 func (s *imagesReadyStep) Description() string { return "All images are built and tagged into stable" }
 
-func (s *imagesReadyStep) IsMultiArch() bool           { return false }
-func (s *imagesReadyStep) SetMultiArch(multiArch bool) {}
-
 func ImagesReadyStep(links []api.StepLink) api.Step {
 	return &imagesReadyStep{
 		links: links,

--- a/pkg/steps/input_env.go
+++ b/pkg/steps/input_env.go
@@ -66,6 +66,3 @@ func (s *inputEnvironmentStep) Provides() api.ParameterMap {
 func (s *inputEnvironmentStep) Objects() []ctrlruntimeclient.Object {
 	return nil
 }
-
-func (s *inputEnvironmentStep) IsMultiArch() bool           { return false }
-func (s *inputEnvironmentStep) SetMultiArch(multiArch bool) {}

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -167,11 +167,6 @@ func (s *inputImageTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *inputImageTagStep) IsMultiArch() bool { return false }
-func (s *inputImageTagStep) SetMultiArch(multiArch bool) {
-	logrus.WithField("step", s.Name()).Warnf("Assuming image %q is multi-arch", s.imageName)
-}
-
 func InputImageTagStep(
 	config *api.InputImageTagStepConfiguration,
 	client loggingclient.LoggingClient,

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -62,9 +62,6 @@ func (s *ipPoolStep) Requires() []api.StepLink            { return s.wrapped.Req
 func (s *ipPoolStep) Creates() []api.StepLink             { return s.wrapped.Creates() }
 func (s *ipPoolStep) Objects() []ctrlruntimeclient.Object { return s.wrapped.Objects() }
 
-func (s *ipPoolStep) IsMultiArch() bool           { return false }
-func (s *ipPoolStep) SetMultiArch(multiArch bool) {}
-
 func (s *ipPoolStep) Provides() api.ParameterMap {
 	parameters := s.wrapped.Provides()
 	if parameters == nil {

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -130,9 +130,6 @@ func (blockingStep) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
-func (s *blockingStep) IsMultiArch() bool           { return false }
-func (s *blockingStep) SetMultiArch(multiArch bool) {}
-
 func TestRun(t *testing.T) {
 	ciOpNamespace := "ci-op-1234"
 

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -123,9 +123,6 @@ func (s *leaseStep) run(ctx context.Context) error {
 	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
 }
 
-func (s *leaseStep) IsMultiArch() bool           { return false }
-func (s *leaseStep) SetMultiArch(multiArch bool) {}
-
 func aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr error) error {
 	// we want a sensible output error for reporting, so we bubble up these individually if we can
 	if wrappedErr != nil && releaseErr == nil {

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -54,9 +54,6 @@ func (stepNeedsLease) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
-func (s *stepNeedsLease) IsMultiArch() bool           { return false }
-func (s *stepNeedsLease) SetMultiArch(multiArch bool) {}
-
 func emptyNamespace() string { return "" }
 
 func TestLeaseStepForward(t *testing.T) {

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -12,6 +12,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -410,13 +411,18 @@ func (s *multiStageTestStep) cancelObserversContext(cancel context.CancelFunc) {
 	}
 }
 
-func (s *multiStageTestStep) IsMultiArch() bool {
-	// If the node architecture is not set, we assume it's AMD64
-	// and if the architecture is anything else, we assume that it's multi-arch
-	return s.nodeArchitecture != "" && s.nodeArchitecture != api.NodeArchitectureAMD64
+func (s *multiStageTestStep) ResolveMultiArch() sets.Set[string] {
+	arch := string(api.NodeArchitectureAMD64)
+	if s.nodeArchitecture != "" {
+		arch = string(s.nodeArchitecture)
+	}
+	return sets.New[string](arch)
 }
 
-func (s *multiStageTestStep) SetMultiArch(multiArch bool) {}
+func (s *multiStageTestStep) AddArchitectures(archs ...string) {
+	// We don't want anything else rather than the node_architecture in the config
+	// to add another architecture.
+}
 
 // secretsForCensoring returns the secret volumes and mounts that will allow sidecar to censor
 // their content from uploads. This is the full secret list in our namespace, except for the ones

--- a/pkg/steps/output_image_tag.go
+++ b/pkg/steps/output_image_tag.go
@@ -165,9 +165,6 @@ func (s *outputImageTagStep) imageStreamTag(fromImage string) *imagev1.ImageStre
 	}
 }
 
-func (s *outputImageTagStep) IsMultiArch() bool           { return false }
-func (s *outputImageTagStep) SetMultiArch(multiArch bool) {}
-
 func OutputImageTagStep(config api.OutputImageTagStepConfiguration, client loggingclient.LoggingClient, jobSpec *api.JobSpec) api.Step {
 	return &outputImageTagStep{
 		config:  config,

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -12,6 +12,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	"sigs.k8s.io/prow/pkg/pod-utils/decorate"
@@ -161,10 +162,11 @@ func (s *podStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *podStep) IsMultiArch() bool {
-	return s.config.NodeArchitecture != "" && s.config.NodeArchitecture != api.NodeArchitectureAMD64
+func (s *podStep) ResolveMultiArch() sets.Set[string] {
+	return sets.New[string](string(s.config.NodeArchitecture))
 }
-func (s *podStep) SetMultiArch(multiArch bool) {}
+
+func (s *podStep) AddArchitectures(archs []string) {}
 
 func TestStep(config api.TestStepConfiguration, resources api.ResourceConfiguration, client kubernetes.PodClient, jobSpec *api.JobSpec, nodeName string) api.Step {
 	return PodStep(

--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -242,9 +242,6 @@ func (s *assembleReleaseStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *assembleReleaseStep) IsMultiArch() bool           { return false }
-func (s *assembleReleaseStep) SetMultiArch(multiArch bool) {}
-
 // AssembleReleaseStep builds a new update payload image based on the cluster version operator
 // and the operators defined in the release configuration.
 func AssembleReleaseStep(name, nodeName string, config *api.ReleaseTagConfiguration, resources api.ResourceConfiguration,

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -301,9 +301,6 @@ func (s *importReleaseStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *importReleaseStep) IsMultiArch() bool           { return false }
-func (s *importReleaseStep) SetMultiArch(multiArch bool) {}
-
 // ImportReleaseStep imports an existing update payload image
 func ImportReleaseStep(
 	name, nodeName, target string,

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -450,9 +450,6 @@ func (s *promotionStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *promotionStep) IsMultiArch() bool           { return false }
-func (s *promotionStep) SetMultiArch(multiArch bool) {}
-
 // PromotionStep copies tags from the pipeline image stream to the destination defined in the promotion config.
 // If the source tag does not exist it is silently skipped.
 func PromotionStep(

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -87,9 +87,6 @@ func (s *stableImagesTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *stableImagesTagStep) IsMultiArch() bool           { return false }
-func (s *stableImagesTagStep) SetMultiArch(multiArch bool) {}
-
 // releaseImagesTagStep will tag a full release suite
 // of images in from the configured namespace. It is
 // expected that builds will overwrite these tags at
@@ -206,9 +203,6 @@ func (s *releaseImagesTagStep) Description() string {
 func (s *releaseImagesTagStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
-
-func (s *releaseImagesTagStep) IsMultiArch() bool           { return false }
-func (s *releaseImagesTagStep) SetMultiArch(multiArch bool) {}
 
 func ReleaseImagesTagStep(config api.ReleaseTagConfiguration, client loggingclient.LoggingClient, params *api.DeferredParameters, jobSpec *api.JobSpec, integratedStream *configresolver.IntegratedStream) api.Step {
 	return &releaseImagesTagStep{

--- a/pkg/steps/release/snapshot.go
+++ b/pkg/steps/release/snapshot.go
@@ -144,9 +144,6 @@ func (r *releaseSnapshotStep) Objects() []ctrlruntimeclient.Object {
 	return r.client.Objects()
 }
 
-func (s *releaseSnapshotStep) IsMultiArch() bool           { return false }
-func (s *releaseSnapshotStep) SetMultiArch(multiArch bool) {}
-
 func ReleaseSnapshotStep(release string, config api.Integration, client loggingclient.LoggingClient, jobSpec *api.JobSpec, integratedStream *configresolver.IntegratedStream) api.Step {
 	return &releaseSnapshotStep{
 		name:             release,

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -410,9 +410,6 @@ func (s *rpmServerStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *rpmServerStep) IsMultiArch() bool           { return false }
-func (s *rpmServerStep) SetMultiArch(multiArch bool) {}
-
 func admittedHostForRoute(client ctrlruntimeclient.Client, namespace, name string, timeout time.Duration) (string, error) {
 	var repoHost string
 	if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -44,8 +44,6 @@ func (f *fakeStep) Name() string                      { return f.name }
 func (f *fakeStep) Description() string               { return f.name }
 func (*fakeStep) Objects() []ctrlruntimeclient.Object { return nil }
 func (f *fakeStep) Provides() api.ParameterMap        { return nil }
-func (f *fakeStep) IsMultiArch() bool                 { return false }
-func (f *fakeStep) SetMultiArch(multiArch bool)       {}
 
 func TestStepsRun(t *testing.T) {
 	testCases := []struct {

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -773,14 +773,49 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 	tests := []struct {
 		name              string
 		build             buildapi.Build
-		nodeArchitectures []string
-		multiArch         bool
+		stepArchitectures []string
 		want              []buildapi.Build
 	}{
 		{
 			name:              "basic case - only amd64",
-			nodeArchitectures: []string{"amd64"},
-			multiArch:         true,
+			stepArchitectures: []string{"amd64"},
+			build: buildapi.Build{
+				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
+				Spec: buildv1.BuildSpec{
+					CommonSpec: buildv1.CommonSpec{
+						Output: buildv1.BuildOutput{
+							ImageLabels: []buildapi.ImageLabel{
+								{Name: "io.openshift.build.namespace", Value: "namespace"},
+								{Name: "io.openshift.build.commit.id", Value: "commit-id"},
+								{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
+							},
+						},
+					},
+				},
+			},
+			want: []buildapi.Build{
+				{
+					ObjectMeta: meta.ObjectMeta{Name: "test-build-amd64"},
+					Spec: buildapi.BuildSpec{
+						CommonSpec: buildapi.CommonSpec{
+							NodeSelector: map[string]string{
+								"kubernetes.io/arch": "amd64",
+							},
+							Output: buildv1.BuildOutput{
+								ImageLabels: []buildapi.ImageLabel{
+									{Name: "io.openshift.build.namespace", Value: "namespace"},
+									{Name: "io.openshift.build.commit.id", Value: "commit-id"},
+									{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
+								},
+								To: &coreapi.ObjectReference{Name: "pipeline:test-build-amd64"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "basic case - empty architecture - default to amd64",
 			build: buildapi.Build{
 				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
 				Spec: buildv1.BuildSpec{
@@ -818,8 +853,7 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 		},
 		{
 			name:              "basic case - multi architectures",
-			nodeArchitectures: []string{"amd64", "arm64", "ppc64"},
-			multiArch:         true,
+			stepArchitectures: []string{"amd64", "arm64", "ppc64"},
 			build: buildapi.Build{
 				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
 				Spec: buildv1.BuildSpec{
@@ -891,50 +925,11 @@ func Test_constructMultiArchBuilds(t *testing.T) {
 				},
 			},
 		},
-		{
-			name:              "basic case - multi architectures - multi arch image disabled",
-			nodeArchitectures: []string{"amd64", "arm64", "ppc64"},
-			multiArch:         false,
-			build: buildapi.Build{
-				ObjectMeta: meta.ObjectMeta{Name: "test-build"},
-				Spec: buildv1.BuildSpec{
-					CommonSpec: buildv1.CommonSpec{
-						Output: buildv1.BuildOutput{
-							ImageLabels: []buildapi.ImageLabel{
-								{Name: "io.openshift.build.namespace", Value: "namespace"},
-								{Name: "io.openshift.build.commit.id", Value: "commit-id"},
-								{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
-							},
-						},
-					},
-				},
-			},
-			want: []buildapi.Build{
-				{
-					ObjectMeta: meta.ObjectMeta{Name: "test-build-amd64"},
-					Spec: buildapi.BuildSpec{
-						CommonSpec: buildapi.CommonSpec{
-							NodeSelector: map[string]string{
-								"kubernetes.io/arch": "amd64",
-							},
-							Output: buildv1.BuildOutput{
-								ImageLabels: []buildapi.ImageLabel{
-									{Name: "io.openshift.build.namespace", Value: "namespace"},
-									{Name: "io.openshift.build.commit.id", Value: "commit-id"},
-									{Name: "io.openshift.build.commit.ref", Value: "commit-id"},
-								},
-								To: &coreapi.ObjectReference{Name: "pipeline:test-build-amd64"},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := cmp.Diff(constructMultiArchBuilds(tt.build, tt.nodeArchitectures, tt.multiArch), tt.want, cmpopts.IgnoreFields(coreapi.ObjectReference{}, "Kind")); diff != "" {
+			if diff := cmp.Diff(constructMultiArchBuilds(tt.build, tt.stepArchitectures), tt.want, cmpopts.IgnoreFields(coreapi.ObjectReference{}, "Kind")); diff != "" {
 				t.Fatal(diff)
 			}
 		})

--- a/pkg/steps/template.go
+++ b/pkg/steps/template.go
@@ -278,9 +278,6 @@ func (s *templateExecutionStep) Objects() []ctrlruntimeclient.Object {
 	return s.client.Objects()
 }
 
-func (s *templateExecutionStep) IsMultiArch() bool           { return false }
-func (s *templateExecutionStep) SetMultiArch(multiArch bool) {}
-
 func TemplateExecutionStep(template *templateapi.Template, params api.Parameters, podClient kubernetes.PodClient, templateClient TemplateClient, jobSpec *api.JobSpec, resources api.ResourceConfiguration) api.Step {
 	return &templateExecutionStep{
 		template:  template,

--- a/pkg/steps/write_params.go
+++ b/pkg/steps/write_params.go
@@ -75,9 +75,6 @@ func (s *writeParametersStep) Objects() []ctrlruntimeclient.Object {
 	return nil
 }
 
-func (s *writeParametersStep) IsMultiArch() bool           { return false }
-func (s *writeParametersStep) SetMultiArch(multiArch bool) {}
-
 func WriteParametersStep(params *api.DeferredParameters, paramFile string) api.Step {
 	return &writeParametersStep{
 		params:    params,


### PR DESCRIPTION
This change allows the step graph to be resolved for specific architectures instead of using all architectures available in the cluster.

For instance, for any tests that need to run on arm64 nodes, the depended images will be built only for arm64 architecture.

For images with `multi_arch: true` we still build them for all available architectures in the cluster. 

https://issues.redhat.com/browse/DPTP-4180
/cc @openshift/test-platform @deepsm007 