### PR TITLE
DPTP-4731: fix cluster profile secret race in aggregated runs 2

### DIFF
--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -72,11 +72,12 @@ const (
 	// `podStartTimeout`.
 	ReasonPending = "pod_pending"
 	// CliEnv if the env we use to expose the path to the cli
-	CliEnv                = "CLI_DIR"
-	DefaultLeaseEnv       = "LEASED_RESOURCE"
-	DefaultIPPoolLeaseEnv = "IP_POOL_AVAILABLE"
-	ClusterProfileSetEnv  = "CLUSTER_PROFILE_SET_NAME"
-	ClusterProfileParam   = "CLUSTER_PROFILE"
+	CliEnv                        = "CLI_DIR"
+	DefaultLeaseEnv               = "LEASED_RESOURCE"
+	DefaultIPPoolLeaseEnv         = "IP_POOL_AVAILABLE"
+	ClusterProfileSetEnv          = "CLUSTER_PROFILE_SET_NAME"
+	ClusterProfileParam           = "CLUSTER_PROFILE"
+	ClusterProfileSecretNameParam = "CLUSTER_PROFILE_SECRET_NAME"
 
 	// SkipCensoringLabel is the label we use to mark a secret as not needing to be censored
 	SkipCensoringLabel = "ci.openshift.io/skip-censoring"

--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -9,19 +8,14 @@ import (
 // LeasesForTest aggregates all the lease configurations in a test.
 // It is assumed that they have been validated and contain only valid and
 // unique values.
-func LeasesForTest(test *TestStepConfiguration, targetAdditionalSuffix string) (ret []StepLease) {
+func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
 	multiStageTest := test.MultiStageTestConfigurationLiteral
 	if p := multiStageTest.ClusterProfile; p != "" {
-		clusterProfileTarget := test.As
-		if targetAdditionalSuffix != "" {
-			clusterProfileTarget = strings.TrimSuffix(clusterProfileTarget, fmt.Sprintf("-%s", targetAdditionalSuffix))
-		}
 		ret = append(ret, StepLease{
-			ResourceType:         p.LeaseType(),
-			Env:                  DefaultLeaseEnv,
-			Count:                1,
-			ClusterProfile:       multiStageTest.ClusterProfile.Name(),
-			ClusterProfileTarget: clusterProfileTarget,
+			ResourceType:   p.LeaseType(),
+			Env:            DefaultLeaseEnv,
+			Count:          1,
+			ClusterProfile: multiStageTest.ClusterProfile.Name(),
 		})
 	}
 	for _, step := range append(multiStageTest.Pre, append(multiStageTest.Test, multiStageTest.Post...)...) {

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -29,22 +29,6 @@ func TestLeasesForTest(t *testing.T) {
 			ClusterProfile: string(ClusterProfileAWS),
 		}},
 	}, {
-		name: "cluster profile target trim suffix",
-		tests: TestStepConfiguration{
-			As: "e2e-6",
-			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
-				ClusterProfile: ClusterProfileAWS,
-			},
-		},
-		targetAdditionalSuffix: "6",
-		expected: []StepLease{{
-			ResourceType:         "aws-quota-slice",
-			Env:                  DefaultLeaseEnv,
-			Count:                1,
-			ClusterProfile:       string(ClusterProfileAWS),
-			ClusterProfileTarget: "e2e",
-		}},
-	}, {
 		name: "explicit configuration, lease",
 		tests: TestStepConfiguration{
 			MultiStageTestConfigurationLiteral: &MultiStageTestConfigurationLiteral{
@@ -64,7 +48,7 @@ func TestLeasesForTest(t *testing.T) {
 		expected: []StepLease{{ResourceType: "aws-quota-slice"}},
 	}} {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := LeasesForTest(&tc.tests, tc.targetAdditionalSuffix)
+			ret := LeasesForTest(&tc.tests)
 			if diff := cmp.Diff(tc.expected, ret); diff != "" {
 				t.Errorf("incorrect leases, diff: %s", diff)
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1183,9 +1183,8 @@ type StepLease struct {
 	// Env is the environment variable that will contain the resource name.
 	Env string `json:"env"`
 	// Count is the number of resources to acquire (optional, defaults to 1).
-	Count                uint   `json:"count,omitempty"`
-	ClusterProfile       string `json:"-"`
-	ClusterProfileTarget string `json:"-"`
+	Count          uint   `json:"count,omitempty"`
+	ClusterProfile string `json:"-"`
 }
 
 // FromImageTag returns the internal name for the image tag that will be used

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -356,7 +356,7 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 ) []api.Step {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		params := cfg.params
-		leases := api.LeasesForTest(c, cfg.TargetAdditionalSuffix)
+		leases := api.LeasesForTest(c)
 		ipPoolLease := api.IPPoolLeaseForTest(test, cfg.CIConfig.Metadata)
 		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
 			params = api.NewDeferredParameters(params)

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -43,9 +43,10 @@ type leaseStep struct {
 	clusterProfileGetter ClusterProfileGetter
 
 	// for sending heartbeats during lease acquisition
-	namespace             func() string
-	clusterProfileSetName string
-	clusterProfileName    string
+	namespace                func() string
+	clusterProfileSetName    string
+	clusterProfileName       string
+	clusterProfileSecretName string
 }
 
 func LeaseStep(client *lease.Client, leases []api.StepLease, wrapped api.Step, namespace func() string, metricsAgent *metrics.MetricsAgent,
@@ -91,6 +92,8 @@ func (s *leaseStep) Provides() api.ParameterMap {
 	parameters[api.ClusterProfileSetEnv] = func() (string, error) { return s.clusterProfileSetName, nil }
 	// nolint:unparam
 	parameters[api.ClusterProfileParam] = func() (string, error) { return s.clusterProfileName, nil }
+	// nolint:unparam
+	parameters[api.ClusterProfileSecretNameParam] = func() (string, error) { return s.clusterProfileSecretName, nil }
 
 	for _, l := range s.leases {
 		// nolint:unparam
@@ -264,16 +267,17 @@ func (s *leaseStep) handleClusterProfile(ctx context.Context, l *stepLease, name
 		return fmt.Errorf("resolve cluster profile %s: %w", s.clusterProfileName, err)
 	}
 
-	if err := s.importClusterProfileSecret(ctx, cpDetails.Secret, l.ClusterProfileTarget); err != nil {
+	if err := s.importClusterProfileSecret(ctx, cpDetails.Secret); err != nil {
 		return fmt.Errorf("import secret %s for cluster profile %s: %w", cpDetails.Secret, s.clusterProfileName, err)
 	}
 
+	s.clusterProfileSecretName = cpDetails.Secret
 	return nil
 }
 
 // importClusterProfileSecret retrieves the cluster profile secret name using config resolver,
 // and gets the secret from the ci namespace
-func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName, testName string) error {
+func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName string) error {
 	ciSecret := &coreapi.Secret{}
 	err := s.kubeClient.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: secretName}, ciSecret)
 	if err != nil {
@@ -284,7 +288,7 @@ func (s *leaseStep) importClusterProfileSecret(ctx context.Context, secretName, 
 		Data: ciSecret.Data,
 		Type: ciSecret.Type,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-cluster-profile", testName),
+			Name:      secretName,
 			Namespace: s.namespace(),
 		},
 	}

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -282,11 +282,12 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				api.ClusterProfileSetEnv: "",
-				api.ClusterProfileParam:  "",
-				"lease-0":                "res-type-0",
-				"lease-1":                "res-type-1",
-				"parameter":              "map",
+				api.ClusterProfileSetEnv:          "",
+				api.ClusterProfileParam:           "",
+				api.ClusterProfileSecretNameParam: "",
+				"lease-0":                         "res-type-0",
+				"lease-1":                         "res-type-1",
+				"parameter":                       "map",
 			},
 			wantCalls: []string{
 				"acquireWaitWithPriority owner res-type-0 free leased random",
@@ -299,11 +300,10 @@ func TestAcquireLeases(t *testing.T) {
 		{
 			name: "Cluster profile lease",
 			leases: []api.StepLease{{
-				ResourceType:         "aws",
-				Env:                  api.DefaultLeaseEnv,
-				Count:                1,
-				ClusterProfile:       "aws",
-				ClusterProfileTarget: "e2e-aws-ovn",
+				ResourceType:   "aws",
+				Env:            api.DefaultLeaseEnv,
+				Count:          1,
+				ClusterProfile: "aws",
 			}},
 			resources: map[string]*common.Resource{
 				"acquireWaitWithPriority_aws_free_leased_random": {
@@ -327,10 +327,11 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				"parameter":              "map",
-				api.ClusterProfileSetEnv: "",
-				api.ClusterProfileParam:  "aws",
-				api.DefaultLeaseEnv:      "us-east-1",
+				"parameter":                       "map",
+				api.ClusterProfileSetEnv:          "",
+				api.ClusterProfileParam:           "aws",
+				api.ClusterProfileSecretNameParam: "cluster-secrets-aws",
+				api.DefaultLeaseEnv:               "us-east-1",
 			},
 			wantSecrets: corev1.SecretList{
 				Items: []corev1.Secret{
@@ -348,7 +349,7 @@ func TestAcquireLeases(t *testing.T) {
 					{
 						ObjectMeta: v1.ObjectMeta{
 							Namespace:       ns,
-							Name:            "e2e-aws-ovn-cluster-profile",
+							Name:            "cluster-secrets-aws",
 							ResourceVersion: "1",
 						},
 						Data: map[string][]byte{
@@ -367,11 +368,10 @@ func TestAcquireLeases(t *testing.T) {
 		{
 			name: "Cluster profile and regular lease",
 			leases: []api.StepLease{{
-				ResourceType:         "aws",
-				Env:                  api.DefaultLeaseEnv,
-				Count:                1,
-				ClusterProfile:       "aws",
-				ClusterProfileTarget: "e2e-aws-ovn",
+				ResourceType:   "aws",
+				Env:            api.DefaultLeaseEnv,
+				Count:          1,
+				ClusterProfile: "aws",
 			}, {
 				ResourceType: "foobar",
 				Env:          "FOOBAR_RESOURCE",
@@ -402,11 +402,12 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				"parameter":              "map",
-				api.ClusterProfileSetEnv: "",
-				api.ClusterProfileParam:  "aws",
-				api.DefaultLeaseEnv:      "us-east-1",
-				"FOOBAR_RESOURCE":        "foobar-res-0",
+				"parameter":                       "map",
+				api.ClusterProfileSetEnv:          "",
+				api.ClusterProfileParam:           "aws",
+				api.ClusterProfileSecretNameParam: "cluster-secrets-aws",
+				api.DefaultLeaseEnv:               "us-east-1",
+				"FOOBAR_RESOURCE":                 "foobar-res-0",
 			},
 			wantSecrets: corev1.SecretList{
 				Items: []corev1.Secret{
@@ -424,7 +425,7 @@ func TestAcquireLeases(t *testing.T) {
 					{
 						ObjectMeta: v1.ObjectMeta{
 							Namespace:       ns,
-							Name:            "e2e-aws-ovn-cluster-profile",
+							Name:            "cluster-secrets-aws",
 							ResourceVersion: "1",
 						},
 						Data: map[string][]byte{
@@ -445,11 +446,10 @@ func TestAcquireLeases(t *testing.T) {
 		{
 			name: "Nested cluster profile",
 			leases: []api.StepLease{{
-				ResourceType:         "openshift-org-aws",
-				Env:                  api.DefaultLeaseEnv,
-				Count:                1,
-				ClusterProfile:       "aws-set",
-				ClusterProfileTarget: "e2e-aws-ovn",
+				ResourceType:   "openshift-org-aws",
+				Env:            api.DefaultLeaseEnv,
+				Count:          1,
+				ClusterProfile: "aws-set",
 			}},
 			resources: map[string]*common.Resource{
 				"acquireWaitWithPriority_openshift-org-aws_free_leased_random": {
@@ -476,10 +476,11 @@ func TestAcquireLeases(t *testing.T) {
 				},
 			},
 			wantProvides: map[string]string{
-				"parameter":              "map",
-				api.ClusterProfileSetEnv: "aws-set",
-				api.ClusterProfileParam:  "aws",
-				api.DefaultLeaseEnv:      "us-east-1",
+				"parameter":                       "map",
+				api.ClusterProfileSetEnv:          "aws-set",
+				api.ClusterProfileParam:           "aws",
+				api.ClusterProfileSecretNameParam: "cluster-secrets-aws",
+				api.DefaultLeaseEnv:               "us-east-1",
 			},
 			wantSecrets: corev1.SecretList{
 				Items: []corev1.Secret{
@@ -497,7 +498,7 @@ func TestAcquireLeases(t *testing.T) {
 					{
 						ObjectMeta: v1.ObjectMeta{
 							Namespace:       ns,
-							Name:            "e2e-aws-ovn-cluster-profile",
+							Name:            "cluster-secrets-aws",
 							ResourceVersion: "1",
 						},
 						Data: map[string][]byte{

--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -233,7 +233,11 @@ func (s *multiStageTestStep) generatePods(
 			addDshmVolume(shmSize, pod, container)
 		}
 		if s.profile != "" {
-			addProfile(s.profileSecretName(), s.profile, pod)
+			profileSecret, err := s.profileSecretName()
+			if err != nil {
+				return nil, nil, fmt.Errorf("get profile secret name: %w", err)
+			}
+			addProfile(profileSecret, s.profile, pod)
 		}
 		if step.Cli != "" {
 			dependency := api.StepDependency{Name: fmt.Sprintf("%s:cli", api.ReleaseStreamFor(step.Cli))}

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -71,6 +71,7 @@ func TestGeneratePods(t *testing.T) {
 		secretVolumes             []coreapi.Volume
 		secretVolumeMounts        []coreapi.VolumeMount
 		leaseProxyServerAvailable bool
+		paramsFunc                func() api.Parameters
 	}{
 		{
 			name: "generate pods",
@@ -115,6 +116,13 @@ func TestGeneratePods(t *testing.T) {
 				Name:      "secret",
 				MountPath: "/secret",
 			}},
+			paramsFunc: func() api.Parameters {
+				params := api.NewDeferredParameters(nil)
+				params.Add(api.ClusterProfileSecretNameParam, func() (string, error) {
+					return "cluster-secrets-aws-5", nil
+				})
+				return params
+			},
 		},
 		{
 			name: "enable nested podman",
@@ -157,8 +165,13 @@ func TestGeneratePods(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			var params api.Parameters = api.NewDeferredParameters(nil)
+			if tc.paramsFunc != nil {
+				params = tc.paramsFunc()
+			}
+
 			js := jobSpec()
-			step := newMultiStageTestStep(tc.config.Tests[0], tc.config, nil, nil, &js, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable, wait.Backoff{})
+			step := newMultiStageTestStep(tc.config.Tests[0], tc.config, params, nil, &js, nil, "node-name", "", nil, false, nil, tc.leaseProxyServerAvailable, wait.Backoff{})
 			step.test[0].Resources = resourceRequirements
 
 			ret, _, err := step.generatePods(tc.config.Tests[0].MultiStageTestConfigurationLiteral.Test, tc.env, tc.secretVolumes, tc.secretVolumeMounts, nil)

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -206,12 +206,17 @@ func newMultiStageTestStep(
 	return s
 }
 
-func (s *multiStageTestStep) profileSecretName() string {
-	name := s.name
-	if s.additionalSuffix != "" {
-		name = strings.TrimSuffix(name, fmt.Sprintf("-%s", s.additionalSuffix))
+func (s *multiStageTestStep) profileSecretName() (string, error) {
+	if s.params == nil {
+		return "", nil
 	}
-	return name + "-cluster-profile"
+
+	cpSecretName, err := s.params.Get(api.ClusterProfileSecretNameParam)
+	if err != nil {
+		return "", fmt.Errorf("get param %s: %w", api.ClusterProfileSecretNameParam, err)
+	}
+
+	return cpSecretName, nil
 }
 
 func (s *multiStageTestStep) Inputs() (api.InputDefinition, error) {
@@ -422,7 +427,10 @@ func (s *multiStageTestStep) SubTests() []*junit.TestCase { return s.subTests }
 // namespace and to gather information used when generating the test pods.
 func (s *multiStageTestStep) getProfileData(ctx context.Context) error {
 	var secret coreapi.Secret
-	name := s.profileSecretName()
+	name, err := s.profileSecretName()
+	if err != nil {
+		return fmt.Errorf("get profile secret name: %w", err)
+	}
 	if err := s.client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: s.jobSpec.Namespace(), Name: name}, &secret); err != nil {
 		return fmt.Errorf("could not get cluster profile secret %q: %w", name, err)
 	}

--- a/pkg/steps/multi_stage/multi_stage_test.go
+++ b/pkg/steps/multi_stage/multi_stage_test.go
@@ -410,27 +410,33 @@ func TestEnvironment(t *testing.T) {
 func TestProfileSecretName(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name             string
-		stepName         string
-		additionalSuffix string
-		expected         string
+		name       string
+		stepName   string
+		paramsFunc func() api.Parameters
+		expected   string
 	}{
 		{
-			name:     "no additional suffix",
-			stepName: "step",
-			expected: "step-cluster-profile",
-		},
-		{
-			name:             "additional suffix",
-			stepName:         "step-0",
-			additionalSuffix: "0",
-			expected:         "step-cluster-profile",
+			name:     "cluster profile secret name from param",
+			stepName: "step-0",
+			paramsFunc: func() api.Parameters {
+				params := api.NewDeferredParameters(nil)
+				params.Add(api.ClusterProfileSecretNameParam, func() (string, error) {
+					return "foobar", nil
+				})
+				return params
+			},
+			expected: "foobar",
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			step := multiStageTestStep{name: tc.stepName, additionalSuffix: tc.additionalSuffix}
-			result := step.profileSecretName()
+			step := multiStageTestStep{name: tc.stepName, params: tc.paramsFunc()}
+
+			result, err := step.profileSecretName()
+			if err != nil {
+				t.Fatalf("unexpected get profile secret name error: %s", err)
+			}
+
 			if diff := cmp.Diff(tc.expected, result); diff != "" {
 				t.Fatalf("result does not match expected, diff: %s", diff)
 			}

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGenerateObservers.yaml
@@ -158,8 +158,7 @@
     - emptyDir: {}
       name: entrypoint-wrapper
     - name: cluster-profile
-      secret:
-        secretName: test-cluster-profile
+      secret: {}
     - name: test
       secret:
         secretName: test
@@ -327,8 +326,7 @@
     - emptyDir: {}
       name: entrypoint-wrapper
     - name: cluster-profile
-      secret:
-        secretName: test-cluster-profile
+      secret: {}
     - name: test
       secret:
         secretName: test

--- a/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_generate_pods.yaml
+++ b/pkg/steps/multi_stage/testdata/zz_fixture_TestGeneratePods_generate_pods.yaml
@@ -176,7 +176,7 @@
       name: dshm
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test
@@ -356,7 +356,7 @@
       name: entrypoint-wrapper
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test
@@ -536,7 +536,7 @@
       name: entrypoint-wrapper
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test
@@ -728,7 +728,7 @@
       name: entrypoint-wrapper
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test
@@ -910,7 +910,7 @@
       name: entrypoint-wrapper
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test
@@ -1092,7 +1092,7 @@
       name: entrypoint-wrapper
     - name: cluster-profile
       secret:
-        secretName: test-cluster-profile
+        secretName: cluster-secrets-aws-5
     - name: test
       secret:
         secretName: test


### PR DESCRIPTION
An alternative to https://github.com/openshift/ci-tools/pull/5083 that uses `api.Parameters` to pass information across steps.