### PR TITLE
DPTP-4740: private-prow-configs-mirror clear stale openshift-priv branch-protection

### DIFF
--- a/cmd/private-prow-configs-mirror/main.go
+++ b/cmd/private-prow-configs-mirror/main.go
@@ -172,6 +172,8 @@ func getOrgReposWithOfficialImages(configDir string, whitelist map[string][]stri
 }
 
 func injectPrivateBranchProtection(branchProtection prowconfig.BranchProtection, orgRepos orgReposWithOfficialImages) {
+	delete(branchProtection.Orgs, openshiftPrivOrg)
+
 	privateOrg := prowconfig.Org{
 		Repos: make(map[string]prowconfig.Repo),
 	}

--- a/cmd/private-prow-configs-mirror/main_test.go
+++ b/cmd/private-prow-configs-mirror/main_test.go
@@ -71,6 +71,23 @@ func TestInjectPrivateBranchProtection(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: "stale openshift-priv removed when no longer official",
+			branchProtection: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{}},
+					"openshift-priv": {Repos: map[string]prowconfig.Repo{
+						"deleted-from-github": {Branches: map[string]prowconfig.Branch{
+							"branch1": {Policy: prowconfig.Policy{Protect: pBool(true)}}}}},
+					},
+				},
+			},
+			expected: prowconfig.BranchProtection{
+				Orgs: map[string]prowconfig.Org{
+					"openshift": {Repos: map[string]prowconfig.Repo{}},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## What

`private-prow-configs-mirror`: at the start of `injectPrivateBranchProtection`, delete the existing `openshift-priv` entry from `branch-protection` before rebuilding it from official `openshift` repos.

## Why

Branch-protection for `openshift-priv` is derived from the mirror, but if there was nothing to mirror (`privateOrg` empty), the old `openshift-priv` block from the loaded YAML was never overwritten. Stale repo names could remain. Prow’s **branchprotector** calls `GetRepo` for every configured repo; missing repos return **404**, errors accumulate, and the periodic job can fail entirely.

Clearing `openshift-priv` first matches the idea behind `cleanStalePluginConfigs` for plugins: don’t carry forward outdated `openshift-priv` config.


/cc @openshift/test-platform 