### PR TITLE
ci-operator: Use * to exclude images from promotion

### DIFF
--- a/pkg/api/promotion.go
+++ b/pkg/api/promotion.go
@@ -20,6 +20,8 @@ const (
 
 	PromotionStepName     = "promotion"
 	PromotionQuayStepName = "promotion-quay"
+
+	PromotionExcludeImageWildcard = "*"
 )
 
 // PromotionTargets adapts the single-target configuration to the multi-target paradigm.

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/prow/pkg/flagutil"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 )
@@ -39,13 +40,13 @@ func AllPromotionImageStreamTags(configSpec *cioperatorapi.ReleaseBuildConfigura
 			continue
 		}
 
-		disabled := sets.New[string](target.ExcludedImages...)
-		if !disabled.Has("*") {
+		disabled := sets.New(target.ExcludedImages...)
+		if !disabled.Has(api.PromotionExcludeImageWildcard) {
 			for _, image := range configSpec.Images {
 				result.Insert(fmt.Sprintf("%s/%s:%s", target.Namespace, target.Name, image.To))
 			}
 		}
-		for _, image := range disabled.Delete("*").UnsortedList() {
+		for _, image := range disabled.Delete(api.PromotionExcludeImageWildcard).UnsortedList() {
 			delete(result, image)
 		}
 

--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -323,10 +323,17 @@ func toPromote(config api.PromotionTarget, images []api.ProjectDirectoryImageBui
 			names.Insert(tag)
 		}
 	}
+
 	for _, tag := range config.ExcludedImages {
+		if tag == api.PromotionExcludeImageWildcard {
+			clear(tagsByDst)
+			names.Clear()
+			break
+		}
 		delete(tagsByDst, tag)
 		names.Delete(tag)
 	}
+
 	for dst, src := range config.AdditionalImages {
 		tagsByDst[dst] = src
 		names.Insert(dst)


### PR DESCRIPTION
Documenting the new feature with an example: https://github.com/openshift/ci-docs/pull/538.
It is now possible to use `*` in the `promotion.exclude_images` stanza to exclude all images from being promoted.