### PR TITLE
[DPTP-3546] Verifying if issues are enable for automated branching

### DIFF
--- a/hack/local-check-gh-automation.sh
+++ b/hack/local-check-gh-automation.sh
@@ -2,6 +2,26 @@
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
+TEMP=$(getopt --options "p:" --longoptions "candidate-path:" -n $0 -- "$@")
+eval set -- "$TEMP"
+
+while true; do
+  case "$1" in
+    -p | --candidate-path)
+      candidate_path="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo 'Internal error' >&2
+      exit 1
+      ;;
+  esac
+done
+
 function OC() {
 	oc --context app.ci --namespace ci "$@"
 }
@@ -31,6 +51,7 @@ app_id=$(cat "${data}/appid")
 
 os::log::info "Running check-gh-automation"
 go run ./cmd/check-gh-automation --repo="$1" \
+ ${candidate_path:+--candidate-path=$candidate_path} \
   --bot=openshift-merge-robot --bot=openshift-ci-robot \
   --github-app-id="$app_id" --github-app-private-key-path="${data}/cert" \
   --config-path="${data}/prow/config.yaml" --supplemental-prow-config-dir="${data}/prow" \


### PR DESCRIPTION
Repos participating in [automated branching](https://docs.ci.openshift.org/docs/architecture/branching/#how-do-i-opt-my-repository-into-automated-branching) need to have github issues enabled to succeed. There is currently no precheck for this. It should be added as a check in check-gh-automation.

This PR depends on https://github.com/openshift/ci-tools/pull/4442