### PR TITLE
`pj-rehearse`: ignore the cluster-profile-config.yaml file when attempting to get changed registry content

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -222,6 +222,9 @@ func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node
 		if node, ok = graph.References[name]; !ok {
 			node, ok = graph.Observers[name]
 		}
+	case strings.HasSuffix(filename, "cluster-profiles/cluster-profiles-config.yaml"):
+		// This config file should just be ignored
+		return nil, nil
 	default:
 		return nil, fmt.Errorf("invalid step registry filename: %s", filename)
 	}
@@ -244,7 +247,9 @@ func GetChangedRegistrySteps(path, baseRev string, graph registry.NodeByName) ([
 			if err != nil {
 				return changes, err
 			}
-			changes = append(changes, node)
+			if node != nil {
+				changes = append(changes, node)
+			}
 		}
 	}
 	return changes, nil


### PR DESCRIPTION
There is nothing to rehearse based on the change, and not ignoring this file results in The following error:
```
could not determine changed registry steps: could not get step registry differences: invalid step registry filename: cluster-profiles-config.yaml
```
Since this file isn't _real_ step-registry content, I am not sure that it belongs in that directory at all, but that will be addressed in a follow up if necessary.