### PR TITLE
prowgen: use preset for registry pull credentials volume

### DIFF
--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -29,6 +29,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:
@@ -55,9 +56,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -69,9 +67,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -29,6 +29,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:
@@ -55,9 +56,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -69,9 +67,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -32,6 +32,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: rhel
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-branch-rhel-images
     spec:
@@ -59,9 +60,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -73,9 +71,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_postsubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -10,6 +10,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-branch-images
     spec:
@@ -36,9 +37,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -50,9 +48,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Custom_test_timeout.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -67,6 +62,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit
     spec:
@@ -103,9 +99,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -120,9 +113,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Input_is_YAML_and_it_is_correctly_processed.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -66,6 +61,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit
     spec:
@@ -98,9 +94,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -109,9 +102,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_Using_a_variant_config__one_test_and_images__one_existing_job._Expect_one_presubmit__pre_post_submit_images_jobs._Existing_job_should_not_be_changed..yaml
@@ -13,6 +13,7 @@ presubmits:
       ci-operator.openshift.io/variant: rhel
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-rhel-images
     rerun_command: /test rhel-images
     spec:
@@ -38,9 +39,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -49,9 +47,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -69,6 +64,7 @@ presubmits:
       ci-operator.openshift.io/variant: rhel
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-rhel-unit
     rerun_command: /test rhel-unit
     spec:
@@ -102,9 +98,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -113,9 +106,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
+++ b/cmd/ci-operator-prowgen/testdata/zz_fixture_presubmit_TestFromCIOperatorConfigToProwYaml_one_test_and_images__no_previous_jobs._Expect_test_presubmit__pre_post_submit_images_jobs.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -66,6 +61,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-branch-unit
     rerun_command: /test unit
     spec:
@@ -98,9 +94,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -109,9 +102,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_additional_PR_from_the_same_repo.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_additional_PR_from_the_same_repo.yaml
@@ -52,9 +52,6 @@ spec:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -63,9 +60,6 @@ spec:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_multiple_additional_PRs.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_multiple_additional_PRs.yaml
@@ -65,9 +65,6 @@ spec:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -76,9 +73,6 @@ spec:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_sharded_test_looks_up_first_shard_in_dispatcher.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestGenerateProwJob_sharded_test_looks_up_first_shard_in_dispatcher.yaml
@@ -52,9 +52,6 @@ spec:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -63,9 +60,6 @@ spec:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_a_single_multi_pr_job_run_with_additional_PR_from_a_different_repo.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_a_single_multi_pr_job_run_with_additional_PR_from_a_different_repo.yaml
@@ -66,9 +66,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -77,9 +74,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_a_single_multi_pr_job_run_with_additional_PR_from_the_same_repo.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_a_single_multi_pr_job_run_with_additional_PR_from_the_same_repo.yaml
@@ -53,9 +53,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -64,9 +61,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_multiple_multi_pr_job_runs_with_diverse_additional_PRs.yaml
+++ b/cmd/multi-pr-prow-plugin/testdata/zz_fixture_TestHandle_trigger_multiple_multi_pr_job_runs_with_diverse_additional_PRs.yaml
@@ -53,9 +53,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -64,9 +61,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -155,9 +149,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -166,9 +157,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -254,9 +242,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -265,9 +250,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_An_EphemeralCluster_request_creates_a_ProwJob.yaml
@@ -12,6 +12,7 @@ items:
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: ""
       prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
       prow.k8s.io/type: periodic
@@ -140,9 +141,6 @@ items:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -160,9 +158,6 @@ items:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
+++ b/pkg/controller/ephemeralcluster/testdata/zz_fixture_pj_TestCreateProwJob_Hive_cluster_request_creates_a_ProwJob.yaml
@@ -12,6 +12,7 @@ items:
       ci.openshift.io/ephemeral-cluster: ec
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: ""
       prow.k8s.io/job: ephemeralcluster-ci-org-repo-branch-cluster-provisioning
       prow.k8s.io/type: periodic
@@ -149,9 +150,6 @@ items:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -172,9 +170,6 @@ items:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_aggregated_case.yaml
@@ -82,9 +82,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -99,9 +96,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -183,9 +177,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -194,9 +185,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -278,9 +266,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -289,9 +274,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case.yaml
@@ -69,9 +69,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -80,9 +77,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_no_PRs_included__testing_determined_base.yaml
@@ -62,9 +62,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -73,9 +70,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_sharded_job.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_sharded_job.yaml
@@ -70,9 +70,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -81,9 +78,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_with_variant.yaml
@@ -69,9 +69,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -80,9 +77,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_basic_case_without_PR__testing_specified_base.yaml
@@ -63,9 +63,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -74,9 +71,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_different_repositories.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_different_repositories.yaml
@@ -78,9 +78,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -89,9 +86,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_the_same_repository.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_PRs_from_the_same_repository.yaml
@@ -73,9 +73,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -84,9 +81,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_multiple_case__one_of_the_prowjobs_already_exists.yaml
@@ -93,9 +93,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -104,9 +101,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_initial_and_base_payload_pullspecs.yaml
@@ -73,9 +73,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -84,9 +81,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_tag.yaml
+++ b/pkg/controller/prpqr_reconciler/testdata/zz_fixture_prowjobs_TestReconcile_override_tag.yaml
@@ -71,9 +71,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -82,9 +79,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -60,8 +60,11 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	b := &prowJobBaseBuilder{
 		PodSpec: podSpecGenerator,
 		base: prowconfig.JobBase{
-			Agent:  string(prowv1.KubernetesAgent),
-			Labels: map[string]string{},
+			Agent: string(prowv1.KubernetesAgent),
+			Labels: map[string]string{
+				// TODO(muller): inline for now to avoid triggering all image build, move to a named constant later
+				"presets.ci.openshift.io/registry-pull": "true",
+			},
 			UtilityConfig: prowconfig.UtilityConfig{
 				Decorate: utilpointer.Bool(true),
 			},

--- a/pkg/prowgen/podspec.go
+++ b/pkg/prowgen/podspec.go
@@ -11,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/openshift/ci-tools/pkg/api"
 	cioperatorapi "github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/steps/multi_stage"
 	"github.com/openshift/ci-tools/pkg/steps/utils"
@@ -22,6 +21,7 @@ var defaultPodSpec = corev1.PodSpec{
 	Containers: []corev1.Container{
 		{
 			Args: []string{
+				// /etc/pull-secret mount provided by registry-pull preset in Prow config
 				"--image-import-pull-secret=/etc/pull-secret/.dockerconfigjson",
 				"--gcs-upload-secret=/secrets/gcs/service-account.json",
 				"--report-credentials-file=/etc/report/credentials",
@@ -33,11 +33,6 @@ var defaultPodSpec = corev1.PodSpec{
 				Requests: corev1.ResourceList{"cpu": *resource.NewMilliQuantity(10, resource.DecimalSI)},
 			},
 			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "pull-secret",
-					MountPath: "/etc/pull-secret",
-					ReadOnly:  true,
-				},
 				{
 					Name:      "result-aggregator",
 					MountPath: "/etc/report",
@@ -57,12 +52,6 @@ var defaultPodSpec = corev1.PodSpec{
 		},
 	},
 	Volumes: []corev1.Volume{
-		{
-			Name: "pull-secret",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: cioperatorapi.RegistryPullCredentialsSecret},
-			},
-		},
 		{
 			Name: "result-aggregator",
 			VolumeSource: corev1.VolumeSource{
@@ -393,7 +382,7 @@ var (
 	}
 
 	smallHTTPServerEnv = corev1.EnvVar{
-		Name: api.CIOperatorHTTPServerIPEnvVarName,
+		Name: cioperatorapi.CIOperatorHTTPServerIPEnvVarName,
 		ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{
 				FieldPath: "status.podIP",

--- a/pkg/prowgen/testdata/zz_fixture_TestCIPullSecret_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCIPullSecret_secret_is_added.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -36,9 +33,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestClaims_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestClaims_secret_is_added.yaml
@@ -26,9 +26,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -43,9 +40,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_input_is_added.yaml
@@ -19,9 +19,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -30,9 +27,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestCustomHashInput_custom_hash_inputs_are_added.yaml
@@ -20,9 +20,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -31,9 +28,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGSMConfig_add_gsm_config_volume_and_mount.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGSMConfig_add_gsm_config_volume_and_mount.yaml
@@ -28,9 +28,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -48,9 +45,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_config_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_config_variant.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/variant: whatever
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-whatever-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_option_set_but_not_private.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
@@ -3,4 +3,6 @@ decorate: true
 decoration_config:
   skip_cloning: true
 hidden: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_no_special_options.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_no_special_options.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_path_alias.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_path_alias.yaml
@@ -4,5 +4,6 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/variant: whatever
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-whatever-test
 path_alias: /some/where

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_rehearsable.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_rehearsable.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -10,4 +11,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_Promotion_configuration_causes_promote_job_with_unique_targets.yaml
@@ -9,6 +9,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
     spec:
@@ -36,9 +37,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -50,9 +48,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -72,6 +67,7 @@ presubmits:
       skip_cloning: true
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images
     rerun_command: /test images
     spec:
@@ -97,9 +93,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -108,9 +101,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_ci_operator_config_overrides_prowgen_rehearsals.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_ci_operator_config_overrides_prowgen_rehearsals.yaml
@@ -1,4 +1,6 @@
 presubmits:
   organization/repository:
   - always_run: false
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_ci_operator_config_takes_precedence_over_prowgen_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_ci_operator_config_takes_precedence_over_prowgen_config.yaml
@@ -1,4 +1,6 @@
 presubmits:
   organization/repository:
   - always_run: false
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_periodic.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_periodic.yaml
@@ -12,6 +12,7 @@ periodics:
   labels:
     ci-operator.openshift.io/cluster: build01
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-unit
   spec:
     containers:
@@ -43,9 +44,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -54,9 +52,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_postsubmit.yaml
@@ -4,5 +4,6 @@ postsubmits:
     cluster: build01
     labels:
       ci-operator.openshift.io/cluster: build01
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_cluster_label_for_presubmit.yaml
@@ -5,4 +5,5 @@ presubmits:
     labels:
       ci-operator.openshift.io/cluster: build01
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_job_level.yaml
@@ -8,6 +8,8 @@ periodics:
   - base_ref: branch
     org: organization
     repo: repository
+  labels:
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-periodic-unit
   spec:
     containers:
@@ -39,9 +41,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -50,9 +49,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -67,6 +63,7 @@ periodics:
     repo: repository
   labels:
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-periodic-lint
   spec:
     containers:
@@ -98,9 +95,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -109,17 +103,17 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
 presubmits:
   organization/repository:
   - always_run: false
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-lint

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_disabled_rehearsals_at_repo_level.yaml
@@ -8,6 +8,8 @@ periodics:
   - base_ref: branch
     org: organization
     repo: repository
+  labels:
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-periodic-unit
   spec:
     containers:
@@ -39,9 +41,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -50,13 +49,12 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
 presubmits:
   organization/repository:
   - always_run: false
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_is_configured_for_slack_reporting.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_is_configured_for_slack_reporting.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
     reporter_config:
@@ -16,6 +17,7 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images
     reporter_config:
       slack:

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_pipeline_skip_if_only_changed_propagated_to_presubmit_only.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_pipeline_skip_if_only_changed_propagated_to_presubmit_only.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -12,4 +13,5 @@ presubmits:
       pipeline_skip_if_only_changed: ^(docs/|.*\.md$)
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_run_if_changed_propagated_to_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_run_if_changed_propagated_to_presubmit.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -10,5 +11,6 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images
     run_if_changed: ^(Dockerfile|src/)

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_skip_if_only_changed_propagated_to_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_images_job_with_skip_if_only_changed_propagated_to_presubmit.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -10,5 +11,6 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images
     skip_if_only_changed: ^(docs/|.*\.md$)

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_kvm_label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_kvm_label.yaml
@@ -4,4 +4,5 @@ presubmits:
     labels:
       devices.kubevirt.io/kvm: "1"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_postsubmit_images.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_postsubmit_images.yaml
@@ -5,6 +5,7 @@ postsubmits:
       capability/arm64: arm64
       capability/ppc64-le: ppc64-le
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -14,4 +15,5 @@ presubmits:
       capability/arm64: arm64
       capability/ppc64-le: ppc64-le
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_test_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_multiarch_test_job.yaml
@@ -4,4 +4,5 @@ presubmits:
     labels:
       capability/arm64: arm64
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_no_Promotion_configuration_has_no_branch_job.yaml
@@ -3,4 +3,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_bundle_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_bundle_with_capabilities.yaml
@@ -13,6 +13,7 @@ presubmits:
       capability/nested-kvm: nested-kvm
       capability/privileged: privileged
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-ci-index-my-bundle-caps
     rerun_command: /test ci-index-my-bundle-caps
     spec:
@@ -37,9 +38,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -48,9 +46,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_my_bundle_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_my_bundle_presubmit_job.yaml
@@ -11,6 +11,7 @@ presubmits:
       skip_cloning: true
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-ci-index-my-bundle
     rerun_command: /test ci-index-my-bundle
     spec:
@@ -35,9 +36,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -46,9 +44,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_creates_ci_index_presubmit_job.yaml
@@ -3,4 +3,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-ci-index

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_operator_section_without_index_creates_ci_index_my_bundle_presubmit_job.yaml
@@ -11,6 +11,7 @@ presubmits:
       skip_cloning: true
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-ci-bundle-my-bundle
     rerun_command: /test ci-bundle-my-bundle
     spec:
@@ -35,9 +36,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -46,9 +44,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_per_test_disable_rehearsal_from_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_per_test_disable_rehearsal_from_ci_operator_config.yaml
@@ -1,8 +1,11 @@
 presubmits:
   organization/repository:
   - always_run: false
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-lint

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_presubmit_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_presubmit_with_capabilities.yaml
@@ -14,6 +14,7 @@ periodics:
     capability/rce: rce
     capability/sshd-bastion: sshd-bastion
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-unit
   spec:
     containers:
@@ -45,9 +46,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -56,9 +54,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -71,4 +66,5 @@ presubmits:
       capability/rce: rce
       capability/sshd-bastion: sshd-bastion
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_capabilities.yaml
@@ -11,6 +11,7 @@ periodics:
   labels:
     capability/intranet: intranet
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-unit
   spec:
     containers:
@@ -42,9 +43,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -53,9 +51,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_max_concurrency_from_test_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_max_concurrency_from_test_config.yaml
@@ -10,6 +10,7 @@ periodics:
     repo: repository
   labels:
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   max_concurrency: 3
   name: periodic-ci-organization-repository-branch-derTest
   spec:
@@ -42,9 +43,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -53,9 +51,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_presubmit.yaml
@@ -12,6 +12,7 @@ periodics:
   labels:
     ci-operator.openshift.io/cluster: build01
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-organization-repository-branch-unit
   spec:
     containers:
@@ -43,9 +44,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -54,9 +52,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -67,4 +62,5 @@ presubmits:
     labels:
       ci-operator.openshift.io/cluster: build01
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_postsubmit_with_max_concurrency_from_test_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_postsubmit_with_max_concurrency_from_test_config.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   organization/repository:
   - always_run: true
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 6
     name: branch-ci-organization-repository-branch-leTest
 presubmits:
@@ -8,4 +10,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-derTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_promotion_postsubmit_and_periodic_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_promotion_postsubmit_and_periodic_.yaml
@@ -10,6 +10,7 @@ periodics:
     repo: repository
   labels:
     ci-operator.openshift.io/is-promotion: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   max_concurrency: 1
   name: periodic-ci-organization-repository-branch-images
   spec:
@@ -36,9 +37,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/push-secret
         name: push-secret
         readOnly: true
@@ -50,9 +48,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: push-secret
       secret:
         secretName: registry-push-credentials-ci-central
@@ -64,6 +59,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -71,4 +67,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_sharded_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_sharded_presubmit.yaml
@@ -3,12 +3,15 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit-1of3
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit-2of3
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-unit-3of3

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_so_only_two_test_presubmits_are_generated.yaml
@@ -3,8 +3,10 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-derTest
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-leTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_empty_Images_with_one_test_configured_as_a_postsubmit.yaml
@@ -1,6 +1,8 @@
 postsubmits:
   organization/repository:
   - always_run: true
+    labels:
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-leTest
 presubmits:
@@ -8,4 +10,5 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-derTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_two_tests_and_nonempty_Images_so_two_test_presubmits_and_images_pre_postsubmits_are_generated_.yaml
@@ -3,6 +3,7 @@ postsubmits:
   - always_run: true
     labels:
       ci-operator.openshift.io/is-promotion: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-organization-repository-branch-images
 presubmits:
@@ -10,12 +11,15 @@ presubmits:
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-derTest
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-leTest
   - always_run: false
     labels:
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-organization-repository-branch-images

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_in_a_variant_config.yaml
@@ -10,4 +10,5 @@ extra_refs:
 labels:
   ci-operator.openshift.io/variant: also
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-also-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_with_retry.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_a_test_with_retry.yaml
@@ -9,6 +9,7 @@ extra_refs:
   repo: repo
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-testname
 retry:
   attempts: 2

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_for_standard_test.yaml
@@ -9,4 +9,5 @@ extra_refs:
   repo: repo
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_using_interval.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_using_interval.yaml
@@ -9,4 +9,5 @@ extra_refs:
 interval: 6h
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_using_minimum_interval.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_using_minimum_interval.yaml
@@ -8,5 +8,6 @@ extra_refs:
   repo: repo
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 minimum_interval: 4h
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_capabilities.yaml
@@ -13,4 +13,5 @@ labels:
   capability/rce: rce
   capability/sshd-bastion: sshd-bastion
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_disabled_rehearsal.yaml
@@ -7,4 +7,6 @@ extra_refs:
 - base_ref: branch
   org: org
   repo: repo
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_max_concurrency.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_max_concurrency.yaml
@@ -9,5 +9,6 @@ extra_refs:
   repo: repo
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 max_concurrency: 3
 name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Lowercase_org_repo_and_branch.yaml
@@ -5,4 +5,6 @@ branches:
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: branch-ci-organization-repository-branch-postsubmit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_Uppercase_org__repo_and_branch.yaml
@@ -5,4 +5,6 @@ branches:
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: branch-ci-Organization-Repository-Branch-postsubmit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_capabilities.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_capabilities.yaml
@@ -10,4 +10,5 @@ labels:
   capability/intranet: intranet
   capability/rce: rce
   capability/sshd-bastion: sshd-bastion
+  presets.ci.openshift.io/registry-pull: "true"
 name: branch-ci-organization-repository-branch-postsubmit

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_run_if_changed.yaml
@@ -5,5 +5,7 @@ branches:
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: branch-ci-organization-repository-branch-postsubmit
 run_if_changed: ^README.md$

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePostSubmitForTest_postsubmit_with_skip_if_only_changed.yaml
@@ -5,5 +5,7 @@ branches:
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: branch-ci-organization-repository-branch-postsubmit
 skip_if_only_changed: ^README.md$

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_capabilities_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_capabilities_added.yaml
@@ -13,6 +13,7 @@ labels:
   capability/rce: rce
   capability/sshd-bastion: sshd-bastion
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_optional_presubmit.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_optional_presubmit.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 optional: true
 rerun_command: /test testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_a_test_in_a_variant_config.yaml
@@ -10,6 +10,7 @@ decoration_config:
 labels:
   ci-operator.openshift.io/variant: also
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-also-testname
 rerun_command: /test also-testname
 trigger: (?m)^/test( | .* )also-testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_for_standard_test.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_optional_true.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_optional_true.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 optional: true
 rerun_command: /test testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_pipeline_run_if_changed_set.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_pipeline_run_if_changed_set.yaml
@@ -11,6 +11,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_pipeline_skip_if_only_changed_set.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_pipeline_skip_if_only_changed_set.yaml
@@ -11,6 +11,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_run_if_changed_set.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_but_run_if_changed_set.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 run_if_changed: .*

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )(testname|remaining-required),?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false_and_pipeline_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false_and_pipeline_run_if_changed.yaml
@@ -11,6 +11,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false_and_pipeline_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_always_run_false_and_pipeline_skip_if_only_changed.yaml
@@ -11,6 +11,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_max_concurrency.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_max_concurrency.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 max_concurrency: 4
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_run_if_changed.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 run_if_changed: ^README.md$

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_skip_if_only_changed.yaml
@@ -9,6 +9,7 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 skip_if_only_changed: ^README.md$

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_rehearsal_disabled.yaml
@@ -7,6 +7,8 @@ context: ci/prow/testname
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: pull-ci-org-repo-branch-testname
 rerun_command: /test testname
 trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo__reusing_Prow_s_volume_with_credentials.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo__reusing_Prow_s_volume_with_credentials.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -33,9 +30,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo_without_reusing_Prow_s_volume_with_credentials.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGitHubToken_podspec_for_private_repo_without_reusing_Prow_s_volume_with_credentials.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -36,9 +33,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_with_variant.yaml
@@ -20,9 +20,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -31,9 +28,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestInjectTestFrom_inject_coordinates_without_variant.yaml
@@ -20,9 +20,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -31,9 +28,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestLeaseClient_secret_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestLeaseClient_secret_is_added.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -39,9 +36,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_Cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_Cluster.yaml
@@ -3,4 +3,6 @@ cluster: build99
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_PathAlias.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_PathAlias.yaml
@@ -2,5 +2,7 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-
 path_alias: alias.path

--- a/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_Rehearsable.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_Rehearsable.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_TestName.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_TestName.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-best-test

--- a/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_WithLabel.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestMiscellaneous_WithLabel.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   key: value
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_defaults_repo.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_defaults_repo.yaml
@@ -18,9 +18,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -29,9 +26,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_no_parameter_is_added_when_variant_is_empty.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_no_parameter_is_added_when_variant_is_empty.yaml
@@ -18,9 +18,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -29,9 +26,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_parameter_is_added_for_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewCiOperatorPodSpecGenerator_parameter_is_added_for_variant.yaml
@@ -19,9 +19,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -30,9 +27,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_job_excluded_by_patterns_should_not_have_slack_reporter_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_job_excluded_by_patterns_should_not_have_slack_reporter_config.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-unit-skip
 spec:
   containers:
@@ -33,9 +35,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -44,9 +43,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_literal_multi_stage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_literal_multi_stage_test.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -37,9 +39,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -54,9 +53,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -37,9 +39,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -54,9 +53,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -47,9 +49,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -73,9 +72,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled_via_ci_operator_config.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -47,9 +49,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -73,9 +72,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_claim.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_claim.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -45,9 +47,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -68,9 +67,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_cluster_profile.yaml
@@ -5,6 +5,7 @@ decoration_config:
 labels:
   ci-operator.openshift.io/cloud: alibabacloud
   ci-operator.openshift.io/cloud-cluster-profile: alibabacloud
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -40,9 +41,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -57,9 +55,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_releases.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_releases.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -41,9 +43,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -61,9 +60,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -33,9 +35,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -44,9 +43,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_cluster.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_cluster.yaml
@@ -5,6 +5,7 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/cluster: build01
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -36,9 +37,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -47,9 +45,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secret.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -34,9 +36,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -48,9 +47,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_secrets.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -35,9 +37,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -52,9 +51,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout.yaml
@@ -3,6 +3,8 @@ decorate: true
 decoration_config:
   skip_cloning: true
   timeout: 1s
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -34,9 +36,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -45,9 +44,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_container_based_test_with_timeout_and_no_decoration.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   timeout: 1s
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -33,9 +35,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -44,9 +43,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_test_with_CSI_enabled.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_test_with_CSI_enabled.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-simple
 spec:
   containers:
@@ -33,9 +35,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -44,9 +43,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_with_slack_reporter_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_simple_with_slack_reporter_config.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-o-r-b-unit
 spec:
   containers:
@@ -33,9 +35,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -44,9 +43,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestPromotion_secret_and_parameters_are_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestPromotion_secret_and_parameters_are_added.yaml
@@ -20,9 +20,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/push-secret
     name: push-secret
     readOnly: true
@@ -34,9 +31,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: push-secret
   secret:
     secretName: registry-push-credentials-ci-central

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_default_job_without_further_configuration__including_podspec.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-
 spec:
   containers:
@@ -24,9 +26,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -35,9 +34,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_buildroot_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_buildroot_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-openshift-release-main-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/variant: variant
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-variant-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_a_variant__including_podspec.yaml
@@ -4,6 +4,7 @@ decoration_config:
   skip_cloning: true
 labels:
   ci-operator.openshift.io/variant: variant
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-variant-
 spec:
   containers:
@@ -27,9 +28,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -38,9 +36,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_binary_build_in_openshift_release_main__does_not_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_binary_build_in_openshift_release_main__does_not_have_no_builds__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-openshift-release-main-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_configured_prefix.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_configured_prefix.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: prefix-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_image_builds_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_image_builds_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-openshift-release-main-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_latest_release_that_is_a_candidate__has_job_release__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_latest_release_that_is_a_candidate__has_job_release__label.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   job-release: THIS
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_latest_release_that_is_not_a_candidate__does_not_have_job_release__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_latest_release_that_is_not_a_candidate__does_not_have_job_release__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_no_builds_in_openshift_release_main__does_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_no_builds_in_openshift_release_main__does_have_no_builds__label.yaml
@@ -4,4 +4,5 @@ decoration_config:
   skip_cloning: true
 labels:
   ci.openshift.io/no-builds: "true"
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-openshift-release-main-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_no_builds_outside_of_openshift_release_main__does_not_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_no_builds_outside_of_openshift_release_main__does_not_have_no_builds__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_not_a_latest_release_that_is_a_candidate__does_not_have_job_release__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_not_a_latest_release_that_is_a_candidate__does_not_have_job_release__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-org-repo-branch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_test_binary_build_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_job_with_test_binary_build_in_of_openshift_release_main__does_not_have_no_builds__label.yaml
@@ -2,4 +2,6 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-openshift-release-main-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
@@ -3,6 +3,8 @@ decorate: true
 decoration_config:
   skip_cloning: true
 hidden: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-
 spec:
   containers:
@@ -29,9 +31,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -43,9 +42,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_cloning__including_podspec.yaml
@@ -5,6 +5,8 @@ decoration_config:
     key: oauth
     name: github-credentials-openshift-ci-robot-private-git-cloner
 hidden: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-
 spec:
   containers:
@@ -31,9 +33,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -42,9 +41,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
@@ -2,6 +2,8 @@ agent: kubernetes
 decorate: true
 decoration_config:
   skip_cloning: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-
 spec:
   containers:
@@ -28,9 +30,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -42,9 +41,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
@@ -3,6 +3,8 @@ decorate: true
 decoration_config:
   skip_cloning: true
 hidden: true
+labels:
+  presets.ci.openshift.io/registry-pull: "true"
 name: default-ci-vorg-vrepo-vbranch-
 spec:
   containers:
@@ -29,9 +31,6 @@ spec:
     - mountPath: /secrets/manifest-tool
       name: manifest-tool-local-pusher
       readOnly: true
-    - mountPath: /etc/pull-secret
-      name: pull-secret
-      readOnly: true
     - mountPath: /etc/report
       name: result-aggregator
       readOnly: true
@@ -43,9 +42,6 @@ spec:
   - name: manifest-tool-local-pusher
     secret:
       secretName: manifest-tool-local-pusher
-  - name: pull-secret
-    secret:
-      secretName: registry-pull-credentials
   - name: result-aggregator
     secret:
       secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestReleaseInitial_add_release_initial.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestReleaseInitial_add_release_initial.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -33,9 +30,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestReleaseLatest_add_release_latest.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestReleaseLatest_add_release_latest.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -33,9 +30,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_generated_for_non_origin_repo.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestReleaseRpms_envvar_generated_for_non_origin_repo.yaml
@@ -22,9 +22,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -33,9 +30,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_empty_list_is_a_nop.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_empty_list_is_a_nop.yaml
@@ -18,9 +18,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -29,9 +26,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_multiple_secrets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_multiple_secrets.yaml
@@ -23,9 +23,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -40,9 +37,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestSecrets_one_secret.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestSecrets_one_secret.yaml
@@ -19,9 +19,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -33,9 +30,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargetAdditionalSuffix_target_additional_suffix_is_added.yaml
@@ -19,9 +19,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -30,9 +27,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestTargets_multiple_targets.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargets_multiple_targets.yaml
@@ -20,9 +20,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -31,9 +28,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestTargets_single_target.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestTargets_single_target.yaml
@@ -19,9 +19,6 @@ containers:
   - mountPath: /secrets/manifest-tool
     name: manifest-tool-local-pusher
     readOnly: true
-  - mountPath: /etc/pull-secret
-    name: pull-secret
-    readOnly: true
   - mountPath: /etc/report
     name: result-aggregator
     readOnly: true
@@ -30,9 +27,6 @@ volumes:
 - name: manifest-tool-local-pusher
   secret:
     secretName: manifest-tool-local-pusher
-- name: pull-secret
-  secret:
-    secretName: registry-pull-credentials
 - name: result-aggregator
   secret:
     secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-branch-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-branch-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-legacy-branches-separate-files-branch-generated
     rerun_command: /test generated
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/branches-separate-files/legacy-branches-separate-files-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-legacy-branches-separate-files-master-generated
     rerun_command: /test generated
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/legacy/random-file/legacy-random-file-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/legacy/random-file/legacy-random-file-master-periodics.yaml
@@ -11,6 +11,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-legacy-random-file-master-generated
   spec:
     containers:
@@ -42,9 +43,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -53,9 +51,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-norehearsals-duper-master-upload-results
     spec:
@@ -41,9 +42,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -52,9 +50,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/duper/norehearsals-duper-master-presubmits.yaml
@@ -11,6 +11,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-norehearsals-duper-master-lint
     rerun_command: /test lint
     spec:
@@ -43,9 +44,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -54,9 +52,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -72,6 +67,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-norehearsals-duper-master-unit
     rerun_command: /test unit
     spec:
@@ -104,9 +100,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -115,9 +108,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-postsubmits.yaml
@@ -9,6 +9,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-norehearsals-stuper-master-upload-results
     spec:
@@ -41,9 +42,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -52,9 +50,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/norehearsals/stuper/norehearsals-stuper-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-norehearsals-stuper-master-lint
     rerun_command: /test lint
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -73,6 +68,7 @@ presubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-norehearsals-stuper-master-unit
     rerun_command: /test unit
     spec:
@@ -105,9 +101,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -116,9 +109,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/duper/private-org-duper-master-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-private-org-duper-master-unit
     rerun_command: /test unit
     spec:
@@ -49,9 +50,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -63,9 +61,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private-org/super/private-org-super-master-presubmits.yaml
@@ -15,6 +15,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-private-org-super-master-unit
     rerun_command: /test unit
     spec:
@@ -51,9 +52,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -62,9 +60,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-private-duper-master-e2e-nightly
   spec:
     containers:
@@ -47,9 +48,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -61,9 +59,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-postsubmits.yaml
@@ -11,6 +11,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-private-duper-master-images
     spec:
@@ -41,9 +42,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -58,9 +56,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/private/duper/private-duper-master-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-private-duper-master-e2e
     rerun_command: /test e2e
     spec:
@@ -49,9 +50,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -63,9 +61,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -83,6 +78,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-private-duper-master-images
     rerun_command: /test images
     spec:
@@ -112,9 +108,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -126,9 +119,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -146,6 +136,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-private-duper-master-unit
     rerun_command: /test unit
     spec:
@@ -182,9 +173,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -196,9 +184,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/sharded/repo/sharded-repo-main-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-sharded-repo-main-e2e-test-1of3
     rerun_command: /test e2e-test-1of3
     spec:
@@ -49,9 +50,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -66,9 +64,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -85,6 +80,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-sharded-repo-main-e2e-test-2of3
     rerun_command: /test e2e-test-2of3
     spec:
@@ -122,9 +118,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -139,9 +132,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -158,6 +148,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-sharded-repo-main-e2e-test-3of3
     rerun_command: /test e2e-test-3of3
     spec:
@@ -195,9 +186,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -212,9 +200,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
     ci-operator.openshift.io/variant: exclude
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-slack-report-duper-master-exclude-lint
   spec:
     containers:
@@ -44,9 +45,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -55,9 +53,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -73,6 +68,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-slack-report-duper-master-lint
   reporter_config:
     slack:
@@ -115,9 +111,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -126,9 +119,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/variant: exclude
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-slack-report-duper-master-exclude-upload-results
     spec:
@@ -43,9 +44,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -54,9 +52,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -69,6 +64,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-slack-report-duper-master-upload-results
     reporter_config:
@@ -112,9 +108,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -123,9 +116,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/slack-report/duper/slack-report-duper-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-slack-report-duper-master-e2e
     rerun_command: /test e2e
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -75,6 +70,7 @@ presubmits:
       ci-operator.openshift.io/variant: exclude
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-slack-report-duper-master-exclude-e2e
     rerun_command: /test exclude-e2e
     spec:
@@ -108,9 +104,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -119,9 +112,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -139,6 +129,7 @@ presubmits:
       ci-operator.openshift.io/variant: exclude
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-slack-report-duper-master-exclude-unit
     rerun_command: /test exclude-unit
     spec:
@@ -172,9 +163,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -183,9 +171,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -202,6 +187,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-slack-report-duper-master-unit
     reporter_config:
       slack:
@@ -245,9 +231,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -256,9 +239,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/subdir/repo/subdir-repo-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-subdir-repo-master-test
     rerun_command: /test test
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-job-release-periodics.yaml
@@ -12,6 +12,7 @@ periodics:
     ci.openshift.io/generator: prowgen
     job-release: "4.6"
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-job-release-unit
   spec:
     containers:
@@ -43,9 +44,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -54,9 +52,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-periodics.yaml
@@ -11,6 +11,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-master-e2e-aws-nightly
   spec:
     containers:
@@ -42,9 +43,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -53,9 +51,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -71,6 +66,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-master-e2e-aws-nightly-interval
   spec:
     containers:
@@ -102,9 +98,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -113,9 +106,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -131,6 +121,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-master-e2e-nightly
   spec:
     containers:
@@ -162,9 +153,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -173,9 +161,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator
@@ -192,6 +177,7 @@ periodics:
     ci-operator.openshift.io/release-controller: "true"
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-master-informer
   spec:
     containers:
@@ -223,9 +209,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -234,9 +217,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-images
     spec:
@@ -36,9 +37,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -50,9 +48,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -70,6 +65,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-images-build-affected-images
     spec:
@@ -97,9 +93,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -111,9 +104,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -131,6 +121,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-changed
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-images-changed-images
     spec:
@@ -158,9 +149,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -172,9 +160,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -192,6 +177,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-pipeline-changed
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-images-pipeline-changed-images
     spec:
@@ -219,9 +205,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -233,9 +216,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -253,6 +233,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: images-skip-docs
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-images-skip-docs-images
     spec:
@@ -280,9 +261,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -294,9 +272,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central
@@ -319,6 +294,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 6
     name: branch-ci-super-duper-master-upload-results
     spec:
@@ -351,9 +327,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -362,9 +335,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -379,6 +349,7 @@ postsubmits:
       ci-operator.openshift.io/is-promotion: "true"
       ci-operator.openshift.io/variant: variant
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-master-variant-images
     path_alias: whoa.com/super/duper
@@ -407,9 +378,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -421,9 +389,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-ci-index
     rerun_command: /test ci-index
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -66,6 +61,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-ci-index-my-bundle
     optional: true
     rerun_command: /test ci-index-my-bundle
@@ -91,9 +87,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -102,9 +95,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -121,6 +111,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-e2e
     rerun_command: /test e2e
     spec:
@@ -153,9 +144,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -164,9 +152,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -183,6 +168,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 100
     name: pull-ci-super-duper-master-images
     rerun_command: /test images
@@ -210,9 +196,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -221,9 +204,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -241,6 +221,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-build-affected-images
     rerun_command: /test images-build-affected-images
     spec:
@@ -267,9 +248,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -278,9 +256,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -298,6 +273,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-build-affected
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-build-affected-unit
     rerun_command: /test images-build-affected-unit
     spec:
@@ -331,9 +307,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -342,9 +315,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -362,6 +332,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-changed
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-changed-images
     rerun_command: /test images-changed-images
     run_if_changed: ^images/
@@ -389,9 +360,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -400,9 +368,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -420,6 +385,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-changed
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-changed-unit
     rerun_command: /test images-changed-unit
     spec:
@@ -453,9 +419,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -464,9 +427,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -486,6 +446,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-pipeline-changed
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-pipeline-changed-images
     rerun_command: /test images-pipeline-changed-images
     spec:
@@ -512,9 +473,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -523,9 +481,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -543,6 +498,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-pipeline-changed
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-pipeline-changed-unit
     rerun_command: /test images-pipeline-changed-unit
     spec:
@@ -576,9 +532,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -587,9 +540,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -607,6 +557,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-skip-docs
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-skip-docs-images
     rerun_command: /test images-skip-docs-images
     skip_if_only_changed: ^docs/
@@ -634,9 +585,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -645,9 +593,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -665,6 +610,7 @@ presubmits:
       ci-operator.openshift.io/variant: images-skip-docs
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images-skip-docs-unit
     rerun_command: /test images-skip-docs-unit
     spec:
@@ -698,9 +644,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -709,9 +652,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -738,6 +678,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-lint
     rerun_command: /test lint
     spec:
@@ -770,9 +711,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -781,9 +719,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -802,6 +737,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-optional-job
     optional: true
     rerun_command: /test optional-job
@@ -839,9 +775,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -856,9 +789,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -875,6 +805,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-registry
     rerun_command: /test registry
     spec:
@@ -911,9 +842,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -928,9 +856,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -949,6 +874,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-registry-with-profile
     rerun_command: /test registry-with-profile
     spec:
@@ -985,9 +911,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1002,9 +925,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1021,6 +941,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-steps
     rerun_command: /test steps
     spec:
@@ -1057,9 +978,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1074,9 +992,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1093,6 +1008,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-unit
     rerun_command: /test unit
     spec:
@@ -1125,9 +1041,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1136,9 +1049,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1156,6 +1066,7 @@ presubmits:
       ci-operator.openshift.io/variant: variant
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-variant-images
     path_alias: whoa.com/super/duper
     rerun_command: /test variant-images
@@ -1183,9 +1094,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1194,9 +1102,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1214,6 +1119,7 @@ presubmits:
       ci-operator.openshift.io/variant: variant
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-variant-unit
     path_alias: whoa.com/super/duper
     rerun_command: /test variant-unit
@@ -1248,9 +1154,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1259,9 +1162,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-removed-promotion-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-removed-promotion-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-postsubmits.yaml
@@ -10,6 +10,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-super-duper-release-3.11-images
     spec:
@@ -37,9 +38,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -51,9 +49,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-3.11-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-release-3.11-images
     rerun_command: /test images
     spec:
@@ -37,9 +38,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -48,9 +46,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -77,6 +72,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-release-3.11-lint
     rerun_command: /test lint
     spec:
@@ -109,9 +105,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -120,9 +113,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -139,6 +129,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-release-3.11-unit
     rerun_command: /test unit
     spec:
@@ -171,9 +162,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -182,9 +170,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-4.19-periodics.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-release-4.19-periodics.yaml
@@ -10,6 +10,7 @@ periodics:
     ci-operator.openshift.io/variant: periodics
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-duper-release-4.19-periodics-unit
   spec:
     containers:
@@ -42,9 +43,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -53,9 +51,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -45,6 +45,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-ciop-cfg-change-images
     rerun_command: /test images
     spec:
@@ -69,9 +70,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -80,9 +78,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-cluster-profile-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -87,6 +87,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images
     rerun_command: /test images
     spec:
@@ -111,9 +112,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -122,9 +120,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -57,6 +57,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-trooper-master-changed-periodic
   spec:
     containers:
@@ -92,9 +93,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -109,9 +107,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -86,6 +86,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-images
     rerun_command: /test images
     spec:
@@ -110,9 +111,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -121,9 +119,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -169,6 +164,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage
     rerun_command: /test multistage
     spec:
@@ -205,9 +201,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -222,9 +215,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -241,6 +231,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage2
     rerun_command: /test multistage2
     spec:
@@ -277,9 +268,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -294,9 +282,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -315,6 +300,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage3
     rerun_command: /test multistage3
     spec:
@@ -351,9 +337,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -368,9 +351,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -387,6 +367,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage4
     rerun_command: /test multistage4
     spec:
@@ -423,9 +404,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -440,9 +418,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -459,6 +434,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage5
     rerun_command: /test multistage5
     spec:
@@ -495,9 +471,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -512,9 +485,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -531,6 +501,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-unit
     rerun_command: /test unit
     spec:
@@ -563,9 +534,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -574,9 +542,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/candidate/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/candidate/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-should-not-be-rehearsed
     rerun_command: /test should-not-be-rehearsed
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -74,6 +69,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer
     rerun_command: /test test-with-changed-observer
     spec:
@@ -110,9 +106,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -127,9 +120,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -146,6 +136,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer-commands
     rerun_command: /test test-with-changed-observer-commands
     spec:
@@ -182,9 +173,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -199,9 +187,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -218,6 +203,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer-workflow
     rerun_command: /test test-with-changed-observer-workflow
     spec:
@@ -254,9 +240,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -271,9 +254,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -290,6 +270,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-unchanged-observer
     rerun_command: /test test-with-unchanged-observer
     spec:
@@ -326,9 +307,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -343,9 +321,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -362,6 +337,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-unchanged-observer-workflow
     rerun_command: /test test-with-unchanged-observer-workflow
     spec:
@@ -398,9 +374,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -415,9 +388,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -460,6 +460,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: periodic-ci-super-trooper-master-changed-periodic
       prow.k8s.io/job: rehearse-1234-periodic-ci-super-trooper-master-changed-periodic
       prow.k8s.io/refs.base_ref: master
@@ -533,9 +534,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -550,9 +548,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -677,6 +672,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: images
       prow.k8s.io/job: rehearse-1234-pull-ci-super-duper-ciop-cfg-change-images
       prow.k8s.io/refs.base_ref: master
@@ -739,9 +735,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -750,9 +743,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1075,6 +1065,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: multistage
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage
       prow.k8s.io/refs.base_ref: master
@@ -1148,9 +1139,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1165,9 +1153,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1202,6 +1187,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: multistage2
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage2
       prow.k8s.io/refs.base_ref: master
@@ -1275,9 +1261,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1292,9 +1275,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1331,6 +1311,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: multistage3
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage3
       prow.k8s.io/refs.base_ref: master
@@ -1404,9 +1385,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1421,9 +1399,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1458,6 +1433,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedPresubmit
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: multistage5
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-multistage5
       prow.k8s.io/refs.base_ref: master
@@ -1531,9 +1507,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1548,9 +1521,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1585,6 +1555,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedCiopConfig
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: unit
       prow.k8s.io/job: rehearse-1234-pull-ci-super-trooper-master-unit
       prow.k8s.io/refs.base_ref: master
@@ -1654,9 +1625,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1665,9 +1633,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1702,6 +1667,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: test-with-changed-observer
       prow.k8s.io/job: rehearse-1234-pull-ci-uses-observer-master-test-with-changed-ob
       prow.k8s.io/refs.base_ref: master
@@ -1775,9 +1741,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1792,9 +1755,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1829,6 +1789,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: test-with-changed-observer-com
       prow.k8s.io/job: rehearse-1234-pull-ci-uses-observer-master-test-with-changed-ob
       prow.k8s.io/refs.base_ref: master
@@ -1902,9 +1863,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -1919,9 +1877,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -1956,6 +1911,7 @@
       created-by-prow: "true"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
       pj-rehearse.openshift.io/source-type: changedRegistryContent
+      presets.ci.openshift.io/registry-pull: "true"
       prow.k8s.io/context: test-with-changed-observer-wor
       prow.k8s.io/job: rehearse-1234-pull-ci-uses-observer-master-test-with-changed-ob
       prow.k8s.io/refs.base_ref: master
@@ -2029,9 +1985,6 @@
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -2046,9 +1999,6 @@
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-ciop-cfg-change-presubmits.yaml
@@ -45,6 +45,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-ciop-cfg-change-images
     rerun_command: /test images
     spec:
@@ -69,9 +70,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -80,9 +78,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-cluster-profile-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-cluster-profile-images
     rerun_command: /test images
     spec:
@@ -36,9 +37,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -47,9 +45,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/duper/super-duper-master-presubmits.yaml
@@ -82,6 +82,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-duper-master-images
     rerun_command: /test images
     spec:
@@ -106,9 +107,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -117,9 +115,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-periodics.yaml
@@ -56,6 +56,7 @@ periodics:
   labels:
     ci.openshift.io/generator: prowgen
     pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    presets.ci.openshift.io/registry-pull: "true"
   name: periodic-ci-super-trooper-master-changed-periodic
   spec:
     containers:
@@ -91,9 +92,6 @@ periodics:
       - mountPath: /secrets/manifest-tool
         name: manifest-tool-local-pusher
         readOnly: true
-      - mountPath: /etc/pull-secret
-        name: pull-secret
-        readOnly: true
       - mountPath: /etc/report
         name: result-aggregator
         readOnly: true
@@ -108,9 +106,6 @@ periodics:
     - name: manifest-tool-local-pusher
       secret:
         secretName: manifest-tool-local-pusher
-    - name: pull-secret
-      secret:
-        secretName: registry-pull-credentials
     - name: result-aggregator
       secret:
         secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/super/trooper/super-trooper-master-presubmits.yaml
@@ -86,6 +86,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-images
     rerun_command: /test images
     spec:
@@ -110,9 +111,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -121,9 +119,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -169,6 +164,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage
     rerun_command: /test multistage
     spec:
@@ -205,9 +201,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -222,9 +215,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -241,6 +231,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage2
     rerun_command: /test multistage2
     spec:
@@ -277,9 +268,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -294,9 +282,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -315,6 +300,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: azure4
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage3
     rerun_command: /test multistage3
     spec:
@@ -351,9 +337,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -368,9 +351,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -387,6 +367,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-multistage4
     rerun_command: /test multistage4
     spec:
@@ -423,9 +404,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -440,9 +418,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -459,6 +434,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-super-trooper-master-unit
     rerun_command: /test unit
     spec:
@@ -491,9 +467,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -502,9 +475,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/pj-rehearse/master/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
+++ b/test/integration/pj-rehearse/master/ci-operator/jobs/uses/observer/uses-observer-master-presubmits.yaml
@@ -12,6 +12,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-should-not-be-rehearsed
     rerun_command: /test should-not-be-rehearsed
     spec:
@@ -44,9 +45,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -55,9 +53,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -74,6 +69,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer
     rerun_command: /test test-with-changed-observer
     spec:
@@ -110,9 +106,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -127,9 +120,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -146,6 +136,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer-commands
     rerun_command: /test test-with-changed-observer-commands
     spec:
@@ -182,9 +173,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -199,9 +187,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -218,6 +203,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-changed-observer-workflow
     rerun_command: /test test-with-changed-observer-workflow
     spec:
@@ -254,9 +240,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -271,9 +254,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -290,6 +270,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-unchanged-observer
     rerun_command: /test test-with-unchanged-observer
     spec:
@@ -326,9 +307,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -343,9 +321,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -362,6 +337,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-uses-observer-master-test-with-unchanged-observer-workflow
     rerun_command: /test test-with-unchanged-observer-workflow
     spec:
@@ -398,9 +374,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -415,9 +388,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-postsubmits.yaml
@@ -11,6 +11,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-openshift-ci-tools-master-images
     spec:
@@ -37,9 +38,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -51,9 +49,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/ci-tools/openshift-ci-tools-master-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-openshift-ci-tools-master-images
     rerun_command: /test images
     spec:
@@ -37,9 +38,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -48,9 +46,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -68,6 +63,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-openshift-ci-tools-master-unit
     rerun_command: /test unit
     spec:
@@ -100,9 +96,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -111,9 +104,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-postsubmits.yaml
@@ -11,6 +11,7 @@ postsubmits:
     labels:
       ci-operator.openshift.io/is-promotion: "true"
       ci.openshift.io/generator: prowgen
+      presets.ci.openshift.io/registry-pull: "true"
     max_concurrency: 1
     name: branch-ci-openshift-origin-main-images
     spec:
@@ -38,9 +39,6 @@ postsubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/push-secret
           name: push-secret
           readOnly: true
@@ -52,9 +50,6 @@ postsubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: push-secret
         secret:
           secretName: registry-push-credentials-ci-central

--- a/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/openshift/origin/openshift-origin-main-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-openshift-origin-main-images
     rerun_command: /test images
     spec:
@@ -39,9 +40,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -50,9 +48,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -70,6 +65,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-openshift-origin-main-unit
     rerun_command: /test unit
     spec:
@@ -102,9 +98,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -113,9 +106,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/other/org-other-nonstandard-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-other-nonstandard-unit
     path_alias: k8s.io/cool
     rerun_command: /test unit
@@ -46,9 +47,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -57,9 +55,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-main-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/repo/org-repo-main-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-repo-main-cmd
     rerun_command: /test cmd
     spec:
@@ -45,9 +46,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -56,9 +54,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -78,6 +73,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-repo-main-e2e
     rerun_command: /test e2e
     spec:
@@ -118,9 +114,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -138,9 +131,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -160,6 +150,7 @@ presubmits:
       ci-operator.openshift.io/cloud-cluster-profile: aws
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-repo-main-e2e-aws
     rerun_command: /test e2e-aws
     spec:
@@ -200,9 +191,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -220,9 +208,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -240,6 +225,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-repo-main-race
     rerun_command: /test race
     spec:
@@ -272,9 +258,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -283,9 +266,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator
@@ -303,6 +283,7 @@ presubmits:
     labels:
       ci.openshift.io/generator: prowgen
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-repo-main-unit
     rerun_command: /test unit
     spec:
@@ -335,9 +316,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -346,9 +324,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator

--- a/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
+++ b/test/integration/repo-init/expected/ci-operator/jobs/org/third/org-third-nonstandard-presubmits.yaml
@@ -16,6 +16,7 @@ presubmits:
       ci.openshift.io/generator: prowgen
       job-release: "4.4"
       pj-rehearse.openshift.io/can-be-rehearsed: "true"
+      presets.ci.openshift.io/registry-pull: "true"
     name: pull-ci-org-third-nonstandard-e2e
     path_alias: k8s.io/cool
     rerun_command: /test e2e
@@ -57,9 +58,6 @@ presubmits:
         - mountPath: /secrets/manifest-tool
           name: manifest-tool-local-pusher
           readOnly: true
-        - mountPath: /etc/pull-secret
-          name: pull-secret
-          readOnly: true
         - mountPath: /etc/report
           name: result-aggregator
           readOnly: true
@@ -77,9 +75,6 @@ presubmits:
       - name: manifest-tool-local-pusher
         secret:
           secretName: manifest-tool-local-pusher
-      - name: pull-secret
-        secret:
-          secretName: registry-pull-credentials
       - name: result-aggregator
         secret:
           secretName: result-aggregator


### PR DESCRIPTION
Third attempt to do #4994 after we had to revert #5019

Move the pull-secret volume and volumeMount from the hardcoded defaultPodSpec to a Prow preset.

This is a proof of concept for using compositional Prow presets to deduplicate the ~28 lines of boilerplate volumes/mounts that are inlined into every one of the 126K+ generated Prowjob definitions.

The preset is defined in openshift/release and matched via a new label added to all prowgen-generated jobs. The --image-import-pull-secret arg remains inline since presets cannot inject container args.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can opt into registry-pull via a new preset label, enabling platform-provided registry pull credentials.

* **Bug Fixes & Improvements**
  * Removed explicit in-pod registry pull secret mounts from generated job pods; registry pull creds are now provided by the preset, simplifying job specs and reducing duplicated secret wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->