### PR TITLE
DPTP-4801: cmd/ci-secret-bootstrap: Log Secret change keys

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -802,9 +802,23 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 
 				if !shouldCreate {
 					differentData := !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data)
+					var addedKeys, changedKeys, removedKeys []string
+					for k, value := range secret.Data {
+						if existingValue, ok := existingSecret.Data[k]; !ok {
+							addedKeys = append(addedKeys, k)
+						} else if !equality.Semantic.DeepEqual(value, existingValue) {
+							changedKeys = append(changedKeys, k)
+						}
+					}
+					for k := range existingSecret.Data {
+						if _, ok := secret.Data[k]; !ok {
+							removedKeys = append(removedKeys, k)
+						}
+					}
+					change := fmt.Sprintf("added: %v, changed: %v, removed: %v", addedKeys, changedKeys, removedKeys)
 					if !force && differentData {
 						logger.Errorf("actual secret data differs the expected")
-						errs = append(errs, fmt.Errorf("secret %s:%s/%s needs updating in place, use --force to do so", cluster, secret.Namespace, secret.Name))
+						errs = append(errs, fmt.Errorf("secret %s:%s/%s needs updating in place (%s), use --force to do so", cluster, secret.Namespace, secret.Name, change))
 						continue
 					}
 					if existingSecret.Labels == nil || existingSecret.Labels[api.DPTPRequesterLabel] != "ci-secret-bootstrap" || differentData {
@@ -812,7 +826,7 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 							errs = append(errs, fmt.Errorf("error updating secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
 							continue
 						}
-						logger.Debug("secret updated")
+						logger.Debugf("secret updated %s", change)
 					} else {
 						logger.Debug("secret skipped")
 					}

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -1519,7 +1519,7 @@ func TestUpdateSecrets(t *testing.T) {
 					},
 				},
 			},
-			expected: fmt.Errorf("secret default:namespace-1/prod-secret-1 needs updating in place, use --force to do so"),
+			expected: fmt.Errorf("secret default:namespace-1/prod-secret-1 needs updating in place (added: [], changed: [key-name-1], removed: []), use --force to do so"),
 			expectedSecretsOnDefault: []coreapi.Secret{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2721,7 +2721,7 @@ func TestIntegration(t *testing.T) {
 					"secretsync/target-name":      []byte("some-name"),
 				},
 			},
-			expectedError: utilerrors.NewAggregate([]error{errors.New("failed to update secrets: secret cluster-1:namespace-1/prod-secret-1 needs updating in place, use --force to do so")}),
+			expectedError: utilerrors.NewAggregate([]error{errors.New("failed to update secrets: secret cluster-1:namespace-1/prod-secret-1 needs updating in place (added: [], changed: [key-name-1], removed: []), use --force to do so")}),
 		},
 		{
 			id:    "Two items reference the same secret but different keys, success",


### PR DESCRIPTION
Today there was a Deck outage, when both of two Pods restarted their 'deck' containers simultaneously at 22:23, causing:

    Application is not available

errors to https://prow.ci.openshift.org/ users.  Timestamps and exit 0:

```console    
$ oc -n ci get -l component=deck -o json pods | jq -r '.items[].status.containerStatuses[] | select(.restartCount > 0) | {name, restartCount, lastState}'
{
  "name": "deck",
  "restartCount": 1,
  "lastState": {
    "terminated": {
      "containerID": "cri-o://21786efafb65fd5b67e72eb2a1a91405b182d3b20daeb549980217210bf0e22a",
      "exitCode": 0,
      "finishedAt": "2026-04-23T22:23:37Z",
      "reason": "Completed",
      "startedAt": "2026-04-23T20:04:03Z"
    }
  }
}
{
  "name": "deck",
  "restartCount": 1,
  "lastState": {
    "terminated": {
      "containerID": "cri-o://7af2f63b995729d1e8e64b1776a6a2aa3439076e9d55616182ac61b1c64fe855",
      "exitCode": 0,
      "finishedAt": "2026-04-23T22:23:58Z",
      "reason": "Completed",
      "startedAt": "2026-04-23T19:28:51Z"
    }
  }
}
```

The container exits were because of Kubeconfig changes:

```console
$ oc -n ci logs -c deck --previous deck-54c8d55b65-6fxcn | tail -n16 | head -n2
{"component":"deck","file":"sigs.k8s.io/prow/cmd/deck/main.go:392","func":"main.main.func2","level":"info","msg":"Kubeconfig changed, exiting to trigger a restart","severity":"info","time":"2026-04-23T22:23:36Z"}
{"component":"deck","file":"sigs.k8s.io/prow/pkg/interrupts/interrupts.go:63","func":"sigs.k8s.io/prow/pkg/interrupts.handleInterrupt","level":"info","msg":"Received signal.","severity":"info","signal":2,"time":"2026-04-23T22:23:36Z"}
```

The Secret update was [this ci-secret-bootstrapper][1]:

```
{"cluster":"app.ci","component":"ci-secret-bootstrap","file":"/go/src/github.com/openshift/ci-tools/cmd/ci-secret-bootstrap/main.go:815","func":"main.updateSecrets","level":"debug","msg":"secret updated","name":"deck","namespace":"ci","severity":"debug","time":"2026-04-23T22:23:02Z","type":"Opaque"}
```

This commit adds more logs to that `secret updated` entry, to make it easier for us to figure out which change triggered the next bump, so we can decide if it's appropriate, and the kind of thing we'll accept a few minutes of Deck outage over, or if it's surprising churn.

[1]: https://deck-internal-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-private/logs/periodic-ci-secret-bootstrap/2047432829557542912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Error messages now include a key-level summary showing which secret keys were added, changed, or removed when secret data differs, making failed updates clearer.
  * Debug and success logs now include the same key-level change details so updates and troubleshooting surface precise differences rather than generic notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->