### PR TITLE
Konflux: Support EphemeralCluster Deletion

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -12,6 +12,8 @@ const (
 	ClusterProvisioning EphemeralClusterConditionType = "ClusterProvisioning"
 	// ContainersReady indicates whether the cluster is up and running.
 	ClusterReady EphemeralClusterConditionType = "ClusterReady"
+	// ProwJobCompleted indicates whether the ProwJob is running.
+	ProwJobCompleted EphemeralClusterConditionType = "ProwJobCompleted"
 )
 
 type ConditionStatus string
@@ -26,6 +28,7 @@ const (
 const (
 	CIOperatorJobsGenerateFailureReason = "CIOperatorJobsGenerateFailure"
 	ProwJobFailureReason                = "ProwJobFailure"
+	ProwJobCompletedReason              = "ProwJobCompleted"
 	KubeconfigFetchFailureReason        = "KubeconfigFetchFailure"
 
 	CIOperatorNSNotFoundMsg = "ci-operator NS not found"

--- a/pkg/controller/ephemeralcluster/prowjobreconciler.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler.go
@@ -1,0 +1,103 @@
+package ephemeralcluster
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/sirupsen/logrus"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlbldr "sigs.k8s.io/controller-runtime/pkg/builder"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+const (
+	EphemeralClusterProwJobLabel = "ci.openshift.io/ephemeral-cluster"
+	DependentProwJobFinalizer    = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
+	AbortECNotFound              = "Ephemeral Cluster not found"
+)
+
+type prowJobReconciler struct {
+	logger *logrus.Entry
+	client ctrlclient.Client
+
+	now func() time.Time
+}
+
+func ProwJobFilter(object ctrlclient.Object) bool {
+	_, ok := object.GetLabels()[EphemeralClusterProwJobLabel]
+	return ok
+}
+
+func addPJReconcilerToManager(logger *logrus.Entry, mgr manager.Manager) error {
+	r := prowJobReconciler{
+		logger: logger,
+		client: mgr.GetClient(),
+	}
+
+	if err := ctrlbldr.ControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
+		WithEventFilter(predicate.NewPredicateFuncs(ProwJobFilter)).
+		For(&prowv1.ProwJob{}).
+		Complete(&r); err != nil {
+		return fmt.Errorf("build controller: %w", err)
+	}
+
+	return nil
+}
+
+func (r *prowJobReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	pj := &prowv1.ProwJob{}
+	if err := r.client.Get(ctx, req.NamespacedName, pj); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		} else {
+			return reconcile.Result{}, err
+		}
+	}
+
+	ecName, ok := pj.Labels[EphemeralClusterNameLabel]
+	if !ok {
+		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("%s doesn't have the EC label", pj.Name))
+	}
+
+	pj = pj.DeepCopy()
+
+	ec := ephemeralclusterv1.EphemeralCluster{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: ecName, Namespace: EphemeralClusterNamespace}, &ec); err != nil {
+		if kerrors.IsNotFound(err) {
+			return abortProwJob(ctx, r.client, pj, AbortECNotFound, r.now())
+		} else {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func abortProwJob(ctx context.Context, client ctrlclient.Client, pj *prowv1.ProwJob, reason string, now time.Time) (reconcile.Result, error) {
+	if pj.Status.State == prowv1.AbortedState {
+		return reconcile.Result{}, nil
+	}
+
+	pj.Status.State = prowv1.AbortedState
+	pj.Status.Description = reason
+	pj.Status.CompletionTime = ptr.To(v1.NewTime(now))
+
+	if err := client.Update(ctx, pj); err != nil {
+		return reconcile.Result{}, fmt.Errorf("abort prowjob: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
@@ -1,0 +1,175 @@
+package ephemeralcluster
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+)
+
+// pjObjectMock exists because the ProwJob object doesn't implement the Object interface.
+type pjObjectMock struct {
+	ctrlclient.Object
+	labels map[string]string
+}
+
+func (m *pjObjectMock) GetLabels() map[string]string {
+	return m.labels
+}
+
+func TestProwJobFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		obj        ctrlclient.Object
+		wantResult bool
+	}{
+		{
+			name:       "Label set, process",
+			obj:        &pjObjectMock{labels: map[string]string{EphemeralClusterProwJobLabel: ""}},
+			wantResult: true,
+		},
+		{
+			name: "Label not set, do not process",
+			obj:  &pjObjectMock{labels: map[string]string{"": ""}},
+		},
+		{
+			name: "No labels, do not process",
+			obj:  &pjObjectMock{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotResult := ProwJobFilter(tc.obj)
+			if tc.wantResult != gotResult {
+				t.Errorf("want %t but got %t", tc.wantResult, gotResult)
+			}
+		})
+	}
+}
+
+func TestReconcileProwJob(t *testing.T) {
+	addObjs := func(bldr *fake.ClientBuilder, objs ...ctrlclient.Object) *fake.ClientBuilder {
+		for _, obj := range objs {
+			if !reflect.ValueOf(obj).IsNil() {
+				bldr = bldr.WithObjects(obj)
+			}
+		}
+		return bldr
+	}
+	fakeNow := fakeNow(t)
+	scheme := fakeScheme(t)
+
+	for _, tc := range []struct {
+		name         string
+		pj           *prowv1.ProwJob
+		ec           *ephemeralclusterv1.EphemeralCluster
+		interceptors interceptor.Funcs
+		wantEC       *ephemeralclusterv1.EphemeralCluster
+		wantPJ       *prowv1.ProwJob
+		wantRes      reconcile.Result
+		wantErr      error
+	}{
+		{
+			name: "No EphemeralCluster label, stop reconciling",
+			ec:   &ephemeralclusterv1.EphemeralCluster{},
+			pj: &prowv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "bar"},
+			},
+			wantEC:  &ephemeralclusterv1.EphemeralCluster{},
+			wantRes: reconcile.Result{},
+			wantErr: reconcile.TerminalError(errors.New("foo doesn't have the EC label")),
+		},
+		{
+			name: "EphemeralCluster not found, aborting the ProwJob",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterProwJobLabel: "",
+						EphemeralClusterNameLabel:    "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterProwJobLabel: "",
+						EphemeralClusterNameLabel:    "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Status: prowv1.ProwJobStatus{
+					State:          prowv1.AbortedState,
+					Description:    AbortECNotFound,
+					CompletionTime: ptr.To(v1.NewTime(fakeNow)),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bldr := fake.NewClientBuilder().
+				WithInterceptorFuncs(tc.interceptors).
+				WithScheme(scheme)
+			client := addObjs(bldr, tc.pj, tc.ec).Build()
+
+			r := prowJobReconciler{
+				logger: logrus.NewEntry(logrus.StandardLogger()),
+				client: client,
+				now:    func() time.Time { return fakeNow },
+			}
+
+			req := reconcile.Request{}
+			if tc.pj != nil {
+				req = reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.pj.Name, Namespace: tc.pj.Namespace}}
+			}
+			gotRes, gotErr := r.Reconcile(context.TODO(), req)
+			cmpError(t, tc.wantErr, gotErr)
+
+			if diff := cmp.Diff(tc.wantRes, gotRes); diff != "" {
+				t.Errorf("unexpected reconcile.Result: %s", diff)
+			}
+
+			if tc.wantEC != nil {
+				gotEC := ephemeralclusterv1.EphemeralCluster{}
+				if err := client.Get(context.TODO(), types.NamespacedName{Namespace: tc.ec.Namespace, Name: tc.ec.Name}, &gotEC); err != nil {
+					t.Errorf("get ephemeralcluster error: %s", err)
+				}
+
+				ignoreFields := cmpopts.IgnoreFields(ephemeralclusterv1.EphemeralCluster{}, "ResourceVersion")
+				if diff := cmp.Diff(tc.wantEC, &gotEC, ignoreFields); diff != "" {
+					t.Errorf("unexpected ephemeralcluster: %s", diff)
+				}
+			}
+
+			if tc.wantPJ != nil {
+				gotPJ := prowv1.ProwJob{}
+				if err := client.Get(context.TODO(), types.NamespacedName{Namespace: tc.pj.Namespace, Name: tc.pj.Name}, &gotPJ); err != nil {
+					t.Errorf("get prowjob error: %s", err)
+				}
+
+				ignoreFields := cmpopts.IgnoreFields(prowv1.ProwJob{}, "ResourceVersion")
+				if diff := cmp.Diff(tc.wantPJ, &gotPJ, ignoreFields); diff != "" {
+					t.Errorf("unexpected prowjob: %s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -79,6 +79,10 @@ func AddToManager(logger *logrus.Entry, mgr manager.Manager, allManagers map[str
 		return fmt.Errorf("build controller: %w", err)
 	}
 
+	if err := addPJReconcilerToManager(logger, mgr); err != nil {
+		return fmt.Errorf("build prowjob controller: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -1,5 +1,7 @@
 metadata:
   creationTimestamp: null
+  finalizers:
+  - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec
   namespace: ns
   resourceVersion: "1000"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -7,6 +7,7 @@ items:
       prow.k8s.io/job: pull-ci-org-repo-branch-cluster-provisioning
     creationTimestamp: null
     labels:
+      ci.openshift.io/ephemeral-cluster-name: ""
       created-by-prow: "true"
       event-GUID: no-event-guid
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
Introducing some features:
1. Report the status of a `ProwJob` as a condition to the `EphemeralCluster`. As an example: if a PJ is in a `success` state, the following condition will be added to the `EphemeralCluster`:
```yaml
conditions:
- type: ProwJobCompleted,
  status: True
  reason: ProwJobCompleted
  message: "prowjob state: success",
  lastTransitionTime: "2025-04-10T10:23:00Z"
```
3. Add a finalizer to the `EphemeralCluster` when its related `ProwJob` has been created, so to make sure it won't be deleted as long as the PJ exists.
4. Abort `ProwJob` when the `EphemeralCluster` deletion has been requested.
5. Add a new reconciler to handle a corner case: abort a `ProwJob` when its related `EphemeralCluster` doesn't exist anymore.

/label tide/merge-method-squash