### PR TITLE
Konflux: Use Periodics rather than Presubmits

### DIFF
--- a/cmd/dptp-controller-manager/main.go
+++ b/cmd/dptp-controller-manager/main.go
@@ -543,15 +543,10 @@ func main() {
 	}
 
 	if opts.enabledControllersSet.Has(ephemeralcluster.ControllerName) {
-		gitHubClient, err := opts.GitHubClient(opts.dryRun)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to get gitHubClient")
-		}
 		log := logrus.NewEntry(logrus.StandardLogger())
 		if err := ephemeralcluster.AddToManager(log, mgr, allManagers, configAgent,
 			ephemeralcluster.WithPolling(opts.ephemeralClusterProvisinerOptions.polling),
-			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef),
-			ephemeralcluster.WithGHClient(gitHubClient)); err != nil {
+			ephemeralcluster.WithCLIISTagRef(opts.ephemeralClusterProvisinerOptions.cliISTagRef)); err != nil {
 			logrus.WithError(err).Fatalf("Failed to construct the %s controller", ephemeralcluster.ControllerName)
 		}
 	}

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -3,13 +3,12 @@ package ephemeralcluster
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -30,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
-	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/pjutil"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -51,8 +49,6 @@ const (
 	EphemeralClusterNamespace = "ephemeral-cluster"
 	AbortProwJobDeleteEC      = "Ephemeral Cluster deleted"
 	DependentProwJobFinalizer = "ephemeralcluster.ci.openshift.io/dependent-prowjob"
-	PREventPayload            = "ephemeralcluster.ci.openshift.io/pr-event-payload"
-	PREventHeaders            = "ephemeralcluster.ci.openshift.io/pr-event-headers"
 	UnresolvedConfigVar       = "UNRESOLVED_CONFIG"
 	ProwJobCreatingDoneReason = "ProwJob has been properly created"
 	ProwJobNamePrefix         = "ephemeralcluster"
@@ -76,14 +72,12 @@ var (
 		polling: 3 * time.Second,
 	}
 
-	isTagRegexp        = regexp.MustCompile(`(?P<Namespace>.+)/(?P<Name>.+)\:(?P<Tag>.+)`)
-	prOrgRepoNumRegexp = regexp.MustCompile(PROrgRepoNumRegexpPattern)
+	isTagRegexp = regexp.MustCompile(`(?P<Namespace>.+)/(?P<Name>.+)\:(?P<Tag>.+)`)
 )
 
 type reconcilerOptions struct {
 	polling     time.Duration
 	cliISTagRef string
-	ghClient    GitHubClient
 }
 
 type ReconcilerOption func(*reconcilerOptions)
@@ -101,45 +95,19 @@ func WithCLIISTagRef(isTagRef string) ReconcilerOption {
 	}
 }
 
-func WithGHClient(ghClient GitHubClient) ReconcilerOption {
-	return func(o *reconcilerOptions) {
-		o.ghClient = ghClient
-	}
-}
-
-type GitHubClient interface {
-	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
-}
-
-type PRMeta struct {
-	Event   *PullRequestEvent
-	Headers map[string]string
-}
-
-func (prm PRMeta) GitHubGUID() string {
-	return prm.Headers[GitHubGUID]
-}
-
-// pullRequestEvent contains more information than the `pull_request` defined here.
-// So far, that's the only field we need. Check https://docs.github.com/en/rest/using-the-rest-api/github-event-types?apiVersion=2022-11-28#pullrequestevent.
-type PullRequestEvent struct {
-	PullRequest *github.PullRequest `json:"pull_request,omitempty"`
-}
-
-type NewPresubmitFunc func(pr github.PullRequest, baseSHA string, job prowconfig.Presubmit, eventGUID string, additionalLabels map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob
+type NewProwJobFunc func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob
 
 type reconciler struct {
 	logger          *logrus.Entry
 	masterClient    ctrlruntimeclient.Client
 	buildClients    map[string]ctrlruntimeclient.Client
-	newPresubmit    NewPresubmitFunc
+	newProwJob      NewProwJobFunc
 	prowConfigAgent *prowconfig.Agent
 
 	// Mock for testing
 	now         func() time.Time
 	polling     func() time.Duration
 	cliISTagRef api.ImageStreamTagReference
-	ghClient    GitHubClient
 }
 
 func ECPredicateFilter(object ctrlruntimeclient.Object) bool {
@@ -167,11 +135,10 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		masterClient:    mgr.GetClient(),
 		buildClients:    buildClients,
 		prowConfigAgent: prowConfigAgent,
-		newPresubmit:    pjutil.NewPresubmit,
+		newProwJob:      pjutil.NewProwJob,
 		now:             time.Now,
 		polling:         func() time.Duration { return defaultReconcilerOpts.polling },
 		cliISTagRef:     cliISTagRef,
-		ghClient:        defaultReconcilerOpts.ghClient,
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -267,7 +234,7 @@ func (r *reconciler) handleGetProwJobError(ctx context.Context, log *logrus.Entr
 	}
 }
 
-func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, prMeta PRMeta) (*api.ReleaseBuildConfiguration, error) {
+func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster) (*api.ReleaseBuildConfiguration, error) {
 	resources := ec.Spec.CIOperator.Resources
 	if len(resources) == 0 {
 		log.Info("Resources not set, using default values")
@@ -289,10 +256,6 @@ func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralcl
 		cliImgName = r.injectCLIIntoBaseImages(baseImages)
 	}
 
-	org := prMeta.Event.PullRequest.Base.Repo.Owner.Login
-	repo := prMeta.Event.PullRequest.Base.Repo.Name
-	branch := prMeta.Event.PullRequest.Base.Ref
-
 	return &api.ReleaseBuildConfiguration{
 		InputConfiguration: api.InputConfiguration{
 			BuildRootImage: ec.Spec.CIOperator.BuildRootImage,
@@ -303,6 +266,7 @@ func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralcl
 		Resources: resources,
 		Tests: []api.TestStepConfiguration{{
 			As:           EphemeralClusterTestName,
+			Cron:         ptr.To("@yearly"),
 			ClusterClaim: ec.Spec.CIOperator.Test.ClusterClaim,
 			MultiStageTestConfiguration: &api.MultiStageTestConfiguration{
 				Workflow: &ec.Spec.CIOperator.Test.Workflow,
@@ -321,7 +285,7 @@ func (r *reconciler) generateCIOperatorConfig(log *logrus.Entry, ec *ephemeralcl
 				ClusterProfile: api.ClusterProfile(ec.Spec.CIOperator.Test.ClusterProfile),
 			},
 		}},
-		Metadata: api.Metadata{Org: org, Repo: repo, Branch: branch},
+		Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
 	}, nil
 }
 
@@ -400,29 +364,7 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 		upsertCondition(&ec.Status, ephemeralclusterv1.ProwJobCreating, status, r.now(), reason, msg)
 	}
 
-	annotations := ec.Annotations
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-
-	prMeta, err := parsePRMeta(annotations[PREventPayload], annotations[PREventHeaders])
-	if err != nil {
-		log.WithError(err).Error("parse pull request meta")
-		err = fmt.Errorf("parse pull request meta: %w", err)
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
-		ec.Status.Phase = ephemeralclusterv1.EphemeralClusterFailed
-		return reconcile.TerminalError(err)
-	}
-
-	if err := injectPRMetadata(r.ghClient, &prMeta, annotations[PREventPayload]); err != nil {
-		log.WithError(err).Error("inject pull request metadata")
-		err = fmt.Errorf("inject pull request meta: %w", err)
-		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
-		ec.Status.Phase = ephemeralclusterv1.EphemeralClusterFailed
-		return reconcile.TerminalError(err)
-	}
-
-	ciOperatorConfig, err := r.generateCIOperatorConfig(log, ec, prMeta)
+	ciOperatorConfig, err := r.generateCIOperatorConfig(log, ec)
 	if err != nil {
 		log.WithError(err).Error("generate ci-operator config")
 		err = fmt.Errorf("generate ci-operator config: %w", err)
@@ -431,7 +373,7 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 		return reconcile.TerminalError(err)
 	}
 
-	pj, err := r.makeProwJob(ciOperatorConfig, ec, prMeta)
+	pj, err := r.makeProwJob(ciOperatorConfig, ec)
 	if err != nil {
 		log.WithError(err).Error("make prowjob")
 		upsertProvisioningCond(ephemeralclusterv1.ConditionFalse, ephemeralclusterv1.CIOperatorJobsGenerateFailureReason, err.Error())
@@ -455,49 +397,44 @@ func (r *reconciler) createProwJob(ctx context.Context, log *logrus.Entry, ec *e
 	return nil
 }
 
-func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration, ec *ephemeralclusterv1.EphemeralCluster, prMeta PRMeta) (*prowv1.ProwJob, error) {
+func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration, ec *ephemeralclusterv1.EphemeralCluster) (*prowv1.ProwJob, error) {
 	jobConfig, err := prowgen.GenerateJobs(ciOperatorConfig, &prowgen.ProwgenInfo{
 		Metadata: api.Metadata{
-			Org:    prMeta.Event.PullRequest.Base.Repo.Owner.Login,
-			Repo:   prMeta.Event.PullRequest.Base.Repo.Name,
-			Branch: prMeta.Event.PullRequest.Base.Ref,
+			Org:    "org",
+			Repo:   "repo",
+			Branch: "branch",
 		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("generate jobs: %w", err)
 	}
 
-	orgRepo := ciOperatorConfig.Metadata.Org + "/" + ciOperatorConfig.Metadata.Repo
-	presubs, ok := jobConfig.PresubmitsStatic[orgRepo]
-	if !ok {
-		return nil, errors.New("no presubmits generated")
+	if len(jobConfig.Periodics) != 1 {
+		return nil, errors.New("periodic job not found")
 	}
 
-	if len(presubs) != 1 {
-		return nil, errors.New("presubmit job not found")
+	periodic := &jobConfig.Periodics[0]
+	if err := r.prowConfigAgent.Config().DefaultPeriodic(periodic); err != nil {
+		return nil, fmt.Errorf("default periodic: %w", err)
 	}
 
-	presub := &presubs[0]
-	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(presub.JobBase.Name, jobconfig.PresubmitPrefix)
+	jobNameWithoutPrefix, prefixCut := strings.CutPrefix(periodic.JobBase.Name, jobconfig.PeriodicPrefix)
 	if !prefixCut {
-		return nil, fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PresubmitPrefix, presub.JobBase.Name)
+		return nil, fmt.Errorf("failed to strip %s prefix from %s", jobconfig.PeriodicPrefix, periodic.JobBase.Name)
 	}
-	presub.JobBase.Name = ProwJobNamePrefix + jobNameWithoutPrefix
+	periodic.JobBase.Name = ProwJobNamePrefix + jobNameWithoutPrefix
+	periodic.UtilityConfig.ExtraRefs = []prowv1.Refs{}
 
-	prowYAML := prowconfig.ProwYAML{Presubmits: presubs}
-	// This is a workaround to apply some defaults to the prowjob
-	if err := prowconfig.DefaultAndValidateProwYAML(r.prowConfigAgent.Config(), &prowYAML, ""); err != nil {
-		return nil, fmt.Errorf("validate and default presubmit: %w", err)
-	}
+	labels := make(map[string]string)
+	maps.Copy(labels, periodic.Labels)
+	labels[EphemeralClusterLabel] = ec.Name
 
-	presubmit := &prowYAML.Presubmits[0]
-	labels := map[string]string{EphemeralClusterLabel: ec.Name}
-	pj := r.newPresubmit(*prMeta.Event.PullRequest, prMeta.Event.PullRequest.Base.SHA, *presubmit, prMeta.GitHubGUID(), labels, pjutil.RequireScheduling(true))
+	pj := r.newProwJob(pjutil.PeriodicSpec(*periodic), labels, periodic.Annotations, pjutil.RequireScheduling(true))
 	// The cluster will be chosen by the dispatcher. Set a default one here in case things go sideways.
 	pj.Spec.Cluster = string(api.ClusterBuild01)
 	pj.Namespace = r.prowConfigAgent.Config().ProwJobNamespace
-	// Do not report, we are not managing this PR as it's likely it's not comining from the OpenShift CI.
 	pj.Spec.Report = false
+	pj.Spec.Refs = nil
 
 	// Inline ci-operator config
 	ciOperatorConfigYaml, err := yaml.Marshal(ciOperatorConfig)
@@ -768,35 +705,6 @@ func (r *reconciler) findCIOperatorTestNS(ctx context.Context, buildClient ctrlr
 	return nss.Items[0].Name, nil
 }
 
-// injectPRMetadata retrieves the PR metadata from the GitHub api. In some cases (ex.: a check run being rerun)
-// the PR event payload doesn't contain the PR information anymore. We can't keep going this scenario,
-// therefore we make our best effort trying to extract the org, repo and PR number and then manually pull
-// the metadata.
-func injectPRMetadata(ghClient GitHubClient, prMeta *PRMeta, prEventPayload string) error {
-	// The PR exists already, there is nothing to do here
-	if prMeta.Event.PullRequest != nil {
-		return nil
-	}
-
-	matches := prOrgRepoNumRegexp.FindStringSubmatch(prEventPayload)
-	if matches == nil || len(matches) != 4 {
-		return errors.New("unable to extract org, repo and PR number from the PR event payload")
-	}
-
-	org, repo := matches[1], matches[2]
-	prNum, err := strconv.Atoi(matches[3])
-	if err != nil {
-		return fmt.Errorf("failed to parse PR number %s: %w", matches[3], err)
-	}
-
-	prMeta.Event.PullRequest, err = ghClient.GetPullRequest(org, repo, prNum)
-	if err != nil {
-		return fmt.Errorf("failed to get PR %s/%s/pulls/%d: %w", org, repo, prNum, err)
-	}
-
-	return nil
-}
-
 func upsertCondition(ecStatus *ephemeralclusterv1.EphemeralClusterStatus, t ephemeralclusterv1.EphemeralClusterConditionType, status ephemeralclusterv1.ConditionStatus, now time.Time, reason, msg string) {
 	newCond := ephemeralclusterv1.EphemeralClusterCondition{
 		Type:               t,
@@ -823,28 +731,6 @@ func upsertCondition(ecStatus *ephemeralclusterv1.EphemeralClusterStatus, t ephe
 func conditionsEqual(a, b *ephemeralclusterv1.EphemeralClusterCondition) bool {
 	return a.Message == b.Message && a.Reason == b.Reason &&
 		a.Status == b.Status && a.Type == b.Type
-}
-
-func parsePRMeta(event, headers string) (PRMeta, error) {
-	prMeta := PRMeta{}
-
-	if event == "" || headers == "" {
-		return prMeta, errors.New("malformed PR event payload")
-	}
-
-	if err := json.Unmarshal([]byte(event), &prMeta.Event); err != nil {
-		return prMeta, fmt.Errorf("unmarshal event: %w", err)
-	}
-
-	if err := json.Unmarshal([]byte(headers), &prMeta.Headers); err != nil {
-		return prMeta, fmt.Errorf("unmarshal headers: %w", err)
-	}
-
-	if _, ok := prMeta.Headers[GitHubGUID]; !ok {
-		return prMeta, errors.New("unsupported PR event payload")
-	}
-
-	return prMeta, nil
 }
 
 func parseCLIISTagRef(isTag string) (api.ImageStreamTagReference, error) {

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -22,8 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 	prowconfig "sigs.k8s.io/prow/pkg/config"
-	"sigs.k8s.io/prow/pkg/github"
-	"sigs.k8s.io/prow/pkg/github/fakegithub"
 	"sigs.k8s.io/prow/pkg/pjutil"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -35,27 +33,11 @@ import (
 
 const (
 	prowJobNamespace = "ci"
-	prEventPayload   = `
-{
-  "pull_request": {
-    "base": {
-	  "repo": {
-	    "name": "ci-tools",
-	    "owner": {
-		  "login": "openshift"
-		}
-	  },
-	  "ref": "main",
-	  "sha": "8f5e7d6ec106ccf86684fcff808d85cac960f0a3"
-	}
-  }
-}`
-	prEventHeaders = `{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}`
 )
 
-func newPresubmitFaker(name string, now time.Time) NewPresubmitFunc {
-	return func(pr github.PullRequest, baseSHA string, job prowconfig.Presubmit, eventGUID string, additionalLabels map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob {
-		pj := pjutil.NewPresubmit(pr, baseSHA, job, eventGUID, additionalLabels, modifiers...)
+func newProwJobFaker(name string, now time.Time) NewProwJobFunc {
+	return func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob {
+		pj := pjutil.NewProwJob(spec, extraLabels, extraAnnotations, modifiers...)
 		pj.Name = name
 		pj.Status.StartTime = v1.NewTime(now)
 		return pj
@@ -90,7 +72,7 @@ func cmpError(t *testing.T, want, got error) {
 		t.Errorf("want err nil but got: %v", got)
 	}
 	if got == nil && want != nil {
-		t.Errorf("want err %v but nil", want)
+		t.Errorf("want err %v but got nil", want)
 	}
 	if got != nil && want != nil {
 		if diff := cmp.Diff(want.Error(), got.Error()); diff != "" {
@@ -165,7 +147,6 @@ func TestCreateProwJob(t *testing.T) {
 		req          reconcile.Request
 		interceptors interceptor.Funcs
 		prowConfig   *prowconfig.Config
-		ghClient     *fakegithub.FakeClient
 		wantRes      reconcile.Result
 		wantErr      error
 	}{
@@ -173,10 +154,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "An EphemeralCluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -218,10 +195,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Hive cluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -269,10 +242,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Handle invalid prow config",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -288,19 +257,23 @@ func TestCreateProwJob(t *testing.T) {
 					},
 				},
 			},
-			prowConfig: &prowconfig.Config{},
-			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes:    reconcile.Result{},
-			wantErr:    errors.New("terminal error: validate and default presubmit: invalid presubmit job ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning: failed to default namespace"),
+			prowConfig: &prowconfig.Config{
+				JobConfig: prowconfig.JobConfig{
+					Presets: []prowconfig.Preset{{
+						Volumes: []corev1.Volume{{
+							Name: "boskos",
+						}},
+					}},
+				},
+			},
+			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
+			wantRes: reconcile.Result{},
+			wantErr: errors.New("terminal error: default periodic: job periodic-ci-org-repo-branch-cluster-provisioning failed to merge presets for podspec: volume duplicated in pod spec: boskos"),
 		},
 		{
 			name: "Fail to create a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -330,10 +303,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -353,10 +322,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Invalid ci-operator configuration and fail to update EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -382,10 +347,6 @@ func TestCreateProwJob(t *testing.T) {
 			name: "Several PJ for the same EC raises an error",
 			ec: ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: prEventPayload,
-						PREventHeaders: prEventHeaders,
-					},
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -417,143 +378,6 @@ func TestCreateProwJob(t *testing.T) {
 			}}},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
 		},
-		{
-			name: "Unsupported Pull Request event payload",
-			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: `{}`,
-						PREventHeaders: `{}`,
-					},
-					Namespace: "ns",
-					Name:      "ec",
-				},
-				Spec: ephemeralclusterv1.EphemeralClusterSpec{
-					CIOperator: ephemeralclusterv1.CIOperatorSpec{
-						Releases: map[string]api.UnresolvedRelease{
-							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-						},
-						Test: ephemeralclusterv1.TestSpec{
-							Workflow:       "test-workflow",
-							Env:            map[string]string{"foo": "bar"},
-							ClusterProfile: "aws",
-						},
-					},
-				},
-			},
-			wantRes: reconcile.Result{},
-			wantErr: errors.New("terminal error: parse pull request meta: unsupported PR event payload"),
-		}, {
-			name: "Malformed Pull Request event payload",
-			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "ns",
-					Name:      "ec",
-				},
-				Spec: ephemeralclusterv1.EphemeralClusterSpec{
-					CIOperator: ephemeralclusterv1.CIOperatorSpec{
-						Releases: map[string]api.UnresolvedRelease{
-							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-						},
-						Test: ephemeralclusterv1.TestSpec{
-							Workflow:       "test-workflow",
-							Env:            map[string]string{"foo": "bar"},
-							ClusterProfile: "aws",
-						},
-					},
-				},
-			},
-			wantRes: reconcile.Result{},
-			wantErr: errors.New("terminal error: parse pull request meta: malformed PR event payload"),
-		},
-		{
-			name: "Inject missing PR metadata",
-			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: `{"check_run": {"pull_requests": [{"url": "https://api.github.com/repos/danilo-gemoli/foobar/pulls/24"}]}}`,
-						PREventHeaders: prEventHeaders,
-					},
-					Namespace: "ns",
-					Name:      "ec",
-				},
-				Spec: ephemeralclusterv1.EphemeralClusterSpec{
-					CIOperator: ephemeralclusterv1.CIOperatorSpec{
-						BuildRootImage: &api.BuildRootImageConfiguration{
-							ImageStreamTagReference: &api.ImageStreamTagReference{
-								Namespace: "ocp",
-								Name:      "4.20",
-								Tag:       "cli",
-							},
-						},
-						BaseImages: map[string]api.ImageStreamTagReference{
-							"upi-installer": {
-								Namespace: "ocp",
-								Name:      "4.20",
-								Tag:       "upi-installer",
-							},
-						},
-						ExternalImages: map[string]api.ExternalImage{
-							"fedora": {Registry: "quay.io/fedora/fedora:43"},
-						},
-						Releases: map[string]api.UnresolvedRelease{
-							"initial": {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-							"latest":  {Integration: &api.Integration{Name: "4.17", Namespace: "ocp"}},
-						},
-						Test: ephemeralclusterv1.TestSpec{
-							Workflow:       "test-workflow",
-							Env:            map[string]string{"foo": "bar"},
-							ClusterProfile: "aws",
-						},
-					},
-				},
-			},
-			ghClient: func() *fakegithub.FakeClient {
-				c := fakegithub.NewFakeClient()
-				c.PullRequests[24] = &github.PullRequest{
-					Number: 24,
-					Title:  "pr-title",
-					User: github.User{
-						Login:   "author",
-						HTMLURL: "author-link",
-					},
-					Base: github.PullRequestBranch{
-						Ref: "base-ref",
-						Repo: github.Repo{
-							Name:    "repo",
-							HTMLURL: "repo-link",
-							Owner:   github.User{Login: "owner"},
-						},
-					},
-					Head: github.PullRequestBranch{
-						Ref: "head-ref",
-						SHA: "head-sha",
-					},
-				}
-				return c
-			}(),
-			req:     reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes: reconcile.Result{RequeueAfter: pollingTime},
-		},
-		{
-			name: "Failed to pull PR metadata",
-			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
-					Annotations: map[string]string{
-						PREventPayload: `{}`,
-						PREventHeaders: prEventHeaders,
-					},
-					Namespace: "ns",
-					Name:      "ec",
-				},
-			},
-			ghClient: fakegithub.NewFakeClient(),
-			req:      reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "ec"}},
-			wantRes:  reconcile.Result{},
-			wantErr:  errors.New("terminal error: inject pull request meta: unable to extract org, repo and PR number from the PR event payload"),
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -580,9 +404,8 @@ func TestCreateProwJob(t *testing.T) {
 				now:             func() time.Time { return fakeNow },
 				polling:         func() time.Duration { return pollingTime },
 				cliISTagRef:     api.ImageStreamTagReference{Namespace: "ocp", Name: "4.22", Tag: "cli"},
-				newPresubmit:    newPresubmitFaker("foobar", fakeNow),
+				newProwJob:      newProwJobFaker("foobar", fakeNow),
 				prowConfigAgent: prowConfigAgent(pc),
-				ghClient:        tc.ghClient,
 			}
 
 			gotRes, gotErr := r.Reconcile(context.TODO(), reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.ec.Name, Namespace: tc.ec.Namespace}})
@@ -1486,7 +1309,7 @@ func TestReconcile(t *testing.T) {
 				buildClients: clients,
 				now:          func() time.Time { return fakeNow },
 				polling:      func() time.Duration { return pollingTime },
-				newPresubmit: newPresubmitFaker("foobar", fakeNow),
+				newProwJob:   newProwJobFaker("foobar", fakeNow),
 				prowConfigAgent: prowConfigAgent(&prowconfig.Config{
 					ProwConfig: prowconfig.ProwConfig{ProwJobNamespace: prowJobNamespace},
 				}),

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Fail_to_create_a_ProwJob.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Failed_to_pull_PR_metadata.yaml
@@ -1,7 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: '{}'
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -12,8 +9,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'inject pull request meta: unable to extract org, repo and PR number
-      from the PR event payload'
+    message: 'generate ci-operator config: releases stanza not set'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
     type: ProwJobCreating

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Handle_invalid_prow_config.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns
@@ -25,8 +19,8 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'validate and default presubmit: invalid presubmit job ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning:
-      failed to default namespace'
+    message: 'default periodic: job periodic-ci-org-repo-branch-cluster-provisioning
+      failed to merge presets for podspec: volume duplicated in pod spec: boskos'
     reason: CIOperatorJobsGenerateFailure
     status: "False"
     type: ProwJobCreating

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Inject_missing_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Inject_missing_PR_metadata.yaml
@@ -1,8 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: '{"check_run": {"pull_requests":
-      [{"url": "https://api.github.com/repos/danilo-gemoli/foobar/pulls/24"}]}}'
   creationTimestamp: null
   finalizers:
   - ephemeralcluster.ci.openshift.io/dependent-prowjob
@@ -47,4 +43,4 @@ status:
     status: "True"
     type: ProwJobCreating
   phase: Provisioning
-  prowJobId: foobar
+  prowJobId: 1e3d3ebb-8f80-4527-8689-63ecad9fc85a

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Invalid_ci_operator_configuration_and_fail_to_update_EC.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
@@ -1,5 +1,7 @@
 metadata:
   creationTimestamp: null
+  finalizers:
+  - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec
   namespace: ns
   resourceVersion: "1000"
@@ -22,8 +24,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'parse pull request meta: malformed PR event payload'
-    reason: CIOperatorJobsGenerateFailure
-    status: "False"
+    status: "True"
     type: ProwJobCreating
-  phase: Failed
+  phase: Provisioning
+  prowJobId: 37dfc176-b4c5-4254-bf59-092d6550b005

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Several_PJ_for_the_same_EC_raises_an_error.yaml
@@ -1,10 +1,4 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{"X-Github-Delivery": "aa9ede40-8fbb-11f0-8717-9eed0c1315d0"}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: "\n{\n  \"pull_request\": {\n
-      \   \"base\": {\n\t  \"repo\": {\n\t    \"name\": \"ci-tools\",\n\t    \"owner\":
-      {\n\t\t  \"login\": \"openshift\"\n\t\t}\n\t  },\n\t  \"ref\": \"main\",\n\t
-      \ \"sha\": \"8f5e7d6ec106ccf86684fcff808d85cac960f0a3\"\n\t}\n  }\n}"
   creationTimestamp: null
   name: ec
   namespace: ns

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_ec_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
@@ -1,8 +1,7 @@
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: '{}'
-    ephemeralcluster.ci.openshift.io/pr-event-payload: '{}'
   creationTimestamp: null
+  finalizers:
+  - ephemeralcluster.ci.openshift.io/dependent-prowjob
   name: ec
   namespace: ns
   resourceVersion: "1000"
@@ -25,8 +24,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-04-02T12:12:12Z"
-    message: 'parse pull request meta: unsupported PR event payload'
-    reason: CIOperatorJobsGenerateFailure
-    status: "False"
+    status: "True"
     type: ProwJobCreating
-  phase: Failed
+  phase: Provisioning
+  prowJobId: 6ae257a9-545d-422a-858d-ca0b96a09cc2

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -3,31 +3,24 @@ items:
   kind: ProwJob
   metadata:
     annotations:
-      prow.k8s.io/context: ci/prow/cluster-provisioning
-      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
-      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prow.k8s.io/context: cluster-provisioning
-      prow.k8s.io/is-optional: "false"
-      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisionin
-      prow.k8s.io/refs.base_ref: main
-      prow.k8s.io/refs.org: openshift
-      prow.k8s.io/refs.pull: "0"
-      prow.k8s.io/refs.repo: ci-tools
-      prow.k8s.io/type: presubmit
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
     resourceVersion: "1"
   spec:
     agent: kubernetes
     cluster: build01
-    context: ci/prow/cluster-provisioning
     decoration_config:
       gcs_configuration:
         default_org: org
@@ -39,7 +32,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     namespace: ci
     pod_spec:
       containers:
@@ -92,6 +85,7 @@ items:
                   cpu: 200m
             tests:
             - as: cluster-provisioning
+              cron: '@yearly'
               steps:
                 cluster_profile: aws
                 env:
@@ -121,9 +115,9 @@ items:
                       cpu: 10m
                 workflow: test-workflow
             zz_generated_metadata:
-              branch: main
-              org: openshift
-              repo: ci-tools
+              branch: branch
+              org: org
+              repo: repo
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
@@ -174,19 +168,7 @@ items:
           secretName: result-aggregator
     prowjob_defaults:
       tenant_id: GlobalDefaultID
-    refs:
-      base_link: /commit/8f5e7d6ec106ccf86684fcff808d85cac960f0a3
-      base_ref: main
-      base_sha: 8f5e7d6ec106ccf86684fcff808d85cac960f0a3
-      org: openshift
-      pulls:
-      - author: ""
-        commit_link: /pull/0/commits/
-        number: 0
-        sha: ""
-      repo: ci-tools
-    rerun_command: /test cluster-provisioning
-    type: presubmit
+    type: periodic
   status:
     startTime: "2025-04-02T12:12:12Z"
     state: scheduling

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -3,31 +3,24 @@ items:
   kind: ProwJob
   metadata:
     annotations:
-      prow.k8s.io/context: ci/prow/cluster-provisioning
-      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     creationTimestamp: null
     labels:
       ci-operator.openshift.io/cloud: aws
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
-      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prow.k8s.io/context: cluster-provisioning
-      prow.k8s.io/is-optional: "false"
-      prow.k8s.io/job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisionin
-      prow.k8s.io/refs.base_ref: main
-      prow.k8s.io/refs.org: openshift
-      prow.k8s.io/refs.pull: "0"
-      prow.k8s.io/refs.repo: ci-tools
-      prow.k8s.io/type: presubmit
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
+      prow.k8s.io/type: periodic
     name: foobar
     namespace: ci
     resourceVersion: "1"
   spec:
     agent: kubernetes
     cluster: build01
-    context: ci/prow/cluster-provisioning
     decoration_config:
       gcs_configuration:
         default_org: org
@@ -39,7 +32,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-openshift-ci-tools-main-cluster-provisioning
+    job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
     namespace: ci
     pod_spec:
       containers:
@@ -98,6 +91,7 @@ items:
                 product: ocp
                 timeout: 0s
                 version: "4.22"
+              cron: '@yearly'
               steps:
                 cluster_profile: aws
                 env:
@@ -127,9 +121,9 @@ items:
                       cpu: 10m
                 workflow: generic-claim
             zz_generated_metadata:
-              branch: main
-              org: openshift
-              repo: ci-tools
+              branch: branch
+              org: org
+              repo: repo
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
@@ -186,19 +180,7 @@ items:
           secretName: result-aggregator
     prowjob_defaults:
       tenant_id: GlobalDefaultID
-    refs:
-      base_link: /commit/8f5e7d6ec106ccf86684fcff808d85cac960f0a3
-      base_ref: main
-      base_sha: 8f5e7d6ec106ccf86684fcff808d85cac960f0a3
-      org: openshift
-      pulls:
-      - author: ""
-        commit_link: /pull/0/commits/
-        number: 0
-        sha: ""
-      repo: ci-tools
-    rerun_command: /test cluster-provisioning
-    type: presubmit
+    type: periodic
   status:
     startTime: "2025-04-02T12:12:12Z"
     state: scheduling

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Inject_missing_PR_metadata.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Inject_missing_PR_metadata.yaml
@@ -3,31 +3,21 @@ items:
   kind: ProwJob
   metadata:
     annotations:
-      prow.k8s.io/context: ci/prow/cluster-provisioning
-      prow.k8s.io/job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
     creationTimestamp: null
     labels:
-      ci-operator.openshift.io/cloud: aws
-      ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
-      event-GUID: aa9ede40-8fbb-11f0-8717-9eed0c1315d0
-      pj-rehearse.openshift.io/can-be-rehearsed: "true"
-      prow.k8s.io/context: cluster-provisioning
-      prow.k8s.io/is-optional: "false"
-      prow.k8s.io/job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
-      prow.k8s.io/refs.base_ref: base-ref
-      prow.k8s.io/refs.org: owner
-      prow.k8s.io/refs.pull: "24"
-      prow.k8s.io/refs.repo: repo
-      prow.k8s.io/type: presubmit
-    name: foobar
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioni
+      prow.k8s.io/type: periodic
+    name: 1e3d3ebb-8f80-4527-8689-63ecad9fc85a
     namespace: ci
     resourceVersion: "1"
   spec:
     agent: kubernetes
     cluster: build01
-    context: ci/prow/cluster-provisioning
     decoration_config:
       gcs_configuration:
         default_org: org
@@ -39,7 +29,7 @@ items:
         entrypoint: entrypoint
         initupload: initupload
         sidecar: sidecar
-    job: ephemeralcluster-ci-owner-repo-base-ref-cluster-provisioning
+    job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
     namespace: ci
     pod_spec:
       containers:
@@ -92,6 +82,7 @@ items:
                   cpu: 200m
             tests:
             - as: cluster-provisioning
+              cron: '@yearly'
               steps:
                 cluster_profile: aws
                 env:
@@ -121,9 +112,9 @@ items:
                       cpu: 10m
                 workflow: test-workflow
             zz_generated_metadata:
-              branch: base-ref
-              org: owner
-              repo: repo
+              branch: no-branch
+              org: no-org
+              repo: no-repo
         image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
         imagePullPolicy: Always
         name: ""
@@ -174,23 +165,8 @@ items:
           secretName: result-aggregator
     prowjob_defaults:
       tenant_id: GlobalDefaultID
-    refs:
-      base_link: repo-link/commit/
-      base_ref: base-ref
-      org: owner
-      pulls:
-      - author: author
-        author_link: author-link
-        commit_link: repo-link/pull/24/commits/head-sha
-        head_ref: head-ref
-        number: 24
-        sha: head-sha
-        title: pr-title
-      repo: repo
-      repo_link: repo-link
-    rerun_command: /test cluster-provisioning
-    type: presubmit
+    type: periodic
   status:
-    startTime: "2025-04-02T12:12:12Z"
+    startTime: "2026-04-13T14:24:03Z"
     state: scheduling
 metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Malformed_Pull_Request_event_payload.yaml
@@ -1,2 +1,156 @@
-items: []
+items:
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/ephemeral-cluster: ec
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioni
+      prow.k8s.io/type: periodic
+    name: 37dfc176-b4c5-4254-bf59-092d6550b005
+    namespace: ci
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build01
+    decoration_config:
+      gcs_configuration:
+        default_org: org
+        default_repo: repo
+        path_strategy: single
+      skip_cloning: true
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+    job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
+    namespace: ci
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cluster-provisioning
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: UNRESOLVED_CONFIG
+          value: |
+            releases:
+              initial:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+              latest:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+            resources:
+              '*':
+                limits:
+                  memory: 400Mi
+                requests:
+                  cpu: 200m
+            tests:
+            - as: cluster-provisioning
+              cron: '@yearly'
+              steps:
+                cluster_profile: aws
+                env:
+                  foo: bar
+                test:
+                - as: wait-test-complete
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
+                    and then waits for\n# a konflux test to complete. Once the test is done, the
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
+                    into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                  from: cli
+                  resources:
+                    limits:
+                      memory: 100Mi
+                    requests:
+                      cpu: 10m
+                workflow: test-workflow
+            zz_generated_metadata:
+              branch: no-branch
+              org: no-org
+              repo: no-repo
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    type: periodic
+  status:
+    startTime: "2026-04-13T14:24:03Z"
+    state: scheduling
 metadata: {}

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Unsupported_Pull_Request_event_payload.yaml
@@ -1,2 +1,156 @@
-items: []
+items:
+- apiVersion: prow.k8s.io/v1
+  kind: ProwJob
+  metadata:
+    annotations:
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
+    creationTimestamp: null
+    labels:
+      ci.openshift.io/ephemeral-cluster: ec
+      created-by-prow: "true"
+      prow.k8s.io/context: ""
+      prow.k8s.io/job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioni
+      prow.k8s.io/type: periodic
+    name: 6ae257a9-545d-422a-858d-ca0b96a09cc2
+    namespace: ci
+    resourceVersion: "1"
+  spec:
+    agent: kubernetes
+    cluster: build01
+    decoration_config:
+      gcs_configuration:
+        default_org: org
+        default_repo: repo
+        path_strategy: single
+      skip_cloning: true
+      utility_images:
+        clonerefs: clonerefs
+        entrypoint: entrypoint
+        initupload: initupload
+        sidecar: sidecar
+    job: ephemeralcluster-ci-no-org-no-repo-no-branch-cluster-provisioning
+    namespace: ci
+    pod_spec:
+      containers:
+      - args:
+        - --gcs-upload-secret=/secrets/gcs/service-account.json
+        - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+        - --lease-server-credentials-file=/etc/boskos/credentials
+        - --report-credentials-file=/etc/report/credentials
+        - --secret-dir=/secrets/ci-pull-credentials
+        - --target=cluster-provisioning
+        command:
+        - ci-operator
+        env:
+        - name: HTTP_SERVER_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: UNRESOLVED_CONFIG
+          value: |
+            releases:
+              initial:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+              latest:
+                integration:
+                  name: "4.17"
+                  namespace: ocp
+            resources:
+              '*':
+                limits:
+                  memory: 400Mi
+                requests:
+                  cpu: 200m
+            tests:
+            - as: cluster-provisioning
+              cron: '@yearly'
+              steps:
+                cluster_profile: aws
+                env:
+                  foo: bar
+                test:
+                - as: wait-test-complete
+                  commands: "set +e\n\n# This loop keeps the ephemeral cluster up and running
+                    and then waits for\n# a konflux test to complete. Once the test is done, the
+                    EphemeralCluster \n# controller creates a synthetic secret 'test-done-signal'
+                    into this ci-operator NS,\n# unbloking the workflow and starting the deprovisioning
+                    procedures.\n\n# This kubeconfig points to the ephemeral cluster. Unsetting
+                    it as we want to reach out to\n# the build farm cluster.\nunset KUBECONFIG\n\ni=0\nunexpected_err=0\nsecret='test-done-signal'\n\nwhile
+                    true; do\n    printf 'attempt %d\\n' $i\n\n    output=\"$(oc get secret/$secret
+                    2>&1)\"\n    if [ $? -eq 0 ]; then\n        printf 'secret found\\n'\n        break\n
+                    \   fi\n\n    # The sole error we expect to hit is 'not found'. Break the
+                    loop if we collect\n    # this many unexpected errors in a row.\n    if !
+                    $(grep -qF \"secrets \\\"$secret\\\" not found\" <<<\"$output\"); then\n        printf
+                    'unexpected error: %d\\n%s\\n' $unexpected_err \"$output\"\n\n        if [
+                    $unexpected_err -ge 3 ]; then\n            printf 'FAILURE: too many unexpected
+                    errors\\n' $unexpected_err\n            break\n        fi\n\n        unexpected_err=$((unexpected_err+1))\n
+                    \   else\n        unexpected_err=0\n    fi\n\n    i=$((i+1))\n    sleep 5s\ndone\n"
+                  from: cli
+                  resources:
+                    limits:
+                      memory: 100Mi
+                    requests:
+                      cpu: 10m
+                workflow: test-workflow
+            zz_generated_metadata:
+              branch: no-branch
+              org: no-org
+              repo: no-repo
+        image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+        imagePullPolicy: Always
+        name: ""
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/boskos
+          name: boskos
+          readOnly: true
+        - mountPath: /secrets/ci-pull-credentials
+          name: ci-pull-credentials
+          readOnly: true
+        - mountPath: /secrets/gcs
+          name: gcs-credentials
+          readOnly: true
+        - mountPath: /secrets/manifest-tool
+          name: manifest-tool-local-pusher
+          readOnly: true
+        - mountPath: /etc/pull-secret
+          name: pull-secret
+          readOnly: true
+        - mountPath: /etc/report
+          name: result-aggregator
+          readOnly: true
+      serviceAccountName: ci-operator
+      volumes:
+      - name: boskos
+        secret:
+          items:
+          - key: credentials
+            path: credentials
+          secretName: boskos-credentials
+      - name: ci-pull-credentials
+        secret:
+          secretName: ci-pull-credentials
+      - name: manifest-tool-local-pusher
+        secret:
+          secretName: manifest-tool-local-pusher
+      - name: pull-secret
+        secret:
+          secretName: registry-pull-credentials
+      - name: result-aggregator
+        secret:
+          secretName: result-aggregator
+    prowjob_defaults:
+      tenant_id: GlobalDefaultID
+    type: periodic
+  status:
+    startTime: "2026-04-13T14:24:03Z"
+    state: scheduling
 metadata: {}


### PR DESCRIPTION
It turns out that Konflux users can request an ephemeral cluster from different "contexts", and not each of them has a PR associated with it.
This means that we should not rely on any data coming from a PR, like the HTTP Request payload or headers.

For that reason, the reconciler now uses a Periodic rather than a Presubmit in order to setup and run `ci-operator`. That seems more appropriate because a Presubmit, by definition, is strictly tied to a PR, whereas a Periodic is not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed GitHub pull request event handling from ephemeral cluster provisioning.
  * Ephemeral cluster jobs now use periodic scheduling instead of pull request–based scheduling.
  * Simplified job creation workflow by eliminating PR metadata parsing and injection steps.

* **Tests**
  * Updated test fixtures and unit tests to reflect the new periodic job creation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->