### PR TITLE
`prpqr_reconciller`: allow for the absence of any PRs in the PRPQR spec

### DIFF
--- a/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
+++ b/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
@@ -152,8 +152,8 @@ spec:
                     type: array
                 type: object
               pullRequests:
-                description: PullRequests specifies the code to be tested. Immutable
-                  and required.
+                description: PullRequests specifies the code to be tested. Omit to
+                  not include any PR content. Immutable.
                 items:
                   description: |-
                     PullRequestUnderTest describes the state of the repo that will be under test
@@ -200,7 +200,6 @@ spec:
                 type: array
             required:
             - jobs
-            - pullRequests
             type: object
           status:
             description: |-

--- a/pkg/api/pullrequestpayloadqualification/v1/types.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/types.go
@@ -28,8 +28,8 @@ type PullRequestPayloadQualificationRun struct {
 // PullRequestPayloadTestSpec specifies for which PR the payload qualification run was requested
 // and the list of individual jobs that should be executed.
 type PullRequestPayloadTestSpec struct {
-	// PullRequests specifies the code to be tested. Immutable and required.
-	PullRequests []PullRequestUnderTest `json:"pullRequests"`
+	// PullRequests specifies the code to be tested. Omit to not include any PR content. Immutable.
+	PullRequests []PullRequestUnderTest `json:"pullRequests,omitempty"`
 	// Jobs specifies the jobs to be executed. Immutable.
 	Jobs PullRequestPayloadJobSpec `json:"jobs"`
 	// InitialPayloadBase specifies the base payload pullspec for the "initial" release payload

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_basic_case.yaml
@@ -10,7 +10,6 @@
         specifier: ""
       releaseJobSpec: null
     payload: {}
-    pullRequests: null
   status:
     conditions:
     - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_job_is_still_running.yaml
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_job_is_still_running.yaml
@@ -10,7 +10,6 @@
         specifier: ""
       releaseJobSpec: null
     payload: {}
-    pullRequests: null
   status:
     conditions:
     - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_previous_condition_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/pjstatussyncer/testdata/zz_fixture_prpqr_TestReconcile_previous_condition_exists.yaml
@@ -10,7 +10,6 @@
         specifier: ""
       releaseJobSpec: null
     payload: {}
-    pullRequests: null
   status:
     conditions:
     - lastTransitionTime: "1970-01-01T00:00:00Z"

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -66,6 +66,20 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "basic case with no PRs included; testing determined base",
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Spec: v1.PullRequestPayloadTestSpec{
+						Jobs: v1.PullRequestPayloadJobSpec{
+							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "basic case where test name is not found",
 			prpqr: []ctrlruntimeclient.Object{
 				&v1.PullRequestPayloadQualificationRun{

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
@@ -1,0 +1,79 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: no-included-prs-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: no-included-prs-test-name
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: bff80ea4af62f87fcac06a79fc7b242f6f07932f08cdba39ebd7e808
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build02
+    decoration_config:
+      skip_cloning: true
+      timeout: 6h0m0s
+    extra_refs:
+    - base_ref: test-branch
+      org: test-org
+      repo: test-repo
+    job: no-included-prs-test-name
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/no-included-prs-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
@@ -1,0 +1,34 @@
+- metadata:
+    creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    payload: {}
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/no-included-prs-test-name


### PR DESCRIPTION
When no PRs are included, the complex part is determining the base metadata. We can use the metadata from the injected test.

This represents the first requirement in: https://issues.redhat.com/browse/DPTP-4278