### PR TITLE
`prowgen`: ability to add slack reporting to "images" postsubmits

### DIFF
--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	utilpointer "k8s.io/utils/pointer"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -563,6 +564,30 @@ func TestGenerateJobs(t *testing.T) {
 					Org:    "organization",
 					Repo:   "repository",
 					Branch: "branch",
+				},
+			},
+		},
+		{
+			id: "images job is configured for slack reporting",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images:                 []ciop.ProjectDirectoryImageBuildStepConfiguration{{}},
+				PromotionConfiguration: &ciop.PromotionConfiguration{},
+			},
+			repoInfo: &ProwgenInfo{
+				Metadata: ciop.Metadata{
+					Org:    "organization",
+					Repo:   "repository",
+					Branch: "branch",
+				},
+				Config: config.Prowgen{
+					SlackReporterConfigs: []config.SlackReporterConfig{
+						{
+							Channel:           "some-channel",
+							JobStatesToReport: []prowv1.ProwJobState{"error"},
+							ReportTemplate:    "some template",
+							JobNames:          []string{"images", "e2e"},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_is_configured_for_slack_reporting.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_is_configured_for_slack_reporting.yaml
@@ -1,0 +1,19 @@
+postsubmits:
+  organization/repository:
+  - always_run: true
+    labels:
+      ci-operator.openshift.io/is-promotion: "true"
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-images
+    reporter_config:
+      slack:
+        channel: some-channel
+        job_states_to_report:
+        - error
+        report_template: some template
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-images


### PR DESCRIPTION
It was previously made possible to add the slack reporter config for all other postsubmits and periodics. This allows the `images` postsubmit to use this functionality as well.
I will follow this up with a documentation change, and trying it out in `ci-tools`.
For: https://issues.redhat.com/browse/DPTP-4213