### PR TITLE
Remove code related to `cluster/test-deploy`

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -171,12 +171,12 @@ func dryRun(o options, logger *logrus.Entry) error {
 	candidatePath := dro.dryRunPath
 	candidate := rehearse.RehearsalCandidateFromPullRequest(pr, pr.Base.SHA)
 
-	presubmits, periodics, changedClusterProfiles, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
+	presubmits, periodics, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
 	if err != nil {
 		return fmt.Errorf("error determining affected jobs: %w: %s", err, "ERROR: pj-rehearse: misconfiguration")
 	}
 
-	prConfig, prRefs, presubmitsToRehearse, err := rc.SetupJobs(candidate, candidatePath, presubmits, periodics, changedClusterProfiles, dro.limit, logger)
+	prConfig, prRefs, presubmitsToRehearse, err := rc.SetupJobs(candidate, candidatePath, presubmits, periodics, dro.limit, logger)
 	if err != nil {
 		return fmt.Errorf("error setting up jobs: %w: %s", err, "ERROR: pj-rehearse: setup failure")
 	}
@@ -186,7 +186,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 			return fmt.Errorf("%s: %w", "ERROR: pj-rehearse: failed to validate rehearsal jobs", err)
 		}
 
-		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, changedClusterProfiles, prConfig.Prow, true, logger)
+		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, true, logger)
 		return err
 	}
 

--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -37,7 +37,6 @@ type options struct {
 	kubernetesOptions prowflagutil.KubernetesOptions
 	noTemplates       bool
 	noRegistry        bool
-	noClusterProfiles bool
 
 	normalLimit int
 	moreLimit   int
@@ -72,7 +71,6 @@ func gatherOptions() (options, error) {
 	o.kubernetesOptions.AddFlags(fs)
 	fs.BoolVar(&o.noTemplates, "no-templates", false, "If true, do not attempt to compare templates")
 	fs.BoolVar(&o.noRegistry, "no-registry", false, "If true, do not attempt to compare step registry content")
-	fs.BoolVar(&o.noClusterProfiles, "no-cluster-profiles", false, "If true, do not attempt to compare cluster profiles")
 
 	fs.IntVar(&o.normalLimit, "normal-limit", 10, "Upper limit of jobs attempted to rehearse with normal command (if more jobs are being touched, only this many will be rehearsed)")
 	fs.IntVar(&o.moreLimit, "more-limit", 20, "Upper limit of jobs attempted to rehearse with more command (if more jobs are being touched, only this many will be rehearsed)")
@@ -141,7 +139,6 @@ func rehearsalConfigFromOptions(o options) rehearse.RehearsalConfig {
 		ProwjobKubeconfig:  o.prowjobKubeconfig,
 		KubernetesOptions:  o.kubernetesOptions,
 		NoRegistry:         o.noRegistry,
-		NoClusterProfiles:  o.noClusterProfiles,
 		DryRun:             o.dryRun,
 		NormalLimit:        o.normalLimit,
 		MoreLimit:          o.moreLimit,

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -398,7 +398,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 				networkAccessRehearsalsAllowed := allowedLabel && approved
 
 				candidatePath := repoClient.Directory()
-				presubmits, periodics, changedClusterProfiles, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, networkAccessRehearsalsAllowed, logger)
+				presubmits, periodics, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, networkAccessRehearsalsAllowed, logger)
 				if err != nil {
 					logger.WithError(err).Error("couldn't determine affected jobs")
 					s.reportFailure("unable to determine affected jobs", err, org, repo, user, number, true, false, logger)
@@ -428,7 +428,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 						limit = rc.MaxLimit
 					}
 
-					prConfig, prRefs, presubmitsToRehearse, err := rc.SetupJobs(candidate, candidatePath, presubmits, periodics, changedClusterProfiles, limit, logger)
+					prConfig, prRefs, presubmitsToRehearse, err := rc.SetupJobs(candidate, candidatePath, presubmits, periodics, limit, logger)
 					if err != nil {
 						logger.WithError(err).Error("couldn't set up jobs")
 						s.reportFailure("unable to set up jobs", err, org, repo, user, number, true, false, logger)
@@ -442,7 +442,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					}
 
 					autoAckMode := rehearseAutoAck == command
-					success, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, changedClusterProfiles, prConfig.Prow, autoAckMode, logger)
+					success, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, autoAckMode, logger)
 					if err != nil {
 						logger.WithError(err).Error("couldn't rehearse jobs")
 						s.reportFailure("failed to create rehearsal jobs", err, org, repo, user, number, true, false, logger)
@@ -486,7 +486,7 @@ func (s *server) getAffectedJobs(pullRequest *github.PullRequest, logger *logrus
 	//TODO(DPTP-2888): this is the point at which we can use repoClient.RevParse() to see if we even need to load the configs at all, and also prune the set of loaded configs to only the changed files
 
 	candidatePath := repoClient.Directory()
-	presubmits, periodics, _, disabledDueToNetworkAccessToggle, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
+	presubmits, periodics, disabledDueToNetworkAccessToggle, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
 	return presubmits, periodics, disabledDueToNetworkAccessToggle, err
 }
 

--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -40,8 +40,6 @@ const (
 	CiopConfigInRepoPath = "ci-operator/config"
 	// TemplatesPath is the path of the templates from release repo
 	TemplatesPath = "ci-operator/templates"
-	// ClusterProfilesPath is where profiles are stored in the release repo
-	ClusterProfilesPath = "cluster/test-deploy"
 	// StagingNamespace is the staging namespace in api.ci
 	StagingNamespace = "ci-stg"
 	// RegistryPath is the path to the multistage step registry
@@ -250,10 +248,6 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 		}
 	}
 	return changes, nil
-}
-
-func GetChangedClusterProfiles(path, baseRev string) ([]string, error) {
-	return getRevChanges(path, ClusterProfilesPath, baseRev, false)
 }
 
 func GetAddedConfigs(path, baseRev string) ([]string, error) {

--- a/pkg/config/release_test.go
+++ b/pkg/config/release_test.go
@@ -85,31 +85,6 @@ func TestGetChangedTemplates(t *testing.T) {
 	compareChanges(t, TemplatesPath, files, cmd, GetChangedTemplates, expected)
 }
 
-func TestGetChangedClusterProfiles(t *testing.T) {
-	files := []string{
-		"nochanges/file", "changeme/file", "removeme/file", "moveme/file",
-		"renameme/file", "dir/dir/file",
-	}
-	cmd := `
-> changeme/file
-git rm --quiet removeme/file
-mkdir new/ renamed/
-> new/file
-git add new/file
-git mv moveme/file moveme/moved
-git mv renameme/file renamed/file
-> dir/dir/file
-`
-	expected := []string{
-		filepath.Join(ClusterProfilesPath, "changeme", "file"),
-		filepath.Join(ClusterProfilesPath, "dir", "dir", "file"),
-		filepath.Join(ClusterProfilesPath, "moveme", "moved"),
-		filepath.Join(ClusterProfilesPath, "new", "file"),
-		filepath.Join(ClusterProfilesPath, "renamed", "file"),
-	}
-	compareChanges(t, ClusterProfilesPath, files, cmd, GetChangedClusterProfiles, expected)
-}
-
 type testNode struct {
 	string
 }

--- a/pkg/rehearse/configmaps_test.go
+++ b/pkg/rehearse/configmaps_test.go
@@ -1,113 +1,14 @@
 package rehearse
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sirupsen/logrus"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/fake"
 	prowplugins "sigs.k8s.io/prow/pkg/plugins"
-
-	"github.com/openshift/ci-tools/pkg/config"
 )
-
-func TestCreateClusterProfiles(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-	profiles := []string{
-		filepath.Join(config.ClusterProfilesPath, "profile0", "file"),
-		filepath.Join(config.ClusterProfilesPath, "profile1", "file"),
-		filepath.Join(config.ClusterProfilesPath, "unchanged", "file"),
-	}
-	for _, p := range profiles {
-		path := filepath.Join(dir, p)
-		if err := os.MkdirAll(filepath.Dir(path), 0775); err != nil {
-			t.Fatal(err)
-		}
-		content := []byte(p + " content")
-		if err := os.WriteFile(path, content, 0664); err != nil {
-			t.Fatal(err)
-		}
-	}
-	profiles = profiles[:2]
-	cluster := "cluster"
-	ns := "test"
-	pr := 1234
-	SHA := "SOMESHA"
-	configUpdaterCfg := prowplugins.ConfigUpdater{
-		Maps: map[string]prowplugins.ConfigMapSpec{
-			filepath.Join(config.ClusterProfilesPath, "profile0", "file"): {
-				Name:     "profile0",
-				Clusters: map[string][]string{cluster: {ns}},
-			},
-			filepath.Join(config.ClusterProfilesPath, "profile1", "file"): {
-				Name:     "profile1",
-				Clusters: map[string][]string{cluster: {ns}},
-			},
-			filepath.Join(config.ClusterProfilesPath, "unchanged", "file"): {
-				Name:     "unchanged",
-				Clusters: map[string][]string{cluster: {ns}},
-			},
-		},
-	}
-	configUpdaterCfg.SetDefaults()
-	cs := fake.NewSimpleClientset()
-	client := cs.CoreV1().ConfigMaps(ns)
-	m := NewCMManager(cluster, ns, client, configUpdaterCfg, pr, dir, logrus.NewEntry(logrus.New()))
-	ciProfiles, err := NewConfigMaps(profiles, "cluster-profile", SHA, pr, configUpdaterCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := m.Create(ciProfiles); err != nil {
-		t.Fatal(err)
-	}
-	cms, err := client.List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	sort.Slice(cms.Items, func(i, j int) bool {
-		return cms.Items[i].Name < cms.Items[j].Name
-	})
-	expected := []v1.ConfigMap{{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rehearse-1234-SOMESHA-cluster-profile-profile0",
-			Namespace: ns,
-			Labels: map[string]string{
-				createByRehearse:  "true",
-				rehearseLabelPull: strconv.Itoa(pr),
-			},
-		},
-		Data: map[string]string{"file": "cluster/test-deploy/profile0/file content"},
-	}, {
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rehearse-1234-SOMESHA-cluster-profile-profile1",
-			Namespace: ns,
-			Labels: map[string]string{
-				createByRehearse:  "true",
-				rehearseLabelPull: strconv.Itoa(pr),
-			},
-		},
-		Data: map[string]string{"file": "cluster/test-deploy/profile1/file content"},
-	}}
-	if !equality.Semantic.DeepEqual(expected, cms.Items) {
-		t.Fatal(diff.ObjectDiff(expected, cms.Items))
-	}
-}
 
 func TestNewConfigMaps(t *testing.T) {
 	cuCfg := prowplugins.ConfigUpdater{

--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -398,15 +398,14 @@ type JobConfigurer struct {
 }
 
 // NewJobConfigurer filters the jobs and returns a new JobConfigurer.
-func NewJobConfigurer(ciopConfigs config.DataByFilename, prowConfig *prowconfig.Config, resolver registry.Resolver, prNumber int, logger *logrus.Entry, profiles map[string]string, refs *pjapi.Refs) *JobConfigurer {
+func NewJobConfigurer(ciopConfigs config.DataByFilename, prowConfig *prowconfig.Config, resolver registry.Resolver, prNumber int, logger *logrus.Entry, refs *pjapi.Refs) *JobConfigurer {
 	return &JobConfigurer{
-		ciopConfigs:           ciopConfigs,
-		prowConfig:            prowConfig,
-		registryResolver:      resolver,
-		clusterProfileCMNames: profiles,
-		prNumber:              prNumber,
-		refs:                  refs,
-		logger:                logger,
+		ciopConfigs:      ciopConfigs,
+		prowConfig:       prowConfig,
+		registryResolver: resolver,
+		prNumber:         prNumber,
+		refs:             refs,
+		logger:           logger,
 	}
 }
 

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -576,7 +576,7 @@ func TestExecuteJobsErrors(t *testing.T) {
 				setSuccessCreateReactor,
 			)
 
-			jc := NewJobConfigurer(testCiopConfigs, &prowconfig.Config{}, resolver, testPrNumber, logger, nil, makeBaseRefs())
+			jc := NewJobConfigurer(testCiopConfigs, &prowconfig.Config{}, resolver, testPrNumber, logger, makeBaseRefs())
 
 			_, presubmits, err := jc.ConfigurePresubmitRehearsals(tc.jobs)
 			if err != nil {
@@ -643,7 +643,7 @@ func TestExecuteJobsUnsuccessful(t *testing.T) {
 				},
 			)
 
-			jc := NewJobConfigurer(testCiopConfigs, &prowconfig.Config{}, resolver, testPrNumber, logger, nil, makeBaseRefs())
+			jc := NewJobConfigurer(testCiopConfigs, &prowconfig.Config{}, resolver, testPrNumber, logger, makeBaseRefs())
 			_, presubmits, err := jc.ConfigurePresubmitRehearsals(tc.jobs)
 			if err != nil {
 				t.Errorf("Expected to get no error, but got one: %v", err)
@@ -764,7 +764,7 @@ func TestExecuteJobsPositive(t *testing.T) {
 							targetOrgRepo: targetOrgRepoPrefix,
 						}},
 				}}
-			jc := NewJobConfigurer(testCiopConfigs, &pc, resolver, testPrNumber, logger, nil, makeBaseRefs())
+			jc := NewJobConfigurer(testCiopConfigs, &pc, resolver, testPrNumber, logger, makeBaseRefs())
 			imageStreamTags, presubmits, err := jc.ConfigurePresubmitRehearsals(tc.jobs)
 			if err != nil {
 				t.Errorf("Expected to get no error, but got one: %v", err)

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -47,8 +47,7 @@ type RehearsalConfig struct {
 	ProwjobNamespace string
 	PodNamespace     string
 
-	NoRegistry        bool
-	NoClusterProfiles bool
+	NoRegistry bool
 
 	NormalLimit int
 	MoreLimit   int

--- a/test/integration/pj-rehearse.sh
+++ b/test/integration/pj-rehearse.sh
@@ -25,12 +25,12 @@ git init --quiet
 git config --local user.name test
 git config --local user.email test
 cp -R "${suite_dir}/master"/* .
-git add ci-operator core-services cluster
+git add ci-operator core-services
 git commit -m "Master version of openshift/release" --quiet
 base_sha="$(git rev-parse HEAD)"
 rm -rf ./ci-operator/step-registry
 cp -R "${suite_dir}/candidate"/* .
-git add ci-operator core-services cluster
+git add ci-operator core-services
 git commit -m "Candidate version of openshift/release" --quiet
 candidate_sha="$(git rev-parse HEAD)"
 popd >/dev/null

--- a/test/integration/pj-rehearse/candidate/cluster/test-deploy/test-profile/vars-origin.yaml
+++ b/test/integration/pj-rehearse/candidate/cluster/test-deploy/test-profile/vars-origin.yaml
@@ -1,1 +1,0 @@
-vars-origin.yaml

--- a/test/integration/pj-rehearse/candidate/cluster/test-deploy/test-profile/vars.yaml
+++ b/test/integration/pj-rehearse/candidate/cluster/test-deploy/test-profile/vars.yaml
@@ -1,1 +1,0 @@
-changed

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -1,15 +1,3 @@
-- data:
-    vars-origin.yaml: |
-      vars-origin.yaml
-    vars.yaml: |
-      changed
-  metadata:
-    creationTimestamp: null
-    labels:
-      ci.openshift.org/rehearse-pull: "1234"
-      created-by-pj-rehearse: "true"
-    name: rehearse-1234-4de8ab7c20656998264a2593116288f5eb070b32-cluster-profile-cluster-profile-test-profile
-    namespace: test-namespace
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:

--- a/test/integration/pj-rehearse/master/cluster/test-deploy/test-profile/vars-origin.yaml
+++ b/test/integration/pj-rehearse/master/cluster/test-deploy/test-profile/vars-origin.yaml
@@ -1,1 +1,0 @@
-vars-origin.yaml

--- a/test/integration/pj-rehearse/master/cluster/test-deploy/test-profile/vars.yaml
+++ b/test/integration/pj-rehearse/master/cluster/test-deploy/test-profile/vars.yaml
@@ -1,1 +1,0 @@
-vars.yaml


### PR DESCRIPTION
With the deprecation `cluster/test-deploy` in the release repo, removing related code also in ci-tools repo.