### PR TITLE
Ephemeral Cluster Controller: Terminate ci-operator gracefully

### DIFF
--- a/pkg/controller/ephemeralcluster/prowjobreconciler.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler.go
@@ -8,19 +8,22 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlbldr "sigs.k8s.io/controller-runtime/pkg/builder"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/openshift/ci-tools/pkg/steps"
 )
 
 const (
@@ -28,22 +31,24 @@ const (
 )
 
 type prowJobReconciler struct {
-	logger *logrus.Entry
-	client ctrlclient.Client
+	logger       *logrus.Entry
+	masterClient ctrlruntimeclient.Client
+	buildClients buildClients
 
 	now func() time.Time
 }
 
-func ProwJobFilter(object ctrlclient.Object) bool {
+func ProwJobFilter(object ctrlruntimeclient.Object) bool {
 	_, ok := object.GetLabels()[EphemeralClusterLabel]
 	return ok
 }
 
-func addPJReconcilerToManager(logger *logrus.Entry, mgr manager.Manager) error {
+func addPJReconcilerToManager(logger *logrus.Entry, mgr manager.Manager, buildClients buildClients) error {
 	r := prowJobReconciler{
-		logger: logger.WithField("controller", "ephemeral_cluster_provisioner_pj"),
-		client: mgr.GetClient(),
-		now:    time.Now,
+		logger:       logger.WithField("controller", "ephemeral_cluster_provisioner_pj"),
+		masterClient: mgr.GetClient(),
+		buildClients: buildClients,
+		now:          time.Now,
 	}
 
 	if err := ctrlbldr.ControllerManagedBy(mgr).
@@ -58,9 +63,11 @@ func addPJReconcilerToManager(logger *logrus.Entry, mgr manager.Manager) error {
 }
 
 func (r *prowJobReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := r.logger.WithField("request", req.String())
+
 	pj := &prowv1.ProwJob{}
-	if err := r.client.Get(ctx, req.NamespacedName, pj); err != nil {
-		if kerrors.IsNotFound(err) {
+	if err := r.masterClient.Get(ctx, req.NamespacedName, pj); err != nil {
+		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		} else {
 			return reconcile.Result{}, err
@@ -72,13 +79,62 @@ func (r *prowJobReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("%s doesn't have the EC label", pj.Name))
 	}
 
-	ec := ephemeralclusterv1.EphemeralCluster{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: ecName, Namespace: EphemeralClusterNamespace}, &ec); err != nil {
-		if kerrors.IsNotFound(err) {
-			return r.abortProwJob(ctx, pj)
-		} else {
+	log = log.WithField("ephemeralcluster", ecName)
+
+	err := r.masterClient.Get(ctx, types.NamespacedName{Name: ecName, Namespace: EphemeralClusterNamespace}, &ephemeralclusterv1.EphemeralCluster{})
+	if err == nil {
+		return reconcile.Result{}, nil
+	}
+
+	if !apierrors.IsNotFound(err) {
+		return reconcile.Result{}, err
+	}
+
+	return r.gracefullyTerminateClusterProvisioning(ctx, log, pj)
+}
+
+// gracefullyTerminateClusterProvisioning terminates the ProwJob. This procedure makes some assumptions about
+// the cluster provisioning procedure, in particular: if the ci-operator namespace has been created, it's likely
+// that the provisioning procedure has begun already. Therefore let it going but trigger the deprovisioning
+// procedure right away. In this way we avoid leaking cloud resources for too long, but we rather:
+//  1. Provision the cluster
+//  2. Do not use it to test anything at all
+//  3. Deprovision the cluster
+//
+// On the other hand, if ci-operator has not even created a namespace, abort the ProwJob right away since no
+// cloud resources has been created so far.
+func (r *prowJobReconciler) gracefullyTerminateClusterProvisioning(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) (reconcile.Result, error) {
+	buildClient, err := r.buildClients.forCluster(pj.Spec.Cluster)
+	if err != nil {
+		log.WithField("cluster", pj.Spec.Cluster).WithError(err).Warn("Build client not found")
+		return reconcile.Result{}, reconcile.TerminalError(err)
+	}
+
+	ns, err := r.findCIOperatorTestNS(ctx, buildClient, pj)
+	if err != nil {
+		log.WithError(err).Error("Unable to retrieve ci-operator namespace")
+		return reconcile.Result{}, err
+	}
+
+	// If the test NS hasn't been created yet we can just abort the PJ, no graceful termination is needed.
+	if ns == "" {
+		return r.abortProwJob(ctx, pj)
+	}
+
+	log = log.WithField("namespace", ns)
+	log.Info("ci-operator namespace found")
+
+	log = log.WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
+	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      api.EphemeralClusterTestDoneSignalSecretName,
+		Namespace: ns,
+	}}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			log.WithError(err).Warn("Failed to create the secret")
 			return reconcile.Result{}, err
 		}
+	} else {
+		log.Info("Secret created")
 	}
 
 	return reconcile.Result{}, nil
@@ -91,11 +147,24 @@ func (r *prowJobReconciler) abortProwJob(ctx context.Context, pj *prowv1.ProwJob
 
 	pj.Status.State = prowv1.AbortedState
 	pj.Status.Description = AbortECNotFound
-	pj.Status.CompletionTime = ptr.To(v1.NewTime(r.now()))
+	pj.Status.CompletionTime = ptr.To(metav1.NewTime(r.now()))
 
-	if err := r.client.Update(ctx, pj); err != nil {
+	if err := r.masterClient.Update(ctx, pj); err != nil {
 		return reconcile.Result{}, fmt.Errorf("abort prowjob: %w", err)
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *prowJobReconciler) findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {
+	nss := corev1.NamespaceList{}
+	if err := buildClient.List(ctx, &nss, ctrlruntimeclient.MatchingLabels{steps.LabelJobID: pj.Name}); err != nil {
+		return "", fmt.Errorf("get namespace for %s: %w", pj.Name, err)
+	}
+
+	if len(nss.Items) == 0 {
+		return "", nil
+	}
+
+	return nss.Items[0].Name, nil
 }

--- a/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
+++ b/pkg/controller/ephemeralcluster/prowjobreconciler_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/sirupsen/logrus"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +21,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	prowv1 "sigs.k8s.io/prow/pkg/apis/prowjobs/v1"
 
+	"github.com/openshift/ci-tools/pkg/api"
 	ephemeralclusterv1 "github.com/openshift/ci-tools/pkg/api/ephemeralcluster/v1"
+	"github.com/openshift/ci-tools/pkg/steps"
+	ctrlruntimetest "github.com/openshift/ci-tools/pkg/testhelper/kubernetes/ctrlruntime"
 )
 
 // pjObjectMock exists because the ProwJob object doesn't implement the Object interface.
@@ -80,8 +84,10 @@ func TestReconcileProwJob(t *testing.T) {
 		pj           *prowv1.ProwJob
 		ec           *ephemeralclusterv1.EphemeralCluster
 		interceptors interceptor.Funcs
+		buildClients func() map[string]*ctrlruntimetest.FakeClient
 		wantEC       *ephemeralclusterv1.EphemeralCluster
 		wantPJ       *prowv1.ProwJob
+		wantSecret   *corev1.Secret
 		wantRes      reconcile.Result
 		wantErr      error
 	}{
@@ -89,7 +95,7 @@ func TestReconcileProwJob(t *testing.T) {
 			name: "No EphemeralCluster label, stop reconciling",
 			ec:   &ephemeralclusterv1.EphemeralCluster{},
 			pj: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{Name: "foo", Namespace: "bar"},
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"},
 			},
 			wantEC:  &ephemeralclusterv1.EphemeralCluster{},
 			wantRes: reconcile.Result{},
@@ -98,28 +104,143 @@ func TestReconcileProwJob(t *testing.T) {
 		{
 			name: "EphemeralCluster not found, aborting the ProwJob",
 			pj: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						EphemeralClusterLabel: "ec",
 					},
 					Name:      "foo",
 					Namespace: "bar",
 				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				c := fake.NewClientBuilder().WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{"build01": ctrlruntimetest.NewFakeClient(c, scheme)}
 			},
 			wantPJ: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						EphemeralClusterLabel: "ec",
 					},
 					Name:      "foo",
 					Namespace: "bar",
 				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
 				Status: prowv1.ProwJobStatus{
 					State:          prowv1.AbortedState,
 					Description:    AbortECNotFound,
-					CompletionTime: ptr.To(v1.NewTime(fakeNow)),
+					CompletionTime: ptr.To(metav1.NewTime(fakeNow)),
 				},
 			},
+		},
+		{
+			name: "Gracefully terminate ci-operator",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				objs := []ctrlclient.Object{&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{steps.LabelJobID: "foo"},
+						Name:   "ci-op-1234",
+					},
+				}}
+				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
+				}
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      api.EphemeralClusterTestDoneSignalSecretName,
+					Namespace: "ci-op-1234",
+				},
+			},
+		},
+		{
+			name: "Gracefully terminate ci-operator: secret exists already, do not create",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				objs := []ctrlclient.Object{
+					&corev1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{steps.LabelJobID: "foo"},
+							Name:   "ci-op-1234",
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      api.EphemeralClusterTestDoneSignalSecretName,
+							Namespace: "ci-op-1234",
+						},
+						Data: map[string][]byte{"foo": []byte("bar")},
+					},
+				}
+				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
+				return map[string]*ctrlruntimetest.FakeClient{
+					"build01": ctrlruntimetest.NewFakeClient(c, scheme, ctrlruntimetest.WithInitObjects(objs...)),
+				}
+			},
+			wantPJ: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			wantSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      api.EphemeralClusterTestDoneSignalSecretName,
+					Namespace: "ci-op-1234",
+				},
+				Data: map[string][]byte{"foo": []byte("bar")},
+			},
+		},
+		{
+			name: "Build client not found returns a terminal error",
+			pj: &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						EphemeralClusterLabel: "ec",
+					},
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: prowv1.ProwJobSpec{Cluster: "build01"},
+			},
+			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
+				return map[string]*ctrlruntimetest.FakeClient{}
+			},
+			wantErr: reconcile.TerminalError(errors.New("unknown cluster build01")),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -130,10 +251,18 @@ func TestReconcileProwJob(t *testing.T) {
 				WithScheme(scheme)
 			client := addObjs(bldr, tc.pj, tc.ec).Build()
 
+			clients := make(map[string]ctrlclient.Client)
+			if tc.buildClients != nil {
+				for cluster, c := range tc.buildClients() {
+					clients[cluster] = c.WithWatch
+				}
+			}
+
 			r := prowJobReconciler{
-				logger: logrus.NewEntry(logrus.StandardLogger()),
-				client: client,
-				now:    func() time.Time { return fakeNow },
+				logger:       logrus.NewEntry(logrus.StandardLogger()),
+				masterClient: client,
+				buildClients: clients,
+				now:          func() time.Time { return fakeNow },
 			}
 
 			req := reconcile.Request{}
@@ -168,6 +297,24 @@ func TestReconcileProwJob(t *testing.T) {
 				ignoreFields := cmpopts.IgnoreFields(prowv1.ProwJob{}, "ResourceVersion")
 				if diff := cmp.Diff(tc.wantPJ, &gotPJ, ignoreFields); diff != "" {
 					t.Errorf("unexpected prowjob: %s", diff)
+				}
+			}
+
+			if tc.wantSecret != nil {
+				gotSecrets := &corev1.SecretList{}
+				client := clients[tc.pj.Spec.Cluster]
+				if err := client.List(context.TODO(), gotSecrets); err != nil {
+					t.Errorf("get secrets: %s", err)
+				}
+
+				if len(gotSecrets.Items) == 1 {
+					gotSecret := gotSecrets.Items[0]
+					ignoreFields := cmpopts.IgnoreFields(corev1.Secret{}, "ResourceVersion")
+					if diff := cmp.Diff(tc.wantSecret, &gotSecret, ignoreFields); diff != "" {
+						t.Errorf("unexpected secret: %s", diff)
+					}
+				} else {
+					t.Errorf("expected 1 secret, got %d", len(gotSecrets.Items))
 				}
 			}
 		})

--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -16,7 +16,8 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,6 +78,16 @@ var (
 	isTagRegexp = regexp.MustCompile(`(?P<Namespace>.+)/(?P<Name>.+)\:(?P<Tag>.+)`)
 )
 
+type buildClients map[string]ctrlruntimeclient.Client
+
+func (bc buildClients) forCluster(cluster string) (ctrlruntimeclient.Client, error) {
+	buildClient, ok := bc[cluster]
+	if !ok {
+		return nil, fmt.Errorf("unknown cluster %s", cluster)
+	}
+	return buildClient, nil
+}
+
 type reconcilerOptions struct {
 	polling     time.Duration
 	cliISTagRef string
@@ -102,7 +113,7 @@ type NewProwJobFunc func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations 
 type reconciler struct {
 	logger          *logrus.Entry
 	masterClient    ctrlruntimeclient.Client
-	buildClients    map[string]ctrlruntimeclient.Client
+	buildClients    buildClients
 	newProwJob      NewProwJobFunc
 	prowConfigAgent *prowconfig.Agent
 	scheme          *runtime.Scheme
@@ -153,7 +164,7 @@ func AddToManager(log *logrus.Entry, mgr manager.Manager, allManagers map[string
 		return fmt.Errorf("build controller: %w", err)
 	}
 
-	if err := addPJReconcilerToManager(log, mgr); err != nil {
+	if err := addPJReconcilerToManager(log, mgr, buildClients); err != nil {
 		return fmt.Errorf("build prowjob controller: %w", err)
 	}
 
@@ -225,7 +236,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (r *reconciler) handleGetProwJobError(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralCluster, err error) (reconcile.Result, error) {
-	if kerrors.IsNotFound(err) {
+	if apierrors.IsNotFound(err) {
 		finalizers, removed := cislices.Delete(ec.Finalizers, DependentProwJobFinalizer)
 		if removed {
 			log.Info("ProwJob not found, removing the finalizer")
@@ -462,7 +473,7 @@ func (r *reconciler) fetchSecrets(
 	ecStatus *ephemeralclusterv1.EphemeralClusterStatus,
 	pj *prowv1.ProwJob,
 ) error {
-	buildClient, err := r.buildClientFor(pj)
+	buildClient, err := r.buildClients.forCluster(pj.Spec.Cluster)
 	if err != nil {
 		log.WithField("cluster", pj.Spec.Cluster).WithError(err).Error("Build client not found")
 		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())
@@ -509,7 +520,7 @@ func (r *reconciler) fetchHiveSecrets(
 		s := corev1.Secret{}
 		if err := buildClient.Get(ctx, types.NamespacedName{Name: secret.name, Namespace: ns}, &s); err != nil {
 			secretsReady = false
-			if !kerrors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				log.WithField("secret", secret.name).WithError(err).Error("Failed to read secret")
 				readSecretErr := fmt.Errorf("read secret %s/%s: %w", secret.name, ns, err)
 				upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, readSecretErr.Error())
@@ -610,7 +621,7 @@ func (r *reconciler) createCredentialsSecret(
 
 	existing := corev1.Secret{}
 	err := r.masterClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: ec.Namespace}, &existing)
-	if err != nil && !kerrors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return fmt.Errorf("check credentials secret: %w", err)
 	}
 	if err == nil {
@@ -633,7 +644,7 @@ func (r *reconciler) createCredentialsSecret(
 	}
 
 	if err := r.masterClient.Create(ctx, secret); err != nil {
-		if !kerrors.IsAlreadyExists(err) {
+		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("create credentials secret: %w", err)
 		}
 	} else {
@@ -683,7 +694,7 @@ func (r *reconciler) deleteEphemeralCluster(ctx context.Context, log *logrus.Ent
 	pj := prowv1.ProwJob{}
 	nn := types.NamespacedName{Namespace: r.prowConfigAgent.Config().ProwJobNamespace, Name: pjId}
 	if err := r.masterClient.Get(ctx, nn, &pj); err != nil {
-		if kerrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			log.Info("ProwJob not found, removing the finalizer")
 			return removeFinalizer()
 		} else {
@@ -709,7 +720,7 @@ func (r *reconciler) abortProwJob(ctx context.Context, log *logrus.Entry, pj *pr
 
 	pj.Status.State = prowv1.AbortedState
 	pj.Status.Description = reason
-	pj.Status.CompletionTime = ptr.To(v1.NewTime(r.now()))
+	pj.Status.CompletionTime = ptr.To(metav1.NewTime(r.now()))
 
 	if err := r.masterClient.Update(ctx, pj); err != nil {
 		return reconcile.Result{}, fmt.Errorf("abort prowjob: %w", err)
@@ -722,7 +733,7 @@ func (r *reconciler) abortProwJob(ctx context.Context, log *logrus.Entry, pj *pr
 func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, ec *ephemeralclusterv1.EphemeralClusterStatus, pj *prowv1.ProwJob) error {
 	ec.Phase = ephemeralclusterv1.EphemeralClusterDeprovisioning
 
-	buildClient, err := r.buildClientFor(pj)
+	buildClient, err := r.buildClients.forCluster(pj.Spec.Cluster)
 	if err != nil {
 		log.WithField("cluster", pj.Spec.Cluster).WithError(err).Warn("Build client not found")
 		upsertCondition(ec, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, err.Error())
@@ -740,39 +751,22 @@ func (r *reconciler) notifyTestComplete(ctx context.Context, log *logrus.Entry, 
 	log = log.WithField("namespace", ns)
 	log.Info("ci-operator namespace found")
 
-	createSecret := false
-	if err := buildClient.Get(ctx, types.NamespacedName{Name: api.EphemeralClusterTestDoneSignalSecretName, Namespace: ns}, &corev1.Secret{}); err != nil {
-		if kerrors.IsNotFound(err) {
-			createSecret = true
-		} else {
-			log.WithError(err).Warn("Failed to fetch the secret")
-			return err
-		}
-	}
-
 	log = log.WithField("secret", api.EphemeralClusterTestDoneSignalSecretName)
-	if createSecret {
-		if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: v1.ObjectMeta{
-			Name:      api.EphemeralClusterTestDoneSignalSecretName,
-			Namespace: ns,
-		}}); err != nil {
+	if err := buildClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name:      api.EphemeralClusterTestDoneSignalSecretName,
+		Namespace: ns,
+	}}); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
 			log.WithError(err).Warn("Failed to create the secret")
 			upsertCondition(ec, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.CreateTestCompletedSecretFailureReason, err.Error())
-			return nil
+			return err
 		}
+	} else {
 		log.Info("Secret created")
 	}
 
 	upsertCondition(ec, ephemeralclusterv1.TestCompleted, ephemeralclusterv1.ConditionTrue, r.now(), "", "")
 	return nil
-}
-
-func (r *reconciler) buildClientFor(pj *prowv1.ProwJob) (ctrlruntimeclient.Client, error) {
-	buildClient, ok := r.buildClients[pj.Spec.Cluster]
-	if !ok {
-		return nil, fmt.Errorf("uknown cluster %s", pj.Spec.Cluster)
-	}
-	return buildClient, nil
 }
 
 func (r *reconciler) findCIOperatorTestNS(ctx context.Context, buildClient ctrlruntimeclient.Client, pj *prowv1.ProwJob) (string, error) {
@@ -793,7 +787,7 @@ func upsertCondition(ecStatus *ephemeralclusterv1.EphemeralClusterStatus, t ephe
 	newCond := ephemeralclusterv1.EphemeralClusterCondition{
 		Type:               t,
 		Status:             status,
-		LastTransitionTime: v1.NewTime(now),
+		LastTransitionTime: metav1.NewTime(now),
 		Reason:             reason,
 		Message:            msg,
 	}

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,7 +40,7 @@ func newProwJobFaker(name string, now time.Time) NewProwJobFunc {
 	return func(spec prowv1.ProwJobSpec, extraLabels, extraAnnotations map[string]string, modifiers ...pjutil.Modifier) prowv1.ProwJob {
 		pj := pjutil.NewProwJob(spec, extraLabels, extraAnnotations, modifiers...)
 		pj.Name = name
-		pj.Status.StartTime = v1.NewTime(now)
+		pj.Status.StartTime = metav1.NewTime(now)
 		return pj
 	}
 }
@@ -89,12 +90,12 @@ func TestEphemeralClusterFilter(t *testing.T) {
 	}{
 		{
 			name:       "Namespace set, process",
-			obj:        &ephemeralclusterv1.EphemeralCluster{ObjectMeta: v1.ObjectMeta{Namespace: EphemeralClusterNamespace}},
+			obj:        &ephemeralclusterv1.EphemeralCluster{ObjectMeta: metav1.ObjectMeta{Namespace: EphemeralClusterNamespace}},
 			wantResult: true,
 		},
 		{
 			name: "Unexpected namespace, do not process",
-			obj:  &ephemeralclusterv1.EphemeralCluster{ObjectMeta: v1.ObjectMeta{Namespace: "foo"}},
+			obj:  &ephemeralclusterv1.EphemeralCluster{ObjectMeta: metav1.ObjectMeta{Namespace: "foo"}},
 		},
 		{
 			name: "Namespace unset, do not process",
@@ -153,7 +154,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "An EphemeralCluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -194,7 +195,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Hive cluster request creates a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -241,7 +242,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Handle invalid prow config",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -273,7 +274,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Fail to create a ProwJob",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -302,7 +303,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Invalid ci-operator configuration",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -321,7 +322,7 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Invalid ci-operator configuration and fail to update EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
@@ -346,18 +347,18 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "Several PJ for the same EC raises an error",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "ec",
 				},
 			},
 			pjs: []ctrlclient.Object{
-				&prowv1.ProwJob{ObjectMeta: v1.ObjectMeta{
+				&prowv1.ProwJob{ObjectMeta: metav1.ObjectMeta{
 					Labels:    map[string]string{EphemeralClusterLabel: "ec"},
 					Name:      "pj1",
 					Namespace: prowJobNamespace,
 				}},
-				&prowv1.ProwJob{ObjectMeta: v1.ObjectMeta{
+				&prowv1.ProwJob{ObjectMeta: metav1.ObjectMeta{
 					Labels:    map[string]string{EphemeralClusterLabel: "ec"},
 					Name:      "pj2",
 					Namespace: prowJobNamespace,
@@ -369,9 +370,9 @@ func TestCreateProwJob(t *testing.T) {
 		{
 			name: "PJ found but was not bound to the EC",
 			ec: ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{Namespace: "ns", Name: "ec"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "ec"},
 			},
-			pjs: []ctrlclient.Object{&prowv1.ProwJob{ObjectMeta: v1.ObjectMeta{
+			pjs: []ctrlclient.Object{&prowv1.ProwJob{ObjectMeta: metav1.ObjectMeta{
 				Labels:    map[string]string{EphemeralClusterLabel: "ec"},
 				Name:      "pj",
 				Namespace: prowJobNamespace,
@@ -450,7 +451,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Kubeconfig ready",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -461,7 +462,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 					Status:     prowv1.ProwJobStatus{URL: "https://pj-123.html"},
 				},
@@ -469,13 +470,13 @@ func TestReconcile(t *testing.T) {
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 					},
 				}
@@ -485,14 +486,14 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantSecret: &corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-credentials",
 					Namespace: "bar",
 				},
 				Data: map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -506,11 +507,11 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -519,7 +520,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "ci-operator NS doesn't exist yet",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -530,7 +531,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
@@ -541,7 +542,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -554,13 +555,13 @@ func TestReconcile(t *testing.T) {
 							Type:               ephemeralclusterv1.ProwJobCreating,
 							Status:             ephemeralclusterv1.ConditionFalse,
 							Reason:             ProwJobCreatingDoneReason,
-							LastTransitionTime: v1.NewTime(fakeNow),
+							LastTransitionTime: metav1.NewTime(fakeNow),
 						}, {
 							Type:               ephemeralclusterv1.ClusterReady,
 							Status:             ephemeralclusterv1.ConditionFalse,
 							Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 							Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
-							LastTransitionTime: v1.NewTime(fakeNow),
+							LastTransitionTime: metav1.NewTime(fakeNow),
 						}},
 				},
 			},
@@ -569,7 +570,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Secret not found",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -580,14 +581,14 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
@@ -599,7 +600,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -611,13 +612,13 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            fmt.Sprintf("secrets %q not found", EphemeralClusterTestName),
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -626,7 +627,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Kubeconfig not ready",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -637,20 +638,20 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 					},
 				}
 				c := fake.NewClientBuilder().WithObjects(objs...).WithScheme(scheme).Build()
@@ -659,7 +660,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -671,13 +672,13 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            ephemeralclusterv1.KubeconfigNotReadyMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -686,7 +687,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Client not found, return a terminal error",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -697,7 +698,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
@@ -705,7 +706,7 @@ func TestReconcile(t *testing.T) {
 				return map[string]*ctrlruntimetest.FakeClient{}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -717,23 +718,23 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
-						Message:            "uknown cluster build01",
-						LastTransitionTime: v1.NewTime(fakeNow),
+						Message:            "unknown cluster build01",
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
 			wantRes: reconcile.Result{},
-			wantErr: reconcile.TerminalError(errors.New("uknown cluster build01")),
+			wantErr: reconcile.TerminalError(errors.New("unknown cluster build01")),
 		},
 		{
 			name: "Aborted ProwJob maps to ProwJobCompleted condition",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -744,7 +745,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 					Status:     prowv1.ProwJobStatus{State: prowv1.AbortedState},
 				},
@@ -756,7 +757,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 				},
@@ -766,19 +767,19 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ProwJobCompleted,
 						Status:             ephemeralclusterv1.ConditionTrue,
 						Reason:             ephemeralclusterv1.ProwJobFailureReason,
 						Message:            "prowjob state: aborted",
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 					Phase: ephemeralclusterv1.EphemeralClusterFailed,
 				},
@@ -788,7 +789,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Succeeded ProwJob maps to ProwJobCompleted condition",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -799,7 +800,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 					Status:     prowv1.ProwJobStatus{State: prowv1.SuccessState},
 				},
@@ -807,13 +808,13 @@ func TestReconcile(t *testing.T) {
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 					},
 				}
@@ -823,7 +824,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 				},
@@ -835,17 +836,17 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ProwJobCompleted,
 						Status:             ephemeralclusterv1.ConditionTrue,
 						Reason:             string(ephemeralclusterv1.ProwJobCompleted),
 						Message:            "prowjob state: success",
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -854,7 +855,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "ProwJob not found remove the finalizer",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:       "foo",
 					Namespace:  "bar",
 					UID:        types.UID("test-ec-uid"),
@@ -865,7 +866,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 				},
@@ -878,7 +879,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Test completed, create secret",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -890,20 +891,20 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: EphemeralClusterTestName, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{"kubeconfig": []byte("kubeconfig")},
 					},
 				}
@@ -913,7 +914,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -927,15 +928,15 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.TestCompleted,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -944,7 +945,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Test completed, ci-operator NS not found",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -956,7 +957,7 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
@@ -967,7 +968,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -980,19 +981,19 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.TestCompleted,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.CreateTestCompletedSecretFailureReason,
 						Message:            ephemeralclusterv1.CIOperatorNSNotFoundMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -1001,7 +1002,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Test completed, secret exists do nothing",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -1013,20 +1014,20 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels:    map[string]string{"do-not-change": ""},
 							Name:      api.EphemeralClusterTestDoneSignalSecretName,
 							Namespace: "ci-op-1234",
@@ -1039,7 +1040,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -1052,17 +1053,17 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            `secrets "cluster-provisioning" not found`,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.TestCompleted,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -1071,7 +1072,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Hive cluster provisioned, report secrets",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -1089,24 +1090,24 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: HiveKubeconfigSecret, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: HiveKubeconfigSecret, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{api.HiveAdminKubeconfigSecretKey: []byte("kubeconfig")},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: HiveAdminPasswdSecret, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: HiveAdminPasswdSecret, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{api.HiveAdminPasswordSecretKey: []byte("admin-passwd")},
 					},
 				}
@@ -1116,7 +1117,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantSecret: &corev1.Secret{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo-credentials",
 					Namespace: "bar",
 				},
@@ -1126,7 +1127,7 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -1146,11 +1147,11 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionTrue,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -1159,7 +1160,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Hive cluster not ready yet, kubeconfig missing",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -1177,20 +1178,20 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: HiveAdminPasswdSecret, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: HiveAdminPasswdSecret, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{api.HiveAdminPasswordSecretKey: []byte("admin-passwd")},
 					},
 				}
@@ -1200,7 +1201,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -1219,13 +1220,13 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            ephemeralclusterv1.HiveSecretsNotReadyMsg,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -1234,7 +1235,7 @@ func TestReconcile(t *testing.T) {
 		{
 			name: "Hive cluster not ready yet, errs out when fetching a secret",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
 					Namespace: "bar",
 					UID:       types.UID("test-ec-uid"),
@@ -1252,20 +1253,20 @@ func TestReconcile(t *testing.T) {
 			},
 			objs: []ctrlclient.Object{
 				&prowv1.ProwJob{
-					ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+					ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 					Spec:       prowv1.ProwJobSpec{Cluster: "build01"},
 				},
 			},
 			buildClients: func() map[string]*ctrlruntimetest.FakeClient {
 				objs := []ctrlclient.Object{
 					&corev1.Namespace{
-						ObjectMeta: v1.ObjectMeta{
+						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{steps.LabelJobID: "pj-123"},
 							Name:   "ci-op-1234",
 						},
 					},
 					&corev1.Secret{
-						ObjectMeta: v1.ObjectMeta{Name: api.HiveAdminPasswordSecret, Namespace: "ci-op-1234"},
+						ObjectMeta: metav1.ObjectMeta{Name: api.HiveAdminPasswordSecret, Namespace: "ci-op-1234"},
 						Data:       map[string][]byte{api.HiveAdminPasswordSecretKey: []byte("admin-passwd")},
 					},
 				}
@@ -1284,7 +1285,7 @@ func TestReconcile(t *testing.T) {
 				}
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
 					Namespace:       "bar",
 					ResourceVersion: "1000",
@@ -1303,13 +1304,13 @@ func TestReconcile(t *testing.T) {
 						Type:               ephemeralclusterv1.ProwJobCreating,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ProwJobCreatingDoneReason,
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}, {
 						Type:               ephemeralclusterv1.ClusterReady,
 						Status:             ephemeralclusterv1.ConditionFalse,
 						Reason:             ephemeralclusterv1.SecretsFetchFailureReason,
 						Message:            "read secret cluster-provisioning-hive-admin-kubeconfig/ci-op-1234: injected",
-						LastTransitionTime: v1.NewTime(fakeNow),
+						LastTransitionTime: metav1.NewTime(fakeNow),
 					}},
 				},
 			},
@@ -1412,10 +1413,10 @@ func TestDeleteProwJob(t *testing.T) {
 		{
 			name: "Delete EC: abort the ProwJob",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "foo",
 					Namespace:         "bar",
-					DeletionTimestamp: ptr.To(v1.NewTime(fakeNow)),
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
 					Finalizers:        []string{DependentProwJobFinalizer},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1423,13 +1424,13 @@ func TestDeleteProwJob(t *testing.T) {
 				},
 			},
 			pj: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "foo",
 					Namespace:         "bar",
-					DeletionTimestamp: ptr.To(v1.NewTime(fakeNow)),
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
 					Finalizers:        []string{DependentProwJobFinalizer},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1437,11 +1438,11 @@ func TestDeleteProwJob(t *testing.T) {
 				},
 			},
 			wantPJ: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 				Status: prowv1.ProwJobStatus{
 					State:          prowv1.AbortedState,
 					Description:    AbortProwJobDeleteEC,
-					CompletionTime: ptr.To(v1.NewTime(fakeNow)),
+					CompletionTime: ptr.To(metav1.NewTime(fakeNow)),
 				},
 			},
 			wantRes: reconcile.Result{RequeueAfter: pollingTime},
@@ -1449,10 +1450,10 @@ func TestDeleteProwJob(t *testing.T) {
 		{
 			name: "Delete EC: ProwJob is gone already, remove the finalizer and delete EC",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "foo",
 					Namespace:         "bar",
-					DeletionTimestamp: ptr.To(v1.NewTime(fakeNow)),
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
 					Finalizers:        []string{DependentProwJobFinalizer},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{
@@ -1464,20 +1465,20 @@ func TestDeleteProwJob(t *testing.T) {
 		{
 			name: "Aborted ProwJob remove the finalizer and delete",
 			ec: &ephemeralclusterv1.EphemeralCluster{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:              "foo",
 					Namespace:         "bar",
-					DeletionTimestamp: ptr.To(v1.NewTime(fakeNow)),
+					DeletionTimestamp: ptr.To(metav1.NewTime(fakeNow)),
 					Finalizers:        []string{DependentProwJobFinalizer},
 				},
 				Status: ephemeralclusterv1.EphemeralClusterStatus{ProwJobID: "pj-123"},
 			},
 			pj: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 				Status:     prowv1.ProwJobStatus{State: prowv1.AbortedState},
 			},
 			wantPJ: &prowv1.ProwJob{
-				ObjectMeta: v1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "pj-123", Namespace: prowJobNamespace},
 				Status:     prowv1.ProwJobStatus{State: prowv1.AbortedState},
 			},
 			wantRes: reconcile.Result{},


### PR DESCRIPTION
Up until now, when the `EphemeralCluster` object is gone, the `ProwJob` running `ci-operator` is simply aborted.
This might lead to an unpleasant situation in which `ci-operator` is getting killed in the middle of provisioning an ephemeral-cluster, without giving it the chance to clean up the resources that have been created in the cloud so far.

With the new approach, the controller lets `ci-operator` finish the provisioning procedure and then triggers the deprovision right away, without waiting for the Konflux's test to complete.

In this way we let `ci-operator` to gracefully terminate its job.

In order to ease the review, I will provide a real use case:
1. The `EphemeralCluster` object in `app.ci` gets delete. This might result as a consequence of the Konflux's pipeling being canceled, as an example.
1. The `prowjobreconciler` kicks in and get the `ProwJob` object tied to the `EphemeralCluster`. We don't know what is the status of this `ProwJob`, it might be running, pending, etc.
1. The `prowjobreconciler` looks for the `ci-op-xxx` NS that should have been created by the `ci-operator` instance run by the `ProwJob`
    1. If the **NS exists**, the reconciler create the `test-done-signal` secret in order to inform `ci-operator` to start the cluster deprovisioning procedures as soon as possible.
    1. If the **NS doesn't exist**, the reconciler simply aborts the `ProwJob`, as it currently does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Graceful handling when a referenced ephemeral cluster is missing: triggers deprovisioning via a test-namespace signal secret or cleanly aborts the job; aborts now reliably record completion time.

* **Improvements**
  * Better multi-cluster behavior: reconciler selects the correct cluster-specific client per job and standardizes metadata/time handling and error checks.
  * Simplified test-complete signaling to treat existing signals as success.

* **Tests**
  * Added/updated tests for graceful termination, signal secret creation/preservation, and unknown-cluster error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->