### PR TITLE
`payload-testing-prow-plugin`: provide a more useful comment when promotion from the base branch is disabled

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -369,8 +369,8 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) (string, [
 		return formatError(fmt.Errorf("could not resolve ci-operator's config for %s/%s/%s: %w", org, repo, pr.Base.Ref, err)), nil
 	}
 	if !api.PromotesOfficialImages(ciOpConfig, api.WithOKD) {
-		logger.Info("the repo does not contribute to the OpenShift official images")
-		return fmt.Sprintf("the repo %s/%s does not contribute to the OpenShift official images", org, repo), nil
+		logger.Info("the repo does not contribute to the OpenShift official images, or the branch's promotion is disabled")
+		return fmt.Sprintf("the repo %s/%s does not contribute to the OpenShift official images, or the base branch is not currently having images promoted", org, repo), nil
 	}
 
 	var messages []string

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -1000,7 +1000,7 @@ trigger 0 job(s) of type all for the ci release of OCP 4.8
 					Body: "/payload 4.10 nightly informing",
 				},
 			},
-			expectedMessage: `the repo org/repo does not contribute to the OpenShift official images`,
+			expectedMessage: `the repo org/repo does not contribute to the OpenShift official images, or the base branch is not currently having images promoted`,
 		},
 		{
 			name: "abort all jobs",


### PR DESCRIPTION
We ran into this [here](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1756156151622769), and were initially confused as to why payload tests weren't working in `origin`. The updated error message does a better job at hinting at what the actual problem is. We could determine which of the two cases it is, and specify only that, but I don't think it is worth the convoluted logic that it would require to do so. This only gives the user two different things to check on, and will likely let them discover the problem for themselves.