### PR TITLE
tide-config-manager: replace bugzilla/valid-bug with jira/valid-bug

### DIFF
--- a/cmd/branchingconfigmanagers/tide-config-manager/main.go
+++ b/cmd/branchingconfigmanagers/tide-config-manager/main.go
@@ -40,7 +40,7 @@ const (
 	qeApproved             = "qe-approved"
 	docsApproved           = "docs-approved"
 	pxApproved             = "px-approved"
-	validBug               = "bugzilla/valid-bug"
+	validBug               = "jira/valid-bug"
 	release                = "release-"
 	openshift              = "openshift-"
 	mainBranch             = "main"

--- a/cmd/determinize-prow-config/main_test.go
+++ b/cmd/determinize-prow-config/main_test.go
@@ -165,7 +165,7 @@ func TestShardProwConfig(t *testing.T) {
 		{
 			name: "Tide queries get sharded",
 			in: &config.ProwConfig{Tide: config.Tide{TideGitHubConfig: config.TideGitHubConfig{Queries: config.TideQueries{
-				{Orgs: []string{"openshift", "openshift-priv"}, Repos: []string{"kube-reporting/ghostunnel", "kube-reporting/presto"}, Labels: []string{"lgtm", "approved", "bugzilla/valid-bug"}},
+				{Orgs: []string{"openshift", "openshift-priv"}, Repos: []string{"kube-reporting/ghostunnel", "kube-reporting/presto"}, Labels: []string{"lgtm", "approved", "jira/valid-bug"}},
 				{Orgs: []string{"codeready-toolchain", "integr8ly"}, Repos: []string{"containers/buildah", "containers/common"}, Labels: []string{"lgtm", "approved"}},
 				{Orgs: []string{"integr8ly"}, Author: "openshift-bot"},
 				{Repos: []string{"openshift/release"}, Author: "openshift-bot"},
@@ -211,7 +211,7 @@ func TestShardProwConfig(t *testing.T) {
   - labels:
     - lgtm
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     repos:
     - kube-reporting/ghostunnel
 `,
@@ -220,7 +220,7 @@ func TestShardProwConfig(t *testing.T) {
   - labels:
     - lgtm
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     repos:
     - kube-reporting/presto
 `,
@@ -229,7 +229,7 @@ func TestShardProwConfig(t *testing.T) {
   - labels:
     - lgtm
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     orgs:
     - openshift-priv
 `,
@@ -238,7 +238,7 @@ func TestShardProwConfig(t *testing.T) {
   - labels:
     - lgtm
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     orgs:
     - openshift
 `,

--- a/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/_config.yaml
@@ -57,15 +57,15 @@ tide:
     - release-4.4
     labels:
     - approved
-    - bugzilla/valid-bug
     - cherry-pick-approved
+    - jira/valid-bug
     - lgtm
     missingLabels:
-    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/unsharded-b
@@ -80,11 +80,11 @@ tide:
     - approved
     - lgtm
     missingLabels:
-    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/unsharded-a

--- a/test/integration/repo-init/expected/core-services/prow/02_config/openshift/ci-tools/_prowconfig.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/openshift/ci-tools/_prowconfig.yaml
@@ -5,10 +5,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/ci-tools

--- a/test/integration/repo-init/expected/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
@@ -25,15 +25,15 @@ tide:
     labels:
     - approved
     - backport-risk-assessed
-    - bugzilla/valid-bug
     - cherry-pick-approved
+    - jira/valid-bug
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator
@@ -42,15 +42,15 @@ tide:
     - release-4.11
     labels:
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     - lgtm
     - staff-eng-approved
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator
@@ -62,10 +62,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - keep-main-query-separate
     - needs-rebase
     repos:
@@ -104,10 +104,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator

--- a/test/integration/repo-init/expected/core-services/prow/02_config/org/other/_prowconfig.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/org/other/_prowconfig.yaml
@@ -5,10 +5,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - org/other

--- a/test/integration/repo-init/expected/core-services/prow/02_config/org/repo/_prowconfig.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/org/repo/_prowconfig.yaml
@@ -25,15 +25,15 @@ tide:
     labels:
     - approved
     - backport-risk-assessed
-    - bugzilla/valid-bug
     - cherry-pick-approved
+    - jira/valid-bug
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - org/repo
@@ -42,15 +42,15 @@ tide:
     - release-4.11
     labels:
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     - lgtm
     - staff-eng-approved
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - org/repo
@@ -62,10 +62,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - keep-main-query-separate
     - needs-rebase
     repos:
@@ -104,10 +104,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - org/repo

--- a/test/integration/repo-init/expected/core-services/prow/02_config/org/third/_prowconfig.yaml
+++ b/test/integration/repo-init/expected/core-services/prow/02_config/org/third/_prowconfig.yaml
@@ -5,10 +5,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - org/third

--- a/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/_config.yaml
@@ -57,15 +57,15 @@ tide:
     - release-4.4
     labels:
     - approved
-    - bugzilla/valid-bug
     - cherry-pick-approved
+    - jira/valid-bug
     - lgtm
     missingLabels:
-    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/unsharded-b
@@ -80,11 +80,11 @@ tide:
     - approved
     - lgtm
     missingLabels:
-    - bugzilla/invalid-bug
     - do-not-merge/blocked-paths
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/unsharded-a

--- a/test/integration/repo-init/input/core-services/prow/02_config/openshift/ci-tools/_prowconfig.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/openshift/ci-tools/_prowconfig.yaml
@@ -5,10 +5,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/ci-tools

--- a/test/integration/repo-init/input/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
+++ b/test/integration/repo-init/input/core-services/prow/02_config/openshift/cluster-version-operator/_prowconfig.yaml
@@ -25,15 +25,15 @@ tide:
     labels:
     - approved
     - backport-risk-assessed
-    - bugzilla/valid-bug
     - cherry-pick-approved
+    - jira/valid-bug
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator
@@ -42,15 +42,15 @@ tide:
     - release-4.11
     labels:
     - approved
-    - bugzilla/valid-bug
+    - jira/valid-bug
     - lgtm
     - staff-eng-approved
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator
@@ -62,10 +62,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - keep-main-query-separate
     - needs-rebase
     repos:
@@ -104,10 +104,10 @@ tide:
     - lgtm
     missingLabels:
     - backports/unvalidated-commits
-    - bugzilla/invalid-bug
     - do-not-merge/hold
     - do-not-merge/invalid-owners-file
     - do-not-merge/work-in-progress
+    - jira/invalid-bug
     - needs-rebase
     repos:
     - openshift/cluster-version-operator


### PR DESCRIPTION
We have some PR's from openshift-bot like https://github.com/openshift/csi-external-snapshotter/pull/172 that did not automatically merge because they are missing the `jira/valid-bug` label. The bot adds `bugzilla/valid-bug` but we no longer check that label in our [prow config](https://github.com/openshift/release/blob/3fc58d801c90cc49be50af02746b4cb0bc92296d/core-services/prow/02_config/openshift/csi-external-snapshotter/_prowconfig.yaml#L9).

This PR updates tide-config-manager to use `jira/valid-bug` and `jira/invalid-bug` instead of the bugzilla labels.
