### PR TITLE
`payload-testing-prow-plugin`: add "release-repo-git-sync-path"

### DIFF
--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -34,6 +34,7 @@ type options struct {
 	kubernetesOptions        prowflagutil.KubernetesOptions
 	namespace                string
 	ciOpConfigDir            string
+	releaseRepoGitSyncPath   string
 	webhookSecretFile        string
 }
 
@@ -49,6 +50,7 @@ func gatherOptions() options {
 	o.kubernetesOptions.AddFlags(fs)
 	fs.StringVar(&o.namespace, "namespace", "ci", "Namespace to create PullRequestPayloadQualificationRuns.")
 	fs.StringVar(&o.ciOpConfigDir, "ci-op-config-dir", "", "Path to CI Operator configuration directory.")
+	fs.StringVar(&o.releaseRepoGitSyncPath, "release-repo-git-sync-path", "/var/repo/release", "Path to release repository dir")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatalf("cannot parse args: '%s'", os.Args[1:])
 	}
@@ -148,7 +150,7 @@ func main() {
 	universalSymlinkWatcher := &agents.UniversalSymlinkWatcher{
 		EventCh:   eventCh,
 		ErrCh:     errCh,
-		WatchPath: o.ciOpConfigDir,
+		WatchPath: o.releaseRepoGitSyncPath,
 	}
 
 	configAgentOption := func(opt *agents.ConfigAgentOptions) {


### PR DESCRIPTION
Adds the argument, and populates with the proper default value for the symlink watcher. I thought that we could use the "ci-op-config-dir" for this, but that results in the following error:
```json
{"component":"payload-testing-prow-plugin","error":"readlink /var/repo/release/ci-operator/config: invalid argument","file":"/go/src/github.com/openshift/ci-tools/pkg/load/agents/utils.go:137","func":"github.com/openshift/ci-tools/pkg/load/agents.(*UniversalSymlinkWatcher).GetWatcher.func1","level":"error","msg":"couldn't read the destination link of /var/repo/release/ci-operator/config","severity":"error","time":"2024-09-18T22:20:51Z"}
```

This follows the same pattern as the other tools using the symlink watcher.

/cc @droslean @openshift/test-platform 