### PR TITLE
Update ci-scheduling-webhook for volumeSize based on workload types

### DIFF
--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-longtests-worker-aarch64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-longtests-worker-aarch64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-longtests-worker-amd64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 0
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-prowjobs-worker-aarch64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-prowjobs-worker-aarch64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-prowjobs-worker-amd64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 0
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 100
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-tests-worker-aarch64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-tests-worker-aarch64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/ci-scheduling-webhook/ci-tests-worker-amd64.yaml
@@ -32,7 +32,7 @@ spec:
               iops: 0
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -116,7 +116,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials
@@ -200,7 +200,7 @@ spec:
               iops: 5000
               kmsKey:
                 arn: ""
-              volumeSize: 800
+              volumeSize: 500
               volumeType: gp3
           credentialsSecret:
             name: aws-cloud-credentials


### PR DESCRIPTION
/cc @danilo-gemoli @openshift/test-platform 

https://github.com/openshift/release/pull/61640
