### PR TITLE
prowgen: allow ci-operator config to set max_concurrency

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -882,6 +882,9 @@ type TestStepConfiguration struct {
 	// Only applicable to presubmits and periodics
 	ShardCount *int `json:"shard_count,omitempty"`
 
+	// MaxConcurrency sets the maximum number of this job running concurrently. 0 means no limit.
+	MaxConcurrency int `json:"max_concurrency,omitempty"`
+
 	// Only one of the following can be not-null.
 	ContainerTestConfiguration         *ContainerTestConfiguration         `json:"container,omitempty"`
 	MultiStageTestConfiguration        *MultiStageTestConfiguration        `json:"steps,omitempty"`

--- a/pkg/prowgen/prowgen.go
+++ b/pkg/prowgen/prowgen.go
@@ -97,6 +97,7 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 					options.ReleaseController = element.ReleaseController
 					options.DisableRehearsal = disableRehearsal
 					options.Retry = element.Retry
+					options.MaxConcurrency = element.MaxConcurrency
 				})
 				periodics = append(periodics, *periodic)
 				if element.Presubmit {
@@ -109,6 +110,9 @@ func GenerateJobs(configSpec *cioperatorapi.ReleaseBuildConfiguration, info *Pro
 					options.skipIfOnlyChanged = element.SkipIfOnlyChanged
 				})
 				postsubmit.MaxConcurrency = 1
+				if element.MaxConcurrency != 0 {
+					postsubmit.MaxConcurrency = element.MaxConcurrency
+				}
 				postsubmits[orgrepo] = append(postsubmits[orgrepo], *postsubmit)
 			} else {
 				handlePresubmit(g, element, info, name, disableRehearsal, configSpec.Resources.RequirementsForStep(element.As).Requests, presubmits, orgrepo)
@@ -228,6 +232,7 @@ func handlePresubmit(g *prowJobBaseBuilder, element cioperatorapi.TestStepConfig
 		options.defaultDisable = element.AlwaysRun != nil && !*element.AlwaysRun
 		options.optional = element.Optional
 		options.disableRehearsal = disableRehearsal
+		options.maxConcurrency = element.MaxConcurrency
 	})
 	v, requestingKVM := requests[cioperatorapi.KVMDeviceLabel]
 	if requestingKVM {
@@ -245,6 +250,7 @@ type generatePresubmitOptions struct {
 	defaultDisable            bool
 	optional                  bool
 	disableRehearsal          bool
+	maxConcurrency            int
 }
 
 func (opts *generatePresubmitOptions) shouldAlwaysRun() bool {
@@ -314,6 +320,7 @@ func generatePresubmitForTest(jobBaseBuilder *prowJobBaseBuilder, name string, i
 		},
 		Optional: opts.optional,
 	}
+	pj.MaxConcurrency = opts.maxConcurrency
 	injectCapabilities(pj.Labels, opts.Capabilities)
 	return pj
 }
@@ -374,6 +381,7 @@ type GeneratePeriodicOptions struct {
 	PathAlias         *string
 	DisableRehearsal  bool
 	Retry             *prowconfig.Retry
+	MaxConcurrency    int
 }
 
 type GeneratePeriodicOption func(options *GeneratePeriodicOptions)
@@ -427,6 +435,7 @@ func GeneratePeriodicForTest(jobBaseBuilder *prowJobBaseBuilder, info *ProwgenIn
 		MinimumInterval: opts.MinimumInterval,
 		Retry:           opts.Retry,
 	}
+	pj.MaxConcurrency = opts.MaxConcurrency
 	injectCapabilities(pj.Labels, opts.Capabilities)
 	return pj
 }

--- a/pkg/prowgen/prowgen_test.go
+++ b/pkg/prowgen/prowgen_test.go
@@ -234,6 +234,14 @@ func TestGeneratePresubmitForTest(t *testing.T) {
 				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
 			},
 		},
+		{
+			description: "presubmit with max_concurrency",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			generateOption: func(options *generatePresubmitOptions) {
+				options.maxConcurrency = 4
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
@@ -315,6 +323,15 @@ func TestGeneratePeriodicForTest(t *testing.T) {
 			generateOption: func(options *GeneratePeriodicOptions) {
 				options.Cron = "@yearly"
 				options.Capabilities = []string{"intranet", "arm64", "rce", "sshd-bastion"} // rce - release-controller-eligible, sshd-bastion - for multiarch P/Z libvirt jobs
+			},
+		},
+		{
+			description: "periodic with max_concurrency",
+			test:        "testname",
+			repoInfo:    &ProwgenInfo{Metadata: ciop.Metadata{Org: "org", Repo: "repo", Branch: "branch"}},
+			generateOption: func(options *GeneratePeriodicOptions) {
+				options.Cron = "@yearly"
+				options.MaxConcurrency = 3
 			},
 		},
 	}
@@ -892,6 +909,32 @@ func TestGenerateJobs(t *testing.T) {
 					PipelineSkipIfOnlyChanged: `^(docs/|.*\.md$)`,
 				},
 				PromotionConfiguration: &ciop.PromotionConfiguration{},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
+		{
+			id: "postsubmit with max_concurrency from test config",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}},
+					{As: "leTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}, Postsubmit: true, MaxConcurrency: 6}},
+			},
+			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
+				Org:    "organization",
+				Repo:   "repository",
+				Branch: "branch",
+			}},
+		},
+		{
+			id: "periodic with max_concurrency from test config",
+			config: &ciop.ReleaseBuildConfiguration{
+				Tests: []ciop.TestStepConfiguration{
+					{As: "derTest", ContainerTestConfiguration: &ciop.ContainerTestConfiguration{From: "from"}, Cron: utilpointer.String(cron), MaxConcurrency: 3},
+				},
 			},
 			repoInfo: &ProwgenInfo{Metadata: ciop.Metadata{
 				Org:    "organization",

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_max_concurrency_from_test_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_periodic_with_max_concurrency_from_test_config.yaml
@@ -1,0 +1,61 @@
+periodics:
+- agent: kubernetes
+  cron: 0 0 * * *
+  decorate: true
+  decoration_config:
+    skip_cloning: true
+  extra_refs:
+  - base_ref: branch
+    org: organization
+    repo: repository
+  labels:
+    pj-rehearse.openshift.io/can-be-rehearsed: "true"
+  max_concurrency: 3
+  name: periodic-ci-organization-repository-branch-derTest
+  spec:
+    containers:
+    - args:
+      - --gcs-upload-secret=/secrets/gcs/service-account.json
+      - --image-import-pull-secret=/etc/pull-secret/.dockerconfigjson
+      - --report-credentials-file=/etc/report/credentials
+      - --target=derTest
+      command:
+      - ci-operator
+      env:
+      - name: HTTP_SERVER_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
+      image: quay-proxy.ci.openshift.org/openshift/ci:ci_ci-operator_latest
+      imagePullPolicy: Always
+      name: ""
+      ports:
+      - containerPort: 8080
+        name: http
+      resources:
+        requests:
+          cpu: 10m
+      volumeMounts:
+      - mountPath: /secrets/gcs
+        name: gcs-credentials
+        readOnly: true
+      - mountPath: /secrets/manifest-tool
+        name: manifest-tool-local-pusher
+        readOnly: true
+      - mountPath: /etc/pull-secret
+        name: pull-secret
+        readOnly: true
+      - mountPath: /etc/report
+        name: result-aggregator
+        readOnly: true
+    serviceAccountName: ci-operator
+    volumes:
+    - name: manifest-tool-local-pusher
+      secret:
+        secretName: manifest-tool-local-pusher
+    - name: pull-secret
+      secret:
+        secretName: registry-pull-credentials
+    - name: result-aggregator
+      secret:
+        secretName: result-aggregator

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_postsubmit_with_max_concurrency_from_test_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobs_postsubmit_with_max_concurrency_from_test_config.yaml
@@ -1,0 +1,11 @@
+postsubmits:
+  organization/repository:
+  - always_run: true
+    max_concurrency: 6
+    name: branch-ci-organization-repository-branch-leTest
+presubmits:
+  organization/repository:
+  - always_run: false
+    labels:
+      pj-rehearse.openshift.io/can-be-rehearsed: "true"
+    name: pull-ci-organization-repository-branch-derTest

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_max_concurrency.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePeriodicForTest_periodic_with_max_concurrency.yaml
@@ -1,0 +1,13 @@
+agent: kubernetes
+cron: '@yearly'
+decorate: true
+decoration_config:
+  skip_cloning: true
+extra_refs:
+- base_ref: branch
+  org: org
+  repo: repo
+labels:
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+max_concurrency: 3
+name: periodic-ci-org-repo-branch-testname

--- a/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_max_concurrency.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGeneratePresubmitForTest_presubmit_with_max_concurrency.yaml
@@ -1,0 +1,15 @@
+agent: kubernetes
+always_run: true
+branches:
+- ^branch$
+- ^branch-
+context: ci/prow/testname
+decorate: true
+decoration_config:
+  skip_cloning: true
+labels:
+  pj-rehearse.openshift.io/can-be-rehearsed: "true"
+max_concurrency: 4
+name: pull-ci-org-repo-branch-testname
+rerun_command: /test testname
+trigger: (?m)^/test( | .* )testname,?($|\s.*)

--- a/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
+++ b/test/integration/ci-operator-prowgen/input/config/super/duper/super-duper-master.yaml
@@ -43,6 +43,7 @@ tests:
   container:
     from: src
   postsubmit: true
+  max_concurrency: 6
 - as: lint
   commands: make test-lint
   container:

--- a/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
+++ b/test/integration/ci-operator-prowgen/output/jobs/super/duper/super-duper-master-postsubmits.yaml
@@ -319,7 +319,7 @@ postsubmits:
       skip_cloning: true
     labels:
       ci.openshift.io/generator: prowgen
-    max_concurrency: 1
+    max_concurrency: 6
     name: branch-ci-super-duper-master-upload-results
     spec:
       containers:


### PR DESCRIPTION
## Summary
- Adds `max_concurrency` field to `TestStepConfiguration` in ci-operator config
- Prowgen now propagates this field to generated presubmit, postsubmit, and periodic jobs
- Postsubmits default to `max_concurrency: 1` (unchanged), config can override
- No behavioral change for existing configs — field uses `omitempty`, so only takes effect when explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now configure concurrency limits on test steps to control the maximum number of simultaneous job executions across different job types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->