### PR TITLE
Avoid race condition for builds and use newly created image

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -554,6 +554,8 @@ func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.P
 	var errs []error
 	if err := wait.ExponentialBackoff(wait.Backoff{Duration: time.Minute, Factor: 1.5, Steps: attempts}, func() (bool, error) {
 		var attempt buildapi.Build
+		// builds are using older src image, adding wait to avoid race condition
+		time.Sleep(5 * time.Second)
 		build.DeepCopyInto(&attempt)
 		if err := client.Create(ctx, &attempt); err == nil {
 			logrus.Infof("Created build %q", name)


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C013VBYBJQH/p1761570500427039

/cc @droslean @openshift/test-platform 