### PR TITLE
Konflux: Fetch EphemeralCluster kubeconfig

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -24,7 +24,12 @@ const (
 )
 
 const (
-	CIOperatorJobsGenerateFailure = "CIOperatorJobsGenerateFailure"
+	CIOperatorJobsGenerateFailureReason = "CIOperatorJobsGenerateFailure"
+	ProwJobFailureReason                = "ProwJobFailure"
+	KubeconfigFetchFailureReason        = "KubeconfigFetchFailure"
+
+	CIOperatorNSNotFoundMsg = "ci-operator NS not found"
+	KubeconfigNotReadMsg    = "kubeconfig not ready"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -242,7 +242,7 @@ func (r *reconciler) uploadCIOperatorConfig(ctx context.Context, config *api.Rel
 func (r *reconciler) fetchKubeconfig(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, pj *prowv1.ProwJob) (reconcile.Result, error) {
 	buildClient, ok := r.buildClients[pj.Spec.Cluster]
 	if !ok {
-		err := fmt.Errorf("unkown cluster %s", pj.Spec.Cluster)
+		err := fmt.Errorf("uknown cluster %s", pj.Spec.Cluster)
 		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, err.Error())
 		return reconcile.Result{}, reconcile.TerminalError(err)
 	}

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -27,9 +27,11 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/openshift/ci-tools/pkg/prowgen"
+	"github.com/openshift/ci-tools/pkg/steps"
 )
 
 const (
+	WaitTestStepName = "wait-test-complete"
 	ProwJobNamespace = "ci"
 )
 
@@ -51,7 +53,8 @@ type reconciler struct {
 	configUploader ConfigSpecUploader
 
 	// Mock for testing
-	now func() time.Time
+	now     func() time.Time
+	polling func() time.Duration
 }
 
 func AddToManager(logger *logrus.Entry, mgr manager.Manager, allManagers map[string]manager.Manager) error {
@@ -77,7 +80,7 @@ func AddToManager(logger *logrus.Entry, mgr manager.Manager, allManagers map[str
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := r.logger.WithField("request", req.String())
+	log := r.logger.WithField("request", req.String())
 
 	ec := &ephemeralclusterv1.EphemeralCluster{}
 	if err := r.masterClient.Get(ctx, req.NamespacedName, ec); err != nil {
@@ -98,16 +101,20 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return r.handleGetProwJobError(err)
 		}
 	} else {
-		r.logger.Info("ProwJob not found, creating")
-		r.createProwJob(ctx, ec)
-		err := r.masterClient.Update(ctx, ec)
-		if err != nil {
-			err = fmt.Errorf("update ephemeral cluster: %w", err)
-		}
-		return reconcile.Result{}, err
+		log.Info("ProwJob not found, creating")
+		r.createProwJob(ctx, log, ec)
+		return reconcile.Result{RequeueAfter: r.polling()}, r.updateEphemeralCluster(ctx, ec)
 	}
 
-	logger.Info("Finished reconciliation")
+	if ec.Status.Kubeconfig == "" {
+		log.Info("Fetching the kubeconfig")
+		res, err := r.fetchKubeconfig(ctx, log, ec, &pj)
+		if err := r.updateEphemeralCluster(ctx, ec); err != nil {
+			return reconcile.Result{RequeueAfter: r.polling()}, err
+		}
+		return res, err
+	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -120,7 +127,7 @@ func (r *reconciler) handleGetProwJobError(err error) (reconcile.Result, error) 
 	}
 }
 
-func (r *reconciler) createProwJob(ctx context.Context, ec *ephemeralclusterv1.EphemeralCluster) {
+func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster) {
 	ciOperatorConfig := &api.ReleaseBuildConfiguration{
 		InputConfiguration: api.InputConfiguration{
 			Releases: map[string]api.UnresolvedRelease{
@@ -138,7 +145,7 @@ func (r *reconciler) createProwJob(ctx context.Context, ec *ephemeralclusterv1.E
 			As: "cluster-provisioning",
 			MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
 				Test: []api.LiteralTestStep{{
-					As:       "wait-test-complete",
+					As:       WaitTestStepName,
 					From:     "cli",
 					Commands: waitKubeconfigSh,
 					Resources: api.ResourceRequirements{
@@ -157,20 +164,20 @@ func (r *reconciler) createProwJob(ctx context.Context, ec *ephemeralclusterv1.E
 
 	pj, err := r.makeProwJob(ciOperatorConfig)
 	if err != nil {
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailure, err.Error())
+		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
 		return
 	}
 
 	location, err := r.uploadCIOperatorConfig(ctx, ciOperatorConfig)
 	if err != nil {
 		err := fmt.Errorf("upload ci config: %w", err)
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailure, err.Error())
+		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
 		return
 	}
-	r.logger.WithField("Path", location).Info("Config uploaded to GCS")
+	log.WithField("Path", location).Info("Config uploaded to GCS")
 
 	if len(pj.Spec.PodSpec.Containers) != 1 {
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailure, "too many presubmit containers")
+		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, "too many presubmit containers")
 		return
 	}
 	container := &pj.Spec.PodSpec.Containers[0]
@@ -178,7 +185,7 @@ func (r *reconciler) createProwJob(ctx context.Context, ec *ephemeralclusterv1.E
 
 	if err := r.masterClient.Create(ctx, pj); err != nil {
 		err = fmt.Errorf("create prowjob: %w", err)
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailure, err.Error())
+		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
 		return
 	}
 
@@ -230,6 +237,56 @@ func (r *reconciler) uploadCIOperatorConfig(ctx context.Context, config *api.Rel
 		return "", fmt.Errorf("marshal config: %w", err)
 	}
 	return r.configUploader.UploadConfigSpec(ctx, gcsPath, string(configBytes))
+}
+
+func (r *reconciler) fetchKubeconfig(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, pj *prowv1.ProwJob) (reconcile.Result, error) {
+	buildClient, ok := r.buildClients[pj.Spec.Cluster]
+	if !ok {
+		err := fmt.Errorf("unkown cluster %s", pj.Spec.Cluster)
+		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, err.Error())
+		return reconcile.Result{}, reconcile.TerminalError(err)
+	}
+
+	nss := corev1.NamespaceList{}
+	if err := buildClient.List(ctx, &nss, ctrlruntimeclient.MatchingLabels{steps.LabelJobID: pj.Name}); err != nil {
+		err := fmt.Errorf("get namespace for %s: %w", pj.Name, err)
+		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, err.Error())
+		return reconcile.Result{RequeueAfter: r.polling()}, nil
+	}
+
+	// The NS hasn't been created yet, requeuing.
+	if len(nss.Items) == 0 {
+		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, ephemeralclusterv1.CIOperatorNSNotFoundMsg)
+		return reconcile.Result{RequeueAfter: r.polling()}, nil
+	}
+
+	ns := nss.Items[0].Name
+	kubeconfigSecret := corev1.Secret{}
+	// The secret is named after the test step name.
+	if err := buildClient.Get(ctx, types.NamespacedName{Name: WaitTestStepName, Namespace: ns}, &kubeconfigSecret); err != nil {
+		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, err.Error())
+		return reconcile.Result{RequeueAfter: r.polling()}, nil
+	}
+
+	kubeconfig, ok := kubeconfigSecret.Data["kubeconfig"]
+	if !ok {
+		// The kubeconfig takes time before being stored into the secret, requeuing.
+		r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.KubeconfigFetchFailureReason, ephemeralclusterv1.KubeconfigNotReadMsg)
+		return reconcile.Result{RequeueAfter: r.polling()}, nil
+	}
+
+	ec.Status.Kubeconfig = string(kubeconfig)
+	log.Info("kubeconfig fetched")
+	r.upsertCondition(ec, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionTrue, "", "")
+
+	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) updateEphemeralCluster(ctx context.Context, ec *ephemeralclusterv1.EphemeralCluster) error {
+	if err := r.masterClient.Update(ctx, ec); err != nil {
+		return fmt.Errorf("update ephemereal cluster: %w", err)
+	}
+	return nil
 }
 
 func (r *reconciler) upsertCondition(ec *ephemeralclusterv1.EphemeralCluster, t ephemeralclusterv1.EphemeralClusterConditionType, status ephemeralclusterv1.ConditionStatus, reason, msg string) {

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -466,13 +466,13 @@ func TestFetchKubeconfig(t *testing.T) {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
-						Message:            "unkown cluster build01",
+						Message:            "uknown cluster build01",
 						LastTransitionTime: v1.NewTime(fakeNow),
 					}},
 				},
 			},
 			wantRes: reconcile.Result{},
-			wantErr: reconcile.TerminalError(errors.New("unkown cluster build01")),
+			wantErr: reconcile.TerminalError(errors.New("uknown cluster build01")),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -3,11 +3,14 @@ package ephemeralcluster
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,6 +24,7 @@ import (
 	"sigs.k8s.io/prow/pkg/pjutil"
 
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/openshift/ci-tools/pkg/steps"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
@@ -44,17 +48,41 @@ func newPresubmitFaker(name string, now time.Time) NewPresubmitFunc {
 	}
 }
 
-func TestCreateProwJob(t *testing.T) {
+func fakeNow(t *testing.T) time.Time {
 	fakeNow, err := time.Parse("2006-01-02 15:04:05", "2025-04-02 12:12:12")
 	if err != nil {
 		t.Fatalf("parse fake now: %s", err)
 	}
+	return fakeNow
+}
 
+func fakeScheme(t *testing.T) *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme)
+	sb := runtime.NewSchemeBuilder(ephemeralclusterv1.AddToScheme, prowv1.AddToScheme, corev1.AddToScheme)
 	if err := sb.AddToScheme(scheme); err != nil {
 		t.Fatal("build scheme")
 	}
+	return scheme
+}
+
+func cmpError(t *testing.T, want, got error) {
+	if got != nil && want == nil {
+		t.Errorf("want err nil but got: %v", got)
+	}
+	if got == nil && want != nil {
+		t.Errorf("want err %v but nil", want)
+	}
+	if got != nil && want != nil {
+		if diff := cmp.Diff(want.Error(), got.Error()); diff != "" {
+			t.Errorf("unexpected error: %s", diff)
+		}
+	}
+}
+
+func TestCreateProwJob(t *testing.T) {
+	fakeNow := fakeNow(t)
+	scheme := fakeScheme(t)
+	const pollingTime = 5
 
 	for _, tc := range []struct {
 		name            string
@@ -62,6 +90,8 @@ func TestCreateProwJob(t *testing.T) {
 		req             reconcile.Request
 		interceptors    interceptor.Funcs
 		configUploadErr error
+		wantRes         reconcile.Result
+		wantErr         error
 	}{
 		{
 			name: "An EphemeralCluster request creates a ProwJob",
@@ -78,7 +108,8 @@ func TestCreateProwJob(t *testing.T) {
 					},
 				},
 			},
-			req: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
 		{
 			name:            "Handle config upload error",
@@ -96,7 +127,8 @@ func TestCreateProwJob(t *testing.T) {
 					},
 				},
 			},
-			req: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
 		{
 			name: "Fail to create a ProwJob",
@@ -119,10 +151,12 @@ func TestCreateProwJob(t *testing.T) {
 				}
 				return client.Create(ctx, obj, opts...)
 			}},
-			req: reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			client := fake.NewClientBuilder().
 				WithObjects(&tc.ec).
 				WithScheme(scheme).
@@ -133,13 +167,16 @@ func TestCreateProwJob(t *testing.T) {
 				logger:         logrus.NewEntry(logrus.StandardLogger()),
 				masterClient:   client,
 				now:            func() time.Time { return fakeNow },
+				polling:        func() time.Duration { return pollingTime },
 				newPresubmit:   newPresubmitFaker("foobar", fakeNow),
 				configUploader: &fakeGCSUploader{err: tc.configUploadErr},
 			}
 
-			_, err := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Namespace: tc.ec.Namespace, Name: tc.ec.Name}})
-			if err != nil {
-				t.Errorf("unexpected reconcile error: %s", err)
+			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
+			cmpError(t, tc.wantErr, gotErr)
+
+			if diff := cmp.Diff(tc.wantRes, gotRes); diff != "" {
+				t.Errorf("unexpected reconcile.Result: %s", diff)
 			}
 
 			gotEC := ephemeralclusterv1.EphemeralCluster{}
@@ -155,6 +192,328 @@ func TestCreateProwJob(t *testing.T) {
 			}
 
 			testhelper.CompareWithFixture(t, pjs, testhelper.WithPrefix("pj-"))
+		})
+	}
+}
+
+func TestFetchKubeconfig(t *testing.T) {
+	scheme := fakeScheme(t)
+	fakeNow := fakeNow(t)
+	const pollingTime = 5
+
+	for _, tc := range []struct {
+		name             string
+		ec               *ephemeralclusterv1.EphemeralCluster
+		objs             []ctrlclient.Object
+		buildClients     func() map[string]ctrlclient.Client
+		buildClusterObjs []ctrlclient.Object
+		wantEC           *ephemeralclusterv1.EphemeralCluster
+		wantRes          reconcile.Result
+		wantErr          error
+	}{
+		{
+			name: "Kubeconfig stored already, do nothing",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID:  "pj-123",
+					Kubeconfig: "kubeconfig",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "999",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID:  "pj-123",
+					Kubeconfig: "kubeconfig",
+				},
+			},
+			wantRes: reconcile.Result{},
+		},
+		{
+			name: "Kubeconfig ready",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			buildClients: func() map[string]ctrlclient.Client {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "pj-123"},
+							Name:   "ci-op-1234",
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: v1.ObjectMeta{Name: WaitTestStepName, Namespace: "ci-op-1234"},
+						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
+					},
+				}
+				return map[string]ctrlclient.Client{
+					"build01": fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build(),
+				}
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "1000",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID:  "pj-123",
+					Kubeconfig: "kubeconfig",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionTrue,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{},
+		},
+		{
+			name: "ci-operator NS doesn't exist yet",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			buildClients: func() map[string]ctrlclient.Client {
+				return map[string]ctrlclient.Client{
+					"build01": fake.NewClientBuilder().WithScheme(scheme).Build(),
+				}
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "1000",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
+						Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Secret not found",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			buildClients: func() map[string]ctrlclient.Client {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "pj-123"},
+							Name:   "ci-op-1234",
+						},
+					},
+				}
+				return map[string]ctrlclient.Client{
+					"build01": fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build(),
+				}
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "1000",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
+						Message:            fmt.Sprintf("secrets %q not found", WaitTestStepName),
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Kubeconfig not ready",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			buildClients: func() map[string]ctrlclient.Client {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: v1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "pj-123"},
+							Name:   "ci-op-1234",
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: v1.ObjectMeta{Name: WaitTestStepName, Namespace: "ci-op-1234"},
+					},
+				}
+				return map[string]ctrlclient.Client{
+					"build01": fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build(),
+				}
+			},
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "1000",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
+						Message:            ephemeralclusterv1.KubeconfigNotReadMsg,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+		},
+		{
+			name: "Client not found, return a terminal error",
+			ec: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+				},
+			},
+			objs: []ctrlclient.Object{
+				&prowv1.ProwJob{
+					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: ProwJobNamespace},
+					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+				},
+			},
+			buildClients: func() map[string]ctrlclient.Client { return map[string]ctrlclient.Client{} },
+			wantEC: &ephemeralclusterv1.EphemeralCluster{
+				ObjectMeta: v1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "bar",
+					ResourceVersion: "1000",
+				},
+				Status: ephemeralclusterv1.EphemeralClusterStatus{
+					ProwJobID: "pj-123",
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ClusterReady,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
+						Message:            "unkown cluster build01",
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}},
+				},
+			},
+			wantRes: reconcile.Result{},
+			wantErr: reconcile.TerminalError(errors.New("unkown cluster build01")),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := fake.NewClientBuilder().
+				WithObjects(tc.ec).
+				WithObjects(tc.objs...).
+				WithScheme(scheme).
+				Build()
+
+			clients := make(map[string]ctrlclient.Client)
+			if tc.buildClients != nil {
+				clients = tc.buildClients()
+			}
+
+			r := reconciler{
+				logger:         logrus.NewEntry(logrus.StandardLogger()),
+				masterClient:   client,
+				buildClients:   clients,
+				now:            func() time.Time { return fakeNow },
+				polling:        func() time.Duration { return pollingTime },
+				newPresubmit:   newPresubmitFaker("foobar", fakeNow),
+				configUploader: &fakeGCSUploader{err: nil},
+			}
+
+			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
+			cmpError(t, tc.wantErr, gotErr)
+
+			if diff := cmp.Diff(tc.wantRes, gotRes); diff != "" {
+				t.Errorf("unexpected reconcile.Result: %s", diff)
+			}
+
+			gotEC := ephemeralclusterv1.EphemeralCluster{}
+			if err := client.Get(context.TODO(), types.NamespacedName{Namespace: tc.ec.Namespace, Name: tc.ec.Name}, &gotEC); err != nil {
+				t.Errorf("unexpected get ephemeralcluster error: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.wantEC, &gotEC); diff != "" {
+				t.Errorf("unexpected ephemeralcluster: %s", diff)
+			}
 		})
 	}
 }


### PR DESCRIPTION
The `EphemeralCluster` has been requested, and the controller spawned a `ci-operator` instance that is provisioning an ephemeral cluster.

As soon as the cluster is ready, `ci-operator` stores an admin kubeconfig into `secret/wait-test-complete`, as per design.
This reconciler will then retrieve it by following these steps in the `func fetchKubeconfig`:
- Identify the cluster in which `ci-operator` is running by looking at the `.spec.cluster` stanza on the ProwJob.
- Identify the `ci-op-xxxx` test NS by matching any namespace against this label: `ci.openshift.io/jobid == <PJ_ID_HERE>`.
- Get the `kubeconfig` from the `wait-test-complete` and store it into the `EphemeralCluster`'s `.status.kubeconfig` field.