### PR TITLE
DPTP-4739: payload-job expand sharded base names to all shards

### DIFF
--- a/cmd/payload-testing-prow-plugin/filetestresolver.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver.go
@@ -12,7 +12,7 @@ type fileTestResolver struct {
 	configAgent agents.ConfigAgent
 }
 
-func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
+func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, int, error) {
 	byOrgRepo := r.configAgent.GetAll()
 	for _, org := range []string{"openshift", "openshift-eng"} {
 		if v, ok := byOrgRepo[org]; ok {
@@ -22,10 +22,14 @@ func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
 						if element.IsPeriodic() {
 							testName := configuration.Metadata.TestNameFromJobName(job, jc.PeriodicPrefix)
 							if element.As == testName {
+								shardCount := 1
+								if element.ShardCount != nil {
+									shardCount = *element.ShardCount
+								}
 								return api.MetadataWithTest{
 									Metadata: configuration.Metadata,
 									Test:     element.As,
-								}, nil
+								}, shardCount, nil
 							}
 						}
 					}
@@ -33,5 +37,5 @@ func (r *fileTestResolver) resolve(job string) (api.MetadataWithTest, error) {
 			}
 		}
 	}
-	return api.MetadataWithTest{}, fmt.Errorf("failed to resolve job %s", job)
+	return api.MetadataWithTest{}, 0, fmt.Errorf("failed to resolve job %s", job)
 }

--- a/cmd/payload-testing-prow-plugin/filetestresolver_test.go
+++ b/cmd/payload-testing-prow-plugin/filetestresolver_test.go
@@ -22,7 +22,7 @@ func TestFileTestResolver(t *testing.T) {
 			name: "basic case",
 			dir:  filepath.Join("testdata", "config"),
 			verifyFun: func(testResolver testResolver) error {
-				actual, actualErr := testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-serial")
+				actual, shardCount, actualErr := testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-serial")
 				expected := api.MetadataWithTest{Metadata: api.Metadata{
 					Org:     "openshift",
 					Repo:    "release",
@@ -34,11 +34,14 @@ func TestFileTestResolver(t *testing.T) {
 				if diff := cmp.Diff(expected, actual); diff != "" {
 					return fmt.Errorf("actual differs from expected: %s", diff)
 				}
+				if shardCount != 1 {
+					return fmt.Errorf("shardCount: got %d, want 1", shardCount)
+				}
 				if diff := cmp.Diff(nil, actualErr, testhelper.EquateErrorMessage); diff != "" {
 					return fmt.Errorf("actualErr differs from expected: %s", diff)
 				}
 
-				actual, actualErr = testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi")
+				actual, shardCount, actualErr = testResolver.resolve("periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-ipi")
 				expected = api.MetadataWithTest{Metadata: api.Metadata{
 					Org:     "openshift",
 					Repo:    "release",
@@ -50,11 +53,14 @@ func TestFileTestResolver(t *testing.T) {
 				if diff := cmp.Diff(expected, actual); diff != "" {
 					return fmt.Errorf("actual differs from expected: %s", diff)
 				}
+				if shardCount != 1 {
+					return fmt.Errorf("shardCount: got %d, want 1", shardCount)
+				}
 				if diff := cmp.Diff(nil, actualErr, testhelper.EquateErrorMessage); diff != "" {
 					return fmt.Errorf("actualErr differs from expected: %s", diff)
 				}
 
-				actual, actualErr = testResolver.resolve("periodic-ci-openshift-api-master-build")
+				actual, shardCount, actualErr = testResolver.resolve("periodic-ci-openshift-api-master-build")
 				expected = api.MetadataWithTest{Metadata: api.Metadata{
 					Org:    "openshift",
 					Repo:   "api",
@@ -65,14 +71,20 @@ func TestFileTestResolver(t *testing.T) {
 				if diff := cmp.Diff(expected, actual); diff != "" {
 					return fmt.Errorf("actual differs from expected: %s", diff)
 				}
+				if shardCount != 1 {
+					return fmt.Errorf("shardCount: got %d, want 1", shardCount)
+				}
 				if diff := cmp.Diff(nil, actualErr, testhelper.EquateErrorMessage); diff != "" {
 					return fmt.Errorf("actualErr differs from expected: %s", diff)
 				}
 
-				actual, actualErr = testResolver.resolve("some-job")
+				actual, shardCount, actualErr = testResolver.resolve("some-job")
 				expected = api.MetadataWithTest{}
 				if diff := cmp.Diff(expected, actual); diff != "" {
 					return fmt.Errorf("actual differs from expected: %s", diff)
+				}
+				if shardCount != 0 {
+					return fmt.Errorf("shardCount on error: got %d, want 0", shardCount)
 				}
 				if diff := cmp.Diff(fmt.Errorf("failed to resolve job some-job"), actualErr, testhelper.EquateErrorMessage); diff != "" {
 					return fmt.Errorf("actualErr differs from expected: %s", diff)

--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -164,7 +164,7 @@ type jobResolver interface {
 }
 
 type testResolver interface {
-	resolve(job string) (api.MetadataWithTest, error)
+	resolve(job string) (api.MetadataWithTest, int, error)
 }
 
 func specsFromComment(comment string) []jobSetSpecification {
@@ -496,26 +496,45 @@ func (s *server) handle(l *logrus.Entry, ic github.IssueCommentEvent) (string, [
 					AggregatedCount: job.AggregatedCount,
 				})
 			} else {
-				jobTuple, err := s.testResolver.resolve(job.Name)
+				jobTuple, configShardCount, err := s.testResolver.resolve(job.Name)
 				if err != nil {
 					// This is expected for non-generated jobs
 					specLogger.WithError(err).WithField("job.Name", job.Name).Info("could not resolve tests for job")
 					continue
 				}
-				shardCount, shardIndex := extractShardInfo(job.Name)
-				jobNames = append(jobNames, job.Name)
-				releaseJobSpecs = append(releaseJobSpecs, prpqv1.ReleaseJobSpec{
-					CIOperatorConfig: prpqv1.CIOperatorMetadata{
-						Org:     jobTuple.Metadata.Org,
-						Repo:    jobTuple.Metadata.Repo,
-						Branch:  jobTuple.Metadata.Branch,
-						Variant: jobTuple.Metadata.Variant,
-					},
-					Test:            jobTuple.Test,
-					AggregatedCount: job.AggregatedCount,
-					ShardCount:      shardCount,
-					ShardIndex:      shardIndex,
-				})
+				suffixShardCount, suffixShardIndex := extractShardInfo(job.Name)
+				if job.AggregatedCount == 0 && suffixShardCount == 0 && configShardCount > 1 {
+					for i := 1; i <= configShardCount; i++ {
+						name := fmt.Sprintf("%s-%dof%d", job.Name, i, configShardCount)
+						jobNames = append(jobNames, name)
+						releaseJobSpecs = append(releaseJobSpecs, prpqv1.ReleaseJobSpec{
+							CIOperatorConfig: prpqv1.CIOperatorMetadata{
+								Org:     jobTuple.Metadata.Org,
+								Repo:    jobTuple.Metadata.Repo,
+								Branch:  jobTuple.Metadata.Branch,
+								Variant: jobTuple.Metadata.Variant,
+							},
+							Test:            jobTuple.Test,
+							AggregatedCount: job.AggregatedCount,
+							ShardCount:      configShardCount,
+							ShardIndex:      i,
+						})
+					}
+				} else {
+					jobNames = append(jobNames, job.Name)
+					releaseJobSpecs = append(releaseJobSpecs, prpqv1.ReleaseJobSpec{
+						CIOperatorConfig: prpqv1.CIOperatorMetadata{
+							Org:     jobTuple.Metadata.Org,
+							Repo:    jobTuple.Metadata.Repo,
+							Branch:  jobTuple.Metadata.Branch,
+							Variant: jobTuple.Metadata.Variant,
+						},
+						Test:            jobTuple.Test,
+						AggregatedCount: job.AggregatedCount,
+						ShardCount:      suffixShardCount,
+						ShardIndex:      suffixShardIndex,
+					})
+				}
 			}
 		}
 

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -716,6 +716,36 @@ See details on https://pr-payload-tests.ci.openshift.org/runs/ci/guid-0
 `,
 		},
 		{
+			name: "payload-job with sharded job base name expands all shards",
+			s: &server{
+				ghc:                ghc,
+				ctx:                context.TODO(),
+				kubeClient:         fakeclient.NewClientBuilder().Build(),
+				namespace:          "ci",
+				testResolver:       newFakeTestResolver(),
+				trustedChecker:     &fakeTrustedChecker{},
+				ciOpConfigResolver: &fakeCIOpConfigResolver{},
+			},
+			ic: github.IssueCommentEvent{
+				GUID: "guid",
+				Repo: github.Repo{Owner: github.User{Login: "openshift"}},
+				Issue: github.Issue{
+					Number:      123,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/payload-job periodic-ci-openshift-release-master-nightly-4.10-e2e-sharded",
+				},
+			},
+			expectedMessage: `trigger 3 job(s) for the /payload-(with-prs|job|aggregate|job-with-prs|aggregate-with-prs) command
+- periodic-ci-openshift-release-master-nightly-4.10-e2e-sharded-1of3
+- periodic-ci-openshift-release-master-nightly-4.10-e2e-sharded-2of3
+- periodic-ci-openshift-release-master-nightly-4.10-e2e-sharded-3of3
+
+See details on https://pr-payload-tests.ci.openshift.org/runs/ci/guid-0
+`,
+		},
+		{
 			name: "payload-job",
 			s: &server{
 				ghc:                ghc,
@@ -1230,13 +1260,16 @@ func newFakeTestResolver() testResolver {
 	}
 }
 
-func (r *fakeTestResolver) resolve(job string) (api.MetadataWithTest, error) {
-	// Remove shard suffix from job if present prior to searching for it in map
+func (r *fakeTestResolver) resolve(job string) (api.MetadataWithTest, int, error) {
 	baseJob := shardSuffixPattern.ReplaceAllString(job, "")
 	if jt, ok := r.tuples[baseJob]; ok {
-		return jt, nil
+		shardCount := 1
+		if jt.Test == "e2e-sharded" {
+			shardCount = 3
+		}
+		return jt, shardCount, nil
 	}
-	return api.MetadataWithTest{}, fmt.Errorf("failed to resolve job %s", job)
+	return api.MetadataWithTest{}, 0, fmt.Errorf("failed to resolve job %s", job)
 }
 
 func TestFormatError(t *testing.T) {


### PR DESCRIPTION
## What

When a periodic is **sharded** (`-1ofN`, …, `-NofN`), `/payload-job` with the **base** job name (no shard suffix) now submits **all shards** in one run. Passing the **full** name including `-XofY` still runs **only that shard**.

## Why

Matches pre-sharding UX: one command with the usual job name runs the full job; optional `-XofY` selects a single shard.

## Behavior

| Command | Result |
|--------|--------|
| `/payload-job <base-periodic-name>` | All shards if `shard_count` > 1 in ci-operator |
| `/payload-job <name>-XofY` | Shard X only |

`/payload-aggregate` is unchanged: it does not expand a base name to all shards (still one target job per invocation).

## How it works

`fileTestResolver` returns the test’s configured shard count from ci-operator. If the comment has no `-XofY` suffix, shard count > 1, and the job is not an aggregate command, the handler emits one `ReleaseJobSpec` per shard.


/cc @openshift/test-platform 