### PR TITLE
DPTP-4505: Extend max namespace lifecycle from 24h to 72h

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -456,7 +456,7 @@ type options struct {
 func bindOptions(flag *flag.FlagSet) *options {
 	opt := &options{
 		idleCleanupDuration: 1 * time.Hour,
-		cleanupDuration:     24 * time.Hour,
+		cleanupDuration:     72 * time.Hour,
 	}
 
 	// command specific options


### PR DESCRIPTION
To allow jobs in Prow to run up to 72 hours, we shall not hard kill the namespace (which holds the test pods) after 24 hours. 
Most of the jobs will not be affected by this change, as the namespaces holding those short term pods will be killed in 1 hour after no pod is running for longer than this interval (controlled by **idleCleanupDuration**, defaults to 1 hour).

/assign @jmguzik @pruan-rht 