### PR TITLE
OPRUN-3914: Add periodic-ci-openshift-operator-framework-operator-controller- to the OCP stream

### DIFF
--- a/cmd/testgrid-config-generator/main.go
+++ b/cmd/testgrid-config-generator/main.go
@@ -263,7 +263,8 @@ func addDashboardTab(p prowConfig.Periodic,
 			strings.HasPrefix(prowName, "periodic-ci-openshift-release-master-nightly-"),
 			strings.HasPrefix(prowName, "periodic-ci-openshift-verification-tests-master-"),
 			strings.HasPrefix(prowName, "periodic-ci-shiftstack-shiftstack-ci-main-periodic-"),
-			strings.HasPrefix(prowName, "periodic-ci-openshift-osde2e-main-nightly-"):
+			strings.HasPrefix(prowName, "periodic-ci-openshift-osde2e-main-nightly-"),
+			strings.HasPrefix(prowName, "periodic-ci-openshift-operator-framework-operator-controller-"):
 			stream = "ocp"
 		case strings.Contains(prowName, "-okd-"):
 			stream = "okd"


### PR DESCRIPTION
We added the test in the PR: https://github.com/openshift/ci-tools/pull/4590/files
However, after 8 hours, the jobs are still not appearing.

By looking at the code, I realised that any job configured as https://github.com/openshift/ci-tools/pull/4590/files only appears at: https://sippy.dptools.openshift.org/sippy-ng/jobs/4.20 if the stream is configured in: cmd/testgrid-config-generator/main.go

