### PR TITLE
`prpqr_reconciller`: temporarily remove the wait for the URL to be present

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -362,10 +362,6 @@ func (r *reconciler) triggerJobs(ctx context.Context,
 						return false, nil
 					}
 					return false, fmt.Errorf("getting prowJob failed: %w", err)
-				} else if retrievedJob.Status.URL == "" {
-					// There will be no URL yet if the job is still in the "Scheduling" state, we should try again until we have one
-					logger.Infof("no URL exists yet for job: %s", prowjob.Name)
-					return false, nil
 				}
 				return true, nil
 			}); err != nil {

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_url_not_found_in_created_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_url_not_found_in_created_job.yaml
@@ -1,5 +1,7 @@
 - metadata:
     creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
     name: prpqr-test
     namespace: test-namespace
     resourceVersion: "1000"
@@ -29,15 +31,13 @@
   status:
     conditions:
     - lastTransitionTime: "1970-01-01T00:00:00Z"
-      message: Jobs triggered with errors
-      reason: WithErrors
-      status: "False"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
       type: AllJobsTriggered
     jobs:
     - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
       prowJob: some-uuid
       status:
-        description: 'created job never appeared in cache: timed out waiting for the
-          condition'
         startTime: "1970-01-01T00:00:00Z"
-        state: error
+        state: triggered


### PR DESCRIPTION
There is reason to believe that this is causing jobs to be double triggered in some instances. I will remove this for a couple of days, and check if this problem is no longer occurring. If that is the case, I will figure out a different way to ensure the URL exists.