### PR TITLE
Konflux: Compute the EphemeralCluster status from scratch

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -11,7 +11,7 @@ const (
 	ProwJobFailureReason                   = "ProwJobFailure"
 	ProwJobCompletedReason                 = "ProwJobCompleted"
 	KubeconfigFetchFailureReason           = "KubeconfigFetchFailure"
-	CreateTestCompletedFailureSecretReason = "CreateTestCompletedFailure"
+	CreateTestCompletedSecretFailureReason = "CreateTestCompletedSecretFailure"
 
 	CIOperatorNSNotFoundMsg = "ci-operator NS not found"
 	KubeconfigNotReadMsg    = "kubeconfig not ready"
@@ -45,16 +45,16 @@ type EphemeralClusterPhase string
 const (
 	// EphemeralClusterProvisioning describes everything that happens before the kubeconfig is available.
 	// This phase includes creating a ProwJob and waiting for the kubeconfig to show up.
-	EphemeralClusterProvisioning = "Provisioning"
+	EphemeralClusterProvisioning EphemeralClusterPhase = "Provisioning"
 	// EphemeralClusterReady means the cluster is running and the kubeconfig is available.
-	EphemeralClusterReady = "Ready"
+	EphemeralClusterReady EphemeralClusterPhase = "Ready"
 	// EphemeralClusterDeprovisioning means that the deprovisioning procedures are happening.
-	EphemeralClusterDeprovisioning = "Deprovisioning"
+	EphemeralClusterDeprovisioning EphemeralClusterPhase = "Deprovisioning"
 	// EphemeralClusterDeprovisioning means that the cluster has been deprovisioned.
-	EphemeralClusterDeprovisioned = "Deprovisioned"
+	EphemeralClusterDeprovisioned EphemeralClusterPhase = "Deprovisioned"
 	// EphemeralClusterFailed means that either the cluster is in a error state or the
 	// provisioning/deprovisioning procedures didn't succeed.
-	EphemeralClusterFailed = "Failed"
+	EphemeralClusterFailed EphemeralClusterPhase = "Failed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Succeeded_ProwJob_maps_to_ProwJobCompleted_condition.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Succeeded_ProwJob_maps_to_ProwJobCompleted_condition.yaml
@@ -17,10 +17,3 @@
     name: cluster-provisioning
     namespace: ci-op-1234
     resourceVersion: "999"
-- apiVersion: v1
-  kind: Secret
-  metadata:
-    creationTimestamp: null
-    name: test-done-signal
-    namespace: ci-op-1234
-    resourceVersion: "1"


### PR DESCRIPTION
This is an attempt to simplify the reconcile logic.

Apart from `.status.prowJobId`, the `.status` stanza is now computed at every cycle. From an high level perspective, the reconcile loop accomplishes the following actions:
- Create a `ProwJob` if not exist, then re-queue the reconcile request
- Fetch the kubeconfig
- Tear the ephemeral cluster down if `.spec.tearDownCluster` is set
- Check the ProwJob status:
  - If a final status is reached (`aborted`, `error`, `completed`, etc.), then update the `EphemeralCluster` object and exit
  - Otherwise update the `EphemeralCluster` object and re-queue the reconcile request

This would hopefully ensure that the `.status` is properly constructed from what the reconciler observes on the clusters.