### PR TITLE
`PRPQR`: wait for the job status to contain a URL after creating the job

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -135,7 +135,7 @@ type reconciler struct {
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger := r.logger.WithField("request", req.String())
-	err := r.reconcile(ctx, req, logger)
+	err := r.reconcile(ctx, req, logger, time.Second)
 	if err != nil {
 		logger.WithError(err).Error("Reconciliation failed")
 	} else {
@@ -144,7 +144,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	return reconcile.Result{}, controllerutil.SwallowIfTerminal(err)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logger *logrus.Entry) error {
+func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logger *logrus.Entry, second time.Duration) error {
 	logger = logger.WithField("namespace", req.Namespace).WithField("prpqr_name", req.Name)
 	logger.Info("Starting reconciliation")
 
@@ -163,7 +163,7 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 	if !prpqr.GetDeletionTimestamp().IsZero() {
 		r.abortJobs(ctx, logger, prpqr, existingProwjobs, statuses)
 	} else {
-		r.triggerJobs(ctx, logger, req, prpqr, existingProwjobs, statuses)
+		r.triggerJobs(ctx, logger, req, prpqr, existingProwjobs, statuses, second)
 	}
 
 	allJobsTriggeredCondition := constructCondition(statuses)
@@ -198,6 +198,7 @@ func (r *reconciler) triggerJobs(ctx context.Context,
 	prpqr *v1.PullRequestPayloadQualificationRun,
 	existingProwjobs *prowv1.ProwJobList,
 	statuses map[string]*v1.PullRequestPayloadJobStatus,
+	second time.Duration,
 ) {
 	existingProwjobsByNameHash := map[string]*prowv1.ProwJob{}
 	for i, pj := range existingProwjobs.Items {
@@ -334,7 +335,7 @@ func (r *reconciler) triggerJobs(ctx context.Context,
 			// it successfully.
 			key := ctrlruntimeclient.ObjectKey{Namespace: prowjob.Namespace, Name: prowjob.Name}
 			retrievedJob := prowv1.ProwJob{}
-			if err := wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+			if err := wait.Poll(second, 20*second, func() (bool, error) {
 				if err := r.client.Get(ctx, key, &retrievedJob); err != nil {
 					if kerrors.IsNotFound(err) {
 						return false, nil

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -334,7 +334,7 @@ func (r *reconciler) triggerJobs(ctx context.Context,
 			// it successfully.
 			key := ctrlruntimeclient.ObjectKey{Namespace: prowjob.Namespace, Name: prowjob.Name}
 			retrievedJob := prowv1.ProwJob{}
-			if err := wait.Poll(time.Second, 10*time.Second, func() (bool, error) {
+			if err := wait.Poll(100*time.Millisecond, 5*time.Second, func() (bool, error) {
 				if err := r.client.Get(ctx, key, &retrievedJob); err != nil {
 					if kerrors.IsNotFound(err) {
 						return false, nil

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -460,7 +460,7 @@ func TestReconcile(t *testing.T) {
 				prowConfigGetter:     &fakeProwConfigGetter{cfg: &tc.prowConfig},
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "test-namespace", Name: "prpqr-test"}}
-			if err := r.reconcile(context.Background(), req, r.logger); err != nil {
+			if err := r.reconcile(context.Background(), req, r.logger, time.Millisecond); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -2,6 +2,7 @@ package prpqr_reconciler
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
@@ -27,10 +29,11 @@ func TestReconcile(t *testing.T) {
 
 	logrus.SetLevel(logrus.DebugLevel)
 	testCases := []struct {
-		name       string
-		prowJobs   []ctrlruntimeclient.Object
-		prpqr      []ctrlruntimeclient.Object
-		prowConfig prowconfig.Config
+		name          string
+		prowJobs      []ctrlruntimeclient.Object
+		prpqr         []ctrlruntimeclient.Object
+		prowConfig    prowconfig.Config
+		omitStatusURL bool
 	}{
 		{
 			name: "basic case",
@@ -161,6 +164,22 @@ func TestReconcile(t *testing.T) {
 					Status: prowv1.ProwJobStatus{State: "triggered"},
 				},
 			},
+		},
+		{
+			name: "url not found in created job",
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Spec: v1.PullRequestPayloadTestSpec{
+						PullRequests: []v1.PullRequestUnderTest{{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: &v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}}},
+						Jobs: v1.PullRequestPayloadJobSpec{
+							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
+						},
+					},
+				},
+			},
+			omitStatusURL: true,
 		},
 		{
 			name: "multiple PRs from different repositories",
@@ -419,9 +438,24 @@ func TestReconcile(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			createInterceptor := func(omitStatusURL bool) func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+				return func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+					if prowJob, ok := obj.(*prowv1.ProwJob); ok && !omitStatusURL {
+						prowJob.Status.URL = fmt.Sprintf("https://prow.ci.openshift.org/view/gs/test-platform-results/%s", prowJob.Spec.Job)
+					}
+					return client.Create(ctx, obj, opts...)
+				}
+			}
+			client := fakectrlruntimeclient.NewClientBuilder().
+				WithObjects(append(tc.prpqr, tc.prowJobs...)...).
+				WithInterceptorFuncs(
+					interceptor.Funcs{
+						Create: createInterceptor(tc.omitStatusURL),
+					}).
+				Build()
 			r := &reconciler{
 				logger:               logrus.WithField("test-name", tc.name),
-				client:               fakectrlruntimeclient.NewClientBuilder().WithObjects(append(tc.prpqr, tc.prowJobs...)...).Build(),
+				client:               client,
 				configResolverClient: &fakeResolverClient{},
 				prowConfigGetter:     &fakeProwConfigGetter{cfg: &tc.prowConfig},
 			}

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -93,6 +93,7 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:
@@ -178,6 +179,7 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:
@@ -263,3 +265,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case_with_scheduling.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case_with_scheduling.yaml
@@ -93,6 +93,7 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: scheduling
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/aggregator-periodic-ci-test-org-test-repo-test-branch-test-name
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:
@@ -178,6 +179,7 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: scheduling
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:
@@ -263,3 +265,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: scheduling
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -82,3 +82,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_metal_override.yaml
@@ -82,3 +82,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-metal

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_scheduling.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_scheduling.yaml
@@ -82,3 +82,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: scheduling
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -82,3 +82,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-vsphere

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
@@ -76,3 +76,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_different_repositories.yaml
@@ -92,3 +92,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-org-another-test-repo-101-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_the_same_repository.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_the_same_repository.yaml
@@ -87,3 +87,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-org-test-repo-101-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -82,6 +82,7 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-2
 - apiVersion: prow.k8s.io/v1
   kind: ProwJob
   metadata:

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
@@ -87,3 +87,4 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_url_not_found_in_created_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_url_not_found_in_created_job.yaml
@@ -3,20 +3,20 @@
   metadata:
     annotations:
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-variant-test-name
-      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-variant-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
     creationTimestamp: null
     labels:
       created-by-prow: "true"
       prow.k8s.io/context: ""
-      prow.k8s.io/job: test-org-test-repo-100-test-variant-test-name
+      prow.k8s.io/job: test-org-test-repo-100-test-name
       prow.k8s.io/refs.base_ref: test-branch
       prow.k8s.io/refs.org: test-org
       prow.k8s.io/refs.pull: "100"
       prow.k8s.io/refs.repo: test-repo
       prow.k8s.io/type: periodic
       pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
-      releaseJobNameHash: 96fc864a2c83534793cb2d421fbf394a
+      releaseJobNameHash: ee3858eff62263cd7266320c00d1d38b
     name: some-uuid
     namespace: test-namespace
     resourceVersion: "1"
@@ -35,7 +35,7 @@
         sha: "12345"
         title: test-pr
       repo: test-repo
-    job: test-org-test-repo-100-test-variant-test-name
+    job: test-org-test-repo-100-test-name
     pod_spec:
       containers:
       - args:
@@ -44,7 +44,7 @@
         - --input-hash=prpqr-test
         - --report-credentials-file=/etc/report/credentials
         - --target=test-name
-        - --with-test-from=test-org/test-repo@test-branch__test-variant:test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
         command:
         - ci-operator
         image: ci-operator:latest
@@ -82,4 +82,3 @@
   status:
     startTime: "1970-01-01T00:00:00Z"
     state: triggered
-    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-variant-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case.yaml
@@ -42,3 +42,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/aggregator-periodic-ci-test-org-test-repo-test-branch-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case_with_scheduling.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case_with_scheduling.yaml
@@ -40,3 +40,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: scheduling
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/aggregator-periodic-ci-test-org-test-repo-test-branch-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
@@ -41,3 +41,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_metal_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_metal_override.yaml
@@ -41,3 +41,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-metal

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_variant.yaml
@@ -42,3 +42,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-variant-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_vsphere_override.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_vsphere_override.yaml
@@ -41,3 +41,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-vsphere

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
@@ -36,3 +36,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_PRs_from_different_repositories.yaml
@@ -50,3 +50,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-org-another-test-repo-101-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_PRs_from_the_same_repository.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_PRs_from_the_same_repository.yaml
@@ -50,3 +50,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-org-test-repo-101-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -51,3 +51,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-2

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
@@ -43,3 +43,4 @@
       status:
         startTime: "1970-01-01T00:00:00Z"
         state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_url_not_found_in_created_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_url_not_found_in_created_job.yaml
@@ -29,14 +29,15 @@
   status:
     conditions:
     - lastTransitionTime: "1970-01-01T00:00:00Z"
-      message: All jobs triggered successfully
-      reason: AllJobsTriggered
-      status: "True"
+      message: Jobs triggered with errors
+      reason: WithErrors
+      status: "False"
       type: AllJobsTriggered
     jobs:
     - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
       prowJob: some-uuid
       status:
+        description: 'created job never appeared in cache: timed out waiting for the
+          condition'
         startTime: "1970-01-01T00:00:00Z"
-        state: scheduling
-        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name
+        state: error


### PR DESCRIPTION
Not doing this can result in statuses on the PRPQR that don't have a URL to the spyglass page until after the job is complete. This has been brought on by the new `Scheduling` state. No URL will exist until the job is actually in `Triggered`, but rather than check that specifically, we can just check for the existence of a URL. The `20` second poll period is a guess that we may have to tune later.

For: https://issues.redhat.com/browse/DPTP-4174

