### PR TITLE
ci-operator: fix failure detection in release build

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -196,10 +196,14 @@ for ((i=1; i<=5; i++)); do
 		echo "Payload creation success."
 		exit_code="0"
 		break
+	else
+		exit_code="$?" # has to be in else block to actually capture oc exit code
+		echo "Payload creation failure (attempt $i/5)."
+		if [[ $i < 5 ]]; then
+			echo "Will be retried in 60 seconds..."
+			sleep 60
+		fi
 	fi
-	exit_code="$?"
-	echo "Payload creation failure. Will be retried in 60 seconds..."
-	sleep 60
 done
 if [[ "$exit_code" != "0" ]]; then
 	exit $exit_code
@@ -210,10 +214,14 @@ for ((i=1; i<=5; i++)); do
 		echo "Release payload extraction success."
 		exit_code="0"
 		break
+	else
+		exit_code="$?" # has to be in else block to actually capture oc exit code
+		echo "Release payload extraction failure (attempt $i/5)."
+		if [[ $i < 5 ]]; then
+			echo "Will be retried in 60 seconds..."
+			sleep 60
+		fi
 	fi
-	exit_code="$?"
-	echo "Release payload extraction failure. Retrying in 60 seconds..."
-	sleep 60
 done
 if [[ "$exit_code" != "0" ]]; then
 	exit $exit_code


### PR DESCRIPTION
Bash sucks:

```console
$ if /bin/false; then echo "false"; fi; echo $?
0
$ if /bin/false; then echo "false"; else echo $?; fi
1
```

I discovered this by actually breaking `oc adm release new` in https://github.com/openshift/oc/pull/1998, where I saw tests failing in multi-stage step consuming `RELEASE_IMAGE_LATEST`:

```
ERRO[2025-03-26T15:39:33Z] Some steps failed:
ERRO[2025-03-26T15:39:33Z]
  * could not run steps: step e2e-aws-ovn-serial failed: could not lazily evaluate deferred parameter "RELEASE_IMAGE_LATEST": image stream "release" has no tag "latest" in spec or status
```

But the preceding release build step was actually pretending to be successful:

```
INFO[2025-03-26T15:25:26Z] Creating release image registry.build01.ci.openshift.org/ci-op-7i976kdw/release:latest.
INFO[2025-03-26T15:39:33Z] Snapshot integration stream into release 4.19.0-0.ci.test-2025-03-26-152526-ci-op-7i976kdw-latest to tag release:latest
```

The [release build log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_oc/1998/pull-ci-openshift-oc-master-e2e-aws-ovn-serial/1904899252660736000/artifacts/release/build-log.txt) shows the issue though (notice the `exit_code=0` line):

```
error: failed to push image registry.build01.ci.openshift.org/ci-op-7i976kdw/release:latest: unable to upload new layer (0): Patch "https://registry.build01.ci.openshift.org/v2/ci-op-7i976kdw/release/blobs/uploads/aafa8fe9-00fb-48b1-9a36-0a4388e60ca2?_state=7XLZOhF3eKOx2Z6ZBEN2J1A_F_EaDlZ7xYouygBrf757Ik5hbWUiOiJjaS1vcC03aTk3Nmtkdy9yZWxlYXNlIiwiVVVJRCI6ImFhZmE4ZmU5LTAwZmItNDhiMS05YTM2LTBhNDM4OGU2MGNhMiIsIk9mZnNldCI6MCwiU3RhcnRlZEF0IjoiMjAyNS0wMy0yNlQxNTozMzoyOS44MzU4MDAzODRaIn0%3D": cluster-version-operator/0000_00_cluster-version-operator_03_deployment.yaml: invalid YAML/JSON: invalid map key: map[interface {}]interface {}{".ReleaseImage":interface {}(nil)}
+ exit_code=0
+ echo 'Payload creation failure. Will be retried in 60 seconds...'
Payload creation failure. Will be retried in 60 seconds...
```
