### PR TITLE
Adding AWS managed ROSA RHOAI QE Cluster Profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1400,6 +1400,7 @@ const (
 	ClusterProfileGCPSDCICD             ClusterProfile = "gcp-sd-cicd"
 	ClusterProfileAroRH                 ClusterProfile = "aro-redhat-tenant"
 	ClusterProfileAWSRHOAIQE            ClusterProfile = "aws-rhoai-qe"
+	ClusterProfileAWSManagedRosaRHOAIQE ClusterProfile = "aws-managed-rosa-rhoai-qe"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1605,7 +1606,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSObservabiltity,
 		ClusterProfileAWSSDCICD,
 		ClusterProfileKonfluxWorkspacesAWS,
-		ClusterProfileAWSRHOAIQE:
+		ClusterProfileAWSRHOAIQE,
+		ClusterProfileAWSManagedRosaRHOAIQE:
 		return string(CloudAWS)
 	case
 		ClusterProfileAlibabaCloud,
@@ -2067,6 +2069,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "gcp-sd-cicd-quota-slice"
 	case ClusterProfileAroRH:
 		return "aro-redhat-tenant-quota-slice"
+	case ClusterProfileAWSManagedRosaRHOAIQE:
+		return "aws-managed-rosa-rhoai-qe-quota-slice"
 	default:
 		return ""
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1550,6 +1550,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileGCPSDCICD,
 		ClusterProfileAroRH,
 		ClusterProfileAWSRHOAIQE,
+		ClusterProfileAWSManagedRosaRHOAIQE,
 	}
 }
 


### PR DESCRIPTION
The RHOAI QE team requires a dedicated cluster profile for spinning up Openshift clusters using our AWS managed rosa account as well as creating S3 buckets for internal testing config.