### PR TITLE
Dispatch EphemeralCluster requests coming from Konflux

### DIFF
--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -371,7 +371,7 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 	presubmit := &prowYAML.Presubmits[0]
 	labels := map[string]string{EphemeralClusterLabel: ec.Name}
 	pj := r.newPresubmit(github.PullRequest{}, "fake", *presubmit, "no-event-guid", labels, pjutil.RequireScheduling(true))
-	// The cluster will be choosen by the dispatcher. Set a default one here in case things go sideways.
+	// The cluster will be chosen by the dispatcher. Set a default one here in case things go sideways.
 	pj.Spec.Cluster = string(api.ClusterBuild01)
 	pj.Namespace = r.prowConfigAgent.Config().ProwJobNamespace
 	// Do not report, we are not managing this PR as it's likely it's not comining from the OpenShift CI.

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/openshift/ci-tools/pkg/jobconfig"
 	"github.com/openshift/ci-tools/pkg/prowgen"
 	"github.com/openshift/ci-tools/pkg/steps"
 	cislices "github.com/openshift/ci-tools/pkg/util/slices"
@@ -45,6 +47,7 @@ const (
 	DependentProwJobFinalizer = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
 	UnresolvedConfigVar       = "UNRESOLVED_CONFIG"
 	ProwJobCreatingDoneReason = "ProwJob has been properly created"
+	ProwJobNamePrefix         = "ephemeralcluster"
 )
 
 var (
@@ -352,6 +355,13 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 		return nil, errors.New("presubmit job not found")
 	}
 
+	presub := &presubs[0]
+	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(presub.JobBase.Name, jobconfig.PresubmitPrefix)
+	if !prefixCut {
+		return nil, fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PresubmitPrefix, presub.JobBase.Name)
+	}
+	presub.JobBase.Name = ProwJobNamePrefix + jobNameWithoutPrefix
+
 	prowYAML := prowconfig.ProwYAML{Presubmits: presubs}
 	// This is a workaround to apply some defaults to the prowjob
 	if err := prowconfig.DefaultAndValidateProwYAML(r.prowConfigAgent.Config(), &prowYAML, ""); err != nil {
@@ -360,10 +370,8 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 
 	presubmit := &prowYAML.Presubmits[0]
 	labels := map[string]string{EphemeralClusterLabel: ec.Name}
-	// TODO: enable scheduling only when the ci-operator config will stored into the openshift/release repository. Until then
-	// the scheduler won't be able to assign a cluster properly.
-	pj := r.newPresubmit(github.PullRequest{}, "fake", *presubmit, "no-event-guid", labels, pjutil.RequireScheduling(false))
-	// TODO: temporary workaround: we should leverage the scheduler instead, check the comment above.
+	pj := r.newPresubmit(github.PullRequest{}, "fake", *presubmit, "no-event-guid", labels, pjutil.RequireScheduling(true))
+	// The cluster will be choosen by the dispatcher. Set a default one here in case things go sideways.
 	pj.Spec.Cluster = string(api.ClusterBuild01)
 	pj.Namespace = r.prowConfigAgent.Config().ProwJobNamespace
 	// Do not report, we are not managing this PR as it's likely it's not comining from the OpenShift CI.

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -197,7 +197,7 @@ func TestCreateProwJob(t *testing.T) {
 			prowConfig: &prowconfig.Config{},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
 			wantRes:    reconcile.Result{},
-			wantErr:    errors.New("terminal error: validate and default presubmit: invalid presubmit job pull-ci-org-repo-branch-cluster-provisioning: failed to default namespace"),
+			wantErr:    errors.New("terminal error: validate and default presubmit: invalid presubmit job ephemeralcluster-ci-org-repo-branch-cluster-provisioning: failed to default namespace"),
 		},
 		{
 			name: "Fail to create a ProwJob",

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -19,7 +19,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'validate and default presubmit: invalid presubmit job pull-ci-org-repo-branch-cluster-provisioning:
+    message: 'validate and default presubmit: invalid presubmit job ephemeralcluster-ci-org-repo-branch-cluster-provisioning:
       failed to default namespace'
     reason: CIOperatorJobsGenerateFailure
     status: "False"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -4,7 +4,7 @@ items:
   metadata:
     annotations:
       prow.k8s.io/context: ci/prow/cluster-provisioning
-      prow.k8s.io/job: pull-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/cloud: aws
@@ -15,7 +15,7 @@ items:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: cluster-provisioning
       prow.k8s.io/is-optional: "false"
-      prow.k8s.io/job: pull-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
       prow.k8s.io/refs.base_ref: ""
       prow.k8s.io/refs.org: ""
       prow.k8s.io/refs.pull: "0"
@@ -39,7 +39,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: pull-ci-org-repo-branch-cluster-provisioning
+    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     namespace: ci
     pod_spec:
       containers:
@@ -165,5 +165,5 @@ items:
     type: presubmit
   status:
     startTime: "2025-04-02T12:12:12Z"
-    state: triggered
+    state: scheduling
 metadata: {}

--- a/pkg/dispatcher/ephemeralcluster.go
+++ b/pkg/dispatcher/ephemeralcluster.go
@@ -16,11 +16,11 @@ var (
 	ErrNoClusterAvailable = errors.New("no clusters available")
 )
 
-// ephemeralClusterScheduler schedules Konflux ephemeral cluster requests accross the build farms
+// ephemeralClusterScheduler schedules Konflux ephemeral cluster requests across the build farms
 // by implementing a simple round-robin algorithm.
 type ephemeralClusterScheduler struct {
 	clusters []string
-	// idx is the index of the last choosen cluster
+	// idx is the index of the last chosen cluster
 	idx int
 	// m keeps this struct thread safe
 	m sync.Mutex

--- a/pkg/dispatcher/ephemeralcluster.go
+++ b/pkg/dispatcher/ephemeralcluster.go
@@ -1,0 +1,93 @@
+package dispatcher
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+const (
+	// cacheTTL denotes how long an entry within the cache is supposed to exist. This value matches the default TTL
+	// value (see the --delete-after option) of a namespace created by ci-operator.
+	cacheTTL = 24 * time.Hour
+)
+
+var (
+	ErrNoClusterAvailable = errors.New("no clusters available")
+)
+
+// ephemeralClusterScheduler schedules Konflux ephemeral cluster requests accross the build farms
+// by implementing a simple round-robin algorithm.
+type ephemeralClusterScheduler struct {
+	clusters []string
+	// idx is the index of the last choosen cluster
+	idx int
+	// m keeps this struct thread safe
+	m sync.Mutex
+
+	// This cache keeps track of which cluster has been assigned to a PJ. Each entry has a TTL associated.
+	cache map[string]struct {
+		cluster       string
+		insertionTime time.Time
+	}
+
+	// For testing purposes only
+	now func() time.Time
+}
+
+func (ecs *ephemeralClusterScheduler) Dispatch(jobName string) (string, error) {
+	ecs.m.Lock()
+	defer ecs.m.Unlock()
+
+	if len(ecs.clusters) == 0 {
+		return "", ErrNoClusterAvailable
+	}
+
+	now := ecs.now()
+	if entry, ok := ecs.cache[jobName]; ok {
+		if now.Sub(entry.insertionTime) <= cacheTTL {
+			return entry.cluster, nil
+		}
+		delete(ecs.cache, jobName)
+	}
+
+	next := (ecs.idx + 1) % len(ecs.clusters)
+	c := ecs.clusters[next]
+	ecs.idx = next
+	ecs.cache[jobName] = struct {
+		cluster       string
+		insertionTime time.Time
+	}{
+		cluster:       c,
+		insertionTime: now,
+	}
+
+	return c, nil
+}
+
+// Reset should be called each time the dispatcher receives a full dispatch request.
+// It resets the scheduler to its default values and assign the new cluster list (that it might
+// have changed from the last time)
+func (ecs *ephemeralClusterScheduler) Reset(clusters []string) {
+	ecs.m.Lock()
+	defer ecs.m.Unlock()
+
+	ecs.idx = -1
+	ecs.clusters = clusters
+	for k := range ecs.cache {
+		delete(ecs.cache, k)
+	}
+}
+
+func NewEphemeralClusterDispatcher(clusters []string) *ephemeralClusterScheduler {
+	return &ephemeralClusterScheduler{
+		clusters: clusters,
+		idx:      -1,
+		m:        sync.Mutex{},
+		cache: make(map[string]struct {
+			cluster       string
+			insertionTime time.Time
+		}),
+		now: time.Now,
+	}
+}

--- a/pkg/dispatcher/ephemeralcluster_test.go
+++ b/pkg/dispatcher/ephemeralcluster_test.go
@@ -1,0 +1,94 @@
+package dispatcher
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestErrOutWhenNoClusterIsAvailable(t *testing.T) {
+	t.Parallel()
+
+	s := NewEphemeralClusterDispatcher([]string{})
+
+	_, err := s.Dispatch("foobar")
+	if !errors.Is(err, ErrNoClusterAvailable) {
+		t.Errorf("Expected error %T but got %T", ErrNoClusterAvailable, err)
+	}
+}
+
+func TestDispatch(t *testing.T) {
+	t.Parallel()
+
+	s := NewEphemeralClusterDispatcher([]string{"b01", "b02", "b03"})
+
+	for _, res := range []struct {
+		jobName     string
+		wantCluster string
+	}{
+		{jobName: "pj1", wantCluster: "b01"},
+		{jobName: "pj2", wantCluster: "b02"},
+		{jobName: "pj1", wantCluster: "b01"},
+	} {
+		c, err := s.Dispatch(res.jobName)
+		if err != nil {
+			t.Fatalf("unexpected error %s", err)
+		}
+
+		if res.wantCluster != c {
+			t.Errorf("want cluster %s but got %s", res.wantCluster, c)
+		}
+	}
+}
+
+func TestCacheExpires(t *testing.T) {
+	t.Parallel()
+
+	s := NewEphemeralClusterDispatcher([]string{"b01", "b02", "b03"})
+	now := time.Now()
+	s.now = func() time.Time { return now }
+	jobName := "foo"
+
+	c, err := s.Dispatch(jobName)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if c != "b01" {
+		t.Errorf("want b01 but got %s", c)
+	}
+
+	s.now = func() time.Time { return now.Add(cacheTTL + time.Nanosecond) }
+
+	c, err = s.Dispatch(jobName)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if c != "b02" {
+		t.Errorf("want b02 but got %s", c)
+	}
+}
+
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	s := NewEphemeralClusterDispatcher([]string{"b01", "b02", "b03"})
+	jobName := "foo"
+
+	c, err := s.Dispatch(jobName)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if c != "b01" {
+		t.Errorf("want b01 but got %s", c)
+	}
+
+	s.Reset([]string{"b04", "b05", "b06"})
+
+	c, err = s.Dispatch(jobName)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if c != "b04" {
+		t.Errorf("want b02 but got %s", c)
+	}
+}

--- a/pkg/dispatcher/ephemeralcluster_test.go
+++ b/pkg/dispatcher/ephemeralcluster_test.go
@@ -12,8 +12,8 @@ func TestErrOutWhenNoClusterIsAvailable(t *testing.T) {
 	s := NewEphemeralClusterDispatcher([]string{})
 
 	_, err := s.Dispatch("foobar")
-	if !errors.Is(err, ErrNoClusterAvailable) {
-		t.Errorf("Expected error %T but got %T", ErrNoClusterAvailable, err)
+	if !errors.Is(err, errNoClusterAvailable) {
+		t.Errorf("Expected error %T but got %T", errNoClusterAvailable, err)
 	}
 }
 

--- a/pkg/dispatcher/server.go
+++ b/pkg/dispatcher/server.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 	"github.com/sirupsen/logrus"
 )
 
@@ -65,7 +66,7 @@ func (s *Server) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	cluster := ""
-	if strings.HasPrefix(req.Job, "ephemeralcluster-") {
+	if strings.HasPrefix(req.Job, ephemeralcluster.ProwJobNamePrefix) {
 		cluster, err = s.ecd.Dispatch(req.Job)
 		if err != nil {
 			http.Error(w, "Failed to get the cluster", http.StatusInternalServerError)

--- a/pkg/dispatcher/server.go
+++ b/pkg/dispatcher/server.go
@@ -5,11 +5,8 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 )
 
 type Server struct {
@@ -67,7 +64,7 @@ func (s *Server) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 
 	cluster := ""
-	if strings.HasPrefix(req.Job, ephemeralcluster.ProwJobNamePrefix) {
+	if s.ecd.ShouldHandle(req.Job) {
 		cluster, err = s.ecd.Dispatch(req.Job)
 		if err != nil {
 			http.Error(w, "Failed to get the cluster", http.StatusInternalServerError)

--- a/pkg/dispatcher/server.go
+++ b/pkg/dispatcher/server.go
@@ -5,18 +5,21 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
 type Server struct {
 	pjs      *Prowjobs
+	ecd      *ephemeralClusterScheduler
 	dispatch func(bool)
 }
 
-func NewServer(jobs *Prowjobs, dispatch func(bool)) *Server {
+func NewServer(jobs *Prowjobs, ecd *ephemeralClusterScheduler, dispatch func(bool)) *Server {
 	return &Server{
 		pjs:      jobs,
+		ecd:      ecd,
 		dispatch: dispatch,
 	}
 }
@@ -61,7 +64,17 @@ func (s *Server) RequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 
-	cluster := s.pjs.GetCluster(removeRehearsePrefix(req.Job))
+	cluster := ""
+	if strings.HasPrefix(req.Job, "ephemeralcluster-") {
+		cluster, err = s.ecd.Dispatch(req.Job)
+		if err != nil {
+			http.Error(w, "Failed to get the cluster", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		cluster = s.pjs.GetCluster(removeRehearsePrefix(req.Job))
+	}
+
 	if cluster == "" {
 		http.Error(w, "Cluster not found", http.StatusNotFound)
 		return

--- a/pkg/dispatcher/server.go
+++ b/pkg/dispatcher/server.go
@@ -7,8 +7,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/ci-tools/pkg/controller/ephemeralcluster"
 )
 
 type Server struct {


### PR DESCRIPTION
Allow the possibility to properly dispatch any `ProwJob` originated by `EphemeralCluster` requests.

Prior to this, each PJ was statically assigned to `build01`, but now the dispatcher will use a new scheduling mechanism for every PJ whose name starts with the `ephemeralcluster` prefix.

The scheduling algorithm is a simple round-robin across the enabled clusters and, once a PJ is assigned to a cluster, the dispatcher remembers its decision for `24h`, that is the `TTL` for any NS created by ci-operator.
The PJ to cluster mapping is accomplished by using the human readable PJ name rather than the `metadata.name` stanza.

These two design decisions would ensure that any PJ gets dispatched to the same cluster and `ci-operator` will possibly reuse the same test NS. This means that `ci-operator` should, in case, find any successful `Build` in there without rebuilding the same images over and over again.

/label tide/merge-method-squash