### PR TITLE
DPTP-4422: allow for triggering of sharded jobs via payload testing

### DIFF
--- a/cmd/payload-testing-prow-plugin/filetestresolver.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver.go
@@ -14,17 +14,19 @@ type fileTestResolver struct {
 
 func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
 	byOrgRepo := r.configAgent.GetAll()
-	if v, ok := byOrgRepo["openshift"]; ok {
-		for _, configurations := range v {
-			for _, configuration := range configurations {
-				for _, element := range configuration.Tests {
-					if element.IsPeriodic() {
-						jobName := configuration.Metadata.JobName(jc.PeriodicPrefix, element.As)
-						if jobName == job {
-							return api.MetadataWithTest{
-								Metadata: configuration.Metadata,
-								Test:     element.As,
-							}, nil
+	for _, org := range []string{"openshift", "openshift-eng"} {
+		if v, ok := byOrgRepo[org]; ok {
+			for _, configurations := range v {
+				for _, configuration := range configurations {
+					for _, element := range configuration.Tests {
+						if element.IsPeriodic() {
+							testName := configuration.Metadata.TestNameFromJobName(job, jc.PeriodicPrefix)
+							if element.As == testName {
+								return api.MetadataWithTest{
+									Metadata: configuration.Metadata,
+									Test:     element.As,
+								}, nil
+							}
 						}
 					}
 				}

--- a/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
+++ b/pkg/api/pullrequestpayloadqualification/v1/ci.openshift.io_pullrequestpayloadqualificationruns.yaml
@@ -110,6 +110,14 @@ spec:
                           - org
                           - repo
                           type: object
+                        shardCount:
+                          description: ShardCount is the number of shards the main
+                            test has been broken into
+                          type: integer
+                        shardIndex:
+                          description: ShardIndex is the particular shard the job
+                            will run
+                          type: integer
                         test:
                           description: Test is the name of the test in the ci-operator
                             configuration

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler_test.go
@@ -149,6 +149,21 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
+			name: "basic case with sharded job",
+			prpqr: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "prpqr-test", Namespace: "test-namespace"},
+					Spec: v1.PullRequestPayloadTestSpec{
+						PullRequests: []v1.PullRequestUnderTest{{Org: "test-org", Repo: "test-repo", BaseRef: "test-branch", BaseSHA: "123456", PullRequest: &v1.PullRequest{Number: 100, Author: "test", SHA: "12345", Title: "test-pr"}}},
+						Jobs: v1.PullRequestPayloadJobSpec{
+							ReleaseControllerConfig: v1.ReleaseControllerConfig{OCP: "4.9", Release: "ci", Specifier: "informing"},
+							Jobs:                    []v1.ReleaseJobSpec{{CIOperatorConfig: v1.CIOperatorMetadata{Org: "test-org", Repo: "test-repo", Branch: "test-branch"}, Test: "test-name", ShardCount: 3, ShardIndex: 1}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple PRs from different repositories",
 			prpqr: []ctrlruntimeclient.Object{
 				&v1.PullRequestPayloadQualificationRun{

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_sharded_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_sharded_job.yaml
@@ -1,0 +1,87 @@
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1of3
+      releaseJobName: periodic-ci-test-org-test-repo-test-branch-test-name-1of3
+    creationTimestamp: null
+    labels:
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: test-org-test-repo-100-test-name-1of3
+      prow.k8s.io/refs.base_ref: test-branch
+      prow.k8s.io/refs.org: test-org
+      prow.k8s.io/refs.pull: "100"
+      prow.k8s.io/refs.repo: test-repo
+      prow.k8s.io/type: periodic
+      pullrequestpayloadqualificationruns.ci.openshift.io: prpqr-test
+      releaseJobNameHash: 9ffde57b6f1d11d584b8f024000f8fbce2ae85ee8a418f57245ff607
+    name: some-uuid
+    namespace: test-namespace
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build02
+    decoration_config:
+      skip_cloning: true
+      timeout: 6h0m0s
+    extra_refs:
+    - base_ref: test-branch
+      base_sha: "123456"
+      org: test-org
+      pulls:
+      - author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+    job: test-org-test-repo-100-test-name-1of3
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --input-hash=prpqr-test
+        - --multi-stage-param=SHARD_ARGS="--shard-count 3 --shard-id 1"
+        - --report-credentials-file=/etc/report/credentials
+        - --target=test-name
+        - --with-test-from=test-org/test-repo@test-branch:test-name
+        command:
+        - ci-operator
+        image: ci-operator:latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    report: true
+    type: periodic
+  status:
+    startTime: "1970-01-01T00:00:00Z"
+    state: triggered
+    url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-1of3

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_sharded_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prpqr_TestReconcile_basic_case_with_sharded_job.yaml
@@ -1,0 +1,46 @@
+- metadata:
+    creationTimestamp: null
+    finalizers:
+    - pullrequestpayloadqualificationruns.ci.openshift.io/dependent-prowjobs
+    name: prpqr-test
+    namespace: test-namespace
+    resourceVersion: "1000"
+  spec:
+    jobs:
+      releaseControllerConfig:
+        ocp: "4.9"
+        release: ci
+        specifier: informing
+      releaseJobSpec:
+      - ciOperatorConfig:
+          branch: test-branch
+          org: test-org
+          repo: test-repo
+        shardCount: 3
+        shardIndex: 1
+        test: test-name
+    payload: {}
+    pullRequests:
+    - baseRef: test-branch
+      baseSHA: "123456"
+      org: test-org
+      pr:
+        author: test
+        number: 100
+        sha: "12345"
+        title: test-pr
+      repo: test-repo
+  status:
+    conditions:
+    - lastTransitionTime: "1970-01-01T00:00:00Z"
+      message: All jobs triggered successfully
+      reason: AllJobsTriggered
+      status: "True"
+      type: AllJobsTriggered
+    jobs:
+    - jobName: periodic-ci-test-org-test-repo-test-branch-test-name-1of3
+      prowJob: some-uuid
+      status:
+        startTime: "1970-01-01T00:00:00Z"
+        state: triggered
+        url: https://prow.ci.openshift.org/view/gs/test-platform-results/test-org-test-repo-100-test-name-1of3

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -593,6 +593,11 @@ func MultiStageParam(key, value string) PodSpecMutator {
 	}
 }
 
+func ShardArgs(shardCount, shardIndex int) PodSpecMutator {
+	shardArgs := fmt.Sprintf("--shard-count %d --shard-id %d", shardCount, shardIndex)
+	return MultiStageParam("SHARD_ARGS", shardArgs)
+}
+
 // InjectTestFrom configures ci-operator to inject the specified test from the
 // specified ci-operator config into the base config and target it
 func InjectTestFrom(source *cioperatorapi.MetadataWithTest) PodSpecMutator {

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -49,7 +49,6 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 		shardCount := 1
 		if element.ShardCount != nil {
 			shardCount = *element.ShardCount
-
 		}
 
 		// Most of the time, this loop will only run once. the exception is if shard_count is set to an integer greater than 1
@@ -59,8 +58,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 			if shardCount > 1 {
 				name = fmt.Sprintf("%s-%dof%d", name, i, shardCount)
 				g.TestName(name)
-				shardArgs := fmt.Sprintf("--shard-count %d --shard-id %d", shardCount, i)
-				g.PodSpec.Add(MultiStageParam("SHARD_ARGS", shardArgs))
+				g.PodSpec.Add(ShardArgs(shardCount, i))
 			}
 
 			if element.NodeArchitecture != "" {


### PR DESCRIPTION
We need to handle the shard suffix in a few places, and make sure that the requested shard is the one triggered.

[DPTP-4422](https://issues.redhat.com//browse/DPTP-4422) makes mention of the possibility to trigger all shard indices with a single command, but that is complicated to implement and unnecessary. It is possible to simply enumerate each of the job names in the same `/payload-job` invocation.

The release-controller jobs are not currently sharded, so it is not necessary to handle that case. There may be some additional work here if we shard those in the future.

This also makes it possible for `openshift-eng` jobs to be triggered (https://issues.redhat.com/browse/DPTP-4478) because it was trivial, and I was there.

Note: https://github.com/openshift/release/pull/67989 already handles the CRD change

Slightly assisted by Cursor