### PR TITLE
ci-operator: Report leaked leases properly

### DIFF
--- a/cmd/ci-operator/main.go
+++ b/cmd/ci-operator/main.go
@@ -1176,11 +1176,13 @@ func (o *options) Run() (errs []error) {
 			stopHeartbeating := o.startLeaseHearthbeating()
 			defer func() {
 				close(stopHeartbeating)
-				if l, err := o.leaseClient.ReleaseAll(); err != nil {
-					logrus.WithError(err).Errorf("Failed to release leaked leases (%v)", l)
-				} else if len(l) != 0 {
-					o.metricsAgent.Record(metrics.NewInsightsEvent(metrics.InsightLeaseReleased, metrics.Context{"released_count": len(l)}))
-					logrus.Warnf("Would leak leases: %v", l)
+				released, err := o.leaseClient.ReleaseAll()
+				if err != nil {
+					logrus.WithError(err).Errorf("Failed to release leaked leases")
+				}
+				if leaked := o.leaseClient.Leases(); len(leaked) > 0 {
+					o.metricsAgent.Record(metrics.NewInsightsEvent(metrics.InsightLeaseReleased, metrics.Context{"released_count": len(released)}))
+					logrus.Warnf("Would leak leases: %v", leaked)
 				}
 			}()
 		}

--- a/pkg/lease/client.go
+++ b/pkg/lease/client.go
@@ -3,7 +3,9 @@ package lease
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -72,6 +74,8 @@ type Client interface {
 	// Metrics queries the states of a particular resource, for informational
 	// purposes.
 	Metrics(rtype string) (Metrics, error)
+	// Leases returns the leases collected so far.
+	Leases() []string
 }
 
 // NewClient creates a client that leases resources with the specified owner.
@@ -213,4 +217,12 @@ func (c *client) Metrics(rtype string) (Metrics, error) {
 		Free:   metrics.Current[freeState],
 		Leased: metrics.Current[leasedState],
 	}, nil
+}
+
+func (c *client) Leases() []string {
+	c.Lock()
+	defer c.Unlock()
+	l := slices.Collect(maps.Keys(c.leases))
+	slices.Sort(l)
+	return l
 }

--- a/pkg/lease/client_test.go
+++ b/pkg/lease/client_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -130,4 +132,55 @@ func TestHeartbeatRetries(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLeases(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		acquire    []string
+		release    []string
+		wantLeases []string
+	}{
+		{
+			name:       "Acquire several leases",
+			acquire:    []string{"a", "b", "c"},
+			wantLeases: []string{"a_0", "b_1", "c_2"},
+		},
+		{
+			name:       "Acquire and release several leases",
+			acquire:    []string{"a", "b", "c"},
+			release:    []string{"a_0", "b_1"},
+			wantLeases: []string{"c_2"},
+		},
+		{
+			name:    "Acquire no leases",
+			acquire: []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.TODO()
+			client := NewFakeClient("owner", "url", 0, nil, new([]string), nil)
+			for _, l := range tc.acquire {
+				if _, err := client.Acquire(l, 1, ctx, nil); err != nil {
+					t.Fatalf("acquire: %s", err)
+				}
+			}
+
+			for _, l := range tc.release {
+				if err := client.Release(l); err != nil {
+					t.Fatalf("release: %s", err)
+				}
+			}
+
+			gotLeases := client.Leases()
+			if diff := cmp.Diff(tc.wantLeases, gotLeases); diff != "" {
+				t.Errorf("unexpected leases: %s", diff)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
`ReleaseAll()` return the leases that have released instead of the ones that have not been releases, like the old code assumed.
Fix that by introducing the new `Leases()` method.