### PR TITLE
Always include kubeAdminPassword in EphemeralCluster credentials Secret

### DIFF
--- a/pkg/controller/ephemeralcluster/reconciler.go
+++ b/pkg/controller/ephemeralcluster/reconciler.go
@@ -532,7 +532,10 @@ func (r *reconciler) fetchHiveSecrets(
 		return
 	}
 
-	secretData := map[string][]byte{"kubeconfig": kubeconfig, "kubeAdminPassword": passwd}
+	secretData := map[string][]byte{
+		"kubeconfig":        kubeconfig,
+		"kubeAdminPassword": passwd,
+	}
 	if err := r.createCredentialsSecret(ctx, log, ec, secretData); err != nil {
 		log.WithError(err).Error("Failed to create credentials secret")
 		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())
@@ -568,7 +571,10 @@ func (r *reconciler) fetchClusterKubeconfig(
 		return
 	}
 
-	secretData := map[string][]byte{"kubeconfig": kubeconfig}
+	secretData := map[string][]byte{
+		"kubeconfig":        kubeconfig,
+		"kubeAdminPassword": {},
+	}
 	if err := r.createCredentialsSecret(ctx, log, ec, secretData); err != nil {
 		log.WithError(err).Error("Failed to create credentials secret")
 		upsertCondition(ecStatus, ephemeralclusterv1.ClusterReady, ephemeralclusterv1.ConditionFalse, r.now(), ephemeralclusterv1.SecretsFetchFailureReason, err.Error())

--- a/pkg/controller/ephemeralcluster/reconciler_test.go
+++ b/pkg/controller/ephemeralcluster/reconciler_test.go
@@ -489,7 +489,10 @@ func TestReconcile(t *testing.T) {
 					Name:      "foo-credentials",
 					Namespace: "bar",
 				},
-				Data: map[string][]byte{"kubeconfig": []byte("kubeconfig")},
+				Data: map[string][]byte{
+					"kubeconfig":        []byte("kubeconfig"),
+					"kubeAdminPassword": {},
+				},
 			},
 			wantEC: &ephemeralclusterv1.EphemeralCluster{
 				ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
The credentials Secret created by the EphemeralCluster controller was missing the kubeAdminPassword key when provisioned via the non-Hive code path. Ensure both credential keys are always present so downstream consumers never encounter a missing key.

Assisted-by: Claude claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Credentials secrets now consistently include both kubeconfig and admin password fields (admin password may be empty), standardizing secret structure.

* **Tests**
  * Updated test expectations to validate the revised credentials secret format, ensuring both fields are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->