### PR TITLE
Konflux: Retrieve PR Metadata

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -543,10 +543,15 @@ func main() {
 	}
 
 	if opts.enabledControllersSet.Has(ephemeralcluster.ControllerName) {
+		gitHubClient, err := opts.GitHubClient(opts.dryRun)
+		if err != nil {
+			logrus.WithError(err).Fatal("Failed to get gitHubClient")
+		}
 		log := logrus.NewEntry(logrus.StandardLogger())
 		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent,
 			ephemeralcluster.WithPolling(opts.ephemeralClusterProvisinerOptions.polling),
-			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef)); err != nil {
+			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef),
+			ephemeralcluster.WithGHClient(gitHubClient)); err != nil {
 			logrus.WithError(err).Fatalf("Failed to construct the %s controller", ephemeralcluster.ControllerName)
 		}
 	}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
@@ -1,0 +1,20 @@
+metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: '{}'
+  creationTimestamp: null
+  name: ec
+  namespace: ns
+  resourceVersion: "1000"
+spec:
+  ciOperator:
+    test: {}
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-02T12:12:12Z"
+    message: 'inject pull request meta: unable to extract org, repo and PR number
+      from the PR event payload'
+    reason: CIOperatorJobsGenerateFailure
+    status: "False"
+    type: ProwJobCreating
+  phase: Failed

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Inject_missing_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Inject_missing_PR_metadata.yaml
@@ -1,0 +1,50 @@
+metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
+    ephemeralcluster.ci.openshift.io/pr-event-payload: '{"check_run": {"pull_requests":
+      [{"url": "https://api.github.com/repos/danilo-gemoli/foobar/pulls/24"}]}}'
+  creationTimestamp: null
+  finalizers:
+  - ephemeralcluster.ci.openshift.io/dependent-prowjob
+  name: ec
+  namespace: ns
+  resourceVersion: "1000"
+spec:
+  ciOperator:
+    baseImages:
+      upi-installer:
+        name: "4.20"
+        namespace: ocp
+        tag: upi-installer
+    buildRoot:
+      image_stream_tag:
+        name: "4.20"
+        namespace: ocp
+        tag: cli
+    externalImages:
+      fedora:
+        name: ""
+        namespace: ""
+        registry: quay.io/fedora/fedora:43
+        tag: ""
+    releases:
+      initial:
+        integration:
+          name: "4.17"
+          namespace: ocp
+      latest:
+        integration:
+          name: "4.17"
+          namespace: ocp
+    test:
+      clusterProfile: aws
+      env:
+        foo: bar
+      workflow: test-workflow
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-02T12:12:12Z"
+    status: "True"
+    type: ProwJobCreating
+  phase: Provisioning
+  prowJobId: foobar

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
@@ -1,0 +1,2 @@
+items: null
+metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Inject_missing_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Inject_missing_PR_metadata.yaml
@@ -1,0 +1,189 @@
+items:
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ci/prow/cluster-provisioning
+      prow.k8s.io/job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
+    creationTimestamp: null
+    labels:
+      ci-operator.openshift.io/cloud: aws
+      ci-operator.openshift.io/cloud-cluster-profile: aws
+      ci.openshift.io/ephemeral-cluster: ec
+      created-by-prow: "true"
+      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      prow.k8s.io/context: cluster-provisioning
+      prow.k8s.io/is-optional: "false"
+      prow.k8s.io/job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
+      prow.k8s.io/refs.base_ref: base-ref
+      prow.k8s.io/refs.org: owner
+      prow.k8s.io/refs.pull: "24"
+      prow.k8s.io/refs.repo: repo
+      prow.k8s.io/type: presubmit
+    name: foobar
+    namespace: ci
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build01
+    context: ci/prow/cluster-provisioning
+    decoration_config:
+      gcs_configuration:
+        default_org: org
+        default_repo: repo
+        path_strategy: single
+      skip_cloning: true
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+    job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
+    namespace: ci
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cluster-provisioning
+        command:
+        - ci-operator
+        env:
+        - name: UNRESOLVED_CONFIG
+          value: |
+            base_images:
+              upi-installer:
+                name: "4.20"
+                namespace: ocp
+                tag: upi-installer
+            build_root:
+              image_stream_tag:
+                name: "4.20"
+                namespace: ocp
+                tag: cli
+            external_images:
+              fedora:
+                name: ""
+                namespace: ""
+                registry: quay.io/fedora/fedora:43
+                tag: ""
+            releases:
+              initial:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+              latest:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+            resources:
+              '*':
+                limits:
+                  memory: 400Mi
+                requests:
+                  cpu: 200m
+            tests:
+            - as: cluster-provisioning
+              steps:
+                cluster_profile: aws
+                env:
+                  foo: bar
+                test:
+                - as: wait-test-complete
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
+                    and then waits for\n# a konflux test to complete. Once the test is done, the
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
+                    into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                  from: cli
+                  resources:
+                    limits:
+                      memory: 100Mi
+                    requests:
+                      cpu: 10m
+                workflow: test-workflow
+            zz_generated_metadata:
+              branch: base-ref
+              org: owner
+              repo: repo
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    refs:
+      base_link: repo-link/commit/
+      base_ref: base-ref
+      org: owner
+      pulls:
+      - author: author
+        author_link: author-link
+        commit_link: repo-link/pull/24/commits/head-sha
+        head_ref: head-ref
+        number: 24
+        sha: head-sha
+        title: pr-title
+      repo: repo
+      repo_link: repo-link
+    rerun_command: /test cluster-provisioning
+    type: presubmit
+  status:
+    startTime: "2025-04-02T12:12:12Z"
+    state: scheduling
+metadata: {}


### PR DESCRIPTION
The `EphemeralCluster` object carries some metadata about the PR it has originated from. In some cases the metadata information doesn't contain the `pull_request` stanza, that is needed by Prow to properly create a `ProwJob`. When such a case occurs, we try to work around it and pull the metadata from the GitHub REST API endpoint `api.github.com`.