### PR TITLE
payload-testing plugin prunes runs on PR close/merge

### DIFF
--- a/cmd/payload-testing-prow-plugin/main.go
+++ b/cmd/payload-testing-prow-plugin/main.go
@@ -187,6 +187,7 @@ func main() {
 
 	eventServer := githubeventserver.New(o.githubEventServerOptions, getWebhookHMAC, logger)
 	eventServer.RegisterHandleIssueCommentEvent(serv.handleIssueComment)
+	eventServer.RegisterHandlePullRequestEvent(serv.handlePullRequest)
 	eventServer.RegisterHelpProvider(helpProvider, logger)
 
 	interrupts.OnInterrupt(func() {

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -208,6 +208,8 @@ func (r *reconciler) reconcile(ctx context.Context, req reconcile.Request, logge
 	}); err != nil {
 		return err
 	}
+
+	// PRPQR cleanup is done by the payload-testing plugin on PR merge/close.
 	return nil
 }
 


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resources associated with pull requests are now automatically cleaned up when pull requests are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->