### PR TITLE
WIP: Configure VPN capability for prowgen

### DIFF
--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -18,6 +18,7 @@ const (
 	oauthTokenPath              = "/usr/local/github-credentials"
 	oauthKey                    = "oauth"
 	Generator      jc.Generator = "prowgen"
+	VPN                         = "vpn"
 )
 
 type ProwgenInfo struct {
@@ -51,6 +52,10 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 
 		if element.NodeArchitecture != "" {
 			g.WithLabel(fmt.Sprintf("capability/%s", element.NodeArchitecture), string(element.NodeArchitecture))
+		}
+
+		if element.RestrictNetworkAccess != nil && !*element.RestrictNetworkAccess {
+			g.WithLabel(fmt.Sprintf("capability/%s", VPN), string(VPN))
 		}
 
 		disableRehearsal := rehearsals.DisableAll || disabledRehearsals.Has(element.As)

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 
@@ -579,6 +580,74 @@ func TestGenerateJobs(t *testing.T) {
 					{
 						As:               "unit",
 						NodeArchitecture: "arm64",
+					},
+				},
+			},
+			repoInfo: &ProwgenInfo{
+				Metadata: ciop.Metadata{
+					Org:    "organization",
+					Repo:   "repository",
+					Branch: "branch",
+				},
+			},
+		},
+		{
+			id: "vpn label for periodic",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "unit",
+						Cron:                       utilpointer.String(cron),
+						Cluster:                    "build06",
+						ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"},
+						RestrictNetworkAccess:      ptr.To(false)},
+				},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
+		{
+			id: "vpn label for presubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "unit",
+						Cluster:                    "build06",
+						ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"},
+						RestrictNetworkAccess:      ptr.To(false)},
+				},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
+		{
+			id: "vpn label for postsubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "unit",
+						Postsubmit:                 true,
+						Cluster:                    "build06",
+						ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"},
+						RestrictNetworkAccess:      ptr.To(false)},
+				},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
+		{
+			id: "vpn test job",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{
+						As:                    "unit",
+						RestrictNetworkAccess: ptr.To(false),
 					},
 				},
 			},

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_periodic.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_periodic.yaml
@@ -1,0 +1,55 @@
+periodics:
+- agent: kubernetes
+  cluster: build06
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  labels:
+    capability/vpn: vpn
+    ci-operator.openshift.io/cluster: build06
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  name: periodic-ci-organization-repository-branch-unit
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=unit
+      command:
+      - ci-operator
+      image: ci-operator:latest
+      imagePullPolicy: Always
+      name: ""
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_postsubmit.yaml
@@ -1,0 +1,9 @@
+postsubmits:
+  organization/repository:
+  - always_run: true
+    cluster: build06
+    labels:
+      capability/vpn: vpn
+      ci-operator.openshift.io/cluster: build06
+    max_concurrency: 1
+    name: branch-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_label_for_presubmit.yaml
@@ -1,0 +1,9 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    cluster: build06
+    labels:
+      capability/vpn: vpn
+      ci-operator.openshift.io/cluster: build06
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_test_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_vpn_test_job.yaml
@@ -1,0 +1,7 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      capability/vpn: vpn
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-unit


### PR DESCRIPTION
This will add the vpn label to the generated jobs which require intranet network access.
I will open a Follow-up PR to handle the VPN capability

/cc @openshift/test-platform @jmguzik 