### PR TITLE
Adding AWS RHOAI QE Cluster Profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1851,7 +1851,7 @@ func (p ClusterProfile) LeaseType() string {
 	case ClusterProfileAWSKubeVirt:
 		return "aws-kubevirt-quota-slice"
 	case ClusterProfileAWSRHOAIQE:
-        return "aws-rhoai-qe-quota-slice"
+		return "aws-rhoai-qe-quota-slice"
 	case ClusterProfileAWSOVNPerfScale:
 		return "aws-ovn-perfscale-quota-slice"
 	case ClusterProfileAlibabaCloud:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1399,6 +1399,7 @@ const (
 	ClusterProfileAWSSDCICD             ClusterProfile = "aws-sd-cicd"
 	ClusterProfileGCPSDCICD             ClusterProfile = "gcp-sd-cicd"
 	ClusterProfileAroRH                 ClusterProfile = "aro-redhat-tenant"
+	ClusterProfileAWSRHOAIQE            ClusterProfile = "aws-rhoai-qe"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1547,6 +1548,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSSDCICD,
 		ClusterProfileGCPSDCICD,
 		ClusterProfileAroRH,
+		ClusterProfileAWSRHOAIQE,
 	}
 }
 
@@ -1602,7 +1604,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileODFAWS,
 		ClusterProfileAWSObservabiltity,
 		ClusterProfileAWSSDCICD,
-		ClusterProfileKonfluxWorkspacesAWS:
+		ClusterProfileKonfluxWorkspacesAWS,
+		ClusterProfileAWSRHOAIQE:
 		return string(CloudAWS)
 	case
 		ClusterProfileAlibabaCloud,
@@ -1847,6 +1850,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-splat-quota-slice"
 	case ClusterProfileAWSKubeVirt:
 		return "aws-kubevirt-quota-slice"
+	case ClusterProfileAWSRHOAIQE:
+        return "aws-rhoai-qe-quota-slice"
 	case ClusterProfileAWSOVNPerfScale:
 		return "aws-ovn-perfscale-quota-slice"
 	case ClusterProfileAlibabaCloud:


### PR DESCRIPTION
The RHOAI QE team requires a dedicated cluster profile for spinning up Openshift clusters using our AWS account as well as creating S3 buckets for internal testing config.