### PR TITLE
cluster-init: fix common_ocp and common_managed symlinks

### DIFF
--- a/hack/lib/integration.sh
+++ b/hack/lib/integration.sh
@@ -29,6 +29,16 @@ function os::integration::compare() {
 }
 readonly -f os::integration::compare
 
+# os::integration::compare_tree is like os::integration::compare but it also ensures that
+# the directories being compared have the same structure.
+function os::integration::compare_tree() {
+    local actual="$1"
+    local expected="$2"
+    os::integration::compare $@
+    os::cmd::expect_success "diff --suppress-common-lines -y <(cd ${actual}; find .|sort) <(cd ${expected}; find .|sort)"
+}
+readonly -f os::integration::compare_tree
+
 # os::integration::sanitize_prowjob_yaml replaces known variable fields in
 # Kubernetes YAML with static strings in order to make comparisons easy.
 function os::integration::sanitize_prowjob_yaml() {

--- a/pkg/clusterinit/onboard/commonsymlinkstep.go
+++ b/pkg/clusterinit/onboard/commonsymlinkstep.go
@@ -28,11 +28,11 @@ func (s *commonSymlinkStep) Run(ctx context.Context) error {
 	}
 	rr := s.clusterInstall.Onboard.ReleaseRepo
 	clusterName := s.clusterInstall.ClusterName
-	if err := symlink(CommonSymlinkPath(rr, clusterName), "../common_managed"); err != nil {
+	if err := symlink(CommonManagedSymlinkPath(rr, clusterName), "../common_managed"); err != nil {
 		return err
 	}
 	if s.clusterInstall.IsOCP() {
-		if err := symlink(CommonSymlinkPath(rr, clusterName), "../common_ocp"); err != nil {
+		if err := symlink(CommonOCPSymlinkPath(rr, clusterName), "../common_ocp"); err != nil {
 			return err
 		}
 	}

--- a/pkg/clusterinit/onboard/types.go
+++ b/pkg/clusterinit/onboard/types.go
@@ -100,6 +100,10 @@ func CommonManagedSymlinkPath(releaseRepo, clusterName string) string {
 	return filepath.Join(releaseRepo, "clusters", "build-clusters", clusterName, "common_managed")
 }
 
+func CommonOCPSymlinkPath(releaseRepo, clusterName string) string {
+	return filepath.Join(releaseRepo, "clusters", "build-clusters", clusterName, "common_ocp")
+}
+
 func MachineSetManifestsPath(releaseRepo, clusterName string) string {
 	return filepath.Join(releaseRepo, "clusters", "build-clusters", clusterName, "machineset")
 }

--- a/test/integration/cluster-init.sh
+++ b/test/integration/cluster-init.sh
@@ -86,6 +86,6 @@ export CITOOLS_REPLAYTRANSPORT_MODE="read"
 export CITOOLS_REPLAYTRANSPORT_TRACKER="${suite_dir}/build99-replay.yaml"
 
 os::cmd::expect_success "cluster-init onboard config update --release-repo=$actual_update --cluster-install-dir=$clusterinstall_dir --kubeconfig-dir=$kubeconfigs --kubeconfig-suffix=config"
-os::integration::compare "${actual_update}" "${expected_update}"
+os::integration::compare_tree "${actual_update}" "${expected_update}"
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
Fix the `common_ocp` and `common_managed` links being wired to the wrong name `common` instead of `commond_*`.
Furthermore, introduce the utility function `function os::integration::compare_tree` that recursively compares not only the content of two directories, but also their structure.
Assuming the following structure:
```sh
$ tree /tmp/compare/
/tmp/compare/
├── expected
│   └── a
│       ├── a1.txt
│       └── b
└── input
    └── a
        ├── a1.txt
        └── c

```
the outcome would be:
```sh
$ os::integration::compare_tree '/tmp/compare/input' '/tmp/compare/expected'
./a/c                                                         | ./a/b
```

In this way we make sure to catch missing directories from `cluster-init`.
