### PR TITLE
Add multiple underscore replacements

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1155,7 +1155,7 @@ type CredentialReference struct {
 	// MountPath is where the secret should be mounted.
 	MountPath string `json:"mount_path"`
 	// Namespace is where the source secret exists.
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 	// Name is the name of the secret.
 	Name string `json:"name,omitempty"`
 }

--- a/pkg/gsm-validation/gsm.go
+++ b/pkg/gsm-validation/gsm.go
@@ -11,6 +11,10 @@ const (
 
 	// Encoding constants for special characters
 	DotReplacementString = "--dot--"
+	// UnderscorePrefix/Suffix for encoding consecutive underscores
+	// __ → --uu--, ___ → --uuu--, etc.
+	UnderscorePrefix = "--"
+	UnderscoreSuffix = "--"
 
 	CollectionRegex = "^([a-z0-9_-]*[a-z0-9])?$"
 	GroupRegex      = `^[a-z0-9]+([a-z0-9_-]*[a-z0-9]+)?(/[a-z0-9]+([a-z0-9_-]*[a-z0-9]+)?)*$`
@@ -21,6 +25,13 @@ const (
 
 	// GcpMaxNameLength is the maximum length for a GSM secret name
 	GcpMaxNameLength = 255
+)
+
+var (
+	// Regex to find consecutive underscores (2 or more)
+	consecutiveUnderscoresRegex = regexp.MustCompile(`_{2,}`)
+	// Regex to find encoded underscores in format --uu-- (2 or more u's)
+	encodedUnderscoresRegex = regexp.MustCompile(`--u{2,}--`)
 )
 
 var (
@@ -86,20 +97,33 @@ func ValidateSecretName(secretName string) bool {
 	return secretNameRegexp.MatchString(secretName)
 }
 
-// NormalizeName replaces forbidden characters in field names with safe replacements.
-// This is used when migrating from Vault to GSM to handle special characters in field names.
-// Rules:
-//   - `.` → `--dot--` (dots not allowed in GSM secret names)
+// NormalizeName replaces forbidden characters in names with safe replacements.
+// This is used when migrating from Vault to GSM to handle special characters.
+// Rules (applied in order):
+//  1. `__` (2+ consecutive underscores) → `--uu--`, `--uuu--`, etc.
+//  2. `.` → `--dot--` (dots not allowed in GSM secret names)
 //
-// Example: ".dockerconfigjson" → "--dot--dockerconfigjson"
+// Examples:
+//   - ".dockerconfigjson" → "--dot--dockerconfigjson"
+//   - "mac_ai__base_dir" → "mac_ai--uu--base_dir"
+//   - "some___field" → "some--uuu--field"
+//   - "field.with__both" → "field--dot--with--uu--both"
 func NormalizeName(name string) string {
-	// Encode in specific order to avoid conflicts
-	return strings.ReplaceAll(name, ".", DotReplacementString)
+	result := consecutiveUnderscoresRegex.ReplaceAllStringFunc(name, func(match string) string {
+		count := len(match)
+		return UnderscorePrefix + strings.Repeat("u", count) + UnderscoreSuffix
+	})
+	return strings.ReplaceAll(result, ".", DotReplacementString)
 }
 
 // DenormalizeName decodes field names back to their original form.
 // This reverses the encoding done by NormalizeName.
+// Decodes in reverse order of NormalizeName.
 func DenormalizeName(name string) string {
-	// Decode in reverse order
-	return strings.ReplaceAll(name, DotReplacementString, ".")
+	result := strings.ReplaceAll(name, DotReplacementString, ".")
+	result = encodedUnderscoresRegex.ReplaceAllStringFunc(result, func(match string) string {
+		uCount := len(match) - len(UnderscorePrefix) - len(UnderscoreSuffix)
+		return strings.Repeat("_", uCount)
+	})
+	return result
 }

--- a/pkg/gsm-validation/gsm_test.go
+++ b/pkg/gsm-validation/gsm_test.go
@@ -269,6 +269,66 @@ func TestNormalizeName(t *testing.T) {
 			input:    "sa.ci-operator.build01.config",
 			expected: fmt.Sprintf("sa%sci-operator%sbuild01%sconfig", DotReplacementString, DotReplacementString, DotReplacementString),
 		},
+		{
+			name:     "double underscores",
+			input:    "mac_ai__base_dir",
+			expected: "mac_ai--uu--base_dir",
+		},
+		{
+			name:     "triple underscores",
+			input:    "some___field",
+			expected: "some--uuu--field",
+		},
+		{
+			name:     "quadruple underscores",
+			input:    "test____name",
+			expected: "test--uuuu--name",
+		},
+		{
+			name:     "dots and double underscores",
+			input:    "field.with__both",
+			expected: "field--dot--with--uu--both",
+		},
+		{
+			name:     "real-world example with underscores and dots",
+			input:    "mac_ai__base_work_dir.mac4",
+			expected: "mac_ai--uu--base_work_dir--dot--mac4",
+		},
+		{
+			name:     "multiple double underscores",
+			input:    "a__b__c",
+			expected: "a--uu--b--uu--c",
+		},
+		{
+			name:     "mixed consecutive underscores",
+			input:    "a__b___c____d",
+			expected: "a--uu--b--uuu--c--uuuu--d",
+		},
+		{
+			name:     "starts with double underscores",
+			input:    "__field",
+			expected: "--uu--field",
+		},
+		{
+			name:     "ends with double underscores",
+			input:    "field__",
+			expected: "field--uu--",
+		},
+		{
+			name:     "starts and ends with double underscores",
+			input:    "__field__",
+			expected: "--uu--field--uu--",
+		},
+		{
+			name:     "starts with triple underscores",
+			input:    "___name",
+			expected: "--uuu--name",
+		},
+		{
+			name:     "ends with triple underscores",
+			input:    "name___",
+			expected: "name--uuu--",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -306,6 +366,66 @@ func TestDenormalizeName(t *testing.T) {
 			name:     "no encoding to decode",
 			input:    "simple-name",
 			expected: "simple-name",
+		},
+		{
+			name:     "decode double underscores",
+			input:    "mac_ai--uu--base_dir",
+			expected: "mac_ai__base_dir",
+		},
+		{
+			name:     "decode triple underscores",
+			input:    "some--uuu--field",
+			expected: "some___field",
+		},
+		{
+			name:     "decode quadruple underscores",
+			input:    "test--uuuu--name",
+			expected: "test____name",
+		},
+		{
+			name:     "decode dots and double underscores",
+			input:    "field--dot--with--uu--both",
+			expected: "field.with__both",
+		},
+		{
+			name:     "decode real-world example with underscores and dots",
+			input:    "mac_ai--uu--base_work_dir--dot--mac4",
+			expected: "mac_ai__base_work_dir.mac4",
+		},
+		{
+			name:     "decode multiple double underscores",
+			input:    "a--uu--b--uu--c",
+			expected: "a__b__c",
+		},
+		{
+			name:     "decode mixed consecutive underscores",
+			input:    "a--uu--b--uuu--c--uuuu--d",
+			expected: "a__b___c____d",
+		},
+		{
+			name:     "decode starts with double underscores",
+			input:    "--uu--field",
+			expected: "__field",
+		},
+		{
+			name:     "decode ends with double underscores",
+			input:    "field--uu--",
+			expected: "field__",
+		},
+		{
+			name:     "decode starts and ends with double underscores",
+			input:    "--uu--field--uu--",
+			expected: "__field__",
+		},
+		{
+			name:     "decode starts with triple underscores",
+			input:    "--uuu--name",
+			expected: "___name",
+		},
+		{
+			name:     "decode ends with triple underscores",
+			input:    "name--uuu--",
+			expected: "name___",
 		},
 	}
 


### PR DESCRIPTION
While one `_` symbol is allowed, mutliple ones would conflict with our naming convention (`__` is a group separator). This is needed for backwards compatibility when we migrate the secrets from Vault, because some of the secrets' names contain multiple underscores. Once the new system is in place, only one `_` will be allowed in a group or a field name.