### PR TITLE
ci-operator-config-mirror: Do not mirror configs without tests and images

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -107,7 +107,81 @@ func main() {
 	}()
 
 	configsByRepo := make(configsByRepo)
-	callback := func(rbc *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	callback := ciOperatorConfigsCallback(o, configsByRepo)
+
+	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, callback); err != nil {
+		logrus.WithError(err).Fatal("error while operating in the ci-operator configuration files")
+	}
+
+	dest := filepath.Join(o.ConfigDir, o.toOrg)
+	logger := logrus.WithField("destination", dest)
+	if o.clean {
+		logger.Info("Cleaning destination's sub directories")
+		if err := configsByRepo.cleanDestinationSubdirs(dest); err != nil {
+			logger.WithError(err).Fatal("couldn't cleanup destination's subdirectories")
+		}
+	}
+
+	logger.Info("Generating configurations...")
+	if err := configsByRepo.generateConfigs(o.ConfigDir); err != nil {
+		logger.WithError(err).Fatal("couldn't generate configurations")
+	}
+}
+
+func privateReleaseTagConfiguration(tagSpecification *api.ReleaseTagConfiguration) {
+	if tagSpecification.Namespace == ocpNamespace {
+		tagSpecification.Name = fmt.Sprintf("%s-priv", tagSpecification.Name)
+		tagSpecification.Namespace = privatePromotionNamespace
+	}
+}
+
+func privateIntegrationRelease(release *api.Integration) {
+	if release.Namespace == ocpNamespace {
+		release.Name = fmt.Sprintf("%s-priv", release.Name)
+		release.Namespace = privatePromotionNamespace
+	}
+}
+
+func privateBuildRoot(buildRoot *api.BuildRootImageConfiguration) {
+	if buildRoot.ImageStreamTagReference.Namespace == ocpNamespace {
+		buildRoot.ImageStreamTagReference.Name = fmt.Sprintf("%s-priv", buildRoot.ImageStreamTagReference.Name)
+		buildRoot.ImageStreamTagReference.Namespace = privatePromotionNamespace
+	}
+}
+
+func privateBaseImages(baseImages map[string]api.ImageStreamTagReference) {
+	for name, reference := range baseImages {
+		if reference.Namespace == ocpNamespace && api.IsValidOCPVersion(reference.Name) {
+			reference.Name = fmt.Sprintf("%s-priv", reference.Name)
+			reference.Namespace = privatePromotionNamespace
+			baseImages[name] = reference
+		}
+	}
+}
+
+func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
+	for i := range promotion.Targets {
+		if promotion.Targets[i].Namespace == ocpNamespace {
+			if promotion.Targets[i].Name != "" {
+				promotion.Targets[i].Name = fmt.Sprintf("%s-priv", promotion.Targets[i].Name)
+			} else { // promotion.Targets[i].Tag must be set
+				promotion.Targets[i].Tag = fmt.Sprintf("%s-priv", promotion.Targets[i].Tag)
+			}
+			promotion.Targets[i].TagByCommit = false // Never use tag_by_commit for mirrored repos
+			promotion.Targets[i].Namespace = privatePromotionNamespace
+		} else {
+			// Disable this target or it will conflict with its non `-priv` counterpart
+			promotion.Targets[i].Disabled = true
+		}
+	}
+}
+
+func strP(str string) *string {
+	return &str
+}
+
+func ciOperatorConfigsCallback(o options, configsByRepo configsByRepo) func(rbc *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
+	return func(rbc *api.ReleaseBuildConfiguration, repoInfo *config.Info) error {
 		logger := logrus.WithFields(logrus.Fields{"org": repoInfo.Org, "repo": repoInfo.Repo, "branch": repoInfo.Branch})
 
 		if repoInfo.Org == o.toOrg {
@@ -186,81 +260,14 @@ func main() {
 
 		repoInfo.Org = o.toOrg
 		rbc.Metadata.Org = o.toOrg
-		configsByRepo[repoInfo.Repo] = append(configsByRepo[repoInfo.Repo], config.DataWithInfo{
-			Configuration: *rbc,
-			Info:          *repoInfo,
-		})
+
+		if len(rbc.Tests) > 0 || len(rbc.Images) > 0 {
+			configsByRepo[repoInfo.Repo] = append(configsByRepo[repoInfo.Repo], config.DataWithInfo{
+				Configuration: *rbc,
+				Info:          *repoInfo,
+			})
+		}
 
 		return nil
 	}
-
-	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, callback); err != nil {
-		logrus.WithError(err).Fatal("error while operating in the ci-operator configuration files")
-	}
-
-	dest := filepath.Join(o.ConfigDir, o.toOrg)
-	logger := logrus.WithField("destination", dest)
-	if o.clean {
-		logger.Info("Cleaning destination's sub directories")
-		if err := configsByRepo.cleanDestinationSubdirs(dest); err != nil {
-			logger.WithError(err).Fatal("couldn't cleanup destination's subdirectories")
-		}
-	}
-
-	logger.Info("Generating configurations...")
-	if err := configsByRepo.generateConfigs(o.ConfigDir); err != nil {
-		logger.WithError(err).Fatal("couldn't generate configurations")
-	}
-}
-
-func privateReleaseTagConfiguration(tagSpecification *api.ReleaseTagConfiguration) {
-	if tagSpecification.Namespace == ocpNamespace {
-		tagSpecification.Name = fmt.Sprintf("%s-priv", tagSpecification.Name)
-		tagSpecification.Namespace = privatePromotionNamespace
-	}
-}
-
-func privateIntegrationRelease(release *api.Integration) {
-	if release.Namespace == ocpNamespace {
-		release.Name = fmt.Sprintf("%s-priv", release.Name)
-		release.Namespace = privatePromotionNamespace
-	}
-}
-
-func privateBuildRoot(buildRoot *api.BuildRootImageConfiguration) {
-	if buildRoot.ImageStreamTagReference.Namespace == ocpNamespace {
-		buildRoot.ImageStreamTagReference.Name = fmt.Sprintf("%s-priv", buildRoot.ImageStreamTagReference.Name)
-		buildRoot.ImageStreamTagReference.Namespace = privatePromotionNamespace
-	}
-}
-
-func privateBaseImages(baseImages map[string]api.ImageStreamTagReference) {
-	for name, reference := range baseImages {
-		if reference.Namespace == ocpNamespace && api.IsValidOCPVersion(reference.Name) {
-			reference.Name = fmt.Sprintf("%s-priv", reference.Name)
-			reference.Namespace = privatePromotionNamespace
-			baseImages[name] = reference
-		}
-	}
-}
-
-func privatePromotionConfiguration(promotion *api.PromotionConfiguration) {
-	for i := range promotion.Targets {
-		if promotion.Targets[i].Namespace == ocpNamespace {
-			if promotion.Targets[i].Name != "" {
-				promotion.Targets[i].Name = fmt.Sprintf("%s-priv", promotion.Targets[i].Name)
-			} else { // promotion.Targets[i].Tag must be set
-				promotion.Targets[i].Tag = fmt.Sprintf("%s-priv", promotion.Targets[i].Tag)
-			}
-			promotion.Targets[i].TagByCommit = false // Never use tag_by_commit for mirrored repos
-			promotion.Targets[i].Namespace = privatePromotionNamespace
-		} else {
-			// Disable this target or it will conflict with its non `-priv` counterpart
-			promotion.Targets[i].Disabled = true
-		}
-	}
-}
-
-func strP(str string) *string {
-	return &str
 }

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/utils/ptr"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
 )
@@ -307,7 +308,10 @@ func TestCIOperatorConfigsCallback(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			gotConfigsByRepo := make(configsByRepo)
 			callback := ciOperatorConfigsCallback(tc.opts, gotConfigsByRepo)
-			callback(tc.rbc, tc.repoInfo)
+
+			if err := callback(tc.rbc, tc.repoInfo); err != nil {
+				t.Fatalf("callback error: %s", err)
+			}
 
 			if diff := cmp.Diff(tc.wantConfigsByRepo, gotConfigsByRepo); diff != "" {
 				t.Errorf("unexpected configs: %s", diff)

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -5,8 +5,11 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/utils/ptr"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/config"
 )
 
 func TestPrivateReleaseTagConfiguration(t *testing.T) {
@@ -230,6 +233,84 @@ func TestPrivatePromotionConfiguration(t *testing.T) {
 			privatePromotionConfiguration(tc.promotion)
 			if !reflect.DeepEqual(tc.promotion, tc.expected) {
 				t.Fatalf("Differences found: %v", diff.ObjectReflectDiff(tc.promotion, tc.expected))
+			}
+		})
+	}
+}
+
+func TestCIOperatorConfigsCallback(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		opts              options
+		rbc               *api.ReleaseBuildConfiguration
+		repoInfo          *config.Info
+		wantConfigsByRepo configsByRepo
+	}{
+		{
+			name: "Mirror a config",
+			opts: options{
+				toOrg:   "openshift-priv",
+				onlyOrg: "openshift",
+				WhitelistOptions: config.WhitelistOptions{
+					WhitelistConfig: config.WhitelistConfig{
+						Whitelist: map[string][]string{
+							"openshift": {"kubernetes"},
+						},
+					},
+				},
+			},
+			rbc: &api.ReleaseBuildConfiguration{
+				Tests: []api.TestStepConfiguration{{
+					As: "e2e",
+				}},
+			},
+			repoInfo: &config.Info{
+				Metadata: api.Metadata{
+					Org:  "openshift",
+					Repo: "kubernetes",
+				},
+			},
+			wantConfigsByRepo: configsByRepo{
+				"kubernetes": []config.DataWithInfo{{
+					Configuration: api.ReleaseBuildConfiguration{
+						Metadata:              api.Metadata{Org: "openshift-priv"},
+						CanonicalGoRepository: ptr.To("github.com/openshift/kubernetes"),
+						Tests:                 []api.TestStepConfiguration{{As: "e2e"}},
+					},
+					Info: config.Info{Metadata: api.Metadata{Org: "openshift-priv", Repo: "kubernetes"}},
+				}},
+			},
+		},
+		{
+			name: "Do not mirror config without tests and images",
+			opts: options{
+				toOrg:   "openshift-priv",
+				onlyOrg: "openshift",
+				WhitelistOptions: config.WhitelistOptions{
+					WhitelistConfig: config.WhitelistConfig{
+						Whitelist: map[string][]string{
+							"openshift": {"kubernetes"},
+						},
+					},
+				},
+			},
+			rbc: &api.ReleaseBuildConfiguration{},
+			repoInfo: &config.Info{
+				Metadata: api.Metadata{
+					Org:  "openshift",
+					Repo: "kubernetes",
+				},
+			},
+			wantConfigsByRepo: configsByRepo{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotConfigsByRepo := make(configsByRepo)
+			callback := ciOperatorConfigsCallback(tc.opts, gotConfigsByRepo)
+			callback(tc.rbc, tc.repoInfo)
+
+			if diff := cmp.Diff(tc.wantConfigsByRepo, gotConfigsByRepo); diff != "" {
+				t.Errorf("unexpected configs: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This PR tries to fix the following error raised by `periodic-prow-auto-config-brancher`:
```
time="2026-03-27T08:04:24Z" level=error msg="Failed to load CI Operator configuration" error="invalid ci-operator config: invalid configuration: you must define at least one test or image build in 'tests' or 'images'" source-file=ci-operator/config/openshift-priv/kubernetes/openshift-priv-kubernetes-release-4.23__periodics.yaml
```
This occurs because https://github.com/openshift/release/pull/76199 introduced some configs that have a single, periodic test and no images. Therefore it goes like this:
1. `ci-operator-config-mirror` mirrors the configuration but skip the periodic test. This leads to a config that has not images nor tests
2. `determinize-ci-operator` runs and complaints by issuing the error above.

With this PR I propose not to copy those configs at all.
I might be wrong but I believe there is no point in having a config without any test and image.