### PR TITLE
prowgen: allow ci-operator config to enable CSI secrets store

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -25,8 +25,9 @@ func IsPromotionJob(jobLabels map[string]string) bool {
 }
 
 type ProwgenOverrides struct {
-	DisableRehearsals      bool `json:"disable_rehearsals,omitempty"`
-	SkipOperatorPresubmits bool `json:"skip_operator_presubmits,omitempty"`
+	DisableRehearsals           bool `json:"disable_rehearsals,omitempty"`
+	SkipOperatorPresubmits      bool `json:"skip_operator_presubmits,omitempty"`
+	EnableSecretsStoreCSIDriver bool `json:"enable_secrets_store_csi_driver,omitempty"`
 }
 
 // ReleaseBuildConfiguration describes how release

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -147,7 +147,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
 		}
-		if info.Config.EnableSecretsStoreCSIDriver {
+		if info.Config.EnableSecretsStoreCSIDriver || (configSpec.Prowgen != nil && configSpec.Prowgen.EnableSecretsStoreCSIDriver) {
 			p.PodSpec.Add(
 				GSMConfig(),
 			)
@@ -161,7 +161,7 @@ func NewProwJobBaseBuilderForTest(configSpec *cioperatorapi.ReleaseBuildConfigur
 		if configSpec.Releases != nil {
 			p.PodSpec.Add(CIPullSecret())
 		}
-		if info.Config.EnableSecretsStoreCSIDriver {
+		if info.Config.EnableSecretsStoreCSIDriver || (configSpec.Prowgen != nil && configSpec.Prowgen.EnableSecretsStoreCSIDriver) {
 			p.PodSpec.Add(
 				GSMConfig(),
 			)

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -355,6 +355,19 @@ func TestNewProwJobBaseBuilderForTest(t *testing.T) {
 			},
 		},
 		{
+			name: "multi-stage test with CSI enabled via ci-operator config",
+			cfg: &ciop.ReleaseBuildConfiguration{
+				Prowgen: &ciop.ProwgenOverrides{EnableSecretsStoreCSIDriver: true},
+			},
+			test: ciop.TestStepConfiguration{
+				As: "simple",
+				MultiStageTestConfiguration: &ciop.MultiStageTestConfiguration{
+					Workflow: pointer.StringPtr("workflow"),
+				},
+			},
+			info: defaultInfo,
+		},
+		{
 			name: "multi-stage test with claim",
 			test: ciop.TestStepConfiguration{
 				As:           "simple",

--- a/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestNewProwJobBaseBuilderForTest_multi_stage_test_with_CSI_enabled_via_ci_operator_config.yaml
@@ -1,0 +1,81 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: prefix-ci-o-r-b-simple
+spec:
+  containers:
+  - args:
+    - --enable-secrets-store-csi-driver=true
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --gsm-config=/etc/gsm-config/gsm-config.yaml
+    - --gsm-credentials-file=/etc/gsm-credentials/key.json
+    - --gsm-project-config=/etc/gsm-config/gsm-project-config.yaml
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --lease-server-credentials-file=/etc/boskos/credentials
+    - --report-credentials-file=/etc/report/credentials
+    - --target=simple
+    command:
+    - ci-operator
+    env:
+    - name: HTTP_SERVER_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    ports:
+    - containerPort: 8080
+      name: http
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /etc/boskos
+      name: boskos
+      readOnly: true
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /etc/gsm-config
+      name: gsm-config
+      readOnly: true
+    - mountPath: /etc/gsm-credentials
+      name: gsm-sa-key
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: boskos
+    secret:
+      items:
+      - key: credentials
+        path: credentials
+      secretName: boskos-credentials
+  - configMap:
+      name: gsm-config
+    name: gsm-config
+  - csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: ci-operator-sa-key-spc
+    name: gsm-sa-key
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -336,6 +336,7 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"          tag_by_commit: true\n" +
 	"prowgen:\n" +
 	"    disable_rehearsals: true\n" +
+	"    enable_secrets_store_csi_driver: true\n" +
 	"    skip_operator_presubmits: true\n" +
 	"# RawSteps are literal Steps that should be\n" +
 	"# included in the final pipeline.\n" +


### PR DESCRIPTION
## Summary
- Add `enable_secrets_store_csi_driver` to the `prowgen` section of ci-operator config
- Jobs can now enable CSI secrets store directly in ci-operator config instead of requiring a `.config.prowgen` file
- Second step toward deprecating `.config.prowgen` (follows #5119 which added rehearsal control)

## Test plan
- [x] New test case: "multi-stage test with CSI enabled via ci-operator config"
- [x] Fixture output identical to existing `.config.prowgen`-based CSI test
- [x] All existing tests pass (`go test ./pkg/prowgen/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable Secrets Store CSI Driver via Prowgen overrides for multi-stage jobs, causing generated jobs to include Secrets Store CSI driver configuration when set.
* **Tests**
  * Added a test case and fixture validating CSI enablement through Prowgen overrides and the resulting job configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->