### PR TITLE
`Payload Testing`: add scheduling state to statuses that are still active

### DIFF
--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
@@ -186,7 +186,7 @@ func getRunningJobs(jobs []v1.PullRequestPayloadJobStatus) []string {
 
 func hasAllJobsFinished(jobs []v1.PullRequestPayloadJobStatus) bool {
 	for _, job := range jobs {
-		if job.Status.State == prowv1.TriggeredState || job.Status.State == prowv1.PendingState {
+		if job.Status.State == prowv1.TriggeredState || job.Status.State == prowv1.PendingState || job.Status.State == prowv1.SchedulingState {
 			return false
 		}
 	}


### PR DESCRIPTION
Without this change the UI incorrectly displays that all jobs are finished