### PR TITLE
Added product okd-scos

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -387,8 +387,9 @@ func BoundsFromQuery(query string) (*VersionBounds, error) {
 type ReleaseProduct string
 
 const (
-	ReleaseProductOCP ReleaseProduct = "ocp"
-	ReleaseProductOKD ReleaseProduct = "okd"
+	ReleaseProductOCP     ReleaseProduct = "ocp"
+	ReleaseProductOKD     ReleaseProduct = "okd"
+	ReleaseProductOKDScos ReleaseProduct = "okd-scos"
 )
 
 // ReleaseArchitecture describes the architecture for the product

--- a/pkg/validation/release.go
+++ b/pkg/validation/release.go
@@ -111,7 +111,7 @@ func validateCandidate(fieldRoot string, candidate api.Candidate) []error {
 }
 
 func validateProduct(fieldRoot string, product api.ReleaseProduct) error {
-	products := sets.New[string](string(api.ReleaseProductOKD), string(api.ReleaseProductOCP))
+	products := sets.New[string](string(api.ReleaseProductOKD), string(api.ReleaseProductOCP), string(api.ReleaseProductOKDScos))
 	if !products.Has(string(product)) {
 		return fmt.Errorf("%s: must be one of %s", fieldRoot, strings.Join(sets.List(products), ", "))
 	}

--- a/pkg/validation/release_test.go
+++ b/pkg/validation/release_test.go
@@ -162,7 +162,7 @@ func TestValidateReleases(t *testing.T) {
 			},
 			hasTagSpec: true,
 			output: []error{
-				errors.New("root.first.product: must be one of ocp, okd"),
+				errors.New("root.first.product: must be one of ocp, okd, okd-scos"),
 				errors.New("root.second.channel: must be one of candidate, fast, stable"),
 				errors.New("root.third.version_bounds.upper: must be set"),
 			},
@@ -283,7 +283,7 @@ func TestValidateCandidate(t *testing.T) {
 				Version: "4.4",
 			},
 			output: []error{
-				errors.New("root.product: must be one of ocp, okd"),
+				errors.New("root.product: must be one of ocp, okd, okd-scos"),
 			},
 		},
 		{
@@ -497,7 +497,7 @@ func TestValidatePrerelease(t *testing.T) {
 				},
 			},
 			output: []error{
-				errors.New("root.product: must be one of ocp, okd"),
+				errors.New("root.product: must be one of ocp, okd, okd-scos"),
 			},
 		},
 		{


### PR DESCRIPTION
This is related to this PR: https://github.com/openshift/ci-tools/pull/4456

Tests are failing since `okd-scos` is not a valid product.