### PR TITLE
Konflux: Improve reconcile loop

### DIFF
--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -21,8 +21,8 @@ const (
 type EphemeralClusterConditionType string
 
 const (
-	// ClusterProvisioning indicates whether the cluster is being provisioned.
-	ClusterProvisioning EphemeralClusterConditionType = "ClusterProvisioning"
+	// ProwJobCreating indicates whether the prowjob is being created.
+	ProwJobCreating EphemeralClusterConditionType = "ProwJobCreating"
 	// ContainersReady indicates whether the cluster is up and running.
 	ClusterReady EphemeralClusterConditionType = "ClusterReady"
 	// ProwJobCompleted indicates whether the ProwJob is running.

--- a/pkg/controller/ephemeralcluster/prowjobreconciler.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler.go
@@ -72,8 +72,6 @@ func (r *prowJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("%s doesn't have the EC label", pj.Name))
 	}
 
-	pj = pj.DeepCopy()
-
 	ec := ephemeralclusterv1.EphemeralCluster{}
 	if err := r.client.Get(ctx, types.NamespacedName{Name: ecName, Namespace: EphemeralClusterNamespace}, &ec); err != nil {
 		if kerrors.IsNotFound(err) {

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -137,8 +137,6 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("get ephemeral cluster: %w", err))
 	}
 
-	ec = ec.DeepCopy()
-
 	// TODO: Retrieve the ProwJob ID without relying on the previous state.
 	// Make sure not to create a ProwJob multiple times. As an example:
 	// 1. EphemeralCluster and its ProwJob exist

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -195,7 +195,7 @@ func TestCreateProwJob(t *testing.T) {
 			},
 			prowConfig: &prowconfig.Config{},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes:    reconcile.Result{RequeueAfter: pollingTime},
+			wantRes:    reconcile.Result{},
 			wantErr:    errors.New("terminal error: validate and default presubmit: invalid presubmit job pull-ci-org-repo-branch-cluster-provisioning: failed to default namespace"),
 		},
 		{
@@ -224,7 +224,7 @@ func TestCreateProwJob(t *testing.T) {
 				return client.Create(ctx, obj, opts...)
 			}},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantRes: reconcile.Result{},
 			wantErr: errors.New("create prowjob: fake err"),
 		},
 		{
@@ -243,7 +243,7 @@ func TestCreateProwJob(t *testing.T) {
 				},
 			},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantRes: reconcile.Result{},
 			wantErr: errors.New("terminal error: generate ci-operator config: releases stanza not set"),
 		},
 		{
@@ -268,7 +268,7 @@ func TestCreateProwJob(t *testing.T) {
 				return client.Update(ctx, obj, opts...)
 			}},
 			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes: reconcile.Result{RequeueAfter: pollingTime},
+			wantRes: reconcile.Result{},
 			wantErr: errors.New("[update ephemeral cluster: fake err, terminal error: generate ci-operator config: releases stanza not set]"),
 		},
 	} {

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -378,6 +378,11 @@ func TestReconcile(t *testing.T) {
 					ProwJobID:  "pj-123",
 					Kubeconfig: "kubeconfig",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
 						LastTransitionTime: v1.NewTime(fakeNow),
@@ -417,13 +422,19 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
-					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
-						Type:               ephemeralclusterv1.ClusterReady,
-						Status:             ephemeralclusterv1.ConditionFalse,
-						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
-						Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
-					}},
+					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{
+						{
+							Type:               ephemeralclusterv1.ProwJobCreating,
+							Status:             ephemeralclusterv1.ConditionFalse,
+							Reason:             ProwJobCreatingDoneReason,
+							LastTransitionTime: v1.NewTime(fakeNow),
+						}, {
+							Type:               ephemeralclusterv1.ClusterReady,
+							Status:             ephemeralclusterv1.ConditionFalse,
+							Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
+							Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
+							LastTransitionTime: v1.NewTime(fakeNow),
+						}},
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
@@ -468,6 +479,11 @@ func TestReconcile(t *testing.T) {
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
@@ -521,6 +537,11 @@ func TestReconcile(t *testing.T) {
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
@@ -561,6 +582,11 @@ func TestReconcile(t *testing.T) {
 					Phase:     ephemeralclusterv1.EphemeralClusterFailed,
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
@@ -604,6 +630,11 @@ func TestReconcile(t *testing.T) {
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
@@ -667,6 +698,11 @@ func TestReconcile(t *testing.T) {
 					ProwJobID:  "pj-123",
 					Kubeconfig: "kubeconfig",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
 						LastTransitionTime: v1.NewTime(fakeNow),
@@ -751,6 +787,11 @@ func TestReconcile(t *testing.T) {
 					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioning,
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
 						LastTransitionTime: v1.NewTime(fakeNow),
@@ -799,6 +840,11 @@ func TestReconcile(t *testing.T) {
 					Phase:     ephemeralclusterv1.EphemeralClusterFailed,
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,
@@ -865,6 +911,11 @@ func TestReconcile(t *testing.T) {
 					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioning,
 					ProwJobID: "pj-123",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
+						Type:               ephemeralclusterv1.ProwJobCreating,
+						Status:             ephemeralclusterv1.ConditionFalse,
+						Reason:             ProwJobCreatingDoneReason,
+						LastTransitionTime: v1.NewTime(fakeNow),
+					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.KubeconfigFetchFailureReason,

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -25,6 +25,6 @@ status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
     status: "True"
-    type: ClusterProvisioning
+    type: ProwJobCreating
   phase: Provisioning
   prowJobId: foobar

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -22,5 +22,5 @@ status:
     message: 'create prowjob: fake err'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
-    type: ClusterProvisioning
+    type: ProwJobCreating
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -23,5 +23,5 @@ status:
       failed to default namespace'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
-    type: ClusterProvisioning
+    type: ProwJobCreating
   phase: Failed

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -13,5 +13,5 @@ status:
     message: 'generate ci-operator config: releases stanza not set'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
-    type: ClusterProvisioning
+    type: ProwJobCreating
   phase: Failed


### PR DESCRIPTION
Several small improvements:
- Replace the `ClusterProvisioning` condition with the more explicit `ProwJobCreating`. Furthermore, the `ProwJobCreating` is "stable" in a sense that the condition stays there even after the ProwJob has been created. It wasn't the case for `ClusterProvisioning` and this situation wasn't handled properly by Crossplane, leading to the following error on the XR:
```
- lastTransitionTime: "2025-07-08T09:35:55Z"
  message: A fatal error occurred before the status of this condition could be determined.
  reason: FatalError
  status: Unknown
  type: ClusterProvisioning
```
- Do not use `RequeueAfter` together with an error
- Calling `DeepCopy` isn't required anymore, see [UnsafeDisableDeepCopy](https://github.com/kubernetes-sigs/controller-runtime/blob/bfd1cf925238323fd53b372780a3d0a1a750a85c/pkg/cache/cache.go#L321)


/label tide/merge-method-squash