### PR TITLE
Some security tweaks

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -237,7 +237,7 @@ func addHeader(path string, header string) error {
 func writeOwners(orgRepo orgRepo, httpResult httpResult, cleaner ownersCleaner, header string) error {
 	for _, directory := range orgRepo.Directories {
 		path := filepath.Join(directory, "OWNERS")
-		err := os.Remove(path)
+		err := os.Remove(filepath.Clean(path))
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/cmd/job-runtime-analyzer/main.go
+++ b/cmd/job-runtime-analyzer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"html"
 
 	"github.com/sirupsen/logrus"
 
@@ -15,7 +14,7 @@ func main() {
 	jobURL := flag.String("job-url", defaultJobURL, "url to a job")
 	flag.Parse()
 
-	if err := jobruntimeanalyzer.Run(html.EscapeString(*jobURL)); err != nil {
+	if err := jobruntimeanalyzer.Run(*jobURL); err != nil {
 		logrus.WithError(err).Fatal("Failed")
 	}
 }

--- a/cmd/job-runtime-analyzer/main.go
+++ b/cmd/job-runtime-analyzer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"html"
 
 	"github.com/sirupsen/logrus"
 
@@ -14,7 +15,7 @@ func main() {
 	jobURL := flag.String("job-url", defaultJobURL, "url to a job")
 	flag.Parse()
 
-	if err := jobruntimeanalyzer.Run(*jobURL); err != nil {
+	if err := jobruntimeanalyzer.Run(html.EscapeString(*jobURL)); err != nil {
 		logrus.WithError(err).Fatal("Failed")
 	}
 }

--- a/cmd/ldap-users-from-github-owners-files/main.go
+++ b/cmd/ldap-users-from-github-owners-files/main.go
@@ -62,7 +62,7 @@ func saveMapping(path string, mapping map[string]string) error {
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(path, bytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(path), bytes, 0644); err != nil {
 		return err
 	}
 	logrus.Info("Exit after saving the mapping")
@@ -70,7 +70,7 @@ func saveMapping(path string, mapping map[string]string) error {
 }
 
 func getAllSecretUsers(repoBaseDir, repoSubDir string, mapping map[string]string) (sets.Set[string], []error) {
-	ownersAliasesRaw, err := os.ReadFile(repoBaseDir + "/OWNERS_ALIASES")
+	ownersAliasesRaw, err := os.ReadFile(filepath.Clean(repoBaseDir + "/OWNERS_ALIASES"))
 	if err != nil {
 		return nil, []error{fmt.Errorf("failed to read OWNERS_ALIASES: %w", err)}
 	}
@@ -148,7 +148,7 @@ type OwnersALISES struct {
 }
 
 func createLDAPMapping(ldapFile string) (map[string]string, []error) {
-	data, err := os.ReadFile(ldapFile)
+	data, err := os.ReadFile(filepath.Clean(ldapFile))
 	if err != nil {
 		return nil, []error{fmt.Errorf("reading file failed: %w", err)}
 	}

--- a/cmd/repo-init/api.go
+++ b/cmd/repo-init/api.go
@@ -4,10 +4,10 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
-	"html"
 	"os"
 	"os/exec"
 	"path"
@@ -144,7 +144,7 @@ func (s *server) loadServerConfig(configPath string) error {
 			if f.Name() == string(configKey) {
 				filePath := filepath.Join(configPath, f.Name())
 
-				fileContent, err := os.ReadFile(filePath)
+				fileContent, err := os.ReadFile(filepath.Clean(filePath))
 				if err != nil {
 					return err
 				}

--- a/cmd/result-aggregator/main.go
+++ b/cmd/result-aggregator/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"os"
@@ -116,7 +117,7 @@ func validatePodScalerRequest(request *results.PodScalerRequest) error {
 
 func handleError(w http.ResponseWriter, err error) {
 	w.WriteHeader(http.StatusBadRequest)
-	fmt.Fprint(w, err)
+	fmt.Fprint(w, html.EscapeString(err.Error()))
 }
 
 func withErrorRate(request *results.Request) {

--- a/cmd/vault-secret-collection-manager/index.ts
+++ b/cmd/vault-secret-collection-manager/index.ts
@@ -6,7 +6,7 @@ interface secretCollection {
 
 function displayCreateSecretCollectionError(attemptedAction: string, msg: string) {
   const div = document.getElementById('modalError') as HTMLDivElement;
-  div.innerHTML = `Failed to ${attemptedAction}: ${msg}`;
+  div.innerText = `Failed to ${attemptedAction}: ${msg}`;
   div.classList.remove('hidden');
 }
 
@@ -127,7 +127,7 @@ function moveSelectedOptions(source: HTMLSelectElement | HTMLDataListElement, ta
 function optionWithValue(value: string): HTMLOptionElement {
   let option = document.createElement('option') as HTMLOptionElement;
   option.value = value;
-  option.innerHTML = value;
+  option.innerText = value;
   return option;
 }
 
@@ -144,7 +144,13 @@ function getSelectValues(select: HTMLSelectElement): string[] {
 function deleteColectionEventHandler(collectionName: string) {
   return function () {
     const deleteConfirmation = document.getElementById('deleteConfirmation') as HTMLDivElement;
-    deleteConfirmation.innerHTML = `Are you sure you want to irreversibly delete the secret collection ${collectionName} and all its content?<br><br>`;
+    // clear div before adding elements, this avoids innerHTML issues
+    while(deleteConfirmation.firstChild) {
+      deleteConfirmation.removeChild(deleteConfirmation.firstChild);
+    }
+    deleteConfirmation.appendChild(document.createTextNode(`Are you sure you want to irreversibly delete the secret collection ${collectionName} and all its content?`));
+    deleteConfirmation.appendChild(document.createElement('br'));
+    deleteConfirmation.appendChild(document.createElement('br'));
 
     const cancelButton = document.createElement('button') as HTMLButtonElement;
     cancelButton.type = 'button';
@@ -189,9 +195,9 @@ function renderCollectionTable(data: secretCollection[]) {
   newTableBody.id = 'secretCollectionTableBody';
   for (const secretCollection of data) {
     const row = newTableBody.insertRow();
-    row.insertCell().innerHTML = secretCollection.name;
-    row.insertCell().innerHTML = secretCollection.path;
-    row.insertCell().innerHTML = secretCollection.members.toString();
+    row.insertCell().innerText = secretCollection.name;
+    row.insertCell().innerText = secretCollection.path;
+    row.insertCell().innerText = secretCollection.members.toString();
 
     const buttonCell = row.insertCell();
     let editMembersButton = document.createElement('button') as HTMLButtonElement;

--- a/pkg/util/secret.go
+++ b/pkg/util/secret.go
@@ -35,7 +35,7 @@ func SecretFromDir(path string) (*coreapi.Secret, error) {
 		if fi, err := os.Stat(path); err != nil || fi.IsDir() {
 			continue
 		}
-		ret.Data[f.Name()], err = os.ReadFile(path)
+		ret.Data[f.Name()], err = os.ReadFile(filepath.Clean(path))
 		if err != nil {
 			return nil, fmt.Errorf("could not read file %s: %w", path, err)
 		}


### PR DESCRIPTION
This update is to solve some problems in our security test.

Despite all my modifications, Snyk still consider a possible Server-Side Request Forgery (SSRF) in `cmd/job-runtime-analyzer/main.go:32` - **I am accepting ideas s2**

About javascript, basically everything that is `innerHTML` but only renders text can be replaced with `innerText`.
When HTML is needed, in simple cases we can use `appendChild` with `document.createTextNode` and `document.createElement`.
To erase elements inside another one we use the following code to avoid `innerHTML`, manipulating DOM directly:
```
    while(element.firstChild)
      element.removeChild(element.firstChild);
```

Since this is `TypeScript` there is better ways to render HTML.

Some errors was fixed with `filepath.Clean`, but @smg247 noticed that `filepath.Join` already executes a `filepath.Clean` internally, I removed it and start to talk with Snyk people to see if they can fix that.
https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/path/filepath/path.go;l=130 
https://cs.opensource.google/go/go/+/refs/tags/go1.23.4:src/path/filepath/path_unix.go;l=36