### PR TITLE
Konflux: Allow provisioning clusters from Hive

### DIFF
--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
@@ -424,15 +424,6 @@ spec:
                         type: string
                     type: object
                 type: object
-              pullRequest:
-                description: PullRequest holds the information regarding the PR this
-                  requested originated from.
-                properties:
-                  event:
-                    type: string
-                  headers:
-                    type: string
-                type: object
               tearDownCluster:
                 description: |-
                   When set to true, signals the controller that the ephemeral cluster is no longer needed,
@@ -472,6 +463,8 @@ spec:
                   - type
                   type: object
                 type: array
+              kubeAdminPassword:
+                type: string
               kubeconfig:
                 description: Kubeconfig to access the ephemeral cluster
                 type: string

--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
@@ -474,6 +474,8 @@ spec:
                 type: string
               prowJobId:
                 type: string
+              prowJobURL:
+                type: string
             required:
             - phase
             type: object

--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
@@ -42,6 +42,178 @@ spec:
               ciOperator:
                 description: CIOperatorSpec contains what is needed to run ci-operator
                 properties:
+                  baseImages:
+                    additionalProperties:
+                      description: ImageStreamTagReference identifies an ImageStreamTag
+                      properties:
+                        as:
+                          description: As is an optional string to use as the intermediate
+                            name for this reference.
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        tag:
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      - tag
+                      type: object
+                    type: object
+                  buildRoot:
+                    description: |-
+                      BuildRootImageConfiguration holds the two ways of using a base image
+                      that the pipeline will caches on.
+                    properties:
+                      from_repository:
+                        description: If the BuildRoot images pullspec should be read
+                          from a file in the repository (BuildRootImageFileName).
+                        type: boolean
+                      image_stream_tag:
+                        description: ImageStreamTagReference identifies an ImageStreamTag
+                        properties:
+                          as:
+                            description: As is an optional string to use as the intermediate
+                              name for this reference.
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          tag:
+                            type: string
+                        required:
+                        - name
+                        - namespace
+                        - tag
+                        type: object
+                      project_image:
+                        description: ProjectDirectoryImageBuildInputs holds inputs
+                          for an image build from the repo under test
+                        properties:
+                          build_args:
+                            description: |-
+                              BuildArgs contains build arguments that will be resolved in the Dockerfile.
+                              See https://docs.docker.com/engine/reference/builder/#/arg for more details.
+                            items:
+                              properties:
+                                name:
+                                  description: Name of the build arg.
+                                  type: string
+                                value:
+                                  description: Value of the build arg.
+                                  type: string
+                              type: object
+                            type: array
+                          context_dir:
+                            description: |-
+                              ContextDir is the directory in the project
+                              from which this build should be run.
+                            type: string
+                          dockerfile_literal:
+                            description: |-
+                              DockerfileLiteral can be used to  provide an inline Dockerfile.
+                              Mutually exclusive with DockerfilePath.
+                            type: string
+                          dockerfile_path:
+                            description: |-
+                              DockerfilePath is the path to a Dockerfile in the
+                              project to run relative to the context_dir.
+                            type: string
+                          inputs:
+                            additionalProperties:
+                              description: |-
+                                ImageBuildInputs is a subset of the v1 OpenShift Build API object
+                                defining an input source.
+                              properties:
+                                as:
+                                  description: |-
+                                    As is a list of multi-stage step names or image names that will
+                                    be replaced by the image reference from this step. For instance,
+                                    if the Dockerfile defines FROM nginx:latest AS base, specifying
+                                    either "nginx:latest" or "base" in this array will replace that
+                                    image with the pipeline input.
+                                  items:
+                                    type: string
+                                  type: array
+                                paths:
+                                  description: |-
+                                    Paths is a list of paths to copy out of this image and into the
+                                    context directory.
+                                  items:
+                                    description: |-
+                                      ImageSourcePath maps a path in the source image into a destination
+                                      path in the context. See the v1 OpenShift Build API for more info.
+                                    properties:
+                                      destination_dir:
+                                        description: |-
+                                          DestinationDir is the directory in the destination image to copy
+                                          to.
+                                        type: string
+                                      source_path:
+                                        description: SourcePath is a file or directory
+                                          in the source image to copy from.
+                                        type: string
+                                    required:
+                                    - destination_dir
+                                    - source_path
+                                    type: object
+                                  type: array
+                              type: object
+                            description: |-
+                              Inputs is a map of tag reference name to image input changes
+                              that will populate the build context for the Dockerfile or
+                              alter the input image for a multi-stage build.
+                            type: object
+                          ref:
+                            description: Ref is an optional string linking to the
+                              extra_ref in "org.repo" format that this belongs to
+                            type: string
+                        type: object
+                      use_build_cache:
+                        description: |-
+                          UseBuildCache enables the import and use of the prior `bin` image
+                          as a build cache, if the underlying build root has not changed since
+                          the previous cache was published.
+                        type: boolean
+                    type: object
+                  externalImages:
+                    additionalProperties:
+                      description: ExternalImage describes the external image that
+                        is imported into the pipeline
+                      properties:
+                        as:
+                          description: As is an optional string to use as the intermediate
+                            name for this reference.
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                        pull_secret:
+                          description: PullSecret is the name of the secret to use
+                            to pull the image
+                          type: string
+                        pull_spec:
+                          description: |-
+                            PullSpec is the full pullSpec of the external image, only to be set programmatically,
+                            and takes precedent over the other fields in ExternalImage
+                          type: string
+                        registry:
+                          description: Registry is the registry to pull images from
+                            (e.g. quay.io)
+                          type: string
+                        tag:
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      - registry
+                      - tag
+                      type: object
+                    type: object
                   releases:
                     additionalProperties:
                       description: |-
@@ -196,6 +368,52 @@ spec:
                     description: TestSpec determines the workflow will be executed
                       by the ci-operator to provision a cluster.
                     properties:
+                      clusterClaim:
+                        description: ClusterClaim claims an OpenShift cluster for
+                          the job.
+                        properties:
+                          architecture:
+                            description: |-
+                              Architecture is the architecture for the product.
+                              Defaults to amd64.
+                            type: string
+                          as:
+                            description: |-
+                              As is the name to use when importing the cluster claim release payload.
+                              If unset, claim release will be imported as `latest`.
+                            type: string
+                          cloud:
+                            description: Cloud is the cloud where the product is installed,
+                              e.g., aws.
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is the labels to select the cluster
+                              pools
+                            type: object
+                          owner:
+                            description: Owner is the owner of cloud account used
+                              to install the product, e.g., dpp.
+                            type: string
+                          product:
+                            description: |-
+                              Product is the name of the product being released.
+                              Defaults to ocp.
+                            type: string
+                          timeout:
+                            description: |-
+                              Timeout is how long ci-operator will wait for the cluster to be ready.
+                              Defaults to 1h.
+                            type: string
+                          version:
+                            description: Version is the version of the product
+                            type: string
+                        required:
+                        - cloud
+                        - owner
+                        - version
+                        type: object
                       clusterProfile:
                         type: string
                       env:
@@ -205,6 +423,15 @@ spec:
                       workflow:
                         type: string
                     type: object
+                type: object
+              pullRequest:
+                description: PullRequest holds the information regarding the PR this
+                  requested originated from.
+                properties:
+                  event:
+                    type: string
+                  headers:
+                    type: string
                 type: object
               tearDownCluster:
                 description: |-

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -77,17 +77,27 @@ type EphemeralClusterList struct {
 }
 
 type EphemeralClusterSpec struct {
-	CIOperator CIOperatorSpec `json:"ciOperator"`
+	// PullRequest holds the information regarding the PR this requested originated from.
+	PullRequest PullRequestMeta `json:"pullRequest,omitempty"`
+	CIOperator  CIOperatorSpec  `json:"ciOperator"`
 	// When set to true, signals the controller that the ephemeral cluster is no longer needed,
 	// allowing decommissioning procedures to begin.
 	TearDownCluster bool `json:"tearDownCluster,omitempty"`
 }
 
+type PullRequestMeta struct {
+	Payload string `json:"event,omitempty"`
+	Headers string `json:"headers,omitempty"`
+}
+
 // CIOperatorSpec contains what is needed to run ci-operator
 type CIOperatorSpec struct {
-	Releases  map[string]api.UnresolvedRelease `json:"releases,omitempty"`
-	Resources api.ResourceConfiguration        `json:"resources,omitempty"`
-	Test      TestSpec                         `json:"test,omitempty"`
+	BuildRootImage *api.BuildRootImageConfiguration       `json:"buildRoot,omitempty"`
+	BaseImages     map[string]api.ImageStreamTagReference `json:"baseImages,omitempty"`
+	ExternalImages map[string]api.ExternalImage           `json:"externalImages,omitempty"`
+	Releases       map[string]api.UnresolvedRelease       `json:"releases,omitempty"`
+	Resources      api.ResourceConfiguration              `json:"resources,omitempty"`
+	Test           TestSpec                               `json:"test,omitempty"`
 }
 
 // TestSpec determines the workflow will be executed by the ci-operator to provision a cluster.
@@ -95,6 +105,7 @@ type TestSpec struct {
 	Workflow       string            `json:"workflow,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 	ClusterProfile string            `json:"clusterProfile,omitempty"`
+	ClusterClaim   *api.ClusterClaim `json:"clusterClaim,omitempty"`
 }
 
 type EphemeralClusterStatus struct {

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -10,6 +10,7 @@ const (
 	CIOperatorJobsGenerateFailureReason    = "CIOperatorJobsGenerateFailure"
 	ProwJobFailureReason                   = "ProwJobFailure"
 	ProwJobCompletedReason                 = "ProwJobCompleted"
+	TooManyProwJobsBoundReason             = "TooManyProwJobsBound"
 	SecretsFetchFailureReason              = "SecretsFetchFailure"
 	CreateTestCompletedSecretFailureReason = "CreateTestCompletedSecretFailure"
 
@@ -26,7 +27,7 @@ const (
 	ProwJobCreating EphemeralClusterConditionType = "ProwJobCreating"
 	// ContainersReady indicates whether the cluster is up and running.
 	ClusterReady EphemeralClusterConditionType = "ClusterReady"
-	// ProwJobCompleted indicates whether the ProwJob is running.
+	// ProwJobCompleted indicates whether the ProwJob has done.
 	ProwJobCompleted EphemeralClusterConditionType = "ProwJobCompleted"
 	// TestCompleted indicates test has completed and the ephemeral cluster isn't needed anymore.
 	TestCompleted EphemeralClusterConditionType = "TestCompleted"
@@ -112,6 +113,7 @@ type EphemeralClusterStatus struct {
 	Phase      EphemeralClusterPhase       `json:"phase"`
 	Conditions []EphemeralClusterCondition `json:"conditions,omitempty"`
 	ProwJobID  string                      `json:"prowJobId,omitempty"`
+	ProwJobURL string                      `json:"prowJobURL,omitempty"`
 	// Kubeconfig to access the ephemeral cluster
 	Kubeconfig        string `json:"kubeconfig,omitempty"`
 	KubeAdminPassword string `json:"kubeAdminPassword,omitempty"`

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -10,11 +10,12 @@ const (
 	CIOperatorJobsGenerateFailureReason    = "CIOperatorJobsGenerateFailure"
 	ProwJobFailureReason                   = "ProwJobFailure"
 	ProwJobCompletedReason                 = "ProwJobCompleted"
-	KubeconfigFetchFailureReason           = "KubeconfigFetchFailure"
+	SecretsFetchFailureReason              = "SecretsFetchFailure"
 	CreateTestCompletedSecretFailureReason = "CreateTestCompletedSecretFailure"
 
 	CIOperatorNSNotFoundMsg = "ci-operator NS not found"
-	KubeconfigNotReadMsg    = "kubeconfig not ready"
+	KubeconfigNotReadyMsg   = "kubeconfig not ready"
+	HiveSecretsNotReadyMsg  = "hive secrets not ready"
 )
 
 // EphemeralClusterCondition is a valid value for EphemeralClusterCondition.Type
@@ -77,9 +78,7 @@ type EphemeralClusterList struct {
 }
 
 type EphemeralClusterSpec struct {
-	// PullRequest holds the information regarding the PR this requested originated from.
-	PullRequest PullRequestMeta `json:"pullRequest,omitempty"`
-	CIOperator  CIOperatorSpec  `json:"ciOperator"`
+	CIOperator CIOperatorSpec `json:"ciOperator"`
 	// When set to true, signals the controller that the ephemeral cluster is no longer needed,
 	// allowing decommissioning procedures to begin.
 	TearDownCluster bool `json:"tearDownCluster,omitempty"`
@@ -114,7 +113,8 @@ type EphemeralClusterStatus struct {
 	Conditions []EphemeralClusterCondition `json:"conditions,omitempty"`
 	ProwJobID  string                      `json:"prowJobId,omitempty"`
 	// Kubeconfig to access the ephemeral cluster
-	Kubeconfig string `json:"kubeconfig,omitempty"`
+	Kubeconfig        string `json:"kubeconfig,omitempty"`
+	KubeAdminPassword string `json:"kubeAdminPassword,omitempty"`
 }
 
 // EphemeralClusterCondition contains details for the current condition of this EphemeralCluster.

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -549,6 +549,7 @@ func TestReconcile(t *testing.T) {
 				&prowv1.ProwJob{
 					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
+					Status:     prowv1.ProwJobStatus{URL: "https://pj-123.html"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
@@ -579,6 +580,7 @@ func TestReconcile(t *testing.T) {
 					Phase:      ephemeralclusterv1.EphemeralClusterReady,
 					ProwJobID:  "pj-123",
 					Kubeconfig: "kubeconfig",
+					ProwJobURL: "https://pj-123.html",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -624,6 +626,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterProvisioning,
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{
 						{
 							Type:               ephemeralclusterv1.ProwJobCreating,
@@ -680,6 +683,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterProvisioning,
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -738,6 +742,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterProvisioning,
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -1267,6 +1272,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterProvisioning,
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -1284,7 +1290,7 @@ func TestReconcile(t *testing.T) {
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
 		{
-			name: "Hive cluster not ready yet, err outs when fetching a secret",
+			name: "Hive cluster not ready yet, errs out when fetching a secret",
 			ec: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
@@ -1349,6 +1355,7 @@ func TestReconcile(t *testing.T) {
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
+					Phase:     ephemeralclusterv1.EphemeralClusterProvisioning,
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__err_outs_when_fetching_a_secret.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__err_outs_when_fetching_a_secret.yaml
@@ -1,0 +1,19 @@
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/jobid: pj-123
+    name: ci-op-1234
+    resourceVersion: "999"
+  spec: {}
+  status: {}
+- apiVersion: v1
+  data:
+    password: YWRtaW4tcGFzc3dk
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: hive-admin-password
+    namespace: ci-op-1234
+    resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__errs_out_when_fetching_a_secret.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__errs_out_when_fetching_a_secret.yaml
@@ -1,0 +1,19 @@
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/jobid: pj-123
+    name: ci-op-1234
+    resourceVersion: "999"
+  spec: {}
+  status: {}
+- apiVersion: v1
+  data:
+    password: YWRtaW4tcGFzc3dk
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: hive-admin-password
+    namespace: ci-op-1234
+    resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__kubeconfig_missing.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_not_ready_yet__kubeconfig_missing.yaml
@@ -1,0 +1,19 @@
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/jobid: pj-123
+    name: ci-op-1234
+    resourceVersion: "999"
+  spec: {}
+  status: {}
+- apiVersion: v1
+  data:
+    password: YWRtaW4tcGFzc3dk
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: cluster-provisioning-hive-admin-password
+    namespace: ci-op-1234
+    resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_provisioned__report_secrets.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_build01_TestReconcile_Hive_cluster_provisioned__report_secrets.yaml
@@ -1,0 +1,28 @@
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/jobid: pj-123
+    name: ci-op-1234
+    resourceVersion: "999"
+  spec: {}
+  status: {}
+- apiVersion: v1
+  data:
+    kubeconfig: a3ViZWNvbmZpZw==
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: cluster-provisioning-hive-admin-kubeconfig
+    namespace: ci-op-1234
+    resourceVersion: "999"
+- apiVersion: v1
+  data:
+    password: YWRtaW4tcGFzc3dk
+  kind: Secret
+  metadata:
+    creationTimestamp: null
+    name: cluster-provisioning-hive-admin-password
+    namespace: ci-op-1234
+    resourceVersion: "999"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -7,6 +7,22 @@ metadata:
   resourceVersion: "1000"
 spec:
   ciOperator:
+    baseImages:
+      upi-installer:
+        name: "4.20"
+        namespace: ocp
+        tag: upi-installer
+    buildRoot:
+      image_stream_tag:
+        name: "4.20"
+        namespace: ocp
+        tag: cli
+    externalImages:
+      fedora:
+        name: ""
+        namespace: ""
+        registry: quay.io/fedora/fedora:43
+        tag: ""
     releases:
       initial:
         integration:
@@ -21,6 +37,12 @@ spec:
       env:
         foo: bar
       workflow: test-workflow
+  pullRequest:
+    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
+      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
+      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
+      \ }\n}"
+    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -16,6 +16,12 @@ spec:
           namespace: ocp
     test:
       workflow: test-workflow
+  pullRequest:
+    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
+      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
+      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
+      \ }\n}"
+    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -1,4 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
+      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
+      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
+      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -16,12 +22,6 @@ spec:
           namespace: ocp
     test:
       workflow: test-workflow
-  pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -1,4 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
+      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
+      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
+      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -16,12 +22,6 @@ spec:
           namespace: ocp
     test:
       workflow: test-workflow
-  pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -14,10 +14,14 @@ metadata:
 spec:
   ciOperator:
     baseImages:
-      upi-installer:
+      cli:
         name: "4.20"
         namespace: ocp
-        tag: upi-installer
+        tag: cli
+      cli-2:
+        name: "4.22"
+        namespace: ocp
+        tag: cli
     buildRoot:
       image_stream_tag:
         name: "4.20"
@@ -29,20 +33,21 @@ spec:
         namespace: ""
         registry: quay.io/fedora/fedora:43
         tag: ""
-    releases:
-      initial:
-        integration:
-          name: "4.17"
-          namespace: ocp
-      latest:
-        integration:
-          name: "4.17"
-          namespace: ocp
     test:
+      clusterClaim:
+        architecture: amd64
+        as: claim
+        cloud: aws
+        labels:
+          region: us-east-1
+        owner: test-platform
+        product: ocp
+        timeout: 0s
+        version: "4.22"
       clusterProfile: aws
       env:
         foo: bar
-      workflow: test-workflow
+      workflow: generic-claim
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -1,4 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
+      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
+      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
+      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -7,12 +13,6 @@ spec:
   ciOperator:
     test:
       workflow: test-workflow
-  pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -7,6 +7,12 @@ spec:
   ciOperator:
     test:
       workflow: test-workflow
+  pullRequest:
+    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
+      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
+      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
+      \ }\n}"
+    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
@@ -1,4 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
+      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
+      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
+      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -7,11 +13,5 @@ spec:
   ciOperator:
     test:
       workflow: test-workflow
-  pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
@@ -7,5 +7,11 @@ spec:
   ciOperator:
     test:
       workflow: test-workflow
+  pullRequest:
+    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
+      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
+      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
+      \ }\n}"
+    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
@@ -19,9 +19,6 @@ spec:
       env:
         foo: bar
       workflow: test-workflow
-  pullRequest:
-    event: '{}'
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
@@ -15,18 +15,17 @@ spec:
           name: "4.17"
           namespace: ocp
     test:
+      clusterProfile: aws
+      env:
+        foo: bar
       workflow: test-workflow
   pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
+    event: '{}'
     headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'validate and default presubmit: invalid presubmit job ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning:
-      failed to default namespace'
+    message: 'parse pull request meta: malformed PR event payload'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
     type: ProwJobCreating

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   ciOperator:
     test: {}
-  pullRequest: {}
 status:
   phase: ""
   prowJobId: pj

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_PJ_found_but_was_not_bound_to_the_EC.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   ciOperator:
     test: {}
+  pullRequest: {}
 status:
   phase: ""
   prowJobId: pj

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -6,5 +6,6 @@ metadata:
 spec:
   ciOperator:
     test: {}
+  pullRequest: {}
 status:
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,4 +1,10 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
+      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
+      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
+      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -6,6 +12,5 @@ metadata:
 spec:
   ciOperator:
     test: {}
-  pullRequest: {}
 status:
   phase: ""

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
@@ -15,18 +15,20 @@ spec:
           name: "4.17"
           namespace: ocp
     test:
+      clusterProfile: aws
+      env:
+        foo: bar
       workflow: test-workflow
   pullRequest:
     event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
       \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
       \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
       \ }\n}"
-    headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    headers: '{}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'validate and default presubmit: invalid presubmit job ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning:
-      failed to default namespace'
+    message: 'parse pull request meta: unsupported PR event payload'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
     type: ProwJobCreating

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
@@ -1,4 +1,7 @@
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: '{}'
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -19,12 +22,6 @@ spec:
       env:
         foo: bar
       workflow: test-workflow
-  pullRequest:
-    event: "\n{\n  \"pull_request\": {\n    \"base\": {\n\t  \"repo\": {\n\t    \"name\":
-      \"ci-tools\",\n\t    \"owner\": {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t
-      \ },\n\t  \"ref\": \"main\",\n\t  \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n
-      \ }\n}"
-    headers: '{}'
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -4,22 +4,22 @@ items:
   metadata:
     annotations:
       prow.k8s.io/context: ci/prow/cluster-provisioning
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
-      event-GUID: no-event-guid
+      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       prow.k8s.io/context: cluster-provisioning
       prow.k8s.io/is-optional: "false"
-      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
-      prow.k8s.io/refs.base_ref: ""
-      prow.k8s.io/refs.org: ""
+      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisionin
+      prow.k8s.io/refs.base_ref: main
+      prow.k8s.io/refs.org: openshift
       prow.k8s.io/refs.pull: "0"
-      prow.k8s.io/refs.repo: ""
+      prow.k8s.io/refs.repo: ci-tools
       prow.k8s.io/type: presubmit
     name: foobar
     namespace: ci
@@ -39,7 +39,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+    job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
     namespace: ci
     pod_spec:
       containers:
@@ -55,6 +55,22 @@ items:
         env:
         - name: UNRESOLVED_CONFIG
           value: |
+            base_images:
+              upi-installer:
+                name: "4.20"
+                namespace: ocp
+                tag: upi-installer
+            build_root:
+              image_stream_tag:
+                name: "4.20"
+                namespace: ocp
+                tag: cli
+            external_images:
+              fedora:
+                name: ""
+                namespace: ""
+                registry: quay.io/fedora/fedora:43
+                tag: ""
             releases:
               initial:
                 integration:
@@ -101,9 +117,9 @@ items:
                       cpu: 10m
                 workflow: test-workflow
             zz_generated_metadata:
-              branch: branch
-              org: org
-              repo: repo
+              branch: main
+              org: openshift
+              repo: ci-tools
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
@@ -152,15 +168,16 @@ items:
     prowjob_defaults:
       tenant_id: GlobalDefaultID
     refs:
-      base_link: /commit/fake
-      base_sha: fake
-      org: ""
+      base_link: /commit/8f5e7d6ec106ccf86684fcff808d85cac960f0a3
+      base_ref: main
+      base_sha: 8f5e7d6ec106ccf86684fcff808d85cac960f0a3
+      org: openshift
       pulls:
       - author: ""
         commit_link: /pull/0/commits/
         number: 0
         sha: ""
-      repo: ""
+      repo: ci-tools
     rerun_command: /test cluster-provisioning
     type: presubmit
   status:

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -1,0 +1,198 @@
+items:
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ci/prow/cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+    creationTimestamp: null
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
+      ci.openshift.io/ephemeral-cluster: ec
+      created-by-prow: "true"
+      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      prow.k8s.io/context: cluster-provisioning
+      prow.k8s.io/is-optional: "false"
+      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisionin
+      prow.k8s.io/refs.base_ref: main
+      prow.k8s.io/refs.org: openshift
+      prow.k8s.io/refs.pull: "0"
+      prow.k8s.io/refs.repo: ci-tools
+      prow.k8s.io/type: presubmit
+    name: foobar
+    namespace: ci
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build01
+    context: ci/prow/cluster-provisioning
+    decoration_config:
+      gcs_configuration:
+        default_org: org
+        default_repo: repo
+        path_strategy: single
+      skip_cloning: true
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+    job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+    namespace: ci
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --hive-kubeconfig=/secrets/hive-hive-credentials/kubeconfig
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cluster-provisioning
+        command:
+        - ci-operator
+        env:
+        - name: UNRESOLVED_CONFIG
+          value: |
+            base_images:
+              cli:
+                name: "4.20"
+                namespace: ocp
+                tag: cli
+              cli-2:
+                name: "4.22"
+                namespace: ocp
+                tag: cli
+            build_root:
+              image_stream_tag:
+                name: "4.20"
+                namespace: ocp
+                tag: cli
+            external_images:
+              fedora:
+                name: ""
+                namespace: ""
+                registry: quay.io/fedora/fedora:43
+                tag: ""
+            resources:
+              '*':
+                limits:
+                  memory: 400Mi
+                requests:
+                  cpu: 200m
+            tests:
+            - as: cluster-provisioning
+              cluster_claim:
+                architecture: amd64
+                as: claim
+                cloud: aws
+                labels:
+                  region: us-east-1
+                owner: test-platform
+                product: ocp
+                timeout: 0s
+                version: "4.22"
+              steps:
+                cluster_profile: aws
+                env:
+                  foo: bar
+                test:
+                - as: wait-test-complete
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
+                    and then waits for\n# a konflux test to complete. Once the test is done, the
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
+                    into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                  from: cli-2
+                  resources:
+                    limits:
+                      memory: 100Mi
+                    requests:
+                      cpu: 10m
+                workflow: generic-claim
+            zz_generated_metadata:
+              branch: main
+              org: openshift
+              repo: ci-tools
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/hive-hive-credentials
+          name: hive-hive-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: hive-hive-credentials
+        secret:
+          secretName: hive-hive-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    refs:
+      base_link: /commit/8f5e7d6ec106ccf86684fcff808d85cac960f0a3
+      base_ref: main
+      base_sha: 8f5e7d6ec106ccf86684fcff808d85cac960f0a3
+      org: openshift
+      pulls:
+      - author: ""
+        commit_link: /pull/0/commits/
+        number: 0
+        sha: ""
+      repo: ci-tools
+    rerun_command: /test cluster-provisioning
+    type: presubmit
+  status:
+    startTime: "2025-04-02T12:12:12Z"
+    state: scheduling
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
@@ -1,0 +1,2 @@
+items: null
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
@@ -1,0 +1,2 @@
+items: null
+metadata: {}


### PR DESCRIPTION
Introducing the following changes:
1. Provision clusters from Hive:
    - The `.spec.ciOperator.test.clusterClaim` stanza has been added. It maps to the `cluster_claim` stanza of a regular `ci-operator` configuration.
    - The EphemeralCluster controller waits until the secrets that hold the hive cluster kubeconfig and admin password exist within the `ci-op-xxxx` NS, then copying them on the `EphemeralCluster` `.status` stanza.
2. Add Pull Request metadata. The idea is that the [tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml](https://github.com/openshift/konflux-tasks/blob/main/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml) task would expand the following variables into the `annotations` of an Ephemeral Cluster object:
```yaml
apiVersion: ci.openshift.org/v1alpha1
kind: TestPlatformCluster
metadata:
  annotations:
    "ephemeralcluster.ci.openshift.io/pr-event-payload": |
      {{ body }}
    "ephemeralcluster.ci.openshift.io/pr-event-headers": |
      {{ headers }}
```
that hold, respectively, the [Pull Request event payload](https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#pullrequestevent) coming from GitHub and the HTTP headers of the same request.
Those are needed in order to properly create a `ci-operator` configuration and a ProwJob, without missing any information. Some of the pieces we need are: `organization`, `repository` and `branch` of the PR from which the Ephemeral Cluster request originated from.


3. Add the following new stanzas:
    - `.spec.ciOperator.buildRoot` mapping to the `build_root` of a regular `ci-operator` configuration.
    - `.spec.ciOperator.baseImages` mapping to the `base_images` of a regular `ci-operator` configuration.
    - `.spec.ciOperator.externalImages` mapping to the `external_images` of a regular `ci-operator` configuration.
