### PR TITLE
feat(slack-bot): automate support-request Jira workflow

### DIFF
--- a/cmd/slack-bot/README.md
+++ b/cmd/slack-bot/README.md
@@ -5,6 +5,7 @@ Currently, the bot can do the following:
 - When the bot is explicitly mentioned in a message (`@DPTP bot`), it lists all available actions it knows how to do, like file a bug, request a consultation, and more. 
 - When a specific job link is included in a message, the bot responds with helpful information related to that job.
 - In the `CoreOS` slack space, when someone tags `@dptp-helpdesk` in the `forum-ocp-testplatform` channel, the bot sends an automatic reply containing helpful basic information in a new thread. 
+- Support-request mode (enabled by default in `#forum-ocp-testplatform`): if a thread exceeds `--support-request-threshold` messages (default `12`), the bot creates a Jira issue in `DPTP`, posts the link in the thread, and closes that Jira with `Done` when `:closed:` is added to the root thread message.
 
 # Local testing
 There is an alpha instance of Slack Bot running on the app.ci cluster that you can use for testing by running a mitmproxy and reverse tunneling requests to your local machine.

--- a/cmd/slack-bot/main.go
+++ b/cmd/slack-bot/main.go
@@ -35,6 +35,7 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 
 	"github.com/openshift/ci-tools/pkg/jira"
+	"github.com/openshift/ci-tools/pkg/pagerdutyutil"
 	eventhandler "github.com/openshift/ci-tools/pkg/slack/events"
 	"github.com/openshift/ci-tools/pkg/slack/events/helpdesk"
 	eventrouter "github.com/openshift/ci-tools/pkg/slack/events/router"
@@ -50,6 +51,7 @@ type options struct {
 	gracePeriod            time.Duration
 	instrumentationOptions prowflagutil.InstrumentationOptions
 	jiraOptions            prowflagutil.JiraOptions
+	pagerDutyOptions       pagerdutyutil.Options
 
 	prowconfig configflagutil.ConfigOptions
 
@@ -62,7 +64,8 @@ type options struct {
 	reviewRequestWorkflowID string
 	namespace               string
 	requireWorkflowsInForum bool
-	jiraActivityTypeField   string
+	supportRequestChannelID string
+	supportRequestThreshold int
 }
 
 func (o *options) Validate() error {
@@ -78,8 +81,11 @@ func (o *options) Validate() error {
 	if o.slackSigningSecretPath == "" {
 		return fmt.Errorf("--slack-signing-secret-path is required")
 	}
+	if o.supportRequestChannelID != "" && o.supportRequestThreshold < 1 {
+		return fmt.Errorf("--support-request-threshold must be >= 1")
+	}
 
-	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions, &o.jiraOptions, &o.prowconfig} {
+	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions, &o.jiraOptions, &o.pagerDutyOptions, &o.prowconfig} {
 		if err := group.Validate(false); err != nil {
 			return err
 		}
@@ -97,7 +103,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 
 	o.prowconfig.ConfigPathFlagName = "prow-config-path"
 	o.prowconfig.JobConfigPathFlagName = "prow-job-config-path"
-	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions, &o.jiraOptions, &o.prowconfig} {
+	for _, group := range []flagutil.OptionGroup{&o.instrumentationOptions, &o.jiraOptions, &o.pagerDutyOptions, &o.prowconfig} {
 		group.AddFlags(fs)
 	}
 
@@ -109,7 +115,8 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.reviewRequestWorkflowID, "review-request-workflow-id", "B06T46F374N", "ID for the 'Review Request' slack workflow")
 	fs.StringVar(&o.namespace, "namespace", "ci", "Namespace to store helpdesk-faq items")
 	fs.BoolVar(&o.requireWorkflowsInForum, "require-workflows-in-forum", true, "Require the use of workflows in the designated forum channel")
-	fs.StringVar(&o.jiraActivityTypeField, "jira-activity-type-custom-field", "", "Activity Type field key (e.g. "+jira.ActivityTypeCustomFieldKey+"); empty omits it")
+	fs.StringVar(&o.supportRequestChannelID, "support-request-channel-id", "CBN38N3MW", "Channel ID where support request mode watches long threads (defaults to #forum-ocp-testplatform)")
+	fs.IntVar(&o.supportRequestThreshold, "support-request-threshold", 12, "Create a support-request Jira when a thread has more than this many messages (total count includes the root message)")
 
 	if err := fs.Parse(args); err != nil {
 		logrus.WithError(err).Fatal("Could not parse args.")
@@ -168,9 +175,13 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not initialize Jira client.")
 	}
+	pagerDutyClient, err := o.pagerDutyOptions.Client()
+	if err != nil {
+		logrus.WithError(err).Fatal("Could not initialize PagerDuty client.")
+	}
 
 	slackClient := slack.New(string(secret.GetSecret(o.slackTokenPath)))
-	issueFiler, err := jira.NewIssueFiler(slackClient, jiraClient.JiraClient(), o.jiraActivityTypeField)
+	issueFiler, err := jira.NewIssueFiler(slackClient, jiraClient.JiraClient(), pagerDutyClient)
 	if err != nil {
 		logrus.WithError(err).Fatal("Could not initialize Jira issue filer.")
 	}
@@ -204,7 +215,7 @@ func main() {
 	// handle the root to allow for a simple uptime probe
 	mux.Handle("/", handler(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) { writer.WriteHeader(http.StatusOK) })))
 	mux.Handle("/slack/interactive-endpoint", handler(handleInteraction(secret.GetTokenGenerator(o.slackSigningSecretPath), interactionrouter.ForModals(issueFiler, slackClient))))
-	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.reviewRequestWorkflowID, o.namespace, o.requireWorkflowsInForum))))
+	mux.Handle("/slack/events-endpoint", handler(handleEvent(secret.GetTokenGenerator(o.slackSigningSecretPath), eventrouter.ForEvents(slackClient, issueFiler, kubeClient, configAgent.Config, gcsClient, keywordsConfig, o.helpdeskAlias, o.forumChannelId, o.reviewRequestWorkflowID, o.namespace, o.supportRequestChannelID, o.supportRequestThreshold, o.requireWorkflowsInForum))))
 	server := &http.Server{Addr: ":" + strconv.Itoa(o.port), Handler: mux}
 
 	health.ServeReady()
@@ -214,7 +225,7 @@ func main() {
 	interrupts.WaitForGracefulShutdown()
 }
 
-func loadKeywordsConfig(configPath string, config interface{}) error {
+func loadConfig(configPath string, config interface{}) error {
 	configContent, err := os.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to read config: %w", err)
@@ -223,6 +234,10 @@ func loadKeywordsConfig(configPath string, config interface{}) error {
 		return fmt.Errorf("failed to unmarshall config: %w", err)
 	}
 	return nil
+}
+
+func loadKeywordsConfig(configPath string, config interface{}) error {
+	return loadConfig(configPath, config)
 }
 
 func verifiedBody(logger *logrus.Entry, request *http.Request, signingSecret func() []byte) ([]byte, bool) {

--- a/cmd/sprint-automation/main.go
+++ b/cmd/sprint-automation/main.go
@@ -315,8 +315,8 @@ func userOnCallDuring(client *pagerduty.Client, query string, since, until time.
 	schedule := scheduleResponse.Schedules[0]
 
 	users, err := client.ListOnCallUsers(schedule.ID, pagerduty.ListOnCallUsersOptions{
-		Since: since.String(),
-		Until: until.String(),
+		Since: since.Format(time.RFC3339),
+		Until: until.Format(time.RFC3339),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not query PagerDuty for the %s on-call: %w", query, err)
@@ -329,8 +329,8 @@ func userOnCallDuring(client *pagerduty.Client, query string, since, until time.
 
 	// more than 1 user means there must be an override, determine who the override is associated with
 	overrides, err := client.ListOverrides(schedule.ID, pagerduty.ListOverridesOptions{
-		Since: since.String(),
-		Until: until.String(),
+		Since: since.Format(time.RFC3339),
+		Until: until.Format(time.RFC3339),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("could not query PagerDuty for the '%s' overrides: %w", query, err)

--- a/pkg/jira/fake.go
+++ b/pkg/jira/fake.go
@@ -13,16 +13,57 @@ type IssueRequest struct {
 	IssueType, Title, Description, Reporter, ActivityType string
 }
 
+// CloseIssueRequest describes a client call to close an issue.
+type CloseIssueRequest struct {
+	IssueKey, Resolution string
+}
+
+// SetIssueStatusRequest describes a client call to set issue status.
+type SetIssueStatusRequest struct {
+	IssueKey, Status string
+}
+
 // IssueResponse describes a client response for filing an issue
 type IssueResponse struct {
 	Issue *jira.Issue
 	Error error
 }
 
+// CloseIssueResponse describes a client response for closing an issue.
+type CloseIssueResponse struct {
+	Closed bool
+	Error  error
+}
+
+// SetIssueStatusResponse describes a client response for setting status.
+type SetIssueStatusResponse struct {
+	Error error
+}
+
 // Fake is an injectable IssueFiler
 type Fake struct {
-	behavior map[IssueRequest]IssueResponse
-	unwanted []IssueRequest
+	behavior            map[IssueRequest]IssueResponse
+	closeBehavior       map[CloseIssueRequest]CloseIssueResponse
+	statusBehavior      map[SetIssueStatusRequest]SetIssueStatusResponse
+	unwanted            []IssueRequest
+	unwantedCloseCalls  []CloseIssueRequest
+	unwantedStatusCalls []SetIssueStatusRequest
+}
+
+// SetCloseBehavior configures expected CloseIssue calls and responses.
+func (f *Fake) SetCloseBehavior(behavior map[CloseIssueRequest]CloseIssueResponse) {
+	f.closeBehavior = make(map[CloseIssueRequest]CloseIssueResponse, len(behavior))
+	for request, response := range behavior {
+		f.closeBehavior[request] = response
+	}
+}
+
+// SetStatusBehavior configures expected SetIssueStatus calls and responses.
+func (f *Fake) SetStatusBehavior(behavior map[SetIssueStatusRequest]SetIssueStatusResponse) {
+	f.statusBehavior = make(map[SetIssueStatusRequest]SetIssueStatusResponse, len(behavior))
+	for request, response := range behavior {
+		f.statusBehavior[request] = response
+	}
 }
 
 // FileIssue files the issue using injected behavior
@@ -43,13 +84,55 @@ func (f *Fake) FileIssue(issueType, title, description, reporter, activityType s
 	return response.Issue, response.Error
 }
 
+// CloseIssue closes the issue using injected behavior.
+func (f *Fake) CloseIssue(issueKey, resolution string, logger *logrus.Entry) (bool, error) {
+	request := CloseIssueRequest{
+		IssueKey:   issueKey,
+		Resolution: resolution,
+	}
+	response, registered := f.closeBehavior[request]
+	if !registered {
+		f.unwantedCloseCalls = append(f.unwantedCloseCalls, request)
+		return false, errors.New("no such close issue behavior in fake")
+	}
+	delete(f.closeBehavior, request)
+	return response.Closed, response.Error
+}
+
+// SetIssueStatus sets issue status using injected behavior.
+func (f *Fake) SetIssueStatus(issueKey, status string, logger *logrus.Entry) error {
+	request := SetIssueStatusRequest{
+		IssueKey: issueKey,
+		Status:   status,
+	}
+	response, registered := f.statusBehavior[request]
+	if !registered {
+		f.unwantedStatusCalls = append(f.unwantedStatusCalls, request)
+		return errors.New("no such set issue status behavior in fake")
+	}
+	delete(f.statusBehavior, request)
+	return response.Error
+}
+
 // Validate ensures that all expected client calls happened
 func (f *Fake) Validate(t *testing.T) {
 	for request := range f.behavior {
 		t.Errorf("fake issue filer did not get request: %v", request)
 	}
+	for request := range f.closeBehavior {
+		t.Errorf("fake issue filer did not get close request: %v", request)
+	}
+	for request := range f.statusBehavior {
+		t.Errorf("fake issue filer did not get set-status request: %v", request)
+	}
 	for _, request := range f.unwanted {
 		t.Errorf("fake issue filer got unwanted request: %v", request)
+	}
+	for _, request := range f.unwantedCloseCalls {
+		t.Errorf("fake issue filer got unwanted close request: %v", request)
+	}
+	for _, request := range f.unwantedStatusCalls {
+		t.Errorf("fake issue filer got unwanted set-status request: %v", request)
 	}
 }
 
@@ -57,5 +140,9 @@ var _ IssueFiler = &Fake{}
 
 // NewFake creates a new fake filer with the injected behavior
 func NewFake(calls map[IssueRequest]IssueResponse) *Fake {
-	return &Fake{behavior: calls}
+	return &Fake{
+		behavior:       calls,
+		closeBehavior:  map[CloseIssueRequest]CloseIssueResponse{},
+		statusBehavior: map[SetIssueStatusRequest]SetIssueStatusResponse{},
+	}
 }

--- a/pkg/jira/issues.go
+++ b/pkg/jira/issues.go
@@ -34,7 +34,7 @@ const (
 
 // IssueFiler knows how to file an issue in Jira
 type IssueFiler interface {
-	FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*jira.Issue, error)
+	FileIssue(issueType, title, description, reporter, activityType string, logger *logrus.Entry) (*jira.Issue, error)
 	SetIssueStatus(issueKey, status string, logger *logrus.Entry) error
 	CloseIssue(issueKey, resolution string, logger *logrus.Entry) (bool, error)
 }
@@ -97,8 +97,8 @@ type filer struct {
 	issueTypesByName map[string]jira.IssueType
 	// activityTypeFieldKey is the Jira custom field key for "Activity Type".
 	activityTypeFieldKey string
-	// activityTypeValueID is the Jira option ID for "Incidents & Support".
-	activityTypeValueID string
+	// activityTypeValueIDs maps Activity Type labels to Jira option IDs.
+	activityTypeValueIDs map[string]string
 	// botUser caches the bot's Jira user metadata for use as a
 	// back-stop when no requester can be found to match the
 	// Slack user that is interacting with us
@@ -108,7 +108,7 @@ type filer struct {
 // FileIssue files an issue, closing over a number of Jira-specific API
 // quirks like how issue types and projects are provided, as well as
 // transforming the Slack reporter ID to a Jira user, when possible.
-func (f *filer) FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*jira.Issue, error) {
+func (f *filer) FileIssue(issueType, title, description, reporter, activityType string, logger *logrus.Entry) (*jira.Issue, error) {
 	suffix := f.requesterSuffix(reporter, logger)
 	requester := f.botUser
 	description = fmt.Sprintf("%s\n\nThis issue was filed by %s", description, suffix)
@@ -123,7 +123,14 @@ func (f *filer) FileIssue(issueType, title, description, reporter string, logger
 		Summary:     title,
 		Description: description,
 	}
-	f.setActivityTypeField(fields)
+	if activityType != "" {
+		if !IsValidActivityType(activityType) {
+			return nil, fmt.Errorf("invalid activity type %q", activityType)
+		}
+		if err := f.setActivityTypeField(fields, activityType); err != nil {
+			logger.WithError(err).WithField("activity_type", activityType).Warn("could not set Jira Activity Type; omitting field from create request")
+		}
+	}
 	toCreate := &jira.Issue{Fields: fields}
 	issue, response, err := f.jiraClient.CreateIssue(toCreate)
 	if err := jirautil.HandleJiraError(response, err); err != nil {
@@ -325,14 +332,22 @@ func userOnCallDuring(client *pagerduty.Client, query string, since, until time.
 	return user, nil
 }
 
-func (f *filer) setActivityTypeField(fields *jira.IssueFields) {
-	if f.activityTypeFieldKey == "" || f.activityTypeValueID == "" || fields == nil {
-		return
+func (f *filer) setActivityTypeField(fields *jira.IssueFields, activityType string) error {
+	if fields == nil {
+		return nil
+	}
+	if f.activityTypeFieldKey == "" {
+		return fmt.Errorf("jira activity type field key is empty")
+	}
+	activityTypeID, found := f.activityTypeValueIDs[activityType]
+	if !found || strings.TrimSpace(activityTypeID) == "" {
+		return fmt.Errorf("jira activity type %q has no option ID", activityType)
 	}
 	if fields.Unknowns == nil {
 		fields.Unknowns = tcontainer.NewMarshalMap()
 	}
-	fields.Unknowns[f.activityTypeFieldKey] = tcontainer.MarshalMap{"id": f.activityTypeValueID}
+	fields.Unknowns[f.activityTypeFieldKey] = tcontainer.MarshalMap{"id": activityTypeID}
+	return nil
 }
 
 // requesterSuffix builds a human-readable suffix for the issue description.
@@ -353,10 +368,11 @@ func (f *filer) requesterSuffix(reporter string, logger *logrus.Entry) string {
 
 func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, pagerDutyClient *pagerduty.Client) (IssueFiler, error) {
 	filer := &filer{
-		slackClient:      slackClient,
-		jiraClient:       &jiraAdapter{delegate: jiraClient},
-		pagerDutyClient:  pagerDutyClient,
-		issueTypesByName: map[string]jira.IssueType{},
+		slackClient:          slackClient,
+		jiraClient:           &jiraAdapter{delegate: jiraClient},
+		pagerDutyClient:      pagerDutyClient,
+		issueTypesByName:     map[string]jira.IssueType{},
+		activityTypeValueIDs: map[string]string{},
 	}
 
 	project, response, err := jiraClient.Project.Get(ProjectDPTP)
@@ -373,34 +389,34 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, pagerDuty
 		}
 	}
 	createMeta, response, err := jiraClient.Issue.GetCreateMeta(ProjectDPTP)
-	if err := jirautil.HandleJiraError(response, err); err != nil {
-		return nil, fmt.Errorf("could not load Jira create metadata for %s: %w", ProjectDPTP, err)
+	if metaErr := jirautil.HandleJiraError(response, err); metaErr != nil {
+		logrus.WithError(metaErr).Warnf("Could not load Jira create metadata for %s; Activity Type field will be best-effort", ProjectDPTP)
+	} else if createMeta == nil {
+		logrus.Warnf("Jira create metadata for %s is empty; Activity Type field will be best-effort", ProjectDPTP)
+	} else if metaProject := createMeta.GetProjectWithKey(ProjectDPTP); metaProject == nil {
+		logrus.Warnf("Jira create metadata missing project %s; Activity Type field will be best-effort", ProjectDPTP)
+	} else if metaIssueType := metaProject.GetIssueTypeWithName(IssueTypeTask); metaIssueType == nil {
+		logrus.Warnf("Jira create metadata missing issue type %s for %s; Activity Type field will be best-effort", IssueTypeTask, ProjectDPTP)
+	} else {
+		allFields, fieldsErr := metaIssueType.GetAllFields()
+		if fieldsErr != nil {
+			logrus.WithError(fieldsErr).Warnf("Could not read Jira create fields for %s/%s; Activity Type field will be best-effort", ProjectDPTP, IssueTypeTask)
+		} else if activityFieldKey, found := allFields[activityTypeField]; !found || strings.TrimSpace(activityFieldKey) == "" {
+			logrus.Warnf("Could not find Jira field %q for %s/%s; Activity Type field will be best-effort", activityTypeField, ProjectDPTP, IssueTypeTask)
+		} else {
+			filer.activityTypeFieldKey = activityFieldKey
+			for _, value := range AllowedActivityTypes {
+				activityTypeValueID, valueErr := activityTypeOptionID(metaIssueType.Fields, activityFieldKey, value)
+				if valueErr != nil {
+					continue
+				}
+				filer.activityTypeValueIDs[value] = activityTypeValueID
+			}
+			if _, found := filer.activityTypeValueIDs[activityTypeValue]; !found {
+				logrus.Warnf("Could not find Jira option %q for field %q; Activity Type field will be best-effort", activityTypeValue, activityTypeField)
+			}
+		}
 	}
-	if createMeta == nil {
-		return nil, fmt.Errorf("jira create metadata for %s is empty", ProjectDPTP)
-	}
-	metaProject := createMeta.GetProjectWithKey(ProjectDPTP)
-	if metaProject == nil {
-		return nil, fmt.Errorf("jira create metadata missing project %s", ProjectDPTP)
-	}
-	metaIssueType := metaProject.GetIssueTypeWithName(IssueTypeTask)
-	if metaIssueType == nil {
-		return nil, fmt.Errorf("jira create metadata missing issue type %s for %s", IssueTypeTask, ProjectDPTP)
-	}
-	allFields, err := metaIssueType.GetAllFields()
-	if err != nil {
-		return nil, fmt.Errorf("could not read Jira create fields for %s/%s: %w", ProjectDPTP, IssueTypeTask, err)
-	}
-	activityFieldKey, found := allFields[activityTypeField]
-	if !found || strings.TrimSpace(activityFieldKey) == "" {
-		return nil, fmt.Errorf("could not find Jira field %q for %s/%s", activityTypeField, ProjectDPTP, IssueTypeTask)
-	}
-	filer.activityTypeFieldKey = activityFieldKey
-	activityTypeValueID, err := activityTypeOptionID(metaIssueType.Fields, activityFieldKey, activityTypeValue)
-	if err != nil {
-		return nil, err
-	}
-	filer.activityTypeValueID = activityTypeValueID
 
 	botUser, response, err := jiraClient.User.GetSelf()
 	if err := jirautil.HandleJiraError(response, err); err != nil {

--- a/pkg/jira/issues.go
+++ b/pkg/jira/issues.go
@@ -3,7 +3,10 @@ package jira
 import (
 	"fmt"
 	"net/url"
+	"strings"
+	"time"
 
+	"github.com/PagerDuty/go-pagerduty"
 	"github.com/andygrunwald/go-jira"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
@@ -20,11 +23,20 @@ const (
 	IssueTypeBug   = "Bug"
 	IssueTypeStory = "Story"
 	IssueTypeTask  = "Task"
+
+	ResolutionDone   = "Done"
+	StatusInProgress = "In Progress"
+
+	helpdeskQuery     = "DPTP Help Desk"
+	activityTypeField = "Activity Type"
+	activityTypeValue = "Incidents & Support"
 )
 
 // IssueFiler knows how to file an issue in Jira
 type IssueFiler interface {
-	FileIssue(issueType, title, description, reporter, activityType string, logger *logrus.Entry) (*jira.Issue, error)
+	FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*jira.Issue, error)
+	SetIssueStatus(issueKey, status string, logger *logrus.Entry) error
+	CloseIssue(issueKey, resolution string, logger *logrus.Entry) (bool, error)
 }
 
 type slackClient interface {
@@ -37,30 +49,44 @@ type jiraAdapter struct {
 	delegate *jira.Client
 }
 
-func (a *jiraAdapter) FindUser(property string) ([]jira.User, *jira.Response, error) {
-	// the JIRA API does not work as documented, and we can therefore not use the jira.Client.User.Find function here.
-	// That function supplies a query parameter to the search endpoint which will result in a 400 as you are required to pass the
-	// username parameter and this parameter behaves as the query parameter should.
-	req, _ := a.delegate.NewRequest("GET", fmt.Sprintf("rest/api/2/user/search?username=%s", url.QueryEscape(property)), nil)
-	var users []jira.User
-	response, err := a.delegate.Do(req, &users)
-
-	return users, response, err
-}
-
 func (a *jiraAdapter) CreateIssue(issue *jira.Issue) (*jira.Issue, *jira.Response, error) {
 	return a.delegate.Issue.Create(issue)
 }
 
+func (a *jiraAdapter) GetTransitions(issueKey string) ([]jira.Transition, *jira.Response, error) {
+	return a.delegate.Issue.GetTransitions(issueKey)
+}
+
+func (a *jiraAdapter) DoTransitionWithPayload(issueKey string, payload interface{}) (*jira.Response, error) {
+	return a.delegate.Issue.DoTransitionWithPayload(issueKey, payload)
+}
+
+func (a *jiraAdapter) FindUsers(query string, maxResults int) ([]jira.User, *jira.Response, error) {
+	return a.delegate.User.Find(query, jira.WithMaxResults(maxResults))
+}
+
+func (a *jiraAdapter) UpdateAssignee(issueKey string, assignee *jira.User) (*jira.Response, error) {
+	return a.delegate.Issue.UpdateAssignee(issueKey, assignee)
+}
+
+func (a *jiraAdapter) GetCreateMeta(projectKey string) (*jira.CreateMetaInfo, *jira.Response, error) {
+	return a.delegate.Issue.GetCreateMeta(projectKey)
+}
+
 type jiraClient interface {
-	FindUser(property string) ([]jira.User, *jira.Response, error)
 	CreateIssue(issue *jira.Issue) (*jira.Issue, *jira.Response, error)
+	GetTransitions(issueKey string) ([]jira.Transition, *jira.Response, error)
+	DoTransitionWithPayload(issueKey string, payload interface{}) (*jira.Response, error)
+	FindUsers(query string, maxResults int) ([]jira.User, *jira.Response, error)
+	UpdateAssignee(issueKey string, assignee *jira.User) (*jira.Response, error)
+	GetCreateMeta(projectKey string) (*jira.CreateMetaInfo, *jira.Response, error)
 }
 
 // filer caches information from Jira to make filing issues easier
 type filer struct {
-	slackClient slackClient
-	jiraClient  jiraClient
+	slackClient     slackClient
+	jiraClient      jiraClient
+	pagerDutyClient *pagerduty.Client
 	// project caches metadata for the Jira project we create
 	// issues under - this will never change so we can read it
 	// once at startup and reuse it forever
@@ -69,82 +95,268 @@ type filer struct {
 	// names - these will never change so we can read them once
 	// at startup and reuse them forever
 	issueTypesByName map[string]jira.IssueType
+	// activityTypeFieldKey is the Jira custom field key for "Activity Type".
+	activityTypeFieldKey string
+	// activityTypeValueID is the Jira option ID for "Incidents & Support".
+	activityTypeValueID string
 	// botUser caches the bot's Jira user metadata for use as a
 	// back-stop when no requester can be found to match the
 	// Slack user that is interacting with us
 	botUser *jira.User
-	// customfield_* key for Activity Type; empty skips setting it on create
-	activityTypeCustomField string
 }
 
 // FileIssue files an issue, closing over a number of Jira-specific API
 // quirks like how issue types and projects are provided, as well as
 // transforming the Slack reporter ID to a Jira user, when possible.
-func (f *filer) FileIssue(issueType, title, description, reporter, activityType string, logger *logrus.Entry) (*jira.Issue, error) {
-	suffix, requester := f.resolveRequester(reporter, logger)
+func (f *filer) FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*jira.Issue, error) {
+	suffix := f.requesterSuffix(reporter, logger)
+	requester := f.botUser
 	description = fmt.Sprintf("%s\n\nThis issue was filed by %s", description, suffix)
 	logger.WithFields(logrus.Fields{
-		"title":    title,
-		"reporter": requester.Name,
-		"type":     issueType,
+		"title": title,
+		"type":  issueType,
 	}).Debug("Filing Jira issue.")
-	toCreate := &jira.Issue{Fields: &jira.IssueFields{
+	fields := &jira.IssueFields{
 		Project:     f.project,
 		Reporter:    requester,
 		Type:        f.issueTypesByName[issueType],
 		Summary:     title,
 		Description: description,
-	}}
-	if activityType != "" {
-		if !IsValidActivityType(activityType) {
-			return nil, fmt.Errorf("invalid activity type %q: must be one of the configured Slack options", activityType)
-		}
-		if f.activityTypeCustomField == "" {
-			logger.WithField("activity_type", activityType).Warn("Activity Type is set but Jira custom field id is not configured; omitting from Jira API request")
-		} else {
-			if toCreate.Fields.Unknowns == nil {
-				toCreate.Fields.Unknowns = tcontainer.NewMarshalMap()
-			}
-			toCreate.Fields.Unknowns[f.activityTypeCustomField] = jira.Option{Value: activityType}
-		}
 	}
+	f.setActivityTypeField(fields)
+	toCreate := &jira.Issue{Fields: fields}
 	issue, response, err := f.jiraClient.CreateIssue(toCreate)
-	return issue, jirautil.HandleJiraError(response, err)
+	if err := jirautil.HandleJiraError(response, err); err != nil {
+		return nil, err
+	}
+	if err := f.assignToHelpdeskOnCall(issue); err != nil {
+		logger.WithError(err).WithField("issue", issue.Key).Warn("failed to assign support request to current helpdesk on-call")
+	}
+	return issue, nil
 }
 
-// resolveRequester attempts to get more information about the Slack
-// user that requested the Jira issue, doing everything best-effort
-func (f *filer) resolveRequester(reporter string, logger *logrus.Entry) (string, *jira.User) {
-	var suffix string
-	var requester *jira.User
+// SetIssueStatus transitions a Jira issue to the requested status when possible.
+func (f *filer) SetIssueStatus(issueKey, status string, logger *logrus.Entry) error {
+	transitions, response, err := f.jiraClient.GetTransitions(issueKey)
+	if err := jirautil.HandleJiraError(response, err); err != nil {
+		return err
+	}
+
+	var transitionID string
+	for _, transition := range transitions {
+		if transition.To.Name == status || transition.Name == status {
+			transitionID = transition.ID
+			break
+		}
+	}
+	if transitionID == "" {
+		logger.WithFields(logrus.Fields{"issue": issueKey, "status": status}).Info("No matching transition found; issue may already be in target status")
+		return nil
+	}
+
+	payload := jira.CreateTransitionPayload{
+		Transition: jira.TransitionPayload{ID: transitionID},
+	}
+	response, err = f.jiraClient.DoTransitionWithPayload(issueKey, payload)
+	return jirautil.HandleJiraError(response, err)
+}
+
+// closingStatusNames are destination statuses that indicate a closing transition.
+var closingStatusNames = []string{"done", "closed", "resolved"}
+var closingTransitionNames = []string{"close issue", "close", "resolve issue", "resolve"}
+
+// CloseIssue transitions a Jira issue using the first available closing
+// transition and sets the provided resolution in the payload.
+// Transition selection: first tries an exact (case-insensitive) match on
+// transition name or destination status against the resolution string,
+// then falls back to well-known closing statuses (Done, Closed, Resolved).
+func (f *filer) CloseIssue(issueKey, resolution string, logger *logrus.Entry) (bool, error) {
+	transitions, response, err := f.jiraClient.GetTransitions(issueKey)
+	if err := jirautil.HandleJiraError(response, err); err != nil {
+		return false, err
+	}
+
+	transitionID := findClosingTransition(transitions, resolution)
+	if transitionID == "" {
+		logger.WithField("issue", issueKey).Info("No closing transition found; issue may already be closed")
+		return false, nil
+	}
+
+	payload := jira.CreateTransitionPayload{
+		Transition: jira.TransitionPayload{ID: transitionID},
+		Fields: jira.TransitionPayloadFields{
+			Resolution: &jira.Resolution{Name: resolution},
+		},
+	}
+	response, err = f.jiraClient.DoTransitionWithPayload(issueKey, payload)
+	return true, jirautil.HandleJiraError(response, err)
+}
+
+func findClosingTransition(transitions []jira.Transition, resolution string) string {
+	const (
+		noMatchPriority = 100
+	)
+	bestPriority := noMatchPriority
+	bestTransitionID := ""
+
+	for _, t := range transitions {
+		priority := closingTransitionPriority(t, resolution)
+		if priority < bestPriority {
+			bestPriority = priority
+			bestTransitionID = t.ID
+		}
+	}
+	return bestTransitionID
+}
+
+func closingTransitionPriority(transition jira.Transition, resolution string) int {
+	const (
+		priorityExactTransitionName = iota
+		priorityExactDestinationStatus
+		priorityKnownTransitionName
+		priorityKnownDestinationStatus
+		priorityNoMatch = 100
+	)
+
+	if strings.EqualFold(transition.Name, resolution) {
+		return priorityExactTransitionName
+	}
+	if strings.EqualFold(transition.To.Name, resolution) {
+		return priorityExactDestinationStatus
+	}
+
+	name := strings.ToLower(transition.Name)
+	for _, transitionName := range closingTransitionNames {
+		if name == transitionName {
+			return priorityKnownTransitionName
+		}
+	}
+
+	status := strings.ToLower(transition.To.Name)
+	for _, closingStatus := range closingStatusNames {
+		if status == closingStatus {
+			return priorityKnownDestinationStatus
+		}
+	}
+	return priorityNoMatch
+}
+
+func (f *filer) assignToHelpdeskOnCall(issue *jira.Issue) error {
+	if f.pagerDutyClient == nil || issue == nil {
+		return nil
+	}
+	assigneeEmail, err := f.helpdeskOnCallEmail()
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(assigneeEmail) == "" {
+		return fmt.Errorf("helpdesk on-call has no email for Jira user lookup")
+	}
+	jiraUsers, response, err := f.jiraClient.FindUsers(url.QueryEscape(assigneeEmail), 20)
+	if err := jirautil.HandleJiraError(response, err); err != nil {
+		return fmt.Errorf("could not find jira user by helpdesk email: %w", err)
+	}
+	if len(jiraUsers) != 1 {
+		return fmt.Errorf("could not find a single jira user for helpdesk email %s: got %d", assigneeEmail, len(jiraUsers))
+	}
+
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		issueID = strings.TrimSpace(issue.Key)
+	}
+	if issueID == "" {
+		return fmt.Errorf("issue has neither ID nor key")
+	}
+	response, err = f.jiraClient.UpdateAssignee(issueID, &jiraUsers[0])
+	return jirautil.HandleJiraError(response, err)
+}
+
+func (f *filer) helpdeskOnCallEmail() (string, error) {
+	now := time.Now().UTC()
+	// Keep the same time window used in sprint-automation.
+	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 8, 0, 1, 0, time.UTC)
+	dayEnd := dayStart.Add(13 * time.Hour).Add(-2 * time.Second)
+	user, err := userOnCallDuring(f.pagerDutyClient, helpdeskQuery, dayStart, dayEnd)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(user.Email), nil
+}
+
+func userOnCallDuring(client *pagerduty.Client, query string, since, until time.Time) (*pagerduty.User, error) {
+	scheduleResponse, err := client.ListSchedules(pagerduty.ListSchedulesOptions{Query: query})
+	if err != nil {
+		return nil, fmt.Errorf("could not query PagerDuty for the %s on-call schedule: %w", query, err)
+	}
+	if len(scheduleResponse.Schedules) != 1 {
+		return nil, fmt.Errorf("did not get exactly one schedule when querying PagerDuty for the '%s' on-call schedule: %d", query, len(scheduleResponse.Schedules))
+	}
+	schedule := scheduleResponse.Schedules[0]
+
+	users, err := client.ListOnCallUsers(schedule.ID, pagerduty.ListOnCallUsersOptions{
+		Since: since.Format(time.RFC3339),
+		Until: until.Format(time.RFC3339),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not query PagerDuty for the %s on-call: %w", query, err)
+	}
+	if len(users) == 0 {
+		return nil, fmt.Errorf("did not get any users when querying PagerDuty for the '%s' on-call", query)
+	}
+	if len(users) == 1 {
+		return &users[0], nil
+	}
+
+	overrides, err := client.ListOverrides(schedule.ID, pagerduty.ListOverridesOptions{
+		Since: since.Format(time.RFC3339),
+		Until: until.Format(time.RFC3339),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not query PagerDuty for the '%s' overrides: %w", query, err)
+	}
+	if len(overrides.Overrides) != 1 {
+		return nil, fmt.Errorf("did not get exactly one override when querying PagerDuty for the '%s' overrides: %d", query, len(overrides.Overrides))
+	}
+	override := overrides.Overrides[0]
+	user, err := client.GetUser(override.User.ID, pagerduty.GetUserOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get PagerDuty user %s for override: %w", override.User.ID, err)
+	}
+	return user, nil
+}
+
+func (f *filer) setActivityTypeField(fields *jira.IssueFields) {
+	if f.activityTypeFieldKey == "" || f.activityTypeValueID == "" || fields == nil {
+		return
+	}
+	if fields.Unknowns == nil {
+		fields.Unknowns = tcontainer.NewMarshalMap()
+	}
+	fields.Unknowns[f.activityTypeFieldKey] = tcontainer.MarshalMap{"id": f.activityTypeValueID}
+}
+
+// requesterSuffix builds a human-readable suffix for the issue description.
+// Jira user resolution is intentionally not attempted.
+func (f *filer) requesterSuffix(reporter string, logger *logrus.Entry) string {
 	slackUser, err := f.slackClient.GetUserInfo(reporter)
 	if err != nil {
 		logger.WithError(err).Warn("could not search Slack for requester")
-		suffix = fmt.Sprintf("[a Slack user|%s/team/%s]", slackutil.RedHatInternalURL, reporter)
-	} else {
-		jiraUsers, response, err := f.jiraClient.FindUser(slackUser.RealName)
-		if err := jirautil.HandleJiraError(response, err); err != nil {
-			logger.WithError(err).Warn("could not search Jira for requester")
-		}
-		if len(jiraUsers) != 0 {
-			requester = &jiraUsers[0]
-		}
-		suffix = fmt.Sprintf("Slack user [%s|%s/team/%s]", slackUser.RealName, slackutil.RedHatInternalURL, slackUser.ID)
+		return fmt.Sprintf("[a Slack user|%s/team/%s]", slackutil.RedHatInternalURL, reporter)
 	}
 
-	if requester == nil {
-		logger.Infof("Could not find a Jira user for Slack user %q, defaulting to bot user.", reporter)
-		requester = f.botUser
+	displayName := strings.TrimSpace(slackUser.RealName)
+	if displayName == "" {
+		displayName = reporter
 	}
-	return suffix, requester
+	return fmt.Sprintf("Slack user [%s|%s/team/%s]", displayName, slackutil.RedHatInternalURL, slackUser.ID)
 }
 
-func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, activityTypeCustomField string) (IssueFiler, error) {
+func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, pagerDutyClient *pagerduty.Client) (IssueFiler, error) {
 	filer := &filer{
-		slackClient:             slackClient,
-		jiraClient:              &jiraAdapter{delegate: jiraClient},
-		issueTypesByName:        map[string]jira.IssueType{},
-		activityTypeCustomField: activityTypeCustomField,
+		slackClient:      slackClient,
+		jiraClient:       &jiraAdapter{delegate: jiraClient},
+		pagerDutyClient:  pagerDutyClient,
+		issueTypesByName: map[string]jira.IssueType{},
 	}
 
 	project, response, err := jiraClient.Project.Get(ProjectDPTP)
@@ -160,6 +372,35 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, activityT
 			return nil, fmt.Errorf("could not find issue type %s in Jira for project %s", name, ProjectDPTP)
 		}
 	}
+	createMeta, response, err := jiraClient.Issue.GetCreateMeta(ProjectDPTP)
+	if err := jirautil.HandleJiraError(response, err); err != nil {
+		return nil, fmt.Errorf("could not load Jira create metadata for %s: %w", ProjectDPTP, err)
+	}
+	if createMeta == nil {
+		return nil, fmt.Errorf("jira create metadata for %s is empty", ProjectDPTP)
+	}
+	metaProject := createMeta.GetProjectWithKey(ProjectDPTP)
+	if metaProject == nil {
+		return nil, fmt.Errorf("jira create metadata missing project %s", ProjectDPTP)
+	}
+	metaIssueType := metaProject.GetIssueTypeWithName(IssueTypeTask)
+	if metaIssueType == nil {
+		return nil, fmt.Errorf("jira create metadata missing issue type %s for %s", IssueTypeTask, ProjectDPTP)
+	}
+	allFields, err := metaIssueType.GetAllFields()
+	if err != nil {
+		return nil, fmt.Errorf("could not read Jira create fields for %s/%s: %w", ProjectDPTP, IssueTypeTask, err)
+	}
+	activityFieldKey, found := allFields[activityTypeField]
+	if !found || strings.TrimSpace(activityFieldKey) == "" {
+		return nil, fmt.Errorf("could not find Jira field %q for %s/%s", activityTypeField, ProjectDPTP, IssueTypeTask)
+	}
+	filer.activityTypeFieldKey = activityFieldKey
+	activityTypeValueID, err := activityTypeOptionID(metaIssueType.Fields, activityFieldKey, activityTypeValue)
+	if err != nil {
+		return nil, err
+	}
+	filer.activityTypeValueID = activityTypeValueID
 
 	botUser, response, err := jiraClient.User.GetSelf()
 	if err := jirautil.HandleJiraError(response, err); err != nil {
@@ -168,4 +409,27 @@ func NewIssueFiler(slackClient *slack.Client, jiraClient *jira.Client, activityT
 	filer.botUser = botUser
 
 	return filer, nil
+}
+
+func activityTypeOptionID(fields tcontainer.MarshalMap, fieldKey, desiredValue string) (string, error) {
+	allowedValues, err := fields.Array(fieldKey + "/allowedValues")
+	if err != nil {
+		return "", fmt.Errorf("could not read allowed values for Jira field %q: %w", activityTypeField, err)
+	}
+	for _, rawValue := range allowedValues {
+		value, err := tcontainer.ConvertToMarshalMap(rawValue, nil)
+		if err != nil {
+			continue
+		}
+		optionValue, err := value.String("value")
+		if err != nil || optionValue != desiredValue {
+			continue
+		}
+		optionID, err := value.String("id")
+		if err != nil || strings.TrimSpace(optionID) == "" {
+			return "", fmt.Errorf("jira field %q value %q has no option ID", activityTypeField, desiredValue)
+		}
+		return optionID, nil
+	}
+	return "", fmt.Errorf("could not find Jira option %q for field %q", desiredValue, activityTypeField)
 }

--- a/pkg/jira/issues_test.go
+++ b/pkg/jira/issues_test.go
@@ -145,10 +145,15 @@ func TestFindClosingTransition(t *testing.T) {
 }
 
 func TestSetActivityTypeField(t *testing.T) {
-	file := filer{activityTypeFieldKey: "customfield_12345", activityTypeValueID: "20001"}
+	file := filer{
+		activityTypeFieldKey: "customfield_12345",
+		activityTypeValueIDs: map[string]string{activityTypeValue: "20001"},
+	}
 	fields := &jira.IssueFields{}
 
-	file.setActivityTypeField(fields)
+	if err := file.setActivityTypeField(fields, activityTypeValue); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if fields.Unknowns == nil {
 		t.Fatalf("expected unknowns to be initialized")
@@ -163,13 +168,11 @@ func TestSetActivityTypeField(t *testing.T) {
 }
 
 func TestSetActivityTypeFieldNoKey(t *testing.T) {
-	file := filer{activityTypeFieldKey: "", activityTypeValueID: "20001"}
+	file := filer{activityTypeFieldKey: "", activityTypeValueIDs: map[string]string{activityTypeValue: "20001"}}
 	fields := &jira.IssueFields{Unknowns: tcontainer.NewMarshalMap()}
 
-	file.setActivityTypeField(fields)
-
-	if len(fields.Unknowns) != 0 {
-		t.Fatalf("expected unknowns to stay unchanged when field key is empty")
+	if err := file.setActivityTypeField(fields, activityTypeValue); err == nil {
+		t.Fatalf("expected error when field key is empty")
 	}
 }
 

--- a/pkg/jira/issues_test.go
+++ b/pkg/jira/issues_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
+	"github.com/trivago/tgo/tcontainer"
 )
 
 type userResponse struct {
@@ -39,49 +40,15 @@ func (f *fakeSlackClient) Validate(t *testing.T) {
 	}
 }
 
-type searchResponse struct {
-	users []jira.User
-	err   error
-}
-
-type fakeJiraClient struct {
-	searchBehavior  map[string]searchResponse
-	unwantedSeaches []string
-}
-
-func (f *fakeJiraClient) FindUser(property string) ([]jira.User, *jira.Response, error) {
-	response, registered := f.searchBehavior[property]
-	if !registered {
-		f.unwantedSeaches = append(f.unwantedSeaches, property)
-		return nil, nil, errors.New("no such user search behavior in fake")
-	}
-	delete(f.searchBehavior, property)
-	return response.users, nil, response.err
-}
-
-func (f *fakeJiraClient) CreateIssue(issue *jira.Issue) (*jira.Issue, *jira.Response, error) {
-	return nil, nil, errors.New("not implemented")
-}
-
-func (f *fakeJiraClient) Validate(t *testing.T) {
-	for user := range f.searchBehavior {
-		t.Errorf("fake did not get search: %v", user)
-	}
-	for _, user := range f.unwantedSeaches {
-		t.Errorf("fake got unwanted search: %v", user)
-	}
-}
-
-func TestResolveRequester(t *testing.T) {
+func TestRequesterSuffix(t *testing.T) {
 	var testCases = []struct {
 		name           string
 		filer          filer
 		reporter       string
 		expectedSuffix string
-		expectedUser   *jira.User
 	}{
 		{
-			name: "all calls work",
+			name: "gets Slack user for suffix",
 			filer: filer{
 				slackClient: &fakeSlackClient{
 					userBehavior: map[string]userResponse{
@@ -89,61 +56,12 @@ func TestResolveRequester(t *testing.T) {
 					},
 					unwantedUsers: []string{},
 				},
-				jiraClient: &fakeJiraClient{
-					searchBehavior: map[string]searchResponse{
-						"Steve Kuznetsov": {users: []jira.User{{AccountID: "jiraIdentifier"}}},
-					},
-					unwantedSeaches: []string{},
-				},
 			},
 			reporter:       "skuznets",
 			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
-			expectedUser:   &jira.User{AccountID: "jiraIdentifier"},
 		},
 		{
-			name: "can get Slack user but no Jira search results",
-			filer: filer{
-				slackClient: &fakeSlackClient{
-					userBehavior: map[string]userResponse{
-						"skuznets": {user: &slack.User{RealName: "Steve Kuznetsov", ID: "slackIdentifier"}},
-					},
-					unwantedUsers: []string{},
-				},
-				jiraClient: &fakeJiraClient{
-					searchBehavior: map[string]searchResponse{
-						"Steve Kuznetsov": {users: []jira.User{}},
-					},
-					unwantedSeaches: []string{},
-				},
-				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
-			},
-			reporter:       "skuznets",
-			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
-			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
-		},
-		{
-			name: "can get Slack user but not Jira search",
-			filer: filer{
-				slackClient: &fakeSlackClient{
-					userBehavior: map[string]userResponse{
-						"skuznets": {user: &slack.User{RealName: "Steve Kuznetsov", ID: "slackIdentifier"}},
-					},
-					unwantedUsers: []string{},
-				},
-				jiraClient: &fakeJiraClient{
-					searchBehavior: map[string]searchResponse{
-						"Steve Kuznetsov": {err: errors.New("oops")},
-					},
-					unwantedSeaches: []string{},
-				},
-				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
-			},
-			reporter:       "skuznets",
-			expectedSuffix: "Slack user [Steve Kuznetsov|https://redhat-internal.slack.com/team/slackIdentifier]",
-			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
-		},
-		{
-			name: "can't get Slack user",
+			name: "falls back when Slack lookup fails",
 			filer: filer{
 				slackClient: &fakeSlackClient{
 					userBehavior: map[string]userResponse{
@@ -151,23 +69,123 @@ func TestResolveRequester(t *testing.T) {
 					},
 					unwantedUsers: []string{},
 				},
-				botUser: &jira.User{AccountID: "jiraBotIdentifier"},
 			},
 			reporter:       "skuznets",
 			expectedSuffix: "[a Slack user|https://redhat-internal.slack.com/team/skuznets]",
-			expectedUser:   &jira.User{AccountID: "jiraBotIdentifier"},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			suffix, user := testCase.filer.resolveRequester(testCase.reporter, logrus.WithField("test", testCase.name))
+			suffix := testCase.filer.requesterSuffix(testCase.reporter, logrus.WithField("test", testCase.name))
 			if diff := cmp.Diff(testCase.expectedSuffix, suffix); diff != "" {
 				t.Errorf("%s: did not get correct suffix: %v", testCase.name, diff)
 			}
-			if diff := cmp.Diff(testCase.expectedUser, user); diff != "" {
-				t.Errorf("%s: did not get correct user: %v", testCase.name, diff)
+		})
+	}
+}
+
+func TestFindClosingTransition(t *testing.T) {
+	testCases := []struct {
+		name        string
+		resolution  string
+		transitions []jira.Transition
+		expectedID  string
+	}{
+		{
+			name:       "prefer exact transition name match on resolution",
+			resolution: "Done",
+			transitions: []jira.Transition{
+				{ID: "1", Name: "Close Issue", To: jira.Status{Name: "Closed"}},
+				{ID: "2", Name: "Done", To: jira.Status{Name: "Done"}},
+			},
+			expectedID: "2",
+		},
+		{
+			name:       "fallback to exact destination status on resolution",
+			resolution: "Done",
+			transitions: []jira.Transition{
+				{ID: "1", Name: "Close Issue", To: jira.Status{Name: "Done"}},
+			},
+			expectedID: "1",
+		},
+		{
+			name:       "fallback to known closing transition names",
+			resolution: "Done",
+			transitions: []jira.Transition{
+				{ID: "1", Name: "Close Issue", To: jira.Status{Name: "In Progress"}},
+			},
+			expectedID: "1",
+		},
+		{
+			name:       "fallback to known closing statuses",
+			resolution: "Done",
+			transitions: []jira.Transition{
+				{ID: "1", Name: "Random Transition", To: jira.Status{Name: "Resolved"}},
+			},
+			expectedID: "1",
+		},
+		{
+			name:       "no matching close transition",
+			resolution: "Done",
+			transitions: []jira.Transition{
+				{ID: "1", Name: "Move", To: jira.Status{Name: "In Progress"}},
+			},
+			expectedID: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := findClosingTransition(tc.transitions, tc.resolution); got != tc.expectedID {
+				t.Fatalf("expected transition %q, got %q", tc.expectedID, got)
 			}
 		})
+	}
+}
+
+func TestSetActivityTypeField(t *testing.T) {
+	file := filer{activityTypeFieldKey: "customfield_12345", activityTypeValueID: "20001"}
+	fields := &jira.IssueFields{}
+
+	file.setActivityTypeField(fields)
+
+	if fields.Unknowns == nil {
+		t.Fatalf("expected unknowns to be initialized")
+	}
+	got, found := fields.Unknowns["customfield_12345"]
+	if !found {
+		t.Fatalf("expected activity type custom field to be set")
+	}
+	if diff := cmp.Diff(tcontainer.MarshalMap{"id": "20001"}, got); diff != "" {
+		t.Fatalf("unexpected activity type field value: %s", diff)
+	}
+}
+
+func TestSetActivityTypeFieldNoKey(t *testing.T) {
+	file := filer{activityTypeFieldKey: "", activityTypeValueID: "20001"}
+	fields := &jira.IssueFields{Unknowns: tcontainer.NewMarshalMap()}
+
+	file.setActivityTypeField(fields)
+
+	if len(fields.Unknowns) != 0 {
+		t.Fatalf("expected unknowns to stay unchanged when field key is empty")
+	}
+}
+
+func TestActivityTypeOptionID(t *testing.T) {
+	fields := tcontainer.NewMarshalMap()
+	fields["customfield_12345"] = tcontainer.NewMarshalMap()
+	fields["customfield_12345"].(tcontainer.MarshalMap)["allowedValues"] = []interface{}{
+		tcontainer.MarshalMap{"id": "20000", "value": "Other"},
+		tcontainer.MarshalMap{"id": "20001", "value": activityTypeValue},
+	}
+
+	got, err := activityTypeOptionID(fields, "customfield_12345", activityTypeValue)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "20001" {
+		t.Fatalf("expected option ID 20001, got %s", got)
 	}
 }

--- a/pkg/slack/events/router/router.go
+++ b/pkg/slack/events/router/router.go
@@ -7,18 +7,21 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/prow/pkg/config"
 
+	"github.com/openshift/ci-tools/pkg/jira"
 	"github.com/openshift/ci-tools/pkg/slack/events"
 	"github.com/openshift/ci-tools/pkg/slack/events/helpdesk"
 	"github.com/openshift/ci-tools/pkg/slack/events/joblink"
 	"github.com/openshift/ci-tools/pkg/slack/events/mention"
+	"github.com/openshift/ci-tools/pkg/slack/events/supportrequest"
 )
 
 // ForEvents returns a Handler that appropriately routes
 // event callbacks for the handlers we know about
-func ForEvents(client *slack.Client, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId, reviewRequestWorkflowID, namespace string, requireWorkflowsInForum bool) events.Handler {
+func ForEvents(client *slack.Client, filer jira.IssueFiler, kubeClient ctrlruntimeclient.Client, config config.Getter, gcsClient *storage.Client, keywordsConfig helpdesk.KeywordsConfig, helpdeskAlias, forumChannelId, reviewRequestWorkflowID, namespace, supportRequestChannelID string, supportRequestThreadMessageThreshold int, requireWorkflowsInForum bool) events.Handler {
 	return events.MultiHandler(
 		helpdesk.MessageHandler(client, keywordsConfig, helpdeskAlias, forumChannelId, reviewRequestWorkflowID, requireWorkflowsInForum),
 		helpdesk.FAQHandler(client, kubeClient, forumChannelId, namespace),
+		supportrequest.HandlerWithLock(client, filer, supportRequestChannelID, supportRequestThreadMessageThreshold, supportrequest.NewConfigMapLockClient(kubeClient, namespace)),
 		mention.Handler(client),
 		joblink.Handler(client, joblink.NewJobGetter(config), gcsClient),
 	)

--- a/pkg/slack/events/supportrequest/handler.go
+++ b/pkg/slack/events/supportrequest/handler.go
@@ -217,7 +217,7 @@ func handleMessage(event *slackevents.MessageEvent, client messageClient, filer 
 		description = fmt.Sprintf("Support request created from Slack thread: %s", permalink)
 	}
 	title := fmt.Sprintf("support request on %s", time.Now().UTC().Format(defaultDateFormat))
-	issue, err := filer.FileIssue(jira.IssueTypeTask, title, description, event.User, logger)
+	issue, err := filer.FileIssue(jira.IssueTypeTask, title, description, event.User, "Incidents & Support", logger)
 	if err != nil {
 		_ = postMessageWithRetry(client, channelID, slack.MsgOptionText("Failed to create corresponding support request in Jira.", false), slack.MsgOptionTS(event.ThreadTimeStamp))
 		return true, err

--- a/pkg/slack/events/supportrequest/handler.go
+++ b/pkg/slack/events/supportrequest/handler.go
@@ -1,0 +1,540 @@
+package supportrequest
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	"github.com/openshift/ci-tools/pkg/jira"
+	"github.com/openshift/ci-tools/pkg/slack/events"
+)
+
+const (
+	closedReaction         = "closed"
+	notApplicableReaction  = "not-applicable"
+	shipHelpPrefix         = "@ship-help"
+	supportRequestPrefix   = "Forum support request ticket:"
+	defaultDateFormat      = "2006-01-02 15:04:05"
+	issuesRedHatBrowseBase = "https://issues.redhat.com/browse/"
+	defaultRepliesPageSize = 200
+	maxSlackRetryAttempts  = 5
+	initialSlackBackoff    = 500 * time.Millisecond
+	maxSlackBackoff        = 8 * time.Second
+)
+
+var jiraKeyRegex = regexp.MustCompile(`\b([A-Z]+-\d+)\b`)
+
+type messageClient interface {
+	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
+	GetConversationReplies(params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
+	GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error)
+	GetPermalink(params *slack.PermalinkParameters) (string, error)
+}
+
+type lockClient interface {
+	Acquire(threadTS string) (bool, error)
+	MarkProcessed(threadTS, issueKey string) error
+	GetProcessedIssueKey(threadTS string) (string, bool, error)
+	Release(threadTS string) error
+}
+
+type noopLockClient struct{}
+
+func (noopLockClient) Acquire(threadTS string) (bool, error)         { return true, nil }
+func (noopLockClient) MarkProcessed(threadTS, issueKey string) error { return nil }
+func (noopLockClient) GetProcessedIssueKey(threadTS string) (string, bool, error) {
+	return "", false, nil
+}
+func (noopLockClient) Release(threadTS string) error { return nil }
+
+type processedThreadCache struct {
+	ttl   time.Duration
+	now   func() time.Time
+	mutex sync.Mutex
+	items map[string]time.Time
+}
+
+func newProcessedThreadCache(ttl time.Duration) *processedThreadCache {
+	return &processedThreadCache{
+		ttl:   ttl,
+		now:   time.Now,
+		items: map[string]time.Time{},
+	}
+}
+
+func (c *processedThreadCache) HasFresh(threadTS string) bool {
+	if c == nil {
+		return false
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	expiresAt, found := c.items[threadTS]
+	if !found {
+		return false
+	}
+	now := c.now()
+	if now.After(expiresAt) {
+		delete(c.items, threadTS)
+		return false
+	}
+	return true
+}
+
+func (c *processedThreadCache) MarkProcessed(threadTS string) {
+	if c == nil {
+		return
+	}
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.items[threadTS] = c.now().Add(c.ttl)
+}
+
+// Handler creates Jira support requests for long threads in a configured channel
+// and closes the corresponding Jira issue when :closed: is added to the main thread.
+func Handler(client messageClient, filer jira.IssueFiler, channelID string, threadMessageThreshold int) events.PartialHandler {
+	return HandlerWithLock(client, filer, channelID, threadMessageThreshold, noopLockClient{})
+}
+
+// HandlerWithLock creates a handler with a cross-replica lock implementation.
+func HandlerWithLock(client messageClient, filer jira.IssueFiler, channelID string, threadMessageThreshold int, locker lockClient) events.PartialHandler {
+	// Prevents concurrent Jira creation for the same thread when
+	// multiple replies arrive at nearly the same time.
+	var inflight sync.Map
+	processedCache := newProcessedThreadCache(24 * time.Hour)
+
+	return events.PartialHandlerFunc("supportrequest", func(callback *slackevents.EventsAPIEvent, logger *logrus.Entry) (bool, error) {
+		if channelID == "" {
+			return false, nil
+		}
+		if callback.Type != slackevents.CallbackEvent {
+			return false, nil
+		}
+
+		switch event := callback.InnerEvent.Data.(type) {
+		case *slackevents.MessageEvent:
+			return handleMessage(event, client, filer, channelID, threadMessageThreshold, &inflight, locker, processedCache, logger)
+		case *slackevents.ReactionAddedEvent:
+			return handleReactionAdded(event, client, filer, channelID, locker, logger)
+		default:
+			return false, nil
+		}
+	})
+}
+
+func handleMessage(event *slackevents.MessageEvent, client messageClient, filer jira.IssueFiler, channelID string, threadMessageThreshold int, inflight *sync.Map, locker lockClient, processedCache *processedThreadCache, logger *logrus.Entry) (bool, error) {
+	if event.Channel != channelID {
+		logger.WithField("channel", event.Channel).Debug("supportrequest: skip message from non-configured channel")
+		return false, nil
+	}
+	if event.ChannelType != "channel" {
+		logger.WithField("channel_type", event.ChannelType).Debug("supportrequest: skip non-channel message event")
+		return false, nil
+	}
+	if event.SubType != "" {
+		logger.WithField("subtype", event.SubType).Debug("supportrequest: skip message subtype event")
+		return false, nil
+	}
+	if event.ThreadTimeStamp == "" {
+		logger.Debug("supportrequest: skip top-level message (not a thread reply)")
+		return false, nil
+	}
+	if event.BotID != "" || event.User == "" {
+		logger.WithFields(logrus.Fields{"bot_id": event.BotID, "user": event.User}).Debug("supportrequest: skip bot/system message")
+		return false, nil
+	}
+	if processedCache.HasFresh(event.ThreadTimeStamp) {
+		logger.WithField("thread_ts", event.ThreadTimeStamp).Debug("supportrequest: skip thread already processed (cache hit)")
+		return false, nil
+	}
+
+	if _, loaded := inflight.LoadOrStore(event.ThreadTimeStamp, struct{}{}); loaded {
+		logger.WithField("thread_ts", event.ThreadTimeStamp).Debug("supportrequest: skip concurrent in-flight processing for thread")
+		return false, nil
+	}
+	defer inflight.Delete(event.ThreadTimeStamp)
+
+	eligible, alreadyProcessed, reason, err := isEligibleSupportThread(client, channelID, event.ThreadTimeStamp, threadMessageThreshold)
+	if err != nil {
+		return true, err
+	}
+	if alreadyProcessed {
+		processedCache.MarkProcessed(event.ThreadTimeStamp)
+		logger.WithField("thread_ts", event.ThreadTimeStamp).Debug("supportrequest: thread has existing Jira marker, caching as processed")
+	}
+	if !eligible {
+		logger.WithFields(logrus.Fields{"thread_ts": event.ThreadTimeStamp, "reason": reason}).Debug("supportrequest: thread not eligible for Jira creation")
+		return false, nil
+	}
+
+	acquired, err := locker.Acquire(event.ThreadTimeStamp)
+	if err != nil {
+		return true, err
+	}
+	if !acquired {
+		logger.WithField("thread_ts", event.ThreadTimeStamp).Debug("supportrequest: lock not acquired (already processing/processed)")
+		return false, nil
+	}
+	shouldReleaseLock := true
+	defer func() {
+		if !shouldReleaseLock {
+			return
+		}
+		if err := locker.Release(event.ThreadTimeStamp); err != nil {
+			logger.WithError(err).Warn("Failed to release support request thread lock")
+		}
+	}()
+
+	// Re-check under lock so only one replica can proceed to create.
+	eligible, alreadyProcessed, reason, err = isEligibleSupportThread(client, channelID, event.ThreadTimeStamp, threadMessageThreshold)
+	if err != nil {
+		return true, err
+	}
+	if alreadyProcessed {
+		processedCache.MarkProcessed(event.ThreadTimeStamp)
+		logger.WithField("thread_ts", event.ThreadTimeStamp).Debug("supportrequest: thread already processed during lock re-check")
+	}
+	if !eligible {
+		logger.WithFields(logrus.Fields{"thread_ts": event.ThreadTimeStamp, "reason": reason}).Debug("supportrequest: thread no longer eligible after lock re-check")
+		return false, nil
+	}
+
+	permalink, err := getPermalinkWithRetry(client, &slack.PermalinkParameters{Channel: channelID, Ts: event.ThreadTimeStamp})
+	if err != nil {
+		logger.WithError(err).Warn("Failed to get Slack permalink for support request thread")
+		permalink = ""
+	}
+
+	description := "Support request created from Slack thread."
+	if permalink != "" {
+		description = fmt.Sprintf("Support request created from Slack thread: %s", permalink)
+	}
+	title := fmt.Sprintf("support request on %s", time.Now().UTC().Format(defaultDateFormat))
+	issue, err := filer.FileIssue(jira.IssueTypeTask, title, description, event.User, logger)
+	if err != nil {
+		_ = postMessageWithRetry(client, channelID, slack.MsgOptionText("Failed to create corresponding support request in Jira.", false), slack.MsgOptionTS(event.ThreadTimeStamp))
+		return true, err
+	}
+	// Persist thread->issue mapping so close handling does not depend only
+	// on parsing the Slack thread marker message.
+	shouldReleaseLock = false
+	if err := locker.MarkProcessed(event.ThreadTimeStamp, issue.Key); err != nil {
+		return true, err
+	}
+	processedCache.MarkProcessed(event.ThreadTimeStamp)
+	if err := filer.SetIssueStatus(issue.Key, jira.StatusInProgress, logger); err != nil {
+		logger.WithError(err).WithField("issue", issue.Key).Warn("Failed to transition support request to In Progress")
+	}
+
+	issueURL := fmt.Sprintf("%s%s", issuesRedHatBrowseBase, issue.Key)
+	postErr := postMessageWithRetry(client, channelID, slack.MsgOptionText(
+		fmt.Sprintf(
+			"%s <%s|%s>\nThis ticket was created automatically after this thread exceeded the threshold of %d messages. No user action is needed and conversation can continue in this forum thread.",
+			supportRequestPrefix, issueURL, issue.Key, threadMessageThreshold,
+		),
+		false,
+	), slack.MsgOptionTS(event.ThreadTimeStamp))
+	if postErr != nil {
+		logger.WithError(postErr).Warn("Failed to post support request Jira link in Slack thread")
+	}
+
+	return true, nil
+}
+
+func handleReactionAdded(event *slackevents.ReactionAddedEvent, client messageClient, filer jira.IssueFiler, channelID string, locker lockClient, logger *logrus.Entry) (bool, error) {
+	if event.Item.Channel != channelID {
+		logger.WithField("channel", event.Item.Channel).Debug("supportrequest: skip reaction from non-configured channel")
+		return false, nil
+	}
+	if event.Reaction != closedReaction {
+		logger.WithField("reaction", event.Reaction).Debug("supportrequest: skip non-closed reaction")
+		return false, nil
+	}
+
+	threadTS, rootText, rootMessage, err := rootThreadTSForReaction(client, channelID, event.Item.Timestamp)
+	if err != nil {
+		return true, err
+	}
+	if !rootMessage {
+		logger.WithField("message_ts", event.Item.Timestamp).Debug("supportrequest: skip closed reaction on non-root message")
+		return false, nil
+	}
+	if rootStartsWithShipHelp(rootText) {
+		logger.WithField("thread_ts", threadTS).Debug("supportrequest: skip close handling for @ship-help thread")
+		return false, nil
+	}
+
+	if issueKey, found, err := locker.GetProcessedIssueKey(threadTS); err != nil {
+		return true, err
+	} else if found {
+		logger.WithFields(logrus.Fields{"thread_ts": threadTS, "issue_key": issueKey}).Debug("supportrequest: closing Jira via lock mapping")
+		return closeIssueAndNotify(client, filer, channelID, threadTS, issueKey, logger)
+	}
+
+	replies, rootMessage, err := getAllRepliesInThread(client, channelID, threadTS, defaultRepliesPageSize)
+	if err != nil {
+		return true, err
+	}
+	if !rootMessage {
+		logger.WithField("thread_ts", threadTS).Debug("supportrequest: skip close handling, thread replies not rooted")
+		return false, nil
+	}
+	issueKey, found := supportRequestIssueKeyFromReplies(replies)
+	if !found {
+		logger.WithField("thread_ts", threadTS).Debug("supportrequest: skip close handling, Jira marker not found in thread")
+		return false, nil
+	}
+
+	logger.WithFields(logrus.Fields{"thread_ts": threadTS, "issue_key": issueKey}).Debug("supportrequest: closing Jira via thread marker")
+	return closeIssueAndNotify(client, filer, channelID, threadTS, issueKey, logger)
+}
+
+func rootThreadTSForReaction(client messageClient, channelID, messageTS string) (threadTS string, rootText string, rootMessage bool, err error) {
+	history, err := getConversationHistoryWithRetry(client, &slack.GetConversationHistoryParameters{
+		ChannelID: channelID,
+		Inclusive: true,
+		Latest:    messageTS,
+		Oldest:    messageTS,
+		Limit:     1,
+	})
+	if err != nil {
+		return "", "", false, err
+	}
+	if history == nil || len(history.Messages) == 0 {
+		return "", "", false, nil
+	}
+	message := history.Messages[0]
+	if message.ThreadTimestamp != "" && message.ThreadTimestamp != message.Timestamp {
+		return "", "", false, nil
+	}
+	if message.Timestamp == "" {
+		return "", "", false, nil
+	}
+	return message.Timestamp, message.Text, true, nil
+}
+
+func closeIssueAndNotify(client messageClient, filer jira.IssueFiler, channelID, threadTS, issueKey string, logger *logrus.Entry) (bool, error) {
+
+	closed, err := filer.CloseIssue(issueKey, jira.ResolutionDone, logger)
+	if err != nil {
+		_ = postMessageWithRetry(client, channelID, slack.MsgOptionText(fmt.Sprintf("Failed to close support request %s.", issueKey), false), slack.MsgOptionTS(threadTS))
+		return true, err
+	}
+	if !closed {
+		_ = postMessageWithRetry(client, channelID, slack.MsgOptionText(fmt.Sprintf("Could not close support request %s because no valid closing transition was found.", issueKey), false), slack.MsgOptionTS(threadTS))
+		return true, nil
+	}
+
+	issueURL := fmt.Sprintf("%s%s", issuesRedHatBrowseBase, issueKey)
+	_ = postMessageWithRetry(client, channelID, slack.MsgOptionText(fmt.Sprintf("Closed corresponding support request: <%s|%s>", issueURL, issueKey), false), slack.MsgOptionTS(threadTS))
+	return true, nil
+}
+
+func isEligibleSupportThread(client messageClient, channelID, threadTS string, threshold int) (eligible, alreadyProcessed bool, reason string, err error) {
+	replies, rootMessage, err := getAllRepliesInThread(client, channelID, threadTS, defaultRepliesPageSize)
+	if err != nil {
+		return false, false, "replies_fetch_error", err
+	}
+	if !rootMessage || humanMessageCount(replies) <= threshold {
+		if !rootMessage {
+			return false, false, "not_root_thread", nil
+		}
+		return false, false, "human_threshold_not_reached", nil
+	}
+	if rootStartsWithShipHelp(replies[0].Text) {
+		return false, false, "root_starts_with_ship_help", nil
+	}
+	if rootHasBlockingReaction(replies) {
+		return false, false, "root_has_blocking_reaction", nil
+	}
+	if _, found := supportRequestIssueKeyFromReplies(replies); found {
+		return false, true, "jira_marker_already_present", nil
+	}
+	return true, false, "eligible", nil
+}
+
+func rootHasBlockingReaction(replies []slack.Message) bool {
+	if len(replies) == 0 {
+		return false
+	}
+	for _, reaction := range replies[0].Reactions {
+		if isBlockingReaction(reaction.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBlockingReaction(name string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(name), "_", "-"))
+	return normalized == closedReaction || normalized == notApplicableReaction
+}
+
+func humanMessageCount(messages []slack.Message) int {
+	count := 0
+	for _, message := range messages {
+		if isHumanMessage(message) {
+			count++
+		}
+	}
+	return count
+}
+
+func isHumanMessage(message slack.Message) bool {
+	if message.BotID != "" {
+		return false
+	}
+	// Slack bot messages carry bot_message subtype.
+	return message.SubType != "bot_message"
+}
+
+func rootStartsWithShipHelp(text string) bool {
+	return strings.HasPrefix(strings.TrimSpace(text), shipHelpPrefix)
+}
+
+func getAllRepliesInThread(client messageClient, channelID, threadTS string, pageSize int) (replies []slack.Message, rootMessage bool, err error) {
+	if pageSize <= 0 {
+		pageSize = defaultRepliesPageSize
+	}
+	cursor := ""
+	firstPage := true
+	allReplies := make([]slack.Message, 0, pageSize)
+	for {
+		pageReplies, hasMore, nextCursor, err := getConversationRepliesWithRetry(client, &slack.GetConversationRepliesParameters{
+			ChannelID: channelID,
+			Timestamp: threadTS,
+			Inclusive: true,
+			Limit:     pageSize,
+			Cursor:    cursor,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+		if len(pageReplies) == 0 {
+			return nil, false, nil
+		}
+		if firstPage {
+			// We query this endpoint by threadTS (and reactions are
+			// pre-validated against root via conversations.history),
+			// so treat the first page as rooted thread context.
+			rootMessage = true
+			firstPage = false
+		}
+		allReplies = append(allReplies, pageReplies...)
+		if !hasMore {
+			break
+		}
+		cursor = nextCursor
+	}
+	return allReplies, rootMessage, nil
+}
+
+func supportRequestIssueKeyFromReplies(replies []slack.Message) (string, bool) {
+	for _, reply := range replies {
+		if !strings.Contains(reply.Text, supportRequestPrefix) {
+			continue
+		}
+		matches := jiraKeyRegex.FindStringSubmatch(reply.Text)
+		if len(matches) >= 2 {
+			return matches[1], true
+		}
+	}
+	return "", false
+}
+
+func getConversationRepliesWithRetry(client messageClient, params *slack.GetConversationRepliesParameters) ([]slack.Message, bool, string, error) {
+	var (
+		msgs       []slack.Message
+		hasMore    bool
+		nextCursor string
+	)
+	err := withSlackRetry(func() error {
+		var err error
+		msgs, hasMore, nextCursor, err = client.GetConversationReplies(params)
+		return err
+	})
+	return msgs, hasMore, nextCursor, err
+}
+
+func getConversationHistoryWithRetry(client messageClient, params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error) {
+	var history *slack.GetConversationHistoryResponse
+	err := withSlackRetry(func() error {
+		var err error
+		history, err = client.GetConversationHistory(params)
+		return err
+	})
+	return history, err
+}
+
+func getPermalinkWithRetry(client messageClient, params *slack.PermalinkParameters) (string, error) {
+	var permalink string
+	err := withSlackRetry(func() error {
+		var err error
+		permalink, err = client.GetPermalink(params)
+		return err
+	})
+	return permalink, err
+}
+
+func postMessageWithRetry(client messageClient, channelID string, options ...slack.MsgOption) error {
+	err := withSlackRetry(func() error {
+		var err error
+		_, _, err = client.PostMessage(channelID, options...)
+		return err
+	})
+	return err
+}
+
+func withSlackRetry(op func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxSlackRetryAttempts; attempt++ {
+		if err := op(); err != nil {
+			lastErr = err
+			var rateLimitErr *slack.RateLimitedError
+			if errors.As(err, &rateLimitErr) {
+				time.Sleep(rateLimitErr.RetryAfter)
+				continue
+			}
+			if !isRetryableSlackError(err) {
+				return err
+			}
+			time.Sleep(backoffForAttempt(attempt))
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("slack request failed after %d retries: %w", maxSlackRetryAttempts, lastErr)
+}
+
+func isRetryableSlackError(err error) bool {
+	type retryable interface {
+		Retryable() bool
+	}
+	var retryableErr retryable
+	if errors.As(err, &retryableErr) {
+		return retryableErr.Retryable()
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+	return false
+}
+
+func backoffForAttempt(attempt int) time.Duration {
+	backoff := initialSlackBackoff << attempt
+	if backoff > maxSlackBackoff {
+		return maxSlackBackoff
+	}
+	if backoff <= 0 {
+		return maxSlackBackoff
+	}
+	return backoff
+}

--- a/pkg/slack/events/supportrequest/handler_test.go
+++ b/pkg/slack/events/supportrequest/handler_test.go
@@ -72,12 +72,13 @@ type fakeFiler struct {
 	closeResult    bool
 }
 
-func (f *fakeFiler) FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*ajira.Issue, error) {
+func (f *fakeFiler) FileIssue(issueType, title, description, reporter, activityType string, logger *logrus.Entry) (*ajira.Issue, error) {
 	f.fileCalls = append(f.fileCalls, ciJira.IssueRequest{
-		IssueType:   issueType,
-		Title:       title,
-		Description: description,
-		Reporter:    reporter,
+		IssueType:    issueType,
+		Title:        title,
+		Description:  description,
+		Reporter:     reporter,
+		ActivityType: activityType,
 	})
 	return f.issue, nil
 }

--- a/pkg/slack/events/supportrequest/handler_test.go
+++ b/pkg/slack/events/supportrequest/handler_test.go
@@ -1,0 +1,722 @@
+package supportrequest
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	ajira "github.com/andygrunwald/go-jira"
+	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slackevents"
+
+	ciJira "github.com/openshift/ci-tools/pkg/jira"
+)
+
+type fakeClient struct {
+	repliesByTS      map[string][]slack.Message
+	pagedRepliesByTS map[string][][]slack.Message
+	historyByTS      map[string]*slack.GetConversationHistoryResponse
+	permalink        string
+	postCount        int
+	repliesCalls     int
+}
+
+func (f *fakeClient) PostMessage(channelID string, options ...slack.MsgOption) (string, string, error) {
+	f.postCount++
+	return channelID, "123.456", nil
+}
+
+func (f *fakeClient) GetConversationReplies(params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error) {
+	f.repliesCalls++
+	if pages, ok := f.pagedRepliesByTS[params.Timestamp]; ok {
+		pageIdx := 0
+		if params.Cursor != "" {
+			if parsed, err := strconv.Atoi(params.Cursor); err == nil {
+				pageIdx = parsed
+			}
+		}
+		if pageIdx >= len(pages) {
+			return nil, false, "", nil
+		}
+		hasMore = pageIdx+1 < len(pages)
+		if hasMore {
+			nextCursor = strconv.Itoa(pageIdx + 1)
+		}
+		return pages[pageIdx], hasMore, nextCursor, nil
+	}
+	return f.repliesByTS[params.Timestamp], false, "", nil
+}
+
+func (f *fakeClient) GetConversationHistory(params *slack.GetConversationHistoryParameters) (*slack.GetConversationHistoryResponse, error) {
+	if f.historyByTS == nil {
+		return &slack.GetConversationHistoryResponse{}, nil
+	}
+	if history, ok := f.historyByTS[params.Latest]; ok {
+		return history, nil
+	}
+	return &slack.GetConversationHistoryResponse{}, nil
+}
+
+func (f *fakeClient) GetPermalink(params *slack.PermalinkParameters) (string, error) {
+	return f.permalink, nil
+}
+
+type fakeFiler struct {
+	fileCalls      []ciJira.IssueRequest
+	closeCalls     []ciJira.CloseIssueRequest
+	setStatusCalls []ciJira.SetIssueStatusRequest
+	issue          *ajira.Issue
+	closeResult    bool
+}
+
+func (f *fakeFiler) FileIssue(issueType, title, description, reporter string, logger *logrus.Entry) (*ajira.Issue, error) {
+	f.fileCalls = append(f.fileCalls, ciJira.IssueRequest{
+		IssueType:   issueType,
+		Title:       title,
+		Description: description,
+		Reporter:    reporter,
+	})
+	return f.issue, nil
+}
+
+func (f *fakeFiler) CloseIssue(issueKey, resolution string, logger *logrus.Entry) (bool, error) {
+	f.closeCalls = append(f.closeCalls, ciJira.CloseIssueRequest{
+		IssueKey:   issueKey,
+		Resolution: resolution,
+	})
+	if !f.closeResult {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (f *fakeFiler) SetIssueStatus(issueKey, status string, logger *logrus.Entry) error {
+	f.setStatusCalls = append(f.setStatusCalls, ciJira.SetIssueStatusRequest{
+		IssueKey: issueKey,
+		Status:   status,
+	})
+	return nil
+}
+
+func TestCreateSupportRequest(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS}},
+				{Msg: slack.Msg{Timestamp: "100.101"}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+		permalink: "https://example.slack.com/archives/C123/p100100",
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected message to be handled")
+	}
+	if len(filer.fileCalls) != 1 {
+		t.Fatalf("expected exactly one jira file call, got %d", len(filer.fileCalls))
+	}
+	if got := filer.fileCalls[0].IssueType; got != ciJira.IssueTypeTask {
+		t.Fatalf("expected issue type %s, got %s", ciJira.IssueTypeTask, got)
+	}
+	if diff := cmp.Diff([]ciJira.SetIssueStatusRequest{{IssueKey: "DPTP-123", Status: ciJira.StatusInProgress}}, filer.setStatusCalls); diff != "" {
+		t.Fatalf("unexpected set-status calls: %s", diff)
+	}
+	if !strings.Contains(filer.fileCalls[0].Description, client.permalink) {
+		t.Fatalf("expected description to include permalink, got: %s", filer.fileCalls[0].Description)
+	}
+	if client.postCount != 1 {
+		t.Fatalf("expected one posted message, got %d", client.postCount)
+	}
+}
+
+func TestCreateSupportRequestWithCanonicalRootTimestamp(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: "100.100000", ThreadTimestamp: threadTS}},
+				{Msg: slack.Msg{Timestamp: "100.101", User: "U1"}},
+				{Msg: slack.Msg{Timestamp: "100.102", User: "U2"}},
+				{Msg: slack.Msg{Timestamp: "100.103", User: "U3"}},
+				{Msg: slack.Msg{Timestamp: "100.104", User: "U4"}},
+				{Msg: slack.Msg{Timestamp: "100.105", User: "U5"}},
+			},
+		},
+		permalink: "https://example.slack.com/archives/C123/p100100",
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected message to be handled")
+	}
+	if len(filer.fileCalls) != 1 {
+		t.Fatalf("expected exactly one jira file call, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestNoDuplicateSupportRequest(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handler not to consume duplicate support request")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestProcessedThreadCacheSkipsRepeatedEligibilityScans(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+	handler := Handler(client, filer, channelID, 5)
+
+	event := &slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}
+	logger := logrus.NewEntry(logrus.StandardLogger())
+	handled, err := handler.Handle(event, logger)
+	if err != nil {
+		t.Fatalf("did not expect error on first event: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected first event to be skipped due to existing jira marker")
+	}
+	handled, err = handler.Handle(event, logger)
+	if err != nil {
+		t.Fatalf("did not expect error on second event: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected second event to be skipped from cache")
+	}
+	if client.repliesCalls != 1 {
+		t.Fatalf("expected one replies fetch across both events, got %d", client.repliesCalls)
+	}
+}
+
+func TestBotMessageEventIgnoredWithoutThreadFetch(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+	handler := Handler(client, filer, channelID, 5)
+
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				SubType:         "bot_message",
+				BotID:           "B123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected bot message event not to be handled")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+	if client.repliesCalls != 0 {
+		t.Fatalf("expected zero replies fetches for bot event, got %d", client.repliesCalls)
+	}
+}
+
+func TestNoSupportRequestWhenRootIsClosed(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{
+					Msg: slack.Msg{
+						Timestamp: threadTS,
+						Reactions: []slack.ItemReaction{{Name: closedReaction}},
+					},
+				},
+				{Msg: slack.Msg{Timestamp: "100.101"}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handler not to create support request for closed root thread")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestNoSupportRequestWhenRootIsNotApplicable(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{
+					Msg: slack.Msg{
+						Timestamp: threadTS,
+						Reactions: []slack.ItemReaction{{Name: notApplicableReaction}},
+					},
+				},
+				{Msg: slack.Msg{Timestamp: "100.101"}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handler not to create support request for not-applicable root thread")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestNoSupportRequestWhenOnlyBotRepliesCrossThreshold(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS, User: "U123"}},
+				{Msg: slack.Msg{Timestamp: "100.101", User: "U124"}},
+				{Msg: slack.Msg{Timestamp: "100.102", User: "U125"}},
+				{Msg: slack.Msg{Timestamp: "100.103", BotID: "B123", SubType: "bot_message"}},
+				{Msg: slack.Msg{Timestamp: "100.104", BotID: "B124", SubType: "bot_message"}},
+				{Msg: slack.Msg{Timestamp: "100.105", BotID: "B125", SubType: "bot_message"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handler not to create support request when only bot messages cross threshold")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestNoSupportRequestWhenRootStartsWithShipHelp(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS, Text: "@ship-help please assist"}},
+				{Msg: slack.Msg{Timestamp: "100.101"}},
+				{Msg: slack.Msg{Timestamp: "100.102"}},
+				{Msg: slack.Msg{Timestamp: "100.103"}},
+				{Msg: slack.Msg{Timestamp: "100.104"}},
+				{Msg: slack.Msg{Timestamp: "100.105"}},
+			},
+		},
+	}
+	filer := &fakeFiler{issue: &ajira.Issue{Key: "DPTP-123"}}
+
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.MessageEvent{
+				Channel:         channelID,
+				ChannelType:     "channel",
+				ThreadTimeStamp: threadTS,
+				User:            "U123",
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handler not to create support request for @ship-help root thread")
+	}
+	if len(filer.fileCalls) != 0 {
+		t.Fatalf("expected zero jira file calls, got %d", len(filer.fileCalls))
+	}
+}
+
+func TestCloseSupportRequest(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: threadTS}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+			},
+		},
+		historyByTS: map[string]*slack.GetConversationHistoryResponse{
+			threadTS: {
+				Messages: []slack.Message{
+					{Msg: slack.Msg{Timestamp: threadTS}},
+				},
+			},
+		},
+	}
+	filer := &fakeFiler{closeResult: true}
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.ReactionAddedEvent{
+				Reaction: closedReaction,
+				Item: slackevents.Item{
+					Channel:   channelID,
+					Timestamp: threadTS,
+				},
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected reaction to be handled")
+	}
+	if len(filer.closeCalls) != 1 {
+		t.Fatalf("expected exactly one jira close call, got %d", len(filer.closeCalls))
+	}
+	if diff := cmp.Diff(ciJira.CloseIssueRequest{IssueKey: "DPTP-42", Resolution: ciJira.ResolutionDone}, filer.closeCalls[0]); diff != "" {
+		t.Fatalf("unexpected close issue call: %s", diff)
+	}
+}
+
+func TestCloseSupportRequestWithCanonicalRootTimestamp(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			threadTS: {
+				{Msg: slack.Msg{Timestamp: "100.100000", ThreadTimestamp: threadTS}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+			},
+		},
+		historyByTS: map[string]*slack.GetConversationHistoryResponse{
+			threadTS: {
+				Messages: []slack.Message{
+					{Msg: slack.Msg{Timestamp: threadTS}},
+				},
+			},
+		},
+	}
+	filer := &fakeFiler{closeResult: true}
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.ReactionAddedEvent{
+				Reaction: closedReaction,
+				Item: slackevents.Item{
+					Channel:   channelID,
+					Timestamp: threadTS,
+				},
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected reaction to be handled")
+	}
+	if len(filer.closeCalls) != 1 {
+		t.Fatalf("expected exactly one jira close call, got %d", len(filer.closeCalls))
+	}
+}
+
+func TestCloseSupportRequestScansByPages(t *testing.T) {
+	channelID := "C123"
+	threadTS := "100.100"
+	client := &fakeClient{
+		pagedRepliesByTS: map[string][][]slack.Message{
+			threadTS: {
+				{
+					{Msg: slack.Msg{Timestamp: threadTS}},
+					{Msg: slack.Msg{Text: "noise-1"}},
+				},
+				{
+					{Msg: slack.Msg{Text: "noise-2"}},
+					{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-99|DPTP-99>", supportRequestPrefix)}},
+				},
+			},
+		},
+		historyByTS: map[string]*slack.GetConversationHistoryResponse{
+			threadTS: {
+				Messages: []slack.Message{
+					{Msg: slack.Msg{Timestamp: threadTS}},
+				},
+			},
+		},
+	}
+	filer := &fakeFiler{closeResult: true}
+	handler := Handler(client, filer, channelID, 1)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.ReactionAddedEvent{
+				Reaction: closedReaction,
+				Item: slackevents.Item{
+					Channel:   channelID,
+					Timestamp: threadTS,
+				},
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected reaction to be handled")
+	}
+	if len(filer.closeCalls) != 1 {
+		t.Fatalf("expected exactly one jira close call, got %d", len(filer.closeCalls))
+	}
+	if diff := cmp.Diff(ciJira.CloseIssueRequest{IssueKey: "DPTP-99", Resolution: ciJira.ResolutionDone}, filer.closeCalls[0]); diff != "" {
+		t.Fatalf("unexpected close issue call: %s", diff)
+	}
+}
+
+func TestCloseSupportRequestIgnoresReplyReaction(t *testing.T) {
+	channelID := "C123"
+	rootTS := "100.100"
+	replyTS := "100.101"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			rootTS: {
+				{Msg: slack.Msg{Timestamp: rootTS}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+			},
+		},
+		historyByTS: map[string]*slack.GetConversationHistoryResponse{
+			replyTS: {
+				Messages: []slack.Message{
+					{Msg: slack.Msg{Timestamp: replyTS, ThreadTimestamp: rootTS}},
+				},
+			},
+		},
+	}
+	filer := &fakeFiler{closeResult: true}
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.ReactionAddedEvent{
+				Reaction: closedReaction,
+				Item: slackevents.Item{
+					Channel:   channelID,
+					Timestamp: replyTS,
+				},
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected reply reaction not to be handled")
+	}
+	if len(filer.closeCalls) != 0 {
+		t.Fatalf("expected zero jira close calls, got %d", len(filer.closeCalls))
+	}
+}
+
+func TestCloseSupportRequestIgnoresShipHelpRootReaction(t *testing.T) {
+	channelID := "C123"
+	rootTS := "100.100"
+	client := &fakeClient{
+		repliesByTS: map[string][]slack.Message{
+			rootTS: {
+				{Msg: slack.Msg{Timestamp: rootTS, Text: "@ship-help please assist"}},
+				{Msg: slack.Msg{Text: fmt.Sprintf("%s <https://issues.redhat.com/browse/DPTP-42|DPTP-42>", supportRequestPrefix)}},
+			},
+		},
+		historyByTS: map[string]*slack.GetConversationHistoryResponse{
+			rootTS: {
+				Messages: []slack.Message{
+					{Msg: slack.Msg{Timestamp: rootTS, Text: "@ship-help please assist"}},
+				},
+			},
+		},
+	}
+	filer := &fakeFiler{closeResult: true}
+	handler := Handler(client, filer, channelID, 5)
+	handled, err := handler.Handle(&slackevents.EventsAPIEvent{
+		Type: slackevents.CallbackEvent,
+		InnerEvent: slackevents.EventsAPIInnerEvent{
+			Data: &slackevents.ReactionAddedEvent{
+				Reaction: closedReaction,
+				Item: slackevents.Item{
+					Channel:   channelID,
+					Timestamp: rootTS,
+				},
+			},
+		},
+	}, logrus.NewEntry(logrus.StandardLogger()))
+	if err != nil {
+		t.Fatalf("did not expect error: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected @ship-help root reaction not to be handled")
+	}
+	if len(filer.closeCalls) != 0 {
+		t.Fatalf("expected zero jira close calls, got %d", len(filer.closeCalls))
+	}
+}

--- a/pkg/slack/events/supportrequest/lock.go
+++ b/pkg/slack/events/supportrequest/lock.go
@@ -1,0 +1,212 @@
+package supportrequest
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	threadLockMapName         = "slack-supportrequest-locks"
+	maxLockRetries            = 5
+	lockTTLSeconds            = int64((30 * time.Minute) / time.Second)
+	lockStateProcessingPrefix = "processing:"
+	lockStateProcessedPrefix  = "processed:"
+)
+
+type configMapLockClient struct {
+	client    ctrlruntimeclient.Client
+	namespace string
+	now       func() time.Time
+}
+
+// NewConfigMapLockClient returns a cross-replica lock based on ConfigMap create/delete.
+func NewConfigMapLockClient(client ctrlruntimeclient.Client, namespace string) lockClient {
+	return &configMapLockClient{
+		client:    client,
+		namespace: namespace,
+		now:       time.Now,
+	}
+}
+
+func (c *configMapLockClient) Acquire(threadTS string) (bool, error) {
+	key := lockNameForThread(threadTS)
+	for i := 0; i < maxLockRetries; i++ {
+		lockMap, err := c.getOrCreateLockMap()
+		if err != nil {
+			return false, err
+		}
+		if lockMap.Data == nil {
+			lockMap.Data = map[string]string{}
+		}
+		if state, exists := lockMap.Data[key]; exists {
+			if _, ok := parseProcessedState(state); ok {
+				return false, nil
+			}
+			if acquiredAt, ok := parseProcessingState(state); ok {
+				if c.now().UTC().Unix()-acquiredAt <= lockTTLSeconds {
+					return false, nil
+				}
+			} else {
+				// Unknown state, keep lock as held to avoid duplicate work.
+				return false, nil
+			}
+		}
+		lockMap.Data[key] = processingState(c.now().UTC().Unix())
+		if err := c.client.Update(context.TODO(), lockMap); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return false, err
+		}
+		return true, nil
+	}
+	return false, fmt.Errorf("failed to acquire lock for %s after retries", threadTS)
+}
+
+func (c *configMapLockClient) MarkProcessed(threadTS, issueKey string) error {
+	key := lockNameForThread(threadTS)
+	for i := 0; i < maxLockRetries; i++ {
+		lockMap := &corev1.ConfigMap{}
+		if err := c.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: c.namespace, Name: threadLockMapName}, lockMap); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if lockMap.Data == nil {
+			lockMap.Data = map[string]string{}
+		}
+		lockMap.Data[key] = processedState(issueKey)
+		if err := c.client.Update(context.TODO(), lockMap); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("failed to mark lock for %s as processed after retries", threadTS)
+}
+
+func (c *configMapLockClient) GetProcessedIssueKey(threadTS string) (string, bool, error) {
+	key := lockNameForThread(threadTS)
+	lockMap := &corev1.ConfigMap{}
+	if err := c.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: c.namespace, Name: threadLockMapName}, lockMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if lockMap.Data == nil {
+		return "", false, nil
+	}
+	state, exists := lockMap.Data[key]
+	if !exists {
+		return "", false, nil
+	}
+	issueKey, ok := parseProcessedState(state)
+	return issueKey, ok, nil
+}
+
+func (c *configMapLockClient) Release(threadTS string) error {
+	key := lockNameForThread(threadTS)
+	for i := 0; i < maxLockRetries; i++ {
+		lockMap := &corev1.ConfigMap{}
+		if err := c.client.Get(context.TODO(), ctrlruntimeclient.ObjectKey{Namespace: c.namespace, Name: threadLockMapName}, lockMap); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		if lockMap.Data == nil {
+			return nil
+		}
+		if _, exists := lockMap.Data[key]; !exists {
+			return nil
+		}
+		if _, ok := parseProcessedState(lockMap.Data[key]); ok {
+			return nil
+		}
+		delete(lockMap.Data, key)
+		if err := c.client.Update(context.TODO(), lockMap); err != nil {
+			if apierrors.IsConflict(err) {
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("failed to release lock for %s after retries", threadTS)
+}
+
+func lockNameForThread(threadTS string) string {
+	sum := sha256.Sum256([]byte(threadTS))
+	return fmt.Sprintf("%x", sum[:8])
+}
+
+func processingState(unixSeconds int64) string {
+	return fmt.Sprintf("%s%d", lockStateProcessingPrefix, unixSeconds)
+}
+
+func processedState(issueKey string) string {
+	return fmt.Sprintf("%s%s", lockStateProcessedPrefix, issueKey)
+}
+
+func parseProcessingState(state string) (int64, bool) {
+	if !strings.HasPrefix(state, lockStateProcessingPrefix) {
+		return 0, false
+	}
+	value := strings.TrimPrefix(state, lockStateProcessingPrefix)
+	ts, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return ts, true
+}
+
+func parseProcessedState(state string) (string, bool) {
+	if !strings.HasPrefix(state, lockStateProcessedPrefix) {
+		return "", false
+	}
+	issueKey := strings.TrimPrefix(state, lockStateProcessedPrefix)
+	if issueKey == "" {
+		return "", false
+	}
+	return issueKey, true
+}
+
+func (c *configMapLockClient) getOrCreateLockMap() (*corev1.ConfigMap, error) {
+	lockMap := &corev1.ConfigMap{}
+	key := ctrlruntimeclient.ObjectKey{Namespace: c.namespace, Name: threadLockMapName}
+	if err := c.client.Get(context.TODO(), key, lockMap); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		toCreate := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: c.namespace,
+				Name:      threadLockMapName,
+				Labels: map[string]string{
+					"app": "slack-bot-supportrequest-lock",
+				},
+			},
+			Data: map[string]string{},
+		}
+		if err := c.client.Create(context.TODO(), toCreate); err != nil && !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+		if err := c.client.Get(context.TODO(), key, lockMap); err != nil {
+			return nil, err
+		}
+	}
+	return lockMap, nil
+}

--- a/pkg/slack/events/supportrequest/lock_test.go
+++ b/pkg/slack/events/supportrequest/lock_test.go
@@ -1,0 +1,149 @@
+package supportrequest
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testNamespace = "ci"
+
+func newTestLockClient(t *testing.T, now func() time.Time) *configMapLockClient {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add corev1 scheme: %v", err)
+	}
+	client := ctrlruntimefake.NewClientBuilder().WithScheme(scheme).Build()
+	return &configMapLockClient{
+		client:    client,
+		namespace: testNamespace,
+		now:       now,
+	}
+}
+
+func TestConfigMapLockAcquireRelease(t *testing.T) {
+	now := time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC)
+	locker := newTestLockClient(t, func() time.Time { return now })
+
+	acquired, err := locker.Acquire("100.100")
+	if err != nil {
+		t.Fatalf("unexpected acquire error: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected first acquire to succeed")
+	}
+
+	acquired, err = locker.Acquire("100.100")
+	if err != nil {
+		t.Fatalf("unexpected second acquire error: %v", err)
+	}
+	if acquired {
+		t.Fatalf("expected second acquire to fail while lock is held")
+	}
+
+	if err := locker.Release("100.100"); err != nil {
+		t.Fatalf("unexpected release error: %v", err)
+	}
+
+	acquired, err = locker.Acquire("100.100")
+	if err != nil {
+		t.Fatalf("unexpected acquire-after-release error: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected acquire after release to succeed")
+	}
+}
+
+func TestConfigMapLockProcessedNeverReacquires(t *testing.T) {
+	now := time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC)
+	locker := newTestLockClient(t, func() time.Time { return now })
+
+	acquired, err := locker.Acquire("200.200")
+	if err != nil || !acquired {
+		t.Fatalf("expected initial acquire success, got acquired=%t err=%v", acquired, err)
+	}
+	if err := locker.MarkProcessed("200.200", "DPTP-200"); err != nil {
+		t.Fatalf("unexpected mark processed error: %v", err)
+	}
+
+	now = now.Add(48 * time.Hour)
+	acquired, err = locker.Acquire("200.200")
+	if err != nil {
+		t.Fatalf("unexpected acquire error for processed lock: %v", err)
+	}
+	if acquired {
+		t.Fatalf("expected processed lock to block reacquire even after TTL")
+	}
+}
+
+func TestConfigMapLockExpiredProcessingCanReacquire(t *testing.T) {
+	now := time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC)
+	locker := newTestLockClient(t, func() time.Time { return now })
+
+	acquired, err := locker.Acquire("300.300")
+	if err != nil || !acquired {
+		t.Fatalf("expected initial acquire success, got acquired=%t err=%v", acquired, err)
+	}
+
+	now = now.Add((time.Duration(lockTTLSeconds) * time.Second) + time.Second)
+	acquired, err = locker.Acquire("300.300")
+	if err != nil {
+		t.Fatalf("unexpected acquire error after TTL: %v", err)
+	}
+	if !acquired {
+		t.Fatalf("expected reacquire after processing TTL expiry")
+	}
+}
+
+func TestConfigMapLockReleaseDoesNotDeleteProcessed(t *testing.T) {
+	now := time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC)
+	locker := newTestLockClient(t, func() time.Time { return now })
+
+	acquired, err := locker.Acquire("400.400")
+	if err != nil || !acquired {
+		t.Fatalf("expected initial acquire success, got acquired=%t err=%v", acquired, err)
+	}
+	if err := locker.MarkProcessed("400.400", "DPTP-400"); err != nil {
+		t.Fatalf("unexpected mark processed error: %v", err)
+	}
+	if err := locker.Release("400.400"); err != nil {
+		t.Fatalf("unexpected release error: %v", err)
+	}
+
+	now = now.Add(24 * time.Hour)
+	acquired, err = locker.Acquire("400.400")
+	if err != nil {
+		t.Fatalf("unexpected acquire error for processed lock: %v", err)
+	}
+	if acquired {
+		t.Fatalf("expected processed lock to remain after release")
+	}
+}
+
+func TestConfigMapLockGetProcessedIssueKey(t *testing.T) {
+	now := time.Date(2026, time.April, 17, 10, 0, 0, 0, time.UTC)
+	locker := newTestLockClient(t, func() time.Time { return now })
+
+	acquired, err := locker.Acquire("500.500")
+	if err != nil || !acquired {
+		t.Fatalf("expected initial acquire success, got acquired=%t err=%v", acquired, err)
+	}
+	if err := locker.MarkProcessed("500.500", "DPTP-500"); err != nil {
+		t.Fatalf("unexpected mark processed error: %v", err)
+	}
+
+	issueKey, found, err := locker.GetProcessedIssueKey("500.500")
+	if err != nil {
+		t.Fatalf("unexpected get processed issue key error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected processed issue key to be found")
+	}
+	if issueKey != "DPTP-500" {
+		t.Fatalf("expected issue key DPTP-500, got %s", issueKey)
+	}
+}


### PR DESCRIPTION
Add support-request handling for long forum threads by creating DPTP Jira tickets, posting thread guidance, and closing linked tickets from :closed: reactions with replica-safe locking and transition-aware Jira updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support-request mode: auto-create Jira issues for forum threads exceeding a configurable message threshold (default 10), post the Jira link in-thread, mark new issues In Progress, and close them when :closed: is added.
  * New PagerDuty on-call assignment and an "Activity Type" field added to created issues; thread permalink included in the issue.

* **Tests**
  * Added tests covering support-request flows and locking behavior.

* **Documentation**
  * README updated with support-request mode and configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->