### PR TITLE
gsm-secrets: Implement hash-based SA IDs

### DIFF
--- a/pkg/group/config.go
+++ b/pkg/group/config.go
@@ -15,6 +15,9 @@ const (
 
 	//CollectionRegex determines the allowed naming pattern for a secret collection
 	CollectionRegex = "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+
+	// MaxCollectionLength is the maximum length of a secret collection name
+	MaxCollectionLength = 50
 )
 
 // Config represents the configuration file for the groups
@@ -80,7 +83,7 @@ func (c *Config) validate() error {
 		}
 		for _, collection := range v.SecretCollections {
 			if !ValidateCollectionName(collection) {
-				return fmt.Errorf("invalid collection name '%s' in the configuration file: must start and end with lowercase letters or numbers, hyphens allowed in the middle", collection)
+				return fmt.Errorf("invalid collection name '%s' in the configuration file: must be max %d characters long and start and end with lowercase letters or numbers, with hyphens allowed in the middle", collection, MaxCollectionLength)
 			}
 		}
 	}
@@ -88,5 +91,6 @@ func (c *Config) validate() error {
 }
 
 func ValidateCollectionName(collection string) bool {
-	return regexp.MustCompile(CollectionRegex).MatchString(collection)
+	return regexp.MustCompile(CollectionRegex).MatchString(collection) &&
+		len(collection) <= MaxCollectionLength
 }

--- a/pkg/gsm-secrets/config.go
+++ b/pkg/gsm-secrets/config.go
@@ -54,8 +54,10 @@ func GetDesiredState(configFile string, config Config) ([]ServiceAccountInfo, ma
 
 		desiredSAs = append(desiredSAs, ServiceAccountInfo{
 			Email:       GetUpdaterSAEmail(collection.Name, config),
-			DisplayName: GetUpdaterSAId(collection.Name),
+			DisplayName: GetUpdaterSADisplayName(collection.Name),
+			ID:          GetUpdaterSAId(collection.Name),
 			Collection:  collection.Name,
+			Description: GetUpdaterSADescription(collection.Name),
 		})
 
 		desiredSecrets[GetUpdaterSASecretName(collection.Name)] = GCPSecret{

--- a/pkg/gsm-secrets/diff_test.go
+++ b/pkg/gsm-secrets/diff_test.go
@@ -19,8 +19,10 @@ func TestDiffServiceAccounts(t *testing.T) {
 	makeServiceAccount := func(collection string) ServiceAccountInfo {
 		return ServiceAccountInfo{
 			Email:       GetUpdaterSAEmail(collection, config),
-			DisplayName: GetUpdaterSAId(collection),
+			DisplayName: GetUpdaterSADisplayName(collection),
+			ID:          GetUpdaterSAId(collection),
 			Collection:  collection,
+			Description: GetUpdaterSADescription(collection),
 		}
 	}
 

--- a/pkg/gsm-secrets/execution.go
+++ b/pkg/gsm-secrets/execution.go
@@ -74,9 +74,10 @@ func (a *Actions) CreateServiceAccounts(ctx context.Context, client IAMClient) {
 	for _, sa := range a.SAsToCreate {
 		request := &adminpb.CreateServiceAccountRequest{
 			Name:      GetProjectResourceString(a.Config.ProjectIdString),
-			AccountId: sa.DisplayName,
+			AccountId: sa.ID,
 			ServiceAccount: &adminpb.ServiceAccount{
 				DisplayName: sa.DisplayName,
+				Description: sa.Description,
 			},
 		}
 		secretName := GetUpdaterSASecretName(sa.Collection)

--- a/pkg/gsm-secrets/testdata/basic-config.yaml
+++ b/pkg/gsm-secrets/testdata/basic-config.yaml
@@ -12,5 +12,5 @@ groups:
     - shared-collection
   team-beta:
     secret_collections:
-    - collection-beta
+    - some-collection-with-a-very-long-name
     - shared-collection

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_basic_config.yaml
@@ -12,7 +12,7 @@
     title: Read access to secrets for collection-alpha
   members:
   - group:team-alpha@redhat.com
-  - serviceAccount:collection-alpha-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -22,33 +22,7 @@
     title: Create, update, and delete access for collection-alpha
   members:
   - group:team-alpha@redhat.com
-  - serviceAccount:collection-alpha-sa@test-project.iam.gserviceaccount.com
-  role: projects/test-project/roles/openshift_ci_secrets_updater
-- condition:
-    description: 'Managed by test platform: Read access to secrets in collection-beta
-      collection'
-    expression: |-
-      (
-        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
-        resource.type == "secretmanager.googleapis.com/Secret"
-      ) && (
-        resource.name.extract("secrets/{secret}") == "collection-beta__updater-service-account" ||
-        resource.name.extract("secrets/{secret}") == "collection-beta____index"
-      )
-    title: Read access to secrets for collection-beta
-  members:
-  - group:team-beta@redhat.com
-  - serviceAccount:collection-beta-sa@test-project.iam.gserviceaccount.com
-  role: projects/test-project/roles/openshift_ci_secrets_viewer
-- condition:
-    description: 'Managed by test platform: Create, update, and delete access to secrets
-      in collection-beta collection'
-    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
-      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"collection-beta__\")"
-    title: Create, update, and delete access for collection-beta
-  members:
-  - group:team-beta@redhat.com
-  - serviceAccount:collection-beta-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in shared-collection
@@ -65,7 +39,7 @@
   members:
   - group:team-alpha@redhat.com
   - group:team-beta@redhat.com
-  - serviceAccount:shared-collection-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -76,5 +50,31 @@
   members:
   - group:team-alpha@redhat.com
   - group:team-beta@redhat.com
-  - serviceAccount:shared-collection-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:shared-collection-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_updater
+- condition:
+    description: 'Managed by test platform: Read access to secrets in some-collection-with-a-very-long-name
+      collection'
+    expression: |-
+      (
+        resource.type == "secretmanager.googleapis.com/SecretVersion" ||
+        resource.type == "secretmanager.googleapis.com/Secret"
+      ) && (
+        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name__updater-service-account" ||
+        resource.name.extract("secrets/{secret}") == "some-collection-with-a-very-long-name____index"
+      )
+    title: Read access to secrets for some-collection-with-a-very-long-name
+  members:
+  - group:team-beta@redhat.com
+  - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
+  role: projects/test-project/roles/openshift_ci_secrets_viewer
+- condition:
+    description: 'Managed by test platform: Create, update, and delete access to secrets
+      in some-collection-with-a-very-long-name collection'
+    expression: "(\n  resource.type == \"secretmanager.googleapis.com/SecretVersion\"
+      ||\n  resource.type == \"secretmanager.googleapis.com/Secret\"\n) && \n  resource.name.extract(\"secrets/{secret}\").startsWith(\"some-collection-with-a-very-long-name__\")"
+    title: Create, update, and delete access for some-collection-with-a-very-long-name
+  members:
+  - group:team-beta@redhat.com
+  - serviceAccount:ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_complex_config.yaml
@@ -12,7 +12,7 @@
     title: Read access to secrets for alpha-secrets
   members:
   - group:team-alpha@redhat.com
-  - serviceAccount:alpha-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -22,7 +22,7 @@
     title: Create, update, and delete access for alpha-secrets
   members:
   - group:team-alpha@redhat.com
-  - serviceAccount:alpha-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:alpha-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in beta-delta-secrets
@@ -39,7 +39,7 @@
   members:
   - group:team-beta@redhat.com
   - group:team-delta@redhat.com
-  - serviceAccount:beta-delta-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -50,7 +50,7 @@
   members:
   - group:team-beta@redhat.com
   - group:team-delta@redhat.com
-  - serviceAccount:beta-delta-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater
 - condition:
     description: 'Managed by test platform: Read access to secrets in epsilon-secrets
@@ -66,7 +66,7 @@
     title: Read access to secrets for epsilon-secrets
   members:
   - group:team-epsilon@redhat.com
-  - serviceAccount:epsilon-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -76,5 +76,5 @@
     title: Create, update, and delete access for epsilon-secrets
   members:
   - group:team-epsilon@redhat.com
-  - serviceAccount:epsilon-secrets-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:epsilon-secrets-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_bindings_TestGetDesiredState_one_secret_collection.yaml
@@ -13,7 +13,7 @@
   members:
   - group:team-alpha@redhat.com
   - group:team-beta@redhat.com
-  - serviceAccount:collection-alpha-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_viewer
 - condition:
     description: 'Managed by test platform: Create, update, and delete access to secrets
@@ -24,5 +24,5 @@
   members:
   - group:team-alpha@redhat.com
   - group:team-beta@redhat.com
-  - serviceAccount:collection-alpha-sa@test-project.iam.gserviceaccount.com
+  - serviceAccount:collection-alpha-updater@test-project.iam.gserviceaccount.com
   role: projects/test-project/roles/openshift_ci_secrets_updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_collections_TestGetDesiredState_basic_config.yaml
@@ -1,3 +1,3 @@
 collection-alpha: true
-collection-beta: true
 shared-collection: true
+some-collection-with-a-very-long-name: true

--- a/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_basic_config.yaml
@@ -1,9 +1,15 @@
 - Collection: collection-alpha
-  DisplayName: collection-alpha-sa
-  Email: collection-alpha-sa@test-project.iam.gserviceaccount.com
-- Collection: collection-beta
-  DisplayName: collection-beta-sa
-  Email: collection-beta-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: collection-alpha'
+  DisplayName: collection-alpha
+  Email: collection-alpha-updater@test-project.iam.gserviceaccount.com
+  ID: collection-alpha-updater
 - Collection: shared-collection
-  DisplayName: shared-collection-sa
-  Email: shared-collection-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: shared-collection'
+  DisplayName: shared-collection
+  Email: shared-collection-updater@test-project.iam.gserviceaccount.com
+  ID: shared-collection-updater
+- Collection: some-collection-with-a-very-long-name
+  Description: 'Updater service account for secret collection: some-collection-with-a-very-long-name'
+  DisplayName: some-collection-with-a-very-long-name
+  Email: ynbbgzp1q3u3iwp8edyqix-updater@test-project.iam.gserviceaccount.com
+  ID: ynbbgzp1q3u3iwp8edyqix-updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_complex_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_complex_config.yaml
@@ -1,9 +1,15 @@
 - Collection: alpha-secrets
-  DisplayName: alpha-secrets-sa
-  Email: alpha-secrets-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: alpha-secrets'
+  DisplayName: alpha-secrets
+  Email: alpha-secrets-updater@test-project.iam.gserviceaccount.com
+  ID: alpha-secrets-updater
 - Collection: beta-delta-secrets
-  DisplayName: beta-delta-secrets-sa
-  Email: beta-delta-secrets-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: beta-delta-secrets'
+  DisplayName: beta-delta-secrets
+  Email: beta-delta-secrets-updater@test-project.iam.gserviceaccount.com
+  ID: beta-delta-secrets-updater
 - Collection: epsilon-secrets
-  DisplayName: epsilon-secrets-sa
-  Email: epsilon-secrets-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: epsilon-secrets'
+  DisplayName: epsilon-secrets
+  Email: epsilon-secrets-updater@test-project.iam.gserviceaccount.com
+  ID: epsilon-secrets-updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_one_secret_collection.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_sa_TestGetDesiredState_one_secret_collection.yaml
@@ -1,3 +1,5 @@
 - Collection: collection-alpha
-  DisplayName: collection-alpha-sa
-  Email: collection-alpha-sa@test-project.iam.gserviceaccount.com
+  Description: 'Updater service account for secret collection: collection-alpha'
+  DisplayName: collection-alpha
+  Email: collection-alpha-updater@test-project.iam.gserviceaccount.com
+  ID: collection-alpha-updater

--- a/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_basic_config.yaml
+++ b/pkg/gsm-secrets/testdata/zz_fixture_secrets_TestGetDesiredState_basic_config.yaml
@@ -14,22 +14,6 @@ collection-alpha__updater-service-account:
   Payload: null
   ResourceName: ""
   Type: 1
-collection-beta____index:
-  Annotations: null
-  Collection: collection-beta
-  Labels: null
-  Name: collection-beta____index
-  Payload: null
-  ResourceName: ""
-  Type: 2
-collection-beta__updater-service-account:
-  Annotations: null
-  Collection: collection-beta
-  Labels: null
-  Name: collection-beta__updater-service-account
-  Payload: null
-  ResourceName: ""
-  Type: 1
 shared-collection____index:
   Annotations: null
   Collection: shared-collection
@@ -43,6 +27,22 @@ shared-collection__updater-service-account:
   Collection: shared-collection
   Labels: null
   Name: shared-collection__updater-service-account
+  Payload: null
+  ResourceName: ""
+  Type: 1
+some-collection-with-a-very-long-name____index:
+  Annotations: null
+  Collection: some-collection-with-a-very-long-name
+  Labels: null
+  Name: some-collection-with-a-very-long-name____index
+  Payload: null
+  ResourceName: ""
+  Type: 2
+some-collection-with-a-very-long-name__updater-service-account:
+  Annotations: null
+  Collection: some-collection-with-a-very-long-name
+  Labels: null
+  Name: some-collection-with-a-very-long-name__updater-service-account
   Payload: null
   ResourceName: ""
   Type: 1


### PR DESCRIPTION
GCP service account IDs have a strict 30-character limit, but our GSM SecretSync tool was using collection names directly as service account IDs (as each secret collection has a Service Account associated with it, that has update permissions to the collection). This would cause problems when users configured collection names longer than ~22 characters (accounting for the "-updater" suffix). We could enforce collection names be at max 22 characters, but 
a) it would be quite restrictive, 
b) it wouldn't solve the initial migration from Vault to GSM, where a lot of collection names are much longer than 22 characters.

### Solution
Implement a smart service account ID generation strategy:

- **Short collection names**: Use the collection name directly (e.g., `alpha-secrets-updater`)
- **Long collection names**: Generate a base64-encoded hash that fits within the 30-character limit (e.g., `wKdXBs3P2taCy4G4M2A-updater`)

This approach works because users will not directly interact with the service account ID - they will use the credentials stored as secrets in GSM and typically work with credential files. The service account display name preserves the full collection name for human readability, while the hashed ID ensures GCP compliance.
I've arbitrarily chosen the collection name to be max 50 characters, but it can be any number as long as we also constrain the secret name length (which is 255 chars) -- this will be constrained by the CLI tool.

### Key Changes
- Service account **ID** is now hash-based when needed (for GCP compliance)
- Service account **display name** remains the full collection name (human-readable)
- Service account **description** also stores the original collection name for reverse mapping
- Changed back the suffix from `-sa` to `-updater` for better clarity
