### PR TITLE
metrics: nil pointer check

### DIFF
--- a/pkg/metrics/pods.go
+++ b/pkg/metrics/pods.go
@@ -72,7 +72,9 @@ func (p *PodLifecyclePlugin) Record(ev MetricsEvent) {
 	}
 
 	e.CreationTime = &pod.CreationTimestamp.Time
-	e.StartTime = &pod.Status.StartTime.Time
+	if pod.Status.StartTime != nil {
+		e.StartTime = &pod.Status.StartTime.Time
+	}
 	e.CompletionTime = getPodCompletionTime(pod)
 	e.CIWorkload = pod.Labels[CIWorkloadLabel]
 


### PR DESCRIPTION
Hopefully this would prevent this from happening:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2a33d59]
goroutine 148 [running]:
github.com/openshift/ci-tools/pkg/metrics.(*PodLifecyclePlugin).Record(0xc000752230, {0x3ce9640?, 0xc00152a210})
	/go/src/github.com/openshift/ci-tools/pkg/metrics/pods.go:75 +0x179
github.com/openshift/ci-tools/pkg/metrics.(*MetricsAgent).Run(0xc000b93c20)
	/go/src/github.com/openshift/ci-tools/pkg/metrics/metrics.go:136 +0x325
created by main.main in goroutine 1
	/go/src/github.com/openshift/ci-tools/cmd/ci-operator/main.go:228 +0x9a9
```