### PR TITLE
Add go.work to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ index.js
 # vscode
 .vscode/
 
+# go workspace
+go.work
+go.work.sum
+
 # default working dir
 /job-aggregator-working-dir
 # go built binary


### PR DESCRIPTION
After https://github.com/openshift/ci-tools/pull/5109 , creating a local `go.work` file with some dependency replacements was the only way I got imports in this repo working (this is a sad Goland IDE limitation in combination with broken v0.0.0 dependencies from kubernetes and assisted-service packages).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration for Go workspace management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->