### PR TITLE
ci-images-mirror: Dump Name and Version

### DIFF
--- a/cmd/ci-images-mirror/main.go
+++ b/cmd/ci-images-mirror/main.go
@@ -238,6 +238,7 @@ func main() {
 	logrusutil.ComponentInit()
 	controllerruntime.SetLogger(logrusr.New(logrus.StandardLogger()))
 	logrus.SetLevel(logrus.TraceLevel)
+	logrus.Infof("%s version %s", version.Name, version.Version)
 	opts := newOpts()
 	if err := opts.validate(); err != nil {
 		logrus.WithError(err).Fatal("Failed to validate options")


### PR DESCRIPTION
We suspect that the test `pull-ci-openshift-release-ci-image-mirroring-config-validation` isn't running the latest version of this tool despite the fact it is pulling the `latest` tag `quay-proxy.ci.openshift.org/openshift/ci:ci_ci-images-mirror_latest`.

As of today, this is causing the following error:
```
invalid ci-operator config: invalid configuration: tests[0]: invalid cluster profile \"openshift-org-azure\"","file":"/go/src/github.com/openshift/ci-tools/pkg/config/load.go:368
```
But the `openshift-org-azure` profile has been already merged in https://github.com/openshift/ci-tools/pull/5000, few days ago.

The `version` variable is defined [here](https://github.com/openshift/ci-tools/blob/e37f16d03d744254b377e8f75afea0176952a30d/hack/install.sh#L23) and it gets wired into the code at linking time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced startup logging to display application name and version information on launch, providing better visibility into the running version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->