### PR TITLE
`prowjob-dispatcher`: refactor dispatcher and create a client for use by other tools

### DIFF
--- a/cmd/prow-job-dispatcher/main.go
+++ b/cmd/prow-job-dispatcher/main.go
@@ -663,7 +663,7 @@ func main() {
 
 	var dispatchWrapper func(cron bool)
 	var dispatchDeltaWrapper func()
-	prowjobs := newProwjobs(o.jobsStoragePath)
+	prowjobs := dispatcher.NewProwjobs(o.jobsStoragePath)
 	c := cron.New()
 
 	{
@@ -684,13 +684,13 @@ func main() {
 				return
 			}
 
-			pjs := prowjobs.getDataCopy()
+			pjs := prowjobs.GetDataCopy()
 
 			if err := dispatchMissingJobs(o.prowJobConfigDir, config, blocked, pjs); err != nil {
 				logrus.WithError(err).Error("failed to dispatch")
 				return
 			}
-			prowjobs.regenerate(pjs)
+			prowjobs.Regenerate(pjs)
 		}
 
 		dispatchWrapper = func(cron bool) {
@@ -715,7 +715,7 @@ func main() {
 				removeDisabledClusters(config, disabled)
 			}
 
-			newBlockedClusters := prowjobs.hasAnyOfClusters(blocked)
+			newBlockedClusters := prowjobs.HasAnyOfClusters(blocked)
 
 			if (!cron && enabled.Len() == 0 && disabled.Len() == 0) && !newBlockedClusters {
 				return
@@ -739,9 +739,9 @@ func main() {
 				logrus.WithError(err).Error("failed to dispatch")
 				return
 			}
-			prowjobs.regenerate(pjs)
+			prowjobs.Regenerate(pjs)
 
-			if err := writeGob(o.jobsStoragePath, pjs); err != nil {
+			if err := dispatcher.WriteGob(o.jobsStoragePath, pjs); err != nil {
 				logrus.WithError(err).Errorf("continuing on cache memory, error writing Gob file")
 			}
 
@@ -806,8 +806,8 @@ func main() {
 		}
 	}(o.clusterConfigPath)
 
-	server := newServer(prowjobs)
-	http.HandleFunc("/", server.requestHandler)
+	server := dispatcher.NewServer(prowjobs)
+	http.HandleFunc("/", server.RequestHandler)
 	logrus.Fatal(http.ListenAndServe(":8080", nil))
 
 }

--- a/pkg/dispatcher/client.go
+++ b/pkg/dispatcher/client.go
@@ -28,20 +28,20 @@ func (c client) ClusterForJob(jobName string) (string, error) {
 	schedulingRequest := SchedulingRequest{Job: jobName}
 	body, err := json.Marshal(schedulingRequest)
 	if err != nil {
-		return "", fmt.Errorf("could not marshal scheduling request: %v", err)
+		return "", fmt.Errorf("could not marshal scheduling request: %w", err)
 	}
 	req, err := http.NewRequest("POST", c.Address, bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("could not create request: %v", err)
+		return "", fmt.Errorf("could not create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	response, err := doRequest(req)
 	if err != nil {
-		return "", fmt.Errorf("error performing request: %v", err)
+		return "", fmt.Errorf("error performing request: %w", err)
 	}
 	schedulingResponse := SchedulingResponse{}
 	if err = json.Unmarshal(response, &schedulingResponse); err != nil {
-		return "", fmt.Errorf("could not parse scheduling response: %v", err)
+		return "", fmt.Errorf("could not parse scheduling response: %w", err)
 	}
 	return schedulingResponse.Cluster, nil
 }

--- a/pkg/dispatcher/client.go
+++ b/pkg/dispatcher/client.go
@@ -1,0 +1,100 @@
+package dispatcher
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/sirupsen/logrus"
+)
+
+type Client interface {
+	ClusterForJob(jobName string) (string, error)
+}
+
+func NewClient(address string) Client {
+	return client{Address: address}
+}
+
+type client struct {
+	Address string
+}
+
+func (c client) ClusterForJob(jobName string) (string, error) {
+	schedulingRequest := SchedulingRequest{Job: jobName}
+	body, err := json.Marshal(schedulingRequest)
+	if err != nil {
+		return "", fmt.Errorf("could not marshal scheduling request: %v", err)
+	}
+	req, err := http.NewRequest("POST", c.Address, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("could not create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	response, err := doRequest(req)
+	if err != nil {
+		return "", fmt.Errorf("error performing request: %v", err)
+	}
+	schedulingResponse := SchedulingResponse{}
+	if err = json.Unmarshal(response, &schedulingResponse); err != nil {
+		return "", fmt.Errorf("could not parse scheduling response: %v", err)
+	}
+	return schedulingResponse.Cluster, nil
+}
+
+type adapter struct{}
+
+func (a adapter) format(s string, i ...interface{}) string {
+	builder := strings.Builder{}
+	builder.WriteString(s)
+	for _, x := range i {
+		builder.WriteString(" ")
+		builder.WriteString(fmt.Sprintf("%v", x))
+	}
+	return builder.String()
+}
+
+func (a adapter) Error(s string, i ...interface{}) {
+	logrus.Error(a.format(s, i...))
+}
+
+func (a adapter) Info(s string, i ...interface{}) {
+	logrus.Info(a.format(s, i...))
+}
+
+func (a adapter) Debug(s string, i ...interface{}) {
+	logrus.Debug(a.format(s, i...))
+}
+
+func (a adapter) Warn(s string, i ...interface{}) {
+	logrus.Warn(a.format(s, i...))
+}
+
+var _ retryablehttp.LeveledLogger = adapter{}
+
+func doRequest(req *http.Request) ([]byte, error) {
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 5
+	retryClient.Logger = adapter{}
+	client := retryClient.StandardClient()
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request to dispatcher: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		var responseBody string
+		if data, err := io.ReadAll(resp.Body); err != nil {
+			logrus.WithError(err).Warn("Failed to read response body from dispatcher.")
+		} else {
+			responseBody = string(data)
+		}
+		return nil, fmt.Errorf("got unexpected http %d status code from dispatcher: %s", resp.StatusCode, responseBody)
+	}
+	return io.ReadAll(resp.Body)
+}

--- a/pkg/dispatcher/gob.go
+++ b/pkg/dispatcher/gob.go
@@ -1,11 +1,11 @@
-package main
+package dispatcher
 
 import (
 	"encoding/gob"
 	"os"
 )
 
-func readGob(filename string, data interface{}) error {
+func ReadGob(filename string, data interface{}) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func readGob(filename string, data interface{}) error {
 	return nil
 }
 
-func writeGob(filename string, data interface{}) error {
+func WriteGob(filename string, data interface{}) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		return err

--- a/pkg/dispatcher/prowjobs.go
+++ b/pkg/dispatcher/prowjobs.go
@@ -1,4 +1,4 @@
-package main
+package dispatcher
 
 import (
 	"sync"
@@ -8,26 +8,26 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type prowjobs struct {
+type Prowjobs struct {
 	mu              sync.Mutex
 	data            map[string]string
 	jobsStoragePath string
 }
 
-func newProwjobs(jobsStoragePath string) *prowjobs {
+func NewProwjobs(jobsStoragePath string) *Prowjobs {
 	var loadedJobs map[string]string
-	if err := readGob(jobsStoragePath, &loadedJobs); err != nil {
+	if err := ReadGob(jobsStoragePath, &loadedJobs); err != nil {
 		logrus.Errorf("falling back to empty map, error reading Gob file: %v", err)
 		loadedJobs = make(map[string]string)
 	}
-	return &prowjobs{
+	return &Prowjobs{
 		data:            loadedJobs,
 		mu:              sync.Mutex{},
 		jobsStoragePath: jobsStoragePath,
 	}
 }
 
-func (pjs *prowjobs) regenerate(prowjobs map[string]string) {
+func (pjs *Prowjobs) Regenerate(prowjobs map[string]string) {
 	pjs.mu.Lock()
 	defer pjs.mu.Unlock()
 	pjs.data = make(map[string]string, len(prowjobs))
@@ -36,7 +36,7 @@ func (pjs *prowjobs) regenerate(prowjobs map[string]string) {
 	}
 }
 
-func (pjs *prowjobs) getDataCopy() map[string]string {
+func (pjs *Prowjobs) GetDataCopy() map[string]string {
 	pjs.mu.Lock()
 	defer pjs.mu.Unlock()
 
@@ -47,7 +47,7 @@ func (pjs *prowjobs) getDataCopy() map[string]string {
 	return copy
 }
 
-func (pjs *prowjobs) get(pj string) string {
+func (pjs *Prowjobs) Get(pj string) string {
 	pjs.mu.Lock()
 	defer pjs.mu.Unlock()
 
@@ -58,7 +58,7 @@ func (pjs *prowjobs) get(pj string) string {
 	return ""
 }
 
-func (pjs *prowjobs) hasAnyOfClusters(clusters sets.Set[string]) bool {
+func (pjs *Prowjobs) HasAnyOfClusters(clusters sets.Set[string]) bool {
 	pjs.mu.Lock()
 	defer pjs.mu.Unlock()
 	for _, cluster := range pjs.data {

--- a/pkg/dispatcher/server.go
+++ b/pkg/dispatcher/server.go
@@ -1,4 +1,4 @@
-package main
+package dispatcher
 
 import (
 	"encoding/json"
@@ -9,10 +9,10 @@ import (
 )
 
 type Server struct {
-	pjs *prowjobs
+	pjs *Prowjobs
 }
 
-func newServer(jobs *prowjobs) *Server {
+func NewServer(jobs *Prowjobs) *Server {
 	return &Server{
 		pjs: jobs,
 	}
@@ -37,7 +37,7 @@ func removeRehearsePrefix(jobName string) string {
 	return jobName
 }
 
-func (s *Server) requestHandler(w http.ResponseWriter, r *http.Request) {
+func (s *Server) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
 		return
@@ -57,7 +57,7 @@ func (s *Server) requestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	cluster := s.pjs.get(removeRehearsePrefix(req.Job))
+	cluster := s.pjs.Get(removeRehearsePrefix(req.Job))
 	if cluster == "" {
 		http.Error(w, "Cluster not found", http.StatusNotFound)
 		return

--- a/pkg/dispatcher/server_test.go
+++ b/pkg/dispatcher/server_test.go
@@ -1,4 +1,4 @@
-package main
+package dispatcher
 
 import (
 	"testing"


### PR DESCRIPTION
This moves the server and necessary logic into the `pkg/dispatcher`, and adds a `client`. This is necessary for tools like `payload-testing's` `prpqr_reconciller` and `multi-pr-prow-plugin` to be able to know which `cluster` to set on job's they create.

/cc @jmguzik @openshift/test-platform 