### PR TITLE
Update helpdesk message with FAQ and AI links

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -109,7 +109,8 @@ func getContactedHelpdeskResponse(botId, reviewRequestWorkflowID string) []slack
 		sections = append(sections, "Your PR will be reviewed based on: age, priority, and capacity.")
 	} else {
 		sections = append(sections,
-			"Please see if our documentation can be of use: https://docs.ci.openshift.org/docs/",
+			"In the meantime, check our <https://docs.ci.openshift.org/docs/|documentation> or <https://docs.ci.openshift.org/docs/getting-started/helpdesk-faq/|Helpdesk FAQ>.",
+			"You can also try our <https://notebooklm.google.com/notebook/cb53610d-1436-4504-9277-0cb3561f7620|forum-ocp-testplatform Advisor AI> :ai-generated: to see if your question has been answered before.",
 			"If this is an urgent CI outage, please ping `(@)dptp-triage`")
 	}
 

--- a/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_empty_botId.yaml
+++ b/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_empty_botId.yaml
@@ -4,7 +4,14 @@
     type: mrkdwn
   type: section
 - text:
-    text: 'Please see if our documentation can be of use: https://docs.ci.openshift.org/docs/'
+    text: In the meantime, check our <https://docs.ci.openshift.org/docs/|documentation>
+      or <https://docs.ci.openshift.org/docs/getting-started/helpdesk-faq/|Helpdesk
+      FAQ>.
+    type: mrkdwn
+  type: section
+- text:
+    text: 'You can also try our <https://notebooklm.google.com/notebook/cb53610d-1436-4504-9277-0cb3561f7620|forum-ocp-testplatform
+      Advisor AI> :ai-generated: to see if your question has been answered before.'
     type: mrkdwn
   type: section
 - text:

--- a/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_random_botId.yaml
+++ b/pkg/slack/events/helpdesk/testdata/zz_fixture_TestGetContactedHelpdeskResponse_random_botId.yaml
@@ -4,7 +4,14 @@
     type: mrkdwn
   type: section
 - text:
-    text: 'Please see if our documentation can be of use: https://docs.ci.openshift.org/docs/'
+    text: In the meantime, check our <https://docs.ci.openshift.org/docs/|documentation>
+      or <https://docs.ci.openshift.org/docs/getting-started/helpdesk-faq/|Helpdesk
+      FAQ>.
+    type: mrkdwn
+  type: section
+- text:
+    text: 'You can also try our <https://notebooklm.google.com/notebook/cb53610d-1436-4504-9277-0cb3561f7620|forum-ocp-testplatform
+      Advisor AI> :ai-generated: to see if your question has been answered before.'
     type: mrkdwn
   type: section
 - text:


### PR DESCRIPTION
Adds info about our helpdesk FAQ and notebookLM to the automatic message sent when user creates a workflow in [#forum-ocp-testplatform](https://redhat.enterprise.slack.com/archives/CBN38N3MW).