### PR TITLE
`prowgen`: Add enable_secrets_store_csi_driver field

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -39,6 +39,9 @@ type Prowgen struct {
 	Rehearsals Rehearsals `json:"rehearsals,omitempty"`
 	// SlackReporterConfigs defines all desired slack reporter info for included jobs
 	SlackReporterConfigs []SlackReporterConfig `json:"slack_reporter,omitempty"`
+	// EnableSecretsStoreCSIDriver indicates that jobs should use the new CSI Secrets Store
+	// mechanism to handle multi-stage credentials secrets.
+	EnableSecretsStoreCSIDriver bool `json:"enable_secrets_store_csi_driver,omitempty"`
 }
 
 // SlackReporterConfig groups test names to a channel to report; mimicking Prow's version, with some unnecessary fields removed
@@ -66,6 +69,9 @@ func (p *Prowgen) MergeDefaults(defaults *Prowgen) {
 	}
 	if defaults.Expose {
 		p.Expose = true
+	}
+	if defaults.EnableSecretsStoreCSIDriver {
+		p.EnableSecretsStoreCSIDriver = true
 	}
 	if defaults.Rehearsals.DisableAll {
 		p.Rehearsals.DisableAll = true

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -160,6 +160,9 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
 		}
+		if info.Config.EnableSecretsStoreCSIDriver {
+			p.PodSpec.Add(Arg("enable-secrets-store-csi-driver", "true"))
+		}
 	case test.MultiStageTestConfiguration != nil:
 		if clusterProfile := test.MultiStageTestConfiguration.ClusterProfile; clusterProfile != "" {
 			p.PodSpec.Add(LeaseClient())
@@ -168,6 +171,9 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 		}
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
+		}
+		if info.Config.EnableSecretsStoreCSIDriver {
+			p.PodSpec.Add(Arg("enable-secrets-store-csi-driver", "true"))
 		}
 	case test.OpenshiftAnsibleClusterTestConfiguration != nil:
 		p.PodSpec.Add(

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -330,6 +330,31 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			info: defaultInfo,
 		},
 		{
+			name: "multi-stage test with CSI enabled",
+			test: ciop.TestStepConfiguration{
+				As: "simple",
+				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+					Workflow: pointer.StringPtr("workflow"),
+				},
+			},
+			info: &ProwgenInfo{
+				Metadata: ciop.Metadata{Org: "o", Repo: "r", Branch: "b"},
+				Config:   config.Prowgen{EnableSecretsStoreCSIDriver: true},
+			},
+		},
+		{
+			name: "simple test with CSI enabled",
+			test: ciop.TestStepConfiguration{
+				As:                         "simple",
+				Commands:                   "make",
+				ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "src"},
+			},
+			info: &ProwgenInfo{
+				Metadata: ciop.Metadata{Org: "o", Repo: "r", Branch: "b"},
+				Config:   config.Prowgen{EnableSecretsStoreCSIDriver: true},
+			},
+		},
+		{
 			name: "multi-stage test with claim",
 			test: ciop.TestStepConfiguration{
 				As:           "simple",

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -301,7 +301,7 @@ func CIPullSecret() PodSpecMutator {
 func Arg(name, value string) PodSpecMutator {
 	return func(spec *corev1.PodSpec) error {
 		container := &spec.Containers[0]
-		addUniqueParameter(container, fmt.Sprintf("%s=%s", name, value))
+		addUniqueParameter(container, fmt.Sprintf("--%s=%s", name, value))
 		return nil
 	}
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled.yaml
@@ -1,0 +1,45 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --enable-secrets-store-csi-driver=true
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    image: ci-operator:latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_test_with_CSI_enabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_test_with_CSI_enabled.yaml
@@ -1,0 +1,44 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    image: ci-operator:latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator


### PR DESCRIPTION
Related to https://github.com/openshift/ci-tools/pull/4507

`enable_secrets_store_csi_driver` is a temporary option for ci-operator to enable us to test out the new CSI Secrets mechanism. This PR allows us to toggle it using the `.config.prowgen` files (which are in the release repo ci-operator/config dirs)