### PR TITLE
support major version 5.0+ in /payload command

### DIFF
--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -48,9 +48,9 @@ const (
 )
 
 var (
-	ocpPayloadTestsPattern                     = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<ocp>4\.\d+)\s+(?P<release>\w+)\s+(?P<jobs>\w+)\s*$`, payloadPrefix))
+	ocpPayloadTestsPattern                     = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<ocp>[45]\.\d+)\s+(?P<release>\w+)\s+(?P<jobs>\w+)\s*$`, payloadPrefix))
 	ocpPayloadJobTestsPattern                  = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+((?:[-\w.]+\s*?)+)\s*$`, payloadJobPrefix))
-	ocpPayloadWithPRsTestsPattern              = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<ocp>4\.\d+)\s+(?P<release>\w+)\s+(?P<jobs>\w+)\s+(?P<prs>(?:[-\w./#]+\s*)+)\s*$`, payloadWithPRsPrefix))
+	ocpPayloadWithPRsTestsPattern              = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<ocp>[45]\.\d+)\s+(?P<release>\w+)\s+(?P<jobs>\w+)\s+(?P<prs>(?:[-\w./#]+\s*)+)\s*$`, payloadWithPRsPrefix))
 	ocpPayloadJobTestsWithPRsPattern           = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<job>[-\w.]+)\s+(?P<prs>(?:[-\w./#]+\s*)+)\s*$`, payloadJobWithPRsPrefix))
 	ocpPayloadAggregatedJobTestsPattern        = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<job>[-\w.]+)\s+(?P<aggregate>\d+)\s*$`, payloadAggregatePrefix))
 	ocpPayloadAggregatedWithPRsJobTestsPattern = regexp.MustCompile(fmt.Sprintf(`(?mi)^%s\s+(?P<job>[-\w.]+)\s+(?P<aggregate>\d+)\s+(?P<prs>(?:[-\w./#]+\s*)+)\s*$`, payloadAggregateWithPRsPrefix))

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -47,6 +47,20 @@ func TestSpecsFromComment(t *testing.T) {
 			expected: []jobSetSpecification{{ocp: "4.8", releaseType: "ci", jobs: "all"}},
 		},
 		{
+			name:     "major version",
+			comment:  "/payload 5.0 ci blocking",
+			expected: []jobSetSpecification{{ocp: "5.0", releaseType: "ci", jobs: "blocking"}},
+		},
+		{
+			name:     "major version with prs",
+			comment:  "/payload-with-prs 5.0 nightly informing openshift/kubernetes#1234",
+			expected: []jobSetSpecification{{ocp: "5.0", releaseType: "nightly", jobs: "informing", additionalPRs: []config.AdditionalPR{"openshift/kubernetes#1234"}}},
+		},
+		{
+			name:    "rejects version below 4",
+			comment: "/payload 3.11 ci all",
+		},
+		{
 			name:    "unknown command",
 			comment: "/cmd 4.8 ci all",
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended payload comment parsing to accept OCP 5.x versions in addition to 4.x, improving compatibility with newer version strings.
  * Added explicit rejection behavior for payload comments specifying versions below 4.x.

* **Tests**
  * Added test cases covering 5.0 payload comments and the rejection of pre-4.x version inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->