### PR TITLE
clusterimageset-updater: use multi payload for 4.12+, amd64 for <4.12

### DIFF
--- a/cmd/clusterimageset-updater/main.go
+++ b/cmd/clusterimageset-updater/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -125,10 +126,15 @@ func main() {
 
 	boundsToPullspec := make(map[api.VersionBounds]string)
 	for versionBounds := range poolFilesByBounds {
+		// Use multi payload for 4.12+; use amd64 for older versions (multi not available).
+		arch, err := architectureForBounds(versionBounds)
+		if err != nil {
+			logrus.WithError(err).Fatalf("Invalid version bounds %s", versionBounds.Query())
+		}
 		release := api.Prerelease{
 			ReleaseDescriptor: api.ReleaseDescriptor{
 				Product:      api.ReleaseProductOCP,
-				Architecture: api.ReleaseArchitectureAMD64,
+				Architecture: arch,
 			},
 			VersionBounds: versionBounds,
 		}
@@ -322,4 +328,25 @@ func labelsToBounds(labels map[string]string) (*api.VersionBounds, error) {
 		return &bounds, nil
 	}
 	return nil, nil
+}
+
+// architectureForBounds returns MULTI for 4.12+ and AMD64 for older versions (multi payload not available).
+// Returns an error if bounds.Lower cannot be parsed as major.minor so misconfigured pools fail fast.
+func architectureForBounds(bounds api.VersionBounds) (api.ReleaseArchitecture, error) {
+	parts := strings.Split(bounds.Lower, ".")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("version_lower %q must be major.minor (e.g. 4.12.0-0)", bounds.Lower)
+	}
+	major, err := strconv.Atoi(strings.TrimPrefix(parts[0], "v"))
+	if err != nil {
+		return "", fmt.Errorf("version_lower %q: major %q is not an integer: %w", bounds.Lower, parts[0], err)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("version_lower %q: minor %q is not an integer: %w", bounds.Lower, parts[1], err)
+	}
+	if major < 4 || (major == 4 && minor < 12) {
+		return api.ReleaseArchitectureAMD64, nil
+	}
+	return api.ReleaseArchitectureMULTI, nil
 }

--- a/cmd/clusterimageset-updater/main_test.go
+++ b/cmd/clusterimageset-updater/main_test.go
@@ -13,8 +13,42 @@ import (
 
 	hivev1 "github.com/openshift/hive/apis/hive/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
+
+func TestArchitectureForBounds(t *testing.T) {
+	tests := []struct {
+		name    string
+		bounds  api.VersionBounds
+		want    api.ReleaseArchitecture
+		wantErr bool
+	}{
+		{"4.7 uses amd64", api.VersionBounds{Lower: "4.7.0-0", Upper: "4.8.0-0"}, api.ReleaseArchitectureAMD64, false},
+		{"4.11 uses amd64", api.VersionBounds{Lower: "4.11.0-0", Upper: "4.12.0-0"}, api.ReleaseArchitectureAMD64, false},
+		{"4.12 uses multi", api.VersionBounds{Lower: "4.12.0-0", Upper: "4.13.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"4.13 uses multi", api.VersionBounds{Lower: "4.13.0-0", Upper: "4.14.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"4.21 uses multi", api.VersionBounds{Lower: "4.21.0-0", Upper: "4.22.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"5.0 uses multi", api.VersionBounds{Lower: "5.0.0-0", Upper: "5.1.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"5.1 uses multi", api.VersionBounds{Lower: "5.1.0-0", Upper: "5.2.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"v4.12 uses multi", api.VersionBounds{Lower: "v4.12.0-0", Upper: "4.13.0-0"}, api.ReleaseArchitectureMULTI, false},
+		{"major 3 uses amd64", api.VersionBounds{Lower: "3.12.0-0", Upper: "4.0.0-0"}, api.ReleaseArchitectureAMD64, false},
+		{"unparseable lower fails", api.VersionBounds{Lower: "bad", Upper: "4.8.0-0"}, "", true},
+		{"single segment fails", api.VersionBounds{Lower: "4", Upper: "4.8.0-0"}, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := architectureForBounds(tt.bounds)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("architectureForBounds() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("architectureForBounds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestEnsureLabels(t *testing.T) {
 	testCases := []struct {

--- a/pkg/steps/utils/clusterpool.go
+++ b/pkg/steps/utils/clusterpool.go
@@ -33,6 +33,25 @@ func ClusterPoolFromClaim(ctx context.Context, claim *api.ClusterClaim, hiveClie
 
 	pools := clusterPools.Items
 	logrus.Debugf("Found %d matching pools", len(pools))
+
+	// When architecture is multi and no pool matches, fall back to amd64 so jobs can run where only amd64 pools exist.
+	if len(pools) == 0 && claim.Architecture == api.ReleaseArchitectureMULTI {
+		fallbackOption := make(ctrlruntimeclient.MatchingLabels, len(listOption)+1)
+		for k, v := range listOption {
+			fallbackOption[k] = v
+		}
+		fallbackOption["architecture"] = string(api.ReleaseArchitectureAMD64)
+		clusterPools = &hivev1.ClusterPoolList{}
+		if err := hiveClient.List(ctx, clusterPools, fallbackOption); err != nil {
+			return nil, fmt.Errorf("failed to list cluster pools with list option %v: %w", listOption, err)
+		}
+		pools = clusterPools.Items
+		logrus.Debugf("No multi pool found; tried amd64 fallback: %d matching pools", len(pools))
+		if len(pools) > 0 {
+			logrus.Infof("Claiming from amd64 pool (no multi pool available for product=%s version=%s cloud=%s owner=%s)", claim.Product, claim.Version, claim.Cloud, claim.Owner)
+		}
+	}
+
 	if len(pools) == 0 {
 		return nil, fmt.Errorf("failed to find a cluster pool providing the cluster: %v", listOption)
 	}

--- a/pkg/steps/utils/clusterpool_test.go
+++ b/pkg/steps/utils/clusterpool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -233,6 +234,91 @@ func TestClusterPoolFromClaimWithLabels(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.expected, got, testhelper.RuntimeObjectIgnoreRvTypeMeta); err == nil && diff != "" {
 				t.Errorf("Selected pool differs from expected:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestClusterPoolFromClaimMultiFallbackToAMD64(t *testing.T) {
+	amd64Pool := &hivev1.ClusterPool{
+		ObjectMeta: v1.ObjectMeta{Name: "pool-amd64", Labels: map[string]string{
+			"architecture": "amd64",
+			"cloud":        "aws",
+			"owner":        "fake",
+			"product":      "ocp",
+			"version":      "4.18",
+		}},
+		Spec:   hivev1.ClusterPoolSpec{Size: 1},
+		Status: hivev1.ClusterPoolStatus{Ready: 1},
+	}
+	multiPool := &hivev1.ClusterPool{
+		ObjectMeta: v1.ObjectMeta{Name: "pool-multi", Labels: map[string]string{
+			"architecture": "multi",
+			"cloud":        "aws",
+			"owner":        "fake",
+			"product":      "ocp",
+			"version":      "4.18",
+		}},
+		Spec:   hivev1.ClusterPoolSpec{Size: 1},
+		Status: hivev1.ClusterPoolStatus{Ready: 1},
+	}
+
+	tests := []struct {
+		name      string
+		pools     []ctrlruntimeclient.Object
+		wantPool  string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:     "multi requested and multi pool exists returns multi pool",
+			pools:    []ctrlruntimeclient.Object{multiPool},
+			wantPool: "pool-multi",
+		},
+		{
+			name:     "multi requested but only amd64 pool exists returns amd64 pool (fallback)",
+			pools:    []ctrlruntimeclient.Object{amd64Pool},
+			wantPool: "pool-amd64",
+		},
+		{
+			name:     "multi requested with both pools prefers multi",
+			pools:    []ctrlruntimeclient.Object{amd64Pool, multiPool},
+			wantPool: "pool-multi",
+		},
+		{
+			name:      "multi requested and no pools returns error",
+			pools:     []ctrlruntimeclient.Object{},
+			wantErr:   true,
+			errSubstr: "failed to find a cluster pool",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claim := &api.ClusterClaim{
+				Architecture: api.ReleaseArchitectureMULTI,
+				Cloud:        api.CloudAWS,
+				Owner:        "fake",
+				Product:      api.ReleaseProductOCP,
+				Version:      "4.18",
+			}
+			client := fakectrlruntimeclient.NewClientBuilder().WithObjects(tt.pools...).Build()
+			got, err := ClusterPoolFromClaim(context.TODO(), claim, client)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ClusterPoolFromClaim() expected error containing %q", tt.errSubstr)
+					return
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("ClusterPoolFromClaim() error = %v, want substring %q", err, tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ClusterPoolFromClaim() unexpected error: %v", err)
+				return
+			}
+			if got.Name != tt.wantPool {
+				t.Errorf("ClusterPoolFromClaim() pool name = %s, want %s", got.Name, tt.wantPool)
 			}
 		})
 	}

--- a/test/e2e/multi-stage/cluster-claim.yaml
+++ b/test/e2e/multi-stage/cluster-claim.yaml
@@ -4,6 +4,7 @@ base_images:
     namespace: openshift
     tag: 'stream9'
 releases:
+  # Use 4.18 for latest so the e2e claim tests match the fake cluster pool in CI (pool is versioned 4.18 multi).
   latest:   # include `latest` as a release to verify that `latest` is automatically overridden when using claims
     release:
       channel: stable
@@ -11,7 +12,7 @@ releases:
   custom:   # include `custom` to make sure named claim imports are properly overridden
     release:
       channel: stable
-      version: "4.17"
+      version: "4.18"
 resources:
   '*':
     requests:
@@ -30,7 +31,7 @@ tests:
               memory: 200Mi
   - as: e2e-claim
     cluster_claim:
-      architecture: amd64
+      architecture: multi
       cloud: aws
       owner: fake
       product: ocp
@@ -51,7 +52,7 @@ tests:
   - as: e2e-claim-as-custom
     cluster_claim:
       as: custom
-      architecture: amd64
+      architecture: multi
       cloud: aws
       owner: fake
       product: ocp
@@ -71,7 +72,7 @@ tests:
               memory: 200Mi
   - as: e2e-claim-depend-on-release-image
     cluster_claim:
-      architecture: amd64
+      architecture: multi
       cloud: aws
       owner: fake
       product: ocp


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clusterimageset-updater now auto-detects architecture from release version bounds, using AMD64 for older releases and enabling multi-architecture payloads for OpenShift 4.12 and later.

* **Tests**
  * Added table-driven tests covering version-based architecture selection, including error cases for invalid version bounds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->