### PR TITLE
Fix CSI credentials naming mechanism

### DIFF
--- a/pkg/steps/multi_stage/csi_utils.go
+++ b/pkg/steps/multi_stage/csi_utils.go
@@ -1,0 +1,109 @@
+package multi_stage
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/config"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	csiapi "sigs.k8s.io/secrets-store-csi-driver/apis/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+// GSMproject is the name of the GCP Secret Manager project where the secrets are stored.
+var GSMproject = "openshift-ci-secrets"
+
+// groupCredentialsByCollectionAndMountPath groups credentials by (collection, mount_path)
+// to avoid duplicate mount paths.
+func groupCredentialsByCollectionAndMountPath(credentials []api.CredentialReference) map[string][]api.CredentialReference {
+	mountGroups := make(map[string][]api.CredentialReference)
+	for _, credential := range credentials {
+		key := fmt.Sprintf("%s:%s", credential.Collection, credential.MountPath)
+		mountGroups[key] = append(mountGroups[key], credential)
+	}
+	return mountGroups
+}
+
+func buildGCPSecretsParameter(credentials []api.CredentialReference) (string, error) {
+	var secrets []config.Secret
+	for _, credential := range credentials {
+		secrets = append(secrets, config.Secret{
+			ResourceName: fmt.Sprintf("projects/%s/secrets/%s__%s/versions/latest", GSMproject, credential.Collection, credential.Name),
+			FileName:     credential.Name, // we want to mount the secret as a file named without the collection prefix
+		})
+	}
+	secretsYaml, err := yaml.Marshal(secrets)
+	if err != nil {
+		return "", fmt.Errorf("could not marshal secrets: %w", err)
+	}
+	return string(secretsYaml), nil
+}
+
+// getSPCName gets the unique SPC name for a collection, mount path, and credential contents
+func getSPCName(namespace, collection, mountPath string, credentials []api.CredentialReference) string {
+	var parts []string
+	parts = append(parts, collection, mountPath)
+
+	// Sort credential names for deterministic hashing
+	var credNames []string
+	for _, cred := range credentials {
+		credNames = append(credNames, cred.Name)
+	}
+	sort.Strings(credNames)
+	parts = append(parts, credNames...)
+
+	hash := sha256.Sum256([]byte(strings.Join(parts, "-")))
+	hashStr := fmt.Sprintf("%x", hash[:12])
+	name := fmt.Sprintf("%s-%s-spc", namespace, hashStr)
+
+	return strings.ToLower(name)
+}
+
+// getCSIVolumeName generates a deterministic, DNS-compliant name for a CSI volume
+// based on the namespace, collection, and mountPath. The name is constructed as
+// "<namespace>-<hash>", where the hash is computed from the collection and mountPath.
+// If the resulting name exceeds 63 characters (the Kubernetes DNS label limit),
+// only the hash is used as the name.
+func getCSIVolumeName(ns, collection, mountPath string) string {
+	// Hash both collection and mountPath together for consistent length
+	hash := sha256.Sum256([]byte(strings.Join([]string{collection, mountPath}, "-")))
+	hashStr := fmt.Sprintf("%x", hash[:8])
+	name := fmt.Sprintf("%s-%s", ns, hashStr)
+
+	// If namespace + hash is still too long, use just the hash
+	if len(name) > 63 {
+		hashStr := fmt.Sprintf("%x", hash[:16])
+		name = hashStr
+	}
+
+	return strings.ToLower(name)
+}
+
+func getCensorMountPath(secretName string) string {
+	return fmt.Sprintf("/censor/%s", secretName)
+}
+
+func buildSecretProviderClass(name, namespace, secrets string) *csiapi.SecretProviderClass {
+	return &csiapi.SecretProviderClass{
+		TypeMeta: meta.TypeMeta{
+			Kind:       "SecretProviderClass",
+			APIVersion: csiapi.GroupVersion.String(),
+		},
+		ObjectMeta: meta.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: csiapi.SecretProviderClassSpec{
+			Provider: "gcp",
+			Parameters: map[string]string{
+				"auth":    "provider-adc",
+				"secrets": secrets,
+			},
+		},
+	}
+}

--- a/pkg/steps/multi_stage/csi_utils_test.go
+++ b/pkg/steps/multi_stage/csi_utils_test.go
@@ -1,0 +1,362 @@
+package multi_stage
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/secrets-store-csi-driver-provider-gcp/config"
+	"github.com/google/go-cmp/cmp"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestGroupCredentialsByCollectionAndMountPath(t *testing.T) {
+	testCases := []struct {
+		name        string
+		credentials []api.CredentialReference
+		expected    map[string][]api.CredentialReference
+	}{
+		{
+			name:        "empty credentials",
+			credentials: []api.CredentialReference{},
+			expected:    map[string][]api.CredentialReference{},
+		},
+		{
+			name: "single credential",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+			},
+			expected: map[string][]api.CredentialReference{
+				"collection1:/tmp/cred1": {
+					{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+				},
+			},
+		},
+		{
+			name: "multiple credentials different collections and paths",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+				{Name: "cred2", Collection: "collection2", MountPath: "/tmp/cred2"},
+			},
+			expected: map[string][]api.CredentialReference{
+				"collection1:/tmp/cred1": {
+					{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+				},
+				"collection2:/tmp/cred2": {
+					{Name: "cred2", Collection: "collection2", MountPath: "/tmp/cred2"},
+				},
+			},
+		},
+		{
+			name: "multiple credentials same collection and path",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/shared"},
+				{Name: "cred2", Collection: "collection1", MountPath: "/tmp/shared"},
+			},
+			expected: map[string][]api.CredentialReference{
+				"collection1:/tmp/shared": {
+					{Name: "cred1", Collection: "collection1", MountPath: "/tmp/shared"},
+					{Name: "cred2", Collection: "collection1", MountPath: "/tmp/shared"},
+				},
+			},
+		},
+		{
+			name: "mixed grouping - some grouped together, some separate",
+			credentials: []api.CredentialReference{
+				{Name: "red", Collection: "colours", MountPath: "/tmp/path"},
+				{Name: "blue", Collection: "colours", MountPath: "/tmp/path"},
+				{Name: "circle", Collection: "shapes", MountPath: "/tmp/path"},
+				{Name: "square", Collection: "shapes", MountPath: "/tmp/other"},
+			},
+			expected: map[string][]api.CredentialReference{
+				"colours:/tmp/path": {
+					{Name: "red", Collection: "colours", MountPath: "/tmp/path"},
+					{Name: "blue", Collection: "colours", MountPath: "/tmp/path"},
+				},
+				"shapes:/tmp/path": {
+					{Name: "circle", Collection: "shapes", MountPath: "/tmp/path"},
+				},
+				"shapes:/tmp/other": {
+					{Name: "square", Collection: "shapes", MountPath: "/tmp/other"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := groupCredentialsByCollectionAndMountPath(tc.credentials)
+			if diff := cmp.Diff(tc.expected, result); diff != "" {
+				t.Errorf("groupCredentialsByCollectionAndMountPath() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBuildGCPSecretsParameter(t *testing.T) {
+	testCases := []struct {
+		name        string
+		credentials []api.CredentialReference
+		expected    []config.Secret
+	}{
+		{
+			name:        "empty credentials",
+			credentials: []api.CredentialReference{},
+			expected:    nil,
+		},
+		{
+			name: "single credential",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1"},
+			},
+			expected: []config.Secret{
+				{
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__cred1/versions/latest", GSMproject),
+					FileName:     "cred1",
+				},
+			},
+		},
+		{
+			name: "multiple credentials",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1"},
+				{Name: "cred2", Collection: "collection2"},
+			},
+			expected: []config.Secret{
+				{
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection1__cred1/versions/latest", GSMproject),
+					FileName:     "cred1",
+				},
+				{
+					ResourceName: fmt.Sprintf("projects/%s/secrets/collection2__cred2/versions/latest", GSMproject),
+					FileName:     "cred2",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			yamlString, err := buildGCPSecretsParameter(tc.credentials)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var actual []config.Secret
+			err = yaml.Unmarshal([]byte(yamlString), &actual)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal YAML output: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("buildGCPSecretsParameter() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetSPCName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		namespace   string
+		collection  string
+		mountPath   string
+		credentials []api.CredentialReference
+	}{
+		{
+			name:       "simple case",
+			namespace:  "test-ns",
+			collection: "collection1",
+			mountPath:  "/tmp/cred1",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+			},
+		},
+		{
+			name:       "typical ci-operator namespace",
+			namespace:  "ci-op-abc123def456",
+			collection: "collection1",
+			mountPath:  "/tmp/cred1",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/cred1"},
+			},
+		},
+		{
+			name:       "multiple credentials same collection and path",
+			namespace:  "test-ns",
+			collection: "collection1",
+			mountPath:  "/tmp/shared",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/shared"},
+				{Name: "cred2", Collection: "collection1", MountPath: "/tmp/shared"},
+			},
+		},
+		{
+			name:       "different credentials should give different names",
+			namespace:  "test-ns",
+			collection: "collection1",
+			mountPath:  "/tmp/shared",
+			credentials: []api.CredentialReference{
+				{Name: "cred1", Collection: "collection1", MountPath: "/tmp/shared"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getSPCName(tc.namespace, tc.collection, tc.mountPath, tc.credentials)
+
+			// Verify the name is lowercased
+			if result != strings.ToLower(result) {
+				t.Errorf("getSPCName() result should be lowercase: %v", result)
+			}
+			// Verify the name doesn't exceed 63 characters
+			if len(result) > 63 {
+				t.Errorf("getSPCName() result too long (%d chars): %v", len(result), result)
+			}
+			// Verify structure
+			if !strings.HasPrefix(result, strings.ToLower(tc.namespace)+"-") {
+				t.Errorf("getSPCName() should start with namespace: %v", result)
+			}
+			if !strings.HasSuffix(result, "-spc") {
+				t.Errorf("getSPCName() should end with '-spc': %v", result)
+			}
+		})
+	}
+}
+
+func TestGetSPCNameUniqueness(t *testing.T) {
+	namespace := "ci-op-test123"
+
+	testCases := []struct {
+		collection  string
+		mountPath   string
+		credentials []api.CredentialReference
+	}{
+		{"collection1", "/tmp/cred1", []api.CredentialReference{
+			{Name: "secret1", Collection: "collection1", MountPath: "/tmp/cred1"},
+		}},
+		{"collection1", "/tmp/cred2", []api.CredentialReference{
+			{Name: "secret2", Collection: "collection1", MountPath: "/tmp/cred2"},
+		}},
+		{"collection2", "/tmp/cred1", []api.CredentialReference{
+			{Name: "secret1", Collection: "collection2", MountPath: "/tmp/cred1"},
+		}},
+		{"collection2", "/tmp/cred2", []api.CredentialReference{
+			{Name: "secret2", Collection: "collection2", MountPath: "/tmp/cred2"},
+		}},
+	}
+
+	seen := make(map[string]bool)
+
+	for _, tc := range testCases {
+		result := getSPCName(namespace, tc.collection, tc.mountPath, tc.credentials)
+		if seen[result] {
+			t.Errorf("getSPCName() produced duplicate name %s for collection=%s, mountPath=%s", result, tc.collection, tc.mountPath)
+		}
+		seen[result] = true
+
+		// Verify structure
+		if !strings.HasPrefix(result, strings.ToLower(namespace)+"-") {
+			t.Errorf("getSPCName() should start with namespace: %v", result)
+		}
+		if !strings.HasSuffix(result, "-spc") {
+			t.Errorf("getSPCName() should end with '-spc': %v", result)
+		}
+		if len(result) > 63 {
+			t.Errorf("getSPCName() result too long (%d chars): %v", len(result), result)
+		}
+	}
+}
+
+func TestGetSPCNameCollisionPrevention(t *testing.T) {
+	namespace := "ci-op-test123"
+	collection := "colours"
+	mountPath := "/tmp/path"
+
+	// Two different sets of credentials with same collection and mountPath
+	credentials1 := []api.CredentialReference{
+		{Name: "red", Collection: collection, MountPath: mountPath},
+		{Name: "blue", Collection: collection, MountPath: mountPath},
+	}
+
+	credentials2 := []api.CredentialReference{
+		{Name: "red", Collection: collection, MountPath: mountPath},
+	}
+
+	// They should get different SPC names
+	spcName1 := getSPCName(namespace, collection, mountPath, credentials1)
+	spcName2 := getSPCName(namespace, collection, mountPath, credentials2)
+
+	if spcName1 == spcName2 {
+		t.Errorf("Expected different SPC names for different credential sets, but got same name: %s", spcName1)
+	}
+
+	// But the same credentials should always give the same name
+	spcName1Again := getSPCName(namespace, collection, mountPath, credentials1)
+	if spcName1 != spcName1Again {
+		t.Errorf("Expected same SPC name for same credentials, but got %s vs %s", spcName1, spcName1Again)
+	}
+}
+
+func TestCSIVolumeName(t *testing.T) {
+	testCases := []struct {
+		name       string
+		namespace  string
+		collection string
+		mountPath  string
+		expected   string
+	}{
+		{
+			name:       "simple case",
+			namespace:  "test-ns",
+			collection: "coll1",
+			mountPath:  "/tmp/cred1",
+			expected:   "test-ns-3b8b9081288110be",
+		},
+		{
+			name:       "mount path with dots",
+			namespace:  "test-ns",
+			collection: "coll1",
+			mountPath:  "/tmp/cred.with.dots",
+			expected:   "test-ns-d0016e4cef6b95bc",
+		},
+		{
+			name:       "mount path with underscores",
+			namespace:  "test-ns",
+			collection: "coll1",
+			mountPath:  "/tmp/cred_with_underscores",
+			expected:   "test-ns-b230621144162a62",
+		},
+		{
+			name:       "long names stay within 63 char limit",
+			namespace:  "long-namespace-name-within-limits",
+			collection: "some-long-collection-name",
+			mountPath:  "/long/mount/path/that/exceeds/kubernetes/limits",
+			expected:   "long-namespace-name-within-limits-5208e4cada72c93e",
+		},
+		{
+			name:       "long namespace triggers hash-only mode",
+			namespace:  "namespace-that-is-just-long-enough-to-trigger-truncation",
+			collection: "collection",
+			mountPath:  "/tmp",
+			expected:   "79bdf22088beba6ec83a0d18127b31df",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getCSIVolumeName(tc.namespace, tc.collection, tc.mountPath)
+			if result != tc.expected {
+				t.Errorf("getCSIVolumeName() = %v, want %v", result, tc.expected)
+			}
+			// Also verify the length constraint
+			if len(result) > 63 {
+				t.Errorf("getCSIVolumeName() result too long (%d chars): %v", len(result), result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As of now, the new CSI mutli-stage step credential system creates one SecretProviderClass (SPC) per credential, mounted to the test pod in as a CSI `volumeMount`. Since we need to shard the existing credential secrets, like this:
```
credentials:
  - collection: team1
    name: name
    mount_path: /var/run
  - collection: team1
    name: diff-name
    mount_path: /var/run
```
the existing system resulted in Kubernetes's `Invalid value: "<mount_path>": must be unique` errors (see e.g. [this test run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/65850/rehearse-65850-periodic-ci-stackrox-stackrox-master-ocp-4-12-merge-qa-e2e-tests-psalajov-test/1941045013337083904#1:build-log.txt%3A202)), because even if this results in a volumeMount with different name, the `mount_path`s cannot be the same.
Also, because the credential's name can be quite long, we were hitting character limit exceeded errors.

**Solution:**
- Credentials with the same (collection, mountPath) are now grouped into a single SPC 
- SPC names are based on a hash of collection, mount path, and credential names to prevent overwrites when different steps use the same collection/mount combination
- Truncation logic -- to stay within Kubernetes' 63-character DNS label limit -- was used for SPC and CSI volumes naming
- For sidecar censoring, all credentials are created as individual SPCs, with different names and mount paths