### PR TITLE
image-detector: support /image commit directive to force image builds

### DIFF
--- a/pkg/tool-detector/detector.go
+++ b/pkg/tool-detector/detector.go
@@ -21,6 +21,7 @@ import (
 const (
 	ModulePrefix = "github.com/openshift/ci-tools"
 	CmdPrefix    = ModulePrefix + "/cmd"
+	imageCommand = "/image"
 )
 
 // Detector detects which cmd tools are affected by code changes
@@ -56,6 +57,16 @@ func (d *Detector) AffectedTools() (sets.Set[string], error) {
 			baseRef += "^"
 		}
 	}
+
+	forcedImages, forceAll, err := d.getForcedImagesFromCommitMessages(baseRef)
+	if err != nil {
+		logrus.WithError(err).Warn("Failed to parse commit messages for forced image directives; falling back to affected-tools detection")
+		forcedImages = sets.New[string]()
+	}
+	if forceAll {
+		return d.getAllImageNames(), nil
+	}
+
 	changedFiles, err := d.getChangedFiles(baseRef)
 	if err != nil {
 		return nil, fmt.Errorf("get changed files: %w", err)
@@ -76,8 +87,9 @@ func (d *Detector) AffectedTools() (sets.Set[string], error) {
 	}
 
 	if len(goFiles) == 0 {
-		combined := affectedByImageChanges.Union(d.getAffectedToolsByBinaryInputs(affectedByImageChanges))
-		return combined, nil
+		binaryInputSeed := affectedByImageChanges.Union(forcedImages)
+		combined := affectedByImageChanges.Union(d.getAffectedToolsByBinaryInputs(binaryInputSeed))
+		return combined.Union(forcedImages), nil
 	}
 
 	changedPackages, err := d.loadChangedPackages(goFiles)
@@ -87,8 +99,9 @@ func (d *Detector) AffectedTools() (sets.Set[string], error) {
 
 	logrus.WithField("count", len(changedPackages)).WithField("packages", sets.List(changedPackages)).Info("Detected changed packages")
 	if len(changedPackages) == 0 {
-		combined := affectedByImageChanges.Union(d.getAffectedToolsByBinaryInputs(affectedByImageChanges))
-		return combined, nil
+		binaryInputSeed := affectedByImageChanges.Union(forcedImages)
+		combined := affectedByImageChanges.Union(d.getAffectedToolsByBinaryInputs(binaryInputSeed))
+		return combined.Union(forcedImages), nil
 	}
 
 	cmdTools, allPackages, err := d.loadCmdTools()
@@ -98,16 +111,74 @@ func (d *Detector) AffectedTools() (sets.Set[string], error) {
 
 	affectedByPackages := d.findAffectedToolsFromPackages(cmdTools, allPackages, changedPackages, baseRef)
 
-	combined := affectedByPackages.Union(affectedByImageChanges)
+	combined := affectedByPackages.Union(affectedByImageChanges).Union(forcedImages)
 	affectedByBinaryInputs := d.getAffectedToolsByBinaryInputs(combined)
 
 	logrus.WithField("affectedByPackages", sets.List(affectedByPackages)).
 		WithField("affectedByImages", sets.List(affectedByImageChanges)).
 		WithField("affectedByBinaryInputs", sets.List(affectedByBinaryInputs)).
+		WithField("forcedByCommitMessage", sets.List(forcedImages)).
 		WithField("total", combined.Union(affectedByBinaryInputs).Len()).
 		Info("Detected affected tools")
 
 	return combined.Union(affectedByBinaryInputs), nil
+}
+
+func (d *Detector) getAllImageNames() sets.Set[string] {
+	imageNames := sets.New[string]()
+	if d.config == nil {
+		return imageNames
+	}
+	for _, image := range d.config.Images.Items {
+		imageNames.Insert(string(image.To))
+	}
+	return imageNames
+}
+
+// getForcedImagesFromCommitMessages scans commit messages in baseRef..HEAD for
+// /image directives. This is only called when build_if_affected is enabled
+// (gated in determineSkippedImages in cmd/ci-operator/main.go).
+func (d *Detector) getForcedImagesFromCommitMessages(baseRef string) (sets.Set[string], bool, error) {
+	cmd := exec.Command("git", "log", "--format=%B%x00", baseRef+"..HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, false, fmt.Errorf("git log %s..HEAD: %w", baseRef, err)
+	}
+
+	messages := strings.Split(string(output), "\x00")
+	forced, forceAll := parseForcedImagesFromCommitMessages(messages, d.getAllImageNames())
+	return forced, forceAll, nil
+}
+
+func parseForcedImagesFromCommitMessages(messages []string, allowedImageNames sets.Set[string]) (sets.Set[string], bool) {
+	forced := sets.New[string]()
+	for _, message := range messages {
+		scanner := bufio.NewScanner(strings.NewReader(message))
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, imageCommand) {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 2 || fields[0] != imageCommand {
+				continue
+			}
+			for _, imageName := range fields[1:] {
+				if imageName == "all" {
+					return allowedImageNames, true
+				}
+				if allowedImageNames.Has(imageName) {
+					forced.Insert(imageName)
+					continue
+				}
+				logrus.WithField("image", imageName).Warn("Ignoring unknown forced image requested via /image commit directive")
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			logrus.WithError(err).Warn("Error scanning commit message for /image directives")
+		}
+	}
+	return forced, false
 }
 
 func (d *Detector) getChangedFiles(baseRef string) ([]string, error) {

--- a/pkg/tool-detector/detector_test.go
+++ b/pkg/tool-detector/detector_test.go
@@ -745,3 +745,132 @@ func TestExtractBeforeSHAFromCompareURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseForcedImagesFromCommitMessages(t *testing.T) {
+	allowed := sets.New("pod-scaler", "pr-reminder", "pipeline-controller")
+
+	tests := []struct {
+		name           string
+		messages       []string
+		expectedForced sets.Set[string]
+		expectedAll    bool
+	}{
+		{
+			name: "single image directive",
+			messages: []string{
+				`commit title
+
+/image pod-scaler`,
+			},
+			expectedForced: sets.New("pod-scaler"),
+		},
+		{
+			name: "multiple image directive",
+			messages: []string{
+				`commit title
+
+/image pod-scaler pr-reminder`,
+			},
+			expectedForced: sets.New("pod-scaler", "pr-reminder"),
+		},
+		{
+			name: "all directive builds everything",
+			messages: []string{
+				`commit title
+
+/image all`,
+			},
+			expectedForced: sets.New("pod-scaler", "pr-reminder", "pipeline-controller"),
+			expectedAll:    true,
+		},
+		{
+			name: "unknown images are ignored",
+			messages: []string{
+				`commit title
+
+/image pod-scaler missing-image`,
+			},
+			expectedForced: sets.New("pod-scaler"),
+		},
+		{
+			name: "must start at beginning of line",
+			messages: []string{
+				`commit title
+
+some context /image pod-scaler
+ /image pr-reminder`,
+			},
+			expectedForced: sets.New[string](),
+		},
+		{
+			name: "supports only singular command",
+			messages: []string{
+				`commit title
+
+/images pod-scaler`,
+			},
+			expectedForced: sets.New[string](),
+		},
+		{
+			name: "collects directives across multiple commits",
+			messages: []string{
+				`commit one
+
+/image pod-scaler`,
+				`commit two
+
+/image pr-reminder`,
+			},
+			expectedForced: sets.New("pod-scaler", "pr-reminder"),
+		},
+		{
+			name: "/image with no arguments has no effect",
+			messages: []string{
+				`commit title
+
+/image`,
+			},
+			expectedForced: sets.New[string](),
+		},
+		{
+			name: "/image with trailing whitespace only has no effect",
+			messages: []string{
+				"commit title\n\n/image   ",
+			},
+			expectedForced: sets.New[string](),
+		},
+		{
+			name:           "empty commit message",
+			messages:       []string{""},
+			expectedForced: sets.New[string](),
+		},
+		{
+			name: "CRLF line endings",
+			messages: []string{
+				"commit title\r\n\r\n/image pod-scaler\r\n",
+			},
+			expectedForced: sets.New("pod-scaler"),
+		},
+		{
+			name: "mixed valid and invalid on one line keeps valid ones",
+			messages: []string{
+				`commit title
+
+/image pod-scaler bad-name pr-reminder also-bad`,
+			},
+			expectedForced: sets.New("pod-scaler", "pr-reminder"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forced, all := parseForcedImagesFromCommitMessages(tt.messages, allowed)
+			if diff := cmp.Diff(tt.expectedForced, forced); diff != "" {
+				t.Fatalf("forced images mismatch (-want +got):\n%s", diff)
+			}
+			if all != tt.expectedAll {
+				t.Fatalf("expected all=%v, got %v", tt.expectedAll, all)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When build_if_affected is enabled, users can now add /image directives in commit messages to force-build specific images regardless of code change detection. The directive must start at the beginning of a line.

Supported syntax:
- /image <name1> <name2> ... - force specific images
- /image all - force all configured images

Image names are validated against images.items[].to in ci-operator config. Unknown names are warned and ignored. Forced images are unioned with auto-detected affected images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Commit messages now support `/image` directives to control which tools and images are selected for builds
  * Use `/image <name>` to force a specific tool, or `/image all` to include all configured images
  * System validates image names against your configuration; warnings are logged for unsupported directives
  * Forced images are properly incorporated across all detection logic paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->