### PR TITLE
Allow for either of the configAgentFn or registryAgentFn to be nil

### DIFF
--- a/pkg/load/agents/utils.go
+++ b/pkg/load/agents/utils.go
@@ -31,11 +31,18 @@ func startWatchers(path string, errCh chan<- error, callback func() error, metri
 					return
 				case event := <-universalSymlinkWatcher.EventCh:
 					logrus.Infof("Received event: %s", event.String())
-					if err := universalSymlinkWatcher.ConfigEventFn(); err != nil {
-						errFunc(err, "failed to load config")
+					configEventFn := universalSymlinkWatcher.ConfigEventFn
+					if configEventFn != nil {
+						if err := configEventFn(); err != nil {
+							errFunc(err, "failed to load config")
+						}
 					}
-					if err := universalSymlinkWatcher.RegistryEventFn(); err != nil {
-						errFunc(err, "failed to load registry")
+
+					registryEventFn := universalSymlinkWatcher.RegistryEventFn
+					if registryEventFn != nil {
+						if err := registryEventFn(); err != nil {
+							errFunc(err, "failed to load registry")
+						}
 					}
 
 				case err := <-universalSymlinkWatcher.ErrCh:


### PR DESCRIPTION
`payload-testing-prow-plugin` is being periodically restarted when it reloads configs. This is due to the recent [introduction](https://github.com/openshift/ci-tools/pull/4330) of the `universalSymlinkWatcher`. The plugin only needs a `ConfigAgent`, and doesn't require a `RegistryAgent`. The watcher assumes that both have been configured, while it is possible that either have been left off. The error in the logs looks like:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e1470c]
goroutine 45 [running]:
github.com/openshift/ci-tools/pkg/load/agents.startWatchers.func1({0x2bcf0a0, 0xc0078b3630})
/go/src/github.com/openshift/ci-tools/pkg/load/agents/utils.go:37 +0x1cc
sigs.k8s.io/prow/pkg/interrupts.Run.func1()
/go/src/github.com/openshift/ci-tools/vendor/sigs.k8s.io/prow/pkg/interrupts/interrupts.go:149 +0x62
created by sigs.k8s.io/prow/pkg/interrupts.Run in goroutine 1
/go/src/github.com/openshift/ci-tools/vendor/sigs.k8s.io/prow/pkg/interrupts/interrupts.go:147 +0xac
```

/cc @droslean @openshift/test-platform 