### PR TITLE
ci-operator: Fix Release All Leases Unreachable Code

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1169,6 +1169,16 @@ func (o *options) Run() (errs []error) {
 				return []error{fmt.Errorf("failed to create the lease client: %w", err)}
 			}
 			o.metricsAgent.RegisterLeaseClient(o.leaseClient)
+			stopHeartbeating := o.startLeaseHearthbeating()
+			defer func() {
+				close(stopHeartbeating)
+				if l, err := o.leaseClient.ReleaseAll(); err != nil {
+					logrus.WithError(err).Errorf("Failed to release leaked leases (%v)", l)
+				} else if len(l) != 0 {
+					o.metricsAgent.Record(metrics.NewInsightsEvent(metrics.InsightLeaseReleased, metrics.Context{"released_count": len(l)}))
+					logrus.Warnf("Would leak leases: %v", l)
+				}
+			}()
 		}
 		go monitorNamespace(ctx, cancel, o.namespace, client.Namespaces())
 		authClient, err := authclientset.NewForConfig(o.clusterConfig)
@@ -2156,21 +2166,27 @@ func (o *options) initializeLeaseClient() error {
 	if o.leaseClient, err = lease.NewClient(owner, o.leaseServer, username, passwordGetter, 60, o.leaseAcquireTimeout); err != nil {
 		return fmt.Errorf("failed to create the lease client: %w", err)
 	}
+	return nil
+}
+
+func (o *options) startLeaseHearthbeating() chan struct{} {
+	stopChan := make(chan struct{})
 	t := time.NewTicker(30 * time.Second)
 	go func() {
-		for range t.C {
-			if err := o.leaseClient.Heartbeat(); err != nil {
-				logrus.WithError(err).Warn("Failed to update leases.")
+	loop:
+		for {
+			select {
+			case <-t.C:
+				if err := o.leaseClient.Heartbeat(); err != nil {
+					logrus.WithError(err).Warn("Failed to update leases.")
+				}
+			case <-stopChan:
+				t.Stop()
+				break loop
 			}
 		}
-		if l, err := o.leaseClient.ReleaseAll(); err != nil {
-			logrus.WithError(err).Errorf("Failed to release leaked leases (%v)", l)
-		} else if len(l) != 0 {
-			o.metricsAgent.Record(metrics.NewInsightsEvent(metrics.InsightLeaseReleased, metrics.Context{"released_count": len(l)}))
-			logrus.Warnf("Would leak leases: %v", l)
-		}
 	}()
-	return nil
+	return stopChan
 }
 
 // eventJobDescription returns a string representing the pull requests and authors description, to be used in events.


### PR DESCRIPTION
The `ReleaseAll()` safety net was, indeed, unreachable:
```golang
t := time.NewTicker(30 * time.Second)
for range t.C {
  if err := o.leaseClient.Heartbeat(); err != nil {
    logrus.WithError(err).Warn("Failed to update leases.")
  }
}
o.leaseClient.ReleaseAll()
```
that is an infinity loop that never ends, therefore `o.leaseClient.ReleaseAll()` won't be ever executed.
This is an attempt to fix it by:
- Running the hearth-beating function into its own, stoppable, goroutine.
- Stopping the hearth-beating goroutine upon test completion and then release all the remaining leases, if any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added dedicated heartbeat control for lease management to improve reliability of background lease maintenance.
  * Centralized and enhanced cleanup to ensure all leased resources are released on exit, preventing potential resource leaks.
  * Streamlined lease startup/shutdown flow for clearer lifecycle handling and more predictable shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->