### PR TITLE
fix: update deprecated APIs in e2e tests (filepath.WalkDir, remove rand.Seed, fix TempDir usage)

### DIFF
--- a/test/e2e/framework/ci-operator.go
+++ b/test/e2e/framework/ci-operator.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -16,10 +17,6 @@ import (
 	"strings"
 	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().Unix())
-}
 
 // CiOperatorCommand exposes a ci-operator invocation to a test and
 // ensures the following semantics:
@@ -67,7 +64,10 @@ func newCiOperatorCommand(t *T) CiOperatorCommand {
 	}
 	artifactDir := ArtifactDir(t)
 	t.Cleanup(func() {
-		if walkErr := filepath.Walk(artifactDir, func(path string, info os.FileInfo, err error) error {
+		if walkErr := filepath.WalkDir(artifactDir, func(path string, info fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
 			if info.IsDir() {
 				return nil
 			}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -5,6 +5,7 @@ package framework
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -16,7 +17,7 @@ import (
 
 // CompareWithFixtureDir will compare all files in a directory with a corresponding test fixture directory.
 func CompareWithFixtureDir(t *T, golden, output string) {
-	if walkErr := filepath.Walk(golden, func(path string, info os.FileInfo, err error) error {
+	if walkErr := filepath.WalkDir(golden, func(path string, info fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}

--- a/test/e2e/pod-scaler/e2e_test.go
+++ b/test/e2e/pod-scaler/e2e_test.go
@@ -240,7 +240,7 @@ func TestBuildPodAdmission(t *testing.T) {
 func TestAdmission(t *testing.T) {
 	t.Parallel()
 	T := testhelper.NewT(interrupts.Context(), t)
-	prometheusAddr, _ := prometheus.Initialize(T, t.TempDir(), rand.New(rand.NewSource(4641280330504625122)), false)
+	prometheusAddr, _ := prometheus.Initialize(T, T.TempDir(), rand.New(rand.NewSource(4641280330504625122)), false)
 
 	kubeconfigFile := kubernetes.Fake(T, T.TempDir(), kubernetes.Prometheus(prometheusAddr), kubernetes.Builds(map[string]map[string]map[string]string{
 		"namespace": {


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized test infrastructure to use current Go standard library best practices for better performance and reliability.

* **Chores**
  * Improved error handling in internal test utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->