### PR TITLE
[DPTP-3546] Verify if the repo is public for branch protection

### DIFF
--- a/cmd/check-gh-automation/main_test.go
+++ b/cmd/check-gh-automation/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/plugins"
 
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -20,6 +21,7 @@ type fakeAutomationClient struct {
 	membersByOrg          map[string][]string
 	reposWithAppInstalled sets.Set[string]
 	permissionsByRepo     map[string]map[string][]string
+	privacyByRepo         map[string]bool
 }
 
 func newFakePluginConfigAgent() *plugins.ConfigAgent {
@@ -78,6 +80,9 @@ func newFakeProwConfigAgent() *prowconfig.Agent {
 								},
 							},
 							"repo-c": {
+								Policy: prowconfig.Policy{},
+							},
+							"repo-d": {
 								Policy: prowconfig.Policy{},
 							},
 						},
@@ -149,6 +154,12 @@ func (c fakeAutomationClient) IsAppInstalled(org, repo string) (bool, error) {
 	return c.reposWithAppInstalled.Has(orgRepo), nil
 }
 
+func (c fakeAutomationClient) GetRepo(owner, name string) (github.FullRepo, error) {
+	orgRepo := fmt.Sprintf("%s/%s", owner, name)
+	private := c.privacyByRepo[orgRepo]
+	return github.FullRepo{Repo: github.Repo{Private: private}}, nil
+}
+
 func TestCheckRepos(t *testing.T) {
 	client := fakeAutomationClient{
 		collaboratorsByRepo: map[string][]string{
@@ -180,6 +191,10 @@ func TestCheckRepos(t *testing.T) {
 			"org-5/repo-c": {
 				"openshift-merge-robot": []string{"read"},
 			},
+		},
+		privacyByRepo: map[string]bool{
+			"org-5/repo-a": false,
+			"org-5/repo-d": true,
 		},
 	}
 
@@ -328,6 +343,18 @@ func TestCheckRepos(t *testing.T) {
 			adminBots: []string{},
 			mode:      standard,
 			expected:  []string{},
+		},
+		{
+			name:     "repository has branch protection enabled and is public",
+			repos:    []string{"org-5/repo-a"},
+			mode:     standard,
+			expected: []string{},
+		},
+		{
+			name:        "repository has branch protection enabled but is private",
+			repos:       []string{"org-5/repo-d"},
+			mode:        standard,
+			expectedErr: errors.New("branch protection is enabled, the repository org-5/repo-d must be public"),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Repos participating in [automated branching](https://docs.ci.openshift.org/docs/architecture/branching/#how-do-i-opt-my-repository-into-automated-branching) need to have github issues enabled and need to be public in order for the [blocking-issue-creator](https://prow.ci.openshift.org/?job=periodic-openshift-release-merge-blockers) to succeed. There is currently no precheck for this.