### PR TITLE
auto-config-brancher: fix mirror args parsing and remove rebalancer

### DIFF
--- a/cmd/auto-config-brancher/main.go
+++ b/cmd/auto-config-brancher/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/robfig/cron.v2"
 
 	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/prow/pkg/config/secret"
@@ -38,13 +37,12 @@ const (
 type options struct {
 	selfApprove bool
 
-	githubLogin    string
-	gitName        string
-	gitEmail       string
-	targetDir      string
-	assign         string
-	whitelist      string
-	rebalancerCron string
+	githubLogin string
+	gitName     string
+	gitEmail    string
+	targetDir   string
+	assign      string
+	whitelist   string
 
 	promotion.FutureOptions
 	flagutil.GitHubOptions
@@ -60,7 +58,6 @@ func parseOptions() options {
 	fs.StringVar(&o.targetDir, "target-dir", "", "The directory containing the target repo.")
 	fs.StringVar(&o.assign, "assign", githubTeam, "The github username or group name to assign the created pull request to.")
 	fs.StringVar(&o.whitelist, "whitelist-file", "", "The path of the whitelisted repositories file.")
-	fs.StringVar(&o.rebalancerCron, "rebalancer-cron", "", "Cron expression defining how often rebalancer should run (plus/minus 1h time window). If not specified, rebalancer will not run.")
 	fs.BoolVar(&o.selfApprove, "self-approve", false, "Self-approve the PR by adding the `approved` and `lgtm` labels. Requires write permissions on the repo.")
 	o.AddFlags(fs)
 	o.AllowAnonymous = true
@@ -142,11 +139,6 @@ func main() {
 		logrus.WithError(err).Fatal("error getting GitHub client")
 	}
 
-	rebalance, err := withinWindow(o.rebalancerCron)
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to parse cron")
-	}
-
 	logrus.Infof("Changing working directory to '%s' ...", o.targetDir)
 	if err := os.Chdir(o.targetDir); err != nil {
 		logrus.WithError(err).Fatal("Failed to change to root dir")
@@ -186,15 +178,17 @@ func main() {
 		{
 			command: "/usr/bin/private-prow-configs-mirror",
 			arguments: func() []string {
-				args := []string{"--release-repo-path", ".",
-					"--github-endpoint", "http://ghproxy",
-					"--dry-run", "false"}
+				args := []string{"--release-repo-path", "."}
 				if o.GitHubOptions.TokenPath != "" {
 					args = append(args, "--github-token-path", o.GitHubOptions.TokenPath)
 				} else {
 					args = append(args, "--github-app-id", o.GitHubOptions.AppID,
 						"--github-app-private-key-path", o.GitHubOptions.AppPrivateKeyPath)
 				}
+				args = append(args,
+					"--github-endpoint", "http://ghproxy",
+					"--dry-run=false",
+				)
 				if o.whitelist != "" {
 					args = append(args, "--whitelist-file", o.whitelist)
 				}
@@ -230,17 +224,6 @@ func main() {
 				"--dry-run=true",
 			},
 		},
-	}
-
-	if rebalance {
-		steps = append([]step{{
-			command: "/usr/bin/rebalancer",
-			arguments: []string{
-				"--profiles=aws,aws-2,aws-3,aws-4,aws-5",
-				"--profiles=gcp-openshift-gce-devel-ci-2,gcp,gcp-3",
-				"--prometheus-bearer-token-path=/etc/prometheus/token",
-			},
-		}}, steps...)
 	}
 
 	stdout := bumper.HideSecretsWriter{Delegate: os.Stdout, Censor: secret.Censor}
@@ -299,6 +282,11 @@ func pushWithGitClientFactory(o options, branch string) error {
 	if err != nil {
 		return fmt.Errorf("error creating git client factory: %w", err)
 	}
+	defer func() {
+		if err := gcf.Clean(); err != nil {
+			logrus.WithError(err).Warn("Failed to clean git client factory cache.")
+		}
+	}()
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -349,27 +337,4 @@ func runSteps(steps []step, author string, stdout, stderr io.Writer) (needsPushi
 	}
 
 	return true, nil
-}
-
-// withinWindow returns true if the schedule fires at any time
-// between now-1h and now+1h.
-func withinWindow(cronExpr string) (bool, error) {
-	if cronExpr == "" {
-		return false, nil
-	}
-	schedule, err := cron.Parse(cronExpr)
-	if err != nil {
-		return false, err
-	}
-
-	now := time.Now()
-	windowStart := now.Add(-1 * time.Hour)
-	windowEnd := now.Add(+1 * time.Hour)
-
-	firstFire := schedule.Next(windowStart)
-
-	if firstFire.Before(windowEnd) {
-		return true, nil
-	}
-	return false, nil
 }


### PR DESCRIPTION
Ensure private-prow-configs-mirror receives auth flags before other args and use --dry-run=false to avoid bool parsing pitfalls. Remove the rebalancer flag/step and related cron window logic from auto-config-brancher.