### PR TITLE
wait for stable:cli via WaitForImportingISTag (10m)

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -464,35 +464,14 @@ func (s *importReleaseStep) getCLIImage(ctx context.Context, target, streamName 
 			},
 		},
 	}
-	key := ctrlruntimeclient.ObjectKeyFromObject(streamTag)
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		return s.client.Update(ctx, streamTag)
 	}); err != nil {
 		return nil, fmt.Errorf("unable to tag the 'cli' image into the stable stream: %w", err)
 	}
 
-	startedWaiting := time.Now()
-	if err := wait.PollImmediate(5*time.Second, 5*time.Minute+5*time.Second, func() (bool, error) {
-		if err := s.client.Get(ctx, key, streamTag); err != nil {
-			if kerrors.IsNotFound(err) {
-				return false, nil
-			}
-			return false, err
-		}
-		populated := streamTag.Tag != nil && streamTag.Tag.Generation != nil && *streamTag.Tag.Generation == streamTag.Generation
-		if streamTag.Tag == nil {
-			logrus.Debug("The 'cli' image in the stable stream is not populated: streamTag.Tag is nil")
-			return false, nil
-		}
-		if !populated {
-			logrus.WithField("streamTag.Tag.Generation", streamTag.Tag.Generation).
-				WithField("streamTag.Generation", streamTag.Generation).
-				Debug("The 'cli' image in the stable stream is not populated")
-		}
-		return populated, nil
-	}); err != nil {
-		duration := time.Since(startedWaiting)
-		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate (waited for %s): %w", duration, err)
+	if err := utils.WaitForImportingISTag(ctx, s.client, s.jobSpec.Namespace(), streamName, nil, sets.New("cli"), 10*time.Minute, s.client.MetricsAgent()); err != nil {
+		return nil, fmt.Errorf("unable to wait for the 'cli' image in the stable stream to populate: %w", err)
 	}
 
 	return &cliImageRef, nil


### PR DESCRIPTION
## What

Replace the custom `PollImmediate` loop in `importReleaseStep.getCLIImage` with `utils.WaitForImportingISTag` for the `stable:cli` tag after tagging the CLI image into the stable imagestream.

## Why

- Aligns with how other release imports wait (watch-based, same evaluation as `create_release` and the bulk import step).
- Reuses existing behavior for transient import failures (`ImportTagWithRetries` when tag conditions report internal errors).
- Uses a **10 minute** timeout for this single-tag wait (instead of the previous ~5 minute poll cap or the full **45 minute** default used for entire-stream imports).

## Files

- `pkg/steps/release/import_release.go`

Failing job https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_hypershift/7940/pull-ci-openshift-hypershift-main-e2e-aks/2032082404130164736 

/cc @droslean @openshift/test-platform 