### PR TITLE
ci-operator-config-mirror: set prowgen.private for openshift-priv mirrored configs

### DIFF
--- a/cmd/ci-operator-config-mirror/main.go
+++ b/cmd/ci-operator-config-mirror/main.go
@@ -274,6 +274,13 @@ func ciOperatorConfigsCallback(o options, configsByRepo configsByRepo, flattened
 		rbc.Metadata.Org = o.toOrg
 		rbc.Metadata.Repo = repoInfo.Repo
 
+		if o.toOrg == "openshift-priv" {
+			if rbc.Prowgen == nil {
+				rbc.Prowgen = &api.ProwgenOverrides{}
+			}
+			rbc.Prowgen.Private = true
+		}
+
 		if len(rbc.Tests) > 0 || len(rbc.Images.Items) > 0 {
 			configsByRepo[repoInfo.Repo] = append(configsByRepo[repoInfo.Repo], config.DataWithInfo{
 				Configuration: *rbc,

--- a/cmd/ci-operator-config-mirror/main_test.go
+++ b/cmd/ci-operator-config-mirror/main_test.go
@@ -278,6 +278,7 @@ func TestCIOperatorConfigsCallback(t *testing.T) {
 					Configuration: api.ReleaseBuildConfiguration{
 						Metadata:              api.Metadata{Org: "openshift-priv", Repo: "kubernetes"},
 						CanonicalGoRepository: ptr.To("github.com/openshift/kubernetes"),
+						Prowgen:               &api.ProwgenOverrides{Private: true},
 						Tests:                 []api.TestStepConfiguration{{As: "e2e"}},
 					},
 					Info: config.Info{Metadata: api.Metadata{Org: "openshift-priv", Repo: "kubernetes"}},
@@ -334,6 +335,7 @@ func TestCIOperatorConfigsCallback(t *testing.T) {
 					Configuration: api.ReleaseBuildConfiguration{
 						Metadata:              api.Metadata{Org: "openshift-priv", Repo: "migtools-filebrowser"},
 						CanonicalGoRepository: ptr.To("github.com/migtools/filebrowser"),
+						Prowgen:               &api.ProwgenOverrides{Private: true},
 						Tests:                 []api.TestStepConfiguration{{As: "e2e"}},
 					},
 					Info: config.Info{Metadata: api.Metadata{Org: "openshift-priv", Repo: "migtools-filebrowser"}},


### PR DESCRIPTION
## Problem

PR #78250 migrated `private: true` from the org-level `openshift-priv/.config.prowgen` into each ci-operator config's `prowgen:` section, then deleted the org-level file. When the automated `ci-operator-config-mirror` subsequently re-mirrored `openshift/` → `openshift-priv/`, it overwrote configs without `prowgen: private: true` (since source configs don't carry it). `ci-operator-prowgen` then regenerated jobs missing `oauth_token_secret`, `hidden: true`, and credential volume mounts — breaking all openshift-priv jobs' ability to clone private repositories.

Related to https://github.com/openshift/release/pull/78250 
https://redhat-internal.slack.com/archives/GB7NB0CUC/p1777577547430419?thread_ts=1777573924.687009&cid=GB7NB0CUC 
/cc @openshift/test-platform 

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration mirroring now automatically marks release build configurations as private when mirroring to the designated private organization.

* **Tests**
  * Updated test expectations to validate private configuration marking during mirroring operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->