### PR TITLE
[DPTP-4313] Respecting always_run from config file

### DIFF
--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_optional_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_optional_presubmit.yaml
@@ -1,5 +1,5 @@
 agent: kubernetes
-always_run: true
+always_run: false
 branches:
 - ^branch$
 - ^branch-

--- a/test/integration/ci-operator-prowgen/input/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/input/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -1,7 +1,7 @@
 presubmits:
   super/duper:
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^master$
     - ^master-
@@ -9,9 +9,7 @@ presubmits:
     decorate: true
     max_concurrency: 100
     name: pull-ci-super-duper-master-images
-    optional: true
     rerun_command: /test images
-    run_if_changed: changes
     skip_cloning: true
     skip_report: true
     spec:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -55,7 +55,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )ci-index,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-
@@ -180,7 +180,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )e2e,?($|\s.*)
   - agent: kubernetes
-    always_run: false
+    always_run: true
     branches:
     - ^master$
     - ^master-
@@ -193,9 +193,7 @@ presubmits:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     max_concurrency: 100
     name: pull-ci-super-duper-master-images
-    optional: true
     rerun_command: /test images
-    run_if_changed: changes
     skip_report: true
     spec:
       containers:
@@ -303,7 +301,7 @@ presubmits:
           secretName: result-aggregator
     trigger: (?m)^/test( | .* )lint,?($|\s.*)
   - agent: kubernetes
-    always_run: true
+    always_run: false
     branches:
     - ^master$
     - ^master-


### PR DESCRIPTION
Basically I added the `optional` option that was being ignored during presubmit creation of the image jobs.
https://github.com/openshift/ci-tools/blob/4db4a5296ec405bc353a459a3a6edef3bdd53bd6/pkg/prowgen/prowgen.go#L124-L145

```
		jobBaseGen.PodSpec.Add(Targets(presubmitTargets...))
		presubmits[orgrepo] = append(presubmits[orgrepo], *generatePresubmitForTest(jobBaseGen, imagesTestName, info, func(options *generatePresubmitOptions) {
			options.optional = optional
		}))
```

And cleaned some priorities based on previous `release/ci-operator/jobs` for some fields.