### PR TITLE
Set TIMEOUT env for prpqr aggregator step from aggregator-job-timeout

### DIFF
--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -811,6 +811,7 @@ func generateAggregatorJob(baseCiop *api.Metadata, uid, aggregatorJobName, jobNa
 						"AGGREGATION_ID":            uid,
 						"WORKING_DIR":               "$(ARTIFACT_DIR)/release-analysis-aggregator",
 						"EXPLICIT_GCS_PREFIX":       fmt.Sprintf("logs/%s", submitted),
+						"TIMEOUT":                   aggregatedJobTimeout.String(),
 					},
 					Test: []api.TestStep{
 						{

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -53,6 +53,7 @@
                   EXPLICIT_GCS_PREFIX: logs/test-org-test-repo-100-test-name
                   GOOGLE_SA_CREDENTIAL_FILE: /var/run/secrets/google-serviceaccount-credentials.json
                   JOB_START_TIME: "1970-01-01T01:00:00+01:00"
+                  TIMEOUT: 6h0m0s
                   VERIFICATION_JOB_NAME: periodic-ci-test-org-test-repo-test-branch-test-name
                   WORKING_DIR: $(ARTIFACT_DIR)/release-analysis-aggregator
                 test:


### PR DESCRIPTION
https://github.com/openshift/release/pull/75312 

/cc @petr-muller @neisw 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timeout configuration is now propagated to aggregated job environments, enabling fine-grained timeout control for aggregation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->