### PR TITLE
aggregation: remove `Cluster should remain functional during upgrade` from always passing

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/pass_fail.go
@@ -689,12 +689,6 @@ func testShouldAlwaysPass(jobName, testName, testSuiteName string) string {
 		return "step graph tests are added by ci and are not useful for aggregation"
 	}
 
-	if strings.Contains(testName, `Cluster should remain functional during upgrade`) {
-		// this test is a side-effect of other tests.  For the purpose of aggregation, we can have each individual job run
-		// fail this test, but the aggregated output can be successful.
-		return "this test is a side-effect of other tests"
-	}
-
 	if strings.HasSuffix(testName, "-gather-azure-cli container test") {
 		// this is only for gathering artifacts.
 		return "used only to collect artifacts"


### PR DESCRIPTION
This test was previously excluded from aggregation because it would fail alongside other results, so we didn't need to aggregate this one (I think that was the reasoning).

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-aws-ovn-upgrade-4.21-micro-fips-release-openshift-release-analysis-aggregator/1991442012515078144 is an example where it failed 8x alone and we didn't aggregate it or catch the problem.

The only reason we caught the problem was openshift/origin#30509, the ClusterOperators test does not always run so we failed on missing results, rather than the actual failing test.