### PR TITLE
`pj-rehearse`: allow the ability to rehearse tests with `network_access_restricted`: 'false'

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -172,7 +172,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 	candidatePath := dro.dryRunPath
 	candidate := rehearse.RehearsalCandidateFromPullRequest(pr, pr.Base.SHA)
 
-	presubmits, periodics, changedTemplates, changedClusterProfiles, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, logger)
+	presubmits, periodics, changedTemplates, changedClusterProfiles, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
 	if err != nil {
 		return fmt.Errorf("error determining affected jobs: %w: %s", err, "ERROR: pj-rehearse: misconfiguration")
 	}

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -162,7 +162,7 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 			},
 		},
 	}, {
-		name: "one potential rehearsal disabled due to un-restricted network access toggle 'true' to 'false'",
+		name: "one potential rehearsal disabled due to un-restricted network access set to 'false'",
 		configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
 			before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
 			afterConfig := config.DataWithInfo{}
@@ -185,42 +185,12 @@ func TestGetChangedCiopConfigs(t *testing.T) {
 		},
 		expectedAffectedJobs: map[string]sets.Set[string]{
 			"org-repo-branch.yaml": {
-				"e2e": sets.Empty{},
+				"unit": sets.Empty{},
+				"e2e":  sets.Empty{},
 			},
 		},
 		expectedDisabledDueToNetworkAccessToggle: []string{"pull-ci-org-repo-branch-unit"},
-	}, {
-		name: "potential rehearsal for new test disabled due to un-restricted network access set to 'false'",
-		configGenerator: func(t *testing.T) (config.DataByFilename, config.DataByFilename) {
-			before := config.DataByFilename{"org-repo-branch.yaml": baseCiopConfig}
-			afterConfig := config.DataWithInfo{}
-			if err := deepcopy.Copy(&afterConfig, &baseCiopConfig); err != nil {
-				t.Fatal(err)
-			}
-			afterConfig.Configuration.Tests = append(afterConfig.Configuration.Tests, cioperatorapi.TestStepConfiguration{
-				As:                    "lint",
-				Commands:              "make lint",
-				RestrictNetworkAccess: utilpointer.Bool(false),
-			})
-			after := config.DataByFilename{"org-repo-branch.yaml": afterConfig}
-			return before, after
-		},
-		expected: func() config.DataByFilename {
-			expected := config.DataWithInfo{}
-			if err := deepcopy.Copy(&expected, &baseCiopConfig); err != nil {
-				t.Fatal(err)
-			}
-			expected.Configuration.Tests = append(expected.Configuration.Tests, cioperatorapi.TestStepConfiguration{
-				As:                    "lint",
-				Commands:              "make lint",
-				RestrictNetworkAccess: utilpointer.Bool(false),
-			})
-			return config.DataByFilename{"org-repo-branch.yaml": expected}
-		},
-		expectedAffectedJobs:                     map[string]sets.Set[string]{},
-		expectedDisabledDueToNetworkAccessToggle: []string{"pull-ci-org-repo-branch-lint"},
-	},
-	}
+	}}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -217,7 +217,7 @@ func filterPresubmits(changedPresubmits config.Presubmits, disabledJobs []string
 			}
 
 			if slices.Contains(disabledJobs, job.Name) {
-				jobLogger.Debug("cannot rehearse due to toggle of 'restrict_network_access' to 'false'")
+				jobLogger.Debug("cannot rehearse due to 'restrict_network_access' set to 'false' without appropriate label on PR")
 				continue
 			}
 
@@ -244,7 +244,7 @@ func filterPeriodics(changedPeriodics config.Periodics, disabledJobs []string, l
 		}
 
 		if slices.Contains(disabledJobs, periodic.Name) {
-			jobLogger.Debug("cannot rehearse due to toggle of 'restrict_network_access' to 'false'")
+			jobLogger.Debug("cannot rehearse due to 'restrict_network_access' set to 'false' without appropriate label on PR")
 			continue
 		}
 


### PR DESCRIPTION
> Any rehearsal of any job with the `restrict_network_access` field set to false will require the PR to have the `network-access-rehearsals-ok` label. This label will only be allowed to be applied via the plugin, and only by an 'openshift' org member who is not the author of the PR. The label will be removed on a new push. The PR will also have to be labeled 'approved' for the job to be rehearsable.

For: https://issues.redhat.com/browse/DPTP-4195