### PR TITLE
`ci-operator`: replace underscore in build name 

### DIFF
--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -407,7 +407,43 @@ func TestBuildFromSource(t *testing.T) {
 				},
 			},
 			buildArgs: []api.BuildArg{{Name: "TAGS", Value: "release"}},
+			toTag:     "src-org.other-repo",
 			ref:       "org.other-repo",
+		},
+		{
+			name: "ref containing underscore specified",
+			jobSpec: &api.JobSpec{
+				JobSpec: downwardapi.JobSpec{
+					Job:       "job",
+					BuildID:   "buildId",
+					ProwJobID: "prowJobId",
+					ExtraRefs: []prowapi.Refs{
+						{
+							Org:     "org",
+							Repo:    "repo",
+							BaseRef: "master",
+							BaseSHA: "masterSHA",
+							Pulls: []prowapi.Pull{{
+								Number: 1,
+								SHA:    "pullSHA",
+							}},
+						},
+						{
+							Org:     "org",
+							Repo:    "other_repo",
+							BaseRef: "master",
+							BaseSHA: "masterSHA",
+							Pulls: []prowapi.Pull{{
+								Number: 10,
+								SHA:    "pullSHA",
+							}},
+						},
+					},
+				},
+			},
+			buildArgs: []api.BuildArg{{Name: "TAGS", Value: "release"}},
+			toTag:     "src-org.other_repo",
+			ref:       "org.other_repo",
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_containing_underscore_specified.yaml
+++ b/pkg/steps/testdata/zz_fixture_TestBuildFromSource_ref_containing_underscore_specified.yaml
@@ -9,7 +9,7 @@ metadata:
     ci.openshift.io/jobtype: ""
     ci.openshift.io/metadata.branch: master
     ci.openshift.io/metadata.org: org
-    ci.openshift.io/metadata.repo: other-repo
+    ci.openshift.io/metadata.repo: other_repo
     ci.openshift.io/metadata.target: ""
     ci.openshift.io/metadata.variant: ""
     created-by-ci: "true"
@@ -34,7 +34,7 @@ spec:
     - name: vcs-url
     to:
       kind: ImageStreamTag
-      name: pipeline:src-org.other-repo
+      name: pipeline:src-org.other_repo
       namespace: test-namespace
   postCommit: {}
   resources: {}


### PR DESCRIPTION
When building from a ref that contains `_` in the repo name, we must replace it in order to name the build resource. The name of the build itself doesn't affect anything that relies on it, as it still has the same `Output` configured.

I have tested this by firing off a manual [job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-node_exporter-165-ci-4.19-upgrade-from-stable-4.18-e2e-aws-ovn-upgrade/1917627205832151040) using a locally built image.