### PR TITLE
Forward SubSteps() through wrapper steps

### DIFF
--- a/pkg/steps/cluster_claim.go
+++ b/pkg/steps/cluster_claim.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	apiutils "github.com/openshift/ci-tools/pkg/api/utils"
+	"github.com/openshift/ci-tools/pkg/junit"
 	"github.com/openshift/ci-tools/pkg/kubernetes"
 	"github.com/openshift/ci-tools/pkg/results"
 	"github.com/openshift/ci-tools/pkg/secrets"
@@ -61,6 +62,20 @@ func (s *clusterClaimStep) Requires() []api.StepLink            { return s.wrapp
 func (s *clusterClaimStep) Creates() []api.StepLink             { return s.wrapped.Creates() }
 func (s *clusterClaimStep) Objects() []ctrlruntimeclient.Object { return s.wrapped.Objects() }
 func (s *clusterClaimStep) Provides() api.ParameterMap          { return s.wrapped.Provides() }
+
+func (s *clusterClaimStep) SubTests() []*junit.TestCase {
+	if subTests, ok := s.wrapped.(SubtestReporter); ok {
+		return subTests.SubTests()
+	}
+	return nil
+}
+
+func (s *clusterClaimStep) SubSteps() []api.CIOperatorStepDetailInfo {
+	if subSteps, ok := s.wrapped.(SubStepReporter); ok {
+		return subSteps.SubSteps()
+	}
+	return nil
+}
 
 func (s *clusterClaimStep) Run(ctx context.Context) error {
 	return results.ForReason("utilizing_cluster_claim").ForError(s.run(ctx))

--- a/pkg/steps/cluster_claim_test.go
+++ b/pkg/steps/cluster_claim_test.go
@@ -334,3 +334,20 @@ func (client *clusterClaimStatusSettingClient) Create(ctx context.Context, obj c
 	}
 	return client.WithWatch.Create(ctx, obj, opts...)
 }
+
+func TestClusterClaimStepForward(t *testing.T) {
+	step := stepNeedsLease{}
+	withClaim := ClusterClaimStep("test", &api.ClusterClaim{}, nil, nil, nil, &step, nil)
+	t.Run("SubTests", func(t *testing.T) {
+		s, l := step.SubTests(), withClaim.(SubtestReporter).SubTests()
+		if diff := cmp.Diff(s, l); diff != "" {
+			t.Errorf("not properly forwarded: %s", diff)
+		}
+	})
+	t.Run("SubSteps", func(t *testing.T) {
+		s, l := step.SubSteps(), withClaim.(SubStepReporter).SubSteps()
+		if diff := cmp.Diff(s, l); diff != "" {
+			t.Errorf("not properly forwarded: %s", diff)
+		}
+	})
+}

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -86,6 +86,13 @@ func (s *ipPoolStep) SubTests() []*junit.TestCase {
 	return nil
 }
 
+func (s *ipPoolStep) SubSteps() []api.CIOperatorStepDetailInfo {
+	if subSteps, ok := s.wrapped.(SubStepReporter); ok {
+		return subSteps.SubSteps()
+	}
+	return nil
+}
+
 func (s *ipPoolStep) Run(ctx context.Context) error {
 	return results.ForReason("utilizing_ip_pool").ForError(s.run(ctx, time.Minute))
 }

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -130,6 +130,10 @@ func (blockingStep) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
+func (blockingStep) SubSteps() []api.CIOperatorStepDetailInfo {
+	return []api.CIOperatorStepDetailInfo{{StepName: "inner-step"}}
+}
+
 func TestRun(t *testing.T) {
 	ciOpNamespace := "ci-op-1234"
 
@@ -334,6 +338,23 @@ func TestRun(t *testing.T) {
 
 		})
 	}
+}
+
+func TestIPPoolStepForward(t *testing.T) {
+	step := stepNeedsLease{}
+	withIPPool := IPPoolStep(nil, nil, api.StepLease{ResourceType: "aws-ip-pool", Env: api.DefaultIPPoolLeaseEnv}, &step, nil, emptyNamespace, nil)
+	t.Run("SubTests", func(t *testing.T) {
+		s, l := step.SubTests(), withIPPool.(SubtestReporter).SubTests()
+		if diff := cmp.Diff(s, l); diff != "" {
+			t.Errorf("not properly forwarded: %s", diff)
+		}
+	})
+	t.Run("SubSteps", func(t *testing.T) {
+		s, l := step.SubSteps(), withIPPool.(SubStepReporter).SubSteps()
+		if diff := cmp.Diff(s, l); diff != "" {
+			t.Errorf("not properly forwarded: %s", diff)
+		}
+	})
 }
 
 type fakeSecretClient struct {

--- a/pkg/steps/lease.go
+++ b/pkg/steps/lease.go
@@ -133,6 +133,13 @@ func (s *leaseStep) SubTests() []*junit.TestCase {
 	return nil
 }
 
+func (s *leaseStep) SubSteps() []api.CIOperatorStepDetailInfo {
+	if subSteps, ok := s.wrapped.(SubStepReporter); ok {
+		return subSteps.SubSteps()
+	}
+	return nil
+}
+
 func (s *leaseStep) Run(ctx context.Context) error {
 	return results.ForReason("utilizing_lease").ForError(s.run(ctx))
 }

--- a/pkg/steps/lease_test.go
+++ b/pkg/steps/lease_test.go
@@ -62,6 +62,10 @@ func (stepNeedsLease) SubTests() []*junit.TestCase {
 	return []*junit.TestCase{&ret}
 }
 
+func (stepNeedsLease) SubSteps() []api.CIOperatorStepDetailInfo {
+	return []api.CIOperatorStepDetailInfo{{StepName: "inner-step"}}
+}
+
 func emptyNamespace() string { return "" }
 
 func TestLeaseStepForward(t *testing.T) {
@@ -121,6 +125,12 @@ func TestLeaseStepForward(t *testing.T) {
 	})
 	t.Run("SubTests", func(T *testing.T) {
 		s, l := step.SubTests(), withLease.(SubtestReporter).SubTests()
+		if !reflect.DeepEqual(l, s) {
+			t.Errorf("not properly forwarded: %s", diff.ObjectDiff(l, s))
+		}
+	})
+	t.Run("SubSteps", func(T *testing.T) {
+		s, l := step.SubSteps(), withLease.(SubStepReporter).SubSteps()
 		if !reflect.DeepEqual(l, s) {
 			t.Errorf("not properly forwarded: %s", diff.ObjectDiff(l, s))
 		}


### PR DESCRIPTION
The purpose of this change is to add substep information to ci-operator-step-graph.json to enable much more efficient automated scraping of prow job artifacts.

The step graph outputs substeps for steps which implement SubStepReporter, but this is lost when the step is wrapped by LeaseStep, IPPoolStep, or ClusterClaimStep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved hierarchical reporting so steps and sub-steps surface detailed test and step information across cluster claim, IP pool, and lease flows.

* **Tests**
  * Added unit tests to verify forwarding of subtest and sub-step details through wrapper components, ensuring consistent reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->