### PR TITLE
OSASINFRA-3649: Add cluster profile for RHOSO

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1361,6 +1361,7 @@ const (
 	ClusterProfileOpenStackPpc64le      ClusterProfile = "openstack-ppc64le"
 	ClusterProfileOpenStackOpVexxhost   ClusterProfile = "openstack-operators-vexxhost"
 	ClusterProfileOpenStackNercDev      ClusterProfile = "openstack-nerc-dev"
+	ClusterProfileRHOSOGiant28          ClusterProfile = "rhoso-giant28"
 	ClusterProfileOvirt                 ClusterProfile = "ovirt"
 	ClusterProfilePacket                ClusterProfile = "packet"
 	ClusterProfilePacketAssisted        ClusterProfile = "packet-assisted"
@@ -1515,6 +1516,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileOpenStackVexxhost,
 		ClusterProfileOpenStackOpVexxhost,
 		ClusterProfileOpenStackNercDev,
+		ClusterProfileRHOSOGiant28,
 		ClusterProfileOvirt,
 		ClusterProfilePacket,
 		ClusterProfilePacketAssisted,
@@ -1731,6 +1733,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "openstack-operators-vexxhost"
 	case ClusterProfileOpenStackNercDev:
 		return "openstack-nerc-dev"
+	case ClusterProfileRHOSOGiant28:
+		return "rhoso-giant28"
 	case
 		ClusterProfileVSphereMultizone2,
 		ClusterProfileVSphereDis2,
@@ -1979,6 +1983,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "openstack-vh-mecha-az0-quota-slice"
 	case ClusterProfileOpenStackNercDev:
 		return "openstack-nerc-dev-quota-slice"
+	case ClusterProfileRHOSOGiant28:
+		return "rhoso-giant28-quota-slice"
 	case ClusterProfileOpenStackOsuosl:
 		return "openstack-osuosl-quota-slice"
 	case ClusterProfileOpenStackVexxhost:


### PR DESCRIPTION
Add a new cluster profile to support OCP clusters on a RHOSO cloud.

The `rhoso-giant28-quota-slice` is requested in this PR https://github.com/openshift/release/pull/59014