### PR TITLE
`payload-testing`: allow for a configurable wait time for the triggered job's URL to appear

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -454,10 +454,11 @@ func TestReconcile(t *testing.T) {
 					}).
 				Build()
 			r := &reconciler{
-				logger:               logrus.WithField("test-name", tc.name),
-				client:               client,
-				configResolverClient: &fakeResolverClient{},
-				prowConfigGetter:     &fakeProwConfigGetter{cfg: &tc.prowConfig},
+				logger:                 logrus.WithField("test-name", tc.name),
+				client:                 client,
+				configResolverClient:   &fakeResolverClient{},
+				prowConfigGetter:       &fakeProwConfigGetter{cfg: &tc.prowConfig},
+				jobTriggerWaitDuration: time.Duration(1) * time.Second,
 			}
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "test-namespace", Name: "prpqr-test"}}
 			if err := r.reconcile(context.Background(), req, r.logger, time.Millisecond); err != nil {


### PR DESCRIPTION
It appears that the `prow-controller-manager` can get a little behind sometimes and `20s` isn't always enough. This value is now configurable with the default being `60s`.