### PR TITLE
Allow for trusted apps to use the /payload command

### DIFF
--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -32,6 +32,7 @@ type options struct {
 	githubEventServerOptions githubeventserver.Options
 	github                   prowflagutil.GitHubOptions
 	kubernetesOptions        prowflagutil.KubernetesOptions
+	trustedApps              prowflagutil.Strings
 	namespace                string
 	ciOpConfigDir            string
 	releaseRepoGitSyncPath   string
@@ -51,6 +52,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.namespace, "namespace", "ci", "Namespace to create PullRequestPayloadQualificationRuns.")
 	fs.StringVar(&o.ciOpConfigDir, "ci-op-config-dir", "", "Path to CI Operator configuration directory.")
 	fs.StringVar(&o.releaseRepoGitSyncPath, "release-repo-git-sync-path", "/var/repo/release", "Path to release repository dir")
+	fs.Var(&o.trustedApps, "trusted-app", "Repeatable. GitHub App slug allowed to issue /payload . Example: --trusted-app=openshift-pr-manager")
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatalf("cannot parse args: '%s'", os.Args[1:])
 	}
@@ -178,6 +180,7 @@ func main() {
 		testResolver: &fileTestResolver{configAgent: configAgent},
 		trustedChecker: &githubTrustedChecker{
 			githubClient: githubClient,
+			trustedApps:  o.trustedApps,
 		},
 		ciOpConfigResolver: registryserver.NewResolverClient(api.URLForService(api.ServiceConfig)),
 	}


### PR DESCRIPTION
this allows for the case that a [bot] (e.g., openshift-pr-manager [0]) wants to use the /payload commands.

the apps can be added in the release project here [1]

[0] https://github.com/apps/openshift-pr-manager
[1] https://github.com/openshift/release/blob/51eba57acb12ad4c28fe894a6578c10fb4d3dbf0/clusters/app.ci/prow/03_deployment/payload-testing-prow-plugin.yaml