### PR TITLE
multi-pr-prow-plugin: keep origin base ref for cross-repo /testwith

### DIFF
--- a/cmd/multi-pr-prow-plugin/server.go
+++ b/cmd/multi-pr-prow-plugin/server.go
@@ -291,11 +291,14 @@ func (s *server) determineJobRuns(comment string, originPR github.PullRequest) (
 				additionalPRs = append(additionalPRs, *pr)
 			}
 
-			// Store the OriginPR with its base branch cleared. The branch is captured
-			// in the job metadata, and clearing it avoids confusion when the PR was
-			// opened against a renamed branch (e.g., "master" when the default is now "main").
+			// When the operand PR is on the job repo, clear Base.Ref: branch comes from
+			// job metadata (avoids renamed default branches, e.g. master vs main).
+			// Otherwise keep the API base ref so configresolver can resolve path aliases.
 			storedOriginPR := originPR
-			storedOriginPR.Base.Ref = ""
+			if originPR.Base.Repo.Owner.Login == jobMetadata.Org &&
+				originPR.Base.Repo.Name == jobMetadata.Repo {
+				storedOriginPR.Base.Ref = ""
+			}
 			jobRuns = append(jobRuns, jobRun{
 				JobMetadata:   *jobMetadata,
 				OriginPR:      storedOriginPR,

--- a/cmd/multi-pr-prow-plugin/server_test.go
+++ b/cmd/multi-pr-prow-plugin/server_test.go
@@ -575,6 +575,52 @@ func TestDetermineJobRuns(t *testing.T) {
 			},
 		},
 		{
+			name:    "cross-repo job preserves origin base ref",
+			comment: "/testwith openshift/cluster-version-operator/main/e2e openshift/cluster-version-operator#1",
+			originPR: github.PullRequest{
+				Base: github.PullRequestBranch{
+					Repo: github.Repo{
+						Owner: github.User{Login: "openshift"},
+						Name:  "oc",
+					},
+					Ref: "main",
+				},
+				Number: 2170,
+			},
+			expected: []jobRun{{
+				JobMetadata: api.MetadataWithTest{
+					Metadata: api.Metadata{
+						Org:    "openshift",
+						Repo:   "cluster-version-operator",
+						Branch: "main",
+					},
+					Test: "e2e",
+				},
+				OriginPR: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{Login: "openshift"},
+							Name:  "oc",
+						},
+						Ref: "main",
+					},
+					Number: 2170,
+				},
+				AdditionalPRs: []github.PullRequest{
+					{
+						Base: github.PullRequestBranch{
+							Repo: github.Repo{
+								Owner: github.User{Login: "openshift"},
+								Name:  "cluster-version-operator",
+							},
+							Ref: "main",
+						},
+						Number: 1,
+					},
+				},
+			}},
+		},
+		{
 			name:    "trigger a single job with multiple additional PRs",
 			comment: "/testwith openshift/ci-tools/main/unit openshift/ci-tools#123 openshift/release#876",
 			originPR: github.PullRequest{
@@ -726,6 +772,16 @@ func TestDetermineJobRuns(t *testing.T) {
 						},
 					},
 					Number: 876,
+				},
+				"openshift/cluster-version-operator#1": {
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{Login: "openshift"},
+							Name:  "cluster-version-operator",
+						},
+						Ref: "main",
+					},
+					Number: 1,
 				},
 			}}
 			s := server{


### PR DESCRIPTION
## What / why

The operand PR’s `Base.Ref` was always cleared for `/testwith`. For **cross-repo** runs (e.g. comment on `openshift/oc` while the job targets `openshift/cluster-version-operator`), the origin repo never gets a branch from job metadata, so `createRefsForPullRequests` called configresolver with an **empty** branch and failed with:

`resolve config openshift/oc@: got unexpected http 400 status code from configresolver: branch query missing or incorrect`

Only clear `Base.Ref` when the operand PR is on the **same** org/repo as the job in the command; otherwise keep the GitHub API base ref.

##
Ref:  [openshift/oc#2170 (comment)](https://github.com/openshift/oc/pull/2170#issuecomment-4109566062) — `testwith: could not generate prow job` with the `branch query missing or incorrect` error.

/cc @openshift/test-platform 