### PR TITLE
`multi-pr-plugin`: clarify error message that is bubbled up to the user

### DIFF
--- a/cmd/multi-pr-prow-plugin/server.go
+++ b/cmd/multi-pr-prow-plugin/server.go
@@ -376,7 +376,7 @@ func (s *server) generateProwJob(jr jobRun) (*prowv1.ProwJob, error) {
 		}
 	}
 	if primaryRef == nil {
-		return nil, fmt.Errorf("no ref for requested test included in command")
+		return nil, fmt.Errorf("No ref for requested test included in command. The org, repo, and branch containing the requested test need to be targeted by at least one of the included PRs.")
 	}
 
 	if err := s.prowConfigGetter.Defaulter().DefaultPeriodic(periodic); err != nil {

--- a/cmd/multi-pr-prow-plugin/server_test.go
+++ b/cmd/multi-pr-prow-plugin/server_test.go
@@ -939,7 +939,7 @@ func TestGenerateProwJob(t *testing.T) {
 					},
 				},
 			},
-			expectedError: errors.New("no ref for requested test included in command"),
+			expectedError: errors.New("No ref for requested test included in command. The org, repo, and branch containing the requested test need to be targeted by at least one of the included PRs."),
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This message ends up as a comment on the PR when this is hit. This only happens when the user has entered an invalid command, so we can provide more info about what was incorrect.