### PR TITLE
Fix cannonical_go_repository error when merging 2 repos

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -199,7 +199,8 @@ func (config ReleaseBuildConfiguration) IsPipelineImage(name string) bool {
 }
 
 // DeterminePathAlias searches through the CanonicalGoRepositoryList to find the matching alias for the provided org and repo.
-// If not found, it returns the CanonicalGoRepository if one is configured
+// If not found, it returns the CanonicalGoRepository if one is configured, but only for single-repository scenarios.
+// For multi-repository scenarios (like multi-PR jobs), it returns empty string to let each repo use its default path alias.
 func (config ReleaseBuildConfiguration) DeterminePathAlias(org, repo string) string {
 	orgRepo := fmt.Sprintf("%s.%s", org, repo)
 	for _, cgr := range config.CanonicalGoRepositoryList {
@@ -208,6 +209,13 @@ func (config ReleaseBuildConfiguration) DeterminePathAlias(org, repo string) str
 		}
 	}
 
+	// Don't fall back to CanonicalGoRepository if we have entries in CanonicalGoRepositoryList,
+	// as this indicates a multi-repository scenario where each repo should have its own specific alias
+	if len(config.CanonicalGoRepositoryList) > 0 {
+		return ""
+	}
+
+	// Only use the global CanonicalGoRepository for single-repository scenarios
 	if config.CanonicalGoRepository != nil {
 		return *config.CanonicalGoRepository
 	}


### PR DESCRIPTION
Updated DeterminePathAlias to only fallback to CanonicalGoRepository in single‑repo scenarios. In multi‑repo (CanonicalGoRepositoryList non‑empty) it now returns an empty string so each repo uses its default alias. Added explanatory comments.

https://redhat-internal.slack.com/archives/CBN38N3MW/p1760440268058599?thread_ts=1760439044.976229&cid=CBN38N3MW 

/cc @openshift/test-platform 