### PR TITLE
Add ocp-qe-perfscale to sippy/testgrid

### DIFF
--- a/pkg/util/testgrid.go
+++ b/pkg/util/testgrid.go
@@ -19,6 +19,7 @@ func IsSpecialInformingJobOnTestGrid(jobName string) bool {
 		"release-openshift-",
 		"periodic-ci-openshift-operator-framework-operator-controller-",
 		"periodic-ci-stolostron-policy-collection-",
+		"periodic-ci-openshift-eng-ocp-qe-perfscale-",
 	}
 	for _, prefix := range testGridInformingPrefixes {
 		if strings.HasPrefix(jobName, prefix) {


### PR DESCRIPTION
This PR will resolve the issue where [the performance test cases are not being displayed on Sippy](https://sippy.dptools.openshift.org/sippy-ng/tests/4.19?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522name%2522%252C%2522not%2522%253Afalse%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522OCP-84092_catalogdMemory_GCP_value%2520regression%2520detection%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=net_improvement).