### PR TITLE
cluster-init: refactor some steps into manifest generators

### DIFF
--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -76,7 +76,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 		onboard.NewManifestGeneratorStep(log, onboard.NewCertificateGenerator(clusterInstall, kubeClient)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCloudabilityAgentGenerator(clusterInstall)),
 		onboard.NewCommonSymlinkStep(log, clusterInstall),
-		onboard.NewMultiarchBuilderControllerStep(log, clusterInstall),
+		onboard.NewManifestGeneratorStep(log, onboard.NewMultiarchBuilderControllerGenerator(clusterInstall)),
 		onboard.NewMultiarchTuningOperatorStep(log, clusterInstall),
 		onboard.NewManifestGeneratorStep(log, onboard.NewImageRegistryGenerator(clusterInstall)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewOpenshiftMonitoringGenerator(clusterInstall)),

--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -71,7 +71,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 		onboard.NewSanitizeProwjobStep(log, clusterInstall),
 		onboard.NewSyncRoverGroupStep(log, clusterInstall),
 		onboard.NewProwPluginStep(log, clusterInstall),
-		onboard.NewDexStep(log, kubeClient, clusterInstall),
+		onboard.NewManifestGeneratorStep(log, onboard.NewDexGenerator(kubeClient, clusterInstall)),
 		onboard.NewQuayioPullThroughCacheStep(log, clusterInstall, kubeClient),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCertificateGenerator(clusterInstall, kubeClient)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCloudabilityAgentGenerator(clusterInstall)),

--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -72,7 +72,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 		onboard.NewSyncRoverGroupStep(log, clusterInstall),
 		onboard.NewProwPluginStep(log, clusterInstall),
 		onboard.NewManifestGeneratorStep(log, onboard.NewDexGenerator(kubeClient, clusterInstall)),
-		onboard.NewQuayioPullThroughCacheStep(log, clusterInstall, kubeClient),
+		onboard.NewManifestGeneratorStep(log, onboard.NewQuayioPullThroughCacheStep(clusterInstall, kubeClient)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCertificateGenerator(clusterInstall, kubeClient)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCloudabilityAgentGenerator(clusterInstall)),
 		onboard.NewCommonSymlinkStep(log, clusterInstall),

--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -65,7 +65,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 	steps := []clusterinittypes.Step{
 		onboard.NewProwJobStep(log, clusterInstall),
 		onboard.NewBuildClusterDirStep(log, clusterInstall),
-		onboard.NewOAuthTemplateStep(log, clusterInstall),
+		onboard.NewManifestGeneratorStep(log, onboard.NewOAuthTemplateGenerator(clusterInstall)),
 		onboard.NewCISecretBootstrapStep(log, clusterInstall),
 		onboard.NewCISecretGeneratorStep(log, clusterInstall),
 		onboard.NewSanitizeProwjobStep(log, clusterInstall),

--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -73,7 +73,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 		onboard.NewProwPluginStep(log, clusterInstall),
 		onboard.NewDexStep(log, kubeClient, clusterInstall),
 		onboard.NewQuayioPullThroughCacheStep(log, clusterInstall, kubeClient),
-		onboard.NewCertificateStep(log, clusterInstall, kubeClient),
+		onboard.NewManifestGeneratorStep(log, onboard.NewCertificateGenerator(clusterInstall, kubeClient)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewCloudabilityAgentGenerator(clusterInstall)),
 		onboard.NewCommonSymlinkStep(log, clusterInstall),
 		onboard.NewMultiarchBuilderControllerStep(log, clusterInstall),

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -58,6 +58,7 @@ type Onboard struct {
 	OpenshiftMonitoring        OpenshiftMonitoring        `json:"openshiftMonitoring,omitempty"`
 	MultiarchTuningOperator    MultiarchTuningOperator    `json:"multiarchTuningOperator,omitempty"`
 	CertManagerOperator        CertManagerOperator        `json:"certManagerOperator,omitempty"`
+	OAuthTemplate              OAuthTemplate              `json:"oauthTemplate,omitempty"`
 }
 
 type Dex struct {
@@ -148,6 +149,12 @@ type Certificate struct {
 }
 
 type CertManagerOperator struct {
+	types.SkipStep
+	types.ExcludeManifest
+	Patches []manifest.Patch `json:"patches,omitempty"`
+}
+
+type OAuthTemplate struct {
 	types.SkipStep
 	types.ExcludeManifest
 	Patches []manifest.Patch `json:"patches,omitempty"`

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -61,7 +61,9 @@ type Onboard struct {
 }
 
 type Dex struct {
-	RedirectURI string `json:"redirectURI,omitempty"`
+	types.SkipStep
+	types.ExcludeManifest
+	Patches []manifest.Patch `json:"patches,omitempty"`
 }
 
 type QuayioPullThroughCache struct {

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -89,6 +89,8 @@ type MachineSet struct {
 
 type MultiarchBuilderController struct {
 	types.SkipStep
+	types.ExcludeManifest
+	Patches []manifest.Patch `json:"patches,omitempty"`
 }
 
 type ImageRegistry struct {

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -137,10 +137,10 @@ var (
 )
 
 type Certificate struct {
-	BaseDomains             string                             `json:"baseDomains,omitempty"`
-	ImageRegistryPublicHost string                             `json:"imageRegistryPublicHost,omitempty"`
-	ClusterIssuer           map[string]string                  `json:"clusterIssuer,omitempty"`
-	ProjectLabel            map[string]CertificateProjectLabel `json:"projectLabel,omitempty"`
+	types.SkipStep
+	types.ExcludeManifest
+	Patches                 []manifest.Patch `json:"patches,omitempty"`
+	ImageRegistryPublicHost string           `json:"imageRegistryPublicHost,omitempty"`
 }
 
 type CertManagerOperator struct {

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -68,7 +68,9 @@ type Dex struct {
 }
 
 type QuayioPullThroughCache struct {
-	MirrorURI string `json:"mirrorURI,omitempty"`
+	types.SkipStep
+	types.ExcludeManifest
+	Patches []manifest.Patch `json:"patches,omitempty"`
 }
 
 type CertificateProjectLabel struct {

--- a/pkg/clusterinit/onboard/certificate.go
+++ b/pkg/clusterinit/onboard/certificate.go
@@ -9,11 +9,11 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	cinitmanifest "github.com/openshift/ci-tools/pkg/clusterinit/manifest"
-	cinittypes "github.com/openshift/ci-tools/pkg/clusterinit/types"
 	"github.com/openshift/library-go/pkg/image/reference"
 
 	"github.com/openshift/ci-tools/pkg/clusterinit/clusterinstall"
+	cinitmanifest "github.com/openshift/ci-tools/pkg/clusterinit/manifest"
+	cinittypes "github.com/openshift/ci-tools/pkg/clusterinit/types"
 )
 
 type certificateGenerator struct {

--- a/pkg/clusterinit/onboard/certificate_test.go
+++ b/pkg/clusterinit/onboard/certificate_test.go
@@ -2,15 +2,11 @@ package onboard
 
 import (
 	"context"
-	"errors"
-	"io/fs"
-	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -18,196 +14,22 @@ import (
 
 	imagev1 "github.com/openshift/api/image/v1"
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
+	"github.com/openshift/installer/pkg/types"
 
 	"github.com/openshift/ci-tools/pkg/clusterinit/clusterinstall"
 )
 
 func TestGenerateCertificate(t *testing.T) {
-	releaseRepo := "/release/repo"
 	for _, tc := range []struct {
 		name           string
 		clusterInstall clusterinstall.ClusterInstall
 		config         imageregistryv1.Config
 		objects        []runtime.Object
-		wantManifest   string
+		wantManifests  map[string][]interface{}
 		wantErr        error
 	}{
 		{
 			name: "Generate certificates successfully",
-			clusterInstall: clusterinstall.ClusterInstall{ClusterName: "build99", Onboard: clusterinstall.Onboard{
-				ReleaseRepo: "/release/repo",
-				OSD:         ptr.To(false),
-				Unmanaged:   ptr.To(false),
-				Hosted:      ptr.To(false),
-			}},
-			objects: []runtime.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
-					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
-				},
-				&imagev1.ImageStreamList{
-					Items: []imagev1.ImageStream{{
-						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
-						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
-					}},
-				},
-			},
-			wantManifest: `apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    aws-project: openshift-ci-infra
-  name: apiserver-tls
-  namespace: openshift-config
-spec:
-  dnsNames:
-  - api.build99.ci.devcluster.openshift.com
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer-aws
-  secretName: apiserver-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    aws-project: openshift-ci-infra
-  name: apps-tls
-  namespace: openshift-ingress
-spec:
-  dnsNames:
-  - '*.apps.build99.ci.devcluster.openshift.com'
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer-aws
-  secretName: apps-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    gcp-project: openshift-ci-infra
-  name: registry-tls
-  namespace: openshift-image-registry
-spec:
-  dnsNames:
-  - registry.build99.ci.openshift.org
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer
-  secretName: public-route-tls
-`,
-		},
-		{
-			name: "Override from config",
-			clusterInstall: clusterinstall.ClusterInstall{ClusterName: "build99", Onboard: clusterinstall.Onboard{
-				ReleaseRepo: "/release/repo",
-				OSD:         ptr.To(false),
-				Unmanaged:   ptr.To(false),
-				Hosted:      ptr.To(false),
-				Certificate: clusterinstall.Certificate{
-					BaseDomains:             "fake-domain",
-					ImageRegistryPublicHost: "fake-public-host",
-					ClusterIssuer:           map[string]string{"apiserver-tls": "overridden"},
-					ProjectLabel:            map[string]clusterinstall.CertificateProjectLabel{"apps-tls": {Key: "foo-project", Value: "bar"}},
-				},
-			}},
-			objects: []runtime.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
-					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
-				},
-				&imagev1.ImageStreamList{
-					Items: []imagev1.ImageStream{{
-						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
-						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
-					}},
-				},
-			},
-			wantManifest: `apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    aws-project: openshift-ci-infra
-  name: apiserver-tls
-  namespace: openshift-config
-spec:
-  dnsNames:
-  - api.build99.fake-domain
-  issuerRef:
-    kind: ClusterIssuer
-    name: overridden
-  secretName: apiserver-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    foo-project: bar
-  name: apps-tls
-  namespace: openshift-ingress
-spec:
-  dnsNames:
-  - '*.apps.build99.fake-domain'
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer-aws
-  secretName: apps-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    gcp-project: openshift-ci-infra
-  name: registry-tls
-  namespace: openshift-image-registry
-spec:
-  dnsNames:
-  - fake-public-host
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer
-  secretName: public-route-tls
-`,
-		},
-		{
-			name: "Non OCP generates image registry certificate only",
-			clusterInstall: clusterinstall.ClusterInstall{ClusterName: "build99", Onboard: clusterinstall.Onboard{
-				ReleaseRepo: "/release/repo",
-				OSD:         ptr.To(true),
-				Unmanaged:   ptr.To(false),
-				Hosted:      ptr.To(false),
-			}},
-			objects: []runtime.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
-					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
-				},
-				&imagev1.ImageStreamList{
-					Items: []imagev1.ImageStream{{
-						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
-						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
-					}},
-				},
-			},
-			wantManifest: `apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    gcp-project: openshift-ci-infra
-  name: registry-tls
-  namespace: openshift-image-registry
-spec:
-  dnsNames:
-  - registry.build99.ci.openshift.org
-  issuerRef:
-    kind: ClusterIssuer
-    name: cert-issuer
-  secretName: public-route-tls
-`,
-		},
-		{
-			name: "No public image registry host",
 			clusterInstall: clusterinstall.ClusterInstall{
 				ClusterName: "build99",
 				Onboard: clusterinstall.Onboard{
@@ -216,23 +38,8 @@ spec:
 					Unmanaged:   ptr.To(false),
 					Hosted:      ptr.To(false),
 				},
+				InstallConfig: types.InstallConfig{BaseDomain: "ci.devcluster.openshift.com"},
 			},
-			objects: []runtime.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "cluster-config-v1"},
-					Data:       map[string]string{"install-config": `baseDomain: "ci.devcluster.openshift.com"`},
-				},
-				&imagev1.ImageStreamList{
-					Items: []imagev1.ImageStream{{
-						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
-					}},
-				},
-			},
-			wantErr: errors.New("image registry public host: no public registry host could be located"),
-		},
-		{
-			name:           "No install-config.yaml",
-			clusterInstall: clusterinstall.ClusterInstall{ClusterName: "build99", Onboard: clusterinstall.Onboard{ReleaseRepo: "/release/repo"}},
 			objects: []runtime.Object{
 				&imagev1.ImageStreamList{
 					Items: []imagev1.ImageStream{{
@@ -241,7 +48,167 @@ spec:
 					}},
 				},
 			},
-			wantErr: errors.New(`base domain: get cluster-config-v1: configmaps "cluster-config-v1" not found`),
+			wantManifests: map[string][]interface{}{
+				"/release/repo/clusters/build-clusters/build99/cert-manager/certificate.yaml": {
+					map[string]interface{}{
+						"kind": "Certificate",
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"aws-project": "openshift-ci-infra",
+							},
+							"name":      "apiserver-tls",
+							"namespace": "openshift-config",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"api.build99.ci.devcluster.openshift.com",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "ClusterIssuer",
+								"name": "cert-issuer-aws",
+							},
+							"secretName": "apiserver-tls",
+						},
+						"apiVersion": "cert-manager.io/v1",
+					},
+					map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"aws-project": "openshift-ci-infra",
+							},
+							"name":      "apps-tls",
+							"namespace": "openshift-ingress",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"*.apps.build99.ci.devcluster.openshift.com",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "ClusterIssuer",
+								"name": "cert-issuer-aws",
+							},
+							"secretName": "apps-tls",
+						},
+					},
+					map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"gcp-project": "openshift-ci-infra",
+							},
+							"name":      "registry-tls",
+							"namespace": "openshift-image-registry",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"registry.build99.ci.openshift.org",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "ClusterIssuer",
+								"name": "cert-issuer",
+							},
+							"secretName": "public-route-tls",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Non OCP generates image registry certificate only",
+			clusterInstall: clusterinstall.ClusterInstall{
+				ClusterName: "build99",
+				Onboard: clusterinstall.Onboard{
+					ReleaseRepo: "/release/repo",
+					OSD:         ptr.To(true),
+					Unmanaged:   ptr.To(false),
+					Hosted:      ptr.To(false),
+				},
+				InstallConfig: types.InstallConfig{BaseDomain: "ci.devcluster.openshift.com"},
+			},
+			objects: []runtime.Object{
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+						Status:     imagev1.ImageStreamStatus{PublicDockerImageRepository: "registry.build99.ci.openshift.org/openshift/cli"},
+					}},
+				},
+			},
+			wantManifests: map[string][]interface{}{
+				"/release/repo/clusters/build-clusters/build99/cert-manager/certificate.yaml": {
+					map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"gcp-project": "openshift-ci-infra",
+							},
+							"name":      "registry-tls",
+							"namespace": "openshift-image-registry",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"registry.build99.ci.openshift.org",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "ClusterIssuer",
+								"name": "cert-issuer",
+							},
+							"secretName": "public-route-tls",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Override image registry hostname",
+			clusterInstall: clusterinstall.ClusterInstall{
+				ClusterName: "build99",
+				Onboard: clusterinstall.Onboard{
+					ReleaseRepo: "/release/repo",
+					OSD:         ptr.To(true),
+					Unmanaged:   ptr.To(false),
+					Hosted:      ptr.To(false),
+					Certificate: clusterinstall.Certificate{
+						ImageRegistryPublicHost: "registry.overridden.ci.openshift.org",
+					},
+				},
+				InstallConfig: types.InstallConfig{BaseDomain: "ci.devcluster.openshift.com"},
+			},
+			objects: []runtime.Object{
+				&imagev1.ImageStreamList{
+					Items: []imagev1.ImageStream{{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "openshift", Name: "cli"},
+					}},
+				},
+			},
+			wantManifests: map[string][]interface{}{
+				"/release/repo/clusters/build-clusters/build99/cert-manager/certificate.yaml": {
+					map[string]interface{}{
+						"apiVersion": "cert-manager.io/v1",
+						"kind":       "Certificate",
+						"metadata": map[string]interface{}{
+							"labels": map[string]interface{}{
+								"gcp-project": "openshift-ci-infra",
+							},
+							"name":      "registry-tls",
+							"namespace": "openshift-image-registry",
+						},
+						"spec": map[string]interface{}{
+							"dnsNames": []interface{}{
+								"registry.overridden.ci.openshift.org",
+							},
+							"issuerRef": map[string]interface{}{
+								"kind": "ClusterIssuer",
+								"name": "cert-issuer",
+							},
+							"secretName": "public-route-tls",
+						},
+					},
+				},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -250,25 +217,12 @@ spec:
 			if err := imageregistryv1.AddToScheme(scheme); err != nil {
 				t.Fatal("add routev1 to scheme")
 			}
-			if err := corev1.AddToScheme(scheme); err != nil {
-				t.Fatal("add corev1 to scheme")
-			}
 			if err := imagev1.AddToScheme(scheme); err != nil {
 				t.Fatal("add imagev1 to scheme")
 			}
 			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tc.objects...).Build()
-			step := NewCertificateStep(logrus.NewEntry(logrus.StandardLogger()), &tc.clusterInstall, kubeClient)
-			var (
-				manifests          string
-				manifestsWritePath string
-			)
-			step.writeManifest = func(name string, data []byte, perm fs.FileMode) error {
-				manifestsWritePath = name
-				manifests = string(data)
-				return nil
-			}
-
-			err := step.Run(context.TODO())
+			generator := NewCertificateGenerator(&tc.clusterInstall, kubeClient)
+			manifests, err := generator.Generate(context.TODO(), logrus.NewEntry(logrus.StandardLogger()))
 
 			if err != nil && tc.wantErr == nil {
 				t.Fatalf("want err nil but got: %v", err)
@@ -283,12 +237,7 @@ spec:
 				return
 			}
 
-			wantManifestsWritePath := path.Join(releaseRepo, "clusters/build-clusters/build99/cert-manager/certificate.yaml")
-			if manifestsWritePath != wantManifestsWritePath {
-				t.Errorf("want manifests path (write) %q but got %q", wantManifestsWritePath, manifestsWritePath)
-			}
-
-			if diff := cmp.Diff(tc.wantManifest, manifests); diff != "" {
+			if diff := cmp.Diff(tc.wantManifests, manifests); diff != "" {
 				t.Errorf("templates differs:\n%s", diff)
 			}
 		})

--- a/pkg/clusterinit/onboard/cisecretbootstrap.go
+++ b/pkg/clusterinit/onboard/cisecretbootstrap.go
@@ -75,7 +75,6 @@ func (s *ciSecretBootstrapStep) updateCiSecretBootstrapConfig(c *secretbootstrap
 	var steps = []func(c *secretbootstrap.Config) error{
 		s.updateBuildFarmSecrets,
 		s.updateDPTPControllerManagerSecret,
-		s.updateRehearseSecret,
 		s.updateGithubLdapUserGroupCreatorSecret,
 		s.updatePromotedImageGovernor,
 		s.updateClusterDisplay,
@@ -282,23 +281,6 @@ func (s *ciSecretBootstrapStep) updateDPTPControllerManagerSecret(c *secretboots
 	}
 	keyAndField := ServiceAccountKubeconfigPath(DPTPControllerManager, s.clusterInstall.ClusterName)
 	return s.updateSecretItemContext(c, DPTPControllerManager, string(api.ClusterAPPCI), keyAndField, secretbootstrap.ItemContext{
-		Field: keyAndField,
-		Item:  BuildUFarm,
-	})
-}
-
-func (s *ciSecretBootstrapStep) updateRehearseSecret(c *secretbootstrap.Config) error {
-	if *s.clusterInstall.Onboard.UseTokenFileInKubeconfig {
-		keyAndFieldToken := ServiceAccountTokenFile(CIOperator, s.clusterInstall.ClusterName)
-		if err := s.updateSecretItemContext(c, pjRehearse, string(api.ClusterBuild01), keyAndFieldToken, secretbootstrap.ItemContext{
-			Field: keyAndFieldToken,
-			Item:  BuildUFarm,
-		}); err != nil {
-			return err
-		}
-	}
-	keyAndField := ServiceAccountKubeconfigPath(CIOperator, s.clusterInstall.ClusterName)
-	return s.updateSecretItemContext(c, pjRehearse, string(api.ClusterBuild01), keyAndField, secretbootstrap.ItemContext{
 		Field: keyAndField,
 		Item:  BuildUFarm,
 	})

--- a/pkg/clusterinit/onboard/multiarchbuildercontroller_test.go
+++ b/pkg/clusterinit/onboard/multiarchbuildercontroller_test.go
@@ -2,13 +2,9 @@ package onboard
 
 import (
 	"context"
-	"io/fs"
-	"path"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/clusterinit/clusterinstall"
@@ -19,7 +15,7 @@ func TestMultiarchBuilderControllerManifests(t *testing.T) {
 	for _, tt := range []struct {
 		name          string
 		ci            clusterinstall.ClusterInstall
-		wantManifests []string
+		wantManifests map[string][]interface{}
 		wantErr       error
 	}{
 		{
@@ -28,97 +24,132 @@ func TestMultiarchBuilderControllerManifests(t *testing.T) {
 				ClusterName: "build99",
 				Onboard:     clusterinstall.Onboard{ReleaseRepo: releaseRepo},
 			},
-			wantManifests: []string{
-				`apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: mabc-updater
-rules:
-- apiGroups:
-  - ci.openshift.io
-  resources:
-  - multiarchbuildconfigs
-  verbs:
-  - '*'
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: mabc-updater
-  namespace: ci
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: self-provisioner-mabc-updater
-  namespace: ci
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: mabc-updater
-subjects:
-- kind: ServiceAccount
-  name: mabc-updater
-  namespace: ci
-`,
-				`apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: multi-arch-builder-controller
-  namespace: ci
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: multi-arch-builder-controller
-  template:
-    metadata:
-      labels:
-        app: multi-arch-builder-controller
-    spec:
-      containers:
-      - args:
-        - --dry-run=false
-        image: quay-proxy.ci.openshift.org/openshift/ci:ci_multi-arch-builder-controller_latest
-        imagePullPolicy: Always
-        name: multi-arch-builder-controller
-        resources:
-          limits:
-            cpu: 100m
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        volumeMounts:
-        - mountPath: /.docker/config.json
-          name: docker-config
-          readOnly: true
-          subPath: .dockerconfigjson
-      nodeSelector:
-        kubernetes.io/arch: amd64
-      serviceAccountName: multi-arch-builder-controller
-      volumes:
-      - name: docker-config
-        secret:
-          secretName: multi-arch-builder-controller-build99-registry-credentials
-`,
+			wantManifests: map[string][]interface{}{
+				"/release/repo/clusters/build-clusters/build99/multi-arch-builder-controller/000_mabc-updater_rbac.yaml": {
+					map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "mabc-updater",
+						},
+						"rules": []interface{}{
+							map[string]interface{}{
+								"apiGroups": []interface{}{
+									"ci.openshift.io",
+								},
+								"resources": []interface{}{
+									"multiarchbuildconfigs",
+								},
+								"verbs": []interface{}{
+									"*",
+								},
+							},
+						},
+						"apiVersion": "rbac.authorization.k8s.io/v1",
+						"kind":       "ClusterRole",
+					},
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "ServiceAccount",
+						"metadata": map[string]interface{}{
+							"name":      "mabc-updater",
+							"namespace": "ci",
+						},
+					},
+					map[string]interface{}{
+						"roleRef": map[string]interface{}{
+							"apiGroup": "rbac.authorization.k8s.io",
+							"kind":     "ClusterRole",
+							"name":     "mabc-updater",
+						},
+						"subjects": []interface{}{
+							map[string]interface{}{
+								"kind":      "ServiceAccount",
+								"name":      "mabc-updater",
+								"namespace": "ci",
+							},
+						},
+						"apiVersion": "rbac.authorization.k8s.io/v1",
+						"kind":       "ClusterRoleBinding",
+						"metadata": map[string]interface{}{
+							"name":      "self-provisioner-mabc-updater",
+							"namespace": "ci",
+						},
+					},
+				},
+				"/release/repo/clusters/build-clusters/build99/multi-arch-builder-controller/100_deploy.yaml": {
+					map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"metadata": map[string]interface{}{
+							"name":      "multi-arch-builder-controller",
+							"namespace": "ci",
+						},
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"app": "multi-arch-builder-controller",
+									},
+								},
+								"spec": map[string]interface{}{
+									"serviceAccountName": "multi-arch-builder-controller",
+									"volumes": []interface{}{
+										map[string]interface{}{
+											"name": "docker-config",
+											"secret": map[string]interface{}{
+												"secretName": "multi-arch-builder-controller-build99-registry-credentials",
+											},
+										},
+									},
+									"containers": []interface{}{
+										map[string]interface{}{
+											"args": []interface{}{
+												"--dry-run=false",
+											},
+											"image":           "quay-proxy.ci.openshift.org/openshift/ci:ci_multi-arch-builder-controller_latest",
+											"imagePullPolicy": "Always",
+											"name":            "multi-arch-builder-controller",
+											"resources": map[string]interface{}{
+												"limits": map[string]interface{}{
+													"cpu":    "100m",
+													"memory": "128Mi",
+												},
+												"requests": map[string]interface{}{
+													"cpu":    "100m",
+													"memory": "128Mi",
+												},
+											},
+											"volumeMounts": []interface{}{
+												map[string]interface{}{
+													"mountPath": "/.docker/config.json",
+													"name":      "docker-config",
+													"readOnly":  true,
+													"subPath":   ".dockerconfigjson",
+												},
+											},
+										},
+									},
+									"nodeSelector": map[string]interface{}{
+										"kubernetes.io/arch": "amd64",
+									},
+								},
+							},
+							"replicas": 1,
+							"selector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									"app": "multi-arch-builder-controller",
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			step := NewMultiarchBuilderControllerStep(logrus.NewEntry(logrus.StandardLogger()), &tt.ci)
+			step := NewMultiarchBuilderControllerGenerator(&tt.ci)
 
-			manifests := make([]string, 0)
-			writeManifestsPaths := make([]string, 0)
-			step.writeManifest = func(name string, data []byte, _ fs.FileMode) error {
-				writeManifestsPaths = append(writeManifestsPaths, name)
-				manifests = append(manifests, string(data))
-				return nil
-			}
-			step.mkdirAll = func(path string, perm fs.FileMode) error { return nil }
-
-			err := step.Run(context.TODO())
+			manifests, err := step.Generate(context.TODO(), logrus.NewEntry(logrus.StandardLogger()))
 
 			if err != nil && tt.wantErr == nil {
 				t.Fatalf("want err nil but got: %v", err)
@@ -133,17 +164,7 @@ spec:
 				return
 			}
 
-			sortStr := func(a, b string) bool { return strings.Compare(a, b) <= 0 }
-
-			wantManifestsPath := []string{
-				path.Join(MultiarchBuilderControllerManifestsPath(releaseRepo, tt.ci.ClusterName), "000_mabc-updater_rbac.yaml"),
-				path.Join(MultiarchBuilderControllerManifestsPath(releaseRepo, tt.ci.ClusterName), "100_deploy.yaml"),
-			}
-			if diff := cmp.Diff(wantManifestsPath, writeManifestsPaths, cmpopts.SortSlices(sortStr)); diff != "" {
-				t.Errorf("manifest paths differs:\n%s", diff)
-			}
-
-			if diff := cmp.Diff(tt.wantManifests, manifests, cmpopts.SortSlices(sortStr)); diff != "" {
+			if diff := cmp.Diff(tt.wantManifests, manifests); diff != "" {
 				t.Errorf("manifests differs:\n%s", diff)
 			}
 		})

--- a/pkg/clusterinit/onboard/quayiopullthroughcache.go
+++ b/pkg/clusterinit/onboard/quayiopullthroughcache.go
@@ -3,59 +3,54 @@ package onboard
 import (
 	"context"
 	"fmt"
-	"io/fs"
-	"os"
 
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
 
 	imageregistryv1 "github.com/openshift/api/imageregistry/v1"
 
 	"github.com/openshift/ci-tools/pkg/clusterinit/clusterinstall"
+	cinitmanifest "github.com/openshift/ci-tools/pkg/clusterinit/manifest"
+	cinittypes "github.com/openshift/ci-tools/pkg/clusterinit/types"
 )
 
 type quayioPullThroughCacheStep struct {
-	log            *logrus.Entry
 	clusterInstall *clusterinstall.ClusterInstall
 	kubeClient     ctrlruntimeclient.Client
-	writeTemplate  func(name string, data []byte, perm fs.FileMode) error
 }
 
 func (s *quayioPullThroughCacheStep) Name() string {
 	return "quayio-pull-through-cache"
 }
 
-func (s *quayioPullThroughCacheStep) Run(ctx context.Context) error {
-	log := s.log.WithField("step", s.Name())
+func (s *quayioPullThroughCacheStep) Skip() cinittypes.SkipStep {
+	return s.clusterInstall.Onboard.QuayioPullThroughCache.SkipStep
+}
 
+func (s *quayioPullThroughCacheStep) ExcludedManifests() cinittypes.ExcludeManifest {
+	return s.clusterInstall.Onboard.QuayioPullThroughCache.ExcludeManifest
+}
+
+func (s *quayioPullThroughCacheStep) Patches() []cinitmanifest.Patch {
+	return s.clusterInstall.Onboard.QuayioPullThroughCache.Patches
+}
+
+func (s *quayioPullThroughCacheStep) Generate(ctx context.Context, log *logrus.Entry) (map[string][]interface{}, error) {
 	mirrorURI, err := s.mirrorURI(ctx)
 	if err != nil {
-		return fmt.Errorf("mirror uri: %w", err)
+		return nil, fmt.Errorf("mirror uri: %w", err)
 	}
 
 	manifest := generatePullThroughCacheManifest(mirrorURI)
-	manifestMarshaled, err := yaml.Marshal(manifest)
-	if err != nil {
-		return fmt.Errorf("marshal: %w", err)
-	}
-
 	outputPath := QuayioPullThroughCacheManifestPath(s.clusterInstall.Onboard.ReleaseRepo, s.clusterInstall.ClusterName)
-	if err := s.writeTemplate(outputPath, manifestMarshaled, 0644); err != nil {
-		return fmt.Errorf("write template %s: %w", outputPath, err)
-	}
 
 	log.WithField("template", outputPath).Info("quay.io pull through cache generated")
-	return nil
+	return map[string][]interface{}{outputPath: {manifest}}, nil
 }
 
 func (s *quayioPullThroughCacheStep) mirrorURI(ctx context.Context) (string, error) {
-	if s.clusterInstall.Onboard.QuayioPullThroughCache.MirrorURI != "" {
-		return s.clusterInstall.Onboard.QuayioPullThroughCache.MirrorURI, nil
-	}
-
 	imageRegConfig := imageregistryv1.Config{}
 	if err := s.kubeClient.Get(ctx, types.NamespacedName{Namespace: "openshift-image-registry", Name: "cluster"}, &imageRegConfig); err != nil {
 		return "", fmt.Errorf("get cluster config: %w", err)
@@ -87,11 +82,9 @@ func generatePullThroughCacheManifest(mirror string) map[string]interface{} {
 	}
 }
 
-func NewQuayioPullThroughCacheStep(log *logrus.Entry, clusterInstall *clusterinstall.ClusterInstall, kubeClient ctrlruntimeclient.Client) *quayioPullThroughCacheStep {
+func NewQuayioPullThroughCacheStep(clusterInstall *clusterinstall.ClusterInstall, kubeClient ctrlruntimeclient.Client) *quayioPullThroughCacheStep {
 	return &quayioPullThroughCacheStep{
-		log:            log,
 		clusterInstall: clusterInstall,
-		writeTemplate:  os.WriteFile,
 		kubeClient:     kubeClient,
 	}
 }

--- a/pkg/clusterinit/onboard/quayiopullthroughcache_test.go
+++ b/pkg/clusterinit/onboard/quayiopullthroughcache_test.go
@@ -46,7 +46,7 @@ func TestUpdateQuayioPullThroughCache(t *testing.T) {
 					Storage: imageregistryv1.ImageRegistryConfigStorage{
 						S3: &imageregistryv1.ImageRegistryConfigStorageS3{}}}},
 			wantManifests: map[string][]interface{}{
-				"/release/repo/clusters/build-clusters/build99/assets/quayio-pull-through-cache-icsp.yaml": []interface{}{
+				"/release/repo/clusters/build-clusters/build99/assets/quayio-pull-through-cache-icsp.yaml": {
 					map[string]interface{}{
 						"apiVersion": "operator.openshift.io/v1alpha1",
 						"kind":       "ImageContentSourcePolicy",
@@ -86,7 +86,7 @@ func TestUpdateQuayioPullThroughCache(t *testing.T) {
 					Storage: imageregistryv1.ImageRegistryConfigStorage{
 						GCS: &imageregistryv1.ImageRegistryConfigStorageGCS{}}}},
 			wantManifests: map[string][]interface{}{
-				"/release/repo/clusters/build-clusters/build99/assets/quayio-pull-through-cache-icsp.yaml": []interface{}{
+				"/release/repo/clusters/build-clusters/build99/assets/quayio-pull-through-cache-icsp.yaml": {
 					map[string]interface{}{
 						"apiVersion": "operator.openshift.io/v1alpha1",
 						"kind":       "ImageContentSourcePolicy",

--- a/test/integration/cluster-init/update-build99/expected/core-services/ci-secret-bootstrap/_config.yaml
+++ b/test/integration/cluster-init/update-build99/expected/core-services/ci-secret-bootstrap/_config.yaml
@@ -184,12 +184,6 @@ secret_configs:
     sa.ci-operator.build01.config:
       field: sa.ci-operator.build01.config
       item: build_farm
-    sa.ci-operator.build99.config:
-      field: sa.ci-operator.build99.config
-      item: build_farm
-    sa.ci-operator.build99.token.txt:
-      field: sa.ci-operator.build99.token.txt
-      item: build_farm
     sa.pj-rehearse.app.ci.config:
       field: sa.pj-rehearse.app.ci.config
       item: build_farm


### PR DESCRIPTION
Two changes:
The `struct`s that generate the following manifests:
- `Certificate`
- `Dex`
- `MultiarchBuilderController`
- `OAuth`
- `ImageContentSourcePolicy`

have been refactored into `*Generator`s, so that they can be used, and enhanced by  the `manifestGeneratorStep`.

Secrets for `pj-rehearse` are not generated anymore, see https://github.com/openshift/release/pull/60440.