### PR TITLE
`ci-operator`: treat building the primary ref differently from the extra_refs

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -892,11 +892,11 @@ func (o *options) Run() []error {
 		return []error{fmt.Errorf("could not resolve the node architectures: %w", err)}
 	}
 
-	mergedConfig := o.injectTest != "" || len(o.jobSpec.ExtraRefs) > 1
+	injectedTest := o.injectTest != ""
 	// load the graph from the configuration
 	buildSteps, promotionSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig,
 		o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig,
-		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, mergedConfig, streams)
+		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, streams, injectedTest)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -79,8 +79,8 @@ func FromConfig(
 	targetAdditionalSuffix string,
 	manifestToolDockerCfg string,
 	localRegistryDNS string,
-	mergedConfig bool,
 	integratedStreams map[string]*configresolver.IntegratedStream,
+	injectedTest bool,
 ) ([]api.Step, []api.Step, error) {
 	crclient, err := ctrlruntimeclient.NewWithWatch(clusterConfig, ctrlruntimeclient.Options{})
 	crclient = secretrecordingclient.Wrap(crclient, censor)
@@ -117,7 +117,7 @@ func FromConfig(
 	httpClient := retryablehttp.NewClient()
 	httpClient.Logger = nil
 
-	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient.StandardClient(), requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost, nodeName, targetAdditionalSuffix, nodeArchitectures, mergedConfig, integratedStreams)
+	return fromConfig(ctx, config, graphConf, jobSpec, templates, paramFile, promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient.StandardClient(), requiredTargets, cloneAuthConfig, pullSecret, pushSecret, api.NewDeferredParameters(nil), censor, consoleHost, nodeName, targetAdditionalSuffix, nodeArchitectures, integratedStreams, injectedTest)
 }
 
 func fromConfig(
@@ -144,8 +144,8 @@ func fromConfig(
 	nodeName string,
 	targetAdditionalSuffix string,
 	nodeArchitectures []string,
-	mergedConfig bool,
 	integratedStreams map[string]*configresolver.IntegratedStream,
+	injectedTest bool,
 ) ([]api.Step, []api.Step, error) {
 	requiredNames := sets.New[string]()
 	for _, target := range requiredTargets {
@@ -175,7 +175,7 @@ func fromConfig(
 	var hasReleaseStep bool
 	resolver := rootImageResolver(client, ctx, promote)
 	imageConfigs := graphConf.InputImages()
-	rawSteps, err := runtimeStepConfigsForBuild(config, jobSpec, os.ReadFile, resolver, imageConfigs, mergedConfig)
+	rawSteps, err := runtimeStepConfigsForBuild(config, jobSpec, os.ReadFile, resolver, imageConfigs, injectedTest)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get steps from configuration: %w", err)
 	}
@@ -644,7 +644,7 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 	if buildRoots == nil {
 		buildRoots = make(map[string]api.BuildRootImageConfiguration)
 	}
-	if target := config.InputConfiguration.BuildRootImage; target != nil { //This will only be the case when config.InputConfiguration.BuildRootImages is empty
+	if target := config.InputConfiguration.BuildRootImage; target != nil {
 		buildRoots[""] = *target
 	}
 
@@ -937,7 +937,7 @@ func runtimeStepConfigsForBuild(
 	readFile readFile,
 	resolveRoot resolveRoot,
 	imageConfigs []*api.InputImageTagStepConfiguration,
-	mergedConfig bool,
+	injectedTest bool,
 ) ([]api.StepConfiguration, error) {
 	buildRoots := config.InputConfiguration.BuildRootImages
 	if buildRoots == nil {
@@ -968,13 +968,16 @@ func runtimeStepConfigsForBuild(
 		if target != nil {
 			istTagRef := &target.InputImage.BaseImage
 			if root.FromRepository {
-				path := "."    // By default, the path will be the working directory
-				if ref != "" { // If we are getting the build root image for a specific ref we must determine the absolute path
+				path := "."        // By default, the path will be the working directory
+				if len(refs) > 1 { // If we are getting the build root image for a specific ref we must determine the absolute path
 					var matchingRefs []prowapi.Refs
 					for _, r := range refs {
 						if ref == fmt.Sprintf("%s.%s", r.Org, r.Repo) {
 							matchingRefs = append(matchingRefs, r)
 						}
+					}
+					if len(matchingRefs) == 0 { // If we didn't find anything, use the primary refs
+						matchingRefs = append(matchingRefs, *jobSpec.Refs)
 					}
 					path = decorate.DetermineWorkDir(codeMountPath, matchingRefs)
 				}
@@ -1011,36 +1014,45 @@ func runtimeStepConfigsForBuild(
 			target.InputImage.BaseImage = *istTagRef
 		}
 	}
-	//If there is a ref we only add a src step for that ref, otherwise do it for each extra_ref supplied
-	var sourceRefs []prowapi.Refs
+
+	var primaryRef *prowapi.Refs
 	if jobSpec.Refs != nil {
-		sourceRefs = []prowapi.Refs{*jobSpec.Refs}
-	} else {
-		sourceRefs = jobSpec.ExtraRefs
+		primaryRef = jobSpec.Refs
+	} else if !injectedTest && len(jobSpec.ExtraRefs) == 1 {
+		primaryRef = &jobSpec.ExtraRefs[0]
 	}
-	for _, r := range sourceRefs {
-		ref := ""
-		root := api.PipelineImageStreamTagReferenceRoot
-		source := api.PipelineImageStreamTagReferenceSource
-		if mergedConfig { // We only care about these suffixes when building from multiple sources
-			ref = fmt.Sprintf("%s.%s", r.Org, r.Repo)
-			root = api.PipelineImageStreamTagReference(fmt.Sprintf("%s-%s", api.PipelineImageStreamTagReferenceRoot, ref))
-			source = api.PipelineImageStreamTagReference(fmt.Sprintf("%s-%s", api.PipelineImageStreamTagReferenceSource, ref))
+	if primaryRef != nil {
+		buildSteps = append(buildSteps, sourceStepForRef(primaryRef, true))
+	}
+
+	if injectedTest {
+		for _, ref := range jobSpec.ExtraRefs {
+			buildSteps = append(buildSteps, sourceStepForRef(&ref, false))
 		}
-		step := api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
-			From: root,
-			To:   source,
-			ClonerefsImage: api.ImageStreamTagReference{
-				Namespace: "ci",
-				Name:      "managed-clonerefs",
-				Tag:       "latest",
-			},
-			ClonerefsPath: "/clonerefs",
-			Ref:           ref,
-		}}
-		buildSteps = append(buildSteps, step)
 	}
 	return buildSteps, nil
+}
+
+func sourceStepForRef(ref *prowapi.Refs, primaryRef bool) api.StepConfiguration {
+	orgRepo := ""
+	root := api.PipelineImageStreamTagReferenceRoot
+	source := api.PipelineImageStreamTagReferenceSource
+	if !primaryRef { // We only care about these suffixes when building extra refs
+		orgRepo = fmt.Sprintf("%s.%s", ref.Org, ref.Repo)
+		root = api.PipelineImageStreamTagReference(fmt.Sprintf("%s-%s", api.PipelineImageStreamTagReferenceRoot, orgRepo))
+		source = api.PipelineImageStreamTagReference(fmt.Sprintf("%s-%s", api.PipelineImageStreamTagReferenceSource, orgRepo))
+	}
+	return api.StepConfiguration{SourceStepConfiguration: &api.SourceStepConfiguration{
+		From: root,
+		To:   source,
+		ClonerefsImage: api.ImageStreamTagReference{
+			Namespace: "ci",
+			Name:      "managed-clonerefs",
+			Tag:       "latest",
+		},
+		ClonerefsPath: "/clonerefs",
+		Ref:           orgRepo,
+	}}
 }
 
 func paramsHasAllParametersAsInput(p api.Parameters, params map[string]func() (string, error)) (map[string]string, bool) {

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -58,7 +58,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 		output        []api.StepConfiguration
 		readFile      readFile
 		resolver      resolveRoot
-		mergedConfig  bool
+		injectedTest  bool
 		expectedError error
 	}{
 		{
@@ -862,6 +862,154 @@ func TestStepConfigsForBuild(t *testing.T) {
 			expectedError: fmt.Errorf("failed to read buildRootImageStream from repository: %w", fmt.Errorf("failed to read .ci-operator.yaml file: %w", fmt.Errorf("fail to read file: reason"))),
 		},
 		{
+			name: "from a primary ref with an additional ref",
+			input: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					BuildRootImage: &api.BuildRootImageConfiguration{
+						ImageStreamTagReference: &api.ImageStreamTagReference{
+							Namespace: "root-ns",
+							Name:      "root-name",
+							Tag:       "manual",
+						},
+					},
+					BuildRootImages: map[string]api.BuildRootImageConfiguration{
+						"org.other-repo": {
+							ImageStreamTagReference: &api.ImageStreamTagReference{Tag: "manual"},
+							UseBuildCache:           true,
+						},
+					},
+				},
+				BinaryBuildCommands: "binbuild",
+				BinaryBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build",
+						Ref:      "org.other-repo",
+					},
+				},
+				TestBinaryBuildCommands: "build test-bin",
+				TestBinaryBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build tb",
+						Ref:      "org.other-repo",
+					},
+				},
+				RpmBuildCommands: "build rpm",
+				RpmBuildCommandsList: []api.RefCommands{
+					{
+						Commands: "build this-rpm",
+						Ref:      "org.other-repo",
+					},
+				},
+				RpmBuildLocation: "here",
+				RpmBuildLocationList: []api.RefLocation{
+					{
+						Location: "there",
+						Ref:      "org.other-repo",
+					},
+				},
+			},
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Refs: &prowapi.Refs{
+						Org:  "org",
+						Repo: "repo",
+					},
+					ExtraRefs: []prowapi.Refs{
+						{
+							Org:  "org",
+							Repo: "other-repo",
+						},
+					},
+				},
+			},
+			resolver: noopResolver,
+			output: []api.StepConfiguration{
+				{
+					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceRoot,
+						To:   api.PipelineImageStreamTagReferenceSource,
+					}),
+				}, {
+					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
+						From: api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRoot)),
+						To:   api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						Ref:  "org.other-repo",
+					}),
+				}, {
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						InputImage: api.InputImage{
+							BaseImage: api.ImageStreamTagReference{
+								Namespace: "root-ns",
+								Name:      "root-name",
+								Tag:       "manual",
+							},
+							To: api.PipelineImageStreamTagReferenceRoot,
+						},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceRoot}},
+					},
+				}, {
+					InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
+						InputImage: api.InputImage{
+							BaseImage: api.ImageStreamTagReference{
+								Tag: "manual",
+							},
+							To:  api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRoot)),
+							Ref: "org.other-repo",
+						},
+						Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceType(fmt.Sprintf("%s-org.other-repo", api.ImageStreamSourceRoot))}},
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceSource,
+						To:       api.PipelineImageStreamTagReferenceBinaries,
+						Commands: "binbuild",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceBinaries)),
+						Commands: "build",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceSource,
+						To:       api.PipelineImageStreamTagReferenceTestBinaries,
+						Commands: "build test-bin",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceSource)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceTestBinaries)),
+						Commands: "build tb",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReferenceBinaries,
+						To:       api.PipelineImageStreamTagReferenceRPMs,
+						Commands: "build rpm; ln -s $( pwd )/here /srv/repo",
+					},
+				}, {
+					PipelineImageCacheStepConfiguration: &api.PipelineImageCacheStepConfiguration{
+						From:     api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceBinaries)),
+						To:       api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRPMs)),
+						Commands: "build this-rpm; ln -s $( pwd )/there /srv/repo",
+						Ref:      "org.other-repo",
+					},
+				}, {
+					RPMServeStepConfiguration: &api.RPMServeStepConfiguration{
+						From: api.PipelineImageStreamTagReferenceRPMs,
+					},
+				}, {
+					RPMServeStepConfiguration: &api.RPMServeStepConfiguration{
+						From: api.PipelineImageStreamTagReference(fmt.Sprintf("%s-org.other-repo", api.PipelineImageStreamTagReferenceRPMs)),
+						Ref:  "org.other-repo",
+					},
+				}},
+			injectedTest: true,
+		},
+		{
 			name: "from multiple repo references",
 			input: &api.ReleaseBuildConfiguration{
 				InputConfiguration: api.InputConfiguration{
@@ -934,8 +1082,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 					},
 				},
 			},
-			resolver:     noopResolver,
-			mergedConfig: true,
+			resolver: noopResolver,
 			output: []api.StepConfiguration{
 				{
 					SourceStepConfiguration: addCloneRefs(&api.SourceStepConfiguration{
@@ -1026,13 +1173,14 @@ func TestStepConfigsForBuild(t *testing.T) {
 						Ref:  "org.other-repo",
 					},
 				}},
+			injectedTest: true,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			graphConf := FromConfigStatic(testCase.input)
-			runtimeSteps, actualError := runtimeStepConfigsForBuild(testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages(), testCase.mergedConfig)
+			runtimeSteps, actualError := runtimeStepConfigsForBuild(testCase.input, testCase.jobSpec, testCase.readFile, testCase.resolver, graphConf.InputImages(), testCase.injectedTest)
 			graphConf.Steps = append(graphConf.Steps, runtimeSteps...)
 			if diff := cmp.Diff(testCase.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("actualError does not match expectedError, diff: %s", diff)
@@ -1184,7 +1332,7 @@ func TestFromConfig(t *testing.T) {
 		env                 api.Parameters
 		params              map[string]string
 		overriddenImagesEnv map[string]string
-		mergedConfig        bool
+		injectedTest        bool
 		expectedSteps       []string
 		expectedPost        []string
 		expectedParams      map[string]string
@@ -1284,7 +1432,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig:  true,
+		injectedTest:  true,
 		expectedSteps: []string{"root-org.repo1", "root-org.repo2", "[output-images]", "[images]"},
 	}, {
 		name: "base RPM images",
@@ -1326,7 +1474,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig: true,
+		injectedTest: true,
 		expectedSteps: []string{
 			"[input:base_rpm_image-org.repo1-without-rpms]",
 			"base_rpm_image-org.repo1",
@@ -1367,7 +1515,7 @@ func TestFromConfig(t *testing.T) {
 				},
 			},
 		},
-		mergedConfig: true,
+		injectedTest: true,
 		expectedSteps: []string{
 			"rpms-org.repo1",
 			"[serve:rpms-org.repo1]",
@@ -1703,7 +1851,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, tc.mergedConfig, map[string]*configresolver.IntegratedStream{})
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, map[string]*configresolver.IntegratedStream{}, tc.injectedTest)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}


### PR DESCRIPTION
https://github.com/openshift/ci-tools/pull/4323 was reverted due to issues with rehearsals due to the primary ref being in the extra_refs. In order to fix this: we need to ensure that if an extra_ref's `workdir` is set to `true` that will be the primary ref.

Original descrption from https://github.com/openshift/ci-tools/pull/4316:

> Since https://github.com/openshift/ci-tools/pull/4311 has merged, the `ci-operator-configresolver` now will not include the ref information for the primary ref. That is due to it being the ref that the requested test comes from. In order to support multi-pr presubmit testing, `ci-operator` needs to be slightly modified to generate build steps for the primary ref that don't include the ref suffixes, etc..

For: https://issues.redhat.com/browse/DPTP-2894