### PR TITLE
auto-config-brancher: wrap GitHub client with OrgAwareClient for PR upsert

### DIFF
--- a/cmd/auto-config-brancher/main.go
+++ b/cmd/auto-config-brancher/main.go
@@ -16,8 +16,10 @@ import (
 	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
 
+	"github.com/openshift/ci-tools/pkg/github/prcreation"
 	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 )
@@ -285,7 +287,9 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("Error retrieving repository data: %v", err)
 	}
-	if err := bumper.UpdatePullRequestWithLabels(gc, githubOrg, githubRepo, title, fmt.Sprintf("/cc @%s", o.assign), prHead, repo.DefaultBranch, remoteBranch, true, labelsToAdd, false); err != nil {
+	isAppAuth := o.GitHubOptions.TokenPath == ""
+	prClient := github.Client(&prcreation.OrgAwareClient{Client: gc, Org: githubOrg, IsAppAuth: isAppAuth})
+	if err := bumper.UpdatePullRequestWithLabels(prClient, githubOrg, githubRepo, title, fmt.Sprintf("/cc @%s", o.assign), prHead, repo.DefaultBranch, remoteBranch, true, labelsToAdd, false); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}
 }


### PR DESCRIPTION


The bumper.UpdatePullRequestWithLabels call chain uses FindIssues which internally calls FindIssuesWithOrg with an empty org. With GitHub App auth the appsRoundTripper needs the org to resolve the installation token, causing "BUG apps auth requested but empty org".

Wrap the client with prcreation.OrgAwareClient (already used by prcreator) which overrides FindIssues to route through FindIssuesWithOrg with the correct org, and appends [bot] to the bot user login so the search author: qualifier matches the App identity.