### PR TITLE
Rename dummy index secret creation on selfservice

### DIFF
--- a/cmd/vault-secret-collection-manager/main.go
+++ b/cmd/vault-secret-collection-manager/main.go
@@ -398,9 +398,10 @@ func (m *secretCollectionManager) createSecretCollection(_ *logrus.Entry, userNa
 		return fmt.Errorf("failed to create group %s: %w", prefixedName(secretCollectionName), err)
 	}
 
-	// Create an empty file so ppl see the secret collection in the vault UI.
-	indexFileLocation := strings.Replace(m.kvDataPrefix, "/data", "", 1) + "/" + secretCollectionName + "/index"
-	if err := m.privilegedVaultClient.UpsertKV(indexFileLocation, map[string]string{".": "."}); err != nil {
+	// Create a placeholder file with name and contents greater than a length of 3 to
+	// bypass censoring plugin's rules and allow people to see the secret collection in the vault UI.
+	indexFileLocation := strings.Replace(m.kvDataPrefix, "/data", "", 1) + "/" + secretCollectionName + "/placeholder"
+	if err := m.privilegedVaultClient.UpsertKV(indexFileLocation, map[string]string{"placeholder": "Make entry visible from the webconsole"}); err != nil {
 		return fmt.Errorf("failed to create %s: %w", indexFileLocation, err)
 	}
 

--- a/cmd/vault-secret-collection-manager/main_test.go
+++ b/cmd/vault-secret-collection-manager/main_test.go
@@ -120,7 +120,7 @@ func TestSecretCollectionManager(t *testing.T) {
 				ModifyIndex:     1,
 			}},
 			expectedVaultPolicies: []string{"default", "secret-collection-manager-managed-mine-alone", "root"},
-			dataCheckScenario:     []dataCheckScenario{{"user-1", "secret/self-managed/mine-alone/index", map[string]string{".": "."}}},
+			dataCheckScenario:     []dataCheckScenario{{"user-1", "secret/self-managed/mine-alone/placeholder", map[string]string{"placeholder": "Make entry visible from the webconsole"}}},
 			permCheckScenarios: []permCheckScenario{
 				{"user-1", "secret/self-managed/mine-alone", true},
 				{"user-2", "secret/self-managed/mine-alone", false},
@@ -296,7 +296,7 @@ func TestSecretCollectionManager(t *testing.T) {
 					if err == nil {
 						var expected []string
 						if scenario.expectSuccess {
-							expected = []string{"index"}
+							expected = []string{"placeholder"}
 						}
 						if diff := cmp.Diff(initialResult, expected); diff != "" {
 							t.Errorf("unexpected initial listing: %s", diff)


### PR DESCRIPTION
This feature is creating secrets with . as name and . as value.

Since we are doing efforts on removing secrets with less than 3 characters, renaming this ones will allow us to see less noise on our investigations.