### PR TITLE
Update Golang v1.23.0

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   namespace: ci
   name: ci-tools-build-root
-  tag: "1.22"
+  tag: "1.23"

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ update-vendor:
 		-e GO111MODULE=on \
 		-e GOPROXY=https://proxy.golang.org \
 		-e GOCACHE=/tmp/go-build-cache \
-		registry.ci.openshift.org/openshift/release:golang-1.21 \
+		registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.23-openshift-4.19 \
 		/bin/bash -c "go mod tidy && go mod vendor"
 .PHONY: update-vendor
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ci-tools
 
-go 1.22.4
+go 1.23
 
 // Forked version that disables diff trimming
 replace github.com/google/go-cmp => github.com/alvaroaleman/go-cmp v0.5.7-0.20210615160450-f8688cd5aaa0

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -29,6 +29,6 @@ else
   $DOCKER run --rm \
     --volume "${PWD}:/go/src/github.com/openshift/ci-tools:z" \
     --workdir /go/src/github.com/openshift/ci-tools \
-    docker.io/golangci/golangci-lint:v1.59.0 \
+    docker.io/golangci/golangci-lint:v1.63.4 \
     golangci-lint run "$GOLANGCI_LINT_ARGS"
 fi


### PR DESCRIPTION
As per title. Some required PRs that have already benn merged:
- https://github.com/openshift/release/pull/60836
- https://github.com/openshift/release/pull/60829

The new build root exists already:
```sh
$ appci -n ci get istag/ci-tools-build-root:1.23 -o name
imagestreamtag.image.openshift.io/ci-tools-build-root:1.23
```