### PR TITLE
check-cluster-profiles-config: Normalize cluster profiles

### DIFF
--- a/cmd/check-cluster-profiles-config/main.go
+++ b/cmd/check-cluster-profiles-config/main.go
@@ -5,11 +5,16 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
+	"sort"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
 	coreapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/ci-tools/pkg/api"
@@ -23,6 +28,7 @@ var (
 
 type options struct {
 	configPath string
+	normalize  bool
 }
 
 type profileValidator struct {
@@ -35,6 +41,7 @@ func gatherOptions() options {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	fs.StringVar(&o.configPath, "config-path", "", "Path to the cluster profile config file")
+	fs.BoolVar(&o.normalize, "normalize", false, "Normalize the cluster profiles")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatal("could not parse arguments")
@@ -54,26 +61,52 @@ func main() {
 	logger := logrus.WithField("component", "check-cluster-profiles-config")
 	o := gatherOptions()
 
-	inClusterConfig, err := util.LoadClusterConfig()
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to load in-cluster config")
-	}
-	client, err := ctrlruntimeclient.New(inClusterConfig, ctrlruntimeclient.Options{})
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to create client")
-	}
-	validator := newValidator(client)
-
-	list, err := loadConfig(o.configPath)
+	profiles, err := loadConfig(o.configPath)
 	if err != nil {
 		logger.WithError(err).Fatal("failed to load cluster profiles from config file")
 	}
 
-	if err := validator.Validate(list); err != nil {
+	if o.normalize {
+		validator := newValidator(fakectrlruntimeclient.NewFakeClient())
+
+		if err := validator.Validate(profiles); err != nil {
+			logger.WithError(err).Fatal("failed to validate cluster profiles")
+		}
+
+		normalize(profiles)
+
+		if err := writeConfig(o.configPath, profiles); err != nil {
+			logger.WithError(err).Fatal("failed to write cluster profiles")
+		}
+
+		return
+	}
+
+	inClusterConfig, err := util.LoadClusterConfig()
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to load in-cluster config")
+	}
+
+	client, err := ctrlruntimeclient.New(inClusterConfig, ctrlruntimeclient.Options{})
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create client")
+	}
+
+	validator := newValidator(client)
+
+	if err := validator.Validate(profiles); err != nil {
 		logger.WithError(err).Fatal("failed to validate cluster profiles")
 	}
 
-	if err := validator.checkCiSecrets(); err != nil {
+	normalizedProfiles := profiles.DeepCopy()
+	normalize(normalizedProfiles)
+
+	if diff := cmp.Diff(profiles, normalizedProfiles); diff != "" {
+		fmt.Print(diff)
+		logger.Fatal("\nProfiles have not been normalized, run `make check-cluster-profiles`")
+	}
+
+	if err := validator.checkCISecrets(); err != nil {
 		logger.WithError(err).Fatal("failed to validate secrets for cluster profiles")
 	}
 
@@ -94,15 +127,52 @@ func loadConfig(configPath string) (api.ClusterProfilesList, error) {
 	return profilesList, nil
 }
 
+func writeConfig(configPath string, profiles api.ClusterProfilesList) error {
+	bytes, err := yaml.Marshal(profiles)
+	if err != nil {
+		return fmt.Errorf("marshal profiles: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, bytes, 0644); err != nil {
+		return fmt.Errorf("write profiles %q: %w", configPath, err)
+	}
+
+	return nil
+}
+
 func (validator *profileValidator) Validate(profiles api.ClusterProfilesList) error {
 	for _, p := range profiles {
-		// Check for duplicate orgs within the profile first
-		orgMap := make(map[string]bool)
+		// Check for duplicate orgs/tenants
+		tenantMap := sets.New[string]()
+		orgMap := sets.New[string]()
+
 		for _, owner := range p.Owners {
-			if orgMap[owner.Org] {
-				return fmt.Errorf("cluster profile '%v' has duplicate org '%v'", p.Profile, owner.Org)
+			tenant := ""
+			if owner.Konflux != nil {
+				tenant = owner.Konflux.Tenant
 			}
-			orgMap[owner.Org] = true
+
+			if tenant == "" && owner.Org == "" {
+				return fmt.Errorf("cluster profile '%v' has an invalid owner", p.Profile)
+			}
+
+			if tenant != "" && owner.Org != "" {
+				return fmt.Errorf("cluster profile '%v' has both org and tenant set", p.Profile)
+			}
+
+			if tenant != "" {
+				if tenantMap.Has(tenant) {
+					return fmt.Errorf("cluster profile '%v' has duplicate tenant %q", p.Profile, tenant)
+				}
+				tenantMap.Insert(tenant)
+			}
+
+			if owner.Org != "" {
+				if orgMap.Has(owner.Org) {
+					return fmt.Errorf("cluster profile '%v' has duplicate org %q", p.Profile, owner.Org)
+				}
+				orgMap.Insert(owner.Org)
+			}
 		}
 
 		// Check if a profile isn't already defined in the config
@@ -115,8 +185,8 @@ func (validator *profileValidator) Validate(profiles api.ClusterProfilesList) er
 	return nil
 }
 
-// checkCiSecrets verifies that the secret for each cluster profile exists in the ci namespace
-func (validator *profileValidator) checkCiSecrets() error {
+// checkCISecrets verifies that the secret for each cluster profile exists in the ci namespace
+func (validator *profileValidator) checkCISecrets() error {
 	for p := range validator.profiles {
 		profileDetails, err := server.NewResolverClient(configResolverAddress).ClusterProfile(p.Name())
 		if err != nil {
@@ -129,4 +199,29 @@ func (validator *profileValidator) checkCiSecrets() error {
 		}
 	}
 	return nil
+}
+
+func normalize(profiles api.ClusterProfilesList) {
+	for i := range profiles {
+		profile := &profiles[i]
+		sortOwners(profile.Owners)
+	}
+}
+
+// sortOwners does what follows:
+//   - Sort repos by name.
+//   - Sort owners by org.
+func sortOwners(owners []api.ClusterProfileOwners) {
+	if len(owners) == 0 {
+		return
+	}
+
+	for i := range owners {
+		owner := &owners[i]
+		if len(owner.Repos) > 0 {
+			slices.Sort(owner.Repos)
+		}
+	}
+
+	sort.Slice(owners, func(i, j int) bool { return owners[i].Org < owners[j].Org })
 }

--- a/cmd/check-cluster-profiles-config/main_test.go
+++ b/cmd/check-cluster-profiles-config/main_test.go
@@ -62,17 +62,354 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expected: fmt.Errorf("cluster profile 'aws' has duplicate org 'aws'"),
+			expected: fmt.Errorf(`cluster profile 'aws' has duplicate org "aws"`),
+		},
+		{
+			name: "Invalid owner",
+			profiles: api.ClusterProfilesList{
+				api.ClusterProfileDetails{
+					Profile: "aws",
+					Owners:  []api.ClusterProfileOwners{{}},
+				},
+			},
+			expected: fmt.Errorf(`cluster profile 'aws' has an invalid owner`),
+		},
+		{
+			name: "Konflux and org mutually exclusive",
+			profiles: api.ClusterProfilesList{
+				api.ClusterProfileDetails{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{{
+						Org:     "openshift",
+						Konflux: &api.ClusterProfileKonfluxOwner{Tenant: "openshift"},
+					}},
+				},
+			},
+			expected: fmt.Errorf(`cluster profile 'aws' has both org and tenant set`),
 		},
 	}
 
-	validator := newValidator(fakectrlruntimeclient.NewFakeClient())
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			validator := newValidator(fakectrlruntimeclient.NewFakeClient())
 			err := validator.Validate(tc.profiles)
 			if diff := cmp.Diff(tc.expected, err, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("error differs from expected:\n%v", diff)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		profiles     api.ClusterProfilesList
+		wantProfiles api.ClusterProfilesList
+	}{
+		{
+			name:         "Empty profile list",
+			profiles:     api.ClusterProfilesList{},
+			wantProfiles: api.ClusterProfilesList{},
+		},
+		{
+			name: "Profile with nil owners",
+			profiles: api.ClusterProfilesList{
+				{Profile: "aws", Secret: "aws-secret", Owners: nil},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{Profile: "aws", Secret: "aws-secret", Owners: nil},
+			},
+		},
+		{
+			name: "Profile with empty owners slice",
+			profiles: api.ClusterProfilesList{
+				{Profile: "aws", Secret: "aws-secret", Owners: []api.ClusterProfileOwners{}},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{Profile: "aws", Secret: "aws-secret", Owners: []api.ClusterProfileOwners{}},
+			},
+		},
+		{
+			name: "Owner with nil repos",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: nil},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: nil},
+					},
+				},
+			},
+		},
+		{
+			name: "Owner with empty repos slice",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{}},
+					},
+				},
+			},
+		},
+		{
+			name: "Mix of nil and empty repos",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: nil},
+						{Org: "redhat-developer", Repos: []string{}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: nil},
+						{Org: "redhat-developer", Repos: []string{}},
+					},
+				},
+			},
+		},
+		{
+			name: "All owners with nil repos",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: nil},
+						{Org: "ComplianceAsCode", Repos: nil},
+						{Org: "openshift", Repos: nil},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "ComplianceAsCode", Repos: nil},
+						{Org: "openshift", Repos: nil},
+						{Org: "redhat-developer", Repos: nil},
+					},
+				},
+			},
+		},
+		{
+			name: "Profile with unsorted repos",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"origin", "api", "installer"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api", "installer", "origin"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Profile with unsorted orgs",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: []string{"kam"}},
+						{Org: "openshift", Repos: []string{"api"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api"}},
+						{Org: "redhat-developer", Repos: []string{"kam"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Profile with already sorted owners and repos",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api", "installer", "origin"}},
+						{Org: "redhat-developer", Repos: []string{"gitops-operator", "kam"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api", "installer", "origin"}},
+						{Org: "redhat-developer", Repos: []string{"gitops-operator", "kam"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Profile with different orgs - sorts orgs alphabetically",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: []string{"installer", "api"}},
+						{Org: "openshift", Repos: []string{"origin", "cli"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"cli", "origin"}},
+						{Org: "redhat-developer", Repos: []string{"api", "installer"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Case-sensitive org sorting",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api"}},
+						{Org: "ComplianceAsCode", Repos: []string{"content"}},
+						{Org: "AWS-Org", Repos: []string{"repo1"}},
+						{Org: "azure-org", Repos: []string{"repo2"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "AWS-Org", Repos: []string{"repo1"}},
+						{Org: "ComplianceAsCode", Repos: []string{"content"}},
+						{Org: "azure-org", Repos: []string{"repo2"}},
+						{Org: "openshift", Repos: []string{"api"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple profiles - sorts each independently",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: []string{"kam", "gitops-operator"}},
+						{Org: "openshift", Repos: []string{"origin", "api"}},
+					},
+				},
+				{
+					Profile: "gcp",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: []string{"cli"}},
+						{Org: "openshift", Repos: []string{"installer"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api", "origin"}},
+						{Org: "redhat-developer", Repos: []string{"gitops-operator", "kam"}},
+					},
+				},
+				{
+					Profile: "gcp",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"installer"}},
+						{Org: "redhat-developer", Repos: []string{"cli"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Single org with single repo",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "openshift", Repos: []string{"api"}},
+					},
+				},
+			},
+		},
+		{
+			name: "Complex: unsorted orgs and repos, with duplicates",
+			profiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "redhat-developer", Repos: []string{"kam", "gitops-operator"}},
+						{Org: "ComplianceAsCode", Repos: []string{"ocp4e2e", "content"}},
+						{Org: "openshift", Repos: []string{"origin", "installer"}},
+						{Org: "azure-org", Repos: []string{"repo2", "repo1"}},
+					},
+				},
+			},
+			wantProfiles: api.ClusterProfilesList{
+				{
+					Profile: "aws",
+					Owners: []api.ClusterProfileOwners{
+						{Org: "ComplianceAsCode", Repos: []string{"content", "ocp4e2e"}},
+						{Org: "azure-org", Repos: []string{"repo1", "repo2"}},
+						{Org: "openshift", Repos: []string{"installer", "origin"}},
+						{Org: "redhat-developer", Repos: []string{"gitops-operator", "kam"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotProfiles := tc.profiles.DeepCopy()
+			normalize(gotProfiles)
+
+			if diff := cmp.Diff(tc.wantProfiles, gotProfiles); diff != "" {
+				t.Errorf("normalized result differs from expected (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
I realized that the tool `check-cluster-profiles-config` and the make target `check-cluster-profiles` in `o/release` overlaps in terms of functionalities, therefore I decided to consolidate everything under a single tool.

This PR introduces the `--normalize` option that performs what follow:
1. Merge the same `org`s across `owners` of a given profile. As an example:
```yaml
- profile: aws
  owners:
    - org: openshift
      repos: 
      - release
    - org: openshift
      repos: 
      - ci-tools
```
  turns into:
```yaml
- profile: aws
  owners:
    - org: openshift
      repos: 
      - ci-tools
      - release
```
3. Sort `repos` by name of a given `owner`.
4. Sort profile by `org`s name.

The tool `check-cluster-profiles-config` must be used both offline by users and in a Presubmit:

### Offline
1. The user adds a new profile.
2. The user runs `make check-cluster-profiles` that, under the hood, invokes:
```sh
check-cluster-profiles-config --normalize --config-path=ci-operator/step-registry/cluster-profiles/cluster-profiles-config.yaml
```

### Presubmit
The Presubmit stays the same but now `check-cluster-profiles` checks whether the configuration has been normalized or not, failing if it had not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --normalize option to normalize cluster profiles: writes normalized YAML when enabled; when disabled, reports normalization diffs and fails CI without modifying files.

* **Improvements / Bug Fixes**
  * Stricter owner validation: requires exactly one of tenant or org and detects duplicate tenants/orgs; normalization now produces deterministic ordering.

* **Tests**
  * Added normalization tests and improved validation test isolation.

* **Chores**
  * Updated CI secrets verification flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->