### PR TITLE
release: add balance profile cmd

### DIFF
--- a/cmd/release/main.go
+++ b/cmd/release/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/spf13/pflag"
@@ -10,7 +11,11 @@ import (
 )
 
 func main() {
-	cmd := release.NewCommand()
+	cmd, err := release.NewCommand()
+	if err != nil {
+		fmt.Printf("%s", err)
+		os.Exit(1)
+	}
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/pkg/cmd/release/profile.go
+++ b/pkg/cmd/release/profile.go
@@ -2,18 +2,93 @@ package release
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
 )
 
-func newProfileCommand() *cobra.Command {
-	return &cobra.Command{
+type balanceProfileOptions struct {
+	*options
+	SrcProfile        string
+	DstProfiles       []string
+	ScalingFactor     float64
+	BalancingFactors  []float64
+	BalancingStrategy string
+	ExcludeOrgs       []string
+}
+
+func (o *balanceProfileOptions) validate() error {
+	if o.ScalingFactor < 0.0 || o.ScalingFactor > 1.0 {
+		return fmt.Errorf("scaling factor not in range [0, 1]")
+	}
+
+	if len(o.BalancingFactors) == 0 {
+		o.BalancingFactors = make([]float64, len(o.DstProfiles))
+		f := 1.0 / float64(len(o.DstProfiles))
+		for i := range len(o.DstProfiles) {
+			o.BalancingFactors[i] = f
+		}
+	} else {
+		if len(o.BalancingFactors) != len(o.DstProfiles) {
+			return fmt.Errorf("balancing factors must match target profiles")
+		}
+		tot := 0.0
+		for _, f := range o.BalancingFactors {
+			if f < 0.0 || f > 1.0 {
+				return fmt.Errorf("balancing factor %f not in range [0, 1]", f)
+			}
+			tot += f
+		}
+		if math.Abs(1.0-tot) > 0.1 {
+			return fmt.Errorf("balancing factors must sum up to 1.0")
+		}
+	}
+
+	return nil
+}
+
+type testInfo struct {
+	test   *api.TestStepConfiguration
+	config *api.ReleaseBuildConfiguration
+	info   *config.Info
+}
+
+type dstProfileInfo struct {
+	Name string
+	// How many test are going to be assigned to this profile
+	Target int
+	// Tests that have been assigned already
+	N int
+}
+
+func newProfileCommand(o *options) (*cobra.Command, error) {
+	cmd := &cobra.Command{
 		Use:   "profile",
 		Short: "cluster profile commands",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	listCmd := newProfileListCommand()
+	reshuffleCmd, err := newBalanceProfileCommand(o)
+	if err != nil {
+		return nil, fmt.Errorf("balance cmd: %w", err)
+	}
+	cmd.AddCommand(listCmd, reshuffleCmd)
+	return cmd, nil
+}
+
+func newProfileListCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "list cluster profiles",
 		RunE: func(_ *cobra.Command, args []string) error {
 			return cmdProfileList(args)
 		},
@@ -59,4 +134,168 @@ func profilePrint(args []string) error {
 		})
 	}
 	return printYAML(l)
+}
+
+// The following incantation:
+//
+//	--from=gcp --scaling-factor=0.5 --to=gcp2,gcp3 --balancing-factors=0.75,0.25 --exclude-orgs=openshift-priv
+//
+// gather every ci-operator config, excluding the ones under openshift-priv/, having at least
+// one test that has `cluster_profile: gcp` set.
+// Assuming the selected tests to be N = 100, it then redistributes R = N*0.5 = 50 of them.
+//
+// The balancing algorithm follows this schema:
+//
+//	tests that will target 'gcp2': R * 0.75 = 37 => adjusted to 38 to compensate truncation errors
+//	tests that will target 'gcp3': R * 0.25 = 12
+//
+// After the distribution has taken place:
+//
+//	'gcp'  tests: 50
+//	'gcp2' tests: +38
+//	'gcp3' tests: +12
+func newBalanceProfileCommand(parent *options) (*cobra.Command, error) {
+	o := balanceProfileOptions{options: parent}
+	cmd := &cobra.Command{
+		Use:   "balance",
+		Short: "balance profiles",
+		Long:  "balance profiles",
+		RunE: func(_ *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			return balanceProfiles(&o)
+		},
+	}
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&o.SrcProfile, "from", "", "Cluster profile we want offload jobs from")
+	flags.StringSliceVar(&o.DstProfiles, "to", nil, "Cluster profiles we want assign jobs to")
+	flags.Float64VarP(&o.ScalingFactor, "scaling-factor", "s", 0.25, "Scaling factor in % for source profile")
+	flags.Float64SliceVarP(&o.BalancingFactors, "balancing-factors", "b", []float64{}, "Balancing factor in % for each target profile")
+	flags.StringVarP(&o.BalancingStrategy, "strategy", "x", "rand", "Balancing algorithm")
+	flags.StringSliceVar(&o.ExcludeOrgs, "exclude-orgs", []string{}, "Skip configs under ci-operator/config/${ORG}")
+	if err := cmd.MarkPersistentFlagRequired("from"); err != nil {
+		return nil, err
+	}
+	if err := cmd.MarkPersistentFlagRequired("to"); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+func gatherTests(configsPath, srcProfile string, excludeOrgs []string) ([]testInfo, error) {
+	tests := make([]testInfo, 0)
+	excludeOrgsSet := sets.New(excludeOrgs...)
+	if err := config.OperateOnCIOperatorConfigDir(configsPath, func(c *api.ReleaseBuildConfiguration, info *config.Info) error {
+		if excludeOrgsSet.Has(info.Org) {
+			return nil
+		}
+		for i := range c.Tests {
+			test := &c.Tests[i]
+			if test.MultiStageTestConfiguration != nil {
+				if test.MultiStageTestConfiguration.ClusterProfile == api.ClusterProfile(srcProfile) {
+					tests = append(tests, testInfo{test: test, config: c, info: info})
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("scan ci-operator configs %s: %w", configsPath, err)
+	}
+	return tests, nil
+}
+
+func balanceRandomly(tests []testInfo, testsToBalance int, dstProfilesInfo []dstProfileInfo) []config.DataWithInfo {
+	modifiedConfigs := sets.New[string]()
+	configsToCommit := make([]config.DataWithInfo, 0, testsToBalance)
+	idxGenerator := rand.New(rand.NewSource(time.Now().Unix()))
+	profileIdx := 0
+	duplicatedIdx := sets.New[int]()
+	for range testsToBalance {
+		var profile api.ClusterProfile
+		for {
+			p := &dstProfilesInfo[profileIdx]
+			if p.N+1 > p.Target {
+				profileIdx = (profileIdx + 1) % len(dstProfilesInfo)
+			} else {
+				profile = api.ClusterProfile(p.Name)
+				p.N += 1
+				break
+			}
+		}
+
+		var i int
+		for {
+			i = idxGenerator.Intn(len(tests))
+			if !duplicatedIdx.Has(i) {
+				duplicatedIdx.Insert(i)
+				break
+			}
+		}
+
+		t := tests[i]
+		t.test.MultiStageTestConfiguration.ClusterProfile = profile
+
+		configName := t.info.AsString()
+		if !modifiedConfigs.Has(configName) {
+			configsToCommit = append(configsToCommit, config.DataWithInfo{Configuration: *t.config, Info: *t.info})
+			modifiedConfigs.Insert(configName)
+		}
+
+		profileIdx = (profileIdx + 1) % len(dstProfilesInfo)
+	}
+
+	return configsToCommit
+}
+
+func dstProfilesInfo(dstProfiles []string, factors []float64, testsToBalance int) []dstProfileInfo {
+	dstProfilesInfo := make([]dstProfileInfo, 0, len(factors))
+	total := 0
+	for i := range len(factors) {
+		target := int(math.Trunc(float64(testsToBalance) * factors[i]))
+		total += target
+		dstProfilesInfo = append(dstProfilesInfo, dstProfileInfo{Name: dstProfiles[i], N: 0, Target: target})
+	}
+
+	// Fix truncation error
+	i := 0
+	for range testsToBalance - total {
+		dstProfilesInfo[i].Target += 1
+		i = (i + 1) & len(dstProfilesInfo)
+	}
+
+	return dstProfilesInfo
+}
+
+func balanceProfiles(o *balanceProfileOptions) error {
+	configsPath := o.argsWithPrefixes(config.CiopConfigInRepoPath, o.ciOperatorConfigPath, nil)[0]
+	tests, err := gatherTests(configsPath, o.SrcProfile, o.ExcludeOrgs)
+	if err != nil {
+		return err
+	}
+
+	testsToBalance := int(math.Trunc(float64(len(tests)) * o.ScalingFactor))
+	dstProfilesInfo := dstProfilesInfo(o.DstProfiles, o.BalancingFactors, testsToBalance)
+
+	fmt.Printf("targeted tests: %d\ntests to balance: %d\nprofiles:\n", len(tests), testsToBalance)
+	for _, dstProfileInfo := range dstProfilesInfo {
+		fmt.Printf("  %s: %d\n", dstProfileInfo.Name, dstProfileInfo.Target)
+	}
+
+	var configsToCommit []config.DataWithInfo
+	switch o.BalancingStrategy {
+	case "rand":
+		configsToCommit = balanceRandomly(tests, testsToBalance, dstProfilesInfo)
+	default:
+		return fmt.Errorf("balancing strategy %s not supported", o.BalancingStrategy)
+	}
+
+	for i := range configsToCommit {
+		c := &configsToCommit[i]
+		if err := c.CommitTo(configsPath); err != nil {
+			return fmt.Errorf("commit config %s: %w", c.Info.AsString(), err)
+		}
+	}
+
+	return nil
 }

--- a/pkg/cmd/release/profile.go
+++ b/pkg/cmd/release/profile.go
@@ -22,6 +22,7 @@ type balanceProfileOptions struct {
 	BalancingFactors  []float64
 	BalancingStrategy string
 	ExcludeOrgs       []string
+	Branches          []string
 }
 
 func (o *balanceProfileOptions) validate() error {
@@ -173,7 +174,8 @@ func newBalanceProfileCommand(parent *options) (*cobra.Command, error) {
 	flags.Float64VarP(&o.ScalingFactor, "scaling-factor", "s", 0.25, "Scaling factor in % for source profile")
 	flags.Float64SliceVarP(&o.BalancingFactors, "balancing-factors", "b", []float64{}, "Balancing factor in % for each target profile")
 	flags.StringVarP(&o.BalancingStrategy, "strategy", "x", "rand", "Balancing algorithm")
-	flags.StringSliceVar(&o.ExcludeOrgs, "exclude-orgs", []string{}, "Skip configs under ci-operator/config/${ORG}")
+	flags.StringSliceVar(&o.ExcludeOrgs, "exclude-orgs", []string{}, "Skip configs by org")
+	flags.StringSliceVar(&o.Branches, "branches", []string{}, "Filter configs by branch")
 	if err := cmd.MarkPersistentFlagRequired("from"); err != nil {
 		return nil, err
 	}
@@ -183,10 +185,14 @@ func newBalanceProfileCommand(parent *options) (*cobra.Command, error) {
 	return cmd, nil
 }
 
-func gatherTests(configsPath, srcProfile string, excludeOrgs []string) ([]testInfo, error) {
+func gatherTests(configsPath, srcProfile string, branches, excludeOrgs []string) ([]testInfo, error) {
 	tests := make([]testInfo, 0)
+	byBranch, includeBranchesSet := len(branches) > 0, sets.New(branches...)
 	excludeOrgsSet := sets.New(excludeOrgs...)
 	if err := config.OperateOnCIOperatorConfigDir(configsPath, func(c *api.ReleaseBuildConfiguration, info *config.Info) error {
+		if byBranch && !includeBranchesSet.Has(info.Branch) {
+			return nil
+		}
 		if excludeOrgsSet.Has(info.Org) {
 			return nil
 		}
@@ -269,7 +275,7 @@ func dstProfilesInfo(dstProfiles []string, factors []float64, testsToBalance int
 
 func balanceProfiles(o *balanceProfileOptions) error {
 	configsPath := o.argsWithPrefixes(config.CiopConfigInRepoPath, o.ciOperatorConfigPath, nil)[0]
-	tests, err := gatherTests(configsPath, o.SrcProfile, o.ExcludeOrgs)
+	tests, err := gatherTests(configsPath, o.SrcProfile, o.Branches, o.ExcludeOrgs)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/release/profile_test.go
+++ b/pkg/cmd/release/profile_test.go
@@ -1,0 +1,215 @@
+package release
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+)
+
+func TestValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		o       *balanceProfileOptions
+		wantErr error
+		wantO   *balanceProfileOptions
+	}{
+		{
+			name: "Valid",
+			o: &balanceProfileOptions{
+				SrcProfile:       "foo",
+				DstProfiles:      []string{"super", "duper", "bar"},
+				ScalingFactor:    0.75,
+				BalancingFactors: []float64{0.33, 0.33, 0.33},
+				ExcludeOrgs:      []string{"openshift-priv"},
+			},
+			wantO: &balanceProfileOptions{
+				SrcProfile:       "foo",
+				DstProfiles:      []string{"super", "duper", "bar"},
+				ScalingFactor:    0.75,
+				BalancingFactors: []float64{0.33, 0.33, 0.33},
+				ExcludeOrgs:      []string{"openshift-priv"},
+			},
+		},
+		{
+			name:    "Scaling factor out of range",
+			o:       &balanceProfileOptions{ScalingFactor: 2},
+			wantErr: errors.New("scaling factor not in range [0, 1]"),
+		},
+		{
+			name: "Balancing factors should match target profiles",
+			o: &balanceProfileOptions{
+				DstProfiles:      []string{"foo", "bar"},
+				BalancingFactors: []float64{0.5},
+			},
+			wantErr: errors.New("balancing factors must match target profiles"),
+		},
+		{
+			name: "Balancing factors don't sum up to 1.0",
+			o: &balanceProfileOptions{
+				DstProfiles:      []string{"foo", "bar"},
+				BalancingFactors: []float64{0.5, 0.6},
+			},
+			wantErr: errors.New("balancing factors must sum up to 1.0"),
+		},
+		{
+			name: "Default balancing factors",
+			o: &balanceProfileOptions{
+				DstProfiles: []string{"foo", "bar"},
+			},
+			wantO: &balanceProfileOptions{
+				DstProfiles:      []string{"foo", "bar"},
+				BalancingFactors: []float64{0.5, 0.5},
+			},
+		},
+	} {
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+			err := tc.o.validate()
+
+			if err != nil && tc.wantErr == nil {
+				t.Fatalf("want err nil but got: %v", err)
+			}
+			if err == nil && tc.wantErr != nil {
+				t.Fatalf("want err %v but got nil", tc.wantErr)
+			}
+			if err != nil && tc.wantErr != nil {
+				if tc.wantErr.Error() != err.Error() {
+					t.Fatalf("expect error %q but got %q", tc.wantErr.Error(), err.Error())
+				}
+				return
+			}
+
+			if diff := cmp.Diff(tc.wantO, tc.o, cmpopts.IgnoreUnexported(balanceProfileOptions{})); diff != "" {
+				t.Errorf("options differ:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDstProfilesInfo(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		testsToBalance int
+		dstProfiles    []string
+		factors        []float64
+		wantProfiles   []dstProfileInfo
+	}{
+		{
+			name:           "Fix truncation err",
+			testsToBalance: 10,
+			dstProfiles:    []string{"foo", "bar", "super"},
+			factors:        []float64{0.3, 0.3, 0.3},
+			wantProfiles: []dstProfileInfo{
+				{Name: "foo", Target: 4},
+				{Name: "bar", Target: 3},
+				{Name: "super", Target: 3},
+			},
+		},
+		{
+			name:           "No truncation err",
+			testsToBalance: 12,
+			dstProfiles:    []string{"foo", "bar", "super", "duper"},
+			factors:        []float64{0.25, 0.25, 0.25, 0.25},
+			wantProfiles: []dstProfileInfo{
+				{Name: "foo", Target: 3},
+				{Name: "bar", Target: 3},
+				{Name: "super", Target: 3},
+				{Name: "duper", Target: 3},
+			},
+		},
+	} {
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			dstProfiles := dstProfilesInfo(tc.dstProfiles, tc.factors, tc.testsToBalance)
+
+			ss := func(a, b string) bool { return strings.Compare(a, b) <= 0 }
+			if diff := cmp.Diff(tc.wantProfiles, dstProfiles, cmpopts.SortSlices(ss)); diff != "" {
+				t.Errorf("profiles differ:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBalanceRandomly(t *testing.T) {
+	genTests := func(p api.ClusterProfile, n int) []testInfo {
+		tests := make([]testInfo, 0)
+		for i := range n {
+			t := api.TestStepConfiguration{MultiStageTestConfiguration: &api.MultiStageTestConfiguration{ClusterProfile: p}}
+			info := config.Info{Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: fmt.Sprintf("branch-%d", i)}}
+			tests = append(tests, testInfo{test: &t, config: &api.ReleaseBuildConfiguration{}, info: &info})
+		}
+		return tests
+	}
+	collectStats := func(tests []testInfo) map[api.ClusterProfile]int {
+		stats := make(map[api.ClusterProfile]int)
+		for _, ti := range tests {
+			n := stats[ti.test.MultiStageTestConfiguration.ClusterProfile]
+			stats[ti.test.MultiStageTestConfiguration.ClusterProfile] = n + 1
+		}
+		return stats
+	}
+	for _, tc := range []struct {
+		name            string
+		tests           []testInfo
+		testsToBalance  int
+		dstProfilesInfo []dstProfileInfo
+		wantStats       map[api.ClusterProfile]int
+	}{
+		{
+			name:           "Do nothing",
+			tests:          genTests(api.ClusterProfileGCP, 1),
+			testsToBalance: 0,
+			wantStats:      map[api.ClusterProfile]int{api.ClusterProfileGCP: 1},
+		},
+		{
+			name:           "Distribute equally",
+			tests:          genTests(api.ClusterProfileGCP, 100),
+			testsToBalance: 40,
+			dstProfilesInfo: []dstProfileInfo{
+				{Name: string(api.ClusterProfileGCP2), Target: 20},
+				{Name: string(api.ClusterProfileGCP3), Target: 20},
+			},
+			wantStats: map[api.ClusterProfile]int{
+				api.ClusterProfileGCP:  60,
+				api.ClusterProfileGCP2: 20,
+				api.ClusterProfileGCP3: 20,
+			},
+		},
+		{
+			name:           "Distribute all",
+			tests:          genTests(api.ClusterProfileGCP, 100),
+			testsToBalance: 100,
+			dstProfilesInfo: []dstProfileInfo{
+				{Name: string(api.ClusterProfileGCP2), Target: 75},
+				{Name: string(api.ClusterProfileGCP3), Target: 25},
+			},
+			wantStats: map[api.ClusterProfile]int{
+				api.ClusterProfileGCP2: 75,
+				api.ClusterProfileGCP3: 25,
+			},
+		},
+	} {
+		t.Run(tc.name, func(tt *testing.T) {
+			tt.Parallel()
+
+			modifiedConfigs := balanceRandomly(tc.tests, tc.testsToBalance, tc.dstProfilesInfo)
+			stats := collectStats(tc.tests)
+
+			if len(modifiedConfigs) != tc.testsToBalance {
+				t.Errorf("expected %d modified configs but got %d instead", tc.testsToBalance, len(modifiedConfigs))
+			}
+
+			if diff := cmp.Diff(tc.wantStats, stats); diff != "" {
+				t.Errorf("stats differ:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/cmd/release/release.go
+++ b/pkg/cmd/release/release.go
@@ -22,7 +22,7 @@ type options struct {
 	resolver  registry.Resolver
 }
 
-func NewCommand() *cobra.Command {
+func NewCommand() (*cobra.Command, error) {
 	var o options
 	ret := cobra.Command{
 		Use: "release",
@@ -41,6 +41,10 @@ directly or as the base for higher-level programs and scripts.`,
 	ret.AddCommand(newConfigCommand(&o))
 	ret.AddCommand(newJobCommand(&o))
 	ret.AddCommand(newRegistryCommand(&o))
-	ret.AddCommand(newProfileCommand())
-	return &ret
+	profileCmd, err := newProfileCommand(&o)
+	if err != nil {
+		return nil, fmt.Errorf("profile cmd: %w", err)
+	}
+	ret.AddCommand(profileCmd)
+	return &ret, nil
 }


### PR DESCRIPTION
The `release` tool acquires a new feature, that is the ability to redistribute cluster profiles used by ci-operator tests.
Quoting what is already stated on a comment:
```golang
// The following incantation:
//
//	--from=gcp --scaling-factor=0.5 --to=gcp2,gcp3 --balancing-factors=0.75,0.25 --exclude-orgs=openshift-priv
//
// gather every ci-operator config, excluding the ones under openshift-priv/, having at least
// one test that has `cluster_profile: gcp` set.
// Assuming the selected tests to be N = 100, it then redistributes R = N*0.5 = 50 of them.
//
// The balancing algorithm follows this schema:
//
//	tests that will target 'gcp2': R * 0.75 = 37 => adjusted to 38 to compensate truncation errors
//	tests that will target 'gcp3': R * 0.25 = 12
//
// After the distribution has taken place:
//
//	'gcp'  tests: 50
//	'gcp2' tests: +38
//	'gcp3' tests: +12
```