### PR TITLE
fix(prowgen): only set oauth_token_secret when sparse checkout is active

### DIFF
--- a/pkg/prowgen/jobbase.go
+++ b/pkg/prowgen/jobbase.go
@@ -103,7 +103,7 @@ func NewProwJobBaseBuilder(configSpec *cioperatorapi.ReleaseBuildConfiguration, 
 	} else {
 		b.base.UtilityConfig.DecorationConfig.SparseCheckoutFiles = sparseFiles
 	}
-	if private {
+	if private && !shouldSkipCloning {
 		b.base.UtilityConfig.DecorationConfig.OauthTokenSecret = &prowv1.OauthTokenSecret{Key: cioperatorapi.OauthTokenSecretKey, Name: cioperatorapi.OauthTokenSecretName}
 	}
 

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_expose_job_for_private_repos_with_public_results.yaml
@@ -1,8 +1,5 @@
 agent: kubernetes
 decorate: true
 decoration_config:
-  oauth_token_secret:
-    key: oauth
-    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestGenerateJobBase_hidden_job_for_private_repos.yaml
@@ -1,9 +1,6 @@
 agent: kubernetes
 decorate: true
 decoration_config:
-  oauth_token_secret:
-    key: oauth
-    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: pull-ci-org-repo-branch-test

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_via_ci_operator_config.yaml
@@ -1,9 +1,6 @@
 agent: kubernetes
 decorate: true
 decoration_config:
-  oauth_token_secret:
-    key: oauth
-    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: default-ci-vorg-vrepo-vbranch-

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_with_expose_via_ci_operator_config.yaml
@@ -1,9 +1,6 @@
 agent: kubernetes
 decorate: true
 decoration_config:
-  oauth_token_secret:
-    key: oauth
-    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 name: default-ci-vorg-vrepo-vbranch-
 spec:

--- a/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
+++ b/pkg/prowgen/testdata/zz_fixture_TestProwJobBaseBuilder_private_job_without_cloning__including_podspec.yaml
@@ -1,9 +1,6 @@
 agent: kubernetes
 decorate: true
 decoration_config:
-  oauth_token_secret:
-    key: oauth
-    name: github-credentials-openshift-ci-robot-private-git-cloner
   skip_cloning: true
 hidden: true
 name: default-ci-vorg-vrepo-vbranch-


### PR DESCRIPTION
## Summary

- Only set `oauth_token_secret` in `decoration_config` when sparse checkout is used (cloning enabled)
- Private repos with `skip_cloning: true` use a manual volume for the github token — adding `oauth_token_secret` causes prow to reserve that volume name, conflicting with the manual volume definition in the pod spec

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected authentication token configuration for private jobs to only be applied when cloning is enabled, ensuring secrets are injected only when necessary for clone operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->