### PR TITLE
config-brancher: skip derived release-* configs for etcd on main/master

### DIFF
--- a/cmd/config-brancher/main.go
+++ b/cmd/config-brancher/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/prow/pkg/flagutil"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
@@ -21,6 +22,8 @@ type options struct {
 
 	BumpRelease   string
 	skipPeriodics bool
+	// skipDerivedConfigBranches lists org/repo values for which main/master is not mirrored to release-*.
+	skipDerivedConfigBranches flagutil.Strings
 }
 
 func (o *options) Validate() error {
@@ -29,12 +32,36 @@ func (o *options) Validate() error {
 		return fmt.Errorf("future releases %v do not contain bump release %v", sets.List(futureReleases), o.BumpRelease)
 	}
 
+	if _, err := o.derivedSkipBranchSet(); err != nil {
+		return err
+	}
+
 	return o.FutureOptions.Validate()
 }
 
 func (o *options) Bind(fs *flag.FlagSet) {
 	fs.StringVar(&o.BumpRelease, "bump-release", "", "Bump the dev config to this release and manage mirroring.")
+	fs.Var(&o.skipDerivedConfigBranches, "skip-derived-config-branch", "Do not mirror main/master to release-* for this org/repo (repeatable). If unset, defaults to openshift/etcd and openshift-priv/etcd.")
 	o.FutureOptions.Bind(fs)
+}
+
+func (o *options) derivedSkipBranchSet() (sets.Set[string], error) {
+	out := sets.New[string]()
+	for _, v := range o.skipDerivedConfigBranches.Strings() {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		parts := strings.Split(v, "/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("--skip-derived-config-branch: %q is not org/repo", v)
+		}
+		out.Insert(v)
+	}
+	if out.Len() == 0 {
+		return sets.New[string]("openshift/etcd", "openshift-priv/etcd"), nil
+	}
+	return out, nil
 }
 
 func gatherOptions() options {
@@ -71,9 +98,14 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
+	skipBranches, err := o.derivedSkipBranchSet()
+	if err != nil {
+		logrus.WithError(err).Fatal("Invalid skip-derived-config-branch values.")
+	}
+
 	var toCommit []config.DataWithInfo
 	if err := o.OperateOnCIOperatorConfigDir(o.ConfigDir, api.WithOKD, func(configuration *api.ReleaseBuildConfiguration, info *config.Info) error {
-		for _, output := range generateBranchedConfigs(o.CurrentRelease, o.BumpRelease, o.FutureReleases.Strings(), config.DataWithInfo{Configuration: *configuration, Info: *info}, o.skipPeriodics) {
+		for _, output := range generateBranchedConfigs(o.CurrentRelease, o.BumpRelease, o.FutureReleases.Strings(), config.DataWithInfo{Configuration: *configuration, Info: *info}, o.skipPeriodics, skipBranches) {
 			if !o.Confirm {
 				output.Logger().Info("Would commit new file.")
 				continue
@@ -99,7 +131,7 @@ func main() {
 	}
 }
 
-func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases []string, input config.DataWithInfo, skipPeriodics bool) []config.DataWithInfo {
+func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases []string, input config.DataWithInfo, skipPeriodics bool, skipDerivedBranches sets.Set[string]) []config.DataWithInfo {
 	var output []config.DataWithInfo
 	input.Logger().Info("Branching configuration.")
 	currentConfig := input.Configuration
@@ -112,6 +144,10 @@ func generateBranchedConfigs(currentRelease, bumpRelease string, futureReleases 
 		updateImages(&currentConfig, currentRelease, bumpRelease)
 		// this config will continue to run for the dev branch but will be bumped
 		output = append(output, config.DataWithInfo{Configuration: currentConfig, Info: input.Info})
+	}
+
+	if promotion.SkipDerivedConfigsFromDefaultBranch(input.Info.Org, input.Info.Repo, input.Info.Branch, skipDerivedBranches) {
+		return output
 	}
 
 	for _, futureRelease := range futureReleases {

--- a/cmd/config-brancher/main_test.go
+++ b/cmd/config-brancher/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/prow/pkg/flagutil"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -17,13 +18,14 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 	interval := "72h"
 	cron := "@weekly"
 	var testCases = []struct {
-		name           string
-		currentRelease string
-		bumpRelease    string
-		futureReleases []string
-		input          config.DataWithInfo
-		skipPeriodics  bool
-		output         []config.DataWithInfo
+		name                string
+		currentRelease      string
+		bumpRelease         string
+		futureReleases      []string
+		input               config.DataWithInfo
+		skipPeriodics       bool
+		skipDerivedBranches sets.Set[string]
+		output              []config.DataWithInfo
 	}{
 		{
 			name:           "config that doesn't promote anywhere is ignored",
@@ -35,6 +37,27 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 				},
 				Info: config.Info{
 					Metadata: api.Metadata{Org: "org", Repo: "repo", Branch: "branch"},
+				},
+			},
+			output: nil,
+		},
+		{
+			name:                "etcd main skips derived release-* configs",
+			currentRelease:      "5.0",
+			bumpRelease:         "",
+			futureReleases:      []string{"5.0", "4.23", "5.1"},
+			skipDerivedBranches: sets.New[string]("openshift/etcd"),
+			input: config.DataWithInfo{
+				Configuration: api.ReleaseBuildConfiguration{
+					PromotionConfiguration: &api.PromotionConfiguration{
+						Targets: []api.PromotionTarget{{
+							Name:      "5.0",
+							Namespace: "ocp",
+						}},
+					},
+				},
+				Info: config.Info{
+					Metadata: api.Metadata{Org: "openshift", Repo: "etcd", Branch: "main"},
 				},
 			},
 			output: nil,
@@ -533,7 +556,7 @@ func TestGenerateBranchedConfigs(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, expected := generateBranchedConfigs(testCase.currentRelease, testCase.bumpRelease, testCase.futureReleases, testCase.input, testCase.skipPeriodics), testCase.output
+			actual, expected := generateBranchedConfigs(testCase.currentRelease, testCase.bumpRelease, testCase.futureReleases, testCase.input, testCase.skipPeriodics, testCase.skipDerivedBranches), testCase.output
 			if len(actual) != len(expected) {
 				t.Fatalf("%s: did not generate correct amount of output configs, needed %d got %d", testCase.name, len(expected), len(actual))
 			}

--- a/pkg/promotion/promotion.go
+++ b/pkg/promotion/promotion.go
@@ -63,6 +63,18 @@ func IsBumpable(branch, currentRelease string) bool {
 	return branch != fmt.Sprintf("openshift-%s", currentRelease)
 }
 
+// SkipDerivedConfigsFromDefaultBranch skips main/master → release-* mirroring when org/repo
+// is in skipBranches (keys are literal "org/repo"). Empty skipBranches never skips.
+func SkipDerivedConfigsFromDefaultBranch(org, repo, branch string, skipBranches sets.Set[string]) bool {
+	if skipBranches == nil || skipBranches.Len() == 0 {
+		return false
+	}
+	if branch != "master" && branch != "main" {
+		return false
+	}
+	return skipBranches.Has(org + "/" + repo)
+}
+
 // DetermineReleaseBranch determines the branch that will be used to the future release,
 // based on the branch that is currently promoting to the current release.
 func DetermineReleaseBranch(currentRelease, futureRelease, currentBranch string) (string, error) {

--- a/pkg/promotion/promotion_test.go
+++ b/pkg/promotion/promotion_test.go
@@ -111,6 +111,35 @@ func TestAllPromotionImageStreamTags(t *testing.T) {
 	}
 }
 
+func TestSkipDerivedConfigsFromDefaultBranch(t *testing.T) {
+	skipPublic := sets.New[string]("openshift/etcd")
+	skipPriv := sets.New[string]("openshift-priv/etcd")
+	skipBoth := sets.New[string]("openshift/etcd", "openshift-priv/etcd")
+	for _, tc := range []struct {
+		name              string
+		org, repo, branch string
+		skipBranches      sets.Set[string]
+		want              bool
+	}{
+		{name: "openshift etcd main", org: "openshift", repo: "etcd", branch: "main", skipBranches: skipPublic, want: true},
+		{name: "openshift etcd master", org: "openshift", repo: "etcd", branch: "master", skipBranches: skipPublic, want: true},
+		{name: "openshift-priv etcd main", org: "openshift-priv", repo: "etcd", branch: "main", skipBranches: skipPriv, want: true},
+		{name: "openshift-priv etcd main only public in set", org: "openshift-priv", repo: "etcd", branch: "main", skipBranches: skipPublic, want: false},
+		{name: "openshift etcd product branch", org: "openshift", repo: "etcd", branch: "openshift-5.0", skipBranches: skipBoth, want: false},
+		{name: "openshift etcd release branch", org: "openshift", repo: "etcd", branch: "release-5.0", skipBranches: skipBoth, want: false},
+		{name: "other repo", org: "openshift", repo: "other", branch: "main", skipBranches: skipBoth, want: false},
+		{name: "other org", org: "other", repo: "etcd", branch: "main", skipBranches: skipBoth, want: false},
+		{name: "nil skip set", org: "openshift", repo: "etcd", branch: "main", skipBranches: nil, want: false},
+		{name: "empty skip set", org: "openshift", repo: "etcd", branch: "main", skipBranches: sets.New[string](), want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SkipDerivedConfigsFromDefaultBranch(tc.org, tc.repo, tc.branch, tc.skipBranches); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestDetermineReleaseBranches(t *testing.T) {
 	var testCases = []struct {
 		name                                         string


### PR DESCRIPTION
Skip mirroring main/master onto release-* for openshift/etcd and openshift-priv/etcd; product configs use openshift-* branches and mirroring duplicates promotion targets.

Add promotion.SkipDerivedConfigsFromDefaultBranch and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config brancher can skip mirroring derived configs from default branches (main/master) for specified repositories, avoiding unnecessary mirrored release-* configs.

* **Tests**
  * Added unit and integration tests validating skip behavior across repo and branch scenarios, including default-branch checks and empty/nil skip lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->