### PR TITLE
fix(pj-rehearse): correct inverted rebase in prepareCandidate

### DIFF
--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -534,9 +534,16 @@ func (s *server) getRepoClient(org, repo string) (git.RepoClient, error) {
 }
 
 func (s *server) prepareCandidate(repoClient git.RepoClient, pullRequest *github.PullRequest, logger *logrus.Entry) (rehearse.RehearsalCandidate, error) {
-	if err := repoClient.CheckoutPullRequest(pullRequest.Number); err != nil {
-		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't checkout pull request: %w", err)
+	// Fetch the PR head without checking it out — we only need the SHA to pass
+	// as commitlike to MergeWithStrategy.
+	if err := repoClient.FetchRef(fmt.Sprintf("pull/%d/head", pullRequest.Number)); err != nil {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't fetch pull request: %w", err)
 	}
+	prHead, err := repoClient.RevParse("FETCH_HEAD")
+	if err != nil {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rev-parse PR HEAD: %w", err)
+	}
+	prHead = strings.TrimSpace(prHead)
 
 	repo := pullRequest.Base.Repo
 	baseSHA, err := s.ghc.GetRef(repo.Owner.Login, repo.Name, fmt.Sprintf("heads/%s", pullRequest.Base.Ref))
@@ -545,23 +552,31 @@ func (s *server) prepareCandidate(repoClient git.RepoClient, pullRequest *github
 	}
 	candidate := rehearse.RehearsalCandidateFromPullRequest(pullRequest, baseSHA)
 
-	// In order to determine *only* the affected jobs from the changes in the PR, we need to rebase onto default
-	baseRef := pullRequest.Base.Ref
+	// In order to determine *only* the affected jobs from the changes in the PR, we need to rebase onto default.
+	// MergeWithStrategy("rebase") internally runs `git rebase --no-stat <HEAD> <commitlike>`, which checks out
+	// commitlike and replays its commits onto HEAD. We check out the exact baseSHA (rather than the branch name)
+	// so the rebase target matches the base commit that DetermineAffectedJobs diffs against.
+	if err := repoClient.Checkout(baseSHA); err != nil {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't checkout base SHA %s: %w", baseSHA, err)
+	}
 
 	// In practice, this command sometimes fails due to seemingly transient issues, we should retry it up to 4 times
 	var rebased bool
 	var rebaseErr error
 	totalAttempts := 4
 	for i := 0; i < totalAttempts; i++ {
-		rebased, rebaseErr = repoClient.MergeWithStrategy(baseRef, "rebase")
+		rebased, rebaseErr = repoClient.MergeWithStrategy(prHead, "rebase")
 		if rebased && rebaseErr == nil {
 			break
 		} else {
 			logger.Warnf("couldn't rebase PR on attempt: %d. Will retry up to %d times.", i+1, totalAttempts)
 		}
 	}
-	if !rebased || rebaseErr != nil {
-		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rebase candidate onto %v: %w", baseRef, rebaseErr)
+	if rebaseErr != nil {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rebase candidate onto %s: %w", baseSHA, rebaseErr)
+	}
+	if !rebased {
+		return rehearse.RehearsalCandidate{}, fmt.Errorf("couldn't rebase candidate onto %s due to conflicts", baseSHA)
 	}
 
 	return candidate, nil

--- a/cmd/pj-rehearse/server_test.go
+++ b/cmd/pj-rehearse/server_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/prow/pkg/git/localgit"
+	"sigs.k8s.io/prow/pkg/git/v2"
+	"sigs.k8s.io/prow/pkg/github"
+)
+
+// testRepoClient wraps a real git.RepoClient and overrides FetchRef to work
+// with local test repos that don't have GitHub pull request refs. The real code
+// fetches "pull/{number}/head"; in tests we fetch the PR branch directly so
+// that FETCH_HEAD points to the PR tip.
+type testRepoClient struct {
+	git.RepoClient
+	prBranch         string
+	expectedFetchRef string
+}
+
+func (t *testRepoClient) FetchRef(ref string) error {
+	if t.expectedFetchRef != "" && ref != t.expectedFetchRef {
+		return fmt.Errorf("unexpected fetch ref: got %q, want %q", ref, t.expectedFetchRef)
+	}
+	return t.RepoClient.FetchRef(t.prBranch)
+}
+
+type fakeGHC struct {
+	refSHA      string
+	expectedRef string
+}
+
+func (f *fakeGHC) CreateComment(string, string, int, string) error                 { return nil }
+func (f *fakeGHC) AddLabel(string, string, int, string) error                      { return nil }
+func (f *fakeGHC) RemoveLabel(string, string, int, string) error                   { return nil }
+func (f *fakeGHC) GetPullRequest(string, string, int) (*github.PullRequest, error) { return nil, nil }
+func (f *fakeGHC) GetRef(_, _, ref string) (string, error) {
+	if f.expectedRef != "" && ref != f.expectedRef {
+		return "", fmt.Errorf("unexpected ref lookup: got %q, want %q", ref, f.expectedRef)
+	}
+	return f.refSHA, nil
+}
+func (f *fakeGHC) ListIssueComments(string, string, int) ([]github.IssueComment, error) {
+	return nil, nil
+}
+func (f *fakeGHC) DeleteComment(string, string, int) error { return nil }
+func (f *fakeGHC) IsMember(string, string) (bool, error)   { return false, nil }
+
+func testPullRequest() *github.PullRequest {
+	return &github.PullRequest{
+		Number: 123,
+		Base: github.PullRequestBranch{
+			Ref: "main",
+			Repo: github.Repo{
+				Owner: github.User{Login: "org"},
+				Name:  "repo",
+			},
+		},
+		Head: github.PullRequestBranch{
+			SHA: "pr-head-sha",
+			Ref: "feature-branch",
+		},
+		User:  github.User{Login: "author"},
+		Title: "Test PR",
+	}
+}
+
+// TestPrepareCandidateRebaseDirection verifies that prepareCandidate rebases PR
+// commits onto the base branch, not the other way around.
+//
+// With the inverted rebase (main onto PR), main's commit history is replayed
+// onto the PR tip. When main contains intermediate states that conflict with
+// the PR (e.g., a file deleted then re-created), this causes spurious rebase
+// conflicts even though the final states are compatible. A correctly-directed
+// rebase (PR onto main) replays PR commits onto the main tip and avoids these
+// intermediate-state conflicts.
+func TestPrepareCandidateRebaseDirection(t *testing.T) {
+	lg, clients, err := localgit.NewV2()
+	if err != nil {
+		t.Fatalf("failed to create localgit: %v", err)
+	}
+	lg.InitialBranch = "main"
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("localgit cleanup failed: %v", err)
+		}
+	}()
+	defer func() {
+		if err := clients.Clean(); err != nil {
+			t.Errorf("client factory cleanup failed: %v", err)
+		}
+	}()
+
+	if err := lg.MakeFakeRepo("org", "repo"); err != nil {
+		t.Fatalf("failed to make fake repo: %v", err)
+	}
+
+	// Set up main branch with a base file
+	if err := lg.AddCommit("org", "repo", map[string][]byte{"base.txt": []byte("base")}); err != nil {
+		t.Fatalf("failed to add base commit: %v", err)
+	}
+
+	// Branch off for the PR and add a PR-only file
+	if err := lg.CheckoutNewBranch("org", "repo", "pr-branch"); err != nil {
+		t.Fatalf("failed to create PR branch: %v", err)
+	}
+	if err := lg.AddCommit("org", "repo", map[string][]byte{"pr.txt": []byte("pr-change")}); err != nil {
+		t.Fatalf("failed to add PR commit: %v", err)
+	}
+
+	// Go back to main and add a main-only file (creating divergence)
+	if err := lg.Checkout("org", "repo", "main"); err != nil {
+		t.Fatalf("failed to checkout main: %v", err)
+	}
+	if err := lg.AddCommit("org", "repo", map[string][]byte{"main-only.txt": []byte("main-change")}); err != nil {
+		t.Fatalf("failed to add main commit: %v", err)
+	}
+
+	// Record main SHA before prepareCandidate runs
+	mainSHABefore, err := lg.RevParse("org", "repo", "main")
+	if err != nil {
+		t.Fatalf("failed to rev-parse main: %v", err)
+	}
+	mainSHABefore = strings.TrimSpace(mainSHABefore)
+
+	// Get a real git client (clones the repo)
+	repoClient, err := clients.ClientFor("org", "repo")
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	defer func() {
+		if err := repoClient.Clean(); err != nil {
+			t.Errorf("repoClient cleanup failed: %v", err)
+		}
+	}()
+
+	wrapped := &testRepoClient{RepoClient: repoClient, prBranch: "pr-branch", expectedFetchRef: "pull/123/head"}
+	s := &server{ghc: &fakeGHC{refSHA: mainSHABefore, expectedRef: "heads/main"}}
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	if _, err := s.prepareCandidate(wrapped, testPullRequest(), logger); err != nil {
+		t.Fatalf("prepareCandidate failed: %v", err)
+	}
+
+	dir := repoClient.Directory()
+
+	// Both PR and main files must exist in the working tree
+	for _, f := range []string{"pr.txt", "main-only.txt"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); err != nil {
+			t.Errorf("expected %s to exist in working tree after rebase: %v", f, err)
+		}
+	}
+
+	// The main ref in the clone must not have been modified by the rebase.
+	// With an inverted rebase, git rewrites the main branch itself (HEAD ends
+	// up ON main). With the correct rebase, main is untouched and HEAD is
+	// ahead of it with the PR commits on top.
+	mainSHAAfter, err := repoClient.RevParse("main")
+	if err != nil {
+		t.Fatalf("failed to rev-parse main after rebase: %v", err)
+	}
+	mainSHAAfter = strings.TrimSpace(mainSHAAfter)
+	if mainSHAAfter != mainSHABefore {
+		t.Fatalf("expected main ref to stay unchanged, before=%s after=%s", mainSHABefore, mainSHAAfter)
+	}
+	headSHA, err := repoClient.RevParse("HEAD")
+	if err != nil {
+		t.Fatalf("failed to rev-parse HEAD after rebase: %v", err)
+	}
+	headSHA = strings.TrimSpace(headSHA)
+	if mainSHAAfter == headSHA {
+		t.Error("HEAD should be ahead of main after rebasing PR onto main, but they point to the same commit (rebase direction is likely inverted)")
+	}
+
+	// Diff between main and HEAD should show exactly the PR file
+	changes, err := repoClient.Diff("main", "HEAD")
+	if err != nil {
+		t.Fatalf("failed to diff: %v", err)
+	}
+	if len(changes) != 1 || changes[0] != "pr.txt" {
+		t.Errorf("expected diff main..HEAD to show only [pr.txt], got %v", changes)
+	}
+}


### PR DESCRIPTION
Fix inverted `MergeWithStrategy` call that replayed main's commits onto the PR instead of the PR's commits onto main, causing spurious rebase conflicts

`mergeRebase(commitlike)` runs `git rebase --no-stat <HEAD> <commitlike>`, which checks out `commitlike` and replays its commits onto `HEAD`. The calling convention (matching [tide](https://github.com/kubernetes-sigs/prow/blob/main/pkg/tide/tide.go#L1166-L1176) and [prow tests](https://github.com/kubernetes-sigs/prow/blob/main/pkg/git/git_test.go#L510-L515)) is: HEAD = base branch, commitlike = PR head.

`prepareCandidate` had it backwards, causing spurious conflicts when main's history contains intermediate states (like delete-then-recreate of a file) that conflict with the PR even though the final states are compatible.

```bash
# Before (buggy): HEAD=PR, commitlike=main → replays main onto PR
git checkout pull/123/head               # HEAD = PR branch
git rebase --no-stat <PR-tip> main       # checks out main, replays main-only commits onto PR-tip

# After (fixed): HEAD=main, commitlike=PR → replays PR onto main
git fetch origin pull/123/head           # fetch PR ref, don't checkout
prHead=$(git rev-parse FETCH_HEAD)       # save PR HEAD SHA
git checkout main                        # HEAD = base branch
git rebase --no-stat <main-tip> $prHead  # checks out prHead, replays PR commits onto main-tip
```

## How it was discovered

I ran `/pj-rehearse` on https://github.com/openshift/release/pull/77784 and got strange "job does not exist" response https://github.com/openshift/release/pull/77784#issuecomment-4256587129

Some digging in the plugin logs gave me the following sequence (extracted by Claude):

```
Inverted rebase (HEAD on PR, commitlike is main):

  Checking out pull request 77784
  Fetching "pull/77784/head"
  Checking out "FETCH_HEAD"
  Checking out new branch "pull77784"
  Merging "main" using the "rebase" strategy
  rebase --no-stat c400bdc0d62e7283b0135fc482005226c50d06c7 main

  c400bdc is rev-parse HEAD (the PR tip). The rebase replays main's commits onto the PR — inverted. It conflicts at commit 30/75:

  CONFLICT (modify/delete): ci-operator/jobs/openshift/cluster-api-actuator-pkg/openshift-cluster-api-actuator-pkg-release-5.0-periodics.yaml deleted in e88d660e27ec and
  modified in HEAD.
  Rebase failed.
  rebase --abort
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how PR commits are fetched and applied during rebases: the PR tip is fetched directly, base is checked out by commit, retries reapply the PR tip, and rebase/fetch/checkout error messages were clarified.

* **Tests**
  * Added integration-style tests validating rebase direction, branch integrity, PR commit application, and conflict detection on retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->