### PR TITLE
[DPTP-4282] Bump e2e test image versions to 4.17 from 4.15

### DIFF
--- a/pkg/release/candidate/client.go
+++ b/pkg/release/candidate/client.go
@@ -19,7 +19,7 @@ func ServiceHost(d api.ReleaseDescriptor) string {
 	switch d.Product {
 	case api.ReleaseProductOCP:
 		product = "ocp"
-	case api.ReleaseProductOKD:
+	case api.ReleaseProductOKD, api.ReleaseProductOKDScos:
 		product = "origin"
 	}
 
@@ -51,6 +51,8 @@ func endpoint(candidate api.Candidate) string {
 func DefaultFields(candidate api.Candidate) api.Candidate {
 	if candidate.Product == api.ReleaseProductOKD && candidate.Stream == "" {
 		candidate.Stream = api.ReleaseStreamOKD
+	} else if candidate.Product == api.ReleaseProductOKDScos && candidate.Stream == "" {
+		candidate.Stream = api.ReleaseStreamOKDScos
 	}
 
 	if candidate.Architecture == "" {

--- a/pkg/validation/release.go
+++ b/pkg/validation/release.go
@@ -93,6 +93,8 @@ func validateCandidate(fieldRoot string, candidate api.Candidate) []error {
 	streamsByProduct := map[api.ReleaseProduct]sets.Set[string]{
 		api.ReleaseProductOKD: sets.New[string]("", string(api.ReleaseStreamOKD),
 			string(api.ReleaseStreamOKDScos)), // we allow unset and will default it
+		api.ReleaseProductOKDScos: sets.New[string]("", string(api.ReleaseStreamOKD),
+			string(api.ReleaseStreamOKDScos)),
 		api.ReleaseProductOCP: sets.New[string](string(api.ReleaseStreamCI), string(api.ReleaseStreamNightly)),
 	}
 	if !streamsByProduct[candidate.Product].Has(string(candidate.Stream)) {

--- a/test/e2e/multi-stage/assembled-release-no-injection.yaml
+++ b/test/e2e/multi-stage/assembled-release-no-injection.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.15"
+    name: "4.17"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.15"
+      name: "4.17"
 resources:
   '*':
     requests:

--- a/test/e2e/multi-stage/assembled-release.yaml
+++ b/test/e2e/multi-stage/assembled-release.yaml
@@ -4,7 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
   cli:
-    name: "4.15"
+    name: "4.17"
     namespace: ocp
     tag: cli
 raw_steps:
@@ -17,7 +17,7 @@ releases:
   latest:
     integration:
       namespace: ocp
-      name: "4.15"
+      name: "4.17"
       include_built_images: true
 resources:
   '*':

--- a/test/e2e/multi-stage/dependencies.yaml
+++ b/test/e2e/multi-stage/dependencies.yaml
@@ -14,12 +14,12 @@ resources:
       cpu: 10m
 tag_specification:
   namespace: ocp
-  name: "4.15"
+  name: "4.17"
 releases:
   custom:
     candidate:
-      product: okd
-      version: "4.15"
+      product: okd-scos
+      version: "4.17"
 tests:
   - as: with-dependencies
     steps:

--- a/test/e2e/multi-stage/e2e_test.go
+++ b/test/e2e/multi-stage/e2e_test.go
@@ -192,7 +192,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.17.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},
@@ -202,7 +202,7 @@ func TestMultiStage(t *testing.T) {
 			env:     []string{defaultJobSpec},
 			success: true,
 			output: []string{
-				`Snapshot integration stream into release 4.15.`, `-latest to tag release:latest`,
+				`Snapshot integration stream into release 4.17.`, `-latest to tag release:latest`,
 				`verify-releases-latest-cli succeeded`,
 			},
 		},


### PR DESCRIPTION
Looks like images based on CentOS 8 stream are failing because of the outdated repositories.

The newer releses of OKD have the suffix `-scos`:
[https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4.17.0-0.okd-scos/latest](https://amd64.origin.releases.ci.openshift.org/api/v1/releasestream/4.17.0-0.okd-scos/latest)

Waiting for: https://github.com/openshift/ci-tools/pull/4458