### PR TITLE
cluster-init: Make json-patch Remove Operation Idempotent

### DIFF
--- a/pkg/clusterinit/manifest/patch.go
+++ b/pkg/clusterinit/manifest/patch.go
@@ -95,7 +95,7 @@ func applyPatch(manifest []byte, patch Patch) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("marshal patch: %w", err)
 		}
-		return yaml.ApplyPatch(manifest, yaml.JsonPatch(patchBytes))
+		return yaml.ApplyPatch(manifest, yaml.JsonPatch(patchBytes), yaml.IgnoreMissingKeyOnRemove())
 	}
 	return nil, fmt.Errorf("unsupported patch type %s", patch.Type)
 }

--- a/pkg/util/yaml/patch_test.go
+++ b/pkg/util/yaml/patch_test.go
@@ -11,6 +11,7 @@ func TestApplyPatch(t *testing.T) {
 		name       string
 		object     string
 		patch      Patch
+		opts       []ApplyPatchOption
 		wantObject string
 	}{
 		{
@@ -37,9 +38,16 @@ func TestApplyPatch(t *testing.T) {
 			patch:      JsonPatch([]byte(`[{"op": "add", "path": "/foo/bar", "value": "duper"}]`)),
 			wantObject: "foo:\n  bar: duper\n",
 		},
+		{
+			name:       "JsonPatch patch: ignore missing key on remove",
+			object:     "foo:\n  bar: super",
+			patch:      JsonPatch([]byte(`[{"op": "remove", "path": "/foo/bax"}, {"op": "remove", "path": "/foo/bar"}]`)),
+			opts:       []ApplyPatchOption{IgnoreMissingKeyOnRemove()},
+			wantObject: "foo: {}\n",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			patched, err := ApplyPatch([]byte(tc.object), tc.patch)
+			patched, err := ApplyPatch([]byte(tc.object), tc.patch, tc.opts...)
 			if err != nil {
 				t.Errorf("unexpected err: %s", err)
 				return


### PR DESCRIPTION
This PR wants to address this error (failing job [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ci-tools/4672/pull-ci-openshift-ci-tools-main-breaking-changes/1961514991249002496)):
```
update config for cluster build02: run config step manifest-generator certificate: apply patch: error in remove for path: '/metadata/labels/aws-project': Unable to remove nonexistent key: aws-project: missing value
```

It turns out that the json-patch remove operation is not idempotent.
This means that applying the following patch:
```json
[{ "op": "remove", "path": "metadata/labels/foo" }]
```
to this object:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    foo: bar
    super: duper
```
will go fine the first time and it will output:
```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    super: duper
```
but it is going to fail from this moment on:
```
Unable to remove nonexistent key: foo: missing value
```