### PR TITLE
Configuring 2 more capabilities

### DIFF
--- a/pkg/dispatcher/config_test.go
+++ b/pkg/dispatcher/config_test.go
@@ -528,10 +528,12 @@ func TestDetermineClusterForJob(t *testing.T) {
 				Labels: map[string]string{
 					"capability/intranet":            "intranet",
 					"capability/arm64":               "arm64",
+					"capability/rce":                 "rce",          // rce - release-controller-eligible
+					"capability/sshd-bastion":        "sshd-bastion", // sshd-bastion - for multiarch P/Z libvirt jobs
 					"ci-operator.openshift.io/cloud": "gcp"},
 			},
-			cm: ClusterMap{"build03": ClusterInfo{Provider: "aws", Capacity: 100, Capabilities: []string{"intranet", "arm64"}},
-				"build02": ClusterInfo{Provider: "gcp", Capacity: 100, Capabilities: []string{"intranet", "arm64"}}},
+			cm: ClusterMap{"build03": ClusterInfo{Provider: "aws", Capacity: 100, Capabilities: []string{"intranet", "arm64", "rce", "sshd-bastion"}},
+				"build02": ClusterInfo{Provider: "gcp", Capacity: 100, Capabilities: []string{"intranet", "arm64", "rce", "sshd-bastion"}}},
 			expected:               "build02",
 			expectedCanBeRelocated: false,
 		},
@@ -542,13 +544,15 @@ func TestDetermineClusterForJob(t *testing.T) {
 				Labels: map[string]string{
 					"capability/intranet":            "intranet",
 					"capability/arm64":               "arm64",
+					"capability/rce":                 "rce",          // rce - release-controller-eligible
+					"capability/sshd-bastion":        "sshd-bastion", // sshd-bastion - for multiarch P/Z libvirt jobs
 					"ci-operator.openshift.io/cloud": "gcp"},
 			},
 			cm: ClusterMap{"build03": ClusterInfo{Provider: "aws", Capacity: 100, Capabilities: []string{"intranet"}},
 				"build02": ClusterInfo{Provider: "aws", Capacity: 100, Capabilities: []string{"arm64"}}},
 			expected:               "",
 			expectedCanBeRelocated: false,
-			expectedErr:            fmt.Errorf("job some-e2e-job can't be matched with any cluster using provided capabilities: arm64,intranet"),
+			expectedErr:            fmt.Errorf("job some-e2e-job can't be matched with any cluster using provided capabilities: arm64,intranet,rce,sshd-bastion"),
 		},
 		{
 			name:   "cluster label has priority over capabilities",

--- a/pkg/dispatcher/helpers_test.go
+++ b/pkg/dispatcher/helpers_test.go
@@ -311,47 +311,47 @@ func TestHasCapacityOrCapabilitiesChanged(t *testing.T) {
 		{
 			name: "No change in capacity or capabilities",
 			prev: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}}, // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			next: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			expected: false,
 		},
 		{
 			name: "Change in capacity for build01",
 			prev: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			next: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 15, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 15, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			expected: true,
 		},
 		{
 			name: "Change in capabilities for build02",
 			prev: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			next: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"aarch64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
 			},
 			expected: true,
 		},
 		{
 			name: "No corresponding clusters in next map",
 			prev: ClusterMap{
-				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet"}},
-				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet"}},
+				"build01": {Provider: "AWS", Capacity: 10, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
+				"build02": {Provider: "GCP", Capacity: 20, Capabilities: []string{"amd64", "intranet", "rce", "sshd-bastion"}},
 			},
 			next: ClusterMap{
-				"build03": {Provider: "AWS", Capacity: 15, Capabilities: []string{"aarch64", "intranet"}},
+				"build03": {Provider: "AWS", Capacity: 15, Capabilities: []string{"aarch64", "intranet", "rce", "sshd-bastion"}},
 			},
 			expected: false,
 		},

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -141,7 +141,7 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 			test:        "testname",
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			generateOption: func(options *generatePresubmitOptions) {
-				options.Capabilities = []string{"intranet", "arm64"}
+				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
 			},
 		},
 	}
@@ -224,7 +224,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
-				options.Capabilities = []string{"intranet", "arm64"}
+				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
 			},
 		},
 	}
@@ -284,7 +284,7 @@ func TestGeneratePostSubmitForTest(t *testing.T) {
 				Branch: "branch",
 			}},
 			generateOption: func(options *generatePostsubmitOptions) {
-				options.Capabilities = []string{"intranet", "arm64"}
+				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
 			},
 		},
 		{
@@ -668,7 +668,7 @@ func TestGenerateJobs(t *testing.T) {
 			id: "periodic/presubmit with capabilities",
 			config: &ciop.ReleaseBuildConfiguration{
 				Tests: []ciop.TestStepConfiguration{
-					{As: "unit", Capabilities: []string{"intranet", "arm64"}, Cron: utilpointer.String(cron), Presubmit: true, ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"}},
+					{As: "unit", Capabilities: []string{"intranet", "arm64", "rce", "sshd-bastion"}, Cron: utilpointer.String(cron), Presubmit: true, ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"}}, // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
 				},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_presubmit_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_presubmit_with_capabilities.yaml
@@ -11,6 +11,8 @@ periodics:
   labels:
     capability/arm64: arm64
     capability/intranet: intranet
+    capability/rce: rce
+    capability/sshd-bastion: sshd-bastion
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
   name: periodic-ci-organization-repository-branch-unit
   spec:
@@ -58,5 +60,7 @@ presubmits:
     labels:
       capability/arm64: arm64
       capability/intranet: intranet
+      capability/rce: rce
+      capability/sshd-bastion: sshd-bastion
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_capabilities.yaml
@@ -10,5 +10,7 @@ extra_refs:
 labels:
   capability/arm64: arm64
   capability/intranet: intranet
+  capability/rce: rce
+  capability/sshd-bastion: sshd-bastion
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_capabilities.yaml
@@ -8,4 +8,6 @@ decoration_config:
 labels:
   capability/arm64: arm64
   capability/intranet: intranet
+  capability/rce: rce
+  capability/sshd-bastion: sshd-bastion
 name: branch-ci-organization-repository-branch-postsubmit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_capabilities_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_capabilities_added.yaml
@@ -10,6 +10,8 @@ decoration_config:
 labels:
   capability/arm64: arm64
   capability/intranet: intranet
+  capability/rce: rce
+  capability/sshd-bastion: sshd-bastion
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname


### PR DESCRIPTION
Adding 2 more capabilities

1. **rce** (release-controller-eligible) - all the jobs triggered by release-controller will be marked by this capability
2. **sshd-bastion** - Multiarch P/Z libvirt jobs which connect to IBM h/w are required to be on a dedicated cluster which has direct access. This capability will move away once the h/w is accessible by redhat intranet

/cc @openshift/test-platform  