### PR TITLE
`pj-rehearse`: Disable rehearsals on tests where the 'restrict_network_access' config is toggled to 'false'

### DIFF
--- a/cmd/config-change-trigger/main.go
+++ b/cmd/config-change-trigger/main.go
@@ -105,7 +105,7 @@ func main() {
 	if prConfig.CiOperator == nil || masterConfig.CiOperator == nil {
 		logger.WithError(err).Fatal("could not load ci-operator configs from base or tested revision of release repo")
 	}
-	changedCiopConfigs, _ := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
+	changedCiopConfigs, _, _ := diffs.GetChangedCiopConfigs(masterConfig.CiOperator, prConfig.CiOperator, logger)
 	changedImagesPostsubmits := diffs.GetImagesPostsubmitsForCiopConfigs(prConfig.Prow, changedCiopConfigs)
 
 	namespace := prConfig.Prow.ProwJobNamespace

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -172,7 +172,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 	candidatePath := dro.dryRunPath
 	candidate := rehearse.RehearsalCandidateFromPullRequest(pr, pr.Base.SHA)
 
-	presubmits, periodics, changedTemplates, changedClusterProfiles, err := rc.DetermineAffectedJobs(candidate, candidatePath, logger)
+	presubmits, periodics, changedTemplates, changedClusterProfiles, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, logger)
 	if err != nil {
 		return fmt.Errorf("error determining affected jobs: %w: %s", err, "ERROR: pj-rehearse: misconfiguration")
 	}

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -556,16 +556,13 @@ func (s *server) getUsageDetailsLines() []string {
 func (s *server) getDisabledRehearsalsLines(disabledDueToNetworkAccessToggle []string) []string {
 	var lines []string
 	if len(disabledDueToNetworkAccessToggle) > 0 {
-		lines = append(lines, "The following jobs are not rehearsable due to the `restrict_network_access` field being set to `false` in this PR. You must first merge this PR, and then subsequent changes to the job will be rehearsable: ")
 		lines = []string{
 			"The following jobs are not rehearsable due to the `restrict_network_access` field being set to `false` in this PR. You must first merge this PR, and then subsequent changes to the job will be rehearsable: ",
 			"",
 			"Test name |",
 			"--- |",
 		}
-		for _, disabled := range disabledDueToNetworkAccessToggle {
-			lines = append(lines, disabled)
-		}
+		lines = append(lines, disabledDueToNetworkAccessToggle...)
 	}
 	return lines
 }

--- a/test/integration/pj-rehearse/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/config/super/trooper/super-trooper-master.yaml
@@ -25,7 +25,6 @@ tests:
   commands: make unit CHANGED
   container:
     from: src
-  restrict_network_access: false
 - as: multistage
   steps:
     test:


### PR DESCRIPTION
This is done to disallow rehearsing any test that bypasses the firewall without first having someone reviewed the configuration.

Iff we find other cases where specific fields being changed should disable the entire rehearsal, we could make this logic more general. For now, this is sufficient.

For: https://issues.redhat.com/browse/DPTP-4171