### PR TITLE
ci-operator: label all resources it creates (2nd attempt)

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -77,6 +77,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/defaults"
 	"github.com/openshift/ci-tools/pkg/interrupt"
 	"github.com/openshift/ci-tools/pkg/junit"
+	"github.com/openshift/ci-tools/pkg/labeledclient"
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/load"
 	"github.com/openshift/ci-tools/pkg/registry"
@@ -1184,6 +1185,7 @@ func (o *options) initializeNamespace() error {
 		return fmt.Errorf("failed to construct client: %w", err)
 	}
 	client = ctrlruntimeclient.NewNamespacedClient(client, o.namespace)
+	client = labeledclient.Wrap(client, o.jobSpec)
 	ctx := context.Background()
 
 	logrus.Debugf("Creating namespace %s", o.namespace)
@@ -1278,11 +1280,7 @@ func (o *options) initializeNamespace() error {
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: o.namespace}, ns); err != nil {
 			return err
 		}
-
-		if ns.Labels == nil {
-			ns.Labels = map[string]string{}
-		}
-		ns.Labels[api.AutoScalePodsLabel] = "true"
+		ns.Labels = steps.LabelsFor(o.jobSpec, map[string]string{api.AutoScalePodsLabel: "true"}, "")
 
 		if ns.Annotations == nil {
 			ns.Annotations = make(map[string]string)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -36,6 +36,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api/configresolver"
 	testimagestreamtagimportv1 "github.com/openshift/ci-tools/pkg/api/testimagestreamtagimport/v1"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
+	"github.com/openshift/ci-tools/pkg/labeledclient"
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/release"
 	"github.com/openshift/ci-tools/pkg/release/official"
@@ -84,6 +85,7 @@ func FromConfig(
 ) ([]api.Step, []api.Step, error) {
 	crclient, err := ctrlruntimeclient.NewWithWatch(clusterConfig, ctrlruntimeclient.Options{})
 	crclient = secretrecordingclient.Wrap(crclient, censor)
+	crclient = labeledclient.WrapWithWatch(crclient, jobSpec)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to construct client: %w", err)
 	}

--- a/pkg/labeledclient/client.go
+++ b/pkg/labeledclient/client.go
@@ -1,0 +1,111 @@
+package labeledclient
+
+import (
+	"context"
+	"maps"
+
+	authapi "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps"
+)
+
+// Wrap wraps the upstream client, adding labels to objects created or updated
+func Wrap(upstream ctrlruntimeclient.Client, jobSpec *api.JobSpec) ctrlruntimeclient.Client {
+	return &client{
+		upstream: upstream,
+		jobSpec:  jobSpec,
+	}
+}
+
+// WrapWithWatch does the same as Wrap, but for clients that support watching
+func WrapWithWatch(upstream ctrlruntimeclient.WithWatch, jobSpec *api.JobSpec) ctrlruntimeclient.WithWatch {
+	return &clientWithWatch{
+		client: &client{
+			upstream: upstream,
+			jobSpec:  jobSpec,
+		},
+		upstream: upstream,
+	}
+}
+
+type client struct {
+	upstream ctrlruntimeclient.Client
+	jobSpec  *api.JobSpec
+}
+
+func (c *client) Get(ctx context.Context, key ctrlruntimeclient.ObjectKey, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.GetOption) error {
+	return c.upstream.Get(ctx, key, obj)
+}
+
+func (c *client) List(ctx context.Context, list ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) error {
+	return c.upstream.List(ctx, list, opts...)
+}
+
+func (c *client) Create(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+	c.addLabels(obj)
+	return c.upstream.Create(ctx, obj, opts...)
+}
+
+func (c *client) Delete(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteOption) error {
+	return c.upstream.Delete(ctx, obj, opts...)
+}
+
+func (c *client) Update(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.UpdateOption) error {
+	return c.upstream.Update(ctx, obj, opts...)
+}
+
+func (c *client) Patch(ctx context.Context, obj ctrlruntimeclient.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
+	return c.upstream.Patch(ctx, obj, patch, opts...)
+}
+
+func (c *client) DeleteAllOf(ctx context.Context, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteAllOfOption) error {
+	return c.upstream.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c *client) Status() ctrlruntimeclient.StatusWriter {
+	return c.upstream.Status()
+}
+
+func (c *client) Scheme() *runtime.Scheme {
+	return c.upstream.Scheme()
+}
+
+func (c *client) RESTMapper() meta.RESTMapper {
+	return c.upstream.RESTMapper()
+}
+
+func (c *client) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.upstream.GroupVersionKindFor(obj)
+}
+
+func (c *client) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.upstream.IsObjectNamespaced(obj)
+}
+
+func (c *client) SubResource(subResource string) ctrlruntimeclient.SubResourceClient {
+	return c.upstream.SubResource(subResource)
+}
+
+func (c *client) addLabels(obj ctrlruntimeclient.Object) {
+	// SelfSubjectAccessReview & LocalSubjectAccessReview do not hold labels
+	switch obj.(type) {
+	case *authapi.SelfSubjectAccessReview, *authapi.LocalSubjectAccessReview:
+	default:
+		obj.SetLabels(steps.LabelsFor(c.jobSpec, maps.Clone(obj.GetLabels()), ""))
+	}
+}
+
+type clientWithWatch struct {
+	*client
+	upstream ctrlruntimeclient.WithWatch
+}
+
+func (c *clientWithWatch) Watch(ctx context.Context, obj ctrlruntimeclient.ObjectList, opts ...ctrlruntimeclient.ListOption) (watch.Interface, error) {
+	return c.upstream.Watch(ctx, obj, opts...)
+}

--- a/pkg/labeledclient/client_test.go
+++ b/pkg/labeledclient/client_test.go
@@ -1,0 +1,128 @@
+package labeledclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	coreapi "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/steps"
+)
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      ctrlruntimeclient.Object
+		expected map[string]string
+	}{
+		{
+			name: "Object without existing labels",
+			obj: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test-pod",
+				},
+			},
+			expected: map[string]string{
+				steps.LabelMetadataOrg:     "test-org",
+				steps.LabelMetadataRepo:    "test-repo",
+				steps.LabelMetadataTarget:  "images",
+				steps.LabelMetadataBranch:  "",
+				steps.LabelMetadataVariant: "",
+				steps.LabelJobType:         "periodic",
+				steps.LabelJobID:           "",
+				steps.LabelJobName:         "test-job",
+				steps.CreatedByCILabel:     "true",
+				"OPENSHIFT_CI":             "true",
+			},
+		},
+		{
+			name: "Object with existing labels",
+			obj: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						"existing": "label",
+						"another":  "label",
+					},
+				},
+			},
+			expected: map[string]string{
+				"existing":                 "label",
+				"another":                  "label",
+				steps.LabelMetadataOrg:     "test-org",
+				steps.LabelMetadataRepo:    "test-repo",
+				steps.LabelMetadataTarget:  "images",
+				steps.LabelMetadataBranch:  "",
+				steps.LabelMetadataVariant: "",
+				steps.LabelJobType:         "periodic",
+				steps.LabelJobID:           "",
+				steps.LabelJobName:         "test-job",
+				steps.CreatedByCILabel:     "true",
+				"OPENSHIFT_CI":             "true",
+			},
+		},
+		{
+			name: "Object with the same labels",
+			obj: &coreapi.Pod{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "test-pod",
+					Labels: map[string]string{
+						steps.LabelMetadataOrg:     "test-org",
+						steps.LabelMetadataRepo:    "test-repo",
+						steps.LabelMetadataTarget:  "images",
+						steps.LabelMetadataBranch:  "",
+						steps.LabelMetadataVariant: "",
+						steps.LabelJobType:         "periodic",
+						steps.LabelJobID:           "",
+						steps.LabelJobName:         "test-job",
+						steps.CreatedByCILabel:     "true",
+						"OPENSHIFT_CI":             "true",
+					},
+				},
+			},
+			expected: map[string]string{
+				steps.LabelMetadataOrg:     "test-org",
+				steps.LabelMetadataRepo:    "test-repo",
+				steps.LabelMetadataTarget:  "images",
+				steps.LabelMetadataBranch:  "",
+				steps.LabelMetadataVariant: "",
+				steps.LabelJobType:         "periodic",
+				steps.LabelJobID:           "",
+				steps.LabelJobName:         "test-job",
+				steps.CreatedByCILabel:     "true",
+				"OPENSHIFT_CI":             "true",
+			},
+		},
+	}
+	for _, tt := range tests {
+		var jobSpec = &api.JobSpec{
+			Metadata: api.Metadata{
+				Org:  "test-org",
+				Repo: "test-repo",
+			},
+			Target: "[images]",
+			JobSpec: downwardapi.JobSpec{
+				Type: v1.PeriodicJob,
+				Job:  "test-job",
+			},
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			c := &client{
+				upstream: fakeclient.NewClientBuilder().Build(),
+				jobSpec:  jobSpec,
+			}
+			_ = c.Create(context.TODO(), tt.obj)
+			if diff := cmp.Diff(tt.expected, tt.obj.GetLabels()); diff != "" {
+				t.Errorf("Labels differ from expected:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -6,6 +6,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -160,6 +163,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods.yaml
@@ -6,6 +6,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -177,6 +180,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -342,6 +348,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -511,6 +520,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -684,6 +696,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo
@@ -851,6 +866,9 @@
     creationTimestamp: null
     labels:
       OPENSHIFT_CI: "true"
+      ci.openshift.io/jobid: prow_job_id
+      ci.openshift.io/jobname: job
+      ci.openshift.io/jobtype: postsubmit
       ci.openshift.io/metadata.branch: base_ref
       ci.openshift.io/metadata.org: org
       ci.openshift.io/metadata.repo: repo

--- a/pkg/steps/pod.go
+++ b/pkg/steps/pod.go
@@ -221,7 +221,7 @@ func GenerateBasePod(
 		ObjectMeta: meta.ObjectMeta{
 			Namespace: jobSpec.Namespace(),
 			Name:      name,
-			Labels:    labelsFor(jobSpec, baseLabels, ""),
+			Labels:    LabelsFor(jobSpec, baseLabels, ""),
 			Annotations: map[string]string{
 				JobSpecAnnotation:                     jobSpec.RawSpec(),
 				annotationContainersForSubTestResults: containerName,

--- a/pkg/steps/rpm_server.go
+++ b/pkg/steps/rpm_server.go
@@ -60,7 +60,7 @@ func (s *rpmServerStep) run(ctx context.Context) error {
 		return fmt.Errorf("could not find source ImageStreamTag for RPM repo deployment: %w", err)
 	}
 
-	labelSet := labelsFor(s.jobSpec, map[string]string{AppLabel: RPMRepoName, TTLIgnoreLabel: "true"}, s.config.Ref)
+	labelSet := LabelsFor(s.jobSpec, map[string]string{AppLabel: RPMRepoName, TTLIgnoreLabel: "true"}, s.config.Ref)
 	selectorSet := map[string]string{
 		AppLabel: RPMRepoName,
 	}

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -121,7 +121,7 @@ const (
 	LabelMetadataStep    = "ci.openshift.io/metadata.step"
 )
 
-func labelsFor(spec *api.JobSpec, base map[string]string, ref string) map[string]string {
+func LabelsFor(spec *api.JobSpec, base map[string]string, ref string) map[string]string {
 	if base == nil {
 		base = map[string]string{}
 	}
@@ -304,7 +304,7 @@ func buildFromSource(jobSpec *api.JobSpec, fromTag, toTag api.PipelineImageStrea
 	}
 
 	layer := buildapi.ImageOptimizationSkipLayers
-	labels := labelsFor(jobSpec, map[string]string{CreatesLabel: string(toTag)}, ref)
+	labels := LabelsFor(jobSpec, map[string]string{CreatesLabel: string(toTag)}, ref)
 	build := &buildapi.Build{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      string(toTag),

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -119,6 +119,9 @@ const (
 	LabelMetadataVariant = "ci.openshift.io/metadata.variant"
 	LabelMetadataTarget  = "ci.openshift.io/metadata.target"
 	LabelMetadataStep    = "ci.openshift.io/metadata.step"
+	LabelJobID           = "ci.openshift.io/jobid"
+	LabelJobType         = "ci.openshift.io/jobtype"
+	LabelJobName         = "ci.openshift.io/jobname"
 )
 
 func LabelsFor(spec *api.JobSpec, base map[string]string, ref string) map[string]string {
@@ -129,6 +132,9 @@ func LabelsFor(spec *api.JobSpec, base map[string]string, ref string) map[string
 	repo := spec.Metadata.Repo
 	branch := spec.Metadata.Branch
 	variant := spec.Metadata.Variant
+	jobID := spec.ProwJobID
+	jobType := spec.Type
+	jobName := spec.Job
 	if ref != "" { //When building for a specific ref, the metadata will be empty and need to be determined from that ref
 		for _, extraRef := range spec.ExtraRefs {
 			orgRepo := fmt.Sprintf("%s.%s", extraRef.Org, extraRef.Repo)
@@ -146,6 +152,9 @@ func LabelsFor(spec *api.JobSpec, base map[string]string, ref string) map[string
 	base[LabelMetadataBranch] = branch
 	base[LabelMetadataVariant] = variant
 	base[LabelMetadataTarget] = spec.Target
+	base[LabelJobID] = jobID
+	base[LabelJobType] = string(jobType)
+	base[LabelJobName] = jobName
 	base[CreatedByCILabel] = "true"
 	base[openshiftCIEnv] = "true"
 	return apiutils.SanitizeLabels(base)

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_build_args.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_specified.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_specified.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: master
     ci.openshift.io/metadata.org: org
     ci.openshift.io/metadata.repo: other-repo

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_basic_options_for_a_presubmit.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_title_in_pull_gets_squashed.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_title_in_pull_gets_squashed.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_OAuth_token.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_path_alias.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_a_pull_secret.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_extra_refs_setting_workdir_and_path_alias.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestCreateBuild_with_ssh_key.yaml
@@ -4,6 +4,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prowJobId
+    ci.openshift.io/jobname: job
+    ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: ""
     ci.openshift.io/metadata.org: ""
     ci.openshift.io/metadata.repo: ""

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_fails_so_PodStep_terminates_and_returns_an_error.yaml
@@ -5,6 +5,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prow-job-id
+    ci.openshift.io/jobname: very-cool-prow-job
+    ci.openshift.io/jobtype: presubmit
     ci.openshift.io/metadata.branch: base-ref
     ci.openshift.io/metadata.org: org
     ci.openshift.io/metadata.repo: repo

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Pod_run_by_PodStep_succeeds_so_PodStep_terminates_and_returns_no_error.yaml
@@ -5,6 +5,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prow-job-id
+    ci.openshift.io/jobname: very-cool-prow-job
+    ci.openshift.io/jobtype: presubmit
     ci.openshift.io/metadata.branch: base-ref
     ci.openshift.io/metadata.org: org
     ci.openshift.io/metadata.repo: repo

--- a/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestPodStepExecution_Successful_pod_with_cloning.yaml
@@ -5,6 +5,9 @@ metadata:
   creationTimestamp: null
   labels:
     OPENSHIFT_CI: "true"
+    ci.openshift.io/jobid: prow-job-id
+    ci.openshift.io/jobname: very-cool-prow-job
+    ci.openshift.io/jobtype: presubmit
     ci.openshift.io/metadata.branch: base-ref
     ci.openshift.io/metadata.org: org
     ci.openshift.io/metadata.repo: repo


### PR DESCRIPTION
This PR resolves issues:
`{  could not create RPM repo server deployment: Deployment.apps "rpm-repo" is invalid: [spec.selector.matchLabels: Invalid value: "[images]": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'), spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"OPENSHIFT_CI":"true", "app":"rpm-repo", "ci.openshift.io/jobid":"a48ae780-8696-4a50-9c09-c173d61e75ad", "ci.openshift.io/jobname":"branch-ci-openshift-kubernetes-release-4.17-images", "ci.openshift.io/jobtype":"postsubmit", "ci.openshift.io/metadata.branch":"release-4.17", "ci.openshift.io/metadata.org":"openshift", "ci.openshift.io/metadata.repo":"kubernetes", "ci.openshift.io/metadata.target":"[images]", "ci.openshift.io/metadata.variant":"", "ci.openshift.io/ttl.ignore":"true", "created-by-ci":"true"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: invalid label selector]}`

by cloning (`maps.Clone()`) the lables first before working with them.

And:
`{  failed to get CLI image: unable to tag the 'cli' image into the stable stream: ImageStreamTag.image.openshift.io "stable:cli" is invalid: metadata: Invalid value: "": may not update fields other than metadata.annotations}`

by not applying the labels when `client.Update()` is done, NS are handled separately

Original PR: https://github.com/openshift/ci-tools/pull/4306
Reverts: https://github.com/openshift/ci-tools/pull/4320