### PR TITLE
[DPTP-4192] adjust bundle image builds to exclude manifest list

### DIFF
--- a/cmd/registry-replacer/main_test.go
+++ b/cmd/registry-replacer/main_test.go
@@ -809,7 +809,7 @@ func TestPruneUnusedReplacements(t *testing.T) {
 			if err := pruneUnusedReplacements(tc.in, tc.allSourceImages); err != nil {
 				t.Fatalf("pruneUnusedReplacements failed: %v", err)
 			}
-			if diff := cmp.Diff(tc.in, tc.expected, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.in, tc.expected, cmpopts.EquateEmpty(), cmpopts.IgnoreUnexported(api.ProjectDirectoryImageBuildStepConfiguration{})); diff != "" {
 				t.Errorf("result differs from expected: %s", diff)
 			}
 		})
@@ -912,7 +912,7 @@ func TestPruneOCPBuilderReplacements(t *testing.T) {
 				t.Fatalf("pruning failed: %v", err)
 			}
 
-			if diff := cmp.Diff(tc.in, tc.expected); diff != "" {
+			if diff := cmp.Diff(tc.in, tc.expected, cmpopts.IgnoreUnexported(api.ProjectDirectoryImageBuildStepConfiguration{})); diff != "" {
 				t.Errorf("actual differs from expected: %s", diff)
 			}
 		})

--- a/pkg/api/config_test.go
+++ b/pkg/api/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"k8s.io/utils/pointer"
 
@@ -196,7 +197,7 @@ func TestWithPresubmitFrom(t *testing.T) {
 				t.Errorf("Error differs from expected:\n%s", errDiff)
 			}
 
-			if diff := cmp.Diff(tc.expected, actual); tc.expectedError == nil && diff != "" {
+			if diff := cmp.Diff(tc.expected, actual, cmpopts.IgnoreUnexported(ProjectDirectoryImageBuildStepConfiguration{})); tc.expectedError == nil && diff != "" {
 				t.Errorf("Result differs from expected:\n%s", diff)
 			}
 		})

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2325,10 +2325,24 @@ type ProjectDirectoryImageBuildStepConfiguration struct {
 
 	// Ref is an optional string linking to the extra_ref in "org.repo" format that this belongs to
 	Ref string `json:"ref,omitempty"`
+
+	// isBundleImage indicates that this build step is a bundle image
+	isBundleImage bool
 }
 
 func (config ProjectDirectoryImageBuildStepConfiguration) TargetName() string {
 	return string(config.To)
+}
+
+// IsBundleImage returns the value of the isBundleImage field
+func (p *ProjectDirectoryImageBuildStepConfiguration) IsBundleImage() bool {
+	return p.isBundleImage
+}
+
+// WithBundleImage sets the isBundleImage field to the provided value
+func (p *ProjectDirectoryImageBuildStepConfiguration) WithBundleImage(isBundleImage bool) *ProjectDirectoryImageBuildStepConfiguration {
+	p.isBundleImage = isBundleImage
+	return p
 }
 
 // ProjectDirectoryImageBuildInputs holds inputs for an image build from the repo under test

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -849,7 +849,7 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 					DockerfilePath: bundleConfig.DockerfilePath,
 				},
 			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: bundle})
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: bundle.WithBundleImage(true)})
 			// Build index generator
 			indexName := api.PipelineImageStreamTagReference(api.IndexName(bundleConfig.As))
 			updateGraph := bundleConfig.UpdateGraph
@@ -869,7 +869,7 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 					DockerfilePath: steps.IndexDockerfileName,
 				},
 			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index})
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: index.WithBundleImage(true)})
 		}
 		// Build non-named bundles following old naming system
 		var bundles []string
@@ -884,7 +884,7 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 					DockerfilePath: bundle.DockerfilePath,
 				},
 			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image.WithBundleImage(true)})
 		}
 		if len(bundles) > 0 {
 			// Build index generator
@@ -900,7 +900,7 @@ func FromConfigStatic(config *api.ReleaseBuildConfiguration) api.GraphConfigurat
 					DockerfilePath: steps.IndexDockerfileName,
 				},
 			}
-			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image})
+			buildSteps = append(buildSteps, api.StepConfiguration{ProjectDirectoryImageBuildStepConfiguration: image.WithBundleImage(true)})
 		}
 	}
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -718,18 +718,18 @@ func TestStepConfigsForBuild(t *testing.T) {
 					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceRoot}},
 				},
 			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
+				ProjectDirectoryImageBuildStepConfiguration: (&api.ProjectDirectoryImageBuildStepConfiguration{
 					To:                               "ci-index",
 					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{DockerfilePath: "index.Dockerfile"},
-				},
+				}).WithBundleImage(true),
 			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
+				ProjectDirectoryImageBuildStepConfiguration: (&api.ProjectDirectoryImageBuildStepConfiguration{
 					To: "ci-bundle0",
 					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
 						ContextDir:     "manifests/olm",
 						DockerfilePath: "bundle.Dockerfile",
 					},
-				},
+				}).WithBundleImage(true),
 			}, {
 				SourceStepConfiguration: &api.SourceStepConfiguration{
 					From:           "root",
@@ -798,18 +798,20 @@ func TestStepConfigsForBuild(t *testing.T) {
 					Sources: []api.ImageStreamSource{{SourceType: api.ImageStreamSourceRoot}},
 				},
 			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
-					To:                               "ci-index-my-bundle",
-					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{DockerfilePath: "index.Dockerfile"},
-				},
+				ProjectDirectoryImageBuildStepConfiguration: (&api.ProjectDirectoryImageBuildStepConfiguration{
+					To: "ci-index-my-bundle",
+					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
+						DockerfilePath: "index.Dockerfile",
+					},
+				}).WithBundleImage(true),
 			}, {
-				ProjectDirectoryImageBuildStepConfiguration: &api.ProjectDirectoryImageBuildStepConfiguration{
+				ProjectDirectoryImageBuildStepConfiguration: (&api.ProjectDirectoryImageBuildStepConfiguration{
 					To: "my-bundle",
 					ProjectDirectoryImageBuildInputs: api.ProjectDirectoryImageBuildInputs{
 						ContextDir:     "manifests/olm",
 						DockerfilePath: "bundle.Dockerfile",
 					},
-				},
+				}).WithBundleImage(true),
 			}, {
 				SourceStepConfiguration: &api.SourceStepConfiguration{
 					From:           "root",
@@ -1191,7 +1193,7 @@ func TestStepConfigsForBuild(t *testing.T) {
 			}
 			actual := sortStepConfig(graphConf.Steps)
 			expected := sortStepConfig(testCase.output)
-			if diff := cmp.Diff(actual, expected); diff != "" {
+			if diff := cmp.Diff(actual, expected, cmp.AllowUnexported(api.ProjectDirectoryImageBuildStepConfiguration{})); diff != "" {
 				t.Errorf("actual differs from expected: %s", diff)
 			}
 		})

--- a/pkg/diffs/diffs.go
+++ b/pkg/diffs/diffs.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/getlantern/deepcopy"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -12,6 +14,7 @@ import (
 	pjapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/jobconfig"
@@ -55,7 +58,7 @@ func GetChangedCiopConfigs(masterConfig, prConfig config.DataByFilename, logger 
 			return out
 		}
 
-		if !equality.Semantic.DeepEqual(withoutTests(oldConfig.Configuration), withoutTests(newConfig.Configuration)) {
+		if diff := cmp.Diff(withoutTests(oldConfig.Configuration), withoutTests(newConfig.Configuration), cmpopts.IgnoreUnexported(api.ProjectDirectoryImageBuildStepConfiguration{})); diff != "" {
 			logger.WithField(logCiopConfig, filename).Info(changedCiopConfigMsg)
 			configs[filename] = newConfig
 			continue

--- a/pkg/steps/project_image.go
+++ b/pkg/steps/project_image.go
@@ -68,6 +68,11 @@ func (s *projectDirectoryImageBuildStep) run(ctx context.Context) error {
 		s.config.Ref,
 	)
 
+	// Bundle images are non multi-arch by design. No manifest list is needed. Here we spawn a single build.
+	if s.config.IsBundleImage() {
+		return handleBuild(ctx, s.client, s.podClient, *build)
+	}
+
 	return handleBuilds(ctx, s.client, s.podClient, *build, newImageBuildOptions(s.architectures.UnsortedList()))
 }
 


### PR DESCRIPTION
Bundle images are not multi-arch by design. Spawn a single build instead when the image build configuration comes from the operator bundles stanza.


Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>


/cc @deepsm007 @aleskandro @openshift/test-platform 
