### PR TITLE
promotion-quay: retry digest-tag when QCI digest moves after mirror

### DIFF
--- a/pkg/steps/release/promote.go
+++ b/pkg/steps/release/promote.go
@@ -287,20 +287,30 @@ func promotionCLIImageInfoFilterOS(nodeArchitectures []string) string {
 	return "linux/amd64"
 }
 
-// getResolveAndTagCommand generates a shell command that queries QCI for the manifest digest of
-// quayProxyTag (via oc image info, after it has been mirrored) and then uses that digest to tag
-// the IS target. This ensures spec.from always holds the exact QCI digest pullspec.
-//
-// Parses digest from oc image info default text (Digest: sha256:… line). Older oc rejects -o jsonpath
-// for oc image info ("unrecognized --output, only 'json' is supported"); jq/python are unnecessary.
-// --filter-by-os selects one manifest when the tag points at an image index (manifest list); it is
-// ignored for single-manifest references (see oc image info --help).
-func getResolveAndTagCommand(registryConfig, quayProxyTag, isTag string, loglevel int, filterByOS string) string {
+const quayPromotionDigestTagAttempts = 5
+
+// getResolveAndTagRetryShell resolves quay-proxy digest via oc image info and oc tags the IST; retries when QCI moves after mirror.
+func getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag string, loglevel int, filterByOS string) string {
 	repo := quayProxyTag[:strings.LastIndex(quayProxyTag, ":")]
-	return fmt.Sprintf(
-		`_digest=$(oc image info --registry-config=%s --filter-by-os=%s %s | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1) && oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference %s@${_digest} %s`,
-		registryConfig, filterByOS, quayProxyTag, loglevel, repo, isTag,
-	)
+	n := quayPromotionDigestTagAttempts
+	return fmt.Sprintf(`for r in {1..%d}; do
+  _digest=$(oc image info --registry-config=%s --filter-by-os=%s %s | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+  if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=%d --reference-policy='source' --import-mode='PreserveOriginal' --reference %s@${_digest} %s; then
+    break
+  fi
+  echo "promotion-quay: digest-tag failed for %s attempt ${r}/%d (QCI digest may have moved after mirror)" >&2
+  if [ "${r}" -eq %d ]; then
+    exit 1
+  fi
+  echo "promotion-quay: retrying digest-tag for %s (attempt $((r+1))/%d after randomized backoff)" >&2
+  backoff=$(($RANDOM %% %d))s
+  sleep "${backoff}"
+done
+`, n, registryConfig, filterByOS, quayProxyTag, loglevel, repo, isTag,
+		isTag, n,
+		n,
+		isTag, n,
+		120)
 }
 
 const (
@@ -385,9 +395,7 @@ func getPromotionPod(imageMirrorTarget map[string]string, timeStr string, namesp
 		// Concrete *-quay IS targets: resolve QCI digest post-mirror, then tag.
 		for _, pair := range resolveAndTagPairs {
 			quayProxyTag, isTag := pair[0], pair[1]
-			resolveCmd := getResolveAndTagCommand(registryConfig, quayProxyTag, isTag, 2, promotionCLIImageInfoFilterOS(nodeArchitectures))
-			retryCmd := fmt.Sprintf(retryLoopTemplate, 3, fmt.Sprintf("'Digest-tag attempt $r (%s)'", isTag), resolveCmd, retryLoopWithBackoff)
-			tagCommands = append(tagCommands, retryCmd)
+			tagCommands = append(tagCommands, getResolveAndTagRetryShell(registryConfig, quayProxyTag, isTag, 2, promotionCLIImageInfoFilterOS(nodeArchitectures)))
 		}
 
 		tagCommands = append(tagCommands, "set -e")

--- a/pkg/steps/release/promote_test.go
+++ b/pkg/steps/release/promote_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1087,6 +1088,29 @@ func TestGetPublicImageReference(t *testing.T) {
 				t.Errorf("%s: got incorrect public image reference: %v", testCase.name, diff.ObjectDiff(actual, expected))
 			}
 		})
+	}
+}
+
+func TestGetResolveAndTagRetryShell(t *testing.T) {
+	regcfg := "/etc/push-secret/.dockerconfigjson"
+	proxyTag := "quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes"
+	isTag := "ocp/4.21-quay:ovn-kubernetes"
+	got := getResolveAndTagRetryShell(regcfg, proxyTag, isTag, 2, "linux/amd64")
+
+	for _, sub := range []string{
+		"for r in {1..5}",
+		"oc image info --registry-config=" + regcfg + " --filter-by-os=linux/amd64 " + proxyTag,
+		"oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} " + isTag,
+		"promotion-quay: digest-tag failed for " + isTag,
+		"promotion-quay: retrying digest-tag for " + isTag,
+		`[ "${r}" -eq 5 ]`,
+		"exit 1",
+		"$(($RANDOM % 120))",
+		`sleep "${backoff}"`,
+	} {
+		if !strings.Contains(got, sub) {
+			t.Fatalf("missing substring %q in:\n%s", sub, got)
+		}
 	}
 }
 

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_multiple_tags.yaml
@@ -11,9 +11,48 @@ spec:
       oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 quay.io/openshift/ci:ocp_4.21_ovn-kubernetes=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-base quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift=quay.io/openshift/ci:20240603235401_prune_ovn-kubernetes-microshift || true
       for r in {1..5}; do echo Mirror attempt $r; oc image mirror --loglevel=2 --keep-manifest-list --registry-config=/etc/push-secret/.dockerconfigjson --max-per-registry=10 registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:aaa=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:bbb=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-base registry.build02.ci.openshift.org/ci-op-y2n8rsh3/pipeline@sha256:ccc=quay.io/openshift/ci:ocp_4.21_ovn-kubernetes-microshift && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
       set +e
-      for r in {1..3}; do echo 'Digest-tag attempt $r (ocp/4.21-quay:ovn-kubernetes)'; _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1) && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo 'Digest-tag attempt $r (ocp/4.21-quay:ovn-kubernetes-base)'; _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1) && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes-base && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo 'Digest-tag attempt $r (ocp/4.21-quay:ovn-kubernetes-microshift)'; _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1) && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes-microshift && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21-quay:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21-quay:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-base | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes-base; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21-quay:ovn-kubernetes-base attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21-quay:ovn-kubernetes-base (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes-microshift | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes-microshift; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21-quay:ovn-kubernetes-microshift attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21-quay:ovn-kubernetes-microshift (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
       set -e
     command:
     - /bin/sh

--- a/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
+++ b/pkg/steps/release/testdata/zz_fixture_TestGetPromotionPod_promotion_quay_non_release_namespace.yaml
@@ -12,7 +12,20 @@ spec:
       set +e
       for r in {1..2}; do echo 'Tag attempt $r (all together)'; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; :; done
       for r in {1..3}; do echo 'Tag attempt $r (individual)'; oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@sha256:bbb ci/ci-quay:sanitize-prow-jobs && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
-      for r in {1..3}; do echo 'Digest-tag attempt $r (ocp/4.21-quay:ovn-kubernetes)'; _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1) && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes && break; backoff=$(($RANDOM % 120))s; echo Sleeping randomized $backoff before retry; sleep $backoff; done
+      for r in {1..5}; do
+        _digest=$(oc image info --registry-config=/etc/push-secret/.dockerconfigjson --filter-by-os=linux/amd64 quay-proxy.ci.openshift.org/openshift/ci:ocp_4.21_ovn-kubernetes | sed -n '/^Digest:[[:space:]]/s/^Digest:[[:space:]]*//p' | head -n1)
+        if [ -n "${_digest}" ] && oc tag --source=docker --loglevel=2 --reference-policy='source' --import-mode='PreserveOriginal' --reference quay-proxy.ci.openshift.org/openshift/ci@${_digest} ocp/4.21-quay:ovn-kubernetes; then
+          break
+        fi
+        echo "promotion-quay: digest-tag failed for ocp/4.21-quay:ovn-kubernetes attempt ${r}/5 (QCI digest may have moved after mirror)" >&2
+        if [ "${r}" -eq 5 ]; then
+          exit 1
+        fi
+        echo "promotion-quay: retrying digest-tag for ocp/4.21-quay:ovn-kubernetes (attempt $((r+1))/5 after randomized backoff)" >&2
+        backoff=$(($RANDOM % 120))s
+        sleep "${backoff}"
+      done
+
       set -e
     command:
     - /bin/sh


### PR DESCRIPTION
Adds a dedicated digest-tag retry loop for quay promotion so `oc image info` + `oc tag @digest` can succeed when the QCI digest shifts right after mirror. Replaces the previous single-shot resolve wrapped in `retryLoopTemplate`.

Keeps the same `oc image info` / `oc tag` flags and aligns backoff with existing promotion loops (`{1..5}`, randomized sleep up to 120s). Tests and promotion-quay pod fixtures updated accordingly.

/cc @Prucek @openshift/test-platform 

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image promotion now includes built-in automatic retry logic with randomized backoff to handle transient digest resolution failures and improve overall resilience.

* **Tests**
  * Added test coverage for the new retry mechanism.
  * Updated test fixtures to validate enhanced retry behavior with improved attempt limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->