### PR TITLE
OCPQE-26170: Add cluster profiles for Azure HCP QE

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1272,6 +1272,8 @@ const (
 	ClusterProfileAzureStackQE          ClusterProfile = "azurestack-qe"
 	ClusterProfileAzureMag              ClusterProfile = "azuremag"
 	ClusterProfileAzureQE               ClusterProfile = "azure-qe"
+	ClusterProfileAzureHCPQE            ClusterProfile = "azure-hcp-qe"
+	ClusterProfileAzureHCPHAQE          ClusterProfile = "azure-hcp-ha-qe"
 	ClusterProfileAzureAutoreleaseQE    ClusterProfile = "azure-autorelease-qe"
 	ClusterProfileAzureArm64QE          ClusterProfile = "azure-arm64-qe"
 	ClusterProfileAzureMagQE            ClusterProfile = "azuremag-qe"
@@ -1410,6 +1412,8 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureMag,
 		ClusterProfileAzureMagQE,
 		ClusterProfileAzureQE,
+		ClusterProfileAzureHCPQE,
+		ClusterProfileAzureHCPHAQE,
 		ClusterProfileAzureAutoreleaseQE,
 		ClusterProfileAzurePerfScale,
 		ClusterProfileAzureStack,
@@ -1572,6 +1576,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAzure4,
 		ClusterProfileAzureArc,
 		ClusterProfileAzureQE,
+		ClusterProfileAzureHCPQE,
+		ClusterProfileAzureHCPHAQE,
 		ClusterProfileAzureAutoreleaseQE,
 		ClusterProfileAzurePerfScale,
 		ClusterProfileAzureVirtualization:
@@ -1804,6 +1810,10 @@ func (p ClusterProfile) LeaseType() string {
 		return "azuremag-quota-slice"
 	case ClusterProfileAzureQE:
 		return "azure-qe-quota-slice"
+	case ClusterProfileAzureHCPQE:
+		return "azure-hcp-qe-quota-slice"
+	case ClusterProfileAzureHCPHAQE:
+		return "azure-hcp-ha-qe-quota-slice"
 	case ClusterProfileAzureAutoreleaseQE:
 		return "azure-autorelease-qe-quota-slice"
 	case ClusterProfileAzureMagQE:
@@ -2024,6 +2034,10 @@ func (p ClusterProfile) Secret() string {
 		ClusterProfileVSphereElastic:
 
 		name = p.ClusterType()
+	case
+		ClusterProfileAzureHCPQE,
+		ClusterProfileAzureHCPHAQE:
+		name = ClusterProfileAzureHCPQE.Name()
 	default:
 		name = string(p)
 	}


### PR DESCRIPTION
Create two distinct cluster profiles: one for HA jobs and one for all other jobs. 