### PR TITLE
`pj-rehearse`: remove defunct build-farm related logic

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -68,7 +68,6 @@ func gatherOptions() (options, error) {
 	o.dryRunOptions.bind(fs)
 
 	fs.StringVar(&o.prowjobKubeconfig, "prowjob-kubeconfig", "", "Path to the prowjob kubeconfig. If unset, default kubeconfig will be used for prowjobs.")
-	o.kubernetesOptions.AddFlags(fs)
 	fs.BoolVar(&o.noTemplates, "no-templates", false, "If true, do not attempt to compare templates")
 	fs.BoolVar(&o.noRegistry, "no-registry", false, "If true, do not attempt to compare step registry content")
 
@@ -183,7 +182,7 @@ func dryRun(o options, logger *logrus.Entry) error {
 			return fmt.Errorf("%s: %w", "ERROR: pj-rehearse: failed to validate rehearsal jobs", err)
 		}
 
-		_, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, true, logger)
+		_, err := rc.RehearseJobs(candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, true, logger)
 		return err
 	}
 

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -442,7 +442,7 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					}
 
 					autoAckMode := rehearseAutoAck == command
-					success, err := rc.RehearseJobs(candidate, candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, autoAckMode, logger)
+					success, err := rc.RehearseJobs(candidatePath, prRefs, presubmitsToRehearse, prConfig.Prow, autoAckMode, logger)
 					if err != nil {
 						logger.WithError(err).Error("couldn't rehearse jobs")
 						s.reportFailure("failed to create rehearsal jobs", err, org, repo, user, number, true, false, logger)


### PR DESCRIPTION
We used to have to ensure ImageStreamTags and setup ConfigMaps for cluster-profiles on the build-farm cluster that the test was to run on. That is no longer necessary, so there is no reason to create a client and manager for the cluster.