### PR TITLE
Introduce Naive Cluster Profile Sets

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -807,6 +807,7 @@ func (o *options) ToGraphConfig() *defaults.Config {
 		LocalRegistryDNS:       o.localRegistryDNS,
 		MetricsAgent:           o.metricsAgent,
 		SkippedImages:          o.skippedImages,
+		ClusterProfileGetter:   o.resolverClient.ClusterProfile,
 	}
 }
 
@@ -1691,17 +1692,6 @@ func (o *options) initializeNamespace() error {
 		if err := client.Create(ctx, o.cloneAuthConfig.Secret); err != nil && !kerrors.IsAlreadyExists(err) {
 			return fmt.Errorf("couldn't create secret %s for %s authentication: %w", o.cloneAuthConfig.Secret.Name, o.cloneAuthConfig.Type, err)
 		}
-	}
-
-	// adds the appropriate cluster profile secrets to o.secrets,
-	// so they can be created by ctrlruntime client in the for cycle below this one
-	for _, cp := range o.clusterProfiles {
-		cpSecret, err := getClusterProfileSecret(cp, labeledclient.Wrap(ctrlClient, o.jobSpec), o.resolverClient, ctx)
-		if err != nil {
-			return fmt.Errorf("failed to create cluster profile secret %s: %w", cp, err)
-		}
-		cpSecret.Namespace = o.namespace
-		o.secrets = append(o.secrets, cpSecret)
 	}
 
 	if o.configSpec.ExternalImages != nil {
@@ -2676,32 +2666,6 @@ func addSchemes() error {
 	}
 
 	return nil
-}
-
-// getClusterProfileSecret retrieves the cluster profile secret name using config resolver,
-// and gets the secret from the ci namespace
-func getClusterProfileSecret(cp metrics.ClusterProfileForTarget, client ctrlruntimeclient.Client, resolverClient server.ResolverClient, ctx context.Context) (*coreapi.Secret, error) {
-	// Use config-resolver to get details about the cluster profile (which includes the secret's name)
-	cpDetails, err := resolverClient.ClusterProfile(cp.ProfileName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve details from config resolver for '%s' cluster cp", cp.ProfileName)
-	}
-	// Get the secret from the ci namespace. We expect it exists
-	ciSecret := &coreapi.Secret{}
-	err = client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: cpDetails.Secret}, ciSecret)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get secret '%s' from ci namespace: %w", cpDetails.Secret, err)
-	}
-
-	newSecret := &coreapi.Secret{
-		Data: ciSecret.Data,
-		Type: ciSecret.Type,
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-cluster-profile", cp.Target),
-		},
-	}
-
-	return newSecret, nil
 }
 
 // getClusterProfileNamesFromTargets extracts the needed cluster profile name(s) from the target arg(s)

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -65,12 +65,11 @@ const (
 	// `podStartTimeout`.
 	ReasonPending = "pod_pending"
 	// CliEnv if the env we use to expose the path to the cli
-	CliEnv                        = "CLI_DIR"
-	DefaultLeaseEnv               = "LEASED_RESOURCE"
-	DefaultIPPoolLeaseEnv         = "IP_POOL_AVAILABLE"
-	ClusterProfileResourceTypeEnv = "CLUSTER_PROFILE_RESOURCE_TYPE"
-	ClusterProfileSetNameParam    = "CLUSTER_PROFILE_SET"
-	ClusterProfileNameParam       = "CLUSTER_PROFILE"
+	CliEnv                = "CLI_DIR"
+	DefaultLeaseEnv       = "LEASED_RESOURCE"
+	DefaultIPPoolLeaseEnv = "IP_POOL_AVAILABLE"
+	ClusterProfileSetEnv  = "CLUSTER_PROFILE_SET_NAME"
+	ClusterProfileParam   = "CLUSTER_PROFILE"
 
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -65,9 +65,13 @@ const (
 	// `podStartTimeout`.
 	ReasonPending = "pod_pending"
 	// CliEnv if the env we use to expose the path to the cli
-	CliEnv                = "CLI_DIR"
-	DefaultLeaseEnv       = "LEASED_RESOURCE"
-	DefaultIPPoolLeaseEnv = "IP_POOL_AVAILABLE"
+	CliEnv                        = "CLI_DIR"
+	DefaultLeaseEnv               = "LEASED_RESOURCE"
+	DefaultIPPoolLeaseEnv         = "IP_POOL_AVAILABLE"
+	ClusterProfileResourceTypeEnv = "CLUSTER_PROFILE_RESOURCE_TYPE"
+	ClusterProfileSetNameParam    = "CLUSTER_PROFILE_SET"
+	ClusterProfileNameParam       = "CLUSTER_PROFILE"
+
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"
 

--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -8,18 +8,21 @@ import (
 // LeasesForTest aggregates all the lease configurations in a test.
 // It is assumed that they have been validated and contain only valid and
 // unique values.
-func LeasesForTest(s *MultiStageTestConfigurationLiteral) (ret []StepLease) {
-	if p := s.ClusterProfile; p != "" {
+func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
+	multiStageTest := test.MultiStageTestConfigurationLiteral
+	if p := multiStageTest.ClusterProfile; p != "" {
 		ret = append(ret, StepLease{
-			ResourceType: p.LeaseType(),
-			Env:          DefaultLeaseEnv,
-			Count:        1,
+			ResourceType:         p.LeaseType(),
+			Env:                  DefaultLeaseEnv,
+			Count:                1,
+			ClusterProfile:       multiStageTest.ClusterProfile.Name(),
+			ClusterProfileTarget: test.As,
 		})
 	}
-	for _, step := range append(s.Pre, append(s.Test, s.Post...)...) {
+	for _, step := range append(multiStageTest.Pre, append(multiStageTest.Test, multiStageTest.Post...)...) {
 		ret = append(ret, step.Leases...)
 	}
-	ret = append(ret, s.Leases...)
+	ret = append(ret, multiStageTest.Leases...)
 	return
 }
 

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -9,32 +9,39 @@ import (
 func TestLeasesForTest(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		tests    MultiStageTestConfigurationLiteral
+		tests    TestStepConfiguration
 		expected []StepLease
 	}{{
 		name:  "no configuration or cluster profile, no lease",
-		tests: MultiStageTestConfigurationLiteral{},
+		tests: TestStepConfiguration{MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{}},
 	}, {
 		name: "cluster profile, lease",
-		tests: MultiStageTestConfigurationLiteral{
-			ClusterProfile: ClusterProfileAWS,
+		tests: TestStepConfiguration{
+			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
+				ClusterProfile: ClusterProfileAWS,
+			},
 		},
 		expected: []StepLease{{
-			ResourceType: "aws-quota-slice",
-			Env:          DefaultLeaseEnv,
-			Count:        1,
+			ResourceType:   "aws-quota-slice",
+			Env:            DefaultLeaseEnv,
+			Count:          1,
+			ClusterProfile: string(ClusterProfileAWS),
 		}},
 	}, {
 		name: "explicit configuration, lease",
-		tests: MultiStageTestConfigurationLiteral{
-			Leases: []StepLease{{ResourceType: "aws-quota-slice"}},
+		tests: TestStepConfiguration{
+			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
+				Leases: []StepLease{{ResourceType: "aws-quota-slice"}},
+			},
 		},
 		expected: []StepLease{{ResourceType: "aws-quota-slice"}},
 	}, {
 		name: "explicit configuration in step, lease",
-		tests: MultiStageTestConfigurationLiteral{
-			Test: []LiteralTestStep{
-				{Leases: []StepLease{{ResourceType: "aws-quota-slice"}}},
+		tests: TestStepConfiguration{
+			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
+				Test: []LiteralTestStep{
+					{Leases: []StepLease{{ResourceType: "aws-quota-slice"}}},
+				},
 			},
 		},
 		expected: []StepLease{{ResourceType: "aws-quota-slice"}},

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1195,7 +1195,9 @@ type StepLease struct {
 	// Env is the environment variable that will contain the resource name.
 	Env string `json:"env"`
 	// Count is the number of resources to acquire (optional, defaults to 1).
-	Count uint `json:"count,omitempty"`
+	Count                uint   `json:"count,omitempty"`
+	ClusterProfile       string `json:"-"`
+	ClusterProfileTarget string `json:"-"`
 }
 
 // FromImageTag returns the internal name for the image tag that will be used

--- a/pkg/defaults/config.go
+++ b/pkg/defaults/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	MetricsAgent           *metrics.MetricsAgent
 	SkippedImages          sets.Set[string]
 	params                 *api.DeferredParameters
+	ClusterProfileGetter   func(profileName string) (*api.ClusterProfileDetails, error)
 
 	HTTPServerAddr string
 	HTTPServerMux  *http.ServeMux

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -311,7 +311,7 @@ func fromConfig(ctx context.Context, cfg *Config) ([]api.Step, []api.Step, error
 					Env:          api.DefaultLeaseEnv,
 					Count:        1,
 				}}
-				step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent)
+				step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 				break
 			}
 		}
@@ -397,7 +397,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 ) ([]api.Step, error) {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		params := cfg.params
-		leases := api.LeasesForTest(test)
+		leases := api.LeasesForTest(c)
 		ipPoolLease := api.IPPoolLeaseForTest(test, cfg.CIConfig.Metadata)
 		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
 			params = api.NewDeferredParameters(params)
@@ -408,7 +408,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, ipPoolLease, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent)
 		}
 		if len(leases) != 0 {
-			step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent)
+			step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 		}
 		if c.ClusterClaim != nil {
 			step = steps.ClusterClaimStep(c.As, c.ClusterClaim, cfg.hiveClient, cfg.kubeClient, cfg.JobSpec, step, cfg.Censor)
@@ -436,7 +436,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 			ResourceType: test.ClusterProfile.LeaseType(),
 			Env:          api.DefaultLeaseEnv,
 			Count:        1,
-		}}, step, cfg.JobSpec.Namespace, cfg.MetricsAgent)
+		}}, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 		addProvidesForStep(step, params)
 		return []api.Step{step}, nil
 	}

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1712,11 +1712,10 @@ func TestFromConfig(t *testing.T) {
 		params:        map[string]string{"CLUSTER_TYPE": "aws"},
 		expectedSteps: []string{"template", "[output-images]", "[images]"},
 		expectedParams: map[string]string{
-			"CLUSTER_PROFILE":               "",
-			"CLUSTER_PROFILE_RESOURCE_TYPE": "",
-			"CLUSTER_PROFILE_SET":           "",
-			"CLUSTER_TYPE":                  "aws",
-			api.DefaultLeaseEnv:             "",
+			"CLUSTER_PROFILE":          "",
+			"CLUSTER_PROFILE_SET_NAME": "",
+			"CLUSTER_TYPE":             "aws",
+			api.DefaultLeaseEnv:        "",
 		},
 	}, {
 		name:       "param files",

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1712,8 +1712,11 @@ func TestFromConfig(t *testing.T) {
 		params:        map[string]string{"CLUSTER_TYPE": "aws"},
 		expectedSteps: []string{"template", "[output-images]", "[images]"},
 		expectedParams: map[string]string{
-			"CLUSTER_TYPE":      "aws",
-			api.DefaultLeaseEnv: "",
+			"CLUSTER_PROFILE":               "",
+			"CLUSTER_PROFILE_RESOURCE_TYPE": "",
+			"CLUSTER_PROFILE_SET":           "",
+			"CLUSTER_TYPE":                  "aws",
+			api.DefaultLeaseEnv:             "",
 		},
 	}, {
 		name:       "param files",

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -232,7 +232,7 @@ func testContainsLease(test *cioperatorapi.TestStepConfiguration) bool {
 		return false
 	}
 
-	return len(cioperatorapi.LeasesForTest(test.MultiStageTestConfigurationLiteral)) > 0
+	return len(cioperatorapi.LeasesForTest(test)) > 0
 }
 
 type generatePresubmitOptions struct {

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -167,15 +167,11 @@ func aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr error) error {
 func (s *leaseStep) acquireLeases(ctx context.Context, cancel context.CancelFunc) error {
 	client := *s.client
 	// Sort by resource type to avoid a(n unlikely and temporary) deadlock.
-	var sorted []int
-	for i := range s.leases {
-		sorted = append(sorted, i)
-	}
-	sort.Slice(sorted, func(i, j int) bool {
+	sort.Slice(s.leases, func(i, j int) bool {
 		return s.leases[i].ResourceType < s.leases[j].ResourceType
 	})
 	var errs []error
-	for _, i := range sorted {
+	for i := range s.leases {
 		l := &s.leases[i]
 		start := time.Now()
 		logrus.Debugf("Acquiring %d lease(s) for %s", l.Count, l.ResourceType)
@@ -188,31 +184,19 @@ func (s *leaseStep) acquireLeases(ctx context.Context, cancel context.CancelFunc
 			break
 		}
 
-		s.clusterProfileName = l.ClusterProfile
-		if clusterProfileName := clusterProfileFromResources(names); clusterProfileName != "" {
-			s.clusterProfileSetName = l.ClusterProfile
-			s.clusterProfileName = clusterProfileName
-		}
-
-		if s.clusterProfileName != "" {
-			cpDetails, err := s.clusterProfileGetter(s.clusterProfileName)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err))
-				break
-			}
-
-			if err := s.importClusterProfileSecret(ctx, cpDetails.Secret, l.ClusterProfileTarget); err != nil {
-				errs = append(errs, fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err))
-				break
-			}
-		}
-
 		for _, name := range names {
 			s.metricsAgent.Record(&metrics.LeaseAcquisitionMetricEvent{RawLeaseName: name, AcquisitionDurationSeconds: time.Since(start).Seconds()})
 		}
 
 		logrus.Infof("Acquired %d lease(s) for %s: %v", l.Count, l.ResourceType, names)
 		l.resources = names
+
+		if l.ClusterProfile != "" {
+			if err := s.handleClusterProfile(ctx, l, names); err != nil {
+				errs = append(errs, err)
+				break
+			}
+		}
 	}
 
 	if errs != nil {
@@ -263,6 +247,30 @@ func clusterProfileFromResources(resources []string) string {
 		}
 	}
 	return ""
+}
+
+func (s *leaseStep) handleClusterProfile(ctx context.Context, l *stepLease, names []string) error {
+	s.clusterProfileName = l.ClusterProfile
+
+	if clusterProfileName := clusterProfileFromResources(names); clusterProfileName != "" {
+		s.clusterProfileSetName = l.ClusterProfile
+		s.clusterProfileName = clusterProfileName
+	}
+
+	if s.clusterProfileName == "" {
+		return nil
+	}
+
+	cpDetails, err := s.clusterProfileGetter(s.clusterProfileName)
+	if err != nil {
+		return fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err)
+	}
+
+	if err := s.importClusterProfileSecret(ctx, cpDetails.Secret, l.ClusterProfileTarget); err != nil {
+		return fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err)
+	}
+
+	return nil
 }
 
 // importClusterProfileSecret retrieves the cluster profile secret name using config resolver,

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -46,7 +46,6 @@ type leaseStep struct {
 	namespace             func() string
 	clusterProfileSetName string
 	clusterProfileName    string
-	clusterProfileResType string
 }
 
 func LeaseStep(client *lease.Client, leases []api.StepLease, wrapped api.Step, namespace func() string, metricsAgent *metrics.MetricsAgent,
@@ -89,11 +88,9 @@ func (s *leaseStep) Provides() api.ParameterMap {
 	}
 
 	// nolint:unparam
-	parameters[api.ClusterProfileSetNameParam] = func() (string, error) { return s.clusterProfileSetName, nil }
+	parameters[api.ClusterProfileSetEnv] = func() (string, error) { return s.clusterProfileSetName, nil }
 	// nolint:unparam
-	parameters[api.ClusterProfileNameParam] = func() (string, error) { return s.clusterProfileName, nil }
-	// nolint:unparam
-	parameters[api.ClusterProfileResourceTypeEnv] = func() (string, error) { return s.clusterProfileResType, nil }
+	parameters[api.ClusterProfileParam] = func() (string, error) { return s.clusterProfileName, nil }
 
 	for i := range s.leases {
 		l := &s.leases[i]
@@ -203,8 +200,6 @@ func (s *leaseStep) acquireLeases(ctx context.Context, cancel context.CancelFunc
 				errs = append(errs, fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err))
 				break
 			}
-
-			s.clusterProfileResType = cpDetails.LeaseType
 
 			if err := s.importClusterProfileSecret(ctx, cpDetails.Secret, l.ClusterProfileTarget); err != nil {
 				errs = append(errs, fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err))

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 
+	coreapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -18,6 +21,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/lease"
 	"github.com/openshift/ci-tools/pkg/metrics"
 	"github.com/openshift/ci-tools/pkg/results"
+	"github.com/openshift/ci-tools/pkg/util"
 )
 
 var NoLeaseClientErr = errors.New("step needs a lease but no lease client provided")
@@ -27,23 +31,33 @@ type stepLease struct {
 	resources []string
 }
 
+type ClusterProfileGetter func(name string) (*api.ClusterProfileDetails, error)
+
 // leaseStep wraps another step and acquires/releases one or more leases.
 type leaseStep struct {
-	client       *lease.Client
-	leases       []stepLease
-	wrapped      api.Step
-	metricsAgent *metrics.MetricsAgent
+	client               *lease.Client
+	leases               []stepLease
+	wrapped              api.Step
+	metricsAgent         *metrics.MetricsAgent
+	kubeClient           ctrlruntimeclient.Client
+	clusterProfileGetter ClusterProfileGetter
 
 	// for sending heartbeats during lease acquisition
-	namespace func() string
+	namespace             func() string
+	clusterProfileSetName string
+	clusterProfileName    string
+	clusterProfileResType string
 }
 
-func LeaseStep(client *lease.Client, leases []api.StepLease, wrapped api.Step, namespace func() string, metricsAgent *metrics.MetricsAgent) api.Step {
+func LeaseStep(client *lease.Client, leases []api.StepLease, wrapped api.Step, namespace func() string, metricsAgent *metrics.MetricsAgent,
+	kubeClient ctrlruntimeclient.Client, clusterProfileGetter ClusterProfileGetter) api.Step {
 	ret := leaseStep{
-		client:       client,
-		wrapped:      wrapped,
-		namespace:    namespace,
-		metricsAgent: metricsAgent,
+		client:               client,
+		wrapped:              wrapped,
+		namespace:            namespace,
+		metricsAgent:         metricsAgent,
+		kubeClient:           kubeClient,
+		clusterProfileGetter: clusterProfileGetter,
 	}
 	for _, l := range leases {
 		ret.leases = append(ret.leases, stepLease{StepLease: l})
@@ -73,28 +87,43 @@ func (s *leaseStep) Provides() api.ParameterMap {
 	if parameters == nil {
 		parameters = api.ParameterMap{}
 	}
+
+	// nolint:unparam
+	parameters[api.ClusterProfileSetNameParam] = func() (string, error) { return s.clusterProfileSetName, nil }
+	// nolint:unparam
+	parameters[api.ClusterProfileNameParam] = func() (string, error) { return s.clusterProfileName, nil }
+	// nolint:unparam
+	parameters[api.ClusterProfileResourceTypeEnv] = func() (string, error) { return s.clusterProfileResType, nil }
+
 	for i := range s.leases {
 		l := &s.leases[i]
+		// nolint:unparam
 		parameters[l.Env] = func() (string, error) {
 			if len(l.resources) == 0 {
 				return "", nil
 			}
-			strip := func(r string) string {
-				if i := strings.Index(r, "--"); i == -1 {
-					return r
-				} else {
-					return r[:i]
+
+			values := func(yield func(resource string) bool) {
+				for _, res := range l.resources {
+					val := res
+					parts := strings.Split(res, "--")
+					switch {
+					case len(parts) > 2:
+						val = parts[1]
+					case len(parts) > 1:
+						val = parts[0]
+					}
+
+					if !yield(val) {
+						return
+					}
 				}
 			}
-			builder := strings.Builder{}
-			builder.WriteString(strip(l.resources[0]))
-			for _, r := range l.resources[1:] {
-				builder.WriteString(" ")
-				builder.WriteString(strip(r))
-			}
-			return builder.String(), nil
+
+			return strings.Join(slices.Collect(values), " "), nil
 		}
 	}
+
 	return parameters
 }
 
@@ -117,7 +146,7 @@ func (s *leaseStep) run(ctx context.Context) error {
 	logrus.Infof("Acquiring leases for test %s: %v", s.Name(), types)
 	client := *s.client
 	ctx, cancel := context.WithCancel(ctx)
-	if err := acquireLeases(client, ctx, cancel, s.leases, s.metricsAgent); err != nil {
+	if err := s.acquireLeases(ctx, cancel); err != nil {
 		return err
 	}
 	wrappedErr := results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
@@ -138,24 +167,19 @@ func aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr error) error {
 	}
 }
 
-func acquireLeases(
-	client lease.Client,
-	ctx context.Context,
-	cancel context.CancelFunc,
-	leases []stepLease,
-	metricsAgent *metrics.MetricsAgent,
-) error {
+func (s *leaseStep) acquireLeases(ctx context.Context, cancel context.CancelFunc) error {
+	client := *s.client
 	// Sort by resource type to avoid a(n unlikely and temporary) deadlock.
 	var sorted []int
-	for i := range leases {
+	for i := range s.leases {
 		sorted = append(sorted, i)
 	}
 	sort.Slice(sorted, func(i, j int) bool {
-		return leases[i].ResourceType < leases[j].ResourceType
+		return s.leases[i].ResourceType < s.leases[j].ResourceType
 	})
 	var errs []error
 	for _, i := range sorted {
-		l := &leases[i]
+		l := &s.leases[i]
 		start := time.Now()
 		logrus.Debugf("Acquiring %d lease(s) for %s", l.Count, l.ResourceType)
 		names, err := client.Acquire(l.ResourceType, l.Count, ctx, cancel)
@@ -167,18 +191,41 @@ func acquireLeases(
 			break
 		}
 
+		s.clusterProfileName = l.ClusterProfile
+		if clusterProfileName := clusterProfileFromResources(names); clusterProfileName != "" {
+			s.clusterProfileSetName = l.ClusterProfile
+			s.clusterProfileName = clusterProfileName
+		}
+
+		if s.clusterProfileName != "" {
+			cpDetails, err := s.clusterProfileGetter(s.clusterProfileName)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err))
+				break
+			}
+
+			s.clusterProfileResType = cpDetails.LeaseType
+
+			if err := s.importClusterProfileSecret(ctx, cpDetails.Secret, l.ClusterProfileTarget); err != nil {
+				errs = append(errs, fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err))
+				break
+			}
+		}
+
 		for _, name := range names {
-			metricsAgent.Record(&metrics.LeaseAcquisitionMetricEvent{RawLeaseName: name, AcquisitionDurationSeconds: time.Since(start).Seconds()})
+			s.metricsAgent.Record(&metrics.LeaseAcquisitionMetricEvent{RawLeaseName: name, AcquisitionDurationSeconds: time.Since(start).Seconds()})
 		}
 
 		logrus.Infof("Acquired %d lease(s) for %s: %v", l.Count, l.ResourceType, names)
 		l.resources = names
 	}
+
 	if errs != nil {
-		if err := releaseLeases(client, metricsAgent, leases...); err != nil {
+		if err := releaseLeases(client, s.metricsAgent, s.leases...); err != nil {
 			errs = append(errs, fmt.Errorf("failed to release leases after acquisition failure: %w", err))
 		}
 	}
+
 	return utilerrors.NewAggregate(errs)
 }
 
@@ -212,4 +259,44 @@ func printResourceMetrics(client lease.Client, rtype string) {
 		return
 	}
 	logrus.Errorf("error: Failed to acquire resource, current capacity: %d free, %d leased", m.Free, m.Leased)
+}
+
+func clusterProfileFromResources(resources []string) string {
+	for _, resource := range resources {
+		if parts := strings.Split(resource, "--"); len(parts) > 2 {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+// importClusterProfileSecret retrieves the cluster profile secret name using config resolver,
+// and gets the secret from the ci namespace
+func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName, testName string) error {
+	ciSecret := &coreapi.Secret{}
+	err := s.kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: secretName}, ciSecret)
+	if err != nil {
+		return fmt.Errorf("failed to get secret '%s' from ci namespace: %w", secretName, err)
+	}
+
+	newSecret := &coreapi.Secret{
+		Data: ciSecret.Data,
+		Type: ciSecret.Type,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-cluster-profile", testName),
+			Namespace: s.namespace(),
+		},
+	}
+
+	created, err := util.UpsertImmutableSecret(ctx, s.kubeClient, newSecret)
+	if err != nil {
+		return fmt.Errorf("could not update secret %s: %w", newSecret.Name, err)
+	}
+	if created {
+		logrus.Debugf("Created secret %s", newSecret.Name)
+	} else {
+		logrus.Debugf("Updated secret %s", newSecret.Name)
+	}
+
+	return nil
 }

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -294,6 +294,7 @@ func TestAcquireLeases(t *testing.T) {
 				"releaseone owner res-type-0--slice-0 free",
 				"releaseone owner res-type-1--slice-0 free",
 			},
+			wantSecrets: corev1.SecretList{Items: []corev1.Secret{}},
 		},
 		{
 			name: "Cluster profile lease",
@@ -361,6 +362,84 @@ func TestAcquireLeases(t *testing.T) {
 			wantCalls: []string{
 				"acquireWaitWithPriority owner aws free leased random",
 				"releaseone owner us-east-1--aws-quota-slice-0 free",
+			},
+		},
+		{
+			name: "Cluster profile and regular lease",
+			leases: []api.StepLease{{
+				ResourceType:         "aws",
+				Env:                  api.DefaultLeaseEnv,
+				Count:                1,
+				ClusterProfile:       "aws",
+				ClusterProfileTarget: "e2e-aws-ovn",
+			}, {
+				ResourceType: "foobar",
+				Env:          "FOOBAR_RESOURCE",
+				Count:        1,
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_aws_free_leased_random": {
+					Name: "us-east-1--aws-quota-slice-0",
+				},
+				"acquireWaitWithPriority_foobar_free_leased_random": {
+					Name: "foobar-res-0",
+				},
+			},
+			objects: []ctrlruntimeclient.Object{&corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "ci",
+					Name:      "cluster-secrets-aws",
+				},
+				Data: map[string][]byte{
+					"k1": []byte("v1"),
+					"k2": []byte("v2"),
+				},
+			}},
+			clusterProfiles: map[string]*api.ClusterProfileDetails{
+				"aws": {
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
+				},
+			},
+			wantProvides: map[string]string{
+				"parameter":              "map",
+				api.ClusterProfileSetEnv: "",
+				api.ClusterProfileParam:  "aws",
+				api.DefaultLeaseEnv:      "us-east-1",
+				"FOOBAR_RESOURCE":        "foobar-res-0",
+			},
+			wantSecrets: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       ns,
+							Name:            "e2e-aws-ovn-cluster-profile",
+							ResourceVersion: "1",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+						Immutable: ptr.To(true),
+					},
+				},
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner aws free leased random",
+				"acquireWaitWithPriority owner foobar free leased random",
+				"releaseone owner us-east-1--aws-quota-slice-0 free",
+				"releaseone owner foobar-res-0 free",
 			},
 		},
 		{
@@ -452,7 +531,7 @@ func TestAcquireLeases(t *testing.T) {
 			for k, f := range provides {
 				v, err := f()
 				if err != nil {
-					t.Errorf("failed to resove provides param %s: %s", k, err)
+					t.Errorf("failed to resolve provides param %s: %s", k, err)
 				}
 				gotProvides[k] = v
 			}

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -3,12 +3,19 @@ package steps
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/boskos/common"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
@@ -62,7 +69,7 @@ func TestLeaseStepForward(t *testing.T) {
 		ResourceType: "lease_name",
 	}}
 	step := stepNeedsLease{}
-	withLease := LeaseStep(nil, leases, &step, emptyNamespace, nil)
+	withLease := LeaseStep(nil, leases, &step, emptyNamespace, nil, nil, nil)
 	t.Run("Inputs", func(t *testing.T) {
 		s, err := step.Inputs()
 		if err != nil {
@@ -121,7 +128,7 @@ func TestLeaseStepForward(t *testing.T) {
 
 func TestProvidesStripsSuffix(t *testing.T) {
 	leases := []api.StepLease{{Env: api.DefaultLeaseEnv, ResourceType: "rtype"}}
-	withLease := LeaseStep(nil, leases, &stepNeedsLease{}, emptyNamespace, nil)
+	withLease := LeaseStep(nil, leases, &stepNeedsLease{}, emptyNamespace, nil, nil, nil)
 	withLease.(*leaseStep).leases[0].resources = []string{"whatever--01"}
 	expected := "whatever"
 	actual, err := withLease.Provides()[api.DefaultLeaseEnv]()
@@ -218,7 +225,7 @@ func TestError(t *testing.T) {
 			var calls []string
 			client := lease.NewFakeClient("owner", "url", 0, tc.failures, &calls, nil)
 			s := stepNeedsLease{fail: tc.runFails}
-			err := LeaseStep(&client, leases, &s, func() string { return "" }, nil).Run(ctx)
+			err := LeaseStep(&client, leases, &s, func() string { return "" }, nil, nil, nil).Run(ctx)
 			if err == nil {
 				t.Fatalf("unexpected success, calls: %#v", calls)
 			}
@@ -230,30 +237,175 @@ func TestError(t *testing.T) {
 	}
 }
 
-func TestAcquireRelease(t *testing.T) {
-	var calls []string
-	client := lease.NewFakeClient("owner", "url", 0, nil, &calls, nil)
-	leases := []api.StepLease{
-		{ResourceType: "rtype1", Count: 1},
-		{ResourceType: "rtype0", Count: 2},
+func TestAcquireLeases(t *testing.T) {
+	ns := "ci-op-xxx"
+	nsFunc := func() string { return ns }
+	newClusterProfileGetter := func(nameToClusterProfile map[string]*api.ClusterProfileDetails) func(name string) (*api.ClusterProfileDetails, error) {
+		return func(name string) (*api.ClusterProfileDetails, error) {
+			cp, ok := nameToClusterProfile[name]
+			if !ok {
+				return nil, fmt.Errorf("cluster profile %s not found", name)
+			}
+			return cp, nil
+		}
 	}
-	step := stepNeedsLease{}
-	withLease := LeaseStep(&client, leases, &step, func() string { return "" }, nil)
-	if err := withLease.Run(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if !step.ran {
-		t.Fatal("step was not executed")
-	}
-	expected := []string{
-		"acquireWaitWithPriority owner rtype0 free leased random",
-		"acquireWaitWithPriority owner rtype0 free leased random",
-		"acquireWaitWithPriority owner rtype1 free leased random",
-		"releaseone owner rtype1_2 free",
-		"releaseone owner rtype0_0 free",
-		"releaseone owner rtype0_1 free",
-	}
-	if !reflect.DeepEqual(calls, expected) {
-		t.Fatalf("wrong calls to the lease client: %s", diff.ObjectDiff(calls, expected))
+
+	for _, tc := range []struct {
+		name                    string
+		leaseClientFailingCalls map[string]error
+		leases                  []api.StepLease
+		resources               map[string]*common.Resource
+		objects                 []ctrlruntimeclient.Object
+		clusterProfiles         map[string]*api.ClusterProfileDetails
+		wantProvides            map[string]string
+		wantSecrets             corev1.SecretList
+		wantCalls               []string
+	}{
+		{
+			name: "Acquire two lease of different types",
+			leases: []api.StepLease{{
+				ResourceType: "res-type-0",
+				Env:          "lease-0",
+				Count:        1,
+			}, {
+				ResourceType: "res-type-1",
+				Env:          "lease-1",
+				Count:        1,
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_res-type-0_free_leased_random": {
+					Name: "res-type-0--slice-0",
+				},
+				"acquireWaitWithPriority_res-type-1_free_leased_random": {
+					Name: "res-type-1--slice-0",
+				},
+			},
+			wantProvides: map[string]string{
+				api.ClusterProfileSetNameParam:    "",
+				api.ClusterProfileNameParam:       "",
+				api.ClusterProfileResourceTypeEnv: "",
+				"lease-0":                         "res-type-0",
+				"lease-1":                         "res-type-1",
+				"parameter":                       "map",
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner res-type-0 free leased random",
+				"acquireWaitWithPriority owner res-type-1 free leased random",
+				"releaseone owner res-type-0--slice-0 free",
+				"releaseone owner res-type-1--slice-0 free",
+			},
+		},
+		{
+			name: "Nested cluster profile",
+			leases: []api.StepLease{{
+				ResourceType:         "openshift-org-aws",
+				Env:                  api.DefaultLeaseEnv,
+				Count:                1,
+				ClusterProfile:       "aws-set",
+				ClusterProfileTarget: "e2e-aws-ovn",
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_openshift-org-aws_free_leased_random": {
+					Name: "aws--us-east-1--quota-slice-0",
+				},
+			},
+			objects: []ctrlruntimeclient.Object{&corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "ci",
+					Name:      "cluster-secrets-aws",
+				},
+				Data: map[string][]byte{
+					"k1": []byte("v1"),
+					"k2": []byte("v2"),
+				},
+			}},
+			clusterProfiles: map[string]*api.ClusterProfileDetails{
+				"aws-set": {
+					LeaseType: "openshift-org-aws",
+				},
+				"aws": {
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
+				},
+			},
+			wantProvides: map[string]string{
+				"parameter":                       "map",
+				api.ClusterProfileSetNameParam:    "aws-set",
+				api.ClusterProfileNameParam:       "aws",
+				api.ClusterProfileResourceTypeEnv: "aws-quota-slice",
+				api.DefaultLeaseEnv:               "us-east-1",
+			},
+			wantSecrets: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       ns,
+							Name:            "e2e-aws-ovn-cluster-profile",
+							ResourceVersion: "1",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+						Immutable: ptr.To(true),
+					},
+				},
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner openshift-org-aws free leased random",
+				"releaseone owner aws--us-east-1--quota-slice-0 free",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCalls := make([]string, 0)
+			leaseClient := lease.NewFakeClient("owner", "", 1, tc.leaseClientFailingCalls, &gotCalls, tc.resources)
+
+			kubeClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(tc.objects...).Build()
+			clusterProfileGetter := newClusterProfileGetter(tc.clusterProfiles)
+			step := LeaseStep(&leaseClient, tc.leases, &stepNeedsLease{}, nsFunc, nil, kubeClient, clusterProfileGetter)
+
+			if err := step.Run(context.TODO()); err != nil {
+				t.Errorf("unexpected run error: %s", err)
+			}
+
+			gotProvides := make(map[string]string)
+			provides := step.Provides()
+			for k, f := range provides {
+				v, err := f()
+				if err != nil {
+					t.Errorf("failed to resove provides param %s: %s", k, err)
+				}
+				gotProvides[k] = v
+			}
+
+			if diff := cmp.Diff(tc.wantProvides, gotProvides); diff != "" {
+				t.Errorf("unexpected provides map: %s", diff)
+			}
+
+			gotSecrets := corev1.SecretList{}
+			if err := kubeClient.List(context.TODO(), &gotSecrets, &ctrlruntimeclient.ListOptions{}); err != nil {
+				t.Errorf("failed list secrets: %s", err)
+			}
+
+			if diff := cmp.Diff(tc.wantSecrets, gotSecrets); diff != "" {
+				t.Errorf("unexpected secrets: %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantCalls, gotCalls); diff != "" {
+				t.Errorf("unexpected lease client calls:\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -15,7 +17,6 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/lease"
@@ -292,6 +293,74 @@ func TestAcquireLeases(t *testing.T) {
 				"acquireWaitWithPriority owner res-type-1 free leased random",
 				"releaseone owner res-type-0--slice-0 free",
 				"releaseone owner res-type-1--slice-0 free",
+			},
+		},
+		{
+			name: "Cluster profile lease",
+			leases: []api.StepLease{{
+				ResourceType:         "aws",
+				Env:                  api.DefaultLeaseEnv,
+				Count:                1,
+				ClusterProfile:       "aws",
+				ClusterProfileTarget: "e2e-aws-ovn",
+			}},
+			resources: map[string]*common.Resource{
+				"acquireWaitWithPriority_aws_free_leased_random": {
+					Name: "us-east-1--aws-quota-slice-0",
+				},
+			},
+			objects: []ctrlruntimeclient.Object{&corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: "ci",
+					Name:      "cluster-secrets-aws",
+				},
+				Data: map[string][]byte{
+					"k1": []byte("v1"),
+					"k2": []byte("v2"),
+				},
+			}},
+			clusterProfiles: map[string]*api.ClusterProfileDetails{
+				"aws": {
+					Secret:    "cluster-secrets-aws",
+					LeaseType: "aws-quota-slice",
+				},
+			},
+			wantProvides: map[string]string{
+				"parameter":              "map",
+				api.ClusterProfileSetEnv: "",
+				api.ClusterProfileParam:  "aws",
+				api.DefaultLeaseEnv:      "us-east-1",
+			},
+			wantSecrets: corev1.SecretList{
+				Items: []corev1.Secret{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       "ci",
+							Name:            "cluster-secrets-aws",
+							ResourceVersion: "999",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Namespace:       ns,
+							Name:            "e2e-aws-ovn-cluster-profile",
+							ResourceVersion: "1",
+						},
+						Data: map[string][]byte{
+							"k1": []byte("v1"),
+							"k2": []byte("v2"),
+						},
+						Immutable: ptr.To(true),
+					},
+				},
+			},
+			wantCalls: []string{
+				"acquireWaitWithPriority owner aws free leased random",
+				"releaseone owner us-east-1--aws-quota-slice-0 free",
 			},
 		},
 		{

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -281,12 +281,11 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				api.ClusterProfileSetNameParam:    "",
-				api.ClusterProfileNameParam:       "",
-				api.ClusterProfileResourceTypeEnv: "",
-				"lease-0":                         "res-type-0",
-				"lease-1":                         "res-type-1",
-				"parameter":                       "map",
+				api.ClusterProfileSetEnv: "",
+				api.ClusterProfileParam:  "",
+				"lease-0":                "res-type-0",
+				"lease-1":                "res-type-1",
+				"parameter":              "map",
 			},
 			wantCalls: []string{
 				"acquireWaitWithPriority owner res-type-0 free leased random",
@@ -329,11 +328,10 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				"parameter":                       "map",
-				api.ClusterProfileSetNameParam:    "aws-set",
-				api.ClusterProfileNameParam:       "aws",
-				api.ClusterProfileResourceTypeEnv: "aws-quota-slice",
-				api.DefaultLeaseEnv:               "us-east-1",
+				"parameter":              "map",
+				api.ClusterProfileSetEnv: "aws-set",
+				api.ClusterProfileParam:  "aws",
+				api.DefaultLeaseEnv:      "us-east-1",
 			},
 			wantSecrets: corev1.SecretList{
 				Items: []corev1.Secret{

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -219,7 +219,9 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("get cluster profile from parameters: %w", err)
 	}
-	s.profile = clusterProfile
+	if clusterProfile != "" {
+		s.profile = clusterProfile
+	}
 
 	if s.profile != "" {
 		if err := s.getProfileData(ctx); err != nil {

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -214,6 +214,13 @@ func (s *multiStageTestStep) Run(ctx context.Context) error {
 
 func (s *multiStageTestStep) run(ctx context.Context) error {
 	logrus.Infof("Running multi-stage test %s", s.name)
+
+	clusterProfile, err := getClusterProfileFromParams(s.params)
+	if err != nil {
+		return fmt.Errorf("get cluster profile from parameters: %w", err)
+	}
+	s.profile = clusterProfile
+
 	if s.profile != "" {
 		if err := s.getProfileData(ctx); err != nil {
 			return err
@@ -423,12 +430,14 @@ func (s *multiStageTestStep) environment() ([]coreapi.EnvVar, error) {
 		ret = append(ret, coreapi.EnvVar{Name: l.Env, Value: val})
 	}
 
-	val, err := s.params.Get(api.LeaseProxyServerURLEnvVarName)
-	if err != nil {
-		return nil, err
-	}
-	if val != "" {
-		ret = append(ret, coreapi.EnvVar{Name: api.LeaseProxyServerURLEnvVarName, Value: val})
+	for _, name := range []string{api.LeaseProxyServerURLEnvVarName, api.ClusterProfileSetEnv} {
+		val, err := s.params.Get(name)
+		if err != nil {
+			return nil, err
+		}
+		if val != "" {
+			ret = append(ret, coreapi.EnvVar{Name: name, Value: val})
+		}
 	}
 
 	for _, name := range []string{api.InitialReleaseName, api.LatestReleaseName} {
@@ -570,4 +579,12 @@ func getMountPath(secretName string) string {
 
 func volumeName(ns, name string) string {
 	return strings.ReplaceAll(fmt.Sprintf("%s-%s", ns, name), ".", "-")
+}
+
+func getClusterProfileFromParams(params api.Parameters) (api.ClusterProfile, error) {
+	if params == nil {
+		return "", nil
+	}
+	cp, err := params.Get(api.ClusterProfileParam)
+	return api.ClusterProfile(cp), err
 }

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -378,10 +379,16 @@ func TestEnvironment(t *testing.T) {
 				{Name: "ORIGINAL_RELEASE_IMAGE_LATEST", Value: "latest"},
 			},
 		},
+		{
+			name:     "cluster profile set exposed in environment",
+			params:   fakeStepParams{api.ClusterProfileSetEnv: "openshift-org-aws"},
+			expected: []coreapi.EnvVar{{Name: api.ClusterProfileSetEnv, Value: "openshift-org-aws"}},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			s := &multiStageTestStep{
 				params: tc.params,
 				leases: tc.leases,
@@ -391,13 +398,9 @@ func TestEnvironment(t *testing.T) {
 				t.Errorf("environment() error = %v, wantErr %v", err, tc.expectErr)
 				return
 			}
-			sort.Slice(tc.expected, func(i, j int) bool {
-				return tc.expected[i].Name < tc.expected[j].Name
-			})
-			sort.Slice(got, func(i, j int) bool {
-				return got[i].Name < got[j].Name
-			})
-			if diff := cmp.Diff(tc.expected, got); diff != "" {
+			if diff := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b string) bool {
+				return strings.Compare(a, b) <= 0
+			})); diff != "" {
 				t.Errorf("%s: result differs from expected:\n %s", tc.name, diff)
 			}
 		})

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -398,8 +397,8 @@ func TestEnvironment(t *testing.T) {
 				t.Errorf("environment() error = %v, wantErr %v", err, tc.expectErr)
 				return
 			}
-			if diff := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b string) bool {
-				return strings.Compare(a, b) <= 0
+			if diff := cmp.Diff(tc.expected, got, cmpopts.SortSlices(func(a, b coreapi.EnvVar) bool {
+				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("%s: result differs from expected:\n %s", tc.name, diff)
 			}


### PR DESCRIPTION
Introducing a simple and naive cluster profile sets implementation by embedding the cluster profile name into the lease resource names.
This PR is much easier to explain with a real example.
As of today, in OpenShift, we have the following `aws` cluster profiles, and their associated lease types:
```
Cluster Profile | Lease Type
----------------+-------------------
aws             | aws-quota-slice
aws-2           | aws-2-quota-slice
aws-3           | aws-3-quota-slice
aws-4           | aws-4-quota-slice
aws-5           | aws-5-quota-slice
```
Each one of them is defined as follow in boskos, (choosing `aws-3` as an example, see [here](https://github.com/openshift/release/blob/1aa30a5ff3e40ff22ec04ec659110207a72c0e44/core-services/prow/02_config/_boskos.yaml#L1003-L1125)):
```yaml
- type: aws-3-quota-slice
  names:
  - us-east-1--aws-3-quota-slice-00
  - us-east-1--aws-3-quota-slice-01
  ...
  - us-west-2--aws-3-quota-slice-24
```
We define a new `openshift-org-aws` set by taking all the names from the `aws-*-quota-slice` lease types and put them all into a single entry `openshift-org-aws-quota-slice`:
```yaml
- type: openshift-org-aws-quota-slice
  names:
  - aws--us-east-1--quota-slice-00
  - aws--us-east-1--quota-slice-01
  ...
  - aws-2--us-east-1--quota-slice-00
  - aws-2--us-east-1--quota-slice-01
  ...
  - aws-3--us-east-1--quota-slice-00
  - aws-3--us-east-1--quota-slice-01
  ...
  - aws-4--us-east-1--quota-slice-00
  - aws-4--us-east-1--quota-slice-01
  ...
  - aws-5--us-east-1--quota-slice-00
  - aws-5--us-east-1--quota-slice-01
  ...
  - aws-5--us-west-2--quota-slice-34
```
The `names` match the pattern `${CLUSTER_PROFILE}--${REGION}--${QUOTA_SLICE}`.

The `openshift-org-aws` has to be added as usual, see https://docs.ci.openshift.org/how-tos/adding-a-cluster-profile/, such that it maps to the `openshift-org-aws-quota-slice` lease type.

At this stage a test, that is referencing the new cluster profile set, runs:
```yaml
- as: e2e-aws-ovn-proxy
  steps:
    cluster_profile: openshift-org-aws
    workflow: openshift-e2e-aws-proxy
```

`ci-operator` starts and performs what follow:
1. It acquires a lease of type `openshift-org-aws-quota-slice` at runtime, hence getting `aws-4--us-east-1--quota-slice-01` as a lease (see `pkg/steps/lease.go`).
2.  It recognizes there is the `aws-4` cluster profile name in it (see `pkg/steps/lease.go`). The code now handles lease names matching the pattern `${CLUSTER_PROFILE}--${REGION}--${QUOTA_SLICE}`.
3.  It copies the secret `cluster-secrets-aws-4` from the `ci` NS into `ci-op-xxxx`. This part was previously handled in `cmd/ci-operator/main.go` but it is now executed in `pkg/steps/lease.go`.
4. It exposes the environment variable `CLUSTER_PROFILE_SET_NAME=openshift-org-aws` to any step. The variable is exported as a parameter by `pkg/steps/lease.go` and then gets cunsumed in `pkg/steps/multi_stage/multi_stage.go`.

Important note about (3): Since a cluster profile might not been know until the moment a lease is acquired, `ci-operator` doesn't copy the secret that belongs to a cluster profile at the beginning of its execution anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leases now include cluster-profile metadata and expose env vars CLUSTER_PROFILE and CLUSTER_PROFILE_SET_NAME to downstream steps.
  * Cluster-profile lookup is plumbed into lease acquisition so profiles can be resolved at runtime.

* **Improvements**
  * Cluster-profile selection is propagated into step environments and test parameters.
  * Cluster-profile secrets are fetched and provisioned into target namespaces during acquisition to enable subsequent steps.

* **Tests**
  * Expanded tests covering cluster-profile scenarios and secret wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->