### PR TITLE
Konflux: Force the reconciler to watch a single namespace

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -18,6 +18,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +36,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler"
@@ -400,16 +402,18 @@ func main() {
 			options.LeaderElectionReleaseOnCancel = true
 			options.LeaderElectionNamespace = opts.leaderElectionNamespace
 			options.LeaderElectionID = fmt.Sprintf("dptp-controller-manager%s", opts.leaderElectionSuffix)
+			options.Cache.ByObject = map[client.Object]cache.ByObject{
+				&ephemeralclusterv1.EphemeralCluster{}: {
+					Namespaces: map[string]cache.Config{ephemeralcluster.EphemeralClusterNamespace: {}},
+				},
+			}
 		} else {
 			options.Metrics = server.Options{
 				BindAddress: "0",
 			}
 		}
 		if cluster == opts.registryClusterName {
-			syncPeriod := 24 * time.Hour
-			options.Cache = cache.Options{
-				SyncPeriod: &syncPeriod,
-			}
+			options.Cache.SyncPeriod = ptr.To(24 * time.Hour)
 		}
 		logrus.WithField("cluster", cluster).Info("Creating manager ...")
 		mgr, err := controllerruntime.NewManager(&cfg, options)
@@ -440,6 +444,10 @@ func main() {
 	if err := prowv1.AddToScheme(mgr.GetScheme()); err != nil {
 		logrus.WithError(err).Fatal("Failed to add prowv1 to scheme")
 	}
+	if err := ephemeralclusterv1.AddToScheme(mgr.GetScheme()); err != nil {
+		logrus.WithError(err).Fatal("Failed to add ephemeralclusterv1 to scheme")
+	}
+
 	pprof.Serve(flagutil.DefaultPProfPort)
 
 	for cluster, buildClusterMgr := range allManagers {

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -36,7 +36,7 @@ const (
 	ControllerName            = "ephemeral_cluster_provisioner"
 	WaitTestStepName          = "wait-test-complete"
 	EphemeralClusterLabel     = "ci.openshift.io/ephemeral-cluster"
-	EphemeralClusterNamespace = "konflux-ephemeral-cluster"
+	EphemeralClusterNamespace = "ephemeral-cluster"
 	AbortProwJobDeleteEC      = "Ephemeral Cluster deleted"
 	DependentProwJobFinalizer = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
 	TestDoneSecretName        = "test-done-keep-going"


### PR DESCRIPTION
By design any `EphemeralCluster` object coming from a Konflux pipeline is supposed to be created into a well defined namespace only. This PR makes sure the reconciler will reconcile only those objects.