### PR TITLE
api: register azure-oadp-qe cluster profile

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1485,6 +1485,7 @@ const (
 	ClusterProfileAzureQUAYQE             ClusterProfile = "azure-quay-qe"
 	ClusterProfileAWSMCOQE                ClusterProfile = "aws-mco-qe"
 	ClusterProfileAWSOADPQE               ClusterProfile = "aws-oadp-qe"
+	ClusterProfileAzureOADPQE             ClusterProfile = "azure-oadp-qe"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1661,6 +1662,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureQUAYQE,
 		ClusterProfileAWSMCOQE,
 		ClusterProfileAWSOADPQE,
+		ClusterProfileAzureOADPQE,
 	}
 }
 
@@ -1757,7 +1759,8 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAzureSustAutoRel412,
 		ClusterProfileAzureQUAYQE,
 		ClusterProfileAzureConfidentialQE,
-		ClusterProfileAzureVirtualization:
+		ClusterProfileAzureVirtualization,
+		ClusterProfileAzureOADPQE:
 		return "azure4"
 	case
 		ClusterProfileAzureArm64,
@@ -2273,6 +2276,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-mco-qe-quota-slice"
 	case ClusterProfileAWSOADPQE:
 		return "aws-oadp-qe-quota-slice"
+	case ClusterProfileAzureOADPQE:
+		return "azure-oadp-qe-quota-slice"
 	default:
 		return ""
 	}
@@ -2305,7 +2310,7 @@ func GetDefaultClusterProfileSecretName(profile ClusterProfile) string {
 // LeaseTypeFromClusterType maps cluster types to lease types
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
-	case "aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-opendatahub", "aws-splat", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x", "libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu", "nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb", "aws-mco-qe", "equinix-edge-enablement", "aws-oadp-qe":
+	case "aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-osd-msp", "aws-opendatahub", "aws-splat", "alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal", "gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x", "libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le", "ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu", "nutanix-qe-flow", "openstack", "openstack-osuosl", "openstack-vexxhost", "openstack-ppc64le", "openstack-nerc-dev", "vsphere", "ovirt", "packet", "packet-edge", "powervs-multi-1", "powervs-1", "powervs-2", "powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs", "hypershift-powervs-cb", "aws-mco-qe", "equinix-edge-enablement", "aws-oadp-qe", "azure-oadp-qe":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
Add new azure-oadp-qe cluster profile to enable OADP QE testing on Azure.

Changes:
- Add ClusterProfileAzureOADPQE constant definition
- Register azure-oadp-qe in ClusterProfiles() list
- Map cluster profile to Azure cluster type (azure4)
- Configure lease type as azure-oadp-qe-quota-slice

Generated by: Claude (AI Assistant)