### PR TITLE
Improve sync-rover-groups logging and config handling

### DIFF
--- a/cmd/sync-rover-groups/main.go
+++ b/cmd/sync-rover-groups/main.go
@@ -84,6 +84,15 @@ func addSchemes() error {
 	return nil
 }
 
+func (o *options) setupLogger() {
+	logrus.SetLevel(o.logLevel)
+	formatter := &logrus.TextFormatter{
+		FullTimestamp: true,
+		ForceColors:   true,
+	}
+	logrus.SetFormatter(formatter)
+}
+
 func main() {
 	logrusutil.ComponentInit()
 
@@ -92,7 +101,7 @@ func main() {
 	if err := opts.validate(); err != nil {
 		logrus.WithError(err).Fatal("failed to validate the option")
 	}
-	logrus.SetLevel(opts.logLevel)
+	opts.setupLogger()
 	opts.manifestDirs = sets.New[string](opts.manifestDirRaw.Strings()...)
 
 	var config *group.Config


### PR DESCRIPTION
Previously, the sync-rover-groups tool error outputs were confusing, making it difficult to debug configuration problems. 
This change adds:

- Strict YAML parsing that fails on unknown fields
- Replace JSON log format with readable text formatter
- SecretCollections (`secret_collections`) field to support the GCP secrets initiative 

Related changes in release repo: https://github.com/openshift/release/pull/68222 (to be merged after this PR)