### PR TITLE
Remove TODO from `ci-operator`

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -633,11 +633,6 @@ func (o *options) Complete() error {
 	}
 
 	for _, path := range o.secretDirectories.values {
-		// TODO: Delete this after regenerating all jobs with the new cluster profile system.
-		if strings.HasSuffix(path, "-cluster-profile") {
-			continue
-		}
-
 		secret, err := util.SecretFromDir(path)
 		name := filepath.Base(path)
 		if err != nil {


### PR DESCRIPTION
Not needed now that https://github.com/openshift/release/pull/58275 merged.