### PR TITLE
Simplified find and avoided glob expansion for regex

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -31,8 +31,8 @@ function find_tests() {
 
     full_test_list=($(
         find "${OS_ROOT}/test/integration" \
-            ! \( -path "${OS_ROOT}/test/integration/pj-rehearse" -prune \) \
-            -a -name '*.sh'
+            -not -path "${OS_ROOT}/test/integration/pj-rehearse/*" \
+            -name '*.sh'
     ))
     for test in "${full_test_list[@]}"; do
         if grep -q -E "${test_regex}" <<< "${test}"; then
@@ -46,7 +46,7 @@ function find_tests() {
         echo "${selected_tests[@]}"
     fi
 }
-tests=( $(find_tests ${1:-.*}) )
+tests=( $(find_tests "${1:-.*}") )
 
 os::cleanup::tmpdir
 


### PR DESCRIPTION
- Simplified the `find` pattern, to exclude `pj-rehearse` scripts.
- Quoted the parameter for `find_tests` function to avoid the default value `.*` it to be expanded in our local machines, making `make integration` or `bash hack/test-integration.sh` fail.

Locally, inside `ci-tools` folder, the error about "invalid regex" happens because `.*` is expanded to `.ci-operator.yaml` - and any other file that starts with a . in its name - when no parameter is given. This doesn't happens inside the container, because the `workdir` is empty or doesn't have any files, only folders.