### PR TITLE
`payload-testing`: add the ability to skip jobs when running payload tests from a PR

### DIFF
--- a/cmd/payload-testing-prow-plugin/rcjobresolver.go
+++ b/cmd/payload-testing-prow-plugin/rcjobresolver.go
@@ -45,7 +45,7 @@ func (r *releaseControllerJobResolver) resolve(ocp string, releaseType api.Relea
 	}
 	jobSkips, err := determineJobSkips(time.Now())
 	if err != nil {
-		return nil, fmt.Errorf("could not determine job skips: %v", err)
+		return nil, fmt.Errorf("could not determine job skips: %w", err)
 	}
 	if len(jobSkips) == 0 {
 		return jobs, nil
@@ -113,11 +113,11 @@ func determineJobSkips(now time.Time) ([]jobSkip, error) {
 			}
 			expiration, err := time.Parse(time.RFC3339, expireEnvVar)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse expiration time %q: %v", expireEnvVar, err)
+				return nil, fmt.Errorf("failed to parse expiration time %q: %w", expireEnvVar, err)
 			}
 			regex, err := regexp.Compile(rawRegex)
 			if err != nil {
-				return nil, fmt.Errorf("could not compile job regexp %s: %v", rawRegex, err)
+				return nil, fmt.Errorf("could not compile job regexp %s: %w", rawRegex, err)
 			}
 			jobSkips = append(jobSkips, jobSkip{
 				regex:      *regex,

--- a/cmd/payload-testing-prow-plugin/rcjobresolver.go
+++ b/cmd/payload-testing-prow-plugin/rcjobresolver.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/release"
@@ -16,6 +22,8 @@ func newReleaseControllerJobResolver(httpClient release.HTTPClient) jobResolver 
 	return &releaseControllerJobResolver{httpClient: httpClient}
 }
 
+// resolve will resolve the jobs of the given parameters from the release-controller.
+// If there is an env var actively configured to skip the job, it will not be included in the returned list
 func (r *releaseControllerJobResolver) resolve(ocp string, releaseType api.ReleaseStream, jobType config.JobType) ([]config.Job, error) {
 	if releaseType != api.ReleaseStreamNightly && releaseType != api.ReleaseStreamCI {
 		return nil, fmt.Errorf("release type is not supported: %s", releaseType)
@@ -24,7 +32,7 @@ func (r *releaseControllerJobResolver) resolve(ocp string, releaseType api.Relea
 	if jobType != config.Informing && jobType != config.Blocking && jobType != config.Periodics && jobType != config.All {
 		return nil, fmt.Errorf("job type is not supported: %s", jobType)
 	}
-	return config.ResolveJobs(r.httpClient, api.Candidate{
+	jobs, err := config.ResolveJobs(r.httpClient, api.Candidate{
 		ReleaseDescriptor: api.ReleaseDescriptor{
 			Product:      api.ReleaseProductOCP,
 			Architecture: api.ReleaseArchitectureAMD64,
@@ -32,4 +40,88 @@ func (r *releaseControllerJobResolver) resolve(ocp string, releaseType api.Relea
 		Stream:  releaseType,
 		Version: ocp,
 	}, jobType)
+	if err != nil {
+		return nil, err
+	}
+	jobSkips, err := determineJobSkips(time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("could not determine job skips: %v", err)
+	}
+
+	var filteredJobs []config.Job
+	for _, job := range jobs {
+		if shouldFilterOutJob(job.Name, jobSkips) {
+			continue
+		}
+
+		filteredJobs = append(filteredJobs, job)
+	}
+
+	return filteredJobs, nil
+}
+
+type jobSkip struct {
+	regex      regexp.Regexp
+	expiration time.Time
+}
+
+func (js jobSkip) String() string {
+	return fmt.Sprintf("%s@%s", js.regex.String(), js.expiration.Format(time.RFC3339))
+}
+
+func shouldFilterOutJob(jobName string, jobSkips []jobSkip) bool {
+	for _, js := range jobSkips {
+		regex := js.regex
+		if time.Now().After(js.expiration) {
+			logrus.Warnf("A configured job skip for %s has expired, it should be removed or extended", regex.String())
+			continue
+		}
+		if regex.MatchString(jobName) {
+			logrus.Infof("Skipping job %s, due to job skip %s", jobName, regex.String())
+			return true
+		}
+	}
+
+	return false
+}
+
+const (
+	regexPrefix      = "SKIP_JOB_REGEX_"
+	expirationPrefix = "SKIP_JOB_EXPIRE_"
+)
+
+// determineJobSkips will find the configured job skips based on env vars.
+// Each skip must include 2 env vars where "123" is a sequential number:
+//  1. SKIP_JOB_REGEX_123 containing the regex to match job name(s) to skip
+//  2. SKIP_JOB_EXPIRE_123 containing the expiration date after which this skip will no longer apply
+func determineJobSkips(now time.Time) ([]jobSkip, error) {
+	var jobSkips []jobSkip
+	for _, env := range os.Environ() {
+		envVarParts := strings.SplitN(env, "=", 2)
+		key := envVarParts[0]
+		rawRegex := envVarParts[1]
+
+		if strings.HasPrefix(key, regexPrefix) {
+			index := strings.TrimPrefix(key, regexPrefix)
+			expireEnvVar := os.Getenv(fmt.Sprintf("%s%s", expirationPrefix, index))
+			if expireEnvVar == "" {
+				// If there is no matching expiration, it should always result in an active skip
+				expireEnvVar = now.Add(time.Hour).Format(time.RFC3339)
+			}
+			expiration, err := time.Parse(time.RFC3339, expireEnvVar)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse expiration time %q: %v", expireEnvVar, err)
+			}
+			regex, err := regexp.Compile(rawRegex)
+			if err != nil {
+				return nil, fmt.Errorf("could not compile job regexp %s: %v", rawRegex, err)
+			}
+			jobSkips = append(jobSkips, jobSkip{
+				regex:      *regex,
+				expiration: expiration,
+			})
+		}
+	}
+
+	return jobSkips, nil
 }

--- a/cmd/payload-testing-prow-plugin/rcjobresolver.go
+++ b/cmd/payload-testing-prow-plugin/rcjobresolver.go
@@ -47,6 +47,9 @@ func (r *releaseControllerJobResolver) resolve(ocp string, releaseType api.Relea
 	if err != nil {
 		return nil, fmt.Errorf("could not determine job skips: %v", err)
 	}
+	if len(jobSkips) == 0 {
+		return jobs, nil
+	}
 
 	var filteredJobs []config.Job
 	for _, job := range jobs {

--- a/cmd/payload-testing-prow-plugin/rcjobresolver_test.go
+++ b/cmd/payload-testing-prow-plugin/rcjobresolver_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -16,12 +20,13 @@ import (
 
 func TestResolve(t *testing.T) {
 	testCases := []struct {
-		name          string
-		ocp           string
-		releaseType   api.ReleaseStream
-		jobType       config.JobType
-		expected      []config.Job
-		expectedError error
+		name           string
+		ocp            string
+		releaseType    api.ReleaseStream
+		jobType        config.JobType
+		jobSkipEnvVars map[string]string
+		expected       []config.Job
+		expectedError  error
 	}{
 		{
 			name:        "basic case",
@@ -29,6 +34,19 @@ func TestResolve(t *testing.T) {
 			jobType:     config.Blocking,
 			expected: []config.Job{
 				{Name: "periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-upgrade", AggregatedCount: 5},
+				{Name: "periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade", AggregatedCount: 10},
+				{Name: "periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade-2"},
+			},
+		},
+		{
+			name:        "skipping a job",
+			releaseType: api.ReleaseStreamNightly,
+			jobType:     config.Blocking,
+			jobSkipEnvVars: map[string]string{
+				fmt.Sprintf("%s1", regexPrefix):      "nightly",
+				fmt.Sprintf("%s1", expirationPrefix): time.Now().Add(time.Hour).Format(time.RFC3339),
+			},
+			expected: []config.Job{
 				{Name: "periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade", AggregatedCount: 10},
 				{Name: "periodic-ci-openshift-release-master-ci-4.10-e2e-azure-ovn-upgrade-2"},
 			},
@@ -80,6 +98,11 @@ func TestResolve(t *testing.T) {
 					Body:       io.NopCloser(bytes.NewBuffer([]byte(content))),
 				}, nil
 			})
+
+			for key, val := range tc.jobSkipEnvVars {
+				t.Setenv(key, val)
+			}
+
 			jobResolver := newReleaseControllerJobResolver(httpClient)
 			actual, actualError := jobResolver.resolve(tc.ocp, tc.releaseType, tc.jobType)
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
@@ -87,6 +110,82 @@ func TestResolve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expectedError, actualError, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("%s differs from expected:\n%s", tc.name, diff)
+			}
+		})
+	}
+}
+
+func TestDetermineJobSkips(t *testing.T) {
+	baseTime := time.Time{}
+	microshiftExpiration := baseTime.Add(time.Hour)
+	rosaExpiration := baseTime.Add(2 * time.Hour)
+	testCases := []struct {
+		name           string
+		jobSkipEnvVars map[string]string
+		expected       []string
+		expectedError  error
+	}{
+		{
+			name: "nothing configured",
+		},
+		{
+			name: "multiple skips configured",
+			jobSkipEnvVars: map[string]string{
+				fmt.Sprintf("%s1", regexPrefix):      "microshift",
+				fmt.Sprintf("%s1", expirationPrefix): microshiftExpiration.Format(time.RFC3339),
+				fmt.Sprintf("%s2", regexPrefix):      "rosa",
+				fmt.Sprintf("%s2", expirationPrefix): rosaExpiration.Format(time.RFC3339),
+			},
+			expected: []string{
+				jobSkip{regex: *regexp.MustCompile("microshift"), expiration: microshiftExpiration}.String(),
+				jobSkip{regex: *regexp.MustCompile("rosa"), expiration: rosaExpiration}.String(),
+			},
+		},
+		{
+			name: "no expiration configured; assume expires 1 hour in future",
+			jobSkipEnvVars: map[string]string{
+				fmt.Sprintf("%s1", regexPrefix): "microshift",
+			},
+			expected: []string{
+				jobSkip{regex: *regexp.MustCompile("microshift"), expiration: baseTime.Add(time.Hour)}.String(),
+			},
+		},
+		{
+			name: "incorrectly formatted regex",
+			jobSkipEnvVars: map[string]string{
+				fmt.Sprintf("%s1", regexPrefix):      "microshift**",
+				fmt.Sprintf("%s1", expirationPrefix): microshiftExpiration.Format(time.RFC3339),
+			},
+			expectedError: fmt.Errorf("could not compile job regexp microshift**: error parsing regexp: invalid nested repetition operator: `**`"),
+		},
+		{
+			name: "incorrectly formatted expiration",
+			jobSkipEnvVars: map[string]string{
+				fmt.Sprintf("%s1", regexPrefix):      "microshift",
+				fmt.Sprintf("%s1", expirationPrefix): microshiftExpiration.Format(time.RFC850),
+			},
+			expectedError: fmt.Errorf("failed to parse expiration time \"Monday, 01-Jan-01 01:00:00 UTC\": parsing time \"Monday, 01-Jan-01 01:00:00 UTC\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"Monday, 01-Jan-01 01:00:00 UTC\" as \"2006\""),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for key, val := range tc.jobSkipEnvVars {
+				t.Setenv(key, val)
+			}
+
+			result, err := determineJobSkips(baseTime)
+			if diff := cmp.Diff(tc.expectedError, err, testhelper.EquateErrorMessage); diff != "" {
+				t.Errorf("expectedError doesn't match err, diff:\n%s", diff)
+			}
+
+			var resultingStrings []string
+			for _, js := range result {
+				resultingStrings = append(resultingStrings, js.String())
+			}
+			slices.Sort(tc.expected)
+			slices.Sort(resultingStrings)
+			if diff := cmp.Diff(tc.expected, resultingStrings); diff != "" {
+				t.Errorf("expected doesn't match result, diff:\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This ability is based on a couple of new environment variables of the form: "SKIP_JOB_REGEX_xyz" and "SKIP_JOB_EXPIRE_xyz". The jobs with names matching the provided regex will be skipped on *all* PRPQR runs until the provided expire time.

This functionality will allow us to skip arbitrary jobs matched by any regex in the future, and will not be enabled at all until a corresponding change is made to add the proper env vars to the plugin deployment. I will add that in a followup PR.

For: https://issues.redhat.com/browse/DPTP-4335