### PR TITLE
ci-operator-checkconfig: Validate cluster profile sets

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -30,22 +31,25 @@ type promotedTag struct {
 type options struct {
 	config.Options
 
-	resolver           registry.Resolver
-	ciOPConfigAgent    agents.ConfigAgent
-	clusterProfiles    api.ClusterProfilesMap
-	clusterClaimOwners api.ClusterClaimOwnersMap
+	resolver                 registry.Resolver
+	ciOPConfigAgent          agents.ConfigAgent
+	clusterProfiles          api.ClusterProfilesMap
+	clusterClaimOwners       api.ClusterClaimOwnersMap
+	clusterProfileSetDetails validation.ClusterProfileSetDetails
 }
 
 func (o *options) parse() error {
 	var registryDir string
 	var profilesConfigPath string
 	var clusterClaimConfigPath string
+	var clusterProfileSetDetailsPath string
 
 	fs := flag.NewFlagSet("", flag.ExitOnError)
 
 	fs.StringVar(&registryDir, "registry", "", "Path to the step registry directory")
 	fs.StringVar(&profilesConfigPath, "cluster-profiles-config", "", "Path to the cluster profile config file")
 	fs.StringVar(&clusterClaimConfigPath, "cluster-claim-owners-config", "", "Path to the cluster claim owners config file")
+	fs.StringVar(&clusterProfileSetDetailsPath, "cluster-profile-set-details", "", "Path to the cluster profile set details file")
 	o.Options.Bind(fs)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -74,6 +78,12 @@ func (o *options) parse() error {
 	}
 	o.ciOPConfigAgent = ciOPConfigAgent
 
+	if clusterProfileSetDetailsPath != "" {
+		if err := o.loadClusterProfileDetails(clusterProfileSetDetailsPath); err != nil {
+			return fmt.Errorf("load cluster profile set details: %w", err)
+		}
+	}
+
 	if err := o.Options.Validate(); err != nil {
 		return fmt.Errorf("failed to validate config options: %w", err)
 	}
@@ -99,7 +109,8 @@ func (o *options) validate() (ret []error) {
 	outputCh := make(chan promotedTag)
 	errCh := make(chan error)
 	map_ := func() error {
-		validator := validation.NewValidator(o.clusterProfiles, o.clusterClaimOwners)
+		validator := validation.NewValidator(o.clusterProfiles, o.clusterClaimOwners,
+			validation.WithClusterProfileSetDetails(o.clusterProfileSetDetails))
 		for c := range inputCh {
 			if err := o.validateConfiguration(&validator, outputCh, c); err != nil {
 				errCh <- fmt.Errorf("failed to validate configuration %s: %w", c.Metadata.RelativePath(), err)
@@ -119,6 +130,20 @@ func (o *options) validate() (ret []error) {
 		ret = append(ret, err)
 	}
 	return append(ret, validateTags(seen)...)
+}
+
+func (o *options) loadClusterProfileDetails(p string) error {
+	cpsDetailsBytes, err := os.ReadFile(p)
+	if err != nil {
+		return fmt.Errorf("read file %s: %w", p, err)
+	}
+
+	o.clusterProfileSetDetails = make(map[api.ClusterProfile][]string)
+	if err := json.Unmarshal(cpsDetailsBytes, &o.clusterProfileSetDetails); err != nil {
+		return fmt.Errorf("unmarshal cluster profile set details: %w", err)
+	}
+
+	return nil
 }
 
 func (o *options) loadResolver(path string) error {

--- a/images/ci-operator-checkconfig/Dockerfile
+++ b/images/ci-operator-checkconfig/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-RUN microdnf install -y git && \
-      microdnf clean all
+RUN microdnf install -y git python3 python3-pip && \
+      microdnf clean all && \
+      pip install pyyaml
 
 ADD ci-operator-checkconfig /usr/bin/ci-operator-checkconfig
 ENTRYPOINT ["/usr/bin/ci-operator-checkconfig"]

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -14,26 +14,43 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
+type ClusterProfileDetails struct {
+	Name string `json:"name"`
+}
+
+type ClusterProfileSetDetails map[api.ClusterProfile][]string
+
 // Validator holds data used across validations.
 type Validator struct {
 	validClusterProfiles    api.ClusterProfilesMap
 	validClusterClaimOwners api.ClusterClaimOwnersMap
 	// hasTrapCache avoids redundant regexp searches on step commands.
 	hasTrapCache map[string]bool
+	cpsDetails   ClusterProfileSetDetails
+}
+
+type ValidatorOption func(*Validator)
+
+func WithClusterProfileSetDetails(cpsDetails ClusterProfileSetDetails) func(*Validator) {
+	return func(v *Validator) { v.cpsDetails = cpsDetails }
 }
 
 // NewValidator creates an object that optimizes bulk validations.
-func NewValidator(profiles api.ClusterProfilesMap, clusterClaimOwners api.ClusterClaimOwnersMap) Validator {
-	ret := Validator{
+func NewValidator(profiles api.ClusterProfilesMap, clusterClaimOwners api.ClusterClaimOwnersMap, opts ...ValidatorOption) Validator {
+	v := Validator{
 		hasTrapCache: make(map[string]bool),
+		cpsDetails:   make(map[api.ClusterProfile][]string),
+	}
+	for _, f := range opts {
+		f(&v)
 	}
 	if profiles != nil {
-		ret.validClusterProfiles = profiles
+		v.validClusterProfiles = profiles
 	}
 	if clusterClaimOwners != nil {
-		ret.validClusterClaimOwners = clusterClaimOwners
+		v.validClusterClaimOwners = clusterClaimOwners
 	}
-	return ret
+	return v
 }
 
 func newSingleUseValidator() Validator {

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -436,16 +437,22 @@ func (v *Validator) validateClusterProfile(fieldRoot string, p api.ClusterProfil
 			if err := verifyClusterProfileOwnership(v.validClusterProfiles[p], metadata); err != nil {
 				return []error{err}
 			}
-			return nil
 		}
 	} else {
-		for _, x := range api.ClusterProfiles() {
-			if x == p {
-				return nil
+		if !slices.Contains(api.ClusterProfiles(), p) {
+			return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}
+		}
+	}
+
+	for cpsName, cpDetails := range v.cpsDetails {
+		for _, cpDetail := range cpDetails {
+			if string(p) == cpDetail {
+				return []error{fmt.Errorf("%s: invalid cluster profile %q, use the cluster profile set %q instead", fieldRoot, p, cpsName)}
 			}
 		}
 	}
-	return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}
+
+	return nil
 }
 
 // verifyClusterProfileOwnership checks if metadata's org and repo match those in the profile,

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	aggerrs "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/diff"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
@@ -2216,6 +2217,56 @@ func TestVerifyClusterClaimOwnership(t *testing.T) {
 			actual := verifyClusterClaimOwnership(tc.claim, tc.metadata)
 			if d := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); d != "" {
 				t.Errorf("expected differs from actual: %s\n", d)
+			}
+		})
+	}
+}
+
+func TestValidateClusterProfiles(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name               string
+		clusterProfile     api.ClusterProfile
+		metadata           *api.Metadata
+		clusterProfilesMap api.ClusterProfilesMap
+		cpsDetails         ClusterProfileSetDetails
+		wantErrs           []error
+	}{
+		{
+			name:           "Valid cluster profile",
+			clusterProfile: api.ClusterProfileAROHCPDev,
+		},
+		{
+			name:           "invalid cluster profile",
+			clusterProfile: "foobar",
+			wantErrs:       []error{errors.New(`foo: invalid cluster profile "foobar"`)},
+		},
+		{
+			name:           "Use cluster profile set",
+			clusterProfile: "azure-2",
+			cpsDetails: ClusterProfileSetDetails{
+				"openshift-org-azure": []string{"azure-2"},
+			},
+			wantErrs: []error{errors.New(`foo: invalid cluster profile "azure-2", use the cluster profile set "openshift-org-azure" instead`)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			v := NewValidator(tc.clusterProfilesMap, nil, WithClusterProfileSetDetails(tc.cpsDetails))
+			gotErrs := v.validateClusterProfile("foo", tc.clusterProfile, tc.metadata)
+
+			wantErrMsg := "<nil>"
+			if tc.wantErrs != nil {
+				wantErrMsg = aggerrs.NewAggregate(tc.wantErrs).Error()
+			}
+			gotErrMsg := "<nil>"
+			if gotErrs != nil {
+				gotErrMsg = aggerrs.NewAggregate(gotErrs).Error()
+			}
+
+			if diff := cmp.Diff(wantErrMsg, gotErrMsg); diff != "" {
+				t.Errorf("unexpected errors: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
New validation code for `ci-operator-checkconfig` that makes sure the cluster profile sets are properly used.

This PR introduce a new flag `--cluster-profile-set-details`, that is a path to a file that contains the cluster profile set details (generated by `core-services/prow/02_config/generate-boskos.py` in `o/release`, another PR will come) in the following format:
```json
{
  "openshift-org-aws": [
    "aws",
    "aws-2",
    "aws-3",
    "aws-4",
    "aws-5"
  ],
  "openshift-org-azure": [
    "azure-2",
    "azure4"
  ]
}
```

The new validation mechanism makes sure that a test uses `openshift-org-aws` instead of `aws`, ..., `aws-5`. Same for the `openshift-org-azure` or any other set.

Add python3 to the `ci-operator-checkconfig` Dockerfile because is needed in https://github.com/openshift/release/pull/77507