### PR TITLE
[DPTP-4310] Clean orgs array on repo-init

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -526,6 +526,9 @@ No additional "tide" queries will be added.
 
 	tideQueries := prowconfig.TideQueries(nil)
 	for _, q := range copyCatQueries {
+		// queries used as examples returns tailored configuration, we need to
+		// overwrite some of them to avoid undesirable values.
+		q.Orgs = []string{}
 		q.Repos = []string{prowconfig.OrgRepo{Org: config.Org, Repo: config.Repo}.String()}
 		tideQueries = append(tideQueries, q)
 	}


### PR DESCRIPTION
This is related to [DPTP-4310](https://issues.redhat.com/browse/DPTP-4310), since `Orgs` are just appended to an array, if there is a duplication in any `_prowconfig.yaml` it will not affect the new repo.

The `prowconfig.TideQueries[x].Orgs` will be cleaned almost the same way as `prowconfig.TideQueries[x].Repos`, avoiding unexpected organizations on generated configuration.

### Explanation:

Tide queries are "de-duplicated" - squashed/compressed is probably a better definition - after calling the `queries.ForRepo` line on https://github.com/openshift/ci-tools/blob/master/cmd/repo-init/main.go#L524 that will trigger `deduplicateTideQueries` on https://github.com/kubernetes-sigs/prow/blob/main/pkg/config/config.go#L3544-L3572.

The queries are squashed based on the following fields:
- Author
- ExcludedBranches
- IncludedBranches
- Labels
- MissingLabels
- Milestone
- ReviewApprovedRequired
- TenantIDs

This will lead to a specific query with a lot of `repos` and possible `orgs`  that match these fields, since this is a repository initiator tool, more and more repositories can include undesirable `orgs` on its configurations.

The `medik8s` organization is a common one because the fields match when a search for `org: openshift` and `repo: ci-tols` happens.