### PR TITLE
`repo-init`: update origin 'master' -> 'main'

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -233,7 +233,7 @@ In order to generate a new set of configurations, some information will be neces
 Let's start with general information about the repository...`)
 		config.Org = fetchWithPrompt("Enter the organization for the repository:")
 		config.Repo = fetchWithPrompt("Enter the repository to initialize:")
-		config.Branch = fetchOrDefaultWithPrompt("Enter the development branch for the repository:", "master")
+		config.Branch = fetchOrDefaultWithPrompt("Enter the development branch for the repository:", "main")
 
 		configPath := path.Join(o.releaseRepo, "ci-operator", "config", config.Org, config.Repo)
 		if _, err := os.Stat(configPath); err == nil {
@@ -633,7 +633,7 @@ func createCIOperatorConfig(config initConfig, releaseRepo string, commit bool) 
 	info := api.Metadata{
 		Org:    "openshift",
 		Repo:   "origin",
-		Branch: "master",
+		Branch: "main",
 	}
 	originPath := path.Join(releaseRepo, ciopconfig.CiopConfigInRepoPath, info.RelativePath())
 	var originConfig *api.ReleaseBuildConfiguration

--- a/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -38,6 +38,6 @@ tests:
     memory_backed_volume:
       size: 4Gi
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: origin

--- a/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-main.yaml
+++ b/test/integration/repo-init/expected/ci-operator/config/org/repo/org-repo-main.yaml
@@ -61,6 +61,6 @@ tests:
           cpu: 100m
     workflow: ipi-aws
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: org
   repo: repo

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
@@ -3,7 +3,7 @@ postsubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
+    - ^main$
     cluster: api.ci
     decorate: true
     decoration_config:
@@ -12,7 +12,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
     max_concurrency: 1
-    name: branch-ci-openshift-origin-master-images
+    name: branch-ci-openshift-origin-main-images
     spec:
       containers:
       - args:

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -62,7 +62,7 @@ presubmits:
     branches:
     - ^main$
     - ^main-
-    cluster: api.ci
+    cluster: ci/api-build01-ci-devcluster-openshift-com:6443
     context: ci/prow/unit
     decorate: true
     decoration_config:

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/images
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-master-images
+    name: pull-ci-openshift-origin-main-images
     rerun_command: /test images
     spec:
       containers:
@@ -60,9 +60,9 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
-    cluster: ci/api-build01-ci-devcluster-openshift-com:6443
+    - ^main$
+    - ^main-
+    cluster: api.ci
     context: ci/prow/unit
     decorate: true
     decoration_config:
@@ -70,7 +70,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-openshift-origin-master-unit
+    name: pull-ci-openshift-origin-main-unit
     rerun_command: /test unit
     spec:
       containers:

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-main-presubmits.yaml
@@ -3,8 +3,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/cmd
     decorate: true
@@ -13,7 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-org-repo-master-cmd
+    name: pull-ci-org-repo-main-cmd
     rerun_command: /test cmd
     spec:
       containers:
@@ -58,8 +58,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/e2e
     decorate: true
@@ -70,7 +70,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-org-repo-master-e2e
+    name: pull-ci-org-repo-main-e2e
     rerun_command: /test e2e
     spec:
       containers:
@@ -132,8 +132,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/e2e-aws
     decorate: true
@@ -144,7 +144,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-org-repo-master-e2e-aws
+    name: pull-ci-org-repo-main-e2e-aws
     rerun_command: /test e2e-aws
     spec:
       containers:
@@ -206,8 +206,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/race
     decorate: true
@@ -216,7 +216,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-org-repo-master-race
+    name: pull-ci-org-repo-main-race
     rerun_command: /test race
     spec:
       containers:
@@ -261,8 +261,8 @@ presubmits:
   - agent: kubernetes
     always_run: true
     branches:
-    - ^master$
-    - ^master-
+    - ^main$
+    - ^main-
     cluster: api.ci
     context: ci/prow/unit
     decorate: true
@@ -271,7 +271,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-    name: pull-ci-org-repo-master-unit
+    name: pull-ci-org-repo-main-unit
     rerun_command: /test unit
     spec:
       containers:

--- a/test/integration/repo-init/expected/core-services/sanitize-prow-jobs/_config.yaml
+++ b/test/integration/repo-init/expected/core-services/sanitize-prow-jobs/_config.yaml
@@ -7,4 +7,4 @@ groups:
   "ci/api-build01-ci-devcluster-openshift-com:6443":
     jobs:
       - pull-ci-org-other-nonstandard-unit
-      - pull-ci-openshift-origin-master-unit
+      - pull-ci-openshift-origin-main-unit

--- a/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-main.yaml
+++ b/test/integration/repo-init/input/ci-operator/config/openshift/origin/openshift-origin-main.yaml
@@ -38,6 +38,6 @@ tests:
     memory_backed_volume:
       size: 4Gi
 zz_generated_metadata:
-  branch: master
+  branch: main
   org: openshift
   repo: origin

--- a/test/integration/repo-init/input/core-services/sanitize-prow-jobs/_config.yaml
+++ b/test/integration/repo-init/input/core-services/sanitize-prow-jobs/_config.yaml
@@ -7,4 +7,4 @@ groups:
   "ci/api-build01-ci-devcluster-openshift-com:6443":
     jobs:
       - pull-ci-org-other-nonstandard-unit
-      - pull-ci-openshift-origin-master-unit
+      - pull-ci-openshift-origin-main-unit


### PR DESCRIPTION
It is failing after the branch name change.

Also have 'main' as the default branch in new repos.