### PR TITLE
Fix lint errors from golangci-lint v1.63.4

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -322,8 +322,8 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 	if err != nil {
 		message := "destination repository does not exist or we cannot access it"
 		if g.failOnNonexistentDst {
-			logger.Errorf(message)
-			return fmt.Errorf(message)
+			logger.Errorf("%s", message)
+			return fmt.Errorf("%s", message)
 		}
 
 		logger.Warn(message)
@@ -395,7 +395,7 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 		if !maybeTooShallow(out) || err != nil {
 			message := "failed to push to destination, no retry possible"
 			logger.WithError(err).WithField("exit-code", exitCode).WithField("output", out).Error(message)
-			return nil, fmt.Errorf(message)
+			return nil, fmt.Errorf("%s", message)
 		}
 
 		if depth == unshallow {
@@ -410,7 +410,7 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 		if shallowErr != nil || shallowExitCode != 0 {
 			message := "failed to push to destination, no retry possible (cannot determine whether our git repo is shallow)"
 			logger.WithError(shallowErr).WithField("exit-code", shallowExitCode).WithField("output", shallowOut).Error(message)
-			return nil, fmt.Errorf(message)
+			return nil, fmt.Errorf("%s", message)
 		}
 
 		switch strings.TrimSpace(shallowOut) {
@@ -427,7 +427,7 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 			message := "failed to push to destination, no retry possible (cannot determine whether our git repo is shallow)"
 			logger.Error(message)
 			logger.Error("`rev-parse --is-shallow-repo` likely not supported by used git")
-			return nil, fmt.Errorf(message)
+			return nil, fmt.Errorf("%s", message)
 		}
 	}
 

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -262,7 +262,7 @@ func TestInjectPrivateMergeType(t *testing.T) {
 		t.Run(tc.id, func(t *testing.T) {
 			injectPrivateMergeType(tc.tideMergeTypes, orgRepos)
 			if !reflect.DeepEqual(tc.tideMergeTypes, tc.expected) {
-				t.Fatalf(cmp.Diff(tc.tideMergeTypes, tc.expected))
+				t.Fatalf("%s", cmp.Diff(tc.tideMergeTypes, tc.expected))
 			}
 		})
 	}

--- a/cmd/publicize/server_test.go
+++ b/cmd/publicize/server_test.go
@@ -169,7 +169,7 @@ func TestCheckPrerequisites(t *testing.T) {
 			actualErr := serv.checkPrerequisites(logrus.WithField("id", tc.id), fc.PullRequests[1111], ice)
 
 			if !reflect.DeepEqual(actualErr, tc.expectedError) {
-				t.Fatalf(cmp.Diff(actualErr.Error(), tc.expectedError.Error()))
+				t.Fatalf("%s", cmp.Diff(actualErr.Error(), tc.expectedError.Error()))
 			}
 		})
 	}

--- a/pkg/backporter/backporter.go
+++ b/pkg/backporter/backporter.go
@@ -713,7 +713,7 @@ func CreateCloneHandler(client bugzilla.Client, sortedTargetReleases []string, m
 		allTargetVersions := sets.New[string](sortedTargetReleases...)
 		if !allTargetVersions.Has(req.FormValue("release")) {
 			absentReleaseErrMsg := fmt.Sprintf("invalid argument - %s is not a valid TargetRelease, must be one of %v", req.FormValue("release"), sets.List(allTargetVersions))
-			handleError(w, fmt.Errorf(absentReleaseErrMsg), absentReleaseErrMsg, http.StatusBadRequest, endpoint, bugID, m)
+			handleError(w, fmt.Errorf("%s", absentReleaseErrMsg), absentReleaseErrMsg, http.StatusBadRequest, endpoint, bugID, m)
 			return
 		}
 
@@ -783,7 +783,7 @@ func CreateCloneHandler(client bugzilla.Client, sortedTargetReleases []string, m
 		}
 		if targetRelease >= len(descMajorMinorRelease) {
 			errMsg := "failed to determine source while creating clone"
-			handleError(w, fmt.Errorf(errMsg), errMsg, http.StatusInternalServerError, endpoint, bugID, m)
+			handleError(w, fmt.Errorf("%s", errMsg), errMsg, http.StatusInternalServerError, endpoint, bugID, m)
 			return
 		}
 		var newClones []string

--- a/pkg/diffs/diffs_test.go
+++ b/pkg/diffs/diffs_test.go
@@ -421,7 +421,7 @@ func TestGetChangedPresubmits(t *testing.T) {
 			before, after := testCase.configGenerator(t)
 			p := GetChangedPresubmits(before, after, logrus.NewEntry(logrus.New()))
 			if !equality.Semantic.DeepEqual(p, testCase.expected) {
-				t.Fatalf(cmp.Diff(testCase.expected["org/repo"], p["org/repo"], ignoreUnexported))
+				t.Fatalf("%s", cmp.Diff(testCase.expected["org/repo"], p["org/repo"], ignoreUnexported))
 			}
 		})
 	}
@@ -947,7 +947,7 @@ func TestGetChangedPeriodics(t *testing.T) {
 			before, after := testCase.configGenerator(t)
 			p := GetChangedPeriodics(before, after, logrus.NewEntry(logrus.New()))
 			if !reflect.DeepEqual(testCase.expected, p) {
-				t.Fatalf(cmp.Diff(testCase.expected, p, ignoreUnexported))
+				t.Fatalf("%s", cmp.Diff(testCase.expected, p, ignoreUnexported))
 			}
 		})
 	}

--- a/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobruntestcaseanalyzer/analyzer_test.go
@@ -61,12 +61,12 @@ func TestGetJobs(t *testing.T) {
 				t.Fatalf("%s flag set parse returned error %#v", name, err)
 			}
 
-			if f.ExcludeJobNames != nil && len(f.ExcludeJobNames) > 0 {
+			if len(f.ExcludeJobNames) > 0 {
 				jobGetter.excludeJobNames = sets.Set[string]{}
 				jobGetter.excludeJobNames.Insert(f.ExcludeJobNames...)
 			}
 
-			if f.IncludeJobNames != nil && len(f.IncludeJobNames) > 0 {
+			if len(f.IncludeJobNames) > 0 {
 				jobGetter.includeJobNames = sets.Set[string]{}
 				jobGetter.includeJobNames.Insert(f.IncludeJobNames...)
 			}

--- a/pkg/results/report.go
+++ b/pkg/results/report.go
@@ -162,7 +162,7 @@ func (r *reporter) report(request Request) {
 		reportMsg = fmt.Sprintf("Reporting job state '%s' with reason '%s'", request.State, request.Reason)
 	}
 
-	logrus.Infof(reportMsg)
+	logrus.Infof("%s", reportMsg)
 	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/result", r.address), bytes.NewReader(data))
 	if err != nil {
 		logrus.Tracef("could not create report request: %v", err)

--- a/pkg/retester/retester_test.go
+++ b/pkg/retester/retester_test.go
@@ -604,7 +604,7 @@ func TestSaveS3BackoffCache(t *testing.T) {
 	sampleErrorMsg := "some AWS error"
 	svcFaulty := &mockS3Client{}
 	svcFaulty.PutObjectFunc = func(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
-		return &s3.PutObjectOutput{}, fmt.Errorf(sampleErrorMsg)
+		return &s3.PutObjectOutput{}, fmt.Errorf("%s", sampleErrorMsg)
 	}
 
 	testCases := []struct {
@@ -707,7 +707,7 @@ func TestLoadFromAwsNow(t *testing.T) {
 	faultyMockClient := &mockS3Client{}
 	sampleErrorMsg := "some AWS error"
 	faultyMockClient.GetObjectFunc = func(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
-		return nil, fmt.Errorf(sampleErrorMsg)
+		return nil, fmt.Errorf("%s", sampleErrorMsg)
 	}
 
 	mockClientForNoFile := &mockS3Client{}

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -82,7 +82,7 @@ func (s *multiStageTestStep) generatePods(
 	for _, step := range steps {
 		name := fmt.Sprintf("%s-%s", s.name, step.As)
 		if o := step.OptionalOnSuccess; o != nil && *o && s.flags&allowSkipOnSuccess != 0 && s.flags&hasPrevErrs == 0 {
-			logrus.Infof(fmt.Sprintf("Skipping optional step %s", name))
+			logrus.Infof("Skipping optional step %s", name)
 			continue
 		}
 		image := step.From

--- a/pkg/steps/run_test.go
+++ b/pkg/steps/run_test.go
@@ -313,7 +313,7 @@ func TestStepsRun(t *testing.T) {
 			sort.Strings(actualErrorsString)
 
 			if !reflect.DeepEqual(expectedErrorsString, actualErrorsString) {
-				t.Fatalf(cmp.Diff(expectedErrorsString, actualErrorsString))
+				t.Fatalf("%s", cmp.Diff(expectedErrorsString, actualErrorsString))
 			}
 
 			if !tc.cancelled {

--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -674,7 +674,7 @@ func waitForBuild(
 			// This second load happens much later and must look at the latest
 			// version of the object.
 			if err := checkPending(ctx, podClient, ret.Load(), timeout, time.Now()); err != nil {
-				logrus.Infof(err.Error())
+				logrus.Infof("%s", err.Error())
 				return err
 			}
 		}

--- a/pkg/testhelper/accessory.go
+++ b/pkg/testhelper/accessory.go
@@ -77,7 +77,7 @@ func (t *T) Fatalf(format string, args ...interface{}) {
 }
 
 func (t *T) Fatal(args ...interface{}) {
-	t.fatals <- fmt.Errorf(fmt.Sprintln(args...))
+	t.fatals <- fmt.Errorf("%s", fmt.Sprintln(args...))
 }
 
 // Wait receives data from producer threads and forwards it

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -444,7 +444,7 @@ func verifyClusterProfileOwnership(profile api.ClusterProfileDetails, m *api.Met
 	if m == nil || m.Org == "" {
 		return fmt.Errorf("can't do ownership check, metadata not defined")
 	}
-	if profile.Owners == nil || len(profile.Owners) == 0 {
+	if len(profile.Owners) == 0 {
 		return nil
 	}
 	for _, owner := range profile.Owners {
@@ -462,7 +462,7 @@ func verifyClusterClaimOwnership(claim api.ClusterClaimDetails, m *api.Metadata)
 	if m == nil || m.Org == "" {
 		return fmt.Errorf("can't do ownership check, metadata not defined")
 	}
-	if claim.Owners == nil || len(claim.Owners) == 0 {
+	if len(claim.Owners) == 0 {
 		return nil
 	}
 	for _, owner := range claim.Owners {


### PR DESCRIPTION
Addressing errors that are showing up [here](https://github.com/openshift/release/pull/60836).
The vast majority of the adjustments deal with bad formatted strings.