### PR TITLE
set the standard prowjob timeout equal to the aggregator timeout

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -660,7 +660,7 @@ func (r *reconciler) generateProwjob(ciopConfig *api.ReleaseBuildConfiguration,
 		if periodic.DecorationConfig == nil {
 			periodic.DecorationConfig = &prowv1.DecorationConfig{}
 		}
-		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: 6 * time.Hour}
+		periodic.DecorationConfig.Timeout = &prowv1.Duration{Duration: r.defaultAggregatorJobTimeout}
 		break
 	}
 	// We did not find the injected test: this is a bug


### PR DESCRIPTION
It looks like it wasn't really something that was missed here, but it did get hardcoded to 6 hours for the regular prowjob time. I think it is safe to just use the `defaultAggregatorJobTimeout` value for that as well. It would only create issues when a timeout is reached, and when that happens, there are already issues anyways.

In the future, this could use a little more thought. It should probably be set to some fraction of the `defaultAggregatorJobTimeout`...