### PR TITLE
`Payload Testing`: consolidate logic to determine if any jobs are still running

### DIFF
--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer.go
@@ -177,7 +177,7 @@ func constructCondition(jobs []v1.PullRequestPayloadJobStatus) metav1.Condition 
 func getRunningJobs(jobs []v1.PullRequestPayloadJobStatus) []string {
 	var ret []string
 	for _, job := range jobs {
-		if job.Status.State == prowv1.TriggeredState || job.Status.State == prowv1.PendingState {
+		if IsActiveState(job.Status.State) {
 			ret = append(ret, job.ReleaseJobName)
 		}
 	}
@@ -186,9 +186,13 @@ func getRunningJobs(jobs []v1.PullRequestPayloadJobStatus) []string {
 
 func hasAllJobsFinished(jobs []v1.PullRequestPayloadJobStatus) bool {
 	for _, job := range jobs {
-		if job.Status.State == prowv1.TriggeredState || job.Status.State == prowv1.PendingState || job.Status.State == prowv1.SchedulingState {
+		if IsActiveState(job.Status.State) {
 			return false
 		}
 	}
 	return true
+}
+
+func IsActiveState(state prowv1.ProwJobState) bool {
+	return state == prowv1.PendingState || state == prowv1.TriggeredState || state == prowv1.SchedulingState
 }

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer_test.go
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/pjstatussyncer_test.go
@@ -105,7 +105,7 @@ func TestReconcile(t *testing.T) {
 				},
 				&prowv1.ProwJob{
 					ObjectMeta: metav1.ObjectMeta{UID: "2", Name: "test-pj", Namespace: "test-namespace", Labels: map[string]string{"pullrequestpayloadqualificationruns.ci.openshift.io": "prpqr-test"}},
-					Status:     prowv1.ProwJobStatus{State: prowv1.TriggeredState, StartTime: metav1.Time{Time: time.Now()}},
+					Status:     prowv1.ProwJobStatus{State: prowv1.SchedulingState, StartTime: metav1.Time{Time: time.Now()}},
 				},
 			},
 			pjMutations: func(obj ctrlruntimeclient.Object, client ctrlruntimeclient.Client, t *testing.T) {
@@ -126,7 +126,7 @@ func TestReconcile(t *testing.T) {
 							{
 								ReleaseJobName: "release-job-name",
 								ProwJob:        "test-pj",
-								Status:         prowv1.ProwJobStatus{State: prowv1.TriggeredState},
+								Status:         prowv1.ProwJobStatus{State: prowv1.SchedulingState},
 							},
 							{
 								ReleaseJobName: "release-job-name-2",

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -390,7 +390,7 @@ func (r *reconciler) abortJobs(ctx context.Context,
 	}
 
 	abort := func(ctx context.Context, logger *logrus.Entry, job *prowv1.ProwJob) {
-		if job.Complete() || (job.Status.State != prowv1.TriggeredState && job.Status.State != prowv1.PendingState) {
+		if job.Complete() || !pjstatussyncer.IsActiveState(job.Status.State) {
 			return
 		}
 
@@ -474,7 +474,9 @@ func reconcileStatus(theirs *v1.PullRequestPayloadQualificationRun, ourStatuses 
 		their := statusByJobName[jobName]
 		reconciled := reconcileJobStatus(jobName, their, our)
 		theirs.Status.Jobs = append(theirs.Status.Jobs, reconciled)
-		atLeastOneActive = reconciled.Status.State == prowv1.PendingState || reconciled.Status.State == prowv1.TriggeredState
+		if !atLeastOneActive {
+			atLeastOneActive = pjstatussyncer.IsActiveState(reconciled.Status.State)
+		}
 	}
 
 	manageDependentProwJobsFinalizer(atLeastOneActive, &theirs.ObjectMeta)

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case_with_scheduling.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_aggregated_case_with_scheduling.yaml
@@ -1,5 +1,7 @@
 - metadata:
     creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
     name: prpqr-test
     namespace: test-namespace
     resourceVersion: "1000"

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_scheduling.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_scheduling.yaml
@@ -1,5 +1,7 @@
 - metadata:
     creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
     name: prpqr-test
     namespace: test-namespace
     resourceVersion: "1000"


### PR DESCRIPTION
Follows up on https://github.com/openshift/ci-tools/pull/4399 adding the `Scheduling` state to **all** areas that were previously only checking for `Triggered` and `Pending`. This fixes a bug where the UI incorrectly reports that all jobs are finished.