### PR TITLE
Add BareMetal with GoldmanSach Configuration Cluster Profile.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1494,7 +1494,7 @@ const (
 	ClusterProfileAzureOADPQE             ClusterProfile = "azure-oadp-qe"
 	ClusterProfileGCPOADPQE               ClusterProfile = "gcp-oadp-qe"
 	ClusterProfileAWSlpChaos              ClusterProfile = "aws-lp-chaos"
-	ClusterProfileMetalGS                 ClusterProfile = "metal-gs"
+	ClusterProfileMetalRHgs               ClusterProfile = "metal-redhat-gs"
 )
 
 // ClusterProfiles are all valid cluster profiles
@@ -1675,7 +1675,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureOADPQE,
 		ClusterProfileGCPOADPQE,
 		ClusterProfileAWSlpChaos,
-		ClusterProfileMetalGS,
+		ClusterProfileMetalRHgs,
 	}
 }
 
@@ -1854,8 +1854,8 @@ func (p ClusterProfile) ClusterType() string {
 		return "libvirt-s390x-amd64"
 	case ClusterProfileLibvirtS390xVPN:
 		return "libvirt-s390x-vpn"
-	case ClusterProfileMetalGS:
-		return "metal-gs"
+	case ClusterProfileMetalRHgs:
+		return "metal-redhat-gs"
 	case ClusterProfileMetalPerfscaleCPT:
 		return "metal-perscale-cpt"
 	case ClusterProfileMetalPerfscaleJetlag:
@@ -2301,8 +2301,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "gcp-oadp-qe-quota-slice"
 	case ClusterProfileAWSlpChaos:
 		return "aws-lp-chaos-quota-slice"
-	case ClusterProfileMetalGS:
-		return "metal-gs-quota-slice"
+	case ClusterProfileMetalRHgs:
+		return "metal-redhat-gs-quota-slice"
 	default:
 		return ""
 	}
@@ -2346,7 +2346,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"powervs-3", "powervs-4", "powervs-5", "powervs-6", "powervs-7", "kubevirt", "aws-cpaas", "osd-ephemeral",
 		"gcp-virtualization", "aws-virtualization", "azure-virtualization", "hypershift-powervs",
 		"hypershift-powervs-cb", "aws-mco-qe", "equinix-edge-enablement", "aws-oadp-qe", "azure-oadp-qe", "gcp-oadp-qe",
-		"aws-lp-chaos", "metal-gs":
+		"aws-lp-chaos", "metal-redhat-gs":
 		return t + "-quota-slice", nil
 	default:
 		return "", fmt.Errorf("invalid cluster type %q", t)


### PR DESCRIPTION
A new BareMetal Cluster Profile `metal-redhat-gs` is created for Integrity Engineering teams for Layered Product related tests.