### PR TITLE
use aws-observability-quota-slice for profile aws-observabiltity

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2195,7 +2195,7 @@ func (p ClusterProfile) LeaseType() string {
 	case ClusterProfileKonfluxWorkspacesAWS:
 		return "konfluxworkspaces-aws-quota-slice"
 	case ClusterProfileAWSObservabiltity:
-		return "observability-aws-quota-slice"
+		return "aws-observability-quota-slice"
 	case ClusterProfileAWSSDCICD:
 		return "aws-sd-cicd-quota-slice"
 	case ClusterProfileGCPSDCICD:


### PR DESCRIPTION
observability-aws-quota-slice had been used  for dynamic resources.   so we create a new one for the cluster-profile aws-observability

The PR For lease https://github.com/openshift/release/pull/66720/files