### PR TITLE
Konflux: Safeguard from creating several PJs for the same request

### DIFF
--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -1,0 +1,11 @@
+metadata:
+  creationTimestamp: null
+  name: ec
+  namespace: ns
+  resourceVersion: "1000"
+spec:
+  ciOperator:
+    test: {}
+status:
+  phase: ""
+  prowJobId: pj

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,0 +1,10 @@
+metadata:
+  creationTimestamp: null
+  name: ec
+  namespace: ns
+  resourceVersion: "999"
+spec:
+  ciOperator:
+    test: {}
+status:
+  phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -1,0 +1,12 @@
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/ephemeral-cluster: ec
+    name: pj
+    namespace: ci
+    resourceVersion: "999"
+  spec: {}
+  status:
+    startTime: null
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,0 +1,22 @@
+items:
+- metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/ephemeral-cluster: ec
+    name: pj1
+    namespace: ci
+    resourceVersion: "999"
+  spec: {}
+  status:
+    startTime: null
+- metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/ephemeral-cluster: ec
+    name: pj2
+    namespace: ci
+    resourceVersion: "999"
+  spec: {}
+  status:
+    startTime: null
+metadata: {}


### PR DESCRIPTION
This check makes sure that no more than one ProwJob is created for any EphemeralCluster request.

When a new EphemeralCluster request arrives, the controller checks whether a ProwJob has been already created or not, by trying to get a ProwJob whose `metadata.name` matches what found within the EphemeralCluster's `status.prowJobId` stanza.

If it finds nothing, it goes ahead and try to list any ProwJobs whose `ci.openshift.io/ephemeral-cluster` label matches the aforementioned id, making sure that there are really no ProwJobs associated to this EphemeralCluster already.