### PR TITLE
`pj-rehearse`: abort active rehearsal jobs when new commit is pushed

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -215,6 +215,7 @@ func (s *server) handleNewPush(l *logrus.Entry, event github.PullRequestEvent) {
 			"pr":   number,
 		})
 		logger.Debug("handling new push")
+		s.rehearsalConfig.AbortAllRehearsalJobs(org, repo, number, logger)
 
 		if err := s.ghc.RemoveLabel(org, repo, number, rehearse.NetworkAccessRehearsalsOkLabel); err != nil {
 			// We shouldn't get an error here if the label doesn't exist, so any error is legitimate


### PR DESCRIPTION
This mimics what happens with regular jobs, and should save on costs. There is no reason to keep the rehearsals active when the HEAD has changed