### PR TITLE
`prowgen`: add `shard_count` field to the test step configuration

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -826,6 +826,11 @@ type TestStepConfiguration struct {
 	// RestrictNetworkAccess restricts network access to RedHat intranet.
 	RestrictNetworkAccess *bool `json:"restrict_network_access,omitempty"`
 
+	// ShardCount describes the number of jobs that should be generated as shards for this test
+	// Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps
+	// Only applicable to presubmits and periodics
+	ShardCount *int `json:"shard_count,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration                                *ContainerTestConfiguration                                `json:"container,omitempty"`
 	MultiStageTestConfiguration                               *MultiStageTestConfiguration                               `json:"steps,omitempty"`

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -2184,6 +2184,11 @@ func (in *TestStepConfiguration) DeepCopyInto(out *TestStepConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ShardCount != nil {
+		in, out := &in.ShardCount, &out.ShardCount
+		*out = new(int)
+		**out = **in
+	}
 	if in.ContainerTestConfiguration != nil {
 		in, out := &in.ContainerTestConfiguration, &out.ContainerTestConfiguration
 		*out = new(ContainerTestConfiguration)

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -584,6 +584,15 @@ func TargetAdditionalSuffix(suffix string) PodSpecMutator {
 	}
 }
 
+func MultiStageParam(key, value string) PodSpecMutator {
+	return func(spec *corev1.PodSpec) error {
+		container := &spec.Containers[0]
+		// We must quote the entire arg as the value could contain spaces
+		container.Args = append(container.Args, fmt.Sprintf(`--multi-stage-param="%s=%s"`, key, value))
+		return nil
+	}
+}
+
 // InjectTestFrom configures ci-operator to inject the specified test from the
 // specified ci-operator config into the base config and target it
 func InjectTestFrom(source *cioperatorapi.MetadataWithTest) PodSpecMutator {

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -689,6 +689,19 @@ func TestGenerateJobs(t *testing.T) {
 				Branch: "branch",
 			}},
 		},
+		{
+			id: "sharded presubmit",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "unit", ShardCount: intPointer(3), ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "bin"}},
+				},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
 	}
 
 	for _, tc := range tests {
@@ -751,4 +764,8 @@ func pruneForTests(jobConfig *prowconfig.JobConfig) {
 			jobConfig.PostsubmitsStatic[repo][i].UtilityConfig = prowconfig.UtilityConfig{}
 		}
 	}
+}
+
+func intPointer(val int) *int {
+	return &val
 }

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_sharded_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_sharded_presubmit.yaml
@@ -1,0 +1,14 @@
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-unit-1of3
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-unit-2of3
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-unit-3of3

--- a/pkg/validation/graph.go
+++ b/pkg/validation/graph.go
@@ -72,6 +72,16 @@ func IsValidGraphConfiguration(rawSteps []api.StepConfiguration) error {
 			} else if c.MultiStageTestConfigurationLiteral != nil {
 				multiStageTests = append(multiStageTests, c)
 			}
+
+			if c.ShardCount != nil {
+				if c.Postsubmit {
+					ret = append(ret, fmt.Errorf("tests[%s].shard_count is not valid for a postsubmit", c.As))
+				}
+				shardCount := *c.ShardCount
+				if shardCount <= 1 {
+					ret = append(ret, fmt.Errorf("tests[%s].shard_count must be greater than 1 if provided", c.As))
+				}
+			}
 		} else if c := s.ProjectDirectoryImageBuildInputs; c != nil {
 			addName(string(api.PipelineImageStreamTagReferenceRoot))
 			pipelineImages[api.PipelineImageStreamTagReferenceRoot] = sets.Empty{}

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -1032,6 +1032,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"              mount_path: ' '\n" +
 	"              # Secret name, used inside test containers\n" +
 	"              name: ' '\n" +
+	"        # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
+	"        # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +
+	"        # Only applicable to presubmits and periodics\n" +
+	"        shard_count: 0\n" +
 	"        # SkipIfOnlyChanged is a regex that will result in the test being skipped if all changed files match that regex.\n" +
 	"        skip_if_only_changed: ' '\n" +
 	"        steps:\n" +
@@ -1882,6 +1886,10 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          mount_path: ' '\n" +
 	"          # Secret name, used inside test containers\n" +
 	"          name: ' '\n" +
+	"      # ShardCount describes the number of jobs that should be generated as shards for this test\n" +
+	"      # Each generated job will be a duplication, but contain a suffix and the necessary SHARD_ARGS will be passed to the steps\n" +
+	"      # Only applicable to presubmits and periodics\n" +
+	"      shard_count: 0\n" +
 	"      # SkipIfOnlyChanged is a regex that will result in the test being skipped if all changed files match that regex.\n" +
 	"      skip_if_only_changed: ' '\n" +
 	"      steps:\n" +

--- a/test/integration/ci-operator-prowgen/input/config/sharded/repo/sharded-repo-main.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/sharded/repo/sharded-repo-main.yaml
@@ -1,0 +1,20 @@
+build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.23
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: e2e-test
+  shard_count: 3
+  steps:
+    workflow: workflow
+zz_generated_metadata:
+  branch: main
+  org: sharded
+  repo: repo

--- a/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
@@ -1,0 +1,167 @@
+presubmits:
+  sharded/repo:
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    context: ci/prow/e2e-test-1of3
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-sharded-repo-main-e2e-test-1of3
+    rerun_command: /test e2e-test-1of3
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 1"
+        - --report-credentials-file=/etc/report/credentials
+        - --target=e2e-test
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-test-1of3,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    context: ci/prow/e2e-test-2of3
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-sharded-repo-main-e2e-test-2of3
+    rerun_command: /test e2e-test-2of3
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 2"
+        - --report-credentials-file=/etc/report/credentials
+        - --target=e2e-test
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-test-2of3,?($|\s.*)
+  - agent: kubernetes
+    always_run: true
+    branches:
+    - ^main$
+    - ^main-
+    context: ci/prow/e2e-test-3of3
+    decorate: true
+    decoration_config:
+      skip_cloning: true
+    labels:
+      ci.openshift.io/generator: prowgen
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-sharded-repo-main-e2e-test-3of3
+    rerun_command: /test e2e-test-3of3
+    spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 3"
+        - --report-credentials-file=/etc/report/credentials
+        - --target=e2e-test
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    trigger: (?m)^/test( | .* )e2e-test-3of3,?($|\s.*)


### PR DESCRIPTION
If provided, this configuration will result in multiple jobs being generated for the ci-op config test. Each job will receive unique SHARD_ARGS values that will flow to the workflow.

This will simplify the sharding of jobs. Currently, we must do something like https://github.com/openshift/release/pull/64180, and duplicate the test configuration.

There will be follow-up PR(s) to `release` that will begin to utilize the `SHARD_ARGS` in the necessary workflow(s).

For: https://issues.redhat.com/browse/TRT-2086