### PR TITLE
Add /run remaining-required for improved manual pipeline experience

### DIFF
--- a/cmd/pipeline-controller/config_data_provider.go
+++ b/cmd/pipeline-controller/config_data_provider.go
@@ -71,6 +71,16 @@ func (c *ConfigDataProvider) gatherData() {
 					}
 					continue
 				}
+				// Also check for pipeline_skip_if_only_changed annotation
+				if val, ok := p.Annotations["pipeline_skip_if_only_changed"]; ok && val != "" {
+					if pre, ok := updatedPresubmits[orgRepo]; !ok {
+						updatedPresubmits[orgRepo] = presubmitTests{pipelineConditionallyRequired: []config.Presubmit{p}}
+					} else {
+						pre.pipelineConditionallyRequired = append(pre.pipelineConditionallyRequired, p)
+						updatedPresubmits[orgRepo] = pre
+					}
+					continue
+				}
 				if !p.Optional {
 					if pre, ok := updatedPresubmits[orgRepo]; !ok {
 						updatedPresubmits[orgRepo] = presubmitTests{protected: []string{p.Name}}

--- a/cmd/pipeline-controller/config_data_provider_test.go
+++ b/cmd/pipeline-controller/config_data_provider_test.go
@@ -147,6 +147,33 @@ func TestConfigDataProviderGatherData(t *testing.T) {
 			},
 			expected: presubmitTests{},
 		},
+		{
+			name: "Jobs with pipeline_skip_if_only_changed are collected",
+			configGetter: func() *config.Config {
+				cfs := config.Config{
+					JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
+						"org/repo": {
+							composeProtectedPresubmit("ps1"),
+							composeRequiredPresubmit("ps2"),
+							composePipelineCondRequiredPresubmit("ps3", false, map[string]string{"pipeline_skip_if_only_changed": "^docs/.*"}),
+							composePipelineCondRequiredPresubmit("ps4", true, map[string]string{"pipeline_skip_if_only_changed": "^test/.*"}),
+							composePipelineCondRequiredPresubmit("ps5", false, map[string]string{"pipeline_run_if_changed": `.*\.go`}),
+						},
+					}},
+					ProwConfig: decorateWithOrgPolicy(composeBPConfig()),
+				}
+				return &cfs
+			},
+			expected: presubmitTests{
+				protected:             []string{"ps1"},
+				alwaysRequired:        []string{"ps2"},
+				conditionallyRequired: []string{},
+				pipelineConditionallyRequired: []config.Presubmit{
+					composePipelineCondRequiredPresubmit("ps3", false, map[string]string{"pipeline_skip_if_only_changed": "^docs/.*"}),
+					composePipelineCondRequiredPresubmit("ps4", true, map[string]string{"pipeline_skip_if_only_changed": "^test/.*"}),
+					composePipelineCondRequiredPresubmit("ps5", false, map[string]string{"pipeline_run_if_changed": `.*\.go`}),
+				}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -157,8 +184,41 @@ func TestConfigDataProviderGatherData(t *testing.T) {
 			}
 			c.gatherData()
 			actual := c.GetPresubmits("org/repo")
-			if !reflect.DeepEqual(actual, tc.expected) {
-				t.Errorf("expected %v, got %v", tc.expected, actual)
+			if !reflect.DeepEqual(actual.protected, tc.expected.protected) {
+				t.Errorf("protected - expected %v, got %v", tc.expected.protected, actual.protected)
+			}
+			if !reflect.DeepEqual(actual.alwaysRequired, tc.expected.alwaysRequired) {
+				t.Errorf("alwaysRequired - expected %v, got %v", tc.expected.alwaysRequired, actual.alwaysRequired)
+			}
+			if !reflect.DeepEqual(actual.conditionallyRequired, tc.expected.conditionallyRequired) {
+				// Check if both are effectively empty
+				if !(len(actual.conditionallyRequired) == 0 && len(tc.expected.conditionallyRequired) == 0) {
+					t.Errorf("conditionallyRequired - expected %v, got %v", tc.expected.conditionallyRequired, actual.conditionallyRequired)
+				}
+			}
+			// For pipelineConditionallyRequired, check length and then check each item exists
+			if len(actual.pipelineConditionallyRequired) != len(tc.expected.pipelineConditionallyRequired) {
+				t.Errorf("pipelineConditionallyRequired length - expected %d, got %d",
+					len(tc.expected.pipelineConditionallyRequired),
+					len(actual.pipelineConditionallyRequired))
+				return
+			}
+
+			// Check that each expected item exists in actual
+			for _, expected := range tc.expected.pipelineConditionallyRequired {
+				found := false
+				for _, actualItem := range actual.pipelineConditionallyRequired {
+					if expected.Name == actualItem.Name &&
+						reflect.DeepEqual(expected.Annotations, actualItem.Annotations) &&
+						expected.Optional == actualItem.Optional {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("pipelineConditionallyRequired - expected to find job %s with annotations %v and optional=%v",
+						expected.Name, expected.Annotations, expected.Optional)
+				}
 			}
 		})
 	}

--- a/cmd/pipeline-controller/helpers.go
+++ b/cmd/pipeline-controller/helpers.go
@@ -15,14 +15,25 @@ type minimalGhClient interface {
 }
 
 func sendComment(presubmits presubmitTests, pj *v1.ProwJob, ghc minimalGhClient, deleteIds func()) error {
+	return sendCommentWithMode(presubmits, pj, ghc, deleteIds, false)
+}
+
+func sendCommentWithMode(presubmits presubmitTests, pj *v1.ProwJob, ghc minimalGhClient, deleteIds func(), isManualMode bool) error {
 	testContexts, overrideContexts, err := acquireConditionalContexts(pj, presubmits.pipelineConditionallyRequired, ghc, deleteIds)
 	if err != nil {
 		deleteIds()
 		return err
 	}
-	comment := "/test remaining-required"
+
+	var comment string
+	if isManualMode {
+		comment = "**Pipeline controller response to `/run remaining-required`**\n\n"
+	}
+
+	comment += "/test remaining-required"
 	if testContexts != "" {
-		comment += "\n\nScheduling tests matching the `pipeline_run_if_changed` parameter:" + testContexts
+		comment += "\n\nScheduling tests matching the `pipeline_run_if_changed` or not excluded by `pipeline_skip_if_only_changed` parameters:"
+		comment += testContexts
 	}
 	if overrideContexts != "" {
 		comment += "\n\nOverriding unmatched contexts:\n" + "/override " + overrideContexts
@@ -44,6 +55,7 @@ func acquireConditionalContexts(pj *v1.ProwJob, pipelineConditionallyRequired []
 			if !strings.Contains(presubmit.Name, repoBaseRef) {
 				continue
 			}
+			// Check pipeline_run_if_changed first (takes precedence)
 			if run, ok := presubmit.Annotations["pipeline_run_if_changed"]; ok && run != "" {
 				psList := []config.Presubmit{presubmit}
 				psList[0].RegexpChangeMatcher = config.RegexpChangeMatcher{RunIfChanged: run}
@@ -61,7 +73,37 @@ func acquireConditionalContexts(pj *v1.ProwJob, pipelineConditionallyRequired []
 					continue
 				}
 				if !presubmit.Optional {
-					overrideCommands += " " + presubmit.Context
+					if overrideCommands == "" {
+						overrideCommands = presubmit.Context
+					} else {
+						overrideCommands += " " + presubmit.Context
+					}
+				}
+				continue
+			}
+			// Check pipeline_skip_if_only_changed if pipeline_run_if_changed is not present
+			if skip, ok := presubmit.Annotations["pipeline_skip_if_only_changed"]; ok && skip != "" {
+				psList := []config.Presubmit{presubmit}
+				psList[0].RegexpChangeMatcher = config.RegexpChangeMatcher{SkipIfOnlyChanged: skip}
+				if err := config.SetPresubmitRegexes(psList); err != nil {
+					deleteIds()
+					return "", "", err
+				}
+				_, shouldRun, err := psList[0].RegexpChangeMatcher.ShouldRun(cfp)
+				if err != nil {
+					deleteIds()
+					return "", "", err
+				}
+				if shouldRun {
+					testCommands += "\n" + presubmit.RerunCommand
+					continue
+				}
+				if !presubmit.Optional {
+					if overrideCommands == "" {
+						overrideCommands = presubmit.Context
+					} else {
+						overrideCommands += " " + presubmit.Context
+					}
 				}
 			}
 		}

--- a/cmd/pipeline-controller/helpers_test.go
+++ b/cmd/pipeline-controller/helpers_test.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	v1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
+	"sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+type fakeGhClientWithChanges struct {
+	changes []github.PullRequestChange
+	comment string
+}
+
+func (f *fakeGhClientWithChanges) GetPullRequest(org, repo string, number int) (*github.PullRequest, error) {
+	return &github.PullRequest{State: github.PullRequestStateOpen}, nil
+}
+
+func (f *fakeGhClientWithChanges) CreateComment(owner, repo string, number int, comment string) error {
+	f.comment = comment
+	return nil
+}
+
+func (f *fakeGhClientWithChanges) GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error) {
+	return f.changes, nil
+}
+
+func TestAcquireConditionalContexts(t *testing.T) {
+	basePJ := &v1.ProwJob{
+		Spec: v1.ProwJobSpec{
+			Refs: &v1.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []v1.Pull{
+					{Number: 123, SHA: "abc"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                          string
+		pipelineConditionallyRequired []config.Presubmit
+		changes                       []github.PullRequestChange
+		expectedTestCommands          []string
+		expectedOverrideContexts      []string
+	}{
+		{
+			name: "pipeline_run_if_changed matches files",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test",
+						Annotations: map[string]string{
+							"pipeline_run_if_changed": ".*\\.go",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test",
+					},
+					RerunCommand: "/test test",
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "main.go"},
+				{Filename: "README.md"},
+			},
+			expectedTestCommands:     []string{"/test test"},
+			expectedOverrideContexts: []string{},
+		},
+		{
+			name: "pipeline_run_if_changed does not match files",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test",
+						Annotations: map[string]string{
+							"pipeline_run_if_changed": ".*\\.go",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test",
+					},
+					RerunCommand: "/test test",
+					Optional:     false,
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "README.md"},
+				{Filename: "docs/guide.md"},
+			},
+			expectedTestCommands:     []string{},
+			expectedOverrideContexts: []string{"test"},
+		},
+		{
+			name: "pipeline_skip_if_only_changed skips when only matching files changed",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test",
+						Annotations: map[string]string{
+							"pipeline_skip_if_only_changed": "^docs/.*|.*\\.md",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test",
+					},
+					RerunCommand: "/test test",
+					Optional:     false,
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "docs/guide.md"},
+				{Filename: "README.md"},
+			},
+			expectedTestCommands:     []string{},
+			expectedOverrideContexts: []string{"test"},
+		},
+		{
+			name: "pipeline_skip_if_only_changed runs when other files are changed",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test",
+						Annotations: map[string]string{
+							"pipeline_skip_if_only_changed": "^docs/.*|.*\\.md",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test",
+					},
+					RerunCommand: "/test test",
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "docs/guide.md"},
+				{Filename: "main.go"},
+			},
+			expectedTestCommands:     []string{"/test test"},
+			expectedOverrideContexts: []string{},
+		},
+		{
+			name: "pipeline_run_if_changed takes precedence over pipeline_skip_if_only_changed",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test",
+						Annotations: map[string]string{
+							"pipeline_run_if_changed":       ".*\\.go",
+							"pipeline_skip_if_only_changed": "^test/.*",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test",
+					},
+					RerunCommand: "/test test",
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "test/test.go"},
+			},
+			expectedTestCommands:     []string{"/test test"},
+			expectedOverrideContexts: []string{},
+		},
+		{
+			name: "multiple jobs with different annotations",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test1",
+						Annotations: map[string]string{
+							"pipeline_run_if_changed": ".*\\.go",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test1",
+					},
+					RerunCommand: "/test test1",
+				},
+				{
+					JobBase: config.JobBase{
+						Name: "org-repo-master-test2",
+						Annotations: map[string]string{
+							"pipeline_skip_if_only_changed": "^docs/.*",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "test2",
+					},
+					RerunCommand: "/test test2",
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "main.go"},
+				{Filename: "docs/guide.md"},
+			},
+			expectedTestCommands:     []string{"/test test1", "/test test2"},
+			expectedOverrideContexts: []string{},
+		},
+		{
+			name: "job name does not contain repo-baseRef",
+			pipelineConditionallyRequired: []config.Presubmit{
+				{
+					JobBase: config.JobBase{
+						Name: "different-job",
+						Annotations: map[string]string{
+							"pipeline_run_if_changed": ".*",
+						},
+					},
+					Reporter: config.Reporter{
+						Context: "different",
+					},
+					RerunCommand: "/test different",
+				},
+			},
+			changes: []github.PullRequestChange{
+				{Filename: "main.go"},
+			},
+			expectedTestCommands:     []string{},
+			expectedOverrideContexts: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGhClientWithChanges{changes: tc.changes}
+			testCmds, overrideCmds, err := acquireConditionalContexts(basePJ, tc.pipelineConditionallyRequired, ghc, func() {})
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			// Check test commands
+			for _, expected := range tc.expectedTestCommands {
+				if !strings.Contains(testCmds, expected) {
+					t.Errorf("expected test commands to contain %q, got %q", expected, testCmds)
+				}
+			}
+
+			// Check override commands
+			for _, expected := range tc.expectedOverrideContexts {
+				if !strings.Contains(overrideCmds, expected) {
+					t.Errorf("expected override commands to contain %q, got %q", expected, overrideCmds)
+				}
+			}
+
+			// Check that we don't have unexpected commands
+			if len(tc.expectedTestCommands) == 0 && testCmds != "" {
+				t.Errorf("expected no test commands, got %q", testCmds)
+			}
+			if len(tc.expectedOverrideContexts) == 0 && overrideCmds != "" {
+				t.Errorf("expected no override commands, got %q", overrideCmds)
+			}
+		})
+	}
+}
+
+func TestSendCommentWithMode(t *testing.T) {
+	basePJ := &v1.ProwJob{
+		Spec: v1.ProwJobSpec{
+			Refs: &v1.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+				Pulls: []v1.Pull{
+					{Number: 123, SHA: "abc"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                       string
+		presubmits                 presubmitTests
+		isManualMode               bool
+		changes                    []github.PullRequestChange
+		expectedCommentContains    []string
+		expectedCommentNotContains []string
+	}{
+		{
+			name: "manual mode with pipeline jobs",
+			presubmits: presubmitTests{
+				pipelineConditionallyRequired: []config.Presubmit{
+					{
+						JobBase: config.JobBase{
+							Name: "org-repo-master-test",
+							Annotations: map[string]string{
+								"pipeline_run_if_changed": ".*\\.go",
+							},
+						},
+						Reporter: config.Reporter{
+							Context: "test",
+						},
+						RerunCommand: "/test test",
+						Optional:     false,
+					},
+				},
+			},
+			isManualMode: true,
+			changes: []github.PullRequestChange{
+				{Filename: "README.md"},
+			},
+			expectedCommentContains: []string{
+				"Pipeline controller response to `/run remaining-required`",
+				"/test remaining-required",
+				"/override test",
+			},
+		},
+		{
+			name: "automatic mode with pipeline jobs",
+			presubmits: presubmitTests{
+				pipelineConditionallyRequired: []config.Presubmit{
+					{
+						JobBase: config.JobBase{
+							Name: "org-repo-master-test",
+							Annotations: map[string]string{
+								"pipeline_skip_if_only_changed": "^docs/.*",
+							},
+						},
+						Reporter: config.Reporter{
+							Context: "test2",
+						},
+						RerunCommand: "/test test2",
+					},
+				},
+			},
+			isManualMode: false,
+			changes: []github.PullRequestChange{
+				{Filename: "main.go"},
+			},
+			expectedCommentContains: []string{
+				"/test remaining-required",
+				"/test test2",
+			},
+			expectedCommentNotContains: []string{
+				"Pipeline controller response",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGhClientWithChanges{changes: tc.changes}
+
+			err := sendCommentWithMode(tc.presubmits, basePJ, ghc, func() {}, tc.isManualMode)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			comment := ghc.comment
+
+			for _, expected := range tc.expectedCommentContains {
+				if !strings.Contains(comment, expected) {
+					t.Errorf("expected comment to contain %q, got:\n%s", expected, comment)
+				}
+			}
+
+			for _, notExpected := range tc.expectedCommentNotContains {
+				if strings.Contains(comment, notExpected) {
+					t.Errorf("expected comment NOT to contain %q, got:\n%s", notExpected, comment)
+				}
+			}
+		})
+	}
+}

--- a/cmd/pipeline-controller/main.go
+++ b/cmd/pipeline-controller/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/bombsimon/logrusr/v3"
@@ -25,7 +26,7 @@ import (
 	"sigs.k8s.io/prow/pkg/logrusutil"
 )
 
-const pullRequestInfoComment = "**Pipeline controller notification**\n This repository is configured to use the [pipeline controller](https://docs.ci.openshift.org/docs/how-tos/creating-a-pipeline/). Second-stage tests will be triggered only if the required tests of the first stage are successful. The pipeline controller will automatically detect which contexts are required, or not needed and will utilize a set of `/test` and `/override` Prow commands to trigger the second stage."
+const pullRequestInfoComment = "**Pipeline controller notification**\nThis repository is configured to use the [pipeline controller](https://docs.ci.openshift.org/docs/how-tos/creating-a-pipeline/). Second-stage tests will be triggered only if the required tests of the first stage are successful. The pipeline controller will automatically detect which contexts are required, or not needed and will utilize a set of `/test` and `/override` Prow commands to trigger the second stage.\n\nFor optional jobs, comment `/test ?` to see a list of all defined jobs. Review these jobs and use `/test <job>` to manually trigger optional jobs most likely to be impacted by the proposed changes."
 
 type options struct {
 	client                   prowflagutil.KubernetesOptions
@@ -99,25 +100,50 @@ func (cw *clientWrapper) handlePullRequestCreation(l *logrus.Entry, event github
 		repo := event.Repo.Name
 		number := event.PullRequest.Number
 
-		presubmits := cw.configDataProvider.GetPresubmits(org + "/" + repo)
-		if len(presubmits.protected) == 0 && len(presubmits.alwaysRequired) == 0 &&
-			len(presubmits.conditionallyRequired) == 0 && len(presubmits.pipelineConditionallyRequired) == 0 {
-			return
-		}
-
-		currentCfg := cw.watcher.getConfig()
-		repos, ok := currentCfg[org]
-		if !ok || !(repos.Len() == 0 || repos.Has(repo)) {
-			return
-		}
-
 		logger := l.WithFields(logrus.Fields{
 			"org":  org,
 			"repo": repo,
 			"pr":   number,
 		})
-		if err := cw.ghc.CreateComment(org, repo, number, pullRequestInfoComment); err != nil {
-			logger.WithError(err).Error("failed to create comment")
+
+		// Check if repo is configured for automatic pipelines
+		currentCfg := cw.watcher.getConfig()
+		repos, ok := currentCfg[org]
+		isAutomaticPipeline := ok && (repos.Len() == 0 || repos.Has(repo))
+
+		if isAutomaticPipeline {
+			// Original behavior for repos configured for automatic pipelines
+			presubmits := cw.configDataProvider.GetPresubmits(org + "/" + repo)
+			if len(presubmits.protected) == 0 && len(presubmits.alwaysRequired) == 0 &&
+				len(presubmits.conditionallyRequired) == 0 && len(presubmits.pipelineConditionallyRequired) == 0 {
+				return
+			}
+
+			if err := cw.ghc.CreateComment(org, repo, number, pullRequestInfoComment); err != nil {
+				logger.WithError(err).Error("failed to create comment")
+			}
+		} else {
+			// Check for non-always-run jobs
+			cfg := cw.configDataProvider.configGetter()
+			presubmits := cfg.GetPresubmitsStatic(org + "/" + repo)
+
+			hasNonAlwaysRunJobs := false
+			for _, p := range presubmits {
+				if !p.AlwaysRun {
+					hasNonAlwaysRunJobs = true
+					break
+				}
+			}
+
+			if hasNonAlwaysRunJobs {
+				comment := "There are test jobs defined for this repository which are not configured to run automatically. " +
+					"Comment `/test ?` to see a list of all defined jobs. Review these jobs and use `/test <job>` to manually trigger jobs most likely to be impacted by the proposed changes. " +
+					"Comment `/run remaining-required` to trigger all required & necessary jobs."
+
+				if err := cw.ghc.CreateComment(org, repo, number, comment); err != nil {
+					logger.WithError(err).Error("failed to create comment")
+				}
+			}
 		}
 	}
 }
@@ -162,6 +188,64 @@ func (cw *clientWrapper) handleLabelAddition(l *logrus.Entry, event github.PullR
 		if err := sendComment(presubmits, prowJob, cw.ghc, func() {}); err != nil {
 			logger.WithError(err).Error("failed to send a comment")
 		}
+	}
+}
+
+func (cw *clientWrapper) handleIssueComment(l *logrus.Entry, event github.IssueCommentEvent) {
+	// Only handle issue comments on PRs
+	if !event.Issue.IsPullRequest() {
+		return
+	}
+
+	// Check if the comment contains "/run remaining-required"
+	if !strings.Contains(event.Comment.Body, "/run remaining-required") {
+		return
+	}
+
+	org := event.Repo.Owner.Login
+	repo := event.Repo.Name
+	number := event.Issue.Number
+
+	logger := l.WithFields(logrus.Fields{
+		"org":  org,
+		"repo": repo,
+		"pr":   number,
+	})
+
+	// Get presubmits for this repo
+	presubmits := cw.configDataProvider.GetPresubmits(org + "/" + repo)
+
+	// Check if there are any pipeline-controlled jobs
+	if len(presubmits.protected) == 0 && len(presubmits.alwaysRequired) == 0 &&
+		len(presubmits.conditionallyRequired) == 0 && len(presubmits.pipelineConditionallyRequired) == 0 {
+		logger.Debug("No pipeline-controlled jobs found for repo")
+		return
+	}
+
+	// Fetch PR details
+	pr, err := cw.ghc.GetPullRequest(org, repo, number)
+	if err != nil {
+		logger.WithError(err).Error("failed to get PR details")
+		return
+	}
+
+	// Create a fake ProwJob to reuse existing logic
+	prowJob := &v1.ProwJob{
+		Spec: v1.ProwJobSpec{
+			Refs: &v1.Refs{
+				Org:     org,
+				Repo:    repo,
+				BaseRef: pr.Base.Ref,
+				Pulls: []v1.Pull{
+					{Number: number, SHA: pr.Head.SHA},
+				},
+			},
+		},
+	}
+
+	// Generate the comment with test/override commands
+	if err := sendCommentWithMode(presubmits, prowJob, cw.ghc, func() {}, true); err != nil {
+		logger.WithError(err).Error("failed to send comment in response to /run remaining-required")
 	}
 }
 
@@ -244,6 +328,7 @@ func main() {
 	eventServer := githubeventserver.New(o.githubEventServerOptions, webhookTokenGenerator, logger)
 	eventServer.RegisterHandlePullRequestEvent(cw.handlePullRequestCreation)
 	eventServer.RegisterHandlePullRequestEvent(cw.handleLabelAddition)
+	eventServer.RegisterHandleIssueCommentEvent(cw.handleIssueComment)
 
 	interrupts.OnInterrupt(func() {
 		eventServer.GracefulShutdown()

--- a/cmd/pipeline-controller/main_test.go
+++ b/cmd/pipeline-controller/main_test.go
@@ -1,20 +1,30 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 
+	"sigs.k8s.io/prow/pkg/config"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
 )
 
 type fakeGhClientWithComment struct {
 	comment string
+	error   error
+	pr      *github.PullRequest
 }
 
 func (f *fakeGhClientWithComment) GetPullRequest(org, repo string, number int) (*github.PullRequest, error) {
+	if f.error != nil {
+		return nil, f.error
+	}
+	if f.pr != nil {
+		return f.pr, nil
+	}
 	return &github.PullRequest{State: github.PullRequestStateOpen}, nil
 }
 func (f *fakeGhClientWithComment) CreateComment(owner, repo string, number int, comment string) error {
@@ -98,6 +108,315 @@ func TestHandleLabelAddition_RealFunctions(t *testing.T) {
 
 			entry := logrus.NewEntry(logrus.New())
 			cw.handleLabelAddition(entry, tc.event)
+
+			if tc.expectCommentCall {
+				if ghc.comment == "" {
+					t.Errorf("expected CreateComment to be called, but no comment was recorded")
+				} else {
+					if !strings.Contains(ghc.comment, tc.expectedComment) {
+						t.Errorf("expected comment to contain %q, got %q", tc.expectedComment, ghc.comment)
+					}
+				}
+			} else {
+				if ghc.comment != "" {
+					t.Errorf("expected CreateComment not to be called, but got comment %q", ghc.comment)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleIssueComment(t *testing.T) {
+	org := "openshift"
+	repo := "test-repo"
+	prNumber := 123
+
+	basicEvent := github.IssueCommentEvent{
+		Action: github.IssueCommentActionCreated,
+		Comment: github.IssueComment{
+			Body: "/run remaining-required",
+		},
+		Repo: github.Repo{
+			Owner: github.User{Login: org},
+			Name:  repo,
+		},
+		Issue: github.Issue{
+			Number:      prNumber,
+			PullRequest: &struct{}{}, // Non-nil means it's a PR
+		},
+	}
+
+	tests := []struct {
+		name              string
+		event             github.IssueCommentEvent
+		configData        map[string]presubmitTests
+		ghPR              *github.PullRequest
+		ghError           error
+		expectCommentCall bool
+		expectedComment   string
+	}{
+		{
+			name: "not a PR: do nothing",
+			event: github.IssueCommentEvent{
+				Issue: github.Issue{
+					PullRequest: nil,
+				},
+			},
+			expectCommentCall: false,
+		},
+		{
+			name: "comment doesn't contain /run remaining-required: do nothing",
+			event: github.IssueCommentEvent{
+				Comment: github.IssueComment{
+					Body: "This is just a regular comment",
+				},
+				Issue: github.Issue{
+					PullRequest: &struct{}{},
+				},
+			},
+			expectCommentCall: false,
+		},
+		{
+			name:  "no pipeline-controlled jobs: do nothing",
+			event: basicEvent,
+			configData: map[string]presubmitTests{
+				org + "/" + repo: {},
+			},
+			expectCommentCall: false,
+		},
+		{
+			name:  "has pipeline jobs, responds with test and override commands",
+			event: basicEvent,
+			configData: map[string]presubmitTests{
+				org + "/" + repo: {
+					protected: []string{"protected-test"},
+					pipelineConditionallyRequired: []config.Presubmit{
+						{
+							JobBase: config.JobBase{
+								Name: repo + "-master-test",
+								Annotations: map[string]string{
+									"pipeline_run_if_changed": ".*\\.go",
+								},
+							},
+							RerunCommand: "/test test",
+							Reporter: config.Reporter{
+								Context: "test",
+							},
+						},
+					},
+				},
+			},
+			ghPR: &github.PullRequest{
+				Base: github.PullRequestBranch{Ref: "master"},
+				Head: github.PullRequestBranch{SHA: "abc123"},
+			},
+			expectCommentCall: true,
+			expectedComment:   "Pipeline controller response to `/run remaining-required`",
+		},
+		{
+			name:  "error getting PR: do nothing",
+			event: basicEvent,
+			configData: map[string]presubmitTests{
+				org + "/" + repo: {
+					protected: []string{"protected-test"},
+				},
+			},
+			ghError:           errors.New("failed to get PR"),
+			expectCommentCall: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGhClientWithComment{}
+			if tc.ghError != nil {
+				ghc = &fakeGhClientWithComment{error: tc.ghError}
+			} else if tc.ghPR != nil {
+				ghc = &fakeGhClientWithComment{pr: tc.ghPR}
+			}
+
+			cw := &clientWrapper{
+				configDataProvider: &ConfigDataProvider{updatedPresubmits: tc.configData},
+				ghc:                ghc,
+			}
+
+			entry := logrus.NewEntry(logrus.New())
+			cw.handleIssueComment(entry, tc.event)
+
+			if tc.expectCommentCall {
+				if ghc.comment == "" {
+					t.Errorf("expected CreateComment to be called, but no comment was recorded")
+				} else {
+					if !strings.Contains(ghc.comment, tc.expectedComment) {
+						t.Errorf("expected comment to contain %q, got %q", tc.expectedComment, ghc.comment)
+					}
+					if !strings.Contains(ghc.comment, "/test remaining-required") {
+						t.Errorf("expected comment to contain '/test remaining-required', got %q", ghc.comment)
+					}
+				}
+			} else {
+				if ghc.comment != "" {
+					t.Errorf("expected CreateComment not to be called, but got comment %q", ghc.comment)
+				}
+			}
+		})
+	}
+}
+
+func TestHandlePullRequestCreation(t *testing.T) {
+	org := "openshift"
+	repo := "test-repo"
+	prNumber := 123
+
+	basicEvent := github.PullRequestEvent{
+		Action: github.PullRequestActionOpened,
+		Repo: github.Repo{
+			Owner: github.User{Login: org},
+			Name:  repo,
+		},
+		PullRequest: github.PullRequest{
+			Number: prNumber,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		event             github.PullRequestEvent
+		watcherConfig     enabledConfig
+		configData        map[string]presubmitTests
+		presubmits        []config.Presubmit
+		configGetter      config.Getter
+		expectCommentCall bool
+		expectedComment   string
+	}{
+		{
+			name: "action not opened: do nothing",
+			event: github.PullRequestEvent{
+				Action: "closed",
+			},
+			expectCommentCall: false,
+		},
+		{
+			name:  "automatic pipeline repo with jobs: shows pipeline info",
+			event: basicEvent,
+			watcherConfig: enabledConfig{Orgs: []struct {
+				Org   string   `yaml:"org"`
+				Repos []string `yaml:"repos"`
+			}{
+				{
+					Org:   org,
+					Repos: []string{repo},
+				},
+			}},
+			configData: map[string]presubmitTests{
+				org + "/" + repo: {
+					protected: []string{"protected-test"},
+				},
+			},
+			expectCommentCall: true,
+			expectedComment:   pullRequestInfoComment,
+		},
+		{
+			name:  "automatic pipeline repo without jobs: no comment",
+			event: basicEvent,
+			watcherConfig: enabledConfig{Orgs: []struct {
+				Org   string   `yaml:"org"`
+				Repos []string `yaml:"repos"`
+			}{
+				{
+					Org:   org,
+					Repos: []string{repo},
+				},
+			}},
+			configData: map[string]presubmitTests{
+				org + "/" + repo: {},
+			},
+			expectCommentCall: false,
+		},
+		{
+			name:          "non-automatic repo with non-always-run jobs: shows manual trigger info",
+			event:         basicEvent,
+			watcherConfig: enabledConfig{}, // Empty config means not automatic
+			configGetter: func() *config.Config {
+				return &config.Config{
+					JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
+						org + "/" + repo: {
+							{
+								JobBase:   config.JobBase{Name: "manual-test"},
+								AlwaysRun: false,
+							},
+						},
+					}},
+				}
+			},
+			expectCommentCall: true,
+			expectedComment:   "There are test jobs defined for this repository which are not configured to run automatically",
+		},
+		{
+			name:          "non-automatic repo with only always-run jobs: no comment",
+			event:         basicEvent,
+			watcherConfig: enabledConfig{}, // Empty config means not automatic
+			configGetter: func() *config.Config {
+				return &config.Config{
+					JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
+						org + "/" + repo: {
+							{
+								JobBase:   config.JobBase{Name: "always-test"},
+								AlwaysRun: true,
+							},
+						},
+					}},
+				}
+			},
+			expectCommentCall: false,
+		},
+		{
+			name:          "non-automatic repo with mixed jobs: shows manual trigger info",
+			event:         basicEvent,
+			watcherConfig: enabledConfig{}, // Empty config means not automatic
+			configGetter: func() *config.Config {
+				return &config.Config{
+					JobConfig: config.JobConfig{PresubmitsStatic: map[string][]config.Presubmit{
+						org + "/" + repo: {
+							{
+								JobBase:   config.JobBase{Name: "always-test"},
+								AlwaysRun: true,
+							},
+							{
+								JobBase:   config.JobBase{Name: "manual-test"},
+								AlwaysRun: false,
+							},
+						},
+					}},
+				}
+			},
+			expectCommentCall: true,
+			expectedComment:   "There are test jobs defined for this repository which are not configured to run automatically",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ghc := &fakeGhClientWithComment{}
+
+			configGetter := tc.configGetter
+			if configGetter == nil {
+				configGetter = func() *config.Config {
+					return &config.Config{}
+				}
+			}
+
+			cw := &clientWrapper{
+				watcher: &watcher{config: tc.watcherConfig},
+				configDataProvider: &ConfigDataProvider{
+					updatedPresubmits: tc.configData,
+					configGetter:      configGetter,
+				},
+				ghc: ghc,
+			}
+
+			entry := logrus.NewEntry(logrus.New())
+			cw.handlePullRequestCreation(entry, tc.event)
 
 			if tc.expectCommentCall {
 				if ghc.comment == "" {


### PR DESCRIPTION
https://docs.ci.openshift.org/docs/how-tos/creating-a-pipeline/ presently suggests using "/test remaining-required" in order to trigger tests in manual pipeline mode. Unfortunately, remaining required is a simple trigger regex created by prowgen and does not honor run_if_changed / skip_if_only_changed.
Updating the pipeline-controller to allow pipeline_run_if_changed and pipeline_skip_if_only_changed to be used to honor similar constraints even when operating in manual mode.