### PR TITLE
Eliminate non-openshift org naming collisions for private org synchronization

### DIFF
--- a/cmd/autoperibolossync/README.md
+++ b/cmd/autoperibolossync/README.md
@@ -27,6 +27,27 @@ containing Peribolos config. If the execution results in Peribolos changes, the 
 in that repository that updates the mainline with the changes, using
 Prow's [generic-autobumper](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/generic-autobumper) package.
 
+The tool uses a special naming convention to prevent repository name collisions:
+- Repositories from the organization specified by `--only-org` keep their original names
+- Repositories from organizations specified by `--flatten-org` keep their original names (can be specified multiple times)
+- Repositories from the following default organizations always keep their original names for backwards compatibility:
+  - `openshift`
+  - `openshift-eng`
+  - `operator-framework`
+  - `redhat-cne`
+  - `openshift-assisted`
+  - `ViaQ`
+- Repositories from other organizations are named as `<org>-<repo>` in the private organization
+
+For example, with `--only-org=openshift --flatten-org=migtools`:
+- `openshift/must-gather` becomes `openshift-priv/must-gather` (from --only-org and default)
+- `openshift-eng/ocp-build-data` becomes `openshift-priv/ocp-build-data` (from default)
+- `migtools/crane` becomes `openshift-priv/crane` (from --flatten-org)
+- `redhat-cne/cloud-event-proxy` becomes `openshift-priv/cloud-event-proxy` (from default)
+- `custom-org/some-repo` becomes `openshift-priv/custom-org-some-repo` (not in flatten list)
+
+This ensures that repositories from different organizations can coexist in the private organization without naming conflicts.
+
 ## How is it deployed
 
 The periodic

--- a/cmd/private-org-peribolos-sync/README.md
+++ b/cmd/private-org-peribolos-sync/README.md
@@ -6,3 +6,24 @@ It walks through the release repository path, given by `--release-repo-path`, an
 are promoting official images. The repositories that are specified in `--include-repo`, will be included if they exist in the release repository's path as well. Furthermore, it will get the required information for each of them from GitHub
 and will generate its peribolos configuration.
 Finally, the tool will update the peribolos configuration given by `--peribolos-config`.
+
+## Repository Naming Convention
+
+To prevent collisions when multiple organizations have repositories with the same name, this tool uses a special naming convention:
+- Repositories from the organization specified by `--only-org` keep their original names
+- Repositories from organizations specified by `--flatten-org` keep their original names (can be specified multiple times)
+- Repositories from the following default organizations always keep their original names for backwards compatibility:
+  - `openshift`
+  - `openshift-eng`
+  - `operator-framework`
+  - `redhat-cne`
+  - `openshift-assisted`
+  - `ViaQ`
+- All other repositories are named as `<org>-<repo>`
+
+For example, with `--only-org=openshift --flatten-org=migtools`:
+- `openshift/must-gather` → `openshift-priv/must-gather` (from --only-org and default)
+- `openshift-eng/ocp-build-data` → `openshift-priv/ocp-build-data` (from default)
+- `migtools/crane` → `openshift-priv/crane` (from --flatten-org)
+- `redhat-cne/cloud-event-proxy` → `openshift-priv/cloud-event-proxy` (from default)
+- `custom-org/some-repo` → `openshift-priv/custom-org-some-repo` (not in flatten list)

--- a/cmd/private-org-peribolos-sync/main_test.go
+++ b/cmd/private-org-peribolos-sync/main_test.go
@@ -248,6 +248,34 @@ func TestGetReposForPrivateOrg(t *testing.T) {
 				"org1": sets.New("repo1"),
 			},
 		},
+		{
+			name: "whitelist includes repos without CI configs",
+			whitelistConfig: config.WhitelistConfig{
+				Whitelist: map[string][]string{
+					"org1": {"repo1", "repo-without-ci-config"},
+					"org2": {"repo3", "another-repo-without-ci-config"},
+				},
+			},
+			onlyOrg: "",
+			expectedRepos: map[string]sets.Set[string]{
+				"org1": sets.New("repo1", "repo-without-ci-config"),
+				"org2": sets.New("repo3", "another-repo-without-ci-config"),
+			},
+		},
+		{
+			name: "whitelist with onlyOrg filter - whitelisted repos bypass filter",
+			whitelistConfig: config.WhitelistConfig{
+				Whitelist: map[string][]string{
+					"org1": {"repo1", "repo-without-ci-config"},
+					"org2": {"repo3", "another-repo-without-ci-config"},
+				},
+			},
+			onlyOrg: "org1",
+			expectedRepos: map[string]sets.Set[string]{
+				"org1": sets.New("repo1", "repo-without-ci-config"),
+				"org2": sets.New("repo3", "another-repo-without-ci-config"),
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/private-org-peribolos-sync/main_test.go
+++ b/cmd/private-org-peribolos-sync/main_test.go
@@ -18,49 +18,208 @@ func TestGenerateRepositories(t *testing.T) {
 	pntrBool := func(b bool) *bool { return &b }
 	pntrString := func(s string) *string { return &s }
 
-	orgRepos := map[string]sets.Set[string]{
-		"openshift": sets.New[string]([]string{"repo1", "repo2"}...),
-		"testshift": sets.New[string]([]string{"repo3", "repo4"}...),
+	testCases := []struct {
+		name          string
+		orgRepos      map[string]sets.Set[string]
+		onlyOrg       string
+		flattenOrgs   []string
+		expectedRepos map[string]org.Repo
+	}{
+		{
+			name: "no onlyOrg specified, default orgs are flattened",
+			orgRepos: map[string]sets.Set[string]{
+				"openshift": sets.New[string]([]string{"repo1", "repo2"}...),
+				"testshift": sets.New[string]([]string{"repo3", "repo4"}...),
+			},
+			onlyOrg:     "",
+			flattenOrgs: nil,
+			expectedRepos: map[string]org.Repo{
+				"repo1": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: repo1"),
+					Private:          pntrBool(true),
+				},
+				"repo2": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: repo2"),
+					Private:          pntrBool(true),
+				},
+				"testshift-repo3": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: repo3"),
+					Private:          pntrBool(true),
+				},
+				"testshift-repo4": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: repo4"),
+					Private:          pntrBool(true),
+				},
+			},
+		},
+		{
+			name: "onlyOrg=openshift, repos from other orgs use prefixed names",
+			orgRepos: map[string]sets.Set[string]{
+				"openshift": sets.New[string]([]string{"must-gather"}...),
+				"migtools":  sets.New[string]([]string{"must-gather", "crane"}...),
+			},
+			onlyOrg:     "openshift",
+			flattenOrgs: nil,
+			expectedRepos: map[string]org.Repo{
+				"must-gather": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: must-gather"),
+					Private:          pntrBool(true),
+				},
+				"migtools-must-gather": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: must-gather"),
+					Private:          pntrBool(true),
+				},
+				"migtools-crane": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: crane"),
+					Private:          pntrBool(true),
+				},
+			},
+		},
+		{
+			name: "flatten-org specified adds to default flattened orgs",
+			orgRepos: map[string]sets.Set[string]{
+				"openshift":     sets.New[string]([]string{"installer"}...),
+				"migtools":      sets.New[string]([]string{"crane"}...),
+				"openshift-eng": sets.New[string]([]string{"ocp-build-data"}...),
+				"custom-org":    sets.New[string]([]string{"custom-repo"}...),
+			},
+			onlyOrg:     "",
+			flattenOrgs: []string{"migtools"},
+			expectedRepos: map[string]org.Repo{
+				"installer": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: installer"),
+					Private:          pntrBool(true),
+				},
+				"crane": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: crane"),
+					Private:          pntrBool(true),
+				},
+				"ocp-build-data": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: ocp-build-data"),
+					Private:          pntrBool(true),
+				},
+				"custom-org-custom-repo": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: custom-repo"),
+					Private:          pntrBool(true),
+				},
+			},
+		},
+		{
+			name: "default flattened orgs keep original names",
+			orgRepos: map[string]sets.Set[string]{
+				"openshift-eng":      sets.New[string]([]string{"ocp-build-data"}...),
+				"operator-framework": sets.New[string]([]string{"operator-sdk"}...),
+				"redhat-cne":         sets.New[string]([]string{"cloud-event-proxy"}...),
+				"openshift-assisted": sets.New[string]([]string{"assisted-installer"}...),
+				"ViaQ":               sets.New[string]([]string{"logging-fluentd"}...),
+				"other-org":          sets.New[string]([]string{"some-repo"}...),
+			},
+			onlyOrg:     "",
+			flattenOrgs: nil,
+			expectedRepos: map[string]org.Repo{
+				"ocp-build-data": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: ocp-build-data"),
+					Private:          pntrBool(true),
+				},
+				"operator-sdk": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: operator-sdk"),
+					Private:          pntrBool(true),
+				},
+				"cloud-event-proxy": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: cloud-event-proxy"),
+					Private:          pntrBool(true),
+				},
+				"assisted-installer": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: assisted-installer"),
+					Private:          pntrBool(true),
+				},
+				"logging-fluentd": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: logging-fluentd"),
+					Private:          pntrBool(true),
+				},
+				"other-org-some-repo": {
+					HasProjects:      pntrBool(false),
+					AllowSquashMerge: pntrBool(false),
+					AllowMergeCommit: pntrBool(false),
+					AllowRebaseMerge: pntrBool(false),
+					Description:      pntrString("Test Repo: some-repo"),
+					Private:          pntrBool(true),
+				},
+			},
+		},
 	}
 
-	expectedRepos := map[string]org.Repo{
-		"repo1": {
-			HasProjects:      pntrBool(false),
-			AllowSquashMerge: pntrBool(false),
-			AllowMergeCommit: pntrBool(false),
-			AllowRebaseMerge: pntrBool(false),
-			Description:      pntrString("Test Repo: repo1"),
-			Private:          pntrBool(true),
-		},
-		"repo2": {
-			HasProjects:      pntrBool(false),
-			AllowSquashMerge: pntrBool(false),
-			AllowMergeCommit: pntrBool(false),
-			AllowRebaseMerge: pntrBool(false),
-			Description:      pntrString("Test Repo: repo2"),
-			Private:          pntrBool(true),
-		},
-		"repo3": {
-			HasProjects:      pntrBool(false),
-			AllowSquashMerge: pntrBool(false),
-			AllowMergeCommit: pntrBool(false),
-			AllowRebaseMerge: pntrBool(false),
-			Description:      pntrString("Test Repo: repo3"),
-			Private:          pntrBool(true),
-		},
-		"repo4": {
-			HasProjects:      pntrBool(false),
-			AllowSquashMerge: pntrBool(false),
-			AllowMergeCommit: pntrBool(false),
-			AllowRebaseMerge: pntrBool(false),
-			Description:      pntrString("Test Repo: repo4"),
-			Private:          pntrBool(true),
-		},
-	}
-
-	repos := generateRepositories(&fakegithub.FakeClient{}, orgRepos, logrus.WithField("destination-org", "testOrg"))
-	if !reflect.DeepEqual(repos, expectedRepos) {
-		t.Fatal(cmp.Diff(repos, expectedRepos))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			repos := generateRepositories(&fakegithub.FakeClient{}, tc.orgRepos, logrus.WithField("destination-org", "testOrg"), tc.onlyOrg, tc.flattenOrgs)
+			if !reflect.DeepEqual(repos, tc.expectedRepos) {
+				t.Fatal(cmp.Diff(repos, tc.expectedRepos))
+			}
+		})
 	}
 }
 

--- a/cmd/private-org-sync/README.md
+++ b/cmd/private-org-sync/README.md
@@ -25,6 +25,29 @@ divergence between the repositories during the process of handling a CVE.  Note
 that this causes repositories to silently diverge in other cases, such as when
 there is a force-push to the source repository.
 
+## Repository Naming Convention
+
+To prevent collisions when multiple organizations have repositories with the same name, this tool uses a special naming convention:
+- Repositories from the organization specified by `--only-org` keep their original names
+- Repositories from organizations specified by `--flatten-org` keep their original names (can be specified multiple times)
+- Repositories from the following default organizations always keep their original names for backwards compatibility:
+  - `openshift`
+  - `openshift-eng`
+  - `operator-framework`
+  - `redhat-cne`
+  - `openshift-assisted`
+  - `ViaQ`
+- All other repositories are synced with names prefixed by their source organization: `<source-org>-<repo>`
+
+For example, with `--only-org=openshift --flatten-org=migtools`:
+- `openshift/must-gather` → `openshift-priv/must-gather` (from --only-org and default)
+- `openshift-eng/ocp-build-data` → `openshift-priv/ocp-build-data` (from default)
+- `migtools/crane` → `openshift-priv/crane` (from --flatten-org)
+- `redhat-cne/cloud-event-proxy` → `openshift-priv/cloud-event-proxy` (from default)
+- `custom-org/some-repo` → `openshift-priv/custom-org-some-repo` (not in flatten list)
+
+This ensures that repositories from different organizations with the same name don't collide in the destination organization.
+
 ## Example
 
 ```console


### PR DESCRIPTION
Private org tools now default to including org names
in target-org destination repos unless the org
is flattened with "--flatten-org". Legacy orgs
are defaulted to flattened to prevent substantial
changes to existing openshift-priv repos.