### PR TITLE
referencePolicy= Source for base_images & cluster_claim releases

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -465,7 +465,7 @@ func stepForTest(
 			step = steps.ClusterClaimStep(c.As, c.ClusterClaim, hiveClient, client, jobSpec, step, censor)
 			name := c.ClusterClaim.ClaimRelease(c.As).ReleaseName
 			target := api.ReleaseConfiguration{Name: name}.TargetName()
-			referencePolicy := imagev1.LocalTagReferencePolicy
+			referencePolicy := imagev1.SourceTagReferencePolicy
 			source := releasesteps.NewReleaseSourceFromClusterClaim(c.As, c.ClusterClaim, hiveClient)
 			ret = append(ret, releasesteps.ImportReleaseStep(name, nodeName, target, referencePolicy, source, false, config.Resources, podClient, jobSpec, pullSecret, nil))
 		}

--- a/pkg/steps/input_image_tag.go
+++ b/pkg/steps/input_image_tag.go
@@ -108,7 +108,7 @@ func (s *inputImageTagStep) run(ctx context.Context) error {
 		},
 		Tag: &imagev1.TagReference{
 			ReferencePolicy: imagev1.TagReferencePolicy{
-				Type: imagev1.LocalTagReferencePolicy,
+				Type: imagev1.SourceTagReferencePolicy,
 			},
 			From: from,
 			ImportPolicy: imagev1.TagImportPolicy{

--- a/pkg/steps/input_image_tag_test.go
+++ b/pkg/steps/input_image_tag_test.go
@@ -120,7 +120,7 @@ func TestInputImageTagStep(t *testing.T) {
 				ImportMode: imagev1.ImportModePreserveOriginal,
 			},
 			ReferencePolicy: imagev1.TagReferencePolicy{
-				Type: imagev1.LocalTagReferencePolicy,
+				Type: imagev1.SourceTagReferencePolicy,
 			},
 		},
 	}
@@ -233,7 +233,7 @@ func TestInputImageTagStepExternal(t *testing.T) {
 				ImportMode: imagev1.ImportModePreserveOriginal,
 			},
 			ReferencePolicy: imagev1.TagReferencePolicy{
-				Type: imagev1.LocalTagReferencePolicy,
+				Type: imagev1.SourceTagReferencePolicy,
 			},
 		},
 	}


### PR DESCRIPTION
- base_images & build_root will have `referencePolicy=Source`
- cluster-claimed releases will have `referencePolicy=Source`