### PR TITLE
[ci-operator]: initial implementation of the images plugin in the metrics agent

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1494,13 +1494,9 @@ func (o *options) initializeNamespace() error {
 			LookupPolicy: imageapi.ImageLookupPolicy{Local: true},
 		},
 	}
-	if err := client.Create(ctx, is); err != nil {
-		if !kerrors.IsAlreadyExists(err) {
-			return fmt.Errorf("could not set up pipeline imagestream for test: %w", err)
-		}
-		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Name: api.PipelineImageStream}, is); err != nil {
-			return fmt.Errorf("failed to get pipeline imagestream: %w", err)
-		}
+	is, err = util.CreateImageStreamWithMetrics(ctx, client, is, o.metricsAgent)
+	if err != nil {
+		return fmt.Errorf("could not set up pipeline imagestream for test: %w", err)
 	}
 	o.jobSpec.SetOwner(&metav1.OwnerReference{
 		APIVersion: "image.openshift.io/v1",

--- a/cmd/ci-operator/main_test.go
+++ b/cmd/ci-operator/main_test.go
@@ -1030,7 +1030,7 @@ func TestBuildPartialGraph(t *testing.T) {
 			input: []api.Step{
 				steps.InputImageTagStep(
 					&api.InputImageTagStepConfiguration{InputImage: api.InputImage{To: api.PipelineImageStreamTagReferenceRoot}},
-					loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(&imagev1.ImageStreamTag{ObjectMeta: metav1.ObjectMeta{Name: ":"}}).Build()),
+					loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(&imagev1.ImageStreamTag{ObjectMeta: metav1.ObjectMeta{Name: ":"}}).Build(), nil),
 					nil,
 				),
 				steps.SourceStep(api.SourceStepConfiguration{From: api.PipelineImageStreamTagReferenceRoot, To: api.PipelineImageStreamTagReferenceSource}, api.ResourceConfiguration{}, nil, nil, &api.JobSpec{}, nil, nil, nil),

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -87,7 +87,7 @@ func FromConfig(
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to construct client: %w", err)
 	}
-	client := loggingclient.New(crclient)
+	client := loggingclient.New(crclient, metricsAgent)
 	buildGetter, err := buildclientset.NewForConfig(clusterConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get build client for cluster config: %w", err)

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1241,7 +1241,7 @@ func TestFromConfig(t *testing.T) {
 			Body:       io.NopCloser(bytes.NewBuffer([]byte(content))),
 		}, nil
 	})
-	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build())
+	client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build(), nil)
 	if err := imageapi.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/metrics/images.go
+++ b/pkg/metrics/images.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ImagesPluginName = "images"
+)
+
+// ImageStreamEvent defines an image stream creation/update event
+type ImageStreamEvent struct {
+	Namespace          string         `json:"namespace"`
+	ImageStreamName    string         `json:"image_stream_name"`
+	FullName           string         `json:"full_name"`
+	Success            bool           `json:"success"`
+	Error              string         `json:"error,omitempty"`
+	ImageStreamDetails map[string]any `json:"image_stream_details,omitempty"`
+	AdditionalContext  map[string]any `json:"additional_context,omitempty"`
+	Timestamp          time.Time      `json:"timestamp"`
+}
+
+// TagImportEvent defines a tag import event
+type TagImportEvent struct {
+	Namespace         string         `json:"namespace"`
+	ImageStreamName   string         `json:"image_stream_name"`
+	TagName           string         `json:"tag_name"`
+	FullTagName       string         `json:"full_tag_name"`
+	SourceImage       string         `json:"source_image"`
+	SourceImageKind   string         `json:"source_image_kind"`
+	StartTime         time.Time      `json:"start_time"`
+	CompletionTime    time.Time      `json:"completion_time"`
+	DurationSeconds   float64        `json:"duration_seconds"`
+	RetryCount        int            `json:"retry_count"`
+	Success           bool           `json:"success"`
+	Error             string         `json:"error,omitempty"`
+	AdditionalContext map[string]any `json:"additional_context,omitempty"`
+	Timestamp         time.Time      `json:"timestamp"`
+}
+
+func (ise *ImageStreamEvent) SetTimestamp(t time.Time) {
+	ise.Timestamp = t
+}
+
+func (tie *TagImportEvent) SetTimestamp(t time.Time) {
+	tie.Timestamp = t
+}
+
+type imagesPlugin struct {
+	mu     sync.Mutex
+	ctx    context.Context
+	logger *logrus.Entry
+	events []MetricsEvent
+	client ctrlruntimeclient.Client
+}
+
+func newImagesPlugin(ctx context.Context, logger *logrus.Entry, client ctrlruntimeclient.Client) *imagesPlugin {
+	return &imagesPlugin{
+		ctx:    ctx,
+		logger: logger.WithField("plugin", ImagesPluginName),
+		client: client,
+	}
+}
+
+func (p *imagesPlugin) Name() string { return ImagesPluginName }
+
+func (p *imagesPlugin) Record(ev MetricsEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := ev.(*ImageStreamEvent); ok {
+		p.events = append(p.events, ev)
+		return
+	}
+	if _, ok := ev.(*TagImportEvent); ok {
+		p.events = append(p.events, ev)
+	}
+}
+
+func (p *imagesPlugin) Events() []MetricsEvent {
+	return p.events
+}

--- a/pkg/steps/artifacts_test.go
+++ b/pkg/steps/artifacts_test.go
@@ -516,7 +516,7 @@ func TestArtifactWorker(t *testing.T) {
 						},
 					},
 				},
-			}).Build()),
+			}).Build(), nil),
 		},
 		Namespace: "namespace",
 		Name:      pod,

--- a/pkg/steps/bundle_source_test.go
+++ b/pkg/steps/bundle_source_test.go
@@ -144,7 +144,8 @@ RUN find . -type f -regex ".*\.\(yaml\|yml\)" -exec sed -i s?quay.io/openshift/o
 					}},
 				}},
 			},
-		}).Build())}
+		}).Build(), nil),
+	}
 
 	s := bundleSourceStep{
 		config: api.BundleSourceStepConfiguration{

--- a/pkg/steps/cluster_claim_test.go
+++ b/pkg/steps/cluster_claim_test.go
@@ -124,7 +124,7 @@ func TestClusterClaimStepAcquireCluster(t *testing.T) {
 				client.namespace = "ci-ocp-4.7.0-amd64-aws-us-east-1-ccx23"
 				client.conditionStatus = corev1.ConditionTrue
 			}),
-			client: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects().Build()),
+			client: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects().Build(), nil),
 			waitForClaim: func(client ctrlruntimeclient.WithWatch, ns, name string, claim *hivev1.ClusterClaim, timeout time.Duration) error {
 				return client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: ns, Name: name}, claim)
 			},
@@ -204,7 +204,7 @@ func TestClusterClaimStepAcquireCluster(t *testing.T) {
 				Timeout:      &prowv1.Duration{Duration: time.Hour},
 			},
 			hiveClient:    bcc(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(aClusterPool()).Build()),
-			client:        loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects().Build()),
+			client:        loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects().Build(), nil),
 			jobSpec:       &api.JobSpec{},
 			expectedError: fmt.Errorf("failed to find a cluster pool providing the cluster: map[architecture:amd64 cloud:aws owner:dpp product:ocp version:4.6.0]"),
 			verifyFunc: func(client ctrlruntimeclient.Client) error {
@@ -233,7 +233,7 @@ func TestClusterClaimStepAcquireCluster(t *testing.T) {
 				client.namespace = "ci-ocp-4.7.0-amd64-aws-us-east-1-ccx23"
 				client.conditionStatus = corev1.ConditionFalse
 			}),
-			client: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build()),
+			client: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build(), nil),
 			jobSpec: &api.JobSpec{
 				JobSpec: downwardapi.JobSpec{
 					ProwJobID: "c2a971b7-947b-11eb-9747-0a580a820213",

--- a/pkg/steps/index_generator_test.go
+++ b/pkg/steps/index_generator_test.go
@@ -58,7 +58,7 @@ func TestIndexGenDockerfile(t *testing.T) {
 				UpdateGraph:   api.IndexUpdateSemver,
 			},
 			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate"]
@@ -75,7 +75,7 @@ COPY --from=builder /database/ database`,
 			},
 			jobSpec:    &api.JobSpec{},
 			pullSecret: &coreapi.Secret{},
-			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
@@ -93,7 +93,7 @@ COPY --from=builder /database/ database`,
 				UpdateGraph:   api.IndexUpdateSemver,
 			},
 			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0,some-reg/target-namespace/pipeline@ci-bundle1", "--out-dockerfile", "index.Dockerfile", "--generate"]
@@ -110,7 +110,7 @@ COPY --from=builder /database/ database`,
 			},
 			jobSpec:    &api.JobSpec{},
 			pullSecret: &coreapi.Secret{},
-			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
@@ -129,7 +129,7 @@ COPY --from=builder /database/ database`,
 				BaseIndex:     "the-index",
 			},
 			jobSpec: &api.JobSpec{},
-			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:  &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 RUN ["opm", "index", "add", "--mode", "semver", "--bundles", "some-reg/target-namespace/pipeline@ci-bundle0", "--out-dockerfile", "index.Dockerfile", "--generate", "--from-index", "some-reg/target-namespace/pipeline@the-index"]
@@ -147,7 +147,7 @@ COPY --from=builder /database/ database`,
 			},
 			jobSpec:    &api.JobSpec{},
 			pullSecret: &coreapi.Secret{},
-			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet)},
+			client:     &buildClient{LoggingClient: loggingclient.New(fakeClientSet, nil)},
 		},
 		expected: `FROM quay.io/operator-framework/upstream-opm-builder AS builder
 COPY .dockerconfigjson .
@@ -231,7 +231,7 @@ func TestDatabaseIndex(t *testing.T) {
 			if err := yaml.Unmarshal(rawImageStreamTag, ist); err != nil {
 				t.Fatalf("failed to unmarshal imagestreamTag: %v", err)
 			}
-			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist, image).Build()), nil, nil, "", "", nil),
+			actual, actualErr := databaseIndex(NewBuildClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithObjects(ist, image).Build(), nil), nil, nil, "", "", nil),
 				testCase.isTagName, "ns")
 			if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 				t.Fatalf("actual did not match expected, diff: %s", diff)

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -66,7 +66,7 @@ func TestInputImageTagStep(t *testing.T) {
 				Namespace: baseImage.Namespace,
 			},
 			Image: imagev1.Image{ObjectMeta: metav1.ObjectMeta{Name: "ddc0de"}},
-		}).Build())
+		}).Build(), nil)
 
 	// Make a step instance
 	jobspec := &api.JobSpec{}
@@ -179,7 +179,7 @@ func TestInputImageTagStepExternal(t *testing.T) {
 		},
 		&imagev1.ImageStreamTag{
 			Image: imagev1.Image{ObjectMeta: metav1.ObjectMeta{Name: "ddc0de"}},
-		}).Build())
+		}).Build(), nil)
 
 	// Make a step instance
 	jobspec := &api.JobSpec{}

--- a/pkg/steps/multi_stage/init_test.go
+++ b/pkg/steps/multi_stage/init_test.go
@@ -142,7 +142,7 @@ func TestCreateSPCs(t *testing.T) {
 				LoggingClient: loggingclient.New(
 					fakectrlruntimeclient.NewClientBuilder().
 						WithScheme(scheme).
-						Build()),
+						Build(), nil),
 			}
 			fakeClient := &testhelper_kube.FakePodClient{
 				FakePodExecutor: crclient,
@@ -339,7 +339,7 @@ func TestSetupRBAC(t *testing.T) {
 
 			tc.step.client = &testhelper_kube.FakePodClient{
 				FakePodExecutor: &testhelper_kube.FakePodExecutor{
-					LoggingClient: loggingclient.New(client),
+					LoggingClient: loggingclient.New(client, nil),
 				},
 			}
 

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -136,7 +136,7 @@ func TestSecretsForCensoring(t *testing.T) {
 					Annotations: map[string]string{"kubernetes.io/service-account.name": "foo"},
 				},
 			},
-		).Build(),
+		).Build(), nil,
 	)
 
 	volumes, mounts, err := secretsForCensoring(client, "target-namespace", context.Background())

--- a/pkg/steps/multi_stage/run_test.go
+++ b/pkg/steps/multi_stage/run_test.go
@@ -92,7 +92,7 @@ func TestRun(t *testing.T) {
 					fakectrlruntimeclient.NewClientBuilder().
 						WithIndex(&v1.Pod{}, "metadata.name", fakePodNameIndexer).
 						WithObjects(sa).
-						Build()),
+						Build(), nil),
 				Failures: tc.failures,
 			}
 			jobSpec := api.JobSpec{
@@ -233,7 +233,7 @@ func TestJUnit(t *testing.T) {
 					fakectrlruntimeclient.NewClientBuilder().
 						WithIndex(&v1.Pod{}, "metadata.name", fakePodNameIndexer).
 						WithObjects(sa).
-						Build()),
+						Build(), nil),
 				Failures: tc.failures,
 			}
 			jobSpec := api.JobSpec{

--- a/pkg/steps/output_image_tag_test.go
+++ b/pkg/steps/output_image_tag_test.go
@@ -132,7 +132,7 @@ func TestOutputImageStep(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(tt.input...).Build())
+			client := loggingclient.New(fakectrlruntimeclient.NewClientBuilder().WithRuntimeObjects(tt.input...).Build(), nil)
 
 			oits := OutputImageTagStep(config, client, jobspec)
 

--- a/pkg/steps/pod_test.go
+++ b/pkg/steps/pod_test.go
@@ -72,7 +72,7 @@ func preparePodStep(namespace string) (*podStep, stepExpectation) {
 	}
 	jobSpec.SetNamespace(namespace)
 
-	client := kubernetes.NewPodClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build()), nil, nil, 0, nil)
+	client := kubernetes.NewPodClient(loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build(), nil), nil, nil, 0, nil)
 	ps := PodStep(stepName, config, resources, client, jobSpec, nil)
 
 	specification := stepExpectation{
@@ -126,7 +126,7 @@ func TestPodStepExecution(t *testing.T) {
 		t.Run(tc.purpose, func(t *testing.T) {
 			ps, _ := preparePodStep(namespace)
 			ps.config.Clone = tc.clone
-			ps.client = kubernetes.NewPodClient(loggingclient.New(&podStatusChangingClient{WithWatch: fakectrlruntimeclient.NewClientBuilder().Build(), dest: tc.podStatus}), nil, nil, 0, nil)
+			ps.client = kubernetes.NewPodClient(loggingclient.New(&podStatusChangingClient{WithWatch: fakectrlruntimeclient.NewClientBuilder().Build(), dest: tc.podStatus}, nil), nil, nil, 0, nil)
 
 			executionExpectation := executionExpectation{
 				prerun: doneExpectation{

--- a/pkg/steps/release/release_images.go
+++ b/pkg/steps/release/release_images.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,9 +55,10 @@ func (s *stableImagesTagStep) run(ctx context.Context) error {
 			},
 		},
 	}
-	if err := s.client.Create(ctx, newIS); err != nil && !kerrors.IsAlreadyExists(err) {
-		return fmt.Errorf("could not create stable imagestreamtag: %w", err)
+	if _, err := util.CreateImageStreamWithMetrics(ctx, s.client, newIS, s.client.MetricsAgent()); err != nil {
+		return fmt.Errorf("could not create stable imagestream: %w", err)
 	}
+
 	return nil
 }
 
@@ -133,11 +133,11 @@ func (s *releaseImagesTagStep) run(ctx context.Context) error {
 	initialIS := newIS.DeepCopy()
 	initialIS.Name = api.ReleaseStreamFor(api.InitialReleaseName)
 
-	if err := s.client.Create(ctx, newIS); err != nil && !kerrors.IsAlreadyExists(err) {
+	if _, err := util.CreateImageStreamWithMetrics(ctx, s.client, newIS, s.client.MetricsAgent()); err != nil {
 		return fmt.Errorf("could not copy stable imagestreamtag: %w", err)
 	}
 
-	if err := s.client.Create(ctx, initialIS); err != nil && !kerrors.IsAlreadyExists(err) {
+	if _, err := util.CreateImageStreamWithMetrics(ctx, s.client, initialIS, s.client.MetricsAgent()); err != nil {
 		return fmt.Errorf("could not copy stable-initial imagestreamtag: %w", err)
 	}
 

--- a/pkg/steps/rpm_server_test.go
+++ b/pkg/steps/rpm_server_test.go
@@ -82,7 +82,7 @@ func TestRPMServerStepProvides(t *testing.T) {
 						}},
 					},
 				},
-			).Build())
+			).Build(), nil)
 			tc.jobSpec.SetNamespace(ns)
 			step := RPMServerStep(api.RPMServeStepConfiguration{}, client, &tc.jobSpec)
 			providesMap := step.Provides()

--- a/pkg/steps/source_test.go
+++ b/pkg/steps/source_test.go
@@ -492,7 +492,7 @@ func TestWaitForBuild(t *testing.T) {
 							CompletionTimestamp: &end,
 						},
 					},
-				).Build()), nil, nil, "", "", nil),
+				).Build(), nil), nil, nil, "", "", nil),
 			expected: fmt.Errorf("build didn't start running within 0s (phase: Pending)"),
 		},
 		{
@@ -521,7 +521,7 @@ func TestWaitForBuild(t *testing.T) {
 							Namespace: ns,
 						},
 					},
-				).Build()), nil, nil, "", "", nil),
+				).Build(), nil), nil, nil, "", "", nil),
 			expected: fmt.Errorf("build didn't start running within 0s (phase: Pending):\nFound 0 events for Pod some-build-build:"),
 		},
 		{
@@ -562,7 +562,7 @@ func TestWaitForBuild(t *testing.T) {
 							}},
 						},
 					},
-				).Build()), nil, nil, "", "", nil),
+				).Build(), nil), nil, nil, "", "", nil),
 			expected: fmt.Errorf(`build didn't start running within 0s (phase: Pending):
 * Container the-container is not ready with reason the_reason and message the_message
 Found 0 events for Pod some-build-build:`),
@@ -581,7 +581,7 @@ Found 0 events for Pod some-build-build:`),
 						StartTimestamp:      &start,
 						CompletionTimestamp: &end,
 					},
-				}).Build()), nil, nil, "", "", nil),
+				}).Build(), nil), nil, nil, "", "", nil),
 			timeout: 30 * time.Minute,
 		},
 		{
@@ -601,7 +601,7 @@ Found 0 events for Pod some-build-build:`),
 						StartTimestamp:      &start,
 						CompletionTimestamp: &end,
 					},
-				}).Build()), "abc\n"), // the line break is for gotestsum https://github.com/gotestyourself/gotestsum/issues/141#issuecomment-1209146526
+				}).Build(), nil), "abc\n"), // the line break is for gotestsum https://github.com/gotestyourself/gotestsum/issues/141#issuecomment-1209146526
 			timeout:  30 * time.Minute,
 			expected: fmt.Errorf("%s\n\n%s", "the build some-build failed after 3s with reason reason: msg", "snippet"),
 		},
@@ -625,7 +625,7 @@ Found 0 events for Pod some-build-build:`),
 							Time: now.Add(-59 * time.Minute),
 						},
 					},
-				}).Build()), nil, nil, "", "", nil),
+				}).Build(), nil), nil, nil, "", "", nil),
 			timeout: 30 * time.Minute,
 		},
 		{
@@ -651,7 +651,7 @@ Found 0 events for Pod some-build-build:`),
 							Time: now.Add(-59 * time.Minute),
 						},
 					},
-				}).Build()), "abc\n"),
+				}).Build(), nil), "abc\n"),
 			timeout:  30 * time.Minute,
 			expected: fmt.Errorf("%s\n\n%s", "the build some-build failed after 1m0s with reason reason: msg", "snippet"),
 		},
@@ -766,7 +766,7 @@ func TestCheckPending(t *testing.T) {
 			timeout := 30 * time.Minute
 			client := testhelper_kube.FakePodClient{
 				FakePodExecutor: &testhelper_kube.FakePodExecutor{
-					LoggingClient: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build()),
+					LoggingClient: loggingclient.New(fakectrlruntimeclient.NewClientBuilder().Build(), nil),
 				},
 				PendingTimeout: timeout,
 			}

--- a/pkg/steps/utils/image_test.go
+++ b/pkg/steps/utils/image_test.go
@@ -68,7 +68,7 @@ func TestReimportTag(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actual, actualErr := ImportTagWithRetries(context.Background(), testCase.client, testCase.ns, testCase.is, testCase.tag, testCase.sourcePullSpec, 3)
+		actual, actualErr := ImportTagWithRetries(context.Background(), testCase.client, testCase.ns, testCase.is, testCase.tag, testCase.sourcePullSpec, 3, nil)
 		if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 			t.Errorf("%s: actualErr does not match expectedErr, diff: %s", testCase.name, diff)
 		}
@@ -442,7 +442,7 @@ func TestGetEvaluator(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		e := getEvaluator(context.Background(), testCase.client, testCase.obj.Namespace, testCase.obj.Name, testCase.tags)
+		e := getEvaluator(context.Background(), testCase.client, testCase.obj.Namespace, testCase.obj.Name, testCase.tags, nil)
 		actual, actualErr := e(testCase.obj)
 		if diff := cmp.Diff(testCase.expectedErr, actualErr, testhelper.EquateErrorMessage); diff != "" {
 			t.Errorf("%s: actualErr does not match expectedErr, diff: %s", testCase.name, diff)

--- a/pkg/util/imagestream.go
+++ b/pkg/util/imagestream.go
@@ -1,12 +1,17 @@
 package util
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	imageapi "github.com/openshift/api/image/v1"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/metrics"
 )
 
 // ParseImageStreamTagReference creates a reference from an "is:tag" string.
@@ -27,6 +32,9 @@ func ParseImageStreamTagReference(s string) (api.ImageStreamTagReference, error)
 // ResolvePullSpec if a tag of an imagestream is resolved
 func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (string, bool, imageapi.TagEventCondition) {
 	var condition imageapi.TagEventCondition
+	var pullSpec string
+	var exists bool
+
 	for _, tags := range is.Status.Tags {
 		if tags.Tag != tag {
 			continue
@@ -39,22 +47,66 @@ func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (s
 		}
 		if image := tags.Items[0].Image; len(image) > 0 {
 			if len(is.Status.PublicDockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image), true, condition
+				pullSpec = fmt.Sprintf("%s@%s", is.Status.PublicDockerImageRepository, image)
+				exists = true
+				break
 			}
 			if len(is.Status.DockerImageRepository) > 0 {
-				return fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image), true, condition
+				pullSpec = fmt.Sprintf("%s@%s", is.Status.DockerImageRepository, image)
+				exists = true
+				break
 			}
 		}
 		break
 	}
-	if requireExact {
-		return "", false, condition
+
+	if !exists && !requireExact {
+		if len(is.Status.PublicDockerImageRepository) > 0 {
+			pullSpec = fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag)
+			exists = true
+		} else if len(is.Status.DockerImageRepository) > 0 {
+			pullSpec = fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag)
+			exists = true
+		}
 	}
-	if len(is.Status.PublicDockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.PublicDockerImageRepository, tag), true, condition
+
+	return pullSpec, exists, condition
+}
+
+// CreateImageStreamWithMetrics creates an ImageStream and records the appropriate metrics event
+func CreateImageStreamWithMetrics(ctx context.Context, client ctrlruntimeclient.Client, imageStream *imageapi.ImageStream, metricsAgent *metrics.MetricsAgent) (*imageapi.ImageStream, error) {
+	created := true
+
+	if err := client.Create(ctx, imageStream); err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			metricsAgent.Record(&metrics.ImageStreamEvent{
+				Namespace:       imageStream.Namespace,
+				ImageStreamName: imageStream.Name,
+				FullName:        imageStream.Namespace + "/" + imageStream.Name,
+				Success:         false,
+				Error:           err.Error(),
+			})
+			return nil, fmt.Errorf("failed to create imagestream %s/%s: %w", imageStream.Namespace, imageStream.Name, err)
+		}
+		created = false // ImageStream already existed, we just retrieved it
+		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: imageStream.Namespace, Name: imageStream.Name}, imageStream); err != nil {
+			metricsAgent.Record(&metrics.ImageStreamEvent{
+				Namespace:       imageStream.Namespace,
+				ImageStreamName: imageStream.Name,
+				FullName:        imageStream.Namespace + "/" + imageStream.Name,
+				Success:         false,
+				Error:           err.Error(),
+			})
+			return nil, fmt.Errorf("failed to get existing imagestream %s/%s: %w", imageStream.Namespace, imageStream.Name, err)
+		}
 	}
-	if len(is.Status.DockerImageRepository) > 0 {
-		return fmt.Sprintf("%s:%s", is.Status.DockerImageRepository, tag), true, condition
-	}
-	return "", false, condition
+
+	metricsAgent.Record(&metrics.ImageStreamEvent{
+		Namespace:         imageStream.Namespace,
+		ImageStreamName:   imageStream.Name,
+		FullName:          imageStream.Namespace + "/" + imageStream.Name,
+		Success:           true,
+		AdditionalContext: map[string]any{"created": created},
+	})
+	return imageStream, nil
 }


### PR DESCRIPTION
This PR introduces the images plugin in the metrics agent. It's responsible for recording metrics for imagestream tags imports and imagestream creations.


/cc @openshift/test-platform 