### PR TITLE
NO-JIRA: add permanent exception for 5.0 periodics.yaml

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	yaml "gopkg.in/yaml.v3"
 
@@ -38,6 +37,9 @@ type jobNameGenerator struct {
 }
 
 var (
+	templateException = []string{
+		"openshift-release-release-5.0-periodics.yaml",
+	}
 	periodicURLTemplates = []string{
 		"https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/release/openshift-release-release-%s-periodics.yaml",
 		"https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-%s-periodics.yaml",
@@ -84,15 +86,23 @@ func (s *jobNameGenerator) UpdateURLsForAllReleases(releases []jobrunaggregatora
 	}
 }
 
+func isTemplateException(url string) bool {
+	for _, exception := range templateException {
+		if strings.Contains(url, exception) {
+			return true
+		}
+	}
+	return false
+}
+
 func readConfigURL(url string, into interface{}, unmarshal func(data []byte, v any) error) (skip bool, failure error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return false, fmt.Errorf("error requesting %v: %w", url, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == 404 && strings.Contains(url, "-5.0") && time.Now().Format(time.DateOnly) < "2026-05-01" {
-		// TRT defined the 5.0 release prior to branch cut for sippy's use; ignore if not defined
-		fmt.Println("SKIPPING premature 5.0 config with URL 404 not found: " + url)
+	if resp.StatusCode == 404 && isTemplateException(url) {
+		fmt.Println("SKIPPING template exception config with URL 404 not found: " + url)
 		return true, nil
 	} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		return false, fmt.Errorf("error reading %v: %v", url, resp.StatusCode)

--- a/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v3"
 
 	"github.com/openshift/ci-tools/pkg/jobrunaggregator/jobrunaggregatorapi"
@@ -101,10 +102,11 @@ func readConfigURL(url string, into interface{}, unmarshal func(data []byte, v a
 		return false, fmt.Errorf("error requesting %v: %w", url, err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == 404 && isTemplateException(url) {
-		fmt.Println("SKIPPING template exception config with URL 404 not found: " + url)
+	if resp.StatusCode == http.StatusNotFound && isTemplateException(url) {
+		logrus.WithField("url", url).Info("skipping pre-branch-cut config: URL 404 not found")
 		return true, nil
-	} else if resp.StatusCode < 200 || resp.StatusCode > 299 {
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return false, fmt.Errorf("error reading %v: %v", url, resp.StatusCode)
 	}
 


### PR DESCRIPTION
Post branching and the config doesn't exist for 5.0.  Adding a permanent exception.

Worth further investigation to see if these are periodics we actually need to include.  [openshift-release-release-4.23-periodics.yaml](https://github.com/openshift/release/blob/b008bbe21998083c38402022402ac453f20bcdeb/ci-operator/jobs/openshift/release/openshift-release-release-4.23-periodics.yaml#L1) looks to only contain multi release upgrades which are not monitored for CR and likely not Sippy either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing job configuration files: the system now skips certain 404s based on configurable template exceptions instead of time-based conditions, yielding more consistent job aggregation and clearer skip logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->