### PR TITLE
ci-operator: Make lease proxy client script always available

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -403,7 +403,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 			params = api.NewDeferredParameters(params)
 		}
 		var ret []api.Step
-		step := multi_stage.MultiStageTestStep(*c, cfg.CIConfig, params, cfg.podClient, cfg.JobSpec, leases, cfg.NodeName, cfg.TargetAdditionalSuffix, nil, cfg.GSMConfig != nil, cfg.GSMConfig, isLeaseProxyServerAvailable(cfg))
+		step := multi_stage.MultiStageTestStep(*c, cfg.CIConfig, params, cfg.podClient, cfg.JobSpec, leases, cfg.NodeName, cfg.TargetAdditionalSuffix, nil, cfg.GSMConfig != nil, cfg.GSMConfig, isLeaseProxyServerAvailable(cfg), retry.DefaultRetry)
 		if ipPoolLease.ResourceType != "" {
 			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, ipPoolLease, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent)
 		}
@@ -1253,7 +1253,6 @@ func leaseProxyServerStep(cfg *Config) []api.Step {
 	}
 
 	logger := logrus.NewEntry(logrus.StandardLogger()).WithField("step", "lease-proxy-server")
-	step := steps.LeaseProxyStep(logger, cfg.HTTPServerAddr, cfg.HTTPServerMux, cfg.LeaseClient,
-		cfg.kubeClient, cfg.JobSpec, retry.DefaultRetry)
+	step := steps.LeaseProxyStep(logger, cfg.HTTPServerAddr, cfg.HTTPServerMux, cfg.LeaseClient)
 	return append(ret, step)
 }

--- a/pkg/steps/lease_proxy.go
+++ b/pkg/steps/lease_proxy.go
@@ -3,19 +3,10 @@ package steps
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -29,13 +20,10 @@ var (
 )
 
 type stepLeaseProxyServer struct {
-	logger                 *logrus.Entry
-	srvMux                 *http.ServeMux
-	srvAddr                string
-	leaseClient            *lease.Client
-	kubeClient             ctrlruntimeclient.Client
-	jobSpec                *api.JobSpec
-	scriptConfigMapBackoff wait.Backoff
+	logger      *logrus.Entry
+	srvMux      *http.ServeMux
+	srvAddr     string
+	leaseClient *lease.Client
 }
 
 func (s *stepLeaseProxyServer) Inputs() (api.InputDefinition, error) {
@@ -68,12 +56,6 @@ func (s *stepLeaseProxyServer) Validate() error {
 	if s.srvAddr == "" {
 		return errors.New("lease proxy server requires an HTTP server address")
 	}
-	if s.kubeClient == nil {
-		return errors.New("lease proxy server requires a kube client")
-	}
-	if s.jobSpec == nil {
-		return errors.New("lease proxy server requires a job spec")
-	}
 	return nil
 }
 
@@ -82,98 +64,17 @@ func (s *stepLeaseProxyServer) Run(ctx context.Context) error {
 }
 
 //nolint:unparam // Remove this as soon as this functions can return an error as well.
-func (s *stepLeaseProxyServer) run(ctx context.Context) error {
+func (s *stepLeaseProxyServer) run(context.Context) error {
 	proxy := leaseproxy.New(s.logger, func() lease.Client { return *s.leaseClient })
 	proxy.RegisterHandlers(s.srvMux)
-
-	if err := s.EnsureScriptConfigMap(ctx,
-		ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: api.LeaseProxyConfigMapName},
-		ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: api.LeaseProxyConfigMapName}); err != nil {
-		return fmt.Errorf("copy lease proxy scripts into ns %s: %w", s.jobSpec.Namespace(), err)
-	}
-
 	return nil
 }
 
-// EnsureScriptConfigMap copies the lease proxy scripts ConfigMap from src to dst.
-// If the destination ConfigMap exists and differs from the source, it is overwritten.
-func (s *stepLeaseProxyServer) EnsureScriptConfigMap(ctx context.Context, src, dst ctrlruntimeclient.ObjectKey) error {
-	// We have a retry in place here because multiple ci-operator instances might be executing
-	// this code simultaneously.
-	type mustRetryErr struct{ error }
-	return retry.OnError(s.scriptConfigMapBackoff,
-		func(err error) bool {
-			_, ok := err.(*mustRetryErr)
-			return ok
-		},
-		func() error {
-			srcCM := &corev1.ConfigMap{}
-			if err := s.kubeClient.Get(ctx, src, srcCM); err != nil {
-				return fmt.Errorf("get configmap %s/%s: %w", src.Namespace, src.Name, err)
-			}
-
-			dstCM := &corev1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      dst.Name,
-					Namespace: dst.Namespace,
-				},
-				Immutable:  ptr.To(true),
-				Data:       srcCM.Data,
-				BinaryData: srcCM.BinaryData,
-			}
-
-			err := s.kubeClient.Create(ctx, dstCM)
-			if err == nil {
-				return nil
-			}
-
-			if !kerrors.IsAlreadyExists(err) {
-				return fmt.Errorf("create configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
-			}
-
-			existingCM := &corev1.ConfigMap{}
-			if err := s.kubeClient.Get(ctx, types.NamespacedName{Namespace: dstCM.Namespace, Name: dstCM.Name}, existingCM); err != nil {
-				e := fmt.Errorf("get existing configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
-				if kerrors.IsNotFound(err) {
-					return &mustRetryErr{e}
-				}
-				return e
-			}
-
-			if equality.Semantic.DeepEqual(dstCM.Data, existingCM.Data) &&
-				equality.Semantic.DeepEqual(dstCM.BinaryData, existingCM.BinaryData) {
-				return nil
-			}
-
-			if err := s.kubeClient.Delete(ctx, existingCM); err != nil {
-				e := fmt.Errorf("delete existing configmap %s/%s: %w", existingCM.Namespace, existingCM.Name, err)
-				if kerrors.IsNotFound(err) {
-					return &mustRetryErr{e}
-				}
-				return e
-			}
-
-			if err := s.kubeClient.Create(ctx, dstCM); err != nil {
-				e := fmt.Errorf("create configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
-				if kerrors.IsAlreadyExists(err) {
-					return &mustRetryErr{e}
-				}
-				return e
-			}
-
-			return nil
-		})
-}
-
-func LeaseProxyStep(logger *logrus.Entry, srvAddr string, srvMux *http.ServeMux, leaseClient *lease.Client,
-	kubeClient ctrlruntimeclient.Client, jobSpec *api.JobSpec, scriptConfigMapBackoff wait.Backoff) api.Step {
+func LeaseProxyStep(logger *logrus.Entry, srvAddr string, srvMux *http.ServeMux, leaseClient *lease.Client) api.Step {
 	return &stepLeaseProxyServer{
-		logger:                 logger,
-		srvMux:                 srvMux,
-		srvAddr:                srvAddr,
-		leaseClient:            leaseClient,
-		kubeClient:             kubeClient,
-		jobSpec:                jobSpec,
-		scriptConfigMapBackoff: scriptConfigMapBackoff,
+		logger:      logger,
+		srvMux:      srvMux,
+		srvAddr:     srvAddr,
+		leaseClient: leaseClient,
 	}
 }

--- a/pkg/steps/lease_proxy_test.go
+++ b/pkg/steps/lease_proxy_test.go
@@ -1,26 +1,12 @@
 package steps
 
 import (
-	"context"
 	"errors"
 	"net/http"
-	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
-
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/ptr"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/lease"
@@ -47,7 +33,7 @@ func TestLeaseProxyProvides(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			step := LeaseProxyStep(logrus.NewEntry(&logrus.Logger{}), tc.httpSrvAddr, &http.ServeMux{}, nil, nil, nil, wait.Backoff{})
+			step := LeaseProxyStep(logrus.NewEntry(&logrus.Logger{}), tc.httpSrvAddr, &http.ServeMux{}, nil)
 
 			gotParams := make(map[string]string)
 			for k, f := range step.Provides() {
@@ -77,15 +63,13 @@ func TestValidate(t *testing.T) {
 			name: "Validation passes",
 			newLeaseProxyStepFunc: func() api.Step {
 				leaseClient := lease.NewFakeClient("owner", "", 1, nil, nil, nil)
-				kubeClient := fakectrlruntimeclient.NewFakeClient()
-				return LeaseProxyStep(nil, "x.y.w.z", &http.ServeMux{}, &leaseClient, kubeClient, &api.JobSpec{}, wait.Backoff{})
+				return LeaseProxyStep(nil, "x.y.w.z", &http.ServeMux{}, &leaseClient)
 			},
 		},
 		{
 			name: "http mux is missing",
 			newLeaseProxyStepFunc: func() api.Step {
-				kubeClient := fakectrlruntimeclient.NewFakeClient()
-				return LeaseProxyStep(nil, "x.y.w.z", nil, nil, kubeClient, &api.JobSpec{}, wait.Backoff{})
+				return LeaseProxyStep(nil, "x.y.w.z", nil, nil)
 			},
 			wantErr: errors.New("lease proxy server requires an HTTP server mux"),
 		},
@@ -93,25 +77,9 @@ func TestValidate(t *testing.T) {
 			name: "http address is empty",
 			newLeaseProxyStepFunc: func() api.Step {
 				leaseClient := lease.NewFakeClient("owner", "", 1, nil, nil, nil)
-				kubeClient := fakectrlruntimeclient.NewFakeClient()
-				return LeaseProxyStep(nil, "", &http.ServeMux{}, &leaseClient, kubeClient, &api.JobSpec{}, wait.Backoff{})
+				return LeaseProxyStep(nil, "", &http.ServeMux{}, &leaseClient)
 			},
 			wantErr: errors.New("lease proxy server requires an HTTP server address"),
-		},
-		{
-			name: "kube client is nil",
-			newLeaseProxyStepFunc: func() api.Step {
-				return LeaseProxyStep(nil, "x.y.w.z", &http.ServeMux{}, nil, nil, &api.JobSpec{}, wait.Backoff{})
-			},
-			wantErr: errors.New("lease proxy server requires a kube client"),
-		},
-		{
-			name: "job spec is nil",
-			newLeaseProxyStepFunc: func() api.Step {
-				kubeClient := fakectrlruntimeclient.NewFakeClient()
-				return LeaseProxyStep(nil, "x.y.w.z", &http.ServeMux{}, nil, kubeClient, nil, wait.Backoff{})
-			},
-			wantErr: errors.New("lease proxy server requires a job spec"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -120,216 +88,6 @@ func TestValidate(t *testing.T) {
 			gotErr := tc.newLeaseProxyStepFunc().Validate()
 
 			cmpError(t, tc.wantErr, gotErr)
-		})
-	}
-}
-
-func TestEnsureScriptConfigMap(t *testing.T) {
-	t.Parallel()
-
-	scheme := runtime.NewScheme()
-	sb := runtime.NewSchemeBuilder(corev1.AddToScheme)
-	if err := sb.AddToScheme(scheme); err != nil {
-		t.Fatalf("add to scheme: %s", err)
-	}
-
-	for _, tc := range []struct {
-		name             string
-		src              types.NamespacedName
-		dst              types.NamespacedName
-		objects          []ctrlruntimeclient.Object
-		interceptorsFunc func() interceptor.Funcs
-		wantErr          error
-		wantConfigMaps   []corev1.ConfigMap
-	}{
-		{
-			name: "Create configmap from scratch",
-			src:  types.NamespacedName{Namespace: "ci", Name: "lease-proxy"},
-			dst:  types.NamespacedName{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-			objects: []ctrlruntimeclient.Object{&corev1.ConfigMap{
-				ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
-				Data:       map[string]string{"foo": "bar"},
-			}},
-			wantConfigMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy", ResourceVersion: "1"},
-					Data:       map[string]string{"foo": "bar"},
-					Immutable:  ptr.To(true),
-				},
-			},
-		},
-		{
-			name: "Update stale configmap",
-			src:  types.NamespacedName{Namespace: "ci", Name: "lease-proxy"},
-			dst:  types.NamespacedName{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-			objects: []ctrlruntimeclient.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-			},
-			wantConfigMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy", ResourceVersion: "1"},
-					Data:       map[string]string{"super": "duper"},
-					Immutable:  ptr.To(true),
-				},
-			},
-		},
-		{
-			name: "Retry on deletion failure",
-			src:  types.NamespacedName{Namespace: "ci", Name: "lease-proxy"},
-			dst:  types.NamespacedName{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-			objects: []ctrlruntimeclient.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-			},
-			interceptorsFunc: func() interceptor.Funcs {
-				deleted := atomic.Bool{}
-				return interceptor.Funcs{
-					Delete: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteOption) error {
-						if _, ok := obj.(*corev1.ConfigMap); ok && deleted.CompareAndSwap(false, true) {
-							return &apierrors.StatusError{ErrStatus: v1.Status{Reason: v1.StatusReasonNotFound}}
-						}
-						return client.Delete(ctx, obj, opts...)
-					},
-				}
-			},
-			wantConfigMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy", ResourceVersion: "1"},
-					Data:       map[string]string{"super": "duper"},
-					Immutable:  ptr.To(true),
-				},
-			},
-		},
-		{
-			name: "Retry when it fails to create the up-to-date configmap",
-			src:  types.NamespacedName{Namespace: "ci", Name: "lease-proxy"},
-			dst:  types.NamespacedName{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-			objects: []ctrlruntimeclient.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-			},
-			interceptorsFunc: func() interceptor.Funcs {
-				createCount := atomic.Int32{}
-				return interceptor.Funcs{
-					Create: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
-						// Fail when `create` is called for the second time. This means the stale configmap
-						// has been deleted and the new one, with the up-to-date content, is about to be created.
-						if _, ok := obj.(*corev1.ConfigMap); ok && createCount.Add(1) == 2 {
-							return &apierrors.StatusError{ErrStatus: v1.Status{Reason: v1.StatusReasonAlreadyExists}}
-						}
-						return client.Create(ctx, obj, opts...)
-					},
-				}
-			},
-			wantConfigMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy", ResourceVersion: "1"},
-					Data:       map[string]string{"super": "duper"},
-					Immutable:  ptr.To(true),
-				},
-			},
-		},
-		{
-			name: "Give up retrying due to create failing consistently",
-			src:  types.NamespacedName{Namespace: "ci", Name: "lease-proxy"},
-			dst:  types.NamespacedName{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-			objects: []ctrlruntimeclient.Object{
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				&corev1.ConfigMap{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-			},
-			interceptorsFunc: func() interceptor.Funcs {
-				return interceptor.Funcs{
-					Create: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
-						if _, ok := obj.(*corev1.ConfigMap); ok {
-							return errors.New("permafailing")
-						}
-						return client.Create(ctx, obj, opts...)
-					},
-				}
-			},
-			wantConfigMaps: []corev1.ConfigMap{
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"super": "duper"},
-				},
-				{
-					ObjectMeta: v1.ObjectMeta{Namespace: "ci-op-xxx", Name: "lease-proxy", ResourceVersion: "999"},
-					Data:       map[string]string{"foo": "bar"},
-				},
-			},
-			wantErr: errors.New("create configmap ci-op-xxx/lease-proxy: permafailing"),
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			if tc.interceptorsFunc == nil {
-				tc.interceptorsFunc = func() interceptor.Funcs { return interceptor.Funcs{} }
-			}
-
-			client := fake.NewClientBuilder().
-				WithObjects(tc.objects...).
-				WithScheme(scheme).
-				WithInterceptorFuncs(tc.interceptorsFunc()).
-				Build()
-
-			jobSpec := api.JobSpec{}
-			jobSpec.SetNamespace("ci-op-xxx")
-			logger := logrus.NewEntry(&logrus.Logger{})
-			step := LeaseProxyStep(logger, "", nil, nil, client, &jobSpec, wait.Backoff{Steps: 3}).(*stepLeaseProxyServer)
-
-			gotErr := step.EnsureScriptConfigMap(context.TODO(), tc.src, tc.dst)
-			cmpError(t, tc.wantErr, gotErr)
-
-			gotCMs := corev1.ConfigMapList{}
-			if err := client.List(context.TODO(), &gotCMs, &ctrlruntimeclient.ListOptions{}); err != nil {
-				t.Fatalf("list configmaps: %s", err)
-			}
-
-			if diff := cmp.Diff(tc.wantConfigMaps, gotCMs.Items); diff != "" {
-				t.Errorf("unexpected configmaps: %s", diff)
-			}
 		})
 	}
 }

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -267,9 +267,7 @@ func (s *multiStageTestStep) generatePods(
 			podsutils.ConfigurePodForNestedPodman(pod, containerName, s.name)
 		}
 
-		if s.leaseProxyServerAvailable {
-			addLeaseProxyScripts(pod, container)
-		}
+		addLeaseProxyScripts(pod, container)
 
 		ret = append(ret, *pod)
 	}

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowdapi "sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
@@ -157,7 +158,7 @@ func TestGeneratePods(t *testing.T) {
 			t.Parallel()
 
 			js := jobSpec()
-			step := newMultiStageTestStep(tc.config.Tests[0], tc.config, nil, nil, &js, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable)
+			step := newMultiStageTestStep(tc.config.Tests[0], tc.config, nil, nil, &js, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable, wait.Backoff{})
 			step.test[0].Resources = resourceRequirements
 
 			ret, _, err := step.generatePods(tc.config.Tests[0].MultiStageTestConfigurationLiteral.Test, tc.env, tc.secretVolumes, tc.secretVolumeMounts, nil)
@@ -224,7 +225,7 @@ func TestGenerateObservers(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false)
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false, wait.Backoff{})
 	ret, err := step.generateObservers(observers, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -298,7 +299,7 @@ func TestGeneratePodsEnvironment(t *testing.T) {
 					Test:        test,
 					Environment: tc.env,
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false)
+			}, &api.ReleaseBuildConfiguration{}, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false, wait.Backoff{})
 			pods, _, err := step.(*multiStageTestStep).generatePods(test, nil, nil, nil, nil)
 			if err != nil {
 				t.Fatal(err)
@@ -366,7 +367,7 @@ func TestGeneratePodBestEffort(t *testing.T) {
 		},
 	}
 	jobSpec.SetNamespace("namespace")
-	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false)
+	step := newMultiStageTestStep(config.Tests[0], &config, nil, nil, &jobSpec, nil, "node-name", "", nil, false, nil, false, wait.Backoff{})
 	_, bestEffortSteps, err := step.generatePods(config.Tests[0].MultiStageTestConfigurationLiteral.Post, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -12,8 +12,15 @@ import (
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -105,25 +112,26 @@ type multiStageTestStep struct {
 	profile          api.ClusterProfile
 	config           *api.ReleaseBuildConfiguration
 	// params exposes getters for variables created by other steps
-	params                      api.Parameters
-	env                         api.TestEnvironment
-	client                      kubernetes.PodClient
-	jobSpec                     *api.JobSpec
-	observers                   []api.Observer
-	pre, test, post             []api.LiteralTestStep
-	subLock                     *sync.Mutex
-	subTests                    []*junit.TestCase
-	subSteps                    []api.CIOperatorStepDetailInfo
-	flags                       stepFlag
-	leases                      []api.StepLease
-	clusterClaim                *api.ClusterClaim
-	vpnConf                     *vpnConf
-	cancelObservers             func(context.CancelFunc)
-	nodeArchitecture            api.NodeArchitecture
-	enableSecretsStoreCSIDriver bool
-	gsm                         *GSMConfiguration
-	requireNestedPodman         bool
-	leaseProxyServerAvailable   bool
+	params                           api.Parameters
+	env                              api.TestEnvironment
+	client                           kubernetes.PodClient
+	jobSpec                          *api.JobSpec
+	observers                        []api.Observer
+	pre, test, post                  []api.LiteralTestStep
+	subLock                          *sync.Mutex
+	subTests                         []*junit.TestCase
+	subSteps                         []api.CIOperatorStepDetailInfo
+	flags                            stepFlag
+	leases                           []api.StepLease
+	clusterClaim                     *api.ClusterClaim
+	vpnConf                          *vpnConf
+	cancelObservers                  func(context.CancelFunc)
+	nodeArchitecture                 api.NodeArchitecture
+	enableSecretsStoreCSIDriver      bool
+	gsm                              *GSMConfiguration
+	requireNestedPodman              bool
+	leaseProxyServerAvailable        bool
+	leaseProxyClientConfigMapBackoff wait.Backoff
 }
 
 func MultiStageTestStep(
@@ -139,8 +147,10 @@ func MultiStageTestStep(
 	enableSecretsStoreCSIDriver bool,
 	gsmConfig *GSMConfiguration,
 	leaseProxyServerAvailable bool,
+	leaseProxyClientConfigMapBackoff wait.Backoff,
 ) api.Step {
-	return newMultiStageTestStep(testConfig, config, params, client, jobSpec, leases, nodeName, targetAdditionalSuffix, cancelObservers, enableSecretsStoreCSIDriver, gsmConfig, leaseProxyServerAvailable)
+	return newMultiStageTestStep(testConfig, config, params, client, jobSpec, leases, nodeName, targetAdditionalSuffix,
+		cancelObservers, enableSecretsStoreCSIDriver, gsmConfig, leaseProxyServerAvailable, leaseProxyClientConfigMapBackoff)
 }
 
 func newMultiStageTestStep(
@@ -156,6 +166,7 @@ func newMultiStageTestStep(
 	enableSecretsStoreCSIDriver bool,
 	gsmConfig *GSMConfiguration,
 	leaseProxyServerAvailable bool,
+	leaseProxyClientConfigMapBackoff wait.Backoff,
 ) *multiStageTestStep {
 	ms := testConfig.MultiStageTestConfigurationLiteral
 	var flags stepFlag
@@ -166,28 +177,29 @@ func newMultiStageTestStep(
 		flags |= allowBestEffortPostSteps
 	}
 	s := &multiStageTestStep{
-		name:                        testConfig.As,
-		additionalSuffix:            targetAdditionalSuffix,
-		nodeName:                    nodeName,
-		profile:                     ms.ClusterProfile,
-		config:                      config,
-		params:                      params,
-		env:                         ms.Environment,
-		client:                      client,
-		jobSpec:                     jobSpec,
-		observers:                   ms.Observers,
-		pre:                         ms.Pre,
-		test:                        ms.Test,
-		post:                        ms.Post,
-		flags:                       flags,
-		leases:                      leases,
-		clusterClaim:                testConfig.ClusterClaim,
-		subLock:                     &sync.Mutex{},
-		cancelObservers:             cancelObservers,
-		nodeArchitecture:            testConfig.NodeArchitecture,
-		enableSecretsStoreCSIDriver: enableSecretsStoreCSIDriver,
-		gsm:                         gsmConfig,
-		leaseProxyServerAvailable:   leaseProxyServerAvailable,
+		name:                             testConfig.As,
+		additionalSuffix:                 targetAdditionalSuffix,
+		nodeName:                         nodeName,
+		profile:                          ms.ClusterProfile,
+		config:                           config,
+		params:                           params,
+		env:                              ms.Environment,
+		client:                           client,
+		jobSpec:                          jobSpec,
+		observers:                        ms.Observers,
+		pre:                              ms.Pre,
+		test:                             ms.Test,
+		post:                             ms.Post,
+		flags:                            flags,
+		leases:                           leases,
+		clusterClaim:                     testConfig.ClusterClaim,
+		subLock:                          &sync.Mutex{},
+		cancelObservers:                  cancelObservers,
+		nodeArchitecture:                 testConfig.NodeArchitecture,
+		enableSecretsStoreCSIDriver:      enableSecretsStoreCSIDriver,
+		gsm:                              gsmConfig,
+		leaseProxyServerAvailable:        leaseProxyServerAvailable,
+		leaseProxyClientConfigMapBackoff: leaseProxyClientConfigMapBackoff,
 	}
 	s.requireNestedPodman = stepRequiresNestedPodman(s)
 
@@ -257,6 +269,11 @@ func (s *multiStageTestStep) run(ctx context.Context) error {
 		if s.vpnConf.namespaceUID, err = getNamespaceUID(ctx, s.jobSpec.Namespace(), s.client); err != nil {
 			return fmt.Errorf("failed to determine namespace UID range: %w", err)
 		}
+	}
+	if err := s.ensureScriptConfigMap(ctx,
+		ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: api.LeaseProxyConfigMapName},
+		ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: api.LeaseProxyConfigMapName}); err != nil {
+		return fmt.Errorf("copy lease proxy scripts into ns %s: %w", s.jobSpec.Namespace(), err)
 	}
 	secretVolumes, secretVolumeMounts, err := secretsForCensoring(s.client, s.jobSpec.Namespace(), ctx)
 	if err != nil {
@@ -589,4 +606,74 @@ func getClusterProfileFromParams(params api.Parameters) (api.ClusterProfile, err
 	}
 	cp, err := params.Get(api.ClusterProfileParam)
 	return api.ClusterProfile(cp), err
+}
+
+// ensureScriptConfigMap copies the lease proxy scripts ConfigMap from src to dst.
+// If the destination ConfigMap exists and differs from the source, it is overwritten.
+func (s *multiStageTestStep) ensureScriptConfigMap(ctx context.Context, src, dst ctrlruntimeclient.ObjectKey) error {
+	// We have a retry in place here because multiple ci-operator instances might be executing
+	// this code simultaneously.
+	type mustRetryErr struct{ error }
+	return retry.OnError(s.leaseProxyClientConfigMapBackoff,
+		func(err error) bool {
+			_, ok := err.(*mustRetryErr)
+			return ok
+		},
+		func() error {
+			srcCM := &coreapi.ConfigMap{}
+			if err := s.client.Get(ctx, src, srcCM); err != nil {
+				return fmt.Errorf("get configmap %s/%s: %w", src.Namespace, src.Name, err)
+			}
+
+			dstCM := &coreapi.ConfigMap{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      dst.Name,
+					Namespace: dst.Namespace,
+				},
+				Immutable:  ptr.To(true),
+				Data:       srcCM.Data,
+				BinaryData: srcCM.BinaryData,
+			}
+
+			err := s.client.Create(ctx, dstCM)
+			if err == nil {
+				return nil
+			}
+
+			if !kerrors.IsAlreadyExists(err) {
+				return fmt.Errorf("create configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
+			}
+
+			existingCM := &coreapi.ConfigMap{}
+			if err := s.client.Get(ctx, types.NamespacedName{Namespace: dstCM.Namespace, Name: dstCM.Name}, existingCM); err != nil {
+				e := fmt.Errorf("get existing configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
+				if kerrors.IsNotFound(err) {
+					return &mustRetryErr{e}
+				}
+				return e
+			}
+
+			if equality.Semantic.DeepEqual(dstCM.Data, existingCM.Data) &&
+				equality.Semantic.DeepEqual(dstCM.BinaryData, existingCM.BinaryData) {
+				return nil
+			}
+
+			if err := s.client.Delete(ctx, existingCM); err != nil {
+				e := fmt.Errorf("delete existing configmap %s/%s: %w", existingCM.Namespace, existingCM.Name, err)
+				if kerrors.IsNotFound(err) {
+					return &mustRetryErr{e}
+				}
+				return e
+			}
+
+			if err := s.client.Create(ctx, dstCM); err != nil {
+				e := fmt.Errorf("create configmap %s/%s: %w", dstCM.Namespace, dstCM.Name, err)
+				if kerrors.IsAlreadyExists(err) {
+					return &mustRetryErr{e}
+				}
+				return e
+			}
+
+			return nil
+		})
 }

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -11,6 +11,7 @@ import (
 
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -87,7 +88,7 @@ func TestRequires(t *testing.T) {
 				As:                                 "some-e2e",
 				ClusterClaim:                       tc.clusterClaim,
 				MultiStageTestConfigurationLiteral: &tc.steps,
-			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable)
+			}, &tc.config, api.NewDeferredParameters(nil), nil, nil, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable, wait.Backoff{})
 			ret := step.Requires()
 			if len(ret) == len(tc.req) {
 				matches := true

--- a/pkg/steps/multi_stage/run_test.go
+++ b/pkg/steps/multi_stage/run_test.go
@@ -2,19 +2,28 @@ package multi_stage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	prowapi "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowdapi "sigs.k8s.io/prow/pkg/pod-utils/downwardapi"
 
@@ -25,66 +34,441 @@ import (
 )
 
 func TestRun(t *testing.T) {
-	yes := true
+	jobSpec := api.JobSpec{
+		JobSpec: prowdapi.JobSpec{
+			Job:       "job",
+			BuildID:   "build_id",
+			ProwJobID: "prow_job_id",
+			Type:      prowapi.PeriodicJob,
+			DecorationConfig: &prowapi.DecorationConfig{
+				Timeout:     &prowapi.Duration{Duration: time.Minute},
+				GracePeriod: &prowapi.Duration{Duration: time.Second},
+				UtilityImages: &prowapi.UtilityImages{
+					Sidecar:    "sidecar",
+					Entrypoint: "entrypoint",
+				},
+			},
+		},
+	}
+	jobSpec.SetNamespace("ns")
+
+	sa := &v1.ServiceAccount{
+		ObjectMeta:       metav1.ObjectMeta{Name: "test", Namespace: "ns", Labels: map[string]string{"ci.openshift.io/multi-stage-test": "test"}},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "ci-operator-dockercfg-12345"}},
+	}
+
 	for _, tc := range []struct {
-		name      string
-		failures  sets.Set[string]
-		observers []api.Observer
-		expected  []string
+		name                             string
+		failures                         sets.Set[string]
+		testConfig                       *api.TestStepConfiguration
+		observers                        []api.Observer
+		objects                          []ctrlruntimeclient.Object
+		leaseProxyClientConfigMapBackoff wait.Backoff
+		interceptorsFunc                 func() interceptor.Funcs
+		wantPodNames                     []string
+		wantConfigMaps                   []corev1.ConfigMap
+		wantSecrets                      []corev1.Secret
+		wantErr                          error
 	}{
 		{
 			name: "no step fails, no error",
-			expected: []string{
+			testConfig: &api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: ptr.To(true)}},
+					AllowSkipOnSuccess: ptr.To(true),
+				},
+			},
+			wantPodNames: []string{
 				"test-pre0", "test-pre1",
 				"test-test0", "test-test1",
 				"test-post0",
 			},
+			wantConfigMaps: []corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+				Immutable:  ptr.To(true),
+				Data:       map[string]string{"post0": "", "post1": "", "pre0": "", "pre1": "", "test0": "", "test1": ""},
+			}},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
 		},
 		{
 			name:     "failure in a pre step, test should not run, post should",
-			failures: sets.New[string]("test-pre0"),
-			expected: []string{
+			failures: sets.New("test-pre0"),
+			testConfig: &api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: ptr.To(true)}},
+					AllowSkipOnSuccess: ptr.To(true),
+				},
+			},
+			wantPodNames: []string{
 				"test-pre0",
 				"test-post0", "test-post1",
 			},
-		}, {
+			wantConfigMaps: []corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+				Immutable:  ptr.To(true),
+				Data:       map[string]string{"post0": "", "post1": "", "pre0": "", "pre1": "", "test0": "", "test1": ""},
+			}},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+			wantErr: errors.New(`"test" pre steps failed: "test" pod "test-pre0" failed: could not watch pod: the pod ns/test-pre0 failed after 0s (failed containers: sidecar, test): ContainerFailed one or more containers exited
+
+Container test exited with code 1, reason 
+Container sidecar exited with code 1, reason
+Link to step on registry info site: https://steps.ci.openshift.org/reference/pre0
+Link to job on registry info site: https://steps.ci.openshift.org/job?org=&repo=&branch=&test=test`),
+		},
+		{
 			name:     "failure in a test step, post should run",
-			failures: sets.New[string]("test-test0"),
-			expected: []string{
+			failures: sets.New("test-test0"),
+			testConfig: &api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: ptr.To(true)}},
+					AllowSkipOnSuccess: ptr.To(true),
+				},
+			},
+			wantPodNames: []string{
 				"test-pre0", "test-pre1",
 				"test-test0",
 				"test-post0", "test-post1",
 			},
+			wantConfigMaps: []corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+				Immutable:  ptr.To(true),
+				Data:       map[string]string{"post0": "", "post1": "", "pre0": "", "pre1": "", "test0": "", "test1": ""},
+			}},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+			wantErr: errors.New(`"test" test steps failed: "test" pod "test-test0" failed: could not watch pod: the pod ns/test-test0 failed after 0s (failed containers: sidecar, test): ContainerFailed one or more containers exited
+
+Container test exited with code 1, reason 
+Container sidecar exited with code 1, reason
+Link to step on registry info site: https://steps.ci.openshift.org/reference/test0
+Link to job on registry info site: https://steps.ci.openshift.org/job?org=&repo=&branch=&test=test`),
 		},
 		{
 			name:     "failure in a post step, other post steps should still run",
-			failures: sets.New[string]("test-post0"),
-			expected: []string{
+			failures: sets.New("test-post0"),
+			testConfig: &api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: ptr.To(true)}},
+					AllowSkipOnSuccess: ptr.To(true),
+				},
+			},
+			wantPodNames: []string{
 				"test-pre0", "test-pre1",
 				"test-test0", "test-test1",
 				"test-post0",
 			},
+			wantConfigMaps: []corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+				Immutable:  ptr.To(true),
+				Data:       map[string]string{"post0": "", "post1": "", "pre0": "", "pre1": "", "test0": "", "test1": ""},
+			}},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+			wantErr: errors.New(`"test" post steps failed: "test" pod "test-post0" failed: could not watch pod: the pod ns/test-post0 failed after 0s (failed containers: sidecar, test): ContainerFailed one or more containers exited
+
+Container test exited with code 1, reason 
+Container sidecar exited with code 1, reason
+Link to step on registry info site: https://steps.ci.openshift.org/reference/post0
+Link to job on registry info site: https://steps.ci.openshift.org/job?org=&repo=&branch=&test=test`),
 		},
 		{
-			name:      "observer fails, no error",
-			observers: []api.Observer{{Name: "obsrv0"}},
-			failures:  sets.New[string]("test-obsrv0"),
-			expected: []string{
+			name:     "observer fails, no error",
+			failures: sets.New("test-obsrv0"),
+			testConfig: &api.TestStepConfiguration{
+				As: "test",
+				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
+					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
+					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
+					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: ptr.To(true)}},
+					Observers:          []api.Observer{{Name: "obsrv0"}},
+					AllowSkipOnSuccess: ptr.To(true),
+				},
+			},
+			wantPodNames: []string{
 				"test-pre0", "test-pre1",
 				"test-test0", "test-test1",
 				"test-post0",
 			},
+			wantConfigMaps: []corev1.ConfigMap{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+				Immutable:  ptr.To(true),
+				Data:       map[string]string{"post0": "", "post1": "", "pre0": "", "pre1": "", "test0": "", "test1": ""},
+			}},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+		},
+		{
+			name: "Copy lease proxy script config map: success",
+			objects: []ctrlruntimeclient.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
+				Data:       map[string]string{"foo": "bar"},
+			}},
+			leaseProxyClientConfigMapBackoff: wait.Backoff{Steps: 3},
+			wantConfigMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy", ResourceVersion: "1"},
+					Data:       map[string]string{"foo": "bar"},
+					Immutable:  ptr.To(true),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+					Immutable:  ptr.To(true),
+				},
+			},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+		},
+		{
+			name: "Copy lease proxy script config map: update stale configmap",
+			objects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+			},
+			leaseProxyClientConfigMapBackoff: wait.Backoff{Steps: 3},
+			wantConfigMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy", ResourceVersion: "1"},
+					Data:       map[string]string{"super": "duper"},
+					Immutable:  ptr.To(true),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+					Immutable:  ptr.To(true),
+				},
+			},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+		},
+		{
+			name: "Copy lease proxy script config map: retry on deletion failure",
+			objects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+			},
+			leaseProxyClientConfigMapBackoff: wait.Backoff{Steps: 3},
+			interceptorsFunc: func() interceptor.Funcs {
+				deleted := atomic.Bool{}
+				return interceptor.Funcs{
+					Delete: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.DeleteOption) error {
+						if _, ok := obj.(*corev1.ConfigMap); ok && deleted.CompareAndSwap(false, true) {
+							return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+						}
+						return client.Delete(ctx, obj, opts...)
+					},
+				}
+			},
+			wantConfigMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy", ResourceVersion: "1"},
+					Data:       map[string]string{"super": "duper"},
+					Immutable:  ptr.To(true),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+					Immutable:  ptr.To(true),
+				},
+			},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+		},
+		{
+			name: "Copy lease proxy script config map: retry when it fails to create the up-to-date configmap",
+			objects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+			},
+			leaseProxyClientConfigMapBackoff: wait.Backoff{Steps: 3},
+			interceptorsFunc: func() interceptor.Funcs {
+				createCount := atomic.Int32{}
+				return interceptor.Funcs{
+					Create: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+						// Fail when `create` is called for the second time. This means the stale configmap
+						// has been deleted and the new one, with the up-to-date content, is about to be created.
+						if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == api.LeaseProxyConfigMapName && createCount.Add(1) == 2 {
+							return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonAlreadyExists}}
+						}
+						return client.Create(ctx, obj, opts...)
+					},
+				}
+			},
+			wantConfigMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy", ResourceVersion: "1"},
+					Data:       map[string]string{"super": "duper"},
+					Immutable:  ptr.To(true),
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+					Immutable:  ptr.To(true),
+				},
+			},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+		},
+		{
+			name: "Copy lease proxy script config map: give up retrying due to create failing consistently",
+			objects: []ctrlruntimeclient.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+			},
+			leaseProxyClientConfigMapBackoff: wait.Backoff{Steps: 3},
+			interceptorsFunc: func() interceptor.Funcs {
+				return interceptor.Funcs{
+					Create: func(ctx context.Context, client ctrlruntimeclient.WithWatch, obj ctrlruntimeclient.Object, opts ...ctrlruntimeclient.CreateOption) error {
+						if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == "lease-proxy" {
+							return errors.New("permafailing")
+						}
+						return client.Create(ctx, obj, opts...)
+					},
+				}
+			},
+			wantConfigMaps: []corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ci", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"super": "duper"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "lease-proxy", ResourceVersion: "999"},
+					Data:       map[string]string{"foo": "bar"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-commands", Namespace: "ns", ResourceVersion: "1"},
+					Immutable:  ptr.To(true),
+				},
+			},
+			wantSecrets: []v1.Secret{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "ns",
+					ResourceVersion: "1",
+					Labels:          map[string]string{"ci.openshift.io/skip-censoring": "true"},
+				},
+			}},
+			wantErr: errors.New("copy lease proxy scripts into ns ns: create configmap ns/lease-proxy: permafailing"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			sa := &v1.ServiceAccount{
-				ObjectMeta:       metav1.ObjectMeta{Name: "test", Namespace: "ns", Labels: map[string]string{"ci.openshift.io/multi-stage-test": "test"}},
-				ImagePullSecrets: []v1.LocalObjectReference{{Name: "ci-operator-dockercfg-12345"}},
+			if tc.testConfig == nil {
+				tc.testConfig = &api.TestStepConfiguration{
+					As:                                 "test",
+					MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{}}
 			}
-			name := "test"
+			if tc.interceptorsFunc == nil {
+				tc.interceptorsFunc = func() interceptor.Funcs { return interceptor.Funcs{} }
+			}
+
 			observerPodNames := sets.New[string]()
-			for _, observerPod := range tc.observers {
-				observerPodNames.Insert(fmt.Sprintf("%s-%s", name, observerPod.Name))
+			for _, observerPod := range tc.testConfig.MultiStageTestConfigurationLiteral.Observers {
+				observerPodNames.Insert(fmt.Sprintf("%s-%s", tc.testConfig.As, observerPod.Name))
 			}
 
 			crclient := &testhelper_kube.FakePodExecutor{
@@ -92,68 +476,80 @@ func TestRun(t *testing.T) {
 					fakectrlruntimeclient.NewClientBuilder().
 						WithIndex(&v1.Pod{}, "metadata.name", fakePodNameIndexer).
 						WithObjects(sa).
+						WithObjects(tc.objects...).
+						WithInterceptorFuncs(tc.interceptorsFunc()).
 						Build(), nil),
 				Failures:     tc.failures,
 				AutoSchedule: true,
 			}
-			jobSpec := api.JobSpec{
-				JobSpec: prowdapi.JobSpec{
-					Job:       "job",
-					BuildID:   "build_id",
-					ProwJobID: "prow_job_id",
-					Type:      prowapi.PeriodicJob,
-					DecorationConfig: &prowapi.DecorationConfig{
-						Timeout:     &prowapi.Duration{Duration: time.Minute},
-						GracePeriod: &prowapi.Duration{Duration: time.Second},
-						UtilityImages: &prowapi.UtilityImages{
-							Sidecar:    "sidecar",
-							Entrypoint: "entrypoint",
-						},
-					},
-				},
-			}
-			jobSpec.SetNamespace("ns")
+
 			client := &testhelper_kube.FakePodClient{
 				PendingTimeout:  30 * time.Minute,
 				FakePodExecutor: crclient,
 			}
-			step := MultiStageTestStep(api.TestStepConfiguration{
-				As: name,
-				MultiStageTestConfigurationLiteral: &api.MultiStageTestConfigurationLiteral{
-					Pre:                []api.LiteralTestStep{{As: "pre0"}, {As: "pre1"}},
-					Test:               []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
-					Post:               []api.LiteralTestStep{{As: "post0"}, {As: "post1", OptionalOnSuccess: &yes}},
-					Observers:          tc.observers,
-					AllowSkipOnSuccess: &yes,
-				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", func(cf context.CancelFunc) {}, false, nil, false)
+			step := MultiStageTestStep(*tc.testConfig, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", func(cf context.CancelFunc) {}, false, nil, false, tc.leaseProxyClientConfigMapBackoff)
 
-			// An Observer pod failure doesn't make the test fail
-			failures := tc.failures.Delete(observerPodNames.UnsortedList()...)
-			hasFailures := failures != nil && failures.Len() > 0
+			gotErr := step.Run(context.Background())
 
-			if err := step.Run(context.Background()); (err != nil) != hasFailures {
-				t.Errorf("expected error: %t, got error: %v", hasFailures, err)
+			// Observer do not produce any error.
+			wantFailures := tc.failures.Clone()
+			observers := sets.New[string]()
+			if len(tc.testConfig.MultiStageTestConfigurationLiteral.Observers) > 0 {
+				for _, o := range tc.testConfig.MultiStageTestConfigurationLiteral.Observers {
+					observers.Insert(tc.testConfig.As + "-" + o.Name)
+				}
 			}
-			secrets := &v1.SecretList{}
-			if err := crclient.List(context.TODO(), secrets, ctrlruntimeclient.InNamespace(jobSpec.Namespace())); err != nil {
+			wantFailures = wantFailures.Difference(observers)
+			// Do not compare errors literally when we expect a pod to fail. The error message is not stable
+			// since a pod might fail after an arbitrary amount of time, therefore we get:
+			// `pod ns/test-post0 failed after <n>s` and we can't predict what the value of <n>
+			// might actually be.
+			if wantFailures.Len() > 0 {
+				if gotErr == nil {
+					t.Fatal("expected pod failure errors but got nil")
+				}
+				msg := gotErr.Error()
+				for pod := range tc.failures {
+					if observers.Has(pod) {
+						continue
+					}
+					if !strings.Contains(msg, fmt.Sprintf("pod %q failed", pod)) {
+						t.Errorf("pod %s didn't fail as expected", pod)
+					}
+				}
+			} else {
+				if gotErr != nil && tc.wantErr == nil {
+					t.Errorf("want err nil but got: %v", gotErr)
+				}
+				if gotErr == nil && tc.wantErr != nil {
+					t.Errorf("want err %v but nil", tc.wantErr)
+				}
+				if gotErr != nil && tc.wantErr != nil {
+					if diff := cmp.Diff(tc.wantErr.Error(), gotErr.Error()); diff != "" {
+						t.Errorf("unexpected error: %s", diff)
+					}
+				}
+			}
+
+			gotSecrets := &v1.SecretList{}
+			if err := crclient.List(context.TODO(), gotSecrets, ctrlruntimeclient.InNamespace(jobSpec.Namespace())); err != nil {
 				t.Fatal(err)
 			}
-			if l := secrets.Items; len(l) != 1 || l[0].ObjectMeta.Name != name {
-				t.Errorf("unexpected secrets: %#v", l)
+			secretSorter := func(a, b *v1.Secret) bool { return a.Namespace+a.Name <= b.Namespace+b.Name }
+			if diff := cmp.Diff(tc.wantSecrets, gotSecrets.Items, cmpopts.SortSlices(secretSorter)); diff != "" {
+				t.Errorf("unexpected secrets: %s", diff)
 			}
-			var names []string
 
 			// An observer pod can be executed at any time, therefore making unstable the output
 			// of the pods the client has created. Do not take into account them.
 			observerPodsToRemove := observerPodNames.Clone()
-
+			var gotPodNames []string
 			for _, pod := range crclient.CreatedPods {
 				if pod.Namespace != jobSpec.Namespace() {
 					t.Errorf("pod %s didn't have namespace %s set, had %q instead", pod.Name, jobSpec.Namespace(), pod.Namespace)
 				}
 				if !observerPodsToRemove.Has(pod.Name) {
-					names = append(names, pod.Name)
+					gotPodNames = append(gotPodNames, pod.Name)
 				} else {
 					observerPodsToRemove.Delete(pod.Name)
 				}
@@ -163,8 +559,18 @@ func TestRun(t *testing.T) {
 				t.Errorf("did not find the following pods to remove: %s", observerPodsToRemove.UnsortedList())
 			}
 
-			if diff := cmp.Diff(names, tc.expected); diff != "" {
-				t.Errorf("did not execute correct pods: %s, actual: %v, expected: %v", diff, names, tc.expected)
+			if diff := cmp.Diff(gotPodNames, tc.wantPodNames); diff != "" {
+				t.Errorf("did not execute correct pods: %s, actual: %v, expected: %v", diff, gotPodNames, tc.wantPodNames)
+			}
+
+			gotCMs := corev1.ConfigMapList{}
+			if err := client.List(context.TODO(), &gotCMs, &ctrlruntimeclient.ListOptions{}); err != nil {
+				t.Fatalf("list configmaps: %s", err)
+			}
+
+			configMapSorter := func(a, b *v1.ConfigMap) bool { return a.Namespace+a.Name <= b.Namespace+b.Name }
+			if diff := cmp.Diff(tc.wantConfigMaps, gotCMs.Items, cmpopts.SortSlices(configMapSorter)); diff != "" {
+				t.Errorf("unexpected configmaps: %s", diff)
 			}
 		})
 	}
@@ -266,11 +672,12 @@ func TestJUnit(t *testing.T) {
 					Test: []api.LiteralTestStep{{As: "test0"}, {As: "test1"}},
 					Post: []api.LiteralTestStep{{As: "post0"}, {As: "post1"}},
 				},
-			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", nil, false, nil, false)
+			}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", nil, false, nil, false, wait.Backoff{})
 			if err := step.Run(context.Background()); tc.failures == nil && err != nil {
 				t.Error(err)
 				return
 			}
+
 			var names []string
 			for _, t := range step.(steps.SubtestReporter).SubTests() {
 				names = append(names, t.Name)
@@ -341,7 +748,7 @@ func TestRunPodDeletesPendingPodsOnError(t *testing.T) {
 			Post:               []api.LiteralTestStep{{As: "post0"}},
 			AllowSkipOnSuccess: &yes,
 		},
-	}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", func(cf context.CancelFunc) {}, false, nil, false)
+	}, &api.ReleaseBuildConfiguration{}, nil, client, &jobSpec, nil, "node-name", "", func(cf context.CancelFunc) {}, false, nil, false, wait.Backoff{})
 
 	// Use a context with timeout to ensure the test doesn't hang
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -89,6 +89,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -106,6 +108,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -158,6 +163,9 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -250,6 +258,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -267,6 +277,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -319,4 +332,7 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_enable_nested_podman.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_enable_nested_podman.yaml
@@ -85,6 +85,8 @@
         value: /var/run/secrets/ci.openshift.io/multi-stage/kubeadmin-password
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -112,6 +114,9 @@
         name: dshm
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: run podman
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -167,4 +172,7 @@
     - name: run podman
       secret:
         secretName: run podman
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_generate_pods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_generate_pods.yaml
@@ -95,6 +95,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -114,6 +116,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -175,6 +180,9 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -273,6 +281,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: stable:image1
       name: test
       resources: {}
@@ -290,6 +300,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -347,6 +360,9 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -444,6 +460,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: stable-initial:installer
       name: test
       resources: {}
@@ -463,6 +481,9 @@
         name: test
       - mountPath: /var/run/configmaps/ci.openshift.io/multi-stage
         name: commands-script
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -523,6 +544,9 @@
         defaultMode: 511
         name: test-commands
       name: commands-script
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -621,6 +645,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -638,6 +664,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -703,6 +732,9 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -801,6 +833,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -818,6 +852,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -877,6 +914,9 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}
 - metadata:
     annotations:
@@ -975,6 +1015,8 @@
         value: /var/run/secrets/ci.openshift.io/cluster-profile
       - name: SHARED_DIR
         value: /var/run/secrets/ci.openshift.io/multi-stage
+      - name: LEASE_PROXY_CLIENT_SH
+        value: /opt/scripts/lease-proxy/client.sh
       image: pipeline:src
       name: test
       resources: {}
@@ -992,6 +1034,9 @@
         name: cluster-profile
       - mountPath: /var/run/secrets/ci.openshift.io/multi-stage
         name: test
+      - mountPath: /opt/scripts/lease-proxy
+        name: lease-proxy
+        readOnly: true
     - env:
       - name: JOB_SPEC
       - name: SIDECAR_OPTIONS
@@ -1051,4 +1096,7 @@
     - name: test
       secret:
         secretName: test
+    - configMap:
+        name: lease-proxy
+      name: lease-proxy
   status: {}


### PR DESCRIPTION
So far `ci-operator` copies the `ci/lease-proxy` ConfigMap into the test NS only when the lease proxy server is available. This is annoying from the step registry step authors point of view because they are forced to write the code defensively:
```sh
#!/bin/sh

if [[ -v $LEASE_PROXY_SCRIPT_SH ]]; then
  source "$LEASE_PROXY_SCRIPT_SH"
else
  # Maybe mock the lease__* functions? This is super annoying.
fi

# ...

azure_lease="$(lease__acquire --type=openshift-org-azure)"
```
Making the script available anyway is safe because, by design, the `lease__*` functions run in dry-run mode when the lease proxy server is not available. Therefore the previous snippet would simply become:
```sh
#!/bin/sh

source "$LEASE_PROXY_SCRIPT_SH"
azure_lease="$(lease__acquire --type=openshift-org-azure)"
```

This PR doesn't introduce anything new, the code that copies the `lease-proxy` ConfigMap from one NS to another has been moved from `pkg/steps/lease_proxy.go` to `pkg/steps/multi_stage/multi_stage.go`.
That's because, in multistage testing, `multi_stage.go` gets executed in any case, whereas `lease_proxy.go` is available only when the test has the `cluster_profile` stanza set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Lease-proxy client scripts are now injected into all test containers and pods.
  - ConfigMap synchronization for lease-proxy includes automated retry/backoff to improve reliability.

* **Refactor**
  - Simplified initialization and reduced runtime dependencies for the lease-proxy flow.
  - Streamlined validation and consolidated configuration copy/management logic for lease-proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->