### PR TITLE
fix(private-org-sync): skip missing non-release branches instead of failing

### DIFF
--- a/cmd/private-org-sync/main.go
+++ b/cmd/private-org-sync/main.go
@@ -394,7 +394,11 @@ func (g gitSyncer) mirror(repoDir string, src, dst location) error {
 	}
 	srcCommitHash, ok := srcHeads[src.branch]
 	if !ok {
-		logger.WithError(err).Error("Branch does not exist in source remote")
+		if api.FlavorForBranch(src.branch) == "misc" {
+			logger.Warn("Non-release branch does not exist in source remote, likely deleted; skipping")
+			return nil
+		}
+		logger.Error("Release/main branch does not exist in source remote; this may indicate the branch was deleted")
 		return fmt.Errorf("branch does not exist in source remote")
 	}
 
@@ -598,7 +602,7 @@ func main() {
 	} else {
 		token = strings.TrimSpace(string(rawToken))
 		getter := func() sets.Set[string] {
-			return sets.New[string](token)
+			return sets.New(token)
 		}
 		logrus.SetFormatter(logrusutil.NewCensoringFormatter(logrus.StandardLogger().Formatter, getter))
 	}
@@ -653,7 +657,7 @@ func main() {
 		grouped[key] = append(grouped[key], source)
 	}
 
-	flattenedOrgs := sets.New[string](privateorg.DefaultFlattenOrgs...)
+	flattenedOrgs := sets.New(privateorg.DefaultFlattenOrgs...)
 	flattenedOrgs.Insert(o.flattenOrgs...)
 	if o.org != "" {
 		flattenedOrgs.Insert(o.org)
@@ -712,10 +716,9 @@ func getWhitelistedLocations(whitelist map[string][]string, git gitFunc, prefix,
 			remoteURL, err := url.Parse(fmt.Sprintf("%s/%s/%s", prefix, org, repo))
 			if err != nil {
 				logrus.WithError(err).Error("Failed to construct URL for the remote")
-				if err != nil {
-					errs = append(errs, err)
-					continue
-				}
+				errs = append(errs, err)
+				continue
+
 			}
 			if token != "" {
 				remoteURL.User = url.User(token)

--- a/cmd/private-org-sync/main_test.go
+++ b/cmd/private-org-sync/main_test.go
@@ -382,11 +382,30 @@ func TestMirror(t *testing.T) {
 			},
 		},
 		{
-			description: "source branch does not exist -> error",
+			description: "non-release source branch does not exist -> no error, skip with warning",
 			src:         location{org: org, repo: repo, branch: branch},
 			dst:         location{org: destOrg, repo: repo, branch: branch},
 			expectedGitCalls: []mockGitCall{
 				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/branch"},
+				{call: "ls-remote --heads org-repo", output: "some-sha refs/heads/not-the-branch"},
+			},
+		},
+		{
+			description: "release source branch does not exist -> error",
+			src:         location{org: org, repo: repo, branch: "release-4.21"},
+			dst:         location{org: destOrg, repo: repo, branch: "release-4.21"},
+			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/release-4.21"},
+				{call: "ls-remote --heads org-repo", output: "some-sha refs/heads/not-the-branch"},
+			},
+			expectError: true,
+		},
+		{
+			description: "main source branch does not exist -> error",
+			src:         location{org: org, repo: repo, branch: "main"},
+			dst:         location{org: destOrg, repo: repo, branch: "main"},
+			expectedGitCalls: []mockGitCall{
+				{call: "ls-remote --heads https://TOKEN@github.com/dest/repo", output: "source-sha refs/heads/main"},
 				{call: "ls-remote --heads org-repo", output: "some-sha refs/heads/not-the-branch"},
 			},
 			expectError: true,


### PR DESCRIPTION
private-org-sync discovers all branches for whitelisted repos via ls-remote. Transient branches (e.g. Konflux/Mintmaker dependency updates) can be deleted between discovery and sync, failing the entire job.

Now uses FlavorForBranch to only error on missing release/main branches. Missing misc branches are warned and skipped.

Should fix issues like:
```
time="2026-04-10T10:01:25Z" level=fatal msg="There were failures" error="[stolostron/acm-mce-operator-catalogs@konflux/component-updates/acm-dev-catalog-component-update-acm-operator-bundle-acm-214->openshift-priv/stolostron-acm-mce-operator-catalogs@konflux/component-updates/acm-dev-catalog-component-update-acm-operator-bundle-acm-214: branch does not exist in source remote, stolostron/discovery@konflux/mintmaker/backplane-2.10-backplane-2.10/github.com-go-playground-validator-v10-10.x->openshift-priv/stolostron-discovery@konflux/mintmaker/backplane-2.10-backplane-2.10/github.com-go-playground-validator-v10-10.x: branch does not exist in source remote, stolostron/prometheus-operator@dependabot/go_modules/scripts/google.golang.org/grpc-1.79.3->openshift-priv/stolostron-prometheus-operator@dependabot/go_modules/scripts/google.golang.org/grpc-1.79.3: branch does not exist in source remote, quay/quay-konflux-components@konflux/mintmaker/dev/lock-file-maintenance->openshift-priv/quay-quay-konflux-components@konflux/mintmaker/dev/lock-file-maintenance: failed to fetch from source, quay/quay-konflux-components@konflux/mintmaker/redhat-3.17/components-quay-pushgateway-digest->openshift-priv/quay-quay-konflux-components@konflux/mintmaker/redhat-3.17/components-quay-pushgateway-digest: failed to fetch from source]"
