### PR TITLE
DPTP-3787: skip digest-resolve for non-release namespaces

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -295,6 +295,7 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 	// resolveAndTagPairs holds [quayProxyTag, isTag] for concrete *-quay IS targets in a
 	// quay promotion step. These are handled post-mirror via oc image info + oc tag so
 	// that spec.from always carries the exact QCI manifest digest rather than a floating tag.
+	// Non-release namespaces use oc tag directly.
 	var resolveAndTagPairs [][2]string
 
 	isQuayStep := name == api.PromotionQuayStepName
@@ -310,12 +311,16 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 			} else if isQuayStep && !strings.Contains(k, api.ComponentFormatReplacement) {
 				// Concrete quay IS target: resolve the QCI digest after mirroring instead of
 				// using a pre-computed (potentially tag-only) source so spec.from is always digest-based.
-				if quayProxyTag, ok := quayProxyTagFromISKey(k); ok {
-					resolveAndTagPairs = append(resolveAndTagPairs, [2]string{quayProxyTag, k})
-				} else {
-					// Fallback for unexpected key formats.
-					tags = append(tags, fmt.Sprintf("%s %s", src, k))
+				// Non-release namespaces use oc tag directly.
+				quayProxyTag, ok := quayProxyTagFromISKey(k)
+				if ok {
+					ns := k[:strings.Index(k, "/")]
+					if api.RefersToOfficialImage(ns, api.WithOKD) {
+						resolveAndTagPairs = append(resolveAndTagPairs, [2]string{quayProxyTag, k})
+						continue
+					}
 				}
+				tags = append(tags, fmt.Sprintf("%s %s", src, k))
 			} else if strings.Contains(k, api.ComponentFormatReplacement) || !strings.Contains(src, "@sha256:") || strings.Contains(src, api.QCIAPPCIDomain) {
 				// Cluster ImageStream tags: oc tag for non-digest sources, quay-proxy imports, or ${component} templates.
 				tags = append(tags, fmt.Sprintf("%s %s", src, k))

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -766,6 +766,18 @@ func TestGetPromotionPod(t *testing.T) {
 			namespace: "ci-op-9bdij1f6",
 		},
 		{
+			name:              "promotion-quay-non-release-namespace",
+			stepName:          "promotion-quay",
+			nodeArchitectures: []string{"amd64"},
+			imageMirror: map[string]string{
+				"quay.io/openshift/ci:ocp_4.21_ovn-kubernetes":  "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa",
+				"ocp/4.21-quay:ovn-kubernetes":                  "quay-proxy.ci.openshift.org/openshift/ci@sha256:aaa",
+				"quay.io/openshift/ci:ci_ci_sanitize-prow-jobs": "registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb",
+				"ci/ci-quay:sanitize-prow-jobs":                 "quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb",
+			},
+			namespace: "ci-op-9bdij1f6",
+		},
+		{
 			name:              "basic case - arm64 only",
 			stepName:          "promotion",
 			nodeArchitectures: []string{"arm64"},

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -1,0 +1,43 @@
+metadata:
+  creationTimestamp: null
+  labels:
+    ci-operator.openshift.io/save-container-logs: "true"
+  name: promotion-quay
+  namespace: ci-op-9bdij1f6
+spec:
+  containers:
+  - args:
+    - |-
+      for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ci_ci_sanitize-prow-jobs registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      set +e
+      for r in {1..2}; do echo 'Tag attempt $r (all together)'; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; :; done
+      for r in {1..3}; do echo 'Tag attempt $r (individual)'; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      for r in {1..3}; do echo 'Digest-tag attempt $r (ocp/4.21-quay:ovn-kubernetes)'; _digest=$(oc image info --output=json --registry-config=/etc/push-secret/.dockerconfigjson quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | jq -r '.digest') && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      set -e
+    command:
+    - /bin/sh
+    - -c
+    env:
+    - name: KUBECONFIG
+      value: /etc/app-ci-kubeconfig/kubeconfig
+    image: registry.ci.openshift.org/ocp/4.14:cli
+    name: promotion
+    resources: {}
+    volumeMounts:
+    - mountPath: /etc/push-secret
+      name: push-secret
+      readOnly: true
+    - mountPath: /etc/app-ci-kubeconfig
+      name: app-ci-kubeconfig
+      readOnly: true
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  restartPolicy: Never
+  volumes:
+  - name: push-secret
+    secret:
+      secretName: registry-push-credentials-ci-central
+  - name: app-ci-kubeconfig
+    secret:
+      secretName: promotion-quay-tagger-kubeconfig
+status: {}


### PR DESCRIPTION
/cc @openshift/test-platform 

Follow https://github.com/openshift/ci-tools/pull/5123 to improve promotion time for ci-tools or any other postsubmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quay image promotion to derive namespaces correctly and use digest-based tagging only when appropriate, reducing incorrect tags and improving reliability.
  * Added robust retry and backoff behavior for image mirror and tag operations to increase success under transient failures.

* **Tests**
  * Added a new test scenario and fixture covering non-release namespace quay promotion with multiple mirror and registry references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->