### PR TITLE
force the build10 clusters on jobs for additional architecture configuration on images and node architectures for tests

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -37,11 +37,6 @@ type Prowgen struct {
 	Expose bool `json:"expose,omitempty"`
 	// Rehearsals declares any disabled rehearsals for jobs
 	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
-	// If true build images targeting multiple architectures
-	MultiArch bool `json:"multi_arch,omitempty"`
-	// MultiArchBranchFilter is a filter of branches that will be built for multiple architectures.
-	// If empty, all branches will be included.
-	MultiArchBranchFilter []string `json:"multi_arch_branch_filter,omitempty"`
 	// SlackReporterConfigs defines all desired slack reporter info for included jobs
 	SlackReporterConfigs []SlackReporterConfig `json:"slack_reporter,omitempty"`
 }
@@ -65,20 +60,6 @@ func (p *Prowgen) GetSlackReporterConfigForTest(test, variant string) *SlackRepo
 	return nil
 }
 
-func (p *Prowgen) HasMultiArchBranchFilter(branch string) bool {
-	// We assume that if the filter is empty, we should build for all branches.
-	if len(p.MultiArchBranchFilter) == 0 {
-		return true
-	}
-
-	for _, b := range p.MultiArchBranchFilter {
-		if b == branch {
-			return true
-		}
-	}
-	return false
-}
-
 func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	if defaults.Private {
 		p.Private = true
@@ -89,13 +70,6 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	if defaults.Rehearsals.DisableAll {
 		p.Rehearsals.DisableAll = true
 	}
-	if defaults.MultiArch {
-		p.MultiArch = true
-	}
-	if defaults.MultiArchBranchFilter != nil {
-		p.MultiArchBranchFilter = defaults.MultiArchBranchFilter
-	}
-
 	p.Rehearsals.DisabledRehearsals = append(p.Rehearsals.DisabledRehearsals, defaults.Rehearsals.DisabledRehearsals...)
 }
 

--- a/pkg/image-graph-generator/operator.go
+++ b/pkg/image-graph-generator/operator.go
@@ -104,7 +104,11 @@ func (o *Operator) callback(c *api.ReleaseBuildConfiguration, i *config.Info) er
 
 		for _, image := range c.Images {
 			if !excludedImages.Has(string(image.To)) {
-				if err := o.UpdateImage(image, c.BaseImages, target, branchID, configProwgen.MultiArch); err != nil {
+				multiArch := false
+				if len(image.AdditionalArchitectures) > 0 {
+					multiArch = true
+				}
+				if err := o.UpdateImage(image, c.BaseImages, target, branchID, multiArch); err != nil {
 					errs = append(errs, err)
 				}
 			}

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -551,79 +551,18 @@ func TestGenerateJobs(t *testing.T) {
 			config: &ciop.ReleaseBuildConfiguration{
 				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
 					{
-						From: "os",
-						To:   "ci-tools",
+						From:                    "os",
+						To:                      "ci-tools",
+						AdditionalArchitectures: []string{"arm64"},
 					},
 				},
 				PromotionConfiguration: &ciop.PromotionConfiguration{},
 			},
 			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{MultiArch: true},
 				Metadata: ciop.Metadata{
 					Org:    "organization",
 					Repo:   "repository",
 					Branch: "branch",
-				},
-			},
-		},
-		{
-			id: "multiarch branch filtered, cluster change",
-			config: &ciop.ReleaseBuildConfiguration{
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{
-						From: "os",
-						To:   "ci-tools",
-					},
-				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{},
-			},
-			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{MultiArch: true, MultiArchBranchFilter: []string{"branch"}},
-				Metadata: ciop.Metadata{
-					Org:    "organization",
-					Repo:   "repository",
-					Branch: "branch",
-				},
-			},
-		},
-		{
-			id: "multiarch branch filtered, no cluster change",
-			config: &ciop.ReleaseBuildConfiguration{
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{
-						From: "os",
-						To:   "ci-tools",
-					},
-				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{},
-			},
-			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{MultiArch: true, MultiArchBranchFilter: []string{"another-branch"}},
-				Metadata: ciop.Metadata{
-					Org:    "organization",
-					Repo:   "repository",
-					Branch: "branch",
-				},
-			},
-		},
-		{
-			id: "multiarch branch filtered with variant, no cluster change",
-			config: &ciop.ReleaseBuildConfiguration{
-				Images: []ciop.ProjectDirectoryImageBuildStepConfiguration{
-					{
-						From: "os",
-						To:   "ci-tools",
-					},
-				},
-				PromotionConfiguration: &ciop.PromotionConfiguration{},
-			},
-			repoInfo: &ProwgenInfo{
-				Config: config.Prowgen{MultiArch: true, MultiArchBranchFilter: []string{"branch"}},
-				Metadata: ciop.Metadata{
-					Org:     "organization",
-					Repo:    "repository",
-					Branch:  "branch",
-					Variant: "variant",
 				},
 			},
 		},


### PR DESCRIPTION
Until the prowjob cluster is determined by the prowjob dispatcher, this is just a workaround to keep the job configuration aligned.

Also, deprecate the `multi_arch` and the `multi_arch_branch_filter` fields in the prowgen configuration.
 
Also, this will allow us to deprecate the multi_arch field in the prowgen configuration.

/cc @openshift/test-platform @deepsm007 