### PR TITLE
OSASINFRA-3795: Add a cluster pofile for Vexxhost BM RHOS Clouds

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1413,6 +1413,7 @@ const (
 	ClusterProfileOpenStackMechaAz0       ClusterProfile = "openstack-vh-mecha-az0"
 	ClusterProfileOpenStackOsuosl         ClusterProfile = "openstack-osuosl"
 	ClusterProfileOpenStackVexxhost       ClusterProfile = "openstack-vexxhost"
+	ClusterProfileOpenStackVexxhostRHOS   ClusterProfile = "openstack-vh-bm-rhos"
 	ClusterProfileOpenStackPpc64le        ClusterProfile = "openstack-ppc64le"
 	ClusterProfileOpenStackOpVexxhost     ClusterProfile = "openstack-operators-vexxhost"
 	ClusterProfileOpenStackNercDev        ClusterProfile = "openstack-nerc-dev"
@@ -1586,6 +1587,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileOpenStackOsuosl,
 		ClusterProfileOpenStackPpc64le,
 		ClusterProfileOpenStackVexxhost,
+		ClusterProfileOpenStackVexxhostRHOS,
 		ClusterProfileOpenStackOpVexxhost,
 		ClusterProfileOpenStackNercDev,
 		ClusterProfileOpenStackRHOSO,
@@ -1823,6 +1825,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "openstack-osuosl"
 	case ClusterProfileOpenStackVexxhost:
 		return "openstack-vexxhost"
+	case ClusterProfileOpenStackVexxhostRHOS:
+		return "openstack-vh-bm-rhos"
 	case ClusterProfileOpenStackPpc64le:
 		return "openstack-ppc64le"
 	case ClusterProfileOpenStackOpVexxhost:
@@ -2111,6 +2115,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "openstack-osuosl-quota-slice"
 	case ClusterProfileOpenStackVexxhost:
 		return "openstack-vexxhost-quota-slice"
+	case ClusterProfileOpenStackVexxhostRHOS:
+		return "openstack-vh-bm-rhos-quota-slice"
 	case ClusterProfileOpenStackPpc64le:
 		return "openstack-ppc64le-quota-slice"
 	case ClusterProfileOpenStackOpVexxhost:


### PR DESCRIPTION
After redeploying mecha-z0, mecha-central and hwoffload with the same ci-config (general.yaml) to populate the OSP 17.1.4 cloud for general job purposes.

I'd like to allow PROW to redistribute the jobs across those 3 baremetal clouds with the following configuration: 

```
'openstack-vh-bm-rhos-quota-slice': {
        'openstack-hwoffload': 3,
        'openstack-vh-mecha-central': 3,
        'openstack-vh-mecha-az0': 3,
    },
```