### PR TITLE
Fix inject-cli for non-amd64 runs

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -512,8 +512,7 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 		// this line to pick appropriate oc version (i.e. oc.rhel9).
 		// Additionally, we need to check the existence of path because releases < 4.15 does not have oc.rhel8,
 		// and we fall back to old path due to backwards compatibility.
-		// In order to support multi arch oc, just change the arch path (i.e. /usr/share/openshift/linux_arm64/oc.rhel8).
-		Args: []string{"-c", fmt.Sprintf("if [[ -e /usr/share/openshift/linux_amd64/oc.rhel8 ]]; then /bin/cp /usr/share/openshift/linux_amd64/oc.rhel8 %s; else /bin/cp /usr/bin/oc %s; fi", filepath.Join(CliMountPath, "oc"), CliMountPath)},
+		Args: []string{"-c", fmt.Sprintf("ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); if [[ -e /usr/share/openshift/linux_${ARCH}/oc.rhel8 ]]; then /bin/cp /usr/share/openshift/linux_${ARCH}/oc.rhel8 %s; else /bin/cp /usr/share/openshift/linux_${ARCH}/oc %s; fi", filepath.Join(CliMountPath, "oc"), CliMountPath)},
 		VolumeMounts: []coreapi.VolumeMount{{
 			Name:      volumeName,
 			MountPath: CliMountPath,


### PR DESCRIPTION
When a pod using the `inject-cli` container is scheduled on non-amd64 nodes (e.g., multi-arch payload or arm64 payload), it should extract the proper `oc` binary based on the architecture of the node where the pod is running.