### PR TITLE
Disable link unfurling in helpdesk messages

### DIFF
--- a/pkg/slack/events/helpdesk/helpdesk-message.go
+++ b/pkg/slack/events/helpdesk/helpdesk-message.go
@@ -67,7 +67,16 @@ func MessageHandler(client messagePoster, keywordsConfig KeywordsConfig, helpdes
 			if event.ThreadTimeStamp != "" {
 				timestamp = event.ThreadTimeStamp
 			}
-			responseChannel, responseTimestamp, err := client.PostMessage(event.Channel, slack.MsgOptionBlocks(response...), slack.MsgOptionTS(timestamp))
+			unfurlParams := slack.PostMessageParameters{
+				UnfurlLinks: false,
+				UnfurlMedia: false,
+			}
+			responseChannel, responseTimestamp, err := client.PostMessage(
+				event.Channel,
+				slack.MsgOptionBlocks(response...),
+				slack.MsgOptionTS(timestamp),
+				slack.MsgOptionPostMessageParameters(unfurlParams),
+			)
 			if err != nil {
 				log.WithError(err).Warn("Failed to post a response")
 			} else {


### PR DESCRIPTION
In the [#forum-ocp-testplatform](https://redhat.enterprise.slack.com/archives/CBN38N3MW) channel, messages that are generated by users through workflows (Question, PR review, etc) have automatically links and media previews under the message itself, e.g. like this:
<img width="787" height="642" alt="Screenshot 2025-08-04 at 13 52 02" src="https://github.com/user-attachments/assets/9a3a26bf-63d8-4c40-b467-af180499632e" />

In my opinion this creates a lot of visual clutter, so this PR toggles off the unfurling of links (which is automatically set to `true` in Slack API).