### PR TITLE
[registry-replacer] Skip disabled configs

### DIFF
--- a/pkg/api/ocpbuilddata/types.go
+++ b/pkg/api/ocpbuilddata/types.go
@@ -205,6 +205,10 @@ func LoadImageConfigs(ocpBuildDataDir string, majorMinor MajorMinor) ([]OCPImage
 	var errs []error
 	var configs []OCPImageConfig
 	for _, cfg := range configsUnverified {
+		// Skip disabled configs
+		if cfg.Mode == "disabled" {
+			continue
+		}
 		if err := cfg.validate(); err != nil {
 			errs = append(errs, fmt.Errorf("error validating %s: %w", cfg.SourceFileName, err))
 			continue


### PR DESCRIPTION
As part of ART pipelines, we want the ability to onboard images which are 
unconventional. They may not always have from/stream/member images defined. (example https://github.com/openshift-eng/ocp-build-data/pull/5511/files)
We mark these images as disabled, so skip operating on these.

Right now the command errors out because of the unconventional config
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-prow-auto-config-brancher/1846521743284375552