### PR TITLE
cluster-init: sort aws security groups

### DIFF
--- a/pkg/clusterinit/onboard/cischedulingwebhook/aws.go
+++ b/pkg/clusterinit/onboard/cischedulingwebhook/aws.go
@@ -3,6 +3,7 @@ package cischedulingwebhook
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
@@ -47,6 +48,9 @@ func (ap *awsProvider) securityGroups(ctx context.Context, client awstypes.EC2Cl
 	if err != nil {
 		return nil, err
 	}
+
+	slices.Sort(sg)
+
 	securityGroups := make([]interface{}, 0)
 	for i := range sg {
 		securityGroups = append(securityGroups, map[string]interface{}{

--- a/pkg/clusterinit/onboard/machineset/aws.go
+++ b/pkg/clusterinit/onboard/machineset/aws.go
@@ -3,6 +3,7 @@ package machineset
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
@@ -42,6 +43,9 @@ func (ap *awsProvider) securityGroups(ctx context.Context, client awstypes.EC2Cl
 	if err != nil {
 		return nil, err
 	}
+
+	slices.Sort(sg)
+
 	securityGroups := make([]interface{}, 0)
 	for i := range sg {
 		securityGroups = append(securityGroups, map[string]interface{}{

--- a/pkg/clusterinit/onboard/manifests/supplemental-ci-images/001_managed-clonerefs_mabc.yaml
+++ b/pkg/clusterinit/onboard/manifests/supplemental-ci-images/001_managed-clonerefs_mabc.yaml
@@ -23,7 +23,7 @@ spec:
       images:
       - from:
           kind: DockerImage
-          name: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250124-d572f855b
+          name: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250326-066356273
         paths:
         - destinationDir: .
           sourcePath: /ko-app/clonerefs

--- a/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/supplemental-ci-images/001_managed-clonerefs_mabc.yaml
+++ b/test/integration/cluster-init/update-build99/expected/clusters/build-clusters/build99/supplemental-ci-images/001_managed-clonerefs_mabc.yaml
@@ -29,7 +29,7 @@ spec:
       images:
       - from:
           kind: DockerImage
-          name: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250124-d572f855b
+          name: us-docker.pkg.dev/k8s-infra-prow/images/clonerefs:v20250326-066356273
         paths:
         - destinationDir: .
           sourcePath: /ko-app/clonerefs


### PR DESCRIPTION
Security groups returned by the AWS API call are not stable. It seems that, despite the values staying the same, ordering is not guaranteed. This may cause flakes for `ci/prow/breaking-changes`.