### PR TITLE
rework payload testing image tag overrides to allow for an aritrary pullspec override

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -939,7 +939,7 @@ func (o *options) Run() []error {
 	// load the graph from the configuration
 	buildSteps, promotionSteps, err := defaults.FromConfig(ctx, o.configSpec, &o.graphConfig, o.jobSpec, o.templates, o.writeParams, o.promote, o.clusterConfig,
 		o.podPendingTimeout, leaseClient, o.targets.values, o.cloneAuthConfig, o.pullSecret, o.pushSecret, o.censor, o.hiveKubeconfig,
-		o.consoleHost, o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, streams, injectedTest, o.enableSecretsStoreCSIDriver)
+		o.nodeName, nodeArchitectures, o.targetAdditionalSuffix, o.manifestToolDockerCfg, o.localRegistryDNS, streams, injectedTest, o.enableSecretsStoreCSIDriver)
 	if err != nil {
 		return []error{results.ForReason("defaulting_config").WithError(err).Errorf("failed to generate steps from config: %v", err)}
 	}

--- a/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
+++ b/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
@@ -138,16 +138,17 @@ spec:
                       description: ImageTagOverride describes a specific image name
                         that should be overridden with the provided tag
                       properties:
+                        image:
+                          description: |-
+                            Image is an arbitrary pullspec to override the image with
+                            like: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9a49368aad56c984302c3cfd7d3dfd3186687381ca9a94501960b0d6a8fb7f98"
+                          type: string
                         name:
                           description: Name is the name of the image like "machine-os-content"
                           type: string
-                        tag:
-                          description: Tag is the tag to override the image with like
-                            "4.16-art-latest-2024-02-05-071231"
-                          type: string
                       required:
+                      - image
                       - name
-                      - tag
                       type: object
                     type: array
                 type: object

--- a/pkg/api/pullrequestpayloadqualification/v1/types.go
+++ b/pkg/api/pullrequestpayloadqualification/v1/types.go
@@ -51,8 +51,9 @@ type PayloadOverrides struct {
 type ImageTagOverride struct {
 	// Name is the name of the image like "machine-os-content"
 	Name string `json:"name"`
-	// Tag is the tag to override the image with like "4.16-art-latest-2024-02-05-071231"
-	Tag string `json:"tag"`
+	// Image is an arbitrary pullspec to override the image with
+	// like: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9a49368aad56c984302c3cfd7d3dfd3186687381ca9a94501960b0d6a8fb7f98"
+	Image string `json:"image"`
 }
 
 // PullRequestUnderTest describes the state of the repo that will be under test

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -303,9 +303,14 @@ type InputConfiguration struct {
 
 // ExternalImage describes the external image that is imported into the pipeline
 type ExternalImage struct {
-	Registry                string `json:"registry"` // Registry is the registry to pull images from (e.g. quay.io)
+	// Registry is the registry to pull images from (e.g. quay.io)
+	Registry                string `json:"registry"`
 	ImageStreamTagReference `json:",inline"`
-	PullSecret              string `json:"pull_secret,omitempty"` // PullSecret is the name of the secret to use to pull the image
+	// PullSecret is the name of the secret to use to pull the image
+	PullSecret string `json:"pull_secret,omitempty"`
+	// PullSpec is the full pullSpec of the external image, only to be set programmatically,
+	// and takes precedent over the other fields in ExternalImage
+	PullSpec string `json:"pull_spec,omitempty"`
 }
 
 // UnresolvedRelease describes a semantic release payload
@@ -607,11 +612,6 @@ type StepConfiguration struct {
 type InputImageTagStepConfiguration struct {
 	InputImage `json:",inline"`
 	Sources    []ImageStreamSource `json:"-"`
-
-	// ExternalPullSpec allows for an arbitrary pullspec that does not have to come from QCI to be used as the image source.
-	// This functionality was created to allow for specific image tag content to be overridden during payload testing.
-	// This field should *not* be used to circumvent the standard mirroring process for QCI.
-	ExternalPullSpec string `json:"external_pull_spec,omitempty"`
 }
 
 func (config InputImageTagStepConfiguration) TargetName() string {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -607,6 +607,11 @@ type StepConfiguration struct {
 type InputImageTagStepConfiguration struct {
 	InputImage `json:",inline"`
 	Sources    []ImageStreamSource `json:"-"`
+
+	// ExternalPullSpec allows for an arbitrary pullspec that does not have to come from QCI to be used as the image source.
+	// This functionality was created to allow for specific image tag content to be overridden during payload testing.
+	// This field should *not* be used to circumvent the standard mirroring process for QCI.
+	ExternalPullSpec string `json:"external_pull_spec,omitempty"`
 }
 
 func (config InputImageTagStepConfiguration) TargetName() string {

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -633,7 +633,7 @@ func (r *reconciler) generateProwjob(ciopConfig *api.ReleaseBuildConfiguration,
 			jobBaseGen.PodSpec.Add(prowgen.ReleaseInitial(initialPayloadPullspec))
 		}
 		for _, ito := range imageTagOverrides {
-			jobBaseGen.PodSpec.Add(prowgen.OverrideImage(ito.Name, ito.Tag))
+			jobBaseGen.PodSpec.Add(prowgen.OverrideImage(ito.Name, ito.Image))
 		}
 		if aggregateIndex != nil {
 			jobBaseGen.PodSpec.Add(prowgen.TargetAdditionalSuffix(strconv.Itoa(*aggregateIndex)))

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -258,6 +258,29 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "override tag",
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Spec: v1.PullRequestPayloadTestSpec{
+						PullRequests: []v1.PullRequestUnderTest{{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: &v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}}},
+						Jobs: v1.PullRequestPayloadJobSpec{
+							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name"}},
+						},
+						PayloadOverrides: v1.PayloadOverrides{
+							ImageTagOverrides: []v1.ImageTagOverride{
+								{
+									Name:  "machine-os-content",
+									Image: "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9a49368aad56c984302c3cfd7d3dfd3186687381ca9a94501960b0d6a8fb7f98",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "all jobs are aborted remove dependant prowjobs finalizer",
 			prpqr: []ctrlruntimeclient.Object{
 				&v1.PullRequestPayloadQualificationRun{

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_tag.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_tag.yaml
@@ -1,0 +1,89 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.pull: "100"
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: bff80ea4af62f87fcac06a79fc7b242f6f07932f08cdba39ebd7e808
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build02
+    decoration_config:
+      skip_cloning: true
+      timeout: 6h0m0s
+    extra_refs:
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    job: test-org-test-repo-100-test-name
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        env:
+        - name: OVERRIDE_IMAGE_MACHINE_OS_CONTENT
+          value: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9a49368aad56c984302c3cfd7d3dfd3186687381ca9a94501960b0d6a8fb7f98
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_override_tag.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_override_tag.yaml
@@ -1,0 +1,47 @@
+- metadata:
+    creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        test: test-name
+    payload:
+      tags:
+      - image: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:9a49368aad56c984302c3cfd7d3dfd3186687381ca9a94501960b0d6a8fb7f98
+        name: machine-os-content
+    pullRequests:
+    - baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -379,11 +379,12 @@ func fromConfig(
 func stepsForImageOverrides(overriddenImages map[string]string) []api.StepConfiguration {
 	var overrideSteps []api.StepConfiguration
 	for tag, value := range overriddenImages {
+
 		inputStep := api.StepConfiguration{InputImageTagStepConfiguration: &api.InputImageTagStepConfiguration{
 			InputImage: api.InputImage{
-				To: api.PipelineImageStreamTagReference(tag),
+				ExternalImage: &api.ExternalImage{PullSpec: value},
+				To:            api.PipelineImageStreamTagReference(tag),
 			},
-			ExternalPullSpec: value,
 		}}
 		overrideSteps = append(overrideSteps, inputStep)
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1833,7 +1833,7 @@ func TestFromConfig(t *testing.T) {
 				params.Add(k, func() (string, error) { return v, nil })
 			}
 			graphConf := FromConfigStatic(&tc.config)
-			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", "", nil, map[string]*configresolver.IntegratedStream{}, tc.injectedTest, false)
+			configSteps, post, err := fromConfig(context.Background(), &tc.config, &graphConf, &jobSpec, tc.templates, tc.paramFiles, tc.promote, client, buildClient, templateClient, podClient, leaseClient, hiveClient, httpClient, requiredTargets, cloneAuthConfig, pullSecret, pushSecret, params, &secrets.DynamicCensor{}, api.ServiceDomainAPPCI, "", nil, map[string]*configresolver.IntegratedStream{}, tc.injectedTest, false)
 			if diff := cmp.Diff(tc.expectedErr, err); diff != "" {
 				t.Errorf("unexpected error: %v", diff)
 			}

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -270,17 +270,17 @@ func ReleaseInitial(pullspec string) PodSpecMutator {
 	}
 }
 
-// OverrideImage sets the "OVERRIDE_IMAGE_*" env var in order to override the respective image with the provided tag
-func OverrideImage(name, tag string) PodSpecMutator {
+// OverrideImage sets the "OVERRIDE_IMAGE_*" env var in order to override the respective image with the provided PullSpec
+func OverrideImage(name, pullSpec string) PodSpecMutator {
 	return func(spec *corev1.PodSpec) error {
-		if name == "" || tag == "" {
-			return fmt.Errorf("empty name('%s') or tag('%s') passed", name, tag)
+		if name == "" || pullSpec == "" {
+			return fmt.Errorf("empty name('%s') or pullSpec('%s') passed", name, pullSpec)
 		}
 		container := &spec.Containers[0]
 
 		return addEnvVar(container, corev1.EnvVar{
 			Name:  utils.OverrideImageEnv(name),
-			Value: tag,
+			Value: pullSpec,
 		})
 	}
 }

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -98,6 +98,13 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 			Namespace: s.config.BaseImage.Namespace,
 		}
 	}
+	if s.config.ExternalPullSpec != "" {
+		from = &coreapi.ObjectReference{
+			Name: s.config.ExternalPullSpec,
+			Kind: "DockerImage",
+		}
+	}
+
 	ist := &imagev1.ImageStreamTag{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s:%s", api.PipelineImageStream, s.config.To),

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -224,6 +224,9 @@ func validateExternalConfiguration(ctx *configContext, externalImages map[string
 	var validationErrors []error
 	istRefs := make(map[string]api.ImageStreamTagReference)
 	for name, ei := range externalImages {
+		if ei.PullSpec != "" {
+			validationErrors = append(validationErrors, ctx.errorf("%s.pull_spec is not valid to be set directly in the config", name))
+		}
 		if ei.Registry == "" {
 			validationErrors = append(validationErrors, ctx.errorf("%s.registry value required but not provided", name))
 		} else {

--- a/pkg/validation/config_test.go
+++ b/pkg/validation/config_test.go
@@ -145,6 +145,13 @@ func TestValidateExternalConfiguration(t *testing.T) {
 			expectedValid: false,
 		},
 		{
+			name: "invalid external configuration, pull_spec set",
+			externalConfig: map[string]api.ExternalImage{
+				"foo": {PullSpec: "quay.io/some-pull-spec/name:tag"},
+			},
+			expectedValid: false,
+		},
+		{
 			name:           "nil external configuration",
 			externalConfig: nil,
 			expectedValid:  true,

--- a/pkg/validation/graph.go
+++ b/pkg/validation/graph.go
@@ -36,9 +36,6 @@ func IsValidGraphConfiguration(rawSteps []api.StepConfiguration) error {
 		if c := s.InputImageTagStepConfiguration; c != nil {
 			addName(c.TargetName())
 			pipelineImages[c.To] = sets.Empty{}
-			if s.InputImageTagStepConfiguration.ExternalPullSpec != "" {
-				ret = append(ret, fmt.Errorf("it is not permissible to directly set external_pull_spec. this should only be used to programttically override an image"))
-			}
 		} else if c := s.PipelineImageCacheStepConfiguration; c != nil {
 			addName(c.TargetName())
 			pipelineImages[c.To] = sets.Empty{}

--- a/pkg/validation/graph.go
+++ b/pkg/validation/graph.go
@@ -36,6 +36,9 @@ func IsValidGraphConfiguration(rawSteps []api.StepConfiguration) error {
 		if c := s.InputImageTagStepConfiguration; c != nil {
 			addName(c.TargetName())
 			pipelineImages[c.To] = sets.Empty{}
+			if s.InputImageTagStepConfiguration.ExternalPullSpec != "" {
+				ret = append(ret, fmt.Errorf("it is not permissible to directly set external_pull_spec. this should only be used to programttically override an image"))
+			}
 		} else if c := s.PipelineImageCacheStepConfiguration; c != nil {
 			addName(c.TargetName())
 			pipelineImages[c.To] = sets.Empty{}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -167,7 +167,12 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"        as: ' '\n" +
 	"        name: ' '\n" +
 	"        namespace: ' '\n" +
+	"        # PullSecret is the name of the secret to use to pull the image\n" +
 	"        pull_secret: ' '\n" +
+	"        # PullSpec is the full pullSpec of the external image, only to be set programmatically,\n" +
+	"        # and takes precedent over the other fields in ExternalImage\n" +
+	"        pull_spec: ' '\n" +
+	"        # Registry is the registry to pull images from (e.g. quay.io)\n" +
 	"        registry: ' '\n" +
 	"        tag: ' '\n" +
 	"# Images describes the images that are built\n" +
@@ -338,13 +343,14 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            as: ' '\n" +
 	"            name: ' '\n" +
 	"            namespace: ' '\n" +
+	"            # PullSecret is the name of the secret to use to pull the image\n" +
 	"            pull_secret: ' '\n" +
+	"            # PullSpec is the full pullSpec of the external image, only to be set programmatically,\n" +
+	"            # and takes precedent over the other fields in ExternalImage\n" +
+	"            pull_spec: ' '\n" +
+	"            # Registry is the registry to pull images from (e.g. quay.io)\n" +
 	"            registry: ' '\n" +
 	"            tag: ' '\n" +
-	"        # ExternalPullSpec allows for an arbitrary pullspec that does not have to come from QCI to be used as the image source.\n" +
-	"        # This functionality was created to allow for specific image tag content to be overridden during payload testing.\n" +
-	"        # This field should *not* be used to circumvent the standard mirroring process for QCI.\n" +
-	"        external_pull_spec: ' '\n" +
 	"        # Ref is an optional string linking to the extra_ref in \"org.repo\" format that this belongs to\n" +
 	"        ref: ' '\n" +
 	"        to: ' '\n" +

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -341,6 +341,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"            pull_secret: ' '\n" +
 	"            registry: ' '\n" +
 	"            tag: ' '\n" +
+	"        # ExternalPullSpec allows for an arbitrary pullspec that does not have to come from QCI to be used as the image source.\n" +
+	"        # This functionality was created to allow for specific image tag content to be overridden during payload testing.\n" +
+	"        # This field should *not* be used to circumvent the standard mirroring process for QCI.\n" +
+	"        external_pull_spec: ' '\n" +
 	"        # Ref is an optional string linking to the extra_ref in \"org.repo\" format that this belongs to\n" +
 	"        ref: ' '\n" +
 	"        to: ' '\n" +


### PR DESCRIPTION
> It is uncommon for users to have the permission necessary to push test images to the ocp namespace or established imagestreams. Instead, permit payload tags to reference arbitrary images.

```
spec:
  payload:
    tags:
      - name: "machine-os-content"
        image: quay.io/openshift-release-dev/.... (arbitrary pullspec)
```

Note that this PR includes both changes for `ci-operator` and `prpqr_reconciller` as they need to merge together, and they are relatively simple on their own.

For: https://issues.redhat.com/browse/DPTP-4278