### PR TITLE
Add `openshift-org-aws` Cluster Profile Set

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1501,6 +1501,7 @@ const (
 	ClusterProfileAWS3                    ClusterProfile = "aws-3"
 	ClusterProfileAWS4                    ClusterProfile = "aws-4"
 	ClusterProfileAWS5                    ClusterProfile = "aws-5"
+	ClusterProfileOpenshiftOrgAWS         ClusterProfile = "openshift-org-aws"
 	ClusterProfileGCPVirtualization       ClusterProfile = "gcp-virtualization"
 	ClusterProfileAWSVirtualization       ClusterProfile = "aws-virtualization"
 	ClusterProfileAzureVirtualization     ClusterProfile = "azure-virtualization"
@@ -1566,6 +1567,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWS3,
 		ClusterProfileAWS4,
 		ClusterProfileAWS5,
+		ClusterProfileOpenshiftOrgAWS,
 		ClusterProfileAWSC2SQE,
 		ClusterProfileAWSCPaaS,
 		ClusterProfileAWSCSPIQE,
@@ -1779,6 +1781,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWS3,
 		ClusterProfileAWS4,
 		ClusterProfileAWS5,
+		ClusterProfileOpenshiftOrgAWS,
 		ClusterProfileAWSQE,
 		ClusterProfileAWSINTEROPQE,
 		ClusterProfileAWS1QE,
@@ -2368,6 +2371,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-4-quota-slice"
 	case ClusterProfileAWS5:
 		return "aws-5-quota-slice"
+	case ClusterProfileOpenshiftOrgAWS:
+		return "openshift-org-aws-quota-slice"
 	case ClusterProfileOCIAgent:
 		return "oci-agent-qe-quota-slice"
 	case ClusterProfileOCIAssisted:


### PR DESCRIPTION
This adds the first cluster profile set.
Require https://github.com/openshift/ci-tools/pull/4983

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new OpenShift cluster profile for AWS environments, now available as a configuration option for cluster provisioning and lease type management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->