### PR TITLE
Konflux: `wait-test-signal.sh` doesn't give up too early

### DIFF
--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -78,7 +78,7 @@ items:
                   foo: bar
                 test:
                 - as: wait-test-complete
-                  commands: "#!/bin/bash\n\n# This loop keeps the ephemeral cluster up and running
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
                     and then waits for\n# a konflux test to complete. Once the test is done, the
                     EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
                     into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning

--- a/pkg/controller/ephemeralcluster/wait-test-complete.sh
+++ b/pkg/controller/ephemeralcluster/wait-test-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+set +e
 
 # This loop keeps the ephemeral cluster up and running and then waits for
 # a konflux test to complete. Once the test is done, the EphemeralCluster 


### PR DESCRIPTION
`ci-operator` is already prepending the following:
```sh
#!/bin/bash
set -eu
```

but this scripts handles pipeline's error on its own, therefore I will disable that shell option.