### PR TITLE
check-gh-automation: move `ignore` at the right place

### DIFF
--- a/cmd/check-gh-automation/main.go
+++ b/cmd/check-gh-automation/main.go
@@ -167,6 +167,11 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 			"repo": repo,
 		})
 
+		if ignore.Has(org) || ignore.Has(orgRepo) {
+			repoLogger.Infof("skipping ignored repo")
+			continue
+		}
+
 		fullRepo, err := client.GetRepo(org, repo)
 		if err != nil {
 			logger.Errorf("Error obtaining repository from github: %s/%s: %v", org, repo, err)
@@ -191,11 +196,6 @@ func checkRepos(repos []string, bots []string, appName string, ignore sets.Set[s
 			}
 		} else {
 			logger.Warnf("No release repository path was given, ignoring automated branching verification.")
-		}
-
-		if ignore.Has(org) || ignore.Has(orgRepo) {
-			repoLogger.Infof("skipping ignored repo")
-			continue
 		}
 
 		var missingBots []string


### PR DESCRIPTION
I suppose that:
```golang
		if ignore.Has(org) || ignore.Has(orgRepo) {
			repoLogger.Infof("skipping ignored repo")
			continue
		}
```
should stay at the top of the `for` as it was intended [here](https://github.com/openshift/ci-tools/pull/2847/files).
Hopefully this will solve the problems we are facing [here](https://redhat-internal.slack.com/archives/CBN38N3MW/p1736933034912959).

/cc @smg247 