### PR TITLE
`pj-rehearse`: fix the check to only look for the 'cluster-profile-config.yaml' base

### DIFF
--- a/pkg/config/release.go
+++ b/pkg/config/release.go
@@ -222,7 +222,7 @@ func loadRegistryStep(filename string, graph registry.NodeByName) (registry.Node
 		if node, ok = graph.References[name]; !ok {
 			node, ok = graph.Observers[name]
 		}
-	case strings.HasSuffix(filename, "cluster-profiles/cluster-profiles-config.yaml"):
+	case strings.HasSuffix(filename, "cluster-profiles-config.yaml"):
 		// This config file should just be ignored
 		return nil, nil
 	default:


### PR DESCRIPTION
Follows up on https://github.com/openshift/ci-tools/pull/4448 to only use the base name. We are only passing the base, rather than the full path.