### PR TITLE
auto-config-brancher: add priority/ci-critical label to PRs

### DIFF
--- a/cmd/auto-config-brancher/main.go
+++ b/cmd/auto-config-brancher/main.go
@@ -259,6 +259,7 @@ func main() {
 	labelsToAdd := []string{
 		"tide/merge-method-merge",
 		rehearse.RehearsalsAckLabel,
+		"priority/ci-critical",
 	}
 	if o.selfApprove {
 		logrus.Infof("Self-approving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull requests now receive the "priority/ci-critical" label during the automated branching configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->