### PR TITLE
Avoid registry.access.redhat.com outage

### DIFF
--- a/cmd/ci-scheduling-webhook/mutation.go
+++ b/cmd/ci-scheduling-webhook/mutation.go
@@ -361,7 +361,7 @@ func mutatePod(w http.ResponseWriter, r *http.Request) {
 			delayInitContainer := []corev1.Container{
 				{
 					Name:  initContainerName,
-					Image: "registry.access.redhat.com/ubi8",
+					Image: "registry.redhat.io/ubi8",
 					Command: []string{
 						"/bin/sh",
 						"-c",


### PR DESCRIPTION
registry.access.redhat.com is returning 503s
inside and outside the clusters.