### PR TITLE
api: register aws-oadp-qe cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1484,6 +1484,7 @@ const (
 	ClusterProfileGCPQUAYQE               ClusterProfile = "gcp-quay-qe"
 	ClusterProfileAzureQUAYQE             ClusterProfile = "azure-quay-qe"
 	ClusterProfileAWSMCOQE                ClusterProfile = "aws-mco-qe"
+	ClusterProfileAWSOADPQE               ClusterProfile = "aws-oadp-qe"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1659,6 +1660,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileGCPQUAYQE,
 		ClusterProfileAzureQUAYQE,
 		ClusterProfileAWSMCOQE,
+		ClusterProfileAWSOADPQE,
 	}
 }
 
@@ -1722,7 +1724,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSManagedRosaRHOAIQE,
 		ClusterProfileAWSQUAYQE,
 		ClusterProfileAWSMCOQE,
-		ClusterProfileAWSManagedOSDRHOAIQE:
+		ClusterProfileAWSManagedOSDRHOAIQE,
+		ClusterProfileAWSOADPQE:
 		return string(CloudAWS)
 	case
 		ClusterProfileAlibabaCloud,
@@ -2268,6 +2271,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "equinix-edge-enablement-quota-slice"
 	case ClusterProfileAWSMCOQE:
 		return "aws-mco-qe-quota-slice"
+	case ClusterProfileAWSOADPQE:
+		return "aws-oadp-qe-quota-slice"
 	default:
 		return ""
 	}
@@ -2300,7 +2305,7 @@ func GetDefaultClusterProfileSecretName(profile ClusterProfile) string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-opendatahub", "aws-splat", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x", "libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu", "nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb", "aws-mco-qe", "equinix-edge-enablement":
+	case "aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-opendatahub", "aws-splat", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x", "libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu", "nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb", "aws-mco-qe", "equinix-edge-enablement", "aws-oadp-qe":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
Add new aws-oadp-qe cluster profile to enable OADP QE team CI testing on dedicated AWS resources.

Changes:
- Add ClusterProfileAWSOADPQE constant definition
- Register aws-oadp-qe in ClusterProfiles() list
- Map cluster profile to AWS cluster type
- Configure lease type as aws-oadp-qe-quota-slice
- Add aws-oadp-qe to LeaseTypeFromClusterType mapping

This enables the OADP QE team to use dedicated AWS quota slices for their CI testing workflows with proper resource isolation and management.

Assisted by: Claude (AI Assistant)