### PR TITLE
sprint-automation: query Jira via GET /rest/api/3/search/jql

### DIFF
--- a/cmd/sprint-automation/jira_search_v3.go
+++ b/cmd/sprint-automation/jira_search_v3.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	jiraapi "github.com/andygrunwald/go-jira"
+)
+
+const (
+	jiraSearchMaxPages    = 500
+	jiraSearchPageSizeCap = 100
+	jiraErrBodyRunes      = 512
+	jiraErrBodyBytesCap   = 16 * 1024
+)
+
+type jiraSearchJQLV3Response struct {
+	IsLast        bool            `json:"isLast"`
+	Issues        []jiraapi.Issue `json:"issues"`
+	NextPageToken string          `json:"nextPageToken"`
+}
+
+func searchIssuesByJQL(ctx context.Context, client *jiraapi.Client, jql string, maxPerPage int, fields []string) ([]jiraapi.Issue, error) {
+	return searchIssuesByJQLPageLimit(ctx, client, jql, maxPerPage, fields, jiraSearchMaxPages)
+}
+
+func searchIssuesByJQLPageLimit(ctx context.Context, client *jiraapi.Client, jql string, maxPerPage int, fields []string, pageLimit int) ([]jiraapi.Issue, error) {
+	if pageLimit < 1 {
+		pageLimit = 1
+	}
+	jql = strings.TrimSpace(jql)
+	if jql == "" {
+		return nil, fmt.Errorf("jira search/jql: empty jql")
+	}
+	if client == nil {
+		return nil, fmt.Errorf("jira search/jql: nil client")
+	}
+	switch {
+	case maxPerPage <= 0:
+		maxPerPage = jiraSearchPageSizeCap
+	case maxPerPage > jiraSearchPageSizeCap:
+		maxPerPage = jiraSearchPageSizeCap
+	}
+
+	fieldsParam := ""
+	if len(fields) > 0 {
+		fieldsParam = strings.Join(fields, ",")
+	}
+
+	out := make([]jiraapi.Issue, 0, pageLimit*maxPerPage)
+	var nextPageToken string
+
+	for page := 0; page < pageLimit; page++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("jira search/jql: %w", err)
+		}
+
+		sentToken := nextPageToken
+		uv := url.Values{}
+		uv.Set("jql", jql)
+		uv.Set("maxResults", strconv.Itoa(maxPerPage))
+		if fieldsParam != "" {
+			uv.Set("fields", fieldsParam)
+		}
+		if nextPageToken != "" {
+			uv.Set("nextPageToken", nextPageToken)
+		}
+
+		req, err := client.NewRequestWithContext(ctx, http.MethodGet, "rest/api/3/search/jql?"+uv.Encode(), nil)
+		if err != nil {
+			return nil, fmt.Errorf("jira search/jql: build request: %w", err)
+		}
+
+		var payload jiraSearchJQLV3Response
+		resp, doErr := client.Do(req, &payload)
+		if doErr != nil {
+			return nil, jiraSearchFormatError(resp, doErr)
+		}
+		if payload.Issues == nil {
+			payload.Issues = []jiraapi.Issue{}
+		}
+		for i := range payload.Issues {
+			iss := &payload.Issues[i]
+			if strings.TrimSpace(iss.Key) == "" {
+				return nil, fmt.Errorf("jira search/jql: page %d issue[%d] has empty key", page+1, i)
+			}
+			if iss.Fields == nil {
+				return nil, fmt.Errorf("jira search/jql: page %d issue %s has nil fields", page+1, iss.Key)
+			}
+		}
+
+		out = append(out, payload.Issues...)
+
+		if payload.IsLast {
+			return out, nil
+		}
+		if payload.NextPageToken == "" {
+			return nil, fmt.Errorf("jira search/jql: page %d not isLast but nextPageToken empty", page+1)
+		}
+		if sentToken != "" && payload.NextPageToken == sentToken {
+			return nil, fmt.Errorf("jira search/jql: page %d nextPageToken equals request token (server loop)", page+1)
+		}
+		nextPageToken = payload.NextPageToken
+	}
+
+	return nil, fmt.Errorf("jira search/jql: exceeded %d pages", pageLimit)
+}
+
+func isDecodeError(err error) bool {
+	var syn *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &syn) || errors.As(err, &typeErr) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "invalid character") && strings.Contains(msg, "literal")
+}
+
+func jiraSearchFormatError(resp *jiraapi.Response, err error) error {
+	if err == nil {
+		return nil
+	}
+	if resp == nil || resp.Response == nil {
+		return fmt.Errorf("jira search/jql: %w", err)
+	}
+	code := resp.StatusCode
+	if code == 0 {
+		code = http.StatusInternalServerError
+	}
+
+	if isDecodeError(err) {
+		return fmt.Errorf("jira search/jql: HTTP %d: decode response: %w", code, err)
+	}
+
+	if resp.Body == nil {
+		if code >= 200 && code <= 299 {
+			return fmt.Errorf("jira search/jql: HTTP %d: decode response: %w", code, err)
+		}
+		return fmt.Errorf("jira search/jql: HTTP %d: (nil response body)", code)
+	}
+	if code >= 200 && code <= 299 {
+		return fmt.Errorf("jira search/jql: HTTP %d: decode response: %w", code, err)
+	}
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, jiraErrBodyBytesCap))
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		if closeErr != nil {
+			return fmt.Errorf("jira search/jql: HTTP %d (read body: %s; close: %s): %w", code, readErr.Error(), closeErr.Error(), err)
+		}
+		return fmt.Errorf("jira search/jql: HTTP %d (body read failed: %s): %w", code, readErr.Error(), err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("jira search/jql: HTTP %d (close body: %s): %w", code, closeErr.Error(), err)
+	}
+	return fmt.Errorf("jira search/jql: HTTP %d: %s", code, truncateJiraErrBody(raw))
+}
+
+func truncateJiraErrBody(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return "(empty body)"
+	}
+	if utf8.RuneCountInString(s) <= jiraErrBodyRunes {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:jiraErrBodyRunes]) + "…"
+}

--- a/cmd/sprint-automation/jira_search_v3_test.go
+++ b/cmd/sprint-automation/jira_search_v3_test.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	jiraapi "github.com/andygrunwald/go-jira"
+)
+
+func jiraTestWriteJSON(w http.ResponseWriter, v interface{}) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func fields() *jiraapi.IssueFields { return &jiraapi.IssueFields{} }
+
+func TestSearchIssuesByJQL_validation(t *testing.T) {
+	ctx := context.Background()
+	c, err := jiraapi.NewClient(nil, "https://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := searchIssuesByJQL(ctx, c, "   ", 0, nil); err == nil || !strings.Contains(err.Error(), "empty jql") {
+		t.Errorf("empty jql: got %v", err)
+	}
+	if _, err := searchIssuesByJQL(ctx, nil, "x", 0, nil); err == nil || !strings.Contains(err.Error(), "nil client") {
+		t.Errorf("nil client: got %v", err)
+	}
+}
+
+func TestSearchIssuesByJQL_maxResultsCapped(t *testing.T) {
+	var mu sync.Mutex
+	var gotMax string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		gotMax = r.URL.Query().Get("maxResults")
+		mu.Unlock()
+		jiraTestWriteJSON(w, jiraSearchJQLV3Response{IsLast: true, Issues: nil})
+	}))
+	t.Cleanup(srv.Close)
+	c, err := jiraapi.NewClient(nil, srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := searchIssuesByJQL(context.Background(), c, "project=X", 9999, nil); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	g := gotMax
+	mu.Unlock()
+	if g != "100" {
+		t.Errorf("maxResults = %q, want 100", g)
+	}
+}
+
+func TestSearchIssuesByJQL_singleAndPaginated(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler func(*testing.T) http.HandlerFunc
+		wantN   int
+		wantErr string
+		limit   int
+	}{
+		{
+			name: "one page",
+			handler: func(t *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path != "/rest/api/3/search/jql" {
+						t.Errorf("path %s", r.URL.Path)
+					}
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+						IsLast: true,
+						Issues: []jiraapi.Issue{{ID: "1", Key: "K-1", Fields: fields()}},
+					})
+				}
+			},
+			wantN: 1,
+			limit: 10,
+		},
+		{
+			name: "two pages",
+			handler: func(t *testing.T) http.HandlerFunc {
+				var n int
+				return func(w http.ResponseWriter, r *http.Request) {
+					n++
+					switch n {
+					case 1:
+						if r.URL.Query().Get("nextPageToken") != "" {
+							t.Error("first page must not send nextPageToken")
+						}
+						jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+							IsLast:        false,
+							NextPageToken: "p2",
+							Issues:        []jiraapi.Issue{{Key: "A", Fields: fields()}},
+						})
+					case 2:
+						if r.URL.Query().Get("nextPageToken") != "p2" {
+							t.Errorf("token %q", r.URL.Query().Get("nextPageToken"))
+						}
+						jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+							IsLast: true,
+							Issues: []jiraapi.Issue{{Key: "B", Fields: fields()}},
+						})
+					default:
+						t.Fatalf("extra request %d", n)
+					}
+				}
+			},
+			wantN: 2,
+			limit: 10,
+		},
+		{
+			name: "missing next token",
+			handler: func(_ *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{IsLast: false, Issues: []jiraapi.Issue{{Key: "x", Fields: fields()}}})
+				}
+			},
+			wantErr: "nextPageToken empty",
+			limit:   5,
+		},
+		{
+			name: "token loop",
+			handler: func(_ *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					tok := r.URL.Query().Get("nextPageToken")
+					if tok == "" {
+						jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+							IsLast:        false,
+							NextPageToken: "same",
+							Issues:        []jiraapi.Issue{{Key: "1", Fields: fields()}},
+						})
+						return
+					}
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+						IsLast:        false,
+						NextPageToken: "same",
+						Issues:        []jiraapi.Issue{{Key: "2", Fields: fields()}},
+					})
+				}
+			},
+			wantErr: "server loop",
+			limit:   10,
+		},
+		{
+			name: "reject issue empty key",
+			handler: func(_ *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+						IsLast: true,
+						Issues: []jiraapi.Issue{{ID: "1", Key: " ", Fields: fields()}},
+					})
+				}
+			},
+			wantErr: "empty key",
+			limit:   5,
+		},
+		{
+			name: "reject nil fields",
+			handler: func(_ *testing.T) http.HandlerFunc {
+				return func(w http.ResponseWriter, r *http.Request) {
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+						IsLast: true,
+						Issues: []jiraapi.Issue{{ID: "1", Key: "K-1", Fields: nil}},
+					})
+				}
+			},
+			wantErr: "nil fields",
+			limit:   5,
+		},
+		{
+			name: "page limit",
+			handler: func(_ *testing.T) http.HandlerFunc {
+				var p int
+				return func(w http.ResponseWriter, r *http.Request) {
+					p++
+					jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+						IsLast:        false,
+						NextPageToken: string(rune('a' + p)),
+						Issues:        []jiraapi.Issue{{Key: "x", Fields: fields()}},
+					})
+				}
+			},
+			wantErr: "exceeded 2 pages",
+			limit:   2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler(t))
+			t.Cleanup(srv.Close)
+			c, err := jiraapi.NewClient(nil, srv.URL+"/")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := searchIssuesByJQLPageLimit(context.Background(), c, "project=DPTP", 10, []string{"*navigable"}, tt.limit)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("err = %v, want substring %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != tt.wantN {
+				t.Fatalf("len = %d want %d", len(got), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestSearchIssuesByJQL_HTTPErrorBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		if _, err := w.Write([]byte(`{"errorMessages":["no-access"]}`)); err != nil {
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := jiraapi.NewClient(nil, srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = searchIssuesByJQL(context.Background(), c, "x", 10, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "no-access") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestSearchIssuesByJQL_decodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := w.Write([]byte(`not json`)); err != nil {
+			return
+		}
+	}))
+	t.Cleanup(srv.Close)
+	c, err := jiraapi.NewClient(nil, srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = searchIssuesByJQL(context.Background(), c, "x", 10, nil)
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestSearchIssuesByJQL_contextTimeoutSecondPage(t *testing.T) {
+	var first bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !first {
+			first = true
+			jiraTestWriteJSON(w, jiraSearchJQLV3Response{
+				IsLast:        false,
+				NextPageToken: "n",
+				Issues:        nil,
+			})
+			return
+		}
+		time.Sleep(300 * time.Millisecond)
+		jiraTestWriteJSON(w, jiraSearchJQLV3Response{IsLast: true})
+	}))
+	t.Cleanup(srv.Close)
+	c, err := jiraapi.NewClient(http.DefaultClient, srv.URL+"/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = searchIssuesByJQLPageLimit(ctx, c, "jql", 10, nil, 10)
+	if err == nil {
+		t.Fatal("want ctx error")
+	}
+	errStr := err.Error()
+	if !strings.Contains(errStr, "deadline") && !strings.Contains(errStr, "canceled") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestTruncateJiraErrBody(t *testing.T) {
+	long := strings.Repeat("é", jiraErrBodyRunes+50)
+	s := truncateJiraErrBody([]byte(long))
+	if !strings.HasSuffix(s, "…") {
+		t.Errorf("expected truncated suffix …, got len %d", len(s))
+	}
+	if utf8.RuneCountInString(strings.TrimSuffix(s, "…")) != jiraErrBodyRunes {
+		t.Errorf("truncated rune count = %d, want %d", utf8.RuneCountInString(strings.TrimSuffix(s, "…")), jiraErrBodyRunes)
+	}
+	short := strings.Repeat("a", 100)
+	if truncateJiraErrBody([]byte(short)) != short {
+		t.Errorf("short string should be unchanged")
+	}
+}

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -415,8 +415,9 @@ func sendNextWeeksRoleDigest(client *pagerduty.Client, slackClient *slack.Client
 }
 
 func getIssuesNeedingApproval(jiraClient *jiraapi.Client) ([]slack.Block, error) {
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND status=Review AND issuetype!=Sub-task`, jira.ProjectDPTP), nil)
-	if err := jirautil.HandleJiraError(response, err); err != nil {
+	jql := fmt.Sprintf(`project=%s AND status=Review AND issuetype!=Sub-task`, jira.ProjectDPTP)
+	issues, err := searchIssuesByJQL(context.Background(), jiraClient, jql, 0, []string{"*navigable"})
+	if err != nil {
 		return nil, fmt.Errorf("could not query for Jira issues: %w", err)
 	}
 
@@ -445,7 +446,7 @@ func getIssuesNeedingApproval(jiraClient *jiraapi.Client) ([]slack.Block, error)
 	for _, issue := range issues {
 		assigneeDisplayName := jiraUnassignedAssigneeDisplayName
 		assigneeAvatarUrl := jiraUnassignedAssigneeAvatarUrl
-		if issue.Fields.Assignee != nil {
+		if issue.Fields != nil && issue.Fields.Assignee != nil {
 			assigneeDisplayName = issue.Fields.Assignee.DisplayName
 			assigneeAvatarUrl = issue.Fields.Assignee.AvatarUrls.Four8X48
 		}
@@ -527,9 +528,9 @@ func postBlocks(slackClient *slack.Client, blocks []slack.Block) error {
 }
 
 func assignAndSendIntakeDigest(slackClient *slack.Client, jiraClient *jiraapi.Client, user user) error {
-	opts := jiraapi.SearchOptions{Fields: []string{"*navigable", "comment"}}
-	issues, response, err := jiraClient.Issue.Search(fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT (labels=ready OR labels=no-intake)) AND created >= -30d AND status = "To Do" AND issuetype != Sub-task AND assignee is EMPTY`, jira.ProjectDPTP), &opts)
-	if err := jirautil.HandleJiraError(response, err); err != nil {
+	jql := fmt.Sprintf(`project=%s AND (labels is EMPTY OR NOT (labels=ready OR labels=no-intake)) AND created >= -30d AND status = "To Do" AND issuetype != Sub-task AND assignee is EMPTY`, jira.ProjectDPTP)
+	issues, err := searchIssuesByJQL(context.Background(), jiraClient, jql, 0, []string{"*navigable", "comment"})
+	if err != nil {
 		return fmt.Errorf("could not query for Jira issues: %w", err)
 	}
 
@@ -692,25 +693,40 @@ func sendTriageBuild02Upgrade(slackClient *slack.Client, version, stableDuration
 const dateFormat = "Mon, 02 Jan 2006"
 
 func blockForIssue(issue jiraapi.Issue) slack.Block {
-	// we really don't want these things to line wrap, so truncate the summary
 	cutoff := 85
-	summary := issue.Fields.Summary
-	if len(summary) > cutoff {
-		summary = summary[0:cutoff-3] + "..."
+	key := strings.TrimSpace(issue.Key)
+	if key == "" {
+		key = strings.TrimSpace(issue.ID)
 	}
-	created := time.Time(issue.Fields.Created).Format(dateFormat)
-	updated := time.Time(issue.Fields.Updated).Format(dateFormat)
+	if key == "" {
+		key = "unknown"
+	}
+	summary := ""
+	createdStr := "—"
+	updatedStr := "—"
+	if issue.Fields != nil {
+		summary = issue.Fields.Summary
+		if len(summary) > cutoff {
+			summary = summary[0:cutoff-3] + "..."
+		}
+		if t := time.Time(issue.Fields.Created); !t.IsZero() {
+			createdStr = t.Format(dateFormat)
+		}
+		if t := time.Time(issue.Fields.Updated); !t.IsZero() {
+			updatedStr = t.Format(dateFormat)
+		}
+	}
 	return &slack.ContextBlock{
 		Type: slack.MBTContext,
 		ContextElements: slack.ContextElements{
 			Elements: []slack.MixedElement{
 				&slack.TextBlockObject{
 					Type: slack.MarkdownType,
-					Text: fmt.Sprintf("<https://issues.redhat.com/browse/%s|*%s*>: %s \n", issue.Key, issue.Key, summary),
+					Text: fmt.Sprintf("<https://issues.redhat.com/browse/%s|*%s*>: %s \n", key, key, summary),
 				},
 				&slack.TextBlockObject{
 					Type: slack.PlainTextType,
-					Text: fmt.Sprintf("Created on: %s  Last updated: %s", created, updated),
+					Text: fmt.Sprintf("Created on: %s  Last updated: %s", createdStr, updatedStr),
 				},
 			},
 		},


### PR DESCRIPTION
## What
`periodic-sprint-automation` was failing against **issues.redhat.com** with **410** and *migrate to `/rest/api/3/search/jql`* (legacy `Issue.Search` → `/rest/api/2/search` removed per CHANGE-2046).

## How
- Add `searchIssuesByJQL`: **GET `/rest/api/3/search/jql`** with `nextPageToken` pagination, page cap, loop detection, context cancellation, and one-shot error body reads for clear HTTP errors.
- **Team digest** (`*navigable` fields); **intake digest** (`*navigable`, `comment`). Default **100** issues per page.

## Tests
- Unit tests in `jira_search_v3_test.go` (pagination, HTTP errors, decode errors, context timeout, validation).

## Release / config
No **openshift/release** changes expected (same Jira credentials/flags).


/cc @openshift/test-platform 