### PR TITLE
`check-gh-automation`: log on error level when repo doesn't give the cherrypick-bot the proper perms

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -262,7 +262,7 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 						return nil, fmt.Errorf("error checking access level (read/write/admin) for 'openshift-cherrypick-robot' in '%s/%s': %w", org, repo, err)
 					}
 					if !isMember && !hasAccess {
-						repoLogger.Infof("'openshift-cherrypick-robot' lacks required permissions (read/write/admin) or org membership in '%s/%s'", org, repo)
+						repoLogger.Errorf("'openshift-cherrypick-robot' lacks required permissions (read/write/admin) or org membership in '%s/%s'", org, repo)
 						failing.Insert(orgRepo)
 					} else {
 						repoLogger.Infof("'openshift-cherrypick-robot' has sufficient permissions (member or read/write/admin) in '%s/%s'", org, repo)


### PR DESCRIPTION
Otherwise, it is hard for the user to tell what made the check fail