### PR TITLE
prowgen: add sparse checkout for .ci-operator.yaml and Dockerfiles

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -25,7 +25,8 @@ postsubmits:
     - ^branch$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -25,7 +25,8 @@ postsubmits:
     - ^branch$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -27,7 +27,8 @@ postsubmits:
     - ^branch$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: rhel

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -6,7 +6,8 @@ postsubmits:
     - ^branch$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -62,7 +63,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 8h0m0s
     labels:
       ci.openshift.io/generator: prowgen

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -62,7 +63,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/rhel-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: rhel
       ci.openshift.io/generator: prowgen
@@ -64,7 +65,8 @@ presubmits:
     context: ci/prow/rhel-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: rhel
       ci.openshift.io/generator: prowgen

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -62,7 +63,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -1,9 +1,11 @@
 package prowgen
 
 import (
+	"path"
 	"time"
 
-	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
 
@@ -20,22 +22,44 @@ type prowJobBaseBuilder struct {
 	testName string
 }
 
-// If any included buildRoot uses from_repository we must not skip cloning
-func skipCloning(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
-	buildRoots := configSpec.BuildRootImages
-	if buildRoots == nil {
-		buildRoots = make(map[string]cioperatorapi.BuildRootImageConfiguration)
+func fromRepositorySet(configSpec *cioperatorapi.ReleaseBuildConfiguration) bool {
+	if configSpec.BuildRootImage != nil && configSpec.BuildRootImage.FromRepository {
+		return true
 	}
-	if configSpec.BuildRootImage != nil {
-		buildRoots[""] = *configSpec.BuildRootImage
-	}
-	for _, buildRoot := range buildRoots {
+	for _, buildRoot := range configSpec.BuildRootImages {
 		if buildRoot.FromRepository {
-			return false
+			return true
 		}
 	}
+	return false
+}
 
-	return true
+// sparseCheckoutFiles returns the list of files to include in a sparse checkout
+// when the configuration requires cloning. This includes the in-repo ci-operator
+// configuration file and any Dockerfiles that need to be built.
+// Returns an empty slice if no sparse checkout is needed.
+func sparseCheckoutFiles(configSpec *cioperatorapi.ReleaseBuildConfiguration) []string {
+	files := sets.New[string]()
+	if fromRepositorySet(configSpec) {
+		files.Insert(cioperatorapi.CIOperatorInrepoConfigFileName)
+	}
+	for _, image := range configSpec.Images.Items {
+		if image.DockerfileLiteral != nil {
+			continue
+		}
+		if image.Ref != "" {
+			continue
+		}
+		dockerfilePath := image.DockerfilePath
+		if dockerfilePath == "" {
+			dockerfilePath = "Dockerfile"
+		}
+		if image.ContextDir != "" {
+			dockerfilePath = path.Join(image.ContextDir, dockerfilePath)
+		}
+		files.Insert(dockerfilePath)
+	}
+	return sets.List(files)
 }
 
 func hasNoBuilds(c *cioperatorapi.ReleaseBuildConfiguration, info *ProwgenInfo) bool {
@@ -63,7 +87,8 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 			Agent:  string(prowv1.KubernetesAgent),
 			Labels: map[string]string{},
 			UtilityConfig: prowconfig.UtilityConfig{
-				Decorate: utilpointer.Bool(true),
+				Decorate:         ptr.To(true),
+				DecorationConfig: &prowv1.DecorationConfig{},
 			},
 		},
 	}
@@ -71,10 +96,15 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	private := info.Config.Private || (configSpec.Prowgen != nil && configSpec.Prowgen.Private)
 	expose := info.Config.Expose || (configSpec.Prowgen != nil && configSpec.Prowgen.Expose)
 
-	if skipCloning(configSpec) {
-		b.base.UtilityConfig.DecorationConfig = &prowv1.DecorationConfig{SkipCloning: utilpointer.Bool(true)}
-	} else if private {
-		b.base.UtilityConfig.DecorationConfig = &prowv1.DecorationConfig{OauthTokenSecret: &prowv1.OauthTokenSecret{Key: cioperatorapi.OauthTokenSecretKey, Name: cioperatorapi.OauthTokenSecretName}}
+	sparseFiles := sparseCheckoutFiles(configSpec)
+	shouldSkipCloning := len(sparseFiles) == 0
+	if shouldSkipCloning {
+		b.base.UtilityConfig.DecorationConfig.SkipCloning = ptr.To(true)
+	} else {
+		b.base.UtilityConfig.DecorationConfig.SparseCheckoutFiles = sparseFiles
+	}
+	if private {
+		b.base.UtilityConfig.DecorationConfig.OauthTokenSecret = &prowv1.OauthTokenSecret{Key: cioperatorapi.OauthTokenSecretKey, Name: cioperatorapi.OauthTokenSecretName}
 	}
 
 	if len(info.Variant) > 0 {
@@ -93,7 +123,7 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 
 	b.PodSpec.Add(Variant(info.Variant))
 	if private {
-		b.PodSpec.Add(GitHubToken(!skipCloning(configSpec)))
+		b.PodSpec.Add(GitHubToken(!shouldSkipCloning))
 	}
 
 	if configSpec.CanonicalGoRepository != nil {

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -13,6 +13,151 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
+func TestSparseCheckoutFiles(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name     string
+		config   *ciop.ReleaseBuildConfiguration
+		expected []string
+	}{
+		{
+			name:     "no build root and no images: empty",
+			config:   &ciop.ReleaseBuildConfiguration{},
+			expected: nil,
+		},
+		{
+			name: "from_repository set: includes .ci-operator.yaml",
+			config: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+				},
+			},
+			expected: []string{".ci-operator.yaml"},
+		},
+		{
+			name: "from_repository not set: no .ci-operator.yaml",
+			config: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImage: &ciop.BuildRootImageConfiguration{
+						ProjectImageBuild: &ciop.ProjectDirectoryImageBuildInputs{},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "image with default Dockerfile",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+				}},
+			},
+			expected: []string{"Dockerfile"},
+		},
+		{
+			name: "image with custom DockerfilePath",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfilePath: "images/tool.Dockerfile"}},
+				}},
+			},
+			expected: []string{"images/tool.Dockerfile"},
+		},
+		{
+			name: "image with ContextDir and DockerfilePath",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "cmd/tool", DockerfilePath: "build.Dockerfile"}},
+				}},
+			},
+			expected: []string{"cmd/tool/build.Dockerfile"},
+		},
+		{
+			name: "image with ContextDir only: defaults to Dockerfile",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "images/app"}},
+				}},
+			},
+			expected: []string{"images/app/Dockerfile"},
+		},
+		{
+			name: "image with DockerfileLiteral: skipped",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfileLiteral: pointer.StringPtr("FROM scratch")}},
+				}},
+			},
+			expected: nil,
+		},
+		{
+			name: "image with Ref: skipped",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image", Ref: "some-ref"},
+				}},
+			},
+			expected: nil,
+		},
+		{
+			name: "from_repository with multiple images: combines all",
+			config: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+				},
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image-default", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+					{To: "image-custom", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfilePath: "images/tool.Dockerfile"}},
+					{To: "image-ctx", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "images/app"}},
+					{To: "image-inline", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfileLiteral: pointer.StringPtr("FROM scratch")}},
+					{To: "image-ref", Ref: "some-ref"},
+				}},
+			},
+			expected: []string{".ci-operator.yaml", "Dockerfile", "images/app/Dockerfile", "images/tool.Dockerfile"},
+		},
+		{
+			name: "duplicate Dockerfile paths are deduplicated",
+			config: &ciop.ReleaseBuildConfiguration{
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image-1", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+					{To: "image-2", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+					{To: "image-3", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "cmd/app"}},
+					{To: "image-4", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "cmd/app"}},
+				}},
+			},
+			expected: []string{"Dockerfile", "cmd/app/Dockerfile"},
+		},
+		{
+			name: "BuildRootImages map with from_repository",
+			config: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImages: map[string]ciop.BuildRootImageConfiguration{
+						"go-1.21": {FromRepository: true},
+					},
+				},
+			},
+			expected: []string{".ci-operator.yaml"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := sparseCheckoutFiles(tc.config)
+			if len(tc.expected) == 0 && len(result) == 0 {
+				return
+			}
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, result)
+			}
+			for i := range tc.expected {
+				if result[i] != tc.expected[i] {
+					t.Errorf("index %d: expected %q, got %q", i, tc.expected[i], result[i])
+				}
+			}
+		})
+	}
+}
+
 func TestProwJobBaseBuilder(t *testing.T) {
 	defaultInfo := &ProwgenInfo{
 		Metadata: ciop.Metadata{
@@ -184,6 +329,31 @@ func TestProwJobBaseBuilder(t *testing.T) {
 			prowgenOverrides: &ciop.ProwgenOverrides{Private: true, Expose: true},
 			prefix:           "default",
 			podSpecBuilder:   NewCiOperatorPodSpecGenerator(),
+		},
+		{
+			name:   "job with from_repository build root: has sparse checkout with .ci-operator.yaml",
+			info:   defaultInfo,
+			prefix: "default",
+			inputs: ciop.InputConfiguration{
+				BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+			},
+			podSpecBuilder: newFakePodSpecBuilder(),
+		},
+		{
+			name:   "job with from_repository build root and images: adds dockerfiles to sparse checkout",
+			info:   defaultInfo,
+			prefix: "default",
+			inputs: ciop.InputConfiguration{
+				BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+			},
+			images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+				{To: "image-default", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+				{To: "image-custom-df", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfilePath: "images/tool.Dockerfile"}},
+				{To: "image-with-ctx", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "cmd/tool", DockerfilePath: "build.Dockerfile"}},
+				{To: "image-ctx-only", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "images/app"}},
+				{To: "image-inline", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{DockerfileLiteral: pointer.StringPtr("FROM scratch")}},
+			}},
+			podSpecBuilder: newFakePodSpecBuilder(),
 		},
 	}
 

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -422,6 +422,9 @@ func GeneratePeriodicForTest(jobBaseBuilder *prowJobBaseBuilder, info *ProwgenIn
 	if opts.PathAlias != nil {
 		ref.PathAlias = *opts.PathAlias
 	}
+	if dc := base.UtilityConfig.DecorationConfig; dc != nil && len(dc.SparseCheckoutFiles) > 0 {
+		ref.SparseCheckoutFiles = dc.SparseCheckoutFiles
+	}
 	base.ExtraRefs = append([]prowv1.Refs{ref}, base.ExtraRefs...)
 	if opts.ReleaseController {
 		opts.Interval = ""

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -262,6 +262,7 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 
 		test           string
 		repoInfo       *ProwgenInfo
+		configSpec     *ciop.ReleaseBuildConfiguration
 		jobRelease     string
 		clone          bool
 		generateOption GeneratePeriodicOption
@@ -334,6 +335,36 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 				options.MaxConcurrency = 3
 			},
 		},
+		{
+			description: "periodic with from_repository build root: ExtraRefs has sparse checkout files",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			configSpec: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+				},
+			},
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+			},
+		},
+		{
+			description: "periodic with from_repository build root and images: ExtraRefs has sparse checkout files with dockerfiles",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			configSpec: &ciop.ReleaseBuildConfiguration{
+				InputConfiguration: ciop.InputConfiguration{
+					BuildRootImage: &ciop.BuildRootImageConfiguration{FromRepository: true},
+				},
+				Images: ciop.ImageConfiguration{Items: []ciop.ProjectDirectoryImageBuildStepConfiguration{
+					{To: "image-default", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{}},
+					{To: "image-with-ctx", ProjectDirectoryImageBuildInputs: ciop.ProjectDirectoryImageBuildInputs{ContextDir: "images/app"}},
+				}},
+			},
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
@@ -341,8 +372,12 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			if generateOption == nil {
 				generateOption = func(options *GeneratePeriodicOptions) {}
 			}
+			configSpec := tc.configSpec
+			if configSpec == nil {
+				configSpec = &ciop.ReleaseBuildConfiguration{}
+			}
 			test := ciop.TestStepConfiguration{As: tc.test}
-			jobBaseGen := NewProwJobBaseBuilderForTest(&ciop.ReleaseBuildConfiguration{}, tc.repoInfo, newFakePodSpecBuilder(), test)
+			jobBaseGen := NewProwJobBaseBuilderForTest(configSpec, tc.repoInfo, newFakePodSpecBuilder(), test)
 			testhelper.CompareWithFixture(t, GeneratePeriodicForTest(jobBaseGen, tc.repoInfo, generateOption))
 		})
 	}

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
@@ -1,5 +1,8 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
@@ -1,6 +1,9 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -6,7 +6,8 @@ postsubmits:
     - ^branch$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
     max_concurrency: 1
@@ -69,7 +70,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_promotion_postsubmit_and_periodic_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_promotion_postsubmit_and_periodic_.yaml
@@ -3,11 +3,14 @@ periodics:
   cron: 5 4 * * *
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: branch
     org: organization
     repo: repository
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci-operator.openshift.io/is-promotion: "true"
   max_concurrency: 1

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_from_repository_build_root__ExtraRefs_has_sparse_checkout_files.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_from_repository_build_root__ExtraRefs_has_sparse_checkout_files.yaml
@@ -1,0 +1,15 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  sparse_checkout_files:
+  - .ci-operator.yaml
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+  sparse_checkout_files:
+  - .ci-operator.yaml
+labels:
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_from_repository_build_root_and_images__ExtraRefs_has_sparse_checkout_files_with_dockerfiles.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_from_repository_build_root_and_images__ExtraRefs_has_sparse_checkout_files_with_dockerfiles.yaml
@@ -1,0 +1,19 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  sparse_checkout_files:
+  - .ci-operator.yaml
+  - Dockerfile
+  - images/app/Dockerfile
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+  sparse_checkout_files:
+  - .ci-operator.yaml
+  - Dockerfile
+  - images/app/Dockerfile
+labels:
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
@@ -1,6 +1,8 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  sparse_checkout_files:
+  - .ci-operator.yaml
   timeout: 1s
 name: prefix-ci-o-r-b-simple
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_from_repository_build_root__has_sparse_checkout_with_.ci_operator.yaml.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_from_repository_build_root__has_sparse_checkout_with_.ci_operator.yaml.yaml
@@ -2,5 +2,5 @@ agent: kubernetes
 decorate: true
 decoration_config:
   sparse_checkout_files:
-  - Dockerfile
-name: default-ci-openshift-release-main-
+  - .ci-operator.yaml
+name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_from_repository_build_root_and_images__adds_dockerfiles_to_sparse_checkout.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_from_repository_build_root_and_images__adds_dockerfiles_to_sparse_checkout.yaml
@@ -1,0 +1,10 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  sparse_checkout_files:
+  - .ci-operator.yaml
+  - Dockerfile
+  - cmd/tool/build.Dockerfile
+  - images/app/Dockerfile
+  - images/tool.Dockerfile
+name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
@@ -1,6 +1,9 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: default-ci-vorg-vrepo-vbranch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
@@ -4,6 +4,8 @@ decoration_config:
   oauth_token_secret:
     key: oauth
     name: github-credentials-openshift-ci-robot-private-git-cloner
+  sparse_checkout_files:
+  - .ci-operator.yaml
 hidden: true
 name: default-ci-vorg-vrepo-vbranch-
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
@@ -1,6 +1,9 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 name: default-ci-vorg-vrepo-vbranch-
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
@@ -1,6 +1,9 @@
 agent: kubernetes
 decorate: true
 decoration_config:
+  oauth_token_secret:
+    key: oauth
+    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: default-ci-vorg-vrepo-vbranch-

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -8,6 +8,9 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
       skip_cloning: true
     hidden: true
     labels:

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
@@ -11,6 +11,8 @@ presubmits:
       oauth_token_secret:
         key: oauth
         name: github-credentials-openshift-ci-robot-private-git-cloner
+      sparse_checkout_files:
+      - .ci-operator.yaml
     hidden: true
     labels:
       ci.openshift.io/generator: prowgen

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -3,11 +3,17 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    oauth_token_secret:
+      key: oauth
+      name: github-credentials-openshift-ci-robot-private-git-cloner
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: private
     repo: duper
+    sparse_checkout_files:
+    - Dockerfile
   hidden: true
   labels:
     ci.openshift.io/generator: prowgen
@@ -55,9 +61,6 @@ periodics:
         readOnly: true
     serviceAccountName: ci-operator
     volumes:
-    - name: github-credentials-openshift-ci-robot-private-git-cloner
-      secret:
-        secretName: github-credentials-openshift-ci-robot-private-git-cloner
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -6,7 +6,11 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+      sparse_checkout_files:
+      - Dockerfile
     hidden: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
@@ -52,9 +56,6 @@ postsubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -8,7 +8,11 @@ presubmits:
     context: ci/prow/e2e
     decorate: true
     decoration_config:
-      skip_cloning: true
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+      sparse_checkout_files:
+      - Dockerfile
     hidden: true
     labels:
       ci.openshift.io/generator: prowgen
@@ -57,9 +61,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -78,7 +79,11 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+      sparse_checkout_files:
+      - Dockerfile
     hidden: true
     labels:
       ci.openshift.io/generator: prowgen
@@ -120,9 +125,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
@@ -141,7 +143,11 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      oauth_token_secret:
+        key: oauth
+        name: github-credentials-openshift-ci-robot-private-git-cloner
+      sparse_checkout_files:
+      - Dockerfile
     hidden: true
     labels:
       ci.openshift.io/generator: prowgen
@@ -190,9 +196,6 @@ presubmits:
           readOnly: true
       serviceAccountName: ci-operator
       volumes:
-      - name: github-credentials-openshift-ci-robot-private-git-cloner
-        secret:
-          secretName: github-credentials-openshift-ci-robot-private-git-cloner
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -3,11 +3,14 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: duper
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -62,11 +65,14 @@ periodics:
 - agent: kubernetes
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: duper
+    sparse_checkout_files:
+    - Dockerfile
   interval: 24h
   labels:
     ci.openshift.io/generator: prowgen
@@ -123,11 +129,14 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: duper
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -183,11 +192,14 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: duper
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci-operator.openshift.io/release-controller: "true"
     ci.openshift.io/generator: prowgen

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -6,7 +6,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
@@ -65,7 +66,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-build-affected
@@ -126,7 +128,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-changed
@@ -187,7 +190,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-pipeline-changed
@@ -248,7 +252,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-skip-docs
@@ -316,7 +321,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
     max_concurrency: 6
@@ -374,7 +380,8 @@ postsubmits:
     - ^master$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: variant

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/ci-index
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -62,7 +63,8 @@ presubmits:
     context: ci/prow/ci-index-my-bundle
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -117,7 +119,8 @@ presubmits:
     context: ci/prow/e2e
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -179,7 +182,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -236,7 +240,8 @@ presubmits:
     context: ci/prow/images-build-affected-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
@@ -293,7 +298,8 @@ presubmits:
     context: ci/prow/images-build-affected-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
@@ -357,7 +363,8 @@ presubmits:
     context: ci/prow/images-changed-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-changed
       ci.openshift.io/generator: prowgen
@@ -415,7 +422,8 @@ presubmits:
     context: ci/prow/images-changed-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-changed
       ci.openshift.io/generator: prowgen
@@ -481,7 +489,8 @@ presubmits:
     context: ci/prow/images-pipeline-changed-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-pipeline-changed
       ci.openshift.io/generator: prowgen
@@ -538,7 +547,8 @@ presubmits:
     context: ci/prow/images-pipeline-changed-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-pipeline-changed
       ci.openshift.io/generator: prowgen
@@ -602,7 +612,8 @@ presubmits:
     context: ci/prow/images-skip-docs-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-skip-docs
       ci.openshift.io/generator: prowgen
@@ -660,7 +671,8 @@ presubmits:
     context: ci/prow/images-skip-docs-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: images-skip-docs
       ci.openshift.io/generator: prowgen
@@ -734,7 +746,8 @@ presubmits:
     context: ci/prow/lint
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -796,7 +809,8 @@ presubmits:
     context: ci/prow/optional-job
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
@@ -871,7 +885,8 @@ presubmits:
     context: ci/prow/registry
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -943,7 +958,8 @@ presubmits:
     context: ci/prow/registry-with-profile
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
@@ -1017,7 +1033,8 @@ presubmits:
     context: ci/prow/steps
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1089,7 +1106,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -1151,7 +1169,8 @@ presubmits:
     context: ci/prow/variant-images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: variant
       ci.openshift.io/generator: prowgen
@@ -1209,7 +1228,8 @@ presubmits:
     context: ci/prow/variant-unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/variant: variant
       ci.openshift.io/generator: prowgen

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -6,7 +6,8 @@ postsubmits:
     - ^release-3\.11$
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -73,7 +74,8 @@ presubmits:
     context: ci/prow/lint
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -135,7 +137,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-4.19-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-4.19-periodics.yaml
@@ -2,10 +2,15 @@ periodics:
 - agent: kubernetes
   cron: 47 3 * * *
   decorate: true
+  decoration_config:
+    sparse_checkout_files:
+    - .ci-operator.yaml
   extra_refs:
   - base_ref: release-4.19
     org: super
     repo: duper
+    sparse_checkout_files:
+    - .ci-operator.yaml
   labels:
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -41,7 +41,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -83,7 +83,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -49,11 +49,14 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: trooper
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -82,7 +82,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -165,7 +166,8 @@ presubmits:
     context: ci/prow/multistage
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -237,7 +239,8 @@ presubmits:
     context: ci/prow/multistage2
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -309,7 +312,8 @@ presubmits:
     context: ci/prow/multistage3
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: azure4
@@ -383,7 +387,8 @@ presubmits:
     context: ci/prow/multistage4
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -455,7 +460,8 @@ presubmits:
     context: ci/prow/multistage5
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -527,7 +533,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -483,7 +483,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -494,6 +495,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-periodic-ci-super-trooper-master-changed-periodic
     namespace: test-namespace
@@ -567,6 +570,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse periodic-ci-super-trooper-master-changed-periodic
     type: presubmit
@@ -700,7 +705,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -711,6 +717,8 @@
     - base_ref: ciop-cfg-change
       org: super
       repo: duper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
     namespace: test-namespace
@@ -767,6 +775,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-duper-ciop-cfg-change-images
     type: presubmit
@@ -1098,7 +1108,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -1109,6 +1120,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-trooper-master-multistage
     namespace: test-namespace
@@ -1182,6 +1195,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage
     type: presubmit
@@ -1225,7 +1240,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -1236,6 +1252,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-trooper-master-multistage2
     namespace: test-namespace
@@ -1309,6 +1327,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage2
     type: presubmit
@@ -1354,7 +1374,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -1365,6 +1386,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-trooper-master-multistage3
     namespace: test-namespace
@@ -1438,6 +1461,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage3
     type: presubmit
@@ -1481,7 +1506,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -1492,6 +1518,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-trooper-master-multistage5
     namespace: test-namespace
@@ -1565,6 +1593,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-trooper-master-multistage5
     type: presubmit
@@ -1608,7 +1638,8 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -1619,6 +1650,8 @@
     - base_ref: master
       org: super
       repo: trooper
+      sparse_checkout_files:
+      - Dockerfile
       workdir: true
     job: rehearse-1234-pull-ci-super-trooper-master-unit
     namespace: test-namespace
@@ -1682,6 +1715,8 @@
         number: 1234
         sha: test_sha
       repo: release
+      sparse_checkout_files:
+      - Dockerfile
     report: true
     rerun_command: /pj-rehearse pull-ci-super-trooper-master-unit
     type: presubmit

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -41,7 +41,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -8,7 +8,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -78,7 +78,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -48,11 +48,14 @@ periodics:
   cron: '@yearly'
   decorate: true
   decoration_config:
-    skip_cloning: true
+    sparse_checkout_files:
+    - Dockerfile
   extra_refs:
   - base_ref: master
     org: super
     repo: trooper
+    sparse_checkout_files:
+    - Dockerfile
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -82,7 +82,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -165,7 +166,8 @@ presubmits:
     context: ci/prow/multistage
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -237,7 +239,8 @@ presubmits:
     context: ci/prow/multistage2
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -309,7 +312,8 @@ presubmits:
     context: ci/prow/multistage3
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci-operator.openshift.io/cloud: azure4
       ci-operator.openshift.io/cloud-cluster-profile: azure4
@@ -383,7 +387,8 @@ presubmits:
     context: ci/prow/multistage4
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -455,7 +460,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -7,7 +7,8 @@ postsubmits:
     cluster: api.ci
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/blocking-issue-creator/Dockerfile
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/blocking-issue-creator/Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -64,7 +65,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/blocking-issue-creator/Dockerfile
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
@@ -7,7 +7,8 @@ postsubmits:
     cluster: api.ci
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/tests/Dockerfile.rhel
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -9,7 +9,8 @@ presubmits:
     context: ci/prow/images
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/tests/Dockerfile.rhel
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
@@ -66,7 +67,8 @@ presubmits:
     context: ci/prow/unit
     decorate: true
     decoration_config:
-      skip_cloning: true
+      sparse_checkout_files:
+      - images/tests/Dockerfile.rhel
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"


### PR DESCRIPTION
## Summary
- Adds sparse checkout support to prowgen-generated jobs, reducing clone size by only fetching files that ci-operator actually needs
- When `from_repository` is set, `.ci-operator.yaml` is included in the sparse checkout
- Dockerfiles from the `images` stanza are included (with deduplication), respecting `context_dir` and `dockerfile_path`
- Images using `dockerfile_literal` or `ref` are skipped (no file to clone)
- Uses `DecorationConfig.SparseCheckoutFiles` which prow applies to the primary ref for presubmits/postsubmits


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replace blanket skip-cloning with sparse-checkout: only required files (Dockerfiles, .ci-operator.yaml) are fetched, with path derivation, ordering preservation and deduplication to minimize checkouts. Private-job decoration now retains token configuration while relying on sparse-checkout emptiness to decide cloning behavior.

* **Tests**
  * Added unit tests and many updated fixtures validating sparse-checkout generation across build roots, image inputs, private jobs, and periodic job scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->