### PR TITLE
cluster-init: generate Certificates

### DIFF
--- a/cmd/cluster-init/cmd/onboard/buildclusterdir/update.go
+++ b/cmd/cluster-init/cmd/onboard/buildclusterdir/update.go
@@ -65,12 +65,12 @@ func createSymlinks(log *logrus.Entry, clusterDir string, ci *clustermgmt.Cluste
 }
 
 func createRequiredDirs(log *logrus.Entry, clusterDir string) error {
-	for _, name := range []string{"assets"} {
+	for _, name := range []string{"assets", "cert-manager"} {
 		dir := path.Join(clusterDir, name)
 		_, err := os.Stat(dir)
 		if os.IsNotExist(err) {
 			log.WithField("dir", dir).Info("Creating directory")
-			if err := os.Mkdir(dir, 0777); err != nil {
+			if err := os.Mkdir(dir, 0755); err != nil {
 				return fmt.Errorf("mkdir %s: %w", dir, err)
 			}
 		} else if err != nil {

--- a/cmd/cluster-init/cmd/onboard/generateconfig.go
+++ b/cmd/cluster-init/cmd/onboard/generateconfig.go
@@ -226,6 +226,10 @@ func generateConfig(ctx context.Context, log *logrus.Entry, clusterInstall clust
 				kubeClient := kubeClientFunc(kubeconfigs, ci, opts.update)
 				return clustermgmtonboard.NewQuayioPullThroughCacheStep(log, ci, kubeClient).Run(ctx)
 			},
+			func(log *logrus.Entry, ci *clustermgmt.ClusterInstall) error {
+				kubeClient := kubeClientFunc(kubeconfigs, ci, opts.update)
+				return clustermgmtonboard.NewCertificateStep(log, ci, kubeClient).Run(ctx)
+			},
 		}
 		if !opts.update {
 			steps = append(steps, buildclusters.UpdateBuildClusters)

--- a/cmd/cluster-init/main.go
+++ b/cmd/cluster-init/main.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
+	imagev1 "github.com/openshift/api/image/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -75,6 +76,9 @@ func addSchemes() error {
 	}
 	if err := imageregistryv1.AddToScheme(scheme.Scheme); err != nil {
 		return fmt.Errorf("add imageregistryv1 to scheme: %w", err)
+	}
+	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
+		return fmt.Errorf("add imagev1 to scheme: %w", err)
 	}
 	return nil
 }

--- a/pkg/clustermgmt/onboard/certificate.go
+++ b/pkg/clustermgmt/onboard/certificate.go
@@ -1,0 +1,204 @@
+package onboard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	"github.com/openshift/library-go/pkg/image/reference"
+
+	"github.com/openshift/ci-tools/pkg/clustermgmt"
+	citoolsyaml "github.com/openshift/ci-tools/pkg/util/yaml"
+)
+
+type certificateStep struct {
+	log            *logrus.Entry
+	clusterInstall *clustermgmt.ClusterInstall
+	kubeClient     KubeClientGetter
+	writeManifest  func(name string, data []byte, perm fs.FileMode) error
+}
+
+func (s *certificateStep) Name() string {
+	return "certificate"
+}
+
+func (s *certificateStep) Run(ctx context.Context) error {
+	log := s.log.WithField("step", s.Name())
+
+	client, err := s.kubeClient()
+	if err != nil {
+		return fmt.Errorf("kube client: %w", err)
+	}
+
+	baseDomain, err := s.baseDomain(ctx, client)
+	if err != nil {
+		return fmt.Errorf("base domain: %w", err)
+	}
+
+	host, err := s.imageRegistryPublicHost(ctx, client)
+	if err != nil {
+		return fmt.Errorf("image registry public host: %w", err)
+	}
+
+	manifests := generateCertificateManifests(s.clusterInstall, baseDomain, host)
+	manifestMarshaled, err := citoolsyaml.MarshalMultidoc(yaml.Marshal, manifests...)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+
+	outputPath := CertificateManifestPath(s.clusterInstall.Onboard.ReleaseRepo, s.clusterInstall.ClusterName)
+	if err := s.writeManifest(outputPath, manifestMarshaled, 0644); err != nil {
+		return fmt.Errorf("write template %s: %w", outputPath, err)
+	}
+
+	log.WithField("certificate", outputPath).Info("certificates generated")
+	return nil
+}
+
+func (s *certificateStep) baseDomain(ctx context.Context, client ctrlruntimeclient.Client) (string, error) {
+	if s.clusterInstall.Onboard.Certificate.BaseDomains != nil {
+		if domain, ok := s.clusterInstall.Onboard.Certificate.BaseDomains[s.clusterInstall.ClusterName]; ok {
+			s.log.Info("override base domain from config")
+			return domain, nil
+		}
+	}
+
+	cm := corev1.ConfigMap{}
+	if err := client.Get(ctx, types.NamespacedName{Namespace: "kube-system", Name: "cluster-config-v1"}, &cm); err != nil {
+		return "", fmt.Errorf("get cluster-config-v1: %w", err)
+	}
+	installConfigRaw, ok := cm.Data["install-config"]
+	if !ok {
+		return "", errors.New("install-config not found")
+	}
+
+	installConfig := struct {
+		BaseDomain string `json:"baseDomain"`
+	}{}
+	if err := yaml.Unmarshal([]byte(installConfigRaw), &installConfig); err != nil {
+		return "", fmt.Errorf("unmarshall install config: %w", err)
+	}
+	return installConfig.BaseDomain, nil
+}
+
+func (s *certificateStep) imageRegistryPublicHost(ctx context.Context, client ctrlruntimeclient.Client) (string, error) {
+	if s.clusterInstall.Onboard.Certificate.ImageRegistryPublicHosts != nil {
+		if publicHost, ok := s.clusterInstall.Onboard.Certificate.ImageRegistryPublicHosts[s.clusterInstall.ClusterName]; ok {
+			s.log.Info("override image registry public host from config")
+			return publicHost, nil
+		}
+	}
+
+	isList := imagev1.ImageStreamList{}
+	if err := client.List(ctx, &isList, &ctrlruntimeclient.ListOptions{Namespace: "openshift"}); err != nil {
+		return "", fmt.Errorf("image streams: %w", err)
+	}
+
+	for i := range isList.Items {
+		is := &isList.Items[i]
+		if value := is.Status.PublicDockerImageRepository; len(value) > 0 {
+			ref, err := reference.Parse(value)
+			if err != nil {
+				return "", fmt.Errorf("parse docker image repository: %w", err)
+			}
+			return ref.Registry, nil
+		}
+	}
+	return "", fmt.Errorf("no public registry host could be located")
+}
+
+func generateCertificateManifests(ci *clustermgmt.ClusterInstall, baseDomain, imageRegistryHost string) []interface{} {
+	clusterName := ci.ClusterName
+	manifests := make([]interface{}, 0)
+
+	apiServerCert := map[string]interface{}{
+		"kind": "Certificate",
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"aws-project": "openshift-ci-infra",
+			},
+			"name":      "apiserver-tls",
+			"namespace": "openshift-config",
+		},
+		"spec": map[string]interface{}{
+			"dnsNames": []interface{}{
+				fmt.Sprintf("api.%s.%s", clusterName, baseDomain),
+			},
+			"issuerRef": map[string]interface{}{
+				"kind": "ClusterIssuer",
+				"name": "cert-issuer-aws",
+			},
+			"secretName": "apiserver-tls",
+		},
+		"apiVersion": "cert-manager.io/v1",
+	}
+	appsCert := map[string]interface{}{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"aws-project": "openshift-ci-infra",
+			},
+			"name":      "apps-tls",
+			"namespace": "openshift-ingress",
+		},
+		"spec": map[string]interface{}{
+			"dnsNames": []interface{}{
+				fmt.Sprintf("*.apps.%s.%s", clusterName, baseDomain),
+			},
+			"issuerRef": map[string]interface{}{
+				"kind": "ClusterIssuer",
+				"name": "cert-issuer-aws",
+			},
+			"secretName": "apps-tls",
+		},
+	}
+	imageRegistryCert := map[string]interface{}{
+		"apiVersion": "cert-manager.io/v1",
+		"kind":       "Certificate",
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"gcp-project": "openshift-ci-infra",
+			},
+			"name":      "registry-tls",
+			"namespace": "openshift-image-registry",
+		},
+		"spec": map[string]interface{}{
+			"dnsNames": []interface{}{
+				imageRegistryHost,
+			},
+			"issuerRef": map[string]interface{}{
+				"kind": "ClusterIssuer",
+				"name": "cert-issuer",
+			},
+			"secretName": "public-route-tls",
+		},
+	}
+
+	if !(*ci.Onboard.OSD || *ci.Onboard.Hosted || *ci.Onboard.Unmanaged) {
+		manifests = append(manifests, apiServerCert, appsCert)
+	}
+	manifests = append(manifests, imageRegistryCert)
+
+	return manifests
+}
+
+func NewCertificateStep(log *logrus.Entry, clusterInstall *clustermgmt.ClusterInstall,
+	kubeClient KubeClientGetter) *certificateStep {
+	return &certificateStep{
+		log:            log,
+		clusterInstall: clusterInstall,
+		writeManifest:  os.WriteFile,
+		kubeClient:     kubeClient,
+	}
+}

--- a/pkg/clustermgmt/onboard/certificate_test.go
+++ b/pkg/clustermgmt/onboard/certificate_test.go
@@ -1,0 +1,301 @@
+package onboard
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	imagev1 "github.com/openshift/api/image/v1"
+	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+
+	"github.com/openshift/ci-tools/pkg/clustermgmt"
+)
+
+func TestGenerateCertificate(t *testing.T) {
+	releaseRepo := "/release/repo"
+	for _, tc := range []struct {
+		name           string
+		clusterInstall clustermgmt.ClusterInstall
+		config         imageregistryv1.Config
+		objects        []runtime.Object
+		wantManifest   string
+		wantErr        error
+	}{
+		{
+			name: "Generate certificates successfully",
+			clusterInstall: clustermgmt.ClusterInstall{ClusterName: "build99", Onboard: clustermgmt.Onboard{
+				ReleaseRepo: "/release/repo",
+				OSD:         ptr.To(false),
+				Unmanaged:   ptr.To(false),
+				Hosted:      ptr.To(false),
+			}},
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
+					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
+				},
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
+					}},
+				},
+			},
+			wantManifest: `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apiserver-tls
+  namespace: openshift-config
+spec:
+  dnsNames:
+  - api.build99.ci.devcluster.openshift.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apiserver-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apps-tls
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+  - '*.apps.build99.ci.devcluster.openshift.com'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apps-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.build99.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls
+`,
+		},
+		{
+			name: "Override from config",
+			clusterInstall: clustermgmt.ClusterInstall{ClusterName: "build99", Onboard: clustermgmt.Onboard{
+				ReleaseRepo: "/release/repo",
+				OSD:         ptr.To(false),
+				Unmanaged:   ptr.To(false),
+				Hosted:      ptr.To(false),
+				Certificate: clustermgmt.Certificate{
+					BaseDomains: map[string]string{
+						"build99": "fake-domain",
+					},
+					ImageRegistryPublicHosts: map[string]string{
+						"build99": "fake-public-host",
+					},
+				},
+			}},
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
+					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
+				},
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
+					}},
+				},
+			},
+			wantManifest: `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apiserver-tls
+  namespace: openshift-config
+spec:
+  dnsNames:
+  - api.build99.fake-domain
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apiserver-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apps-tls
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+  - '*.apps.build99.fake-domain'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apps-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - fake-public-host
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls
+`,
+		},
+		{
+			name: "Non OCP generates image registry certificate only",
+			clusterInstall: clustermgmt.ClusterInstall{ClusterName: "build99", Onboard: clustermgmt.Onboard{
+				ReleaseRepo: "/release/repo",
+				OSD:         ptr.To(true),
+				Unmanaged:   ptr.To(false),
+				Hosted:      ptr.To(false),
+			}},
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
+					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
+				},
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
+					}},
+				},
+			},
+			wantManifest: `apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.build99.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls
+`,
+		},
+		{
+			name: "No public image registry host",
+			clusterInstall: clustermgmt.ClusterInstall{
+				ClusterName: "build99",
+				Onboard: clustermgmt.Onboard{
+					ReleaseRepo: "/release/repo",
+					OSD:         ptr.To(false),
+					Unmanaged:   ptr.To(false),
+					Hosted:      ptr.To(false),
+				},
+			},
+			objects: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
+					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
+				},
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+					}},
+				},
+			},
+			wantErr: errors.New("image registry public host: no public registry host could be located"),
+		},
+		{
+			name:           "No install-config.yaml",
+			clusterInstall: clustermgmt.ClusterInstall{ClusterName: "build99", Onboard: clustermgmt.Onboard{ReleaseRepo: "/release/repo"}},
+			objects: []runtime.Object{
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
+					}},
+				},
+			},
+			wantErr: errors.New(`base domain: get cluster-config-v1: configmaps "cluster-config-v1" not found`),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scheme := runtime.NewScheme()
+			if err := imageregistryv1.AddToScheme(scheme); err != nil {
+				t.Fatal("add routev1 to scheme")
+			}
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal("add corev1 to scheme")
+			}
+			if err := imagev1.AddToScheme(scheme); err != nil {
+				t.Fatal("add imagev1 to scheme")
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.objects...).Build()
+			kubeClientGetter := func() (ctrlruntimeclient.Client, error) { return c, nil }
+			step := NewCertificateStep(logrus.NewEntry(logrus.StandardLogger()),
+				&tc.clusterInstall, kubeClientGetter)
+			var (
+				manifests          string
+				manifestsWritePath string
+			)
+			step.writeManifest = func(name string, data []byte, perm fs.FileMode) error {
+				manifestsWritePath = name
+				manifests = string(data)
+				return nil
+			}
+
+			err := step.Run(context.TODO())
+
+			if err != nil && tc.wantErr == nil {
+				t.Fatalf("want err nil but got: %v", err)
+			}
+			if err == nil && tc.wantErr != nil {
+				t.Fatalf("want err %v but got nil", tc.wantErr)
+			}
+			if err != nil && tc.wantErr != nil {
+				if tc.wantErr.Error() != err.Error() {
+					t.Fatalf("expect error %q but got %q", tc.wantErr.Error(), err.Error())
+				}
+				return
+			}
+
+			wantManifestsWritePath := path.Join(releaseRepo, "clusters/build-clusters/build99/cert-manager/certificate.yaml")
+			if manifestsWritePath != wantManifestsWritePath {
+				t.Errorf("want manifests path (write) %q but got %q", wantManifestsWritePath, manifestsWritePath)
+			}
+
+			if diff := cmp.Diff(tc.wantManifest, manifests); diff != "" {
+				t.Errorf("templates differs:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/clustermgmt/onboard/certificate_test.go
+++ b/pkg/clustermgmt/onboard/certificate_test.go
@@ -113,6 +113,8 @@ spec:
 					ImageRegistryPublicHosts: map[string]string{
 						"build99": "fake-public-host",
 					},
+					ClusterIssuer: map[string]map[string]string{"build99": {"apiserver-tls": "overridden"}},
+					ProjectLabel:  map[string]map[string]clustermgmt.CertificateProjectLabel{"build99": {"apps-tls": {Key: "foo-project", Value: "bar"}}},
 				},
 			}},
 			objects: []runtime.Object{
@@ -139,14 +141,14 @@ spec:
   - api.build99.fake-domain
   issuerRef:
     kind: ClusterIssuer
-    name: cert-issuer-aws
+    name: overridden
   secretName: apiserver-tls
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   labels:
-    aws-project: openshift-ci-infra
+    foo-project: bar
   name: apps-tls
   namespace: openshift-ingress
 spec:

--- a/pkg/clustermgmt/onboard/types.go
+++ b/pkg/clustermgmt/onboard/types.go
@@ -62,3 +62,7 @@ func OAuthTemplatePath(releaseRepo, clusterName string) string {
 func QuayioPullThroughCacheManifestPath(releaseRepo, clusterName string) string {
 	return filepath.Join(releaseRepo, "clusters", "build-clusters", clusterName, "assets/quayio-pull-through-cache-icsp.yaml")
 }
+
+func CertificateManifestPath(releaseRepo, clusterName string) string {
+	return filepath.Join(releaseRepo, "clusters", "build-clusters", clusterName, "cert-manager/certificate.yaml")
+}

--- a/pkg/clustermgmt/types.go
+++ b/pkg/clustermgmt/types.go
@@ -42,6 +42,7 @@ type Onboard struct {
 	UseTokenFileInKubeconfig *bool                  `json:"useTokenFileInKubeconfig,omitempty"`
 	Dex                      Dex                    `json:"dex,omitempty"`
 	QuayioPullThroughCache   QuayioPullThroughCache `json:"quayioPullThroughCache,omitempty"`
+	Certificate              Certificate            `json:"certificate,omitempty"`
 }
 
 type Dex struct {
@@ -50,6 +51,11 @@ type Dex struct {
 
 type QuayioPullThroughCache struct {
 	MirrorURIs map[string]string `json:"mirrorURI,omitempty"`
+}
+
+type Certificate struct {
+	BaseDomains              map[string]string `json:"baseDomains,omitempty"`
+	ImageRegistryPublicHosts map[string]string `json:"imageRegistryPublicHosts,omitempty"`
 }
 
 type Step interface {

--- a/pkg/clustermgmt/types.go
+++ b/pkg/clustermgmt/types.go
@@ -53,9 +53,16 @@ type QuayioPullThroughCache struct {
 	MirrorURIs map[string]string `json:"mirrorURI,omitempty"`
 }
 
+type CertificateProjectLabel struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
 type Certificate struct {
-	BaseDomains              map[string]string `json:"baseDomains,omitempty"`
-	ImageRegistryPublicHosts map[string]string `json:"imageRegistryPublicHosts,omitempty"`
+	BaseDomains              map[string]string                             `json:"baseDomains,omitempty"`
+	ImageRegistryPublicHosts map[string]string                             `json:"imageRegistryPublicHosts,omitempty"`
+	ClusterIssuer            map[string]map[string]string                  `json:"clusterIssuer,omitempty"`
+	ProjectLabel             map[string]map[string]CertificateProjectLabel `json:"projectLabel,omitempty"`
 }
 
 type Step interface {

--- a/pkg/util/yaml/yaml.go
+++ b/pkg/util/yaml/yaml.go
@@ -1,0 +1,20 @@
+package yaml
+
+type Marshaler func(interface{}) ([]byte, error)
+
+func MarshalMultidoc(marshaler Marshaler, objs ...interface{}) ([]byte, error) {
+	yamlBytes := []byte{}
+	l := len(objs) - 1
+	delim := []byte("---\n")
+	for i, obj := range objs {
+		bytes, err := marshaler(obj)
+		if err != nil {
+			return nil, err
+		}
+		yamlBytes = append(yamlBytes, bytes...)
+		if i < l {
+			yamlBytes = append(yamlBytes, delim...)
+		}
+	}
+	return yamlBytes, nil
+}

--- a/pkg/util/yaml/yaml_test.go
+++ b/pkg/util/yaml/yaml_test.go
@@ -1,0 +1,63 @@
+package yaml_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	k8syaml "sigs.k8s.io/yaml"
+
+	citoolsyaml "github.com/openshift/ci-tools/pkg/util/yaml"
+)
+
+func TestMarshalMultidoc(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		objs          []interface{}
+		marshaler     citoolsyaml.Marshaler
+		wantYamlBytes []byte
+		wantErr       error
+	}{
+		{
+			name: "k8syaml: multiple objects success",
+			objs: []interface{}{
+				map[string]interface{}{"foo": "bar"},
+				map[string]interface{}{"super": "duper"},
+			},
+			marshaler:     k8syaml.Marshal,
+			wantYamlBytes: []byte("foo: bar\n---\nsuper: duper\n"),
+		},
+		{
+			name:          "k8syaml: single object success",
+			objs:          []interface{}{map[string]interface{}{"foo": "bar"}},
+			marshaler:     k8syaml.Marshal,
+			wantYamlBytes: []byte("foo: bar\n"),
+		},
+		{
+			name:      "k8syaml: failure",
+			objs:      []interface{}{map[string]interface{}{"foo": "bar"}},
+			marshaler: func(i interface{}) ([]byte, error) { return nil, errors.New("fake") },
+			wantErr:   errors.New("fake"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			yamlBytes, err := citoolsyaml.MarshalMultidoc(tc.marshaler, tc.objs...)
+			if err != nil && tc.wantErr == nil {
+				t.Errorf("want err nil but got: %v", err)
+			}
+			if err == nil && tc.wantErr != nil {
+				t.Errorf("want err %v but got nil", tc.wantErr)
+			}
+			if err != nil && tc.wantErr != nil {
+				if tc.wantErr.Error() != err.Error() {
+					t.Errorf("expect error %q but got %q", tc.wantErr.Error(), err.Error())
+				}
+				return
+			}
+			if diff := cmp.Diff(tc.wantYamlBytes, yamlBytes); diff != "" {
+				t.Errorf("unexpected diff:\n%s", diff)
+			}
+		})
+	}
+}

--- a/test/integration/cluster-init.sh
+++ b/test/integration/cluster-init.sh
@@ -15,14 +15,18 @@ cp -a "${suite_dir}"/* "${tempdir}"
 
 install_base="$tempdir/install-base"
 mkdir -p "$install_base/ocp-install-base/auth"
+kubeconfigs="$tempdir/kubeconfigs"
+mkdir -p "$kubeconfigs"
+
 function generate_kubeconfig() {
     clustername="$1"
-    cat >"$install_base/ocp-install-base/auth/kubeconfig" <<EOF
+    path="$2"
+    cat >"$path" <<EOF
 apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-    server: https://api.${clustername}.ci.devcluster.openshift.com:6443
+    server: https://api.${clustername}.fake:6443
   name: api-${clustername}-ci-devcluster-openshift-com
 contexts:
 - context:
@@ -43,54 +47,68 @@ EOF
 function generate_cluster_install() {
     clustername="$1"
     releaserepo="$2"
-    out="$3"
-    hosted="$4"
-    osd="$5"
-    cat >"${tempdir}/${out}" <<EOF
+    hosted="$3"
+    osd="$4"
+    cat >"${tempdir}/cluster-install.yaml" <<EOF
 clusterName: $clustername
 installBase: $install_base
 onboard:
     releaseRepo: $releaserepo
     hosted: $hosted
     osd: $osd
+    kubeconfigDir: $kubeconfigs
+    kubeconfigSuffix: config
     dex:
       redirectURI:
-        $clustername: https://oauth-openshift.apps.${clustername}.ky4t.p1.openshiftapps.com/oauth2callback/RedHat_Internal_SSO
+        newCluster: https://oauth-openshift.apps.newCluster.ky4t.p1.openshiftapps.com/oauth2callback/RedHat_Internal_SSO
+        existingCluster: https://oauth-openshift.apps.existingCluster.ky4t.p1.openshiftapps.com/oauth2callback/RedHat_Internal_SSO
     quayioPullThroughCache:
       mirrorURI:
-        $clustername: quayio-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
+        newCluster: quayio-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
+        existingCluster: quayio-pull-through-cache-us-east-1-ci.apps.ci.l2s4.p1.openshiftapps.com
+    certificate:
+      baseDomains:
+        newCluster: ci.devcluster.openshift.com
+        existingCluster: ci.devcluster.openshift.com
+      imageRegistryPublicHosts:
+        newCluster: registry.newCluster.ci.openshift.org
+        existingCluster: registry.existingCluster.ci.openshift.org
 EOF
 }
+
+generate_kubeconfig "newCluster" "$kubeconfigs/newCluster.config"
+generate_kubeconfig "existingCluster" "$kubeconfigs/existingCluster.config"
 
 os::test::junit::declare_suite_start "integration/cluster-init"
 
 # test the create scenario
 actual_create="${tempdir}/create/input"
 expected_create="${suite_dir}/create/expected"
-generate_cluster_install "newCluster" "$actual_create" "cluster-install-newCluster.yaml" true true
-generate_kubeconfig "newCluster"
-os::cmd::expect_success "cluster-init --cluster-install=${tempdir}/cluster-install-newCluster.yaml onboard config generate --create-pr=false"
+generate_kubeconfig "newCluster" "$install_base/ocp-install-base/auth/kubeconfig"
+generate_cluster_install "newCluster" "$actual_create" true true
+os::cmd::expect_success "cluster-init --cluster-install=${tempdir}/cluster-install.yaml onboard config generate --create-pr=false"
 os::integration::compare "${actual_create}" "${expected_create}"
+
 # test the update scenario
 actual_update="${tempdir}/update/input"
 expected_update="${suite_dir}/update/expected"
-generate_cluster_install "existingCluster" "$actual_update" "cluster-install-existingCluster.yaml" false true
-generate_kubeconfig "existingCluster"
-os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install-existingCluster.yaml config generate --update=true --create-pr=false"
+generate_cluster_install "existingCluster" "$actual_update" false true
+os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install.yaml config generate --update=true --create-pr=false"
 os::integration::compare "${actual_update}" "${expected_update}"
+
 # test the create ocp scenario
 actual_create="${tempdir}/create-ocp/input"
 expected_create="${suite_dir}/create-ocp/expected"
-generate_cluster_install "newCluster" "$actual_create" "cluster-install-newCluster-ocp.yaml" false false
-generate_kubeconfig "newCluster"
-os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install-newCluster-ocp.yaml config generate --create-pr=false"
+generate_kubeconfig "newCluster" "$install_base/ocp-install-base/auth/kubeconfig"
+generate_cluster_install "newCluster" "$actual_create" false false
+os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install.yaml config generate --create-pr=false"
 os::integration::compare "${actual_create}" "${expected_create}"
+
 # test the update scenario
 actual_update="${tempdir}/update-ocp/input"
 expected_update="${suite_dir}/update-ocp/expected"
-generate_cluster_install "existingCluster" "$actual_update" "cluster-install-existingCluster-ocp.yaml" false false
-generate_kubeconfig "existingCluster"
-os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install-existingCluster-ocp.yaml config generate --update=true --create-pr=false"
+generate_cluster_install "existingCluster" "$actual_update" false false
+os::cmd::expect_success "cluster-init onboard --cluster-install=${tempdir}/cluster-install.yaml config generate --update=true --create-pr=false"
 os::integration::compare "${actual_update}" "${expected_update}"
 
 os::test::junit::declare_suite_end

--- a/test/integration/cluster-init/create-ocp/expected/clusters/build-clusters/newCluster/cert-manager/certificate.yaml
+++ b/test/integration/cluster-init/create-ocp/expected/clusters/build-clusters/newCluster/cert-manager/certificate.yaml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apiserver-tls
+  namespace: openshift-config
+spec:
+  dnsNames:
+  - api.newCluster.ci.devcluster.openshift.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apiserver-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apps-tls
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+  - '*.apps.newCluster.ci.devcluster.openshift.com'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apps-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.newCluster.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls

--- a/test/integration/cluster-init/create/expected/clusters/build-clusters/newCluster/cert-manager/certificate.yaml
+++ b/test/integration/cluster-init/create/expected/clusters/build-clusters/newCluster/cert-manager/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.newCluster.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls

--- a/test/integration/cluster-init/update-ocp/expected/clusters/build-clusters/existingCluster/cert-manager/certificate.yaml
+++ b/test/integration/cluster-init/update-ocp/expected/clusters/build-clusters/existingCluster/cert-manager/certificate.yaml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apiserver-tls
+  namespace: openshift-config
+spec:
+  dnsNames:
+  - api.existingCluster.ci.devcluster.openshift.com
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apiserver-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    aws-project: openshift-ci-infra
+  name: apps-tls
+  namespace: openshift-ingress
+spec:
+  dnsNames:
+  - '*.apps.existingCluster.ci.devcluster.openshift.com'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer-aws
+  secretName: apps-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.existingCluster.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls

--- a/test/integration/cluster-init/update/expected/clusters/build-clusters/existingCluster/cert-manager/certificate.yaml
+++ b/test/integration/cluster-init/update/expected/clusters/build-clusters/existingCluster/cert-manager/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    gcp-project: openshift-ci-infra
+  name: registry-tls
+  namespace: openshift-image-registry
+spec:
+  dnsNames:
+  - registry.existingCluster.ci.openshift.org
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-issuer
+  secretName: public-route-tls

--- a/test/validate-generation-breaking-changes.sh
+++ b/test/validate-generation-breaking-changes.sh
@@ -66,11 +66,24 @@ for org in openshift; do
   fi
 
   echo >&2 "$(date --iso-8601=seconds) Executing cluster-init update"
-    cluster-init onboard config generate --update=true --create-pr=false --cluster-install=<(cat <<EOF
+  cluster-init onboard config generate --update=true --create-pr=false --cluster-install=<(cat <<EOF
 onboard:
   releaseRepo: "$clonedir"
   kubeconfigDir: "$KUBECONFIG_DIR"
   kubeconfigSuffix: "$KUBECONFIG_SUFFIX"
+  certificate:
+    clusterIssuer:
+      build02:
+        apps-tls: cert-issuer-ci-build-farm
+        apiserver-tls: cert-issuer-ci-build-farm
+    projectLabel:
+      build02:
+        apiserver-tls:
+          key: gcp-project
+          value: openshift-ci-build-farm
+        apps-tls:
+          key: gcp-project
+          value: openshift-ci-build-farm
 EOF
 )
     out="$(git status --porcelain)"


### PR DESCRIPTION
Generate `certificates.cert-manager.io` manifests into `assets/cert-manager` directory.
`cluster-init` extracts the following information at runtime:
- DNS base domain: get from the `baseDomain` stanza of `cluster-install.yaml` stored into `oc -n kube-system get cm/cluster-config-v1` 
- Image Registry public host: get from the `publicDockerImageRepository` stanza of any IS from the `openshift` namespace. I didn't come up with this idea, I've stolen from [here](https://github.com/openshift/oc/blob/e75d922ae2a2af65a647dd6c094be9e78d49f7d4/pkg/cli/registry/info/info.go#L1), thanks `oc` guys!


[Check this out](https://github.com/openshift/release/blob/b9355499f2cbcba18f7d90b9bca44bbc0cbbbe59/clusters/build-clusters/build11/cert-manager/certificate.yaml) as an example.