### PR TITLE
Fix Cluster Profile Secret Name when Running Payload Tests

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -8,15 +9,19 @@ import (
 // LeasesForTest aggregates all the lease configurations in a test.
 // It is assumed that they have been validated and contain only valid and
 // unique values.
-func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
+func LeasesForTest(test *TestStepConfiguration, targetAdditionalSuffix string) (ret []StepLease) {
 	multiStageTest := test.MultiStageTestConfigurationLiteral
 	if p := multiStageTest.ClusterProfile; p != "" {
+		clusterProfileTarget := test.As
+		if targetAdditionalSuffix != "" {
+			clusterProfileTarget = strings.TrimSuffix(clusterProfileTarget, fmt.Sprintf("-%s", targetAdditionalSuffix))
+		}
 		ret = append(ret, StepLease{
 			ResourceType:         p.LeaseType(),
 			Env:                  DefaultLeaseEnv,
 			Count:                1,
 			ClusterProfile:       multiStageTest.ClusterProfile.Name(),
-			ClusterProfileTarget: test.As,
+			ClusterProfileTarget: clusterProfileTarget,
 		})
 	}
 	for _, step := range append(multiStageTest.Pre, append(multiStageTest.Test, multiStageTest.Post...)...) {

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -8,9 +8,10 @@ import (
 
 func TestLeasesForTest(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		tests    TestStepConfiguration
-		expected []StepLease
+		name                   string
+		tests                  TestStepConfiguration
+		targetAdditionalSuffix string
+		expected               []StepLease
 	}{{
 		name:  "no configuration or cluster profile, no lease",
 		tests: TestStepConfiguration{MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{}},
@@ -26,6 +27,22 @@ func TestLeasesForTest(t *testing.T) {
 			Env:            DefaultLeaseEnv,
 			Count:          1,
 			ClusterProfile: string(ClusterProfileAWS),
+		}},
+	}, {
+		name: "cluster profile target trim suffix",
+		tests: TestStepConfiguration{
+			As: "e2e-6",
+			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
+				ClusterProfile: ClusterProfileAWS,
+			},
+		},
+		targetAdditionalSuffix: "6",
+		expected: []StepLease{{
+			ResourceType:         "aws-quota-slice",
+			Env:                  DefaultLeaseEnv,
+			Count:                1,
+			ClusterProfile:       string(ClusterProfileAWS),
+			ClusterProfileTarget: "e2e",
 		}},
 	}, {
 		name: "explicit configuration, lease",
@@ -47,7 +64,7 @@ func TestLeasesForTest(t *testing.T) {
 		expected: []StepLease{{ResourceType: "aws-quota-slice"}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := LeasesForTest(&tc.tests)
+			ret := LeasesForTest(&tc.tests, tc.targetAdditionalSuffix)
 			if diff := cmp.Diff(tc.expected, ret); diff != "" {
 				t.Errorf("incorrect leases, diff: %s", diff)
 			}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -397,7 +397,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 ) ([]api.Step, error) {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		params := cfg.params
-		leases := api.LeasesForTest(c)
+		leases := api.LeasesForTest(c, cfg.TargetAdditionalSuffix)
 		ipPoolLease := api.IPPoolLeaseForTest(test, cfg.CIConfig.Metadata)
 		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
 			params = api.NewDeferredParameters(params)

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -232,7 +232,7 @@ func testContainsLease(test *cioperatorapi.TestStepConfiguration) bool {
 		return false
 	}
 
-	return len(cioperatorapi.LeasesForTest(test)) > 0
+	return len(cioperatorapi.LeasesForTest(test, "")) > 0
 }
 
 type generatePresubmitOptions struct {


### PR DESCRIPTION
Payload tests issued by the command `/payload` creates a `ci-operator` configuration with a test injected into it. The following, additional flags are passed (as an example):
```
--target-additional-suffix=6
--with-test-from=openshift/hypershift@release-4.22__periodics:e2e-aws-ovn-conformance
```
The `ci-operator` appeds the suffix `6` to its `target`, therefore:
```
--target=e2e-aws-ovn-conformance
```
becomes:
```
--target=e2e-aws-ovn-conformance-6
```
The `leaseStep` takes the test name as it is, suffix included, and then it creates the cluster profile secret `e2e-aws-ovn-conformance-6-cluster-profile` into the `ci-op-xxxx` test namespace.
On the other hand, the `multiStageTestStep` step looks for `e2e-aws-ovn-conformance-cluster-profile`, which wasn't never created, therefore failing badly.

[Here](https://search.dptools.openshift.org/?search=could+not+get+cluster+profile+secret+&maxAge=6h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) several errors we have hit so far.

This PR is an attempt to address this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Updated `LeasesForTest` method signature to support configurable cluster profile target suffix handling, enabling more flexible lease computation.

* **Tests**
  * Added test coverage for cluster profile target suffix trimming functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->