### PR TITLE
`pj-rehearse`: add empty line for formatting

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -563,6 +563,7 @@ func (s *server) getDisabledRehearsalsLines(disabledDueToNetworkAccessToggle []s
 			"--- |",
 		}
 		lines = append(lines, disabledDueToNetworkAccessToggle...)
+		lines = append(lines, "") // For formatting
 	}
 	return lines
 }


### PR DESCRIPTION
Otherwise, the table gets formatted like the following with the next line as part of the table:
![Screenshot 2024-09-27 at 12 49 19 PM](https://github.com/user-attachments/assets/784c70f2-3684-40f6-91ab-a743257e3ffe)
