### PR TITLE
determinize-ci-operator: add --validate-main-promotion for main/master promotion validation

### DIFF
--- a/cmd/determinize-ci-operator/main.go
+++ b/cmd/determinize-ci-operator/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/validation/promotion"
 )
 
 const (
@@ -31,6 +32,11 @@ type options struct {
 	templateMigrationAllowedBranches        flagutil.Strings
 	templateMigrationAllowedOrgs            flagutil.Strings
 	templateMigrationAllowedClusterProfiles flagutil.Strings
+	validateMainPromotion                   bool
+	currentRelease                          string
+	prowConfigDir                           string
+	infraPeriodicsPath                      string
+	mainPromotionIgnore                     flagutil.Strings
 }
 
 func (o options) validate() error {
@@ -41,7 +47,9 @@ func (o options) validate() error {
 	if diff := sets.New[string](o.enabledTemplateMigrations.Strings()...).Difference(validTemplateMigrations); len(diff) != 0 {
 		errs = append(errs, fmt.Errorf("invalid values %v for --enabled-template-migration, valid values: %v", sets.List(diff), sets.List(validTemplateMigrations)))
 	}
-
+	if o.validateMainPromotion && o.currentRelease == "" && o.infraPeriodicsPath == "" {
+		errs = append(errs, fmt.Errorf("--validate-main-promotion requires either --current-release or --infra-periodics"))
+	}
 	return utilerrors.NewAggregate(errs)
 }
 
@@ -53,6 +61,11 @@ func gatherOptions() options {
 	flag.Var(&o.templateMigrationAllowedBranches, "template-migration-allowed-branch", "Allowed branches to automigrate templates on. Can be passed multiple times. All branches are allowed if unset.")
 	flag.Var(&o.templateMigrationAllowedOrgs, "template-migration-allowed-org", "Allowed orgs to automigrate templates on. Can be passed multiple times. All orgs are allowed if unset.")
 	flag.Var(&o.templateMigrationAllowedClusterProfiles, "template-migration-allowed-cluster-profile", "Allowed cluster profiles to automigrate templates on. Can be passed multiple times. All cluster profiles are allowed if unset.")
+	flag.BoolVar(&o.validateMainPromotion, "validate-main-promotion", false, "Run main-promotion validation (main/master must promote to current release only; release-X configs must have promotion disabled when in scope). Exit 1 on violations.")
+	flag.StringVar(&o.currentRelease, "current-release", "", "Current development release (e.g. 4.22). Required for --validate-main-promotion unless --infra-periodics is set.")
+	flag.StringVar(&o.prowConfigDir, "prow-config-dir", "", "Path to prow 02_config. Optional; when set, enforces release-X promotion disabled when Prow has openshift-X/release-X in includedBranches.")
+	flag.StringVar(&o.infraPeriodicsPath, "infra-periodics", "", "Path to ci-operator/jobs/infra-periodics.yaml. Optional; when set, current-release is read from periodic-prow-auto-config-brancher job.")
+	flag.Var(&o.mainPromotionIgnore, "main-promotion-ignore", "Org/repo to exclude from main-promotion check (e.g. openshift/gatekeeper). Can be passed multiple times.")
 	flag.Parse()
 
 	return o
@@ -66,6 +79,14 @@ func main() {
 
 	if err := o.ConfirmableOptions.Complete(); err != nil {
 		logrus.Fatalf("Couldn't complete the config options: %v", err)
+	}
+
+	if o.validateMainPromotion {
+		ignore := o.mainPromotionIgnore.StringSet()
+		if err := promotion.Validate(o.ConfigDir, o.currentRelease, o.prowConfigDir, o.infraPeriodicsPath, ignore); err != nil {
+			logrus.Fatalf("Main promotion validation failed: %v", err)
+		}
+		return
 	}
 
 	var migratedCount int

--- a/pkg/validation/promotion/validate.go
+++ b/pkg/validation/promotion/validate.go
@@ -1,0 +1,287 @@
+package promotion
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowcfg "sigs.k8s.io/prow/pkg/config"
+	"sigs.k8s.io/yaml"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
+)
+
+const autoConfigBrancherJob = "periodic-prow-auto-config-brancher"
+
+var currentReleaseArgRE = regexp.MustCompile(`^--current-release=(.+)$`)
+
+var DefaultIgnore = sets.New[string](
+	"openshift/gatekeeper",
+	"openshift/gatekeeper-operator",
+	"openshift-priv/gatekeeper",
+	"openshift-priv/gatekeeper-operator",
+	"openshift/network.offline_migration_sdn_to_ovnk",
+	"openshift-priv/network.offline_migration_sdn_to_ovnk",
+	"openshift-pipelines/console-plugin",
+	"kubev2v/migration-planner",
+	"kubev2v/migration-planner-ui-app",
+	"openshift-online/ocm-cluster-service",
+)
+
+type prowTideCache struct {
+	dir   string
+	cache map[string]tideCacheEntry
+}
+
+type tideCacheEntry struct {
+	tide *prowcfg.Tide
+	err  error
+}
+
+func newProwTideCache(prowConfigDir string) *prowTideCache {
+	if prowConfigDir == "" {
+		return nil
+	}
+	return &prowTideCache{
+		dir:   prowConfigDir,
+		cache: map[string]tideCacheEntry{},
+	}
+}
+
+func (c *prowTideCache) loadTide(org, repo string) (*prowcfg.Tide, error) {
+	if c == nil {
+		return nil, nil
+	}
+	key := org + "/" + repo
+	if e, ok := c.cache[key]; ok {
+		return e.tide, e.err
+	}
+	path := filepath.Join(c.dir, org, repo, "_prowconfig.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.cache[key] = tideCacheEntry{tide: nil, err: nil}
+			return nil, nil
+		}
+		wrap := fmt.Errorf("read prow config %s: %w", path, err)
+		c.cache[key] = tideCacheEntry{tide: nil, err: wrap}
+		return nil, wrap
+	}
+	var pc prowcfg.ProwConfig
+	if err := yaml.Unmarshal(data, &pc); err != nil {
+		wrap := fmt.Errorf("unmarshal prow config %s: %w", path, err)
+		c.cache[key] = tideCacheEntry{tide: nil, err: wrap}
+		return nil, wrap
+	}
+	c.cache[key] = tideCacheEntry{tide: &pc.Tide, err: nil}
+	return &pc.Tide, nil
+}
+
+func (c *prowTideCache) hasCurrentReleaseBranchInProw(org, repo, currentRelease string) (bool, error) {
+	tide, err := c.loadTide(org, repo)
+	if err != nil {
+		return false, err
+	}
+	if tide == nil {
+		return false, nil
+	}
+	return tideIncludesCurrentReleaseBranches(tide, currentRelease), nil
+}
+
+func tideIncludesCurrentReleaseBranches(tide *prowcfg.Tide, currentRelease string) bool {
+	want := sets.New[string](
+		fmt.Sprintf("openshift-%s", currentRelease),
+		fmt.Sprintf("release-%s", currentRelease),
+	)
+	for _, q := range tide.Queries {
+		for _, b := range q.IncludedBranches {
+			if want.Has(strings.TrimSpace(b)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func parseCurrentReleaseFromInfraPeriodicsData(data []byte) (string, error) {
+	var doc struct {
+		Periodics []prowcfg.Periodic `json:"periodics"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", err
+	}
+	for _, job := range doc.Periodics {
+		if job.Name != autoConfigBrancherJob {
+			continue
+		}
+		if job.Spec == nil {
+			continue
+		}
+		for _, c := range job.Spec.Containers {
+			for _, arg := range c.Args {
+				if m := currentReleaseArgRE.FindStringSubmatch(strings.TrimSpace(arg)); len(m) > 1 {
+					return strings.TrimSpace(m[1]), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("no --current-release found in %s job", autoConfigBrancherJob)
+}
+
+func getCurrentReleaseFromInfraPeriodics(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	release, err := parseCurrentReleaseFromInfraPeriodicsData(data)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", path, err)
+	}
+	return release, nil
+}
+
+func isMainOrMasterBranch(branch string) bool {
+	return branch == "main" || branch == "master"
+}
+
+func isReleaseBranch(branch, currentRelease string) bool {
+	return branch == fmt.Sprintf("release-%s", currentRelease) || branch == fmt.Sprintf("openshift-%s", currentRelease)
+}
+
+func isPromotionFullyDisabled(cfg *cioperatorapi.ReleaseBuildConfiguration) bool {
+	if cfg.PromotionConfiguration == nil || len(cfg.PromotionConfiguration.Targets) == 0 {
+		return true
+	}
+	for _, t := range cfg.PromotionConfiguration.Targets {
+		if !t.Disabled {
+			return false
+		}
+	}
+	return true
+}
+
+type options struct {
+	configDir           string
+	currentRelease      string
+	prowTideCache       *prowTideCache
+	infraPeriodicsPath  string
+	ignore              sets.Set[string]
+	reposWithMainMaster sets.Set[string]
+}
+
+func (o *options) resolveCurrentRelease() (string, error) {
+	if o.currentRelease != "" {
+		return o.currentRelease, nil
+	}
+	if o.infraPeriodicsPath == "" {
+		return "", fmt.Errorf("either --current-release or --infra-periodics is required for main-promotion validation")
+	}
+	return getCurrentReleaseFromInfraPeriodics(o.infraPeriodicsPath)
+}
+
+func (o *options) collectReposWithMainMaster() error {
+	return config.OperateOnCIOperatorConfigDir(o.configDir, func(cfg *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
+		if isMainOrMasterBranch(info.Branch) {
+			o.reposWithMainMaster.Insert(fmt.Sprintf("%s/%s", info.Org, info.Repo))
+		}
+		return nil
+	})
+}
+
+func Validate(configDir, currentRelease, prowConfigDir, infraPeriodicsPath string, ignore sets.Set[string]) error {
+	if ignore == nil {
+		ignore = sets.New[string]()
+	}
+	ignore = ignore.Union(DefaultIgnore)
+
+	o := &options{
+		configDir:           configDir,
+		currentRelease:      currentRelease,
+		prowTideCache:       newProwTideCache(prowConfigDir),
+		infraPeriodicsPath:  infraPeriodicsPath,
+		ignore:              ignore,
+		reposWithMainMaster: sets.New[string](),
+	}
+	release, err := o.resolveCurrentRelease()
+	if err != nil {
+		return err
+	}
+	releasePriv := release + "-priv"
+
+	if err := o.collectReposWithMainMaster(); err != nil {
+		return err
+	}
+
+	var errs []error
+	if err := config.OperateOnCIOperatorConfigDir(configDir, func(cfg *cioperatorapi.ReleaseBuildConfiguration, info *config.Info) error {
+		orgRepo := fmt.Sprintf("%s/%s", info.Org, info.Repo)
+		relPath := filepath.Join(info.Org, info.Repo, filepath.Base(info.Filename))
+
+		if ignore.Has(orgRepo) {
+			return nil
+		}
+
+		if isMainOrMasterBranch(info.Branch) {
+			if cfg.PromotionConfiguration == nil {
+				return nil
+			}
+			for _, t := range cfg.PromotionConfiguration.Targets {
+				if t.Disabled {
+					continue
+				}
+				ns := t.Namespace
+				if ns == "" {
+					ns = "ocp"
+				}
+				name := strings.Trim(t.Name, `"`)
+				switch ns {
+				case "ocp":
+					if name != release {
+						errs = append(errs, fmt.Errorf("%s: promotes to %s/%s (main/master must only promote to %s)", relPath, ns, name, release))
+					}
+				case "ocp-private":
+					if name != releasePriv {
+						errs = append(errs, fmt.Errorf("%s: promotes to %s/%s (main/master must only promote to %s)", relPath, ns, name, releasePriv))
+					}
+				default:
+					errs = append(errs, fmt.Errorf("%s: promotes to %s/%s (main/master may only promote to ocp/%s or ocp-private/%s)", relPath, ns, name, release, releasePriv))
+				}
+			}
+			return nil
+		}
+
+		if isReleaseBranch(info.Branch, release) && o.reposWithMainMaster.Has(orgRepo) {
+			inScopeProw := false
+			if o.prowTideCache != nil {
+				var perr error
+				inScopeProw, perr = o.prowTideCache.hasCurrentReleaseBranchInProw(info.Org, info.Repo, release)
+				if perr != nil {
+					return perr
+				}
+			}
+			if !inScopeProw {
+				return nil
+			}
+			if !isPromotionFullyDisabled(cfg) {
+				errs = append(errs, fmt.Errorf("%s: release/openshift-%s config must have promotion disabled (only main/master promote to %s)", relPath, release, release))
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if len(errs) > 0 {
+		for _, e := range errs {
+			logrus.Error(e.Error())
+		}
+		return fmt.Errorf("main promotion validation failed: %d violation(s)", len(errs))
+	}
+	return nil
+}

--- a/pkg/validation/promotion/validate_test.go
+++ b/pkg/validation/promotion/validate_test.go
@@ -1,0 +1,409 @@
+package promotion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	prowcfg "sigs.k8s.io/prow/pkg/config"
+
+	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
+)
+
+func TestIsMainOrMasterBranch(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{"main", true},
+		{"master", true},
+		{"release-4.22", false},
+		{"openshift-4.22", false},
+		{"", false},
+		{"other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			if got := isMainOrMasterBranch(tt.branch); got != tt.want {
+				t.Errorf("isMainOrMasterBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsReleaseBranch(t *testing.T) {
+	tests := []struct {
+		branch         string
+		currentRelease string
+		want           bool
+	}{
+		{"release-4.22", "4.22", true},
+		{"openshift-4.22", "4.22", true},
+		{"release-4.21", "4.22", false},
+		{"openshift-4.21", "4.22", false},
+		{"main", "4.22", false},
+		{"master", "4.22", false},
+	}
+	for _, tt := range tests {
+		name := tt.branch + "_" + tt.currentRelease
+		t.Run(name, func(t *testing.T) {
+			if got := isReleaseBranch(tt.branch, tt.currentRelease); got != tt.want {
+				t.Errorf("isReleaseBranch(%q, %q) = %v, want %v", tt.branch, tt.currentRelease, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsPromotionFullyDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *cioperatorapi.ReleaseBuildConfiguration
+		want bool
+	}{
+		{
+			name: "nil promotion",
+			cfg:  &cioperatorapi.ReleaseBuildConfiguration{PromotionConfiguration: nil},
+			want: true,
+		},
+		{
+			name: "empty targets",
+			cfg:  &cioperatorapi.ReleaseBuildConfiguration{PromotionConfiguration: &cioperatorapi.PromotionConfiguration{Targets: nil}},
+			want: true,
+		},
+		{
+			name: "single target disabled",
+			cfg: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{{Name: "4.22", Disabled: true}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "single target enabled",
+			cfg: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{{Name: "4.22", Disabled: false}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "multiple targets all disabled",
+			cfg: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{
+						{Name: "4.22", Disabled: true},
+						{Name: "4.22-priv", Disabled: true},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "multiple targets one enabled",
+			cfg: &cioperatorapi.ReleaseBuildConfiguration{
+				PromotionConfiguration: &cioperatorapi.PromotionConfiguration{
+					Targets: []cioperatorapi.PromotionTarget{
+						{Name: "4.22", Disabled: true},
+						{Name: "4.22-priv", Disabled: false},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPromotionFullyDisabled(tt.cfg); got != tt.want {
+				t.Errorf("isPromotionFullyDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCurrentReleaseFromInfraPeriodicsData(t *testing.T) {
+	got, err := parseCurrentReleaseFromInfraPeriodicsData([]byte(`
+periodics:
+  - name: periodic-prow-auto-config-brancher
+    spec:
+      containers:
+        - args:
+            - --current-release=4.22
+`))
+	if err != nil {
+		t.Fatalf("parseCurrentReleaseFromInfraPeriodicsData: %v", err)
+	}
+	if got != "4.22" {
+		t.Errorf("got %q, want 4.22", got)
+	}
+	_, err = parseCurrentReleaseFromInfraPeriodicsData([]byte("periodics: []"))
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestGetCurrentReleaseFromInfraPeriodics(t *testing.T) {
+	dir := t.TempDir()
+	validPath := filepath.Join(dir, "infra-periodics.yaml")
+	validContent := `
+periodics:
+  - name: periodic-prow-auto-config-brancher
+    spec:
+      containers:
+        - args:
+            - --current-release=4.22
+            - --config-dir=/config
+`
+	if err := os.WriteFile(validPath, []byte(validContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := getCurrentReleaseFromInfraPeriodics(validPath)
+	if err != nil {
+		t.Fatalf("getCurrentReleaseFromInfraPeriodics() error = %v", err)
+	}
+	if got != "4.22" {
+		t.Errorf("getCurrentReleaseFromInfraPeriodics() = %q, want 4.22", got)
+	}
+
+	_, err = getCurrentReleaseFromInfraPeriodics(filepath.Join(dir, "missing.yaml"))
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	noJobPath := filepath.Join(dir, "no-job.yaml")
+	if err := os.WriteFile(noJobPath, []byte("periodics: []"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err = getCurrentReleaseFromInfraPeriodics(noJobPath)
+	if err == nil {
+		t.Error("expected error when job missing")
+	}
+}
+
+func TestTideIncludesCurrentReleaseBranches(t *testing.T) {
+	tide := &prowcfg.Tide{
+		TideGitHubConfig: prowcfg.TideGitHubConfig{
+			Queries: []prowcfg.TideQuery{
+				{IncludedBranches: []string{"release-4.22", "openshift-4.22"}},
+			},
+		},
+	}
+	if !tideIncludesCurrentReleaseBranches(tide, "4.22") {
+		t.Error("expected true")
+	}
+	if tideIncludesCurrentReleaseBranches(tide, "4.21") {
+		t.Error("expected false for 4.21")
+	}
+}
+
+func TestProwTideCache(t *testing.T) {
+	dir := t.TempDir()
+	org, repo := "openshift", "some-repo"
+	base := filepath.Join(dir, org, repo)
+	if err := os.MkdirAll(base, 0755); err != nil {
+		t.Fatal(err)
+	}
+	prowPath := filepath.Join(base, "_prowconfig.yaml")
+	content := `
+tide:
+  queries:
+    - includedBranches:
+        - release-4.22
+        - openshift-4.22
+`
+	if err := os.WriteFile(prowPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c := newProwTideCache(dir)
+	ok, err := c.hasCurrentReleaseBranchInProw(org, repo, "4.22")
+	if err != nil {
+		t.Fatalf("hasCurrentReleaseBranchInProw: %v", err)
+	}
+	if !ok {
+		t.Error("expected true")
+	}
+	ok, err = c.hasCurrentReleaseBranchInProw(org, repo, "4.21")
+	if err != nil {
+		t.Fatalf("hasCurrentReleaseBranchInProw: %v", err)
+	}
+	if ok {
+		t.Error("expected false for 4.21")
+	}
+	ok, err = c.hasCurrentReleaseBranchInProw("other", "repo", "4.22")
+	if err != nil {
+		t.Fatalf("hasCurrentReleaseBranchInProw: %v", err)
+	}
+	if ok {
+		t.Error("expected false for missing file")
+	}
+	_, err = c.hasCurrentReleaseBranchInProw(org, repo, "4.22")
+	if err != nil {
+		t.Errorf("second read should use cache: %v", err)
+	}
+}
+
+func TestProwTideCache_UnmarshalError(t *testing.T) {
+	dir := t.TempDir()
+	org, repo := "openshift", "bad-yaml"
+	base := filepath.Join(dir, org, repo)
+	if err := os.MkdirAll(base, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "_prowconfig.yaml"), []byte("{invalid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c := newProwTideCache(dir)
+	_, err := c.hasCurrentReleaseBranchInProw(org, repo, "4.22")
+	if err == nil {
+		t.Error("expected unmarshal error")
+	}
+}
+
+func TestValidate_EmptyConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	err := Validate(dir, "4.22", "", "", nil)
+	if err != nil {
+		t.Errorf("Validate(empty dir, currentRelease=4.22) = %v", err)
+	}
+}
+
+func TestValidate_RequiresCurrentReleaseOrInfraPeriodics(t *testing.T) {
+	dir := t.TempDir()
+	err := Validate(dir, "", "", "", nil)
+	if err == nil {
+		t.Error("Validate() with no current-release and no infra-periodics expected error")
+	}
+}
+
+func TestValidate_ResolvesCurrentReleaseFromInfraPeriodics(t *testing.T) {
+	configDir := t.TempDir()
+	infraDir := t.TempDir()
+	infraPath := filepath.Join(infraDir, "infra.yaml")
+	if err := os.WriteFile(infraPath, []byte(`
+periodics:
+  - name: periodic-prow-auto-config-brancher
+    spec:
+      containers:
+        - args: ["--current-release=4.21"]
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := Validate(configDir, "", "", infraPath, nil)
+	if err != nil {
+		t.Errorf("Validate() with infra-periodics only = %v", err)
+	}
+}
+
+func TestValidate_IgnoreSet(t *testing.T) {
+	if !DefaultIgnore.Has("openshift/gatekeeper") {
+		t.Error("DefaultIgnore should contain openshift/gatekeeper")
+	}
+	dir := t.TempDir()
+	customIgnore := sets.New[string]("custom/ignored-repo")
+	err := Validate(dir, "4.22", "", "", customIgnore)
+	if err != nil {
+		t.Errorf("Validate(empty dir with custom ignore) = %v", err)
+	}
+}
+
+func TestValidate_RejectsPromotionToDisallowedNamespace(t *testing.T) {
+	dir := t.TempDir()
+	repoDir := filepath.Join(dir, "foo", "bar")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	mainCfg := `build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+promotion:
+  to:
+    - name: "4.22"
+      namespace: not-ocp
+      disabled: false
+tests:
+- as: test
+  commands: make test
+  container:
+    from: src
+zz_generated_metadata:
+  branch: main
+  org: foo
+  repo: bar
+`
+	path := filepath.Join(repoDir, "foo-bar-main.yaml")
+	if err := os.WriteFile(path, []byte(mainCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := Validate(dir, "4.22", "", "", nil)
+	if err == nil {
+		t.Fatal("expected validation error for disallowed promotion namespace")
+	}
+}
+
+func TestValidate_ErrorsOnMalformedProwConfigWhenEnforcingReleaseBranch(t *testing.T) {
+	configDir := t.TempDir()
+	prowDir := t.TempDir()
+	repoDir := filepath.Join(configDir, "foo", "bar")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	prowRepoDir := filepath.Join(prowDir, "foo", "bar")
+	if err := os.MkdirAll(prowRepoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prowRepoDir, "_prowconfig.yaml"), []byte("tide: ["), 0644); err != nil {
+		t.Fatal(err)
+	}
+	base := `build_root:
+  image_stream_tag:
+    name: release
+    namespace: openshift
+    tag: golang-1.10
+resources:
+  '*':
+    limits:
+      cpu: 500Mi
+    requests:
+      cpu: 10Mi
+tests:
+- as: test
+  commands: make test
+  container:
+    from: src
+`
+	mainCfg := base + `zz_generated_metadata:
+  branch: main
+  org: foo
+  repo: bar
+`
+	releaseCfg := base + `promotion:
+  to:
+    - name: "4.22"
+      namespace: ocp
+      disabled: false
+zz_generated_metadata:
+  branch: release-4.22
+  org: foo
+  repo: bar
+`
+	if err := os.WriteFile(filepath.Join(repoDir, "foo-bar-main.yaml"), []byte(mainCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "foo-bar-release-4.22.yaml"), []byte(releaseCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := Validate(configDir, "4.22", prowDir, "", nil)
+	if err == nil {
+		t.Fatal("expected error from malformed prow config")
+	}
+}


### PR DESCRIPTION
## What

Add main-promotion validation to `determinize-ci-operator` so the same rules enforced in openshift/release (via a standalone script) run inside the existing toolchain. No new script in release once release repo is updated to call determinize with the new flag.

## How

- **New package** `pkg/mainpromotion`: `Validate()` enforces (1) main/master configs promote only to the current release (`ocp/{current}`, `ocp-private/{current}-priv`), and (2) release-X/openshift-X configs have promotion disabled when the repo has main/master and Prow has that release in a tide query’s `includedBranches`. Uses the same ignore list as the release script (gatekeeper, offline_migration, etc.; cri-o is not ignored).
- **New flags** on `determinize-ci-operator`: `--validate-main-promotion`, `--current-release`, `--prow-config-dir`, `--infra-periodics`, `--main-promotion-ignore`. When `--validate-main-promotion` is set, validation runs first and the process exits 1 on violations. Current release can come from `--current-release` or from the `periodic-prow-auto-config-brancher` job in `--infra-periodics`.

## Release repo follow-up

After this merges, release will switch `check-validate-main-promotion` to run determinize-ci-operator with `--validate-main-promotion` and the appropriate mounts (`--config-dir`, `--infra-periodics`, `--prow-config-dir`) and remove `hack/validate-main-promotion-guard.py`.

/cc @danilo-gemoli 