### PR TITLE
TRT-1734: sort jobs consistently in sippy-config-generator

### DIFF
--- a/cmd/sippy-config-generator/OWNERS
+++ b/cmd/sippy-config-generator/OWNERS
@@ -2,5 +2,6 @@ approvers:
 - dgoodwin
 - stbenjam
 - xueqzhan
-- DennisPeriquet
 - neisw
+- sosiouxme
+- smg247

--- a/cmd/sippy-config-generator/main.go
+++ b/cmd/sippy-config-generator/main.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 


### PR DESCRIPTION
Also update the OWNERS while I'm in there.

<strike>This is only on the ci-tools side, variant registry generator needs a similar update.</strike> Nevermind that, it's already using v3