### PR TITLE
fix: change separator in release version format

### DIFF
--- a/pkg/steps/release/create_release.go
+++ b/pkg/steps/release/create_release.go
@@ -170,7 +170,7 @@ func (s *assembleReleaseStep) run(ctx context.Context) error {
 		prefix = configName
 	}
 	now := time.Now().UTC().Truncate(time.Second)
-	version := fmt.Sprintf("%s.%s-test-%s-%s", prefix, now.Format("2006-01-02-150405"), s.jobSpec.Namespace(), s.name)
+	version := fmt.Sprintf("%s-%s-test-%s-%s", prefix, now.Format("2006-01-02-150405"), s.jobSpec.Namespace(), s.name)
 
 	destination := fmt.Sprintf("%s:%s", releaseImageStreamRepo, s.name)
 	logrus.Infof("Creating release image %s.", destination)


### PR DESCRIPTION
The current version format is 4.19.0-0.ci.2025-04-10-162714-test-ci-op-w42f90jc-latest,
but all official OCP version formats use 4.19.0-0.ci-2025-04-10-105124.
The separator between ci and the date should be a hyphen `-`, not a dot `.`