### PR TITLE
TRT-2090: quotation mark handling for multi-stage-param override values

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -798,7 +798,8 @@ func overrideMultiStageParams(o *options) error {
 			}
 
 			for paramName, paramVal := range multiStageParams {
-				test.MultiStageTestConfigurationLiteral.Environment[paramName] = paramVal
+				valueWithoutQuotes := strings.Trim(paramVal, `"'`)
+				test.MultiStageTestConfigurationLiteral.Environment[paramName] = valueWithoutQuotes
 			}
 		}
 	}

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1292,6 +1292,23 @@ func TestMultiStageParams(t *testing.T) {
 				"could not parse multi-stage-param: PARAM2 is not in the format key=value",
 			},
 		},
+		{
+			id:          "quoted param with spaces",
+			inputParams: stringSlice{[]string{`ARGS="--test 1 --value text"`}},
+			testConfig: []api.TestStepConfiguration{
+				{
+					MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+						Environment: map[string]string{
+							"OTHERPARAM": "OTHERVAL",
+						},
+					},
+				},
+			},
+			expectedParams: map[string]string{
+				"ARGS":       "--test 1 --value text",
+				"OTHERPARAM": "OTHERVAL",
+			},
+		},
 	}
 
 	t.Parallel()

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -588,7 +588,7 @@ func MultiStageParam(key, value string) PodSpecMutator {
 	return func(spec *corev1.PodSpec) error {
 		container := &spec.Containers[0]
 		// We must quote the entire arg as the value could contain spaces
-		container.Args = append(container.Args, fmt.Sprintf(`--multi-stage-param="%s=%s"`, key, value))
+		container.Args = append(container.Args, fmt.Sprintf(`--multi-stage-param=%s="%s"`, key, value))
 		return nil
 	}
 }

--- a/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
@@ -19,7 +19,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 1"
+        - --multi-stage-param=SHARD_ARGS="--shard-count 3 --shard-id 1"
         - --report-credentials-file=/etc/report/credentials
         - --target=e2e-test
         command:
@@ -74,7 +74,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 2"
+        - --multi-stage-param=SHARD_ARGS="--shard-count 3 --shard-id 2"
         - --report-credentials-file=/etc/report/credentials
         - --target=e2e-test
         command:
@@ -129,7 +129,7 @@ presubmits:
       - args:
         - --gcs-upload-secret=/secrets/gcs/service-account.json
         - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
-        - --multi-stage-param="SHARD_ARGS=--shard-count 3 --shard-id 3"
+        - --multi-stage-param=SHARD_ARGS="--shard-count 3 --shard-id 3"
         - --report-credentials-file=/etc/report/credentials
         - --target=e2e-test
         command:


### PR DESCRIPTION
The args for sharding tests will be passed directly to `openshift-tests` in the workflow, and contain spaces. Consequently, they must be quoted when passed to `ci-operator`. These quotation marks must not be part of the value passed to the mult-stage test, however.

This also changes passing the arg to put the quotes around _only_ the value.

Note, I think we could also quote the entire line, and not have to trim off quotation marks, but I think this is more explicit.