### PR TITLE
Remove manifest-tool from ci-operator-minimal and multi-arch-builder-controller images

### DIFF
--- a/images/ci-operator-minimal/Dockerfile
+++ b/images/ci-operator-minimal/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ADD manifest-tool /usr/bin/manifest-tool
 ADD ci-operator /usr/bin/ci-operator
 ENTRYPOINT ["/usr/bin/ci-operator"]

--- a/images/multi-arch-builder-controller/Dockerfile
+++ b/images/multi-arch-builder-controller/Dockerfile
@@ -1,6 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
-ADD manifest-tool /usr/bin/manifest-tool
 ADD multi-arch-builder-controller /usr/bin/multi-arch-builder-controller
 ADD oc /usr/bin/oc
 ENTRYPOINT ["/usr/bin/multi-arch-builder-controller"]


### PR DESCRIPTION
/cc @droslean @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `manifest-tool` binary from CI operator and multi-arch builder controller container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->