### PR TITLE
DPTP-4183: Fix automation to include candidate release

### DIFF
--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -203,6 +203,11 @@ func updateRelease(config *api.ReleaseBuildConfiguration, currentRelease, future
 			updated.Name = futureRelease
 			config.Releases[name] = api.UnresolvedRelease{Integration: &updated}
 		}
+		if release.Candidate != nil {
+			updated := *release.Candidate
+			updated.Version = futureRelease
+			config.Releases[name] = api.UnresolvedRelease{Candidate: &updated}
+		}
 	}
 }
 

--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -631,3 +631,61 @@ func TestOptions_Bind(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateRelease(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          *api.ReleaseBuildConfiguration
+		currentRelease string
+		futureReleases string
+		output         *api.ReleaseBuildConfiguration
+	}{
+		{
+			name: "Update integration release",
+			input: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						"integration": {Integration: &api.Integration{Name: "current-release"}},
+					},
+				},
+			},
+			currentRelease: "current-release",
+			futureReleases: "future-release",
+			output: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						"integration": {Integration: &api.Integration{Name: "future-release"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Update candidate release",
+			input: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						"candidate": {Candidate: &api.Candidate{Version: "current-release"}},
+					},
+				},
+			},
+			currentRelease: "current-release",
+			futureReleases: "future-release",
+			output: &api.ReleaseBuildConfiguration{
+				InputConfiguration: api.InputConfiguration{
+					Releases: map[string]api.UnresolvedRelease{
+						"candidate": {Candidate: &api.Candidate{Version: "future-release"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			updateRelease(tc.input, tc.currentRelease, tc.futureReleases)
+			if !reflect.DeepEqual(tc.input, tc.output) {
+				t.Errorf("config mismatch (-want +got):\\n%s", diff.ObjectReflectDiff(tc.output, tc.input))
+			}
+		})
+	}
+}


### PR DESCRIPTION
The config-brancher is missing few configuration eg [installer configs](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/installer/openshift-installer-master.yaml#L249-L260) which uses candidate stream along with integration stream. Adding support eliminates the need for manual update during branching https://github.com/openshift/release/commit/4cb16b04945e7e56f0bca37b3efecea5c933c710#diff-92fb8761a3401342e7a5678fa916ff7f552fe64f9fa412105c354e691c76a736L212 

/cc @openshift/test-platform 

/hold