### PR TITLE
Added a logic to chose the name of the mirrored image

### DIFF
--- a/pkg/controller/multiarchbuildconfig/mirror.go
+++ b/pkg/controller/multiarchbuildconfig/mirror.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -64,7 +65,12 @@ func (oci *ocImage) mirror(images []string) error {
 func ocImageMirrorArgs(targetImageRef string, externalRegistries []string) []string {
 	destinations := sets.New[string]()
 	for _, externalRegistry := range externalRegistries {
-		destinations.Insert(fmt.Sprintf("%s/%s", externalRegistry, targetImageRef))
+		// This is a hack to push images to QCI using our naming convention
+		if externalRegistry == "quay.io/openshift/ci" {
+			destinations.Insert(fmt.Sprintf("%s:%s", externalRegistry, strings.ReplaceAll(strings.ReplaceAll(targetImageRef, ":", "_"), "/", "_")))
+		} else {
+			destinations.Insert(fmt.Sprintf("%s/%s", externalRegistry, targetImageRef))
+		}
 	}
 
 	destinationsList := destinations.UnsortedList()

--- a/pkg/controller/multiarchbuildconfig/mirror_test.go
+++ b/pkg/controller/multiarchbuildconfig/mirror_test.go
@@ -46,26 +46,27 @@ func TestOCImageMirrorArgs(t *testing.T) {
 		},
 		{
 			name:               "Mirror to multiple external registries",
-			targetImageRef:     "src-image:latest",
-			externalRegistries: []string{"dst-registry-1.com", "dst-registry-2.com"},
+			targetImageRef:     "ci/src-image:latest",
+			externalRegistries: []string{"dst-registry-1.com", "dst-registry-2.com", "quay.io/openshift/ci"},
 			want: []string{
-				"image-registry.openshift-image-registry.svc:5000/src-image:latest",
-				"dst-registry-1.com/src-image:latest",
-				"dst-registry-2.com/src-image:latest",
+				"image-registry.openshift-image-registry.svc:5000/ci/src-image:latest",
+				"dst-registry-1.com/ci/src-image:latest",
+				"dst-registry-2.com/ci/src-image:latest",
+				"quay.io/openshift/ci:ci_src-image_latest",
 			},
 		},
 		{
 			name:           "Deduplicate destinations",
-			targetImageRef: "src-image:latest",
+			targetImageRef: "ci/src-image:latest",
 			externalRegistries: []string{
 				"dst-registry-1.com",
 				"dst-registry-1.com",
 				"dst-registry-3.com",
 			},
 			want: []string{
-				"image-registry.openshift-image-registry.svc:5000/src-image:latest",
-				"dst-registry-1.com/src-image:latest",
-				"dst-registry-3.com/src-image:latest",
+				"image-registry.openshift-image-registry.svc:5000/ci/src-image:latest",
+				"dst-registry-1.com/ci/src-image:latest",
+				"dst-registry-3.com/ci/src-image:latest",
 			},
 		},
 	} {


### PR DESCRIPTION
This adds a hack into our `MultiArchBuildConfig` to specify mirrors to QCI.
```yaml
apiVersion: ci.openshift.io/v1
kind: MultiArchBuildConfig
metadata:
  name: managed-clonerefs
  namespace: ci
spec:
  build_spec:
    output:
      to:
        kind: ImageStreamTag
        name: managed-clonerefs:latest
        namespace: ci
  external_registries:
  - registry.ci.openshift.org
  - quay.io/openshift/ci
```

Some unit tests were modified because `targetImageRef` always have a `namespace` attached to it, even if it doesn't, registries expect the pattern `registry.url/project/image:tag`:
https://github.com/openshift/ci-tools/blob/890a9c32585a0327824f81f9f28306d771d0651f/pkg/controller/multiarchbuildconfig/multiarchbuildconfig.go#L169