### PR TITLE
prowgen: allow ci-operator config to set private and expose

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -28,6 +28,13 @@ type ProwgenOverrides struct {
 	DisableRehearsals           bool `json:"disable_rehearsals,omitempty"`
 	SkipOperatorPresubmits      bool `json:"skip_operator_presubmits,omitempty"`
 	EnableSecretsStoreCSIDriver bool `json:"enable_secrets_store_csi_driver,omitempty"`
+	// Private indicates that generated jobs should be marked as hidden
+	// from display in deck and that they should mount appropriate git credentials
+	// to clone the repository under test.
+	Private bool `json:"private,omitempty"`
+	// Expose declares that jobs should not be hidden from view in deck if they
+	// are private. This field has no effect if private is not set.
+	Expose bool `json:"expose,omitempty"`
 }
 
 // ReleaseBuildConfiguration describes how release

--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -68,9 +68,12 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 		},
 	}
 
+	private := info.Config.Private || (configSpec.Prowgen != nil && configSpec.Prowgen.Private)
+	expose := info.Config.Expose || (configSpec.Prowgen != nil && configSpec.Prowgen.Expose)
+
 	if skipCloning(configSpec) {
 		b.base.UtilityConfig.DecorationConfig = &prowv1.DecorationConfig{SkipCloning: utilpointer.Bool(true)}
-	} else if info.Config.Private {
+	} else if private {
 		b.base.UtilityConfig.DecorationConfig = &prowv1.DecorationConfig{OauthTokenSecret: &prowv1.OauthTokenSecret{Key: cioperatorapi.OauthTokenSecretKey, Name: cioperatorapi.OauthTokenSecretName}}
 	}
 
@@ -89,8 +92,7 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	}
 
 	b.PodSpec.Add(Variant(info.Variant))
-	if info.Config.Private {
-		// We can reuse Prow's volume with the token if ProwJob itself is cloning the code
+	if private {
 		b.PodSpec.Add(GitHubToken(!skipCloning(configSpec)))
 	}
 
@@ -98,7 +100,7 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 		b.base.UtilityConfig.PathAlias = *configSpec.CanonicalGoRepository
 	}
 
-	if info.Config.Private && !info.Config.Expose {
+	if private && !expose {
 		b.base.Hidden = true
 	}
 

--- a/pkg/prowgen/jobbase_test.go
+++ b/pkg/prowgen/jobbase_test.go
@@ -25,10 +25,11 @@ func TestProwJobBaseBuilder(t *testing.T) {
 	testCases := []struct {
 		name string
 
-		inputs         ciop.InputConfiguration
-		images         ciop.ImageConfiguration
-		binCommand     string
-		testBinCommand string
+		inputs           ciop.InputConfiguration
+		images           ciop.ImageConfiguration
+		binCommand       string
+		testBinCommand   string
+		prowgenOverrides *ciop.ProwgenOverrides
 
 		podSpecBuilder CiOperatorPodSpecGenerator
 		info           *ProwgenInfo
@@ -170,6 +171,20 @@ func TestProwJobBaseBuilder(t *testing.T) {
 			},
 			podSpecBuilder: NewCiOperatorPodSpecGenerator(),
 		},
+		{
+			name:             "private job via ci-operator config",
+			info:             &ProwgenInfo{Metadata: ciop.Metadata{Org: "vorg", Repo: "vrepo", Branch: "vbranch"}},
+			prowgenOverrides: &ciop.ProwgenOverrides{Private: true},
+			prefix:           "default",
+			podSpecBuilder:   NewCiOperatorPodSpecGenerator(),
+		},
+		{
+			name:             "private job with expose via ci-operator config",
+			info:             &ProwgenInfo{Metadata: ciop.Metadata{Org: "vorg", Repo: "vrepo", Branch: "vbranch"}},
+			prowgenOverrides: &ciop.ProwgenOverrides{Private: true, Expose: true},
+			prefix:           "default",
+			podSpecBuilder:   NewCiOperatorPodSpecGenerator(),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -182,6 +197,7 @@ func TestProwJobBaseBuilder(t *testing.T) {
 				BinaryBuildCommands:     tc.binCommand,
 				TestBinaryBuildCommands: tc.testBinCommand,
 				Metadata:                tc.info.Metadata,
+				Prowgen:                 tc.prowgenOverrides,
 			}
 			b := NewProwJobBaseBuilder(ciopconfig, tc.info, tc.podSpecBuilder).Build(tc.prefix)
 			testhelper.CompareWithFixture(t, b)

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
@@ -1,0 +1,51 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+hidden: true
+name: default-ci-vorg-vrepo-vbranch-
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --oauth-token-path=/usr/local/github-credentials/oauth
+    - --report-credentials-file=/etc/report/credentials
+    command:
+    - ci-operator
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /usr/local/github-credentials
+      name: github-credentials-openshift-ci-robot-private-git-cloner
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: github-credentials-openshift-ci-robot-private-git-cloner
+    secret:
+      secretName: github-credentials-openshift-ci-robot-private-git-cloner
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
@@ -1,0 +1,50 @@
+agent: kubernetes
+decorate: true
+decoration_config:
+  skip_cloning: true
+name: default-ci-vorg-vrepo-vbranch-
+spec:
+  containers:
+  - args:
+    - --gcs-upload-secret=/secrets/gcs/service-account.json
+    - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+    - --oauth-token-path=/usr/local/github-credentials/oauth
+    - --report-credentials-file=/etc/report/credentials
+    command:
+    - ci-operator
+    image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+    imagePullPolicy: Always
+    name: ""
+    resources:
+      requests:
+        cpu: 10m
+    volumeMounts:
+    - mountPath: /secrets/gcs
+      name: gcs-credentials
+      readOnly: true
+    - mountPath: /usr/local/github-credentials
+      name: github-credentials-openshift-ci-robot-private-git-cloner
+      readOnly: true
+    - mountPath: /secrets/manifest-tool
+      name: manifest-tool-local-pusher
+      readOnly: true
+    - mountPath: /etc/pull-secret
+      name: pull-secret
+      readOnly: true
+    - mountPath: /etc/report
+      name: result-aggregator
+      readOnly: true
+  serviceAccountName: ci-operator
+  volumes:
+  - name: github-credentials-openshift-ci-robot-private-git-cloner
+    secret:
+      secretName: github-credentials-openshift-ci-robot-private-git-cloner
+  - name: manifest-tool-local-pusher
+    secret:
+      secretName: manifest-tool-local-pusher
+  - name: pull-secret
+    secret:
+      secretName: registry-pull-credentials
+  - name: result-aggregator
+    secret:
+      secretName: result-aggregator

--- a/pkg/webreg/zz_generated.ci_operator_reference.go
+++ b/pkg/webreg/zz_generated.ci_operator_reference.go
@@ -337,6 +337,13 @@ const ciOperatorReferenceYaml = "# The list of base images describe\n" +
 	"prowgen:\n" +
 	"    disable_rehearsals: true\n" +
 	"    enable_secrets_store_csi_driver: true\n" +
+	"    # Expose declares that jobs should not be hidden from view in deck if they\n" +
+	"    # are private. This field has no effect if private is not set.\n" +
+	"    expose: true\n" +
+	"    # Private indicates that generated jobs should be marked as hidden\n" +
+	"    # from display in deck and that they should mount appropriate git credentials\n" +
+	"    # to clone the repository under test.\n" +
+	"    private: true\n" +
 	"    skip_operator_presubmits: true\n" +
 	"# RawSteps are literal Steps that should be\n" +
 	"# included in the final pipeline.\n" +


### PR DESCRIPTION
## Summary
- Add `private` and `expose` fields to the `prowgen` section of ci-operator config
- Jobs can now control visibility (hidden from deck) and git credential mounting directly in ci-operator config
- Continues the incremental deprecation of `.config.prowgen` (follows #5119 rehearsals, #5120 CSI, #5121 skip-presubmits)

## Test plan
- [x] New test: "private job via ci-operator config" — fixture identical to existing `.config.prowgen`-based private test
- [x] New test: "private job with expose via ci-operator config" — verifies `hidden` is not set when expose is true
- [x] All existing tests pass (`go test ./pkg/prowgen/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "private" flag to mark generated jobs as hidden from deck
  * Added an "expose" flag to allow showing jobs that are otherwise private
  * Private jobs now mount appropriate git credentials automatically when needed

* **Tests**
  * Added test coverage and fixtures for private jobs with and without expose enabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->