### PR TITLE
Konflux: Fix RBAC to read test-done-signal secret

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2727,5 +2727,5 @@ type ClusterClaimOwnerDetails struct {
 }
 
 const (
-	EphemeralClusterTestName = "cluster-provisioning"
+	EphemeralClusterTestDoneSignalSecretName = "test-done-signal"
 )

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -389,7 +389,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: api.EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 					},
 				}
@@ -502,7 +502,7 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
-						Message:            fmt.Sprintf("secrets %q not found", api.EphemeralClusterTestName),
+						Message:            fmt.Sprintf("secrets %q not found", EphemeralClusterTestName),
 						LastTransitionTime: v1.NewTime(fakeNow),
 					}},
 				},
@@ -535,7 +535,7 @@ func TestReconcile(t *testing.T) {
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: api.EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 					},
 				}
 				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
@@ -826,7 +826,7 @@ func TestReconcile(t *testing.T) {
 					&corev1.Secret{
 						ObjectMeta: v1.ObjectMeta{
 							Labels:    map[string]string{"do-not-change": ""},
-							Name:      TestDoneSecretName,
+							Name:      api.EphemeralClusterTestDoneSignalSecretName,
 							Namespace: "ci-op-1234",
 						},
 					},

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -89,9 +89,9 @@ items:
                     \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
                     loop if we collect\n    # this many unexpected errors in a row.\n    if !
                     $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
-                    'unexpected error: %d\\n' $unexpected_err\n\n        if [ $unexpected_err
-                    -ge 3 ]; then\n            printf 'FAILURE: too many unexpected errors\\n'
-                    $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
                     \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
                   from: cli
                   resources:

--- a/pkg/controller/ephemeralcluster/wait-test-complete.sh
+++ b/pkg/controller/ephemeralcluster/wait-test-complete.sh
@@ -25,7 +25,7 @@ while true; do
     # The sole error we expect to hit is 'not found'. Break the loop if we collect
     # this many unexpected errors in a row.
     if ! $(grep -qF "secrets \"$secret\" not found" <<<"$output"); then
-        printf 'unexpected error: %d\n' $unexpected_err
+        printf 'unexpected error: %d\n%s\n' $unexpected_err "$output"
 
         if [ $unexpected_err -ge 3 ]; then
             printf 'FAILURE: too many unexpected errors\n' $unexpected_err

--- a/pkg/steps/multi_stage/init.go
+++ b/pkg/steps/multi_stage/init.go
@@ -187,7 +187,7 @@ func (s *multiStageTestStep) setupRBAC(ctx context.Context) error {
 		}, {
 			APIGroups:     []string{""},
 			Resources:     []string{"secrets"},
-			ResourceNames: []string{s.name, api.EphemeralClusterTestName},
+			ResourceNames: []string{s.name, api.EphemeralClusterTestDoneSignalSecretName},
 			Verbs:         []string{"get", "update"},
 		}, {
 			APIGroups: []string{"", "image.openshift.io"},


### PR DESCRIPTION
Follow up of https://github.com/openshift/ci-tools/pull/4578, fix secret name from `cluster-provisioning` to `test-done-signal`.