### PR TITLE
Store ephemeral cluster credentials in a Secret instead of the status

### DIFF
--- a/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
+++ b/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml
@@ -471,11 +471,6 @@ spec:
                   - type
                   type: object
                 type: array
-              kubeAdminPassword:
-                type: string
-              kubeconfig:
-                description: Kubeconfig to access the ephemeral cluster
-                type: string
               phase:
                 description: Phase is an high level description of where the ephemeral
                   cluster is in its lifecycle
@@ -483,6 +478,12 @@ spec:
               prowJobId:
                 type: string
               prowJobURL:
+                type: string
+              secretRef:
+                description: |-
+                  SecretRef is the name of the Secret containing credentials to access the
+                  ephemeral cluster. The Secret is in the same namespace as the EphemeralCluster
+                  and contains a "kubeconfig" key and optionally a "kubeAdminPassword" key.
                 type: string
             required:
             - phase

--- a/pkg/api/ephemeralcluster/v1/types.go
+++ b/pkg/api/ephemeralcluster/v1/types.go
@@ -114,9 +114,10 @@ type EphemeralClusterStatus struct {
 	Conditions []EphemeralClusterCondition `json:"conditions,omitempty"`
 	ProwJobID  string                      `json:"prowJobId,omitempty"`
 	ProwJobURL string                      `json:"prowJobURL,omitempty"`
-	// Kubeconfig to access the ephemeral cluster
-	Kubeconfig        string `json:"kubeconfig,omitempty"`
-	KubeAdminPassword string `json:"kubeAdminPassword,omitempty"`
+	// SecretRef is the name of the Secret containing credentials to access the
+	// ephemeral cluster. The Secret is in the same namespace as the EphemeralCluster
+	// and contains a "kubeconfig" key and optionally a "kubeAdminPassword" key.
+	SecretRef string `json:"secretRef,omitempty"`
 }
 
 // EphemeralClusterCondition contains details for the current condition of this EphemeralCluster.

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -18,12 +18,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
 	ctrlbldr "sigs.k8s.io/controller-runtime/pkg/builder"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	ctrlruntimeutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -103,6 +105,7 @@ type reconciler struct {
 	buildClients    map[string]ctrlruntimeclient.Client
 	newProwJob      NewProwJobFunc
 	prowConfigAgent *prowconfig.Agent
+	scheme          *runtime.Scheme
 
 	// Mock for testing
 	now         func() time.Time
@@ -135,6 +138,7 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		masterClient:    mgr.GetClient(),
 		buildClients:    buildClients,
 		prowConfigAgent: prowConfigAgent,
+		scheme:          mgr.GetScheme(),
 		newProwJob:      pjutil.NewProwJob,
 		now:             time.Now,
 		polling:         func() time.Duration { return defaultReconcilerOpts.polling },
@@ -451,7 +455,13 @@ func (r *reconciler) makeProwJob(ciOperatorConfig *api.ReleaseBuildConfiguration
 	return &pj, nil
 }
 
-func (r *reconciler) fetchSecrets(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, ecStatus *ephemeralclusterv1.EphemeralClusterStatus, pj *prowv1.ProwJob) error {
+func (r *reconciler) fetchSecrets(
+	ctx context.Context,
+	log *logrus.Entry,
+	ec *ephemeralclusterv1.EphemeralCluster,
+	ecStatus *ephemeralclusterv1.EphemeralClusterStatus,
+	pj *prowv1.ProwJob,
+) error {
 	buildClient, err := r.buildClientFor(pj)
 	if err != nil {
 		log.WithField("cluster", pj.Spec.Cluster).WithError(err).Error("Build client not found")
@@ -469,15 +479,22 @@ func (r *reconciler) fetchSecrets(ctx context.Context, log *logrus.Entry, ec *ep
 	log.WithField("namespace", ns).Info("ci-operator namespace found")
 
 	if ec.Spec.CIOperator.Test.ClusterClaim != nil {
-		r.fetchHiveSecrets(ctx, log, buildClient, ns, ecStatus)
+		r.fetchHiveSecrets(ctx, log, ec, buildClient, ns, ecStatus)
 	} else {
-		r.fetchClusterKubeconfig(ctx, log, buildClient, ns, ecStatus)
+		r.fetchClusterKubeconfig(ctx, log, ec, buildClient, ns, ecStatus)
 	}
 
 	return nil
 }
 
-func (r *reconciler) fetchHiveSecrets(ctx context.Context, log *logrus.Entry, buildClient ctrlruntimeclient.Client, ns string, ecStatus *ephemeralclusterv1.EphemeralClusterStatus) {
+func (r *reconciler) fetchHiveSecrets(
+	ctx context.Context,
+	log *logrus.Entry,
+	ec *ephemeralclusterv1.EphemeralCluster,
+	buildClient ctrlruntimeclient.Client,
+	ns string,
+	ecStatus *ephemeralclusterv1.EphemeralClusterStatus,
+) {
 	secretsReady := true
 	var kubeconfig, passwd []byte
 
@@ -515,14 +532,27 @@ func (r *reconciler) fetchHiveSecrets(ctx context.Context, log *logrus.Entry, bu
 		return
 	}
 
-	ecStatus.Kubeconfig = string(kubeconfig)
-	ecStatus.KubeAdminPassword = string(passwd)
+	secretData := map[string][]byte{"kubeconfig": kubeconfig, "kubeAdminPassword": passwd}
+	if err := r.createCredentialsSecret(ctx, log, ec, secretData); err != nil {
+		log.WithError(err).Error("Failed to create credentials secret")
+		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())
+		return
+	}
+
+	ecStatus.SecretRef = credentialsSecretName(ec)
 	log.Info("hive secrets fetched")
 	upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionTrue, r.now(), "", "")
 	ecStatus.Phase = ephemeralclusterv1.EphemeralClusterReady
 }
 
-func (r *reconciler) fetchClusterKubeconfig(ctx context.Context, log *logrus.Entry, buildClient ctrlruntimeclient.Client, ns string, ecStatus *ephemeralclusterv1.EphemeralClusterStatus) {
+func (r *reconciler) fetchClusterKubeconfig(
+	ctx context.Context,
+	log *logrus.Entry,
+	ec *ephemeralclusterv1.EphemeralCluster,
+	buildClient ctrlruntimeclient.Client,
+	ns string,
+	ecStatus *ephemeralclusterv1.EphemeralClusterStatus,
+) {
 	kubeconfigSecret := corev1.Secret{}
 	// The secret is named after the test name.
 	if err := buildClient.Get(ctx, types.NamespacedName{Name: EphemeralClusterTestName, Namespace: ns}, &kubeconfigSecret); err != nil {
@@ -538,7 +568,14 @@ func (r *reconciler) fetchClusterKubeconfig(ctx context.Context, log *logrus.Ent
 		return
 	}
 
-	ecStatus.Kubeconfig = string(kubeconfig)
+	secretData := map[string][]byte{"kubeconfig": kubeconfig}
+	if err := r.createCredentialsSecret(ctx, log, ec, secretData); err != nil {
+		log.WithError(err).Error("Failed to create credentials secret")
+		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())
+		return
+	}
+
+	ecStatus.SecretRef = credentialsSecretName(ec)
 	log.Info("kubeconfig fetched")
 	upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionTrue, r.now(), "", "")
 	ecStatus.Phase = ephemeralclusterv1.EphemeralClusterReady
@@ -556,6 +593,53 @@ func (r *reconciler) updateEphemeralCluster(ctx context.Context, ec *ephemeralcl
 	if err := r.masterClient.Update(ctx, ec); err != nil {
 		return fmt.Errorf("update ephemeral cluster: %w", err)
 	}
+	return nil
+}
+
+func credentialsSecretName(ec *ephemeralclusterv1.EphemeralCluster) string {
+	return ec.Name + "-credentials"
+}
+
+func (r *reconciler) createCredentialsSecret(
+	ctx context.Context,
+	log *logrus.Entry,
+	ec *ephemeralclusterv1.EphemeralCluster,
+	data map[string][]byte,
+) error {
+	secretName := credentialsSecretName(ec)
+
+	existing := corev1.Secret{}
+	err := r.masterClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ec.Namespace}, &existing)
+	if err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("check credentials secret: %w", err)
+	}
+	if err == nil {
+		if !v1.IsControlledBy(&existing, ec) {
+			return fmt.Errorf("credentials secret %s/%s exists but is not owned by ephemeralcluster %s (uid=%s)",
+				ec.Namespace, secretName, ec.Name, ec.UID)
+		}
+		return nil
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secretName,
+			Namespace: ec.Namespace,
+		},
+		Data: data,
+	}
+	if err := ctrlruntimeutil.SetControllerReference(ec, secret, r.scheme); err != nil {
+		return fmt.Errorf("set owner reference on credentials secret: %w", err)
+	}
+
+	if err := r.masterClient.Create(ctx, secret); err != nil {
+		if !kerrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create credentials secret: %w", err)
+		}
+	} else {
+		log.WithField("secret", secretName).Info("Credentials secret created")
+	}
+
 	return nil
 }
 

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -443,6 +443,7 @@ func TestReconcile(t *testing.T) {
 		objs         []ctrlclient.Object
 		buildClients func() map[string]*ctrlruntimetest.FakeClient
 		wantEC       *ephemeralclusterv1.EphemeralCluster
+		wantSecret   *corev1.Secret
 		wantRes      reconcile.Result
 		wantErr      error
 	}{
@@ -452,6 +453,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -482,6 +484,13 @@ func TestReconcile(t *testing.T) {
 					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
 				}
 			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo-credentials",
+					Namespace: "bar",
+				},
+				Data: map[string][]byte{"kubeconfig": []byte("kubeconfig")},
+			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name:            "foo",
@@ -491,7 +500,7 @@ func TestReconcile(t *testing.T) {
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					Phase:      ephemeralclusterv1.EphemeralClusterReady,
 					ProwJobID:  "pj-123",
-					Kubeconfig: "kubeconfig",
+					SecretRef:  "foo-credentials",
 					ProwJobURL: "https://pj-123.html",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
@@ -513,6 +522,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -562,6 +572,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -618,6 +629,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -677,6 +689,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -723,6 +736,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -777,6 +791,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					ProwJobID: "pj-123",
@@ -813,9 +828,9 @@ func TestReconcile(t *testing.T) {
 					Namespace: "bar",
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
-					Phase:      ephemeralclusterv1.EphemeralClusterDeprovisioned,
-					ProwJobID:  "pj-123",
-					Kubeconfig: "kubeconfig",
+					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioned,
+					ProwJobID: "pj-123",
+					SecretRef: "foo-credentials",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -842,6 +857,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:       "foo",
 					Namespace:  "bar",
+					UID:        types.UID("test-ec-uid"),
 					Finalizers: []string{DependentProwJobFinalizer},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -865,6 +881,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{TearDownCluster: true},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -905,6 +922,7 @@ func TestReconcile(t *testing.T) {
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
 					Phase:     ephemeralclusterv1.EphemeralClusterDeprovisioning,
 					ProwJobID: "pj-123",
+					SecretRef: "foo-credentials",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -919,7 +937,6 @@ func TestReconcile(t *testing.T) {
 						Status:             ephemeralclusterv1.ConditionTrue,
 						LastTransitionTime: v1.NewTime(fakeNow),
 					}},
-					Kubeconfig: "kubeconfig",
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
@@ -930,6 +947,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{TearDownCluster: true},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -986,6 +1004,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{TearDownCluster: true},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1055,6 +1074,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
@@ -1095,6 +1115,16 @@ func TestReconcile(t *testing.T) {
 					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
 				}
 			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "foo-credentials",
+					Namespace: "bar",
+				},
+				Data: map[string][]byte{
+					"kubeconfig":        []byte("kubeconfig"),
+					"kubeAdminPassword": []byte("admin-passwd"),
+				},
+			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{
 					Name:            "foo",
@@ -1109,10 +1139,9 @@ func TestReconcile(t *testing.T) {
 					},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
-					Phase:             ephemeralclusterv1.EphemeralClusterReady,
-					ProwJobID:         "pj-123",
-					Kubeconfig:        "kubeconfig",
-					KubeAdminPassword: "admin-passwd",
+					Phase:     ephemeralclusterv1.EphemeralClusterReady,
+					ProwJobID: "pj-123",
+					SecretRef: "foo-credentials",
 					Conditions: []ephemeralclusterv1.EphemeralClusterCondition{{
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
@@ -1133,6 +1162,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
@@ -1207,6 +1237,7 @@ func TestReconcile(t *testing.T) {
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
+					UID:       types.UID("test-ec-uid"),
 				},
 				Spec: ephemeralclusterv1.EphemeralClusterSpec{
 					CIOperator: ephemeralclusterv1.CIOperatorSpec{
@@ -1307,6 +1338,7 @@ func TestReconcile(t *testing.T) {
 				logger:       logrus.NewEntry(logrus.StandardLogger()),
 				masterClient: client,
 				buildClients: clients,
+				scheme:       scheme,
 				now:          func() time.Time { return fakeNow },
 				polling:      func() time.Duration { return pollingTime },
 				newProwJob:   newProwJobFaker("foobar", fakeNow),
@@ -1327,9 +1359,26 @@ func TestReconcile(t *testing.T) {
 				t.Errorf("unexpected get ephemeralcluster error: %s", err)
 			}
 
-			ignoreFields := cmpopts.IgnoreFields(ephemeralclusterv1.EphemeralCluster{}, "ResourceVersion")
+			ignoreFields := cmpopts.IgnoreFields(ephemeralclusterv1.EphemeralCluster{}, "ResourceVersion", "UID")
 			if diff := cmp.Diff(tc.wantEC, &gotEC, ignoreFields); diff != "" {
 				t.Errorf("unexpected ephemeralcluster: %s", diff)
+			}
+
+			if tc.wantSecret != nil {
+				gotSecret := corev1.Secret{}
+				if err := client.Get(context.TODO(), types.NamespacedName{
+					Name:      tc.wantSecret.Name,
+					Namespace: tc.wantSecret.Namespace,
+				}, &gotSecret); err != nil {
+					t.Fatalf("get credentials secret: %s", err)
+				}
+				if diff := cmp.Diff(tc.wantSecret.Data, gotSecret.Data); diff != "" {
+					t.Errorf("unexpected credentials secret data: %s", diff)
+				}
+				if !v1.IsControlledBy(&gotSecret, tc.ec) {
+					t.Errorf("credentials secret %s/%s is not controlled by ephemeralcluster %s",
+						gotSecret.Namespace, gotSecret.Name, tc.ec.Name)
+				}
 			}
 
 			for cluster, c := range fakeClients {
@@ -1471,7 +1520,7 @@ func TestDeleteProwJob(t *testing.T) {
 					t.Errorf("unexpected get ephemeralcluster error: %s", err)
 				}
 
-				ignoreFields := cmpopts.IgnoreFields(ephemeralclusterv1.EphemeralCluster{}, "ResourceVersion")
+				ignoreFields := cmpopts.IgnoreFields(ephemeralclusterv1.EphemeralCluster{}, "ResourceVersion", "UID")
 				if diff := cmp.Diff(tc.wantEC, &gotEC, ignoreFields); diff != "" {
 					t.Errorf("unexpected ephemeralcluster: %s", diff)
 				}


### PR DESCRIPTION
The kubeconfig and kubeAdminPassword were previously written directly to the EphemeralCluster status, exposing sensitive credentials in a resource that may be logged or cached. Instead, create a credentials Secret in the same namespace as the EphemeralCluster and reference it via a new status.secretRef field. The Secret is owned by the EphemeralCluster for automatic cleanup.

Jira: https://redhat.atlassian.net/browse/KFLUXVNGD-899

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EphemeralCluster now uses Secret references (`secretRef`) for storing credentials instead of direct fields in the specification and status. Credentials are consolidated into a single Secret resource in the same namespace containing `kubeconfig` and optional `kubeAdminPassword` keys.

* **Chores**
  * Updated controller reconciliation and test cases to support the new credential storage mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->