### PR TITLE
Konflux: Controller Improvements

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -35,6 +35,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
 	"github.com/openshift/ci-tools/pkg/config"
 	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 	"github.com/openshift/ci-tools/pkg/controller/promotionreconciler"
@@ -439,6 +440,9 @@ func main() {
 	}
 	if err := prowv1.AddToScheme(mgr.GetScheme()); err != nil {
 		logrus.WithError(err).Fatal("Failed to add prowv1 to scheme")
+	}
+	if err := ephemeralclusterv1.AddToScheme(mgr.GetScheme()); err != nil {
+		logrus.WithError(err).Fatal("Failed to add ephemeralclusterv1 to scheme")
 	}
 	pprof.Serve(flagutil.DefaultPProfPort)
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2725,3 +2725,7 @@ type ClusterClaimOwnerDetails struct {
 	Org   string   `yaml:"org"`
 	Repos []string `yaml:"repos,omitempty"`
 }
+
+const (
+	EphemeralClusterTestName = "cluster-provisioning"
+)

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -82,6 +82,36 @@ func cmpError(t *testing.T, want, got error) {
 	}
 }
 
+func TestEphemeralClusterFilter(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		obj        ctrlclient.Object
+		wantResult bool
+	}{
+		{
+			name:       "Namespace set, process",
+			obj:        &ephemeralclusterv1.EphemeralCluster{ObjectMeta: v1.ObjectMeta{Namespace: EphemeralClusterNamespace}},
+			wantResult: true,
+		},
+		{
+			name: "Unexpected namespace, do not process",
+			obj:  &ephemeralclusterv1.EphemeralCluster{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}},
+		},
+		{
+			name: "Namespace unset, do not process",
+			obj:  &ephemeralclusterv1.EphemeralCluster{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotResult := ECPredicateFilter(tc.obj)
+			if tc.wantResult != gotResult {
+				t.Errorf("want %t but got %t", tc.wantResult, gotResult)
+			}
+		})
+	}
+}
+
 func TestCreateProwJob(t *testing.T) {
 	fakeNow := fakeNow(t)
 	scheme := fakeScheme(t)

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -389,7 +389,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: WaitTestStepName, Namespace: "ci-op-1234"},
+						ObjectMeta: v1.ObjectMeta{Name: api.EphemeralClusterTestName, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 					},
 				}
@@ -502,7 +502,7 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
-						Message:            fmt.Sprintf("secrets %q not found", WaitTestStepName),
+						Message:            fmt.Sprintf("secrets %q not found", api.EphemeralClusterTestName),
 						LastTransitionTime: v1.NewTime(fakeNow),
 					}},
 				},
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: WaitTestStepName, Namespace: "ci-op-1234"},
+						ObjectMeta: v1.ObjectMeta{Name: api.EphemeralClusterTestName, Namespace: "ci-op-1234"},
 					},
 				}
 				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Kubeconfig_not_ready.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Kubeconfig_not_ready.yaml
@@ -12,6 +12,6 @@
   kind: Secret
   metadata:
     creationTimestamp: null
-    name: wait-test-complete
+    name: cluster-provisioning
     namespace: ci-op-1234
     resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Kubeconfig_ready.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Kubeconfig_ready.yaml
@@ -14,6 +14,6 @@
   kind: Secret
   metadata:
     creationTimestamp: null
-    name: wait-test-complete
+    name: cluster-provisioning
     namespace: ci-op-1234
     resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Test_completed__create_secret.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Test_completed__create_secret.yaml
@@ -12,6 +12,6 @@
   kind: Secret
   metadata:
     creationTimestamp: null
-    name: test-done-keep-going
+    name: test-done-signal
     namespace: ci-op-1234
     resourceVersion: "1"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Test_completed__secret_exists_do_nothing.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Test_completed__secret_exists_do_nothing.yaml
@@ -14,6 +14,6 @@
     creationTimestamp: null
     labels:
       do-not-change: ""
-    name: test-done-keep-going
+    name: test-done-signal
     namespace: ci-op-1234
     resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -80,11 +80,19 @@ items:
                 - as: wait-test-complete
                   commands: "#!/bin/bash\n\n# This loop keeps the ephemeral cluster up and running
                     and then waits for\n# a konflux test to complete. Once the test is done, the
-                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-keep-going'
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
                     into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
-                    procedures.\n\ni=0\nwhile true ; do\n    printf 'attempt %d\\n' $i\n    if
-                    $(oc get secret/test-done-keep-going 2>&1 | grep -qv 'not found'); then\n
-                    \       break\n    fi\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n' $unexpected_err\n\n        if [ $unexpected_err
+                    -ge 3 ]; then\n            printf 'FAILURE: too many unexpected errors\\n'
+                    $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
                   from: cli
                   resources:
                     limits:

--- a/pkg/controller/ephemeralcluster/wait-test-complete.sh
+++ b/pkg/controller/ephemeralcluster/wait-test-complete.sh
@@ -2,15 +2,41 @@
 
 # This loop keeps the ephemeral cluster up and running and then waits for
 # a konflux test to complete. Once the test is done, the EphemeralCluster 
-# controller creates a synthetic secret 'test-done-keep-going' into this ci-operator NS,
+# controller creates a synthetic secret 'test-done-signal' into this ci-operator NS,
 # unbloking the workflow and starting the deprovisioning procedures.
 
+# This kubeconfig points to the ephemeral cluster. Unsetting it as we want to reach out to
+# the build farm cluster.
+unset KUBECONFIG
+
 i=0
-while true ; do
+unexpected_err=0
+secret='test-done-signal'
+
+while true; do
     printf 'attempt %d\n' $i
-    if $(oc get secret/test-done-keep-going 2>&1 | grep -qv 'not found'); then
+
+    output="$(oc get secret/$secret 2>&1)"
+    if [ $? -eq 0 ]; then
+        printf 'secret found\n'
         break
     fi
+
+    # The sole error we expect to hit is 'not found'. Break the loop if we collect
+    # this many unexpected errors in a row.
+    if ! $(grep -qF "secrets \"$secret\" not found" <<<"$output"); then
+        printf 'unexpected error: %d\n' $unexpected_err
+
+        if [ $unexpected_err -ge 3 ]; then
+            printf 'FAILURE: too many unexpected errors\n' $unexpected_err
+            break
+        fi
+
+        unexpected_err=$((unexpected_err+1))
+    else
+        unexpected_err=0
+    fi
+
     i=$((i+1))
     sleep 5s
 done

--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -187,7 +187,7 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 		}, {
 			APIGroups:     []string{""},
 			Resources:     []string{"secrets"},
-			ResourceNames: []string{s.name},
+			ResourceNames: []string{s.name, api.EphemeralClusterTestName},
 			Verbs:         []string{"get", "update"},
 		}, {
 			APIGroups: []string{"", "image.openshift.io"},


### PR DESCRIPTION
Various improvements:
- Install the `EphemeralCluster` CRD on the `dptp-controller-manager` schema
- `wait-test-complete.sh` is more robust
- `ci-operator` allows a test step pod to read the `test-done-signal` secret
- The `EphemeralCluster` reconciler filter objects by namespace