### PR TITLE
cluster-init: passthrough implements ManifestGenerator

### DIFF
--- a/cmd/cluster-init/cmd/onboard/config/config.go
+++ b/cmd/cluster-init/cmd/onboard/config/config.go
@@ -77,7 +77,7 @@ func runConfigSteps(ctx context.Context, log *logrus.Entry, update bool, cluster
 		onboard.NewMultiarchTuningOperatorStep(log, clusterInstall),
 		onboard.NewManifestGeneratorStep(log, onboard.NewImageRegistryGenerator(clusterInstall)),
 		onboard.NewManifestGeneratorStep(log, onboard.NewOpenshiftMonitoringGenerator(clusterInstall)),
-		onboard.NewPassthroughStep(log, clusterInstall),
+		onboard.NewManifestGeneratorStep(log, onboard.NewPassthroughGenerator(log, clusterInstall)),
 	}
 
 	if clusterInstall.CredentialsMode == operatorv1.CloudCredentialsModeManual {

--- a/pkg/clusterinit/clusterinstall/clusterinstall.go
+++ b/pkg/clusterinit/clusterinstall/clusterinstall.go
@@ -120,6 +120,7 @@ type ImageRegistry struct {
 type PassthroughManifest struct {
 	types.SkipStep
 	types.ExcludeManifest
+	Patches []manifest.Patch `json:"patches,omitempty"`
 }
 
 type CloudabilityAgent struct {

--- a/pkg/clusterinit/onboard/manifestgenerator.go
+++ b/pkg/clusterinit/onboard/manifestgenerator.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/yaml"
+
 	cinitmanifest "github.com/openshift/ci-tools/pkg/clusterinit/manifest"
 	"github.com/openshift/ci-tools/pkg/clusterinit/types"
-	"sigs.k8s.io/yaml"
 )
 
 // manifestGeneratorStep is struct of convenience that enhances a MenifestGenerator capabilities

--- a/pkg/clusterinit/onboard/manifestgenerator.go
+++ b/pkg/clusterinit/onboard/manifestgenerator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -46,19 +47,29 @@ func (w *manifestGeneratorStep) Run(ctx context.Context) error {
 	exclude := w.manifestGenerator.ExcludedManifests()
 	patches := w.manifestGenerator.Patches()
 
-	for path := range pathTomanifests {
-		manifests := pathTomanifests[path]
-		if g, skip := exclude.Filter(path); skip {
-			log.WithField("manifest", path).WithField("pattern", g).Info("exclude manifest")
+	for p := range pathTomanifests {
+		manifests := pathTomanifests[p]
+		if g, skip := exclude.Filter(p); skip {
+			log.WithField("manifest", p).WithField("pattern", g).Info("exclude manifest")
 			continue
 		}
 
-		manifestBytes, err := w.marshal(manifests, patches)
-		if err != nil {
-			return fmt.Errorf("marshal manifests: %w", err)
+		var manifestBytes []byte
+		if path.Ext(p) == ".yaml" {
+			if manifestBytes, err = w.marshalManifests(manifests, patches); err != nil {
+				return err
+			}
+		} else {
+			for i, m := range manifests {
+				bytes, ok := m.([]byte)
+				if !ok {
+					return fmt.Errorf("manifest %d at %s is not %T: %T", i, p, []byte{}, m)
+				}
+				manifestBytes = append(manifestBytes, bytes...)
+			}
 		}
 
-		dir := filepath.Dir(path)
+		dir := filepath.Dir(p)
 		if _, err := os.Stat(dir); err != nil {
 			if !os.IsNotExist(err) {
 				return fmt.Errorf("stat %s: %w", dir, err)
@@ -68,15 +79,15 @@ func (w *manifestGeneratorStep) Run(ctx context.Context) error {
 			}
 		}
 
-		if err := os.WriteFile(path, manifestBytes, 0644); err != nil {
-			return fmt.Errorf("write manifest %s: %w", path, err)
+		if err := os.WriteFile(p, manifestBytes, 0644); err != nil {
+			return fmt.Errorf("write manifest %s: %w", p, err)
 		}
 	}
 
 	return nil
 }
 
-func (w *manifestGeneratorStep) marshal(manifests []interface{}, patches []cinitmanifest.Patch) ([]byte, error) {
+func (w *manifestGeneratorStep) marshalManifests(manifests []interface{}, patches []cinitmanifest.Patch) ([]byte, error) {
 	manifestsBytes := make([][]byte, 0, len(manifests))
 
 	for _, manifest := range manifests {


### PR DESCRIPTION
As per title, the `passthrough` step now implements the `ManifestGenerator` interface.
This means this step is no longer being considered "different" from the others, and yaml patches can now be applied to static manifests as well (see `pkg/clusterinit/clusterinstall/clusterinstall.go`).