### PR TITLE
Change sleep duration to 1 minute in build creation

### DIFF
--- a/pkg/steps/source.go
+++ b/pkg/steps/source.go
@@ -555,7 +555,7 @@ func handleBuild(ctx context.Context, client BuildClient, podClient kubernetes.P
 	if err := wait.ExponentialBackoff(wait.Backoff{Duration: time.Minute, Factor: 1.5, Steps: attempts}, func() (bool, error) {
 		var attempt buildapi.Build
 		// builds are using older src image, adding wait to avoid race condition
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Minute)
 		build.DeepCopyInto(&attempt)
 		if err := client.Create(ctx, &attempt); err == nil {
 			logrus.Infof("Created build %q", name)


### PR DESCRIPTION
Increased sleep duration to 1 minute to avoid race condition.
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ci-tools/4801/pull-ci-openshift-ci-tools-main-images/1985357662090432512 

/cc @droslean 