### PR TITLE
set ORIGINAL_* env vars whenever a release is resolved

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -158,18 +158,6 @@ func fromConfig(
 	params.Add("JOB_NAME_SAFE", func() (string, error) { return strings.Replace(jobSpec.Job, "_", "-", -1), nil })
 	params.Add("UNIQUE_HASH", func() (string, error) { return jobSpec.UniqueHash(), nil })
 	params.Add("NAMESPACE", func() (string, error) { return jobSpec.Namespace(), nil })
-	// when provided, RELEASE_IMAGE_INITIAL and RELASE_IMAGE_LATEST will be overwritten when resolving the respective releases.
-	// some multi-stage steps need the original values of these env vars, so we set them on respective ORIGINAL_* vars
-	for _, name := range []string{api.InitialReleaseName, api.LatestReleaseName} {
-		envVar := utils.ReleaseImageEnv(name)
-		val, err := params.Get(envVar)
-		if err != nil {
-			logrus.WithError(err).Warnf("couldn't get env var for: %s", name)
-		} else if val != "" {
-			logrus.Debugf("setting original value of overridden release image to env var for: %s", name)
-			params.Add(fmt.Sprintf("ORIGINAL_%s", envVar), func() (string, error) { return val, nil })
-		}
-	}
 	inputImages := make(inputImageSet)
 	var overridableSteps []api.Step
 	var buildSteps []api.Step

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1577,7 +1577,7 @@ func TestFromConfig(t *testing.T) {
 			"IMAGE_FORMAT":                  "public_docker_image_repository/ns/stable:${component}",
 			"RELEASE_IMAGE_INITIAL":         "public_docker_image_repository:initial",
 			"RELEASE_IMAGE_LATEST":          "public_docker_image_repository:latest",
-			"ORIGINAL_RELEASE_IMAGE_LATEST": "latest",
+			"ORIGINAL_RELEASE_IMAGE_LATEST": "",
 		},
 	}, {
 		name: "resolve release",
@@ -1591,6 +1591,7 @@ func TestFromConfig(t *testing.T) {
 		expectedSteps: []string{"[release:release]", "[images]"},
 		expectedParams: map[string]string{
 			utils.ReleaseImageEnv("release"): "public_docker_image_repository:release",
+			"ORIGINAL_RELEASE_IMAGE_RELEASE": "",
 		},
 	}, {
 		name: "resolve release with input",
@@ -1609,29 +1610,7 @@ func TestFromConfig(t *testing.T) {
 		expectedSteps: []string{"[release:release]", "[images]"},
 		expectedParams: map[string]string{
 			utils.ReleaseImageEnv("release"): "public_docker_image_repository:release",
-		},
-	}, {
-		name: "resolve initial and latest with input, original vals are set",
-		config: api.ReleaseBuildConfiguration{
-			InputConfiguration: api.InputConfiguration{
-				Releases: map[string]api.UnresolvedRelease{
-					"initial": {Release: &api.Release{Version: "4.0.9"}},
-					"latest":  {Release: &api.Release{Version: "4.1.0"}},
-				},
-			},
-		},
-		env: environmentOverride{
-			m: map[string]string{
-				utils.ReleaseImageEnv("initial"): "initial",
-				utils.ReleaseImageEnv("latest"):  "latest",
-			},
-		},
-		expectedSteps: []string{"[release:initial]", "[release:latest]", "[images]"},
-		expectedParams: map[string]string{
-			utils.ReleaseImageEnv("initial"): "public_docker_image_repository:initial",
-			utils.ReleaseImageEnv("latest"):  "public_docker_image_repository:latest",
-			"ORIGINAL_RELEASE_IMAGE_INITIAL": "initial",
-			"ORIGINAL_RELEASE_IMAGE_LATEST":  "latest",
+			"ORIGINAL_RELEASE_IMAGE_RELEASE": "",
 		},
 	}, {
 		name: "container test",

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -294,6 +294,8 @@ func (s *importReleaseStep) Provides() api.ParameterMap {
 	env := utils.ReleaseImageEnv(s.name)
 	return api.ParameterMap{
 		env: utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+		// Disable unparam lint as we need to confirm to this interface, but there will never be an error
+		//nolint:unparam
 		fmt.Sprintf("ORIGINAL_%s", env): func() (string, error) {
 			return s.originalPullSpec, nil
 		},

--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -61,6 +61,9 @@ type importReleaseStep struct {
 	pullSecret *coreapi.Secret
 	// overrideCLIReleaseExtractImage is given for non-amd64 releases
 	overrideCLIReleaseExtractImage *coreapi.ObjectReference
+
+	// originalPullSpec stores the original value before resolving the release to pass as an env var for multi-stage steps to utilize
+	originalPullSpec string
 }
 
 func (s *importReleaseStep) Inputs() (api.InputDefinition, error) {
@@ -105,6 +108,8 @@ func (s *importReleaseStep) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	logrus.WithField("name", s.name).Debugf("setting originalPullSpec to: %s for multi-stage steps to reference", pullSpec)
+	s.originalPullSpec = pullSpec
 	// retry importing the image a few times because we might race against establishing credentials/roles
 	// and be unable to import images on the same cluster
 	if newPullSpec, err := utils.ImportTagWithRetries(ctx, s.client, s.jobSpec.Namespace(), "release", s.name, pullSpec, api.ImageStreamImportRetries); err != nil {
@@ -286,8 +291,12 @@ func (s *importReleaseStep) Creates() []api.StepLink {
 }
 
 func (s *importReleaseStep) Provides() api.ParameterMap {
+	env := utils.ReleaseImageEnv(s.name)
 	return api.ParameterMap{
-		utils.ReleaseImageEnv(s.name): utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+		env: utils.ImageDigestFor(s.client, s.jobSpec.Namespace, api.ReleaseImageStream, s.name),
+		fmt.Sprintf("ORIGINAL_%s", env): func() (string, error) {
+			return s.originalPullSpec, nil
+		},
 	}
 }
 


### PR DESCRIPTION
Originally, we were only setting these variables when the pullspecs were provided via an env var. It is actually more useful (and simpler) to set them _anytime_ a release is resolved. Unfortunately, there is no good/simple way to write unit or e2e tests for this functionality, but it is simple enough that I believe that is fine.

For: https://issues.redhat.com/browse/DPTP-4212