### PR TITLE
Prioritize `ci-operator.openshift.io/cluster` and `devices.kubevirt.io/kvm` labels when dispatching jobs

### DIFF
--- a/pkg/dispatcher/config.go
+++ b/pkg/dispatcher/config.go
@@ -154,6 +154,15 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 		return config.SSHBastion, false, nil
 	}
 	if jobBase.Labels != nil {
+		if _, ok := jobBase.Labels[api.KVMDeviceLabel]; ok && len(config.KVM) > 0 {
+			// Any deterministic distribution is fine for now.
+			// We could implement more effective distribution when we understand more about the jobs.
+			return config.KVM[len(filepath.Base(path))%len(config.KVM)], false, nil
+		}
+
+		if cluster, ok := jobBase.Labels[api.ClusterLabel]; ok {
+			return api.Cluster(cluster), false, nil
+		}
 
 		requiredCapabilities := extractRequiredCapabilities(jobBase.Labels)
 		if len(requiredCapabilities) > 0 {
@@ -188,15 +197,6 @@ func (config *Config) DetermineClusterForJob(jobBase prowconfig.JobBase, path st
 			// as in other places in this file, use this method to have basic deterministic distribution
 			return api.Cluster(matchingClusters[len(filepath.Base(path))%len(matchingClusters)]), false, nil
 
-		}
-
-		if _, ok := jobBase.Labels[api.KVMDeviceLabel]; ok && len(config.KVM) > 0 {
-			// Any deterministic distribution is fine for now.
-			// We could implement more effective distribution when we understand more about the jobs.
-			return config.KVM[len(filepath.Base(path))%len(config.KVM)], false, nil
-		}
-		if cluster, ok := jobBase.Labels[api.ClusterLabel]; ok {
-			return api.Cluster(cluster), false, nil
 		}
 	}
 

--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -550,6 +550,19 @@ func TestDetermineClusterForJob(t *testing.T) {
 			expectedCanBeRelocated: false,
 			expectedErr:            fmt.Errorf("job some-e2e-job can't be matched with any cluster using provided capabilities: arm64,vpn"),
 		},
+		{
+			name:   "cluster label has priority over capabilities",
+			config: &configWithBuildFarmWithJobsAndDetermineE2EByJob,
+			jobBase: config.JobBase{Agent: "kubernetes", Name: "some-e2e-job",
+				Labels: map[string]string{
+					"capability/vpn":                   "vpn",
+					"ci-operator.openshift.io/cluster": "build10"},
+			},
+			cm: ClusterMap{"build03": ClusterInfo{Provider: "aws", Capacity: 100, Capabilities: []string{"vpn"}},
+				"build10": ClusterInfo{Provider: "aws", Capacity: 100}},
+			expected:               "build10",
+			expectedCanBeRelocated: false,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This should hopefully fix an issue I noticed when trying to introduce `build11`, see https://github.com/openshift/release/pull/61175.

I will try to break the problem down here:
- `build11` added in [core-services/sanitize-prow-jobs/_clusters.yaml](https://github.com/openshift/release/blob/58bd51ba456d7cdc8b096c415589e1efbe55a69e/core-services/sanitize-prow-jobs/_clusters.yaml)
```yaml
aws:
  - name: build11
    capabilities:
    - arm64
    - vpn
```
- Run `make jobs` and notice that `sanitize-prow-jobs` assigns the wrong cluster to some presubmits in `o/ci-tools`.
In particular, let's take the following test from `ci-operator/config/openshift/ci-tools/openshift-ci-tools-master.yaml` as an example:
```yaml
tests:
- as: breaking-changes
  cluster: build10
  node_architecture: arm64
  optional: true
  steps:
    test:
    - as: breaking-changes
...
```
the test strictly requires `build10` but it gets assigned to `build09`, see `ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml`:
```yaml
presubmits:
  openshift/ci-tools:
  - agent: kubernetes
    always_run: true
    branches:
    - ^master$
    - ^master-
    cluster: build09
    context: ci/prow/breaking-changes
    decorate: true
    labels:
      capability/arm64: arm64
      ci-operator.openshift.io/cluster: build10
      ci.openshift.io/generator: prowgen
      pj-rehearse.openshift.io/can-be-rehearsed: "true"
...
```
Notice the mismatch between `cluster: build09` and `ci-operator.openshift.io/cluster: build10`
- Here is where the problem lies as the presubmit `pull-ci-openshift-release-master-generated-config` in `o/release` ultimately runs this command:
```sh
$ ci-operator-prowgen \
  --from-release-repo \
  --to-release-repo \
  --known-infra-file infra-build-farm-periodics.yaml \
  --known-infra-file infra-periodics.yaml \
  --known-infra-file infra-image-mirroring.yaml \
  --known-infra-file infra-periodics-origin-release-images.yaml
```
restoring the correct cluster `build10` and leading to a failure.

It seems that the problem disappears as soon as the label `ci-operator.openshift.io/cluster` (coming from the `cluster` stanza on the ci-operator config) has priority over the capabilities, when it comes to choose a cluster for a ProwJob.