### PR TITLE
Refactor GCS Config Spec Uploader

### DIFF
--- a/pkg/config/gcs.go
+++ b/pkg/config/gcs.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"sigs.k8s.io/prow/pkg/pod-utils/gcs"
+
+	"github.com/openshift/ci-tools/pkg/util/gzip"
+)
+
+type GCSUploader struct {
+	gcsBucket          string
+	gcsCredentialsFile string
+}
+
+// UploadConfigSpec compresses, encodes, and uploads the given ciOpConfigContent to GCS
+// returns the full GCS url to the uploaded file
+func (u *GCSUploader) UploadConfigSpec(ctx context.Context, location, ciOpConfigContent string) (string, error) {
+	compressedConfig, err := gzip.CompressStringAndBase64(ciOpConfigContent)
+	if err != nil {
+		return "", fmt.Errorf("couldn't compress and base64 encode CONFIG_SPEC: %w", err)
+	}
+	uploadTargets := map[string]gcs.UploadFunc{
+		location: gcs.DataUpload(func() (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(compressedConfig)), nil
+		}),
+	}
+	if err := gcs.Upload(ctx, u.gcsBucket, u.gcsCredentialsFile, "", []string{"*"}, uploadTargets); err != nil {
+		return "", fmt.Errorf("couldn't upload CONFIG_SPEC to GCS: %w", err)
+	}
+	return fmt.Sprintf("gs://%s/%s", u.gcsBucket, location), nil
+}
+
+func NewGCSUploader(gcsBucket, gcsCredentialsFile string) *GCSUploader {
+	return &GCSUploader{
+		gcsBucket:          gcsBucket,
+		gcsCredentialsFile: gcsCredentialsFile,
+	}
+}

--- a/pkg/rehearse/jobs_test.go
+++ b/pkg/rehearse/jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,13 +106,18 @@ type fakeConfigUploader struct {
 	baseDir string
 }
 
-func (u *fakeConfigUploader) uploadConfigSpec(ciOpConfigContent, jobName string) (string, error) {
-	location := path.Join(u.baseDir, fmt.Sprintf("%s.yaml", jobName))
-	err := os.WriteFile(location, []byte(ciOpConfigContent), 0666)
+func (u *fakeConfigUploader) UploadConfigSpec(ctx context.Context, location, ciOpConfigContent string) (string, error) {
+	parts := strings.Split(location, "/")
+	if len(parts) == 0 {
+		return "", fmt.Errorf("can't extract job name from %s", location)
+	}
+	jobName := parts[len(parts)-1]
+	filename := path.Join(u.baseDir, fmt.Sprintf("%s.yaml", jobName))
+	err := os.WriteFile(filename, []byte(ciOpConfigContent), 0666)
 	if err != nil {
 		return "", err
 	}
-	return location, nil
+	return filename, nil
 }
 
 func TestInlineCiopConfig(t *testing.T) {

--- a/pkg/rehearse/rehearse.go
+++ b/pkg/rehearse/rehearse.go
@@ -175,11 +175,7 @@ func (r RehearsalConfig) SetupJobs(candidate RehearsalCandidate, candidatePath s
 	repo := candidate.repo
 	prRefs := candidate.createRefs()
 
-	uploader := &gcsConfigSpecUploader{
-		refs:               prRefs,
-		gcsBucket:          r.GCSBucket,
-		gcsCredentialsFile: r.GCSCredentialsFile,
-	}
+	uploader := config.NewGCSUploader(r.GCSBucket, r.GCSCredentialsFile)
 	jobConfigurer := NewJobConfigurer(r.DryRun, prConfig.CiOperator, prConfig.Prow, resolver, logger, prRefs, uploader)
 	imageStreamTags, presubmitsToRehearse, err := jobConfigurer.ConfigurePresubmitRehearsals(presubmits)
 	if err != nil {


### PR DESCRIPTION
Move `gcsConfigSpecUploader` into `pkg/config/gcs.go` and make it public.
I might need to reuse the code elsewhere and I don't want to duplicate it.