### PR TITLE
Revert "feat(ecc): reconcile objs from one namespace only"

### DIFF
--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -36,7 +36,7 @@ const (
 	ControllerName            = "ephemeral_cluster_provisioner"
 	WaitTestStepName          = "wait-test-complete"
 	EphemeralClusterLabel     = "ci.openshift.io/ephemeral-cluster"
-	EphemeralClusterNamespace = "ephemeral-cluster"
+	EphemeralClusterNamespace = "konflux-ephemeral-cluster"
 	AbortProwJobDeleteEC      = "Ephemeral Cluster deleted"
 	DependentProwJobFinalizer = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
 	TestDoneSecretName        = "test-done-keep-going"


### PR DESCRIPTION
Until I figure out why this is happening
```json
{
  "component": "dptp-controller-manager",
  "error": "failed to construct manager for cluster app.ci: failed to determine if *v1.EphemeralCluster is namespaced: no kind is registered for the type v1.EphemeralCluster in scheme \"k8s.io/client-go/kubernetes/scheme/register.go:83\"",
  "file": "/go/src/github.com/openshift/ci-tools/cmd/dptp-controller-manager/main.go:432",
  "func": "main.main",
  "level": "fatal",
  "msg": "Failed to construct cluster managers",
  "severity": "fatal",
  "time": "2025-05-07T20:12:25Z"
}
```