### PR TITLE
store the pod and machine snapshot metrics on pending pods that never got scheduled too

### DIFF
--- a/pkg/steps/multi_stage/run.go
+++ b/pkg/steps/multi_stage/run.go
@@ -155,6 +155,8 @@ func (s *multiStageTestStep) runPod(ctx context.Context, pod *coreapi.Pod, notif
 	// step Pod in the cluster, because it may eventually get scheduled and start testing the cluster that
 	// is already being torn down).
 	if err != nil && pod.Status.Phase == coreapi.PodPending {
+		client.MetricsAgent().StorePodLifecycleMetrics(pod.Name, pod.Namespace, coreapi.PodFailed)
+		client.MetricsAgent().StoreMachinesSnapshot(pod)
 		logrus.Infof("Deleting pod %s that failed to start", pod.Name)
 		deleteCtx, cancel := context.WithTimeout(base_steps.CleanupCtx, 30*time.Second)
 		defer cancel()


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for step pods that fail during initialization phase, ensuring metrics are properly recorded and system state is updated during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->