### PR TITLE
`multi-pr-prow-plugin`: add a readme

### DIFF
--- a/cmd/multi-pr-prow-plugin/README.md
+++ b/cmd/multi-pr-prow-plugin/README.md
@@ -1,0 +1,3 @@
+The `multi-pr-prow-plugin` is an external prow plugin that facilitates running presubmit tests
+from sources built using multiple pull requests. The included pull requests can be from the same, or a different, repo.
+It creates and manages GitHub `check_runs` to keep share the state and logs of the jobs with the user.


### PR DESCRIPTION
This is useful, but is mostly to test out how tide behaves with the check_runs.

/hold until ready