### PR TITLE
DPTP-4369 Enable debug logs on promotion pods, upload promotion artifacts to the gcs bucket

### DIFF
--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case.yaml
@@ -1,13 +1,14 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ci-operator.openshift.io/save-container-logs: "true"
   name: promotion
   namespace: ci-op-zyvwvffx
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true
-      --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=10 --keep-manifest-list
+      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
       docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
       && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
       retry; sleep $backoff; done

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__arm64_only.yaml
@@ -1,13 +1,14 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ci-operator.openshift.io/save-container-logs: "true"
   name: promotion
   namespace: ci-op-zyvwvffx
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true
-      --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=10 --keep-manifest-list
+      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
       docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
       && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
       retry; sleep $backoff; done

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_basic_case__multi_architecture.yaml
@@ -1,13 +1,14 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ci-operator.openshift.io/save-container-logs: "true"
   name: promotion
   namespace: ci-op-zyvwvffx
 spec:
   containers:
   - args:
-    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --keep-manifest-list
-      --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true
-      --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
+    - for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=10 --keep-manifest-list
+      --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:afd71aa3cbbf7d2e00cd8696747b2abf164700147723c657919c20b13d13ec62=registry.ci.openshift.org/ci/applyconfig:latest
       docker-registry.default.svc:5000/ci-op-y2n8rsh3/pipeline@sha256:bbb=registry.ci.openshift.org/ci/bin:latest
       && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before
       retry; sleep $backoff; done

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay.yaml
@@ -1,13 +1,15 @@
 metadata:
   creationTimestamp: null
+  labels:
+    ci-operator.openshift.io/save-container-logs: "true"
   name: promotion
   namespace: ci-op-9bdij1f6
 spec:
   containers:
   - args:
     - |-
-      oc image mirror --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest || true
-      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --continue-on-error=true --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      oc image mirror --loglevel=10 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ci_a_latest=quay.io/openshift/ci:20240603235401_prune_ci_a_latest quay.io/openshift/ci:ci_c_latest=quay.io/openshift/ci:20240603235401_prune_ci_c_latest || true
+      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=10 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_a_latest registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ddd=quay.io/openshift/ci:ci_c_latest && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
     command:
     - /bin/sh
     - -c


### PR DESCRIPTION
- Label `ci-operator.openshift.io/save-container-logs: "true"` was added to the promotion pods to allow the pod logs to be uploaded to the GCS bucket.
- Remove `--continue-on-error=true` flag on the `oc image mirror` commands.
- Add the `--loglevel=10` flag to generate debug logs while mirroring the images.

Log level 10 will generate descriptive logs for the whole image mirroring process. While testing this to make sure we won't leak any sensitive data, I confirm that the oc tool will mask any credentials are being used to push the image to the destination registry. (`-H "Authorization: Bearer <masked>"`)

/cc @openshift/test-platform @deepsm007 