### PR TITLE
`multi-pr`: fix mergedConfig validation

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -584,7 +584,8 @@ func (o *options) Complete() error {
 	}
 	o.configSpec = config
 	o.jobSpec.Metadata = config.Metadata
-	if err := validation.IsValidResolvedConfiguration(o.configSpec); err != nil {
+	mergedConfig := o.injectTest != ""
+	if err := validation.IsValidResolvedConfiguration(o.configSpec, mergedConfig); err != nil {
 		return results.ForReason("validating_config").ForError(err)
 	}
 	o.graphConfig = defaults.FromConfigStatic(o.configSpec)

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -254,8 +254,6 @@ func ResolveAndMergeConfigsAndInjectTest(configs Getter, resolver Resolver, reso
 					logger.WithError(err).Warning("failed to get config")
 					return
 				}
-				// The Metadata needs to be blank so that ci-operator knows this config is the result of a merge
-				config.Metadata = api.Metadata{}
 				mergedConfig = &config
 				injectedTestIncluded = true
 			} else {

--- a/pkg/registry/server/server.go
+++ b/pkg/registry/server/server.go
@@ -254,6 +254,8 @@ func ResolveAndMergeConfigsAndInjectTest(configs Getter, resolver Resolver, reso
 					logger.WithError(err).Warning("failed to get config")
 					return
 				}
+				// The Metadata needs to be blank so that ci-operator knows this config is the result of a merge
+				config.Metadata = api.Metadata{}
 				mergedConfig = &config
 				injectedTestIncluded = true
 			} else {

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -40,10 +40,6 @@ func newSingleUseValidator() Validator {
 	return Validator{}
 }
 
-func (v *Validator) IsValidRuntimeConfiguration(config *api.ReleaseBuildConfiguration) error {
-	return v.validateConfiguration(NewConfigContext(), config, "", "", false, false)
-}
-
 // IsValidResolvedConfiguration behaves as ValidateAtRuntime and also validates that all
 // test steps are fully resolved.
 func (v *Validator) IsValidResolvedConfiguration(config *api.ReleaseBuildConfiguration) error {


### PR DESCRIPTION
Creates a new `mergedConfig` bool based on the presence of an injected test (which **always** means we are merging the configs. This bool is used to trigger specific validation rather than relying on the absence of metadata. This improves our validation, while still allowing for the proper logic to occur when we are running multi-pr presubmit tests for multiple PRs on the same repo.

For: https://issues.redhat.com/browse/DPTP-4246