### PR TITLE
TRT-2090: When determining the testname for a given jobname, we must trim the shard suffix

### DIFF
--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -49,8 +49,12 @@ func (m *Metadata) AsString() string {
 	return identifier
 }
 
+var shardSuffix = regexp.MustCompile(`-\d+of\d+$`)
+
 // TestNameFromJobName returns the name of the test from a given job name and prefix
+// If the test contains shard information in the suffix, that will also be trimmed
 func (m *Metadata) TestNameFromJobName(jobName, prefix string) string {
+	jobName = shardSuffix.ReplaceAllString(jobName, "")
 	return strings.TrimPrefix(jobName, m.JobName(prefix, ""))
 }
 

--- a/pkg/api/metadata_test.go
+++ b/pkg/api/metadata_test.go
@@ -277,6 +277,11 @@ func TestMetadata_TestNameFromJobName(t *testing.T) {
 		metadata: Metadata{Org: "gro", Repo: "oper", Branch: "hcnarb", Variant: "also"},
 		jobName:  "pull-ci-gro-oper-hcnarb-also-test2",
 		expected: "test2",
+	}, {
+		name:     "with shard suffix",
+		metadata: Metadata{Org: "gro", Repo: "oper", Branch: "hcnarb"},
+		jobName:  "pull-ci-gro-oper-hcnarb-test3-1of2",
+		expected: "test3",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
This is necessary to allow the slack-bot to properly link the ci-operator config, and for rehearsals to run for sharded jobs.