### PR TITLE
Update credentials `mount_path` verification

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -808,10 +808,10 @@ func validateCredentials(fieldRoot string, credentials []api.CredentialReference
 		for j, other := range credentials[i+1:] {
 			index := i + j + 1
 			if credential.MountPath == other.MountPath {
-				if credential.Collection == other.Collection && credential.Name != other.Name {
+				if credential.Name != other.Name {
 					continue
 				}
-				errs = append(errs, fmt.Errorf("%s.credentials[%d] and credentials[%d] mount to the same location (%s), but are in different collections", fieldRoot, i, index, credential.MountPath))
+				errs = append(errs, fmt.Errorf("%s.credentials[%d] and credentials[%d] mount to the same location (%s) and have the same name, which would result in a collision", fieldRoot, i, index, credential.MountPath))
 				continue
 			}
 			// we can make a couple of assumptions here to improve our check:

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -808,7 +808,10 @@ func validateCredentials(fieldRoot string, credentials []api.CredentialReference
 		for j, other := range credentials[i+1:] {
 			index := i + j + 1
 			if credential.MountPath == other.MountPath {
-				errs = append(errs, fmt.Errorf("%s.credentials[%d] and credentials[%d] mount to the same location (%s)", fieldRoot, i, index, credential.MountPath))
+				if credential.Collection == other.Collection && credential.Name != other.Name {
+					continue
+				}
+				errs = append(errs, fmt.Errorf("%s.credentials[%d] and credentials[%d] mount to the same location (%s), but are in different collections", fieldRoot, i, index, credential.MountPath))
 				continue
 			}
 			// we can make a couple of assumptions here to improve our check:

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -1285,11 +1285,18 @@ func TestValidateCredentials(t *testing.T) {
 		{
 			name: "duped cred mount path means error",
 			input: []api.CredentialReference{
-				{Namespace: "ns", Name: "name", MountPath: "/foo"},
-				{Namespace: "ns", Name: "name", MountPath: "/foo"},
+				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
+				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "2"},
 			},
 			output: []error{
-				errors.New("root.credentials[0] and credentials[1] mount to the same location (/foo)"),
+				errors.New("root.credentials[0] and credentials[1] mount to the same location (/foo), but are in different collections"),
+			},
+		},
+		{
+			name: "duped cred mount path is ok if in the same collection",
+			input: []api.CredentialReference{
+				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
+				{Namespace: "ns", Name: "different-name", MountPath: "/foo", Collection: "1"},
 			},
 		},
 		{

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -1303,13 +1303,6 @@ func TestValidateCredentials(t *testing.T) {
 			name: "duped cred name is ok if different mount path",
 			input: []api.CredentialReference{
 				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
-				{Namespace: "ns", Name: "different-name", MountPath: "/foo", Collection: "2"},
-			},
-		},
-		{
-			name: "duped cred name is ok if different mount path",
-			input: []api.CredentialReference{
-				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
 				{Namespace: "ns", Name: "name", MountPath: "/bar", Collection: "1"},
 			},
 		},

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -1289,7 +1289,7 @@ func TestValidateCredentials(t *testing.T) {
 				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "2"},
 			},
 			output: []error{
-				errors.New("root.credentials[0] and credentials[1] mount to the same location (/foo), but are in different collections"),
+				errors.New("root.credentials[0] and credentials[1] mount to the same location (/foo) and have the same name, which would result in a collision"),
 			},
 		},
 		{
@@ -1297,6 +1297,20 @@ func TestValidateCredentials(t *testing.T) {
 			input: []api.CredentialReference{
 				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
 				{Namespace: "ns", Name: "different-name", MountPath: "/foo", Collection: "1"},
+			},
+		},
+		{
+			name: "duped cred name is ok if different mount path",
+			input: []api.CredentialReference{
+				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
+				{Namespace: "ns", Name: "different-name", MountPath: "/foo", Collection: "2"},
+			},
+		},
+		{
+			name: "duped cred name is ok if different mount path",
+			input: []api.CredentialReference{
+				{Namespace: "ns", Name: "name", MountPath: "/foo", Collection: "1"},
+				{Namespace: "ns", Name: "name", MountPath: "/bar", Collection: "1"},
 			},
 		},
 		{


### PR DESCRIPTION
This change allows for the same mount path if credentials are in the same collection and have different names. With the new GCP mechanism, this is an allowed use case:
```
credentials:
  - collection: team1
    name: name
    mount_path: /var/run
  - collection: team1
    name: diff-name
    mount_path: /var/run
```
We still enforce that mount paths be different for different collections, to avoid possible collisions of file names.