### PR TITLE
multi_stage: default VPN entrypoint wait timeout to 5m

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -25,6 +25,8 @@ const (
 	profileVolumeName          = "cluster-profile"
 	vpnContainerName           = "vpn-client"
 	leaseProxyScriptsMountPath = "/opt/scripts/lease-proxy"
+	// defaultVPNWaitTimeout is used when vpn.yaml does not set wait_timeout; cluster profiles may override.
+	defaultVPNWaitTimeout = "5m0s"
 )
 
 func (s *multiStageTestStep) generateObservers(
@@ -305,10 +307,14 @@ func addSecretWrapper(pod *coreapi.Pod, vpnConf *vpnConf, skipKubeconfig bool, g
 	container := &pod.Spec.Containers[0]
 	args := container.Args
 	container.Args = make([]string, 0)
-	if c := vpnConf; c != nil && c.WaitTimeout != nil {
+	if c := vpnConf; c != nil {
+		waitTimeout := defaultVPNWaitTimeout
+		if c.WaitTimeout != nil {
+			waitTimeout = *c.WaitTimeout
+		}
 		container.Args = append(container.Args,
 			"--wait-for-file", "/tmp/vpn/up",
-			"--wait-timeout", *c.WaitTimeout)
+			"--wait-timeout", waitTimeout)
 	}
 	if skipKubeconfig {
 		container.Args = append(container.Args, "--mode=skip-kubeconfig")


### PR DESCRIPTION
**Problem**
IBM Z CI jobs that run behind the cluster-profile VPN (for example libvirt / libvirt-s390x-vpn–style workflows) were failing early in the test step. The wrapped command logs showed the entrypoint-wrapper giving up while waiting for the VPN readiness file, e.g. a warning like timeout after waiting for file /tmp/vpn/up. The main container then started (or behaved as if the wait had ended) before the VPN client had finished bringing the tunnel up, which breaks anything that needs intranet/DNS reachability from the first second.

<img width="3360" height="1812" alt="image" src="https://github.com/user-attachments/assets/0b1b0127-eb2c-4da2-b55c-5256f71cb092" />


**What this change does**
Whenever VPN is enabled for a multi-stage step, we always pass --wait-for-file /tmp/vpn/up and a --wait-timeout. If vpn.yaml does not define wait_timeout, we default to 5 minutes so IBM Z (and similar) jobs have time for the VPN sidecar to create /tmp/vpn/up. An explicit wait_timeout in the cluster profile still overrides this default.


https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-main-nightly-4.22-ocp-fips-ovn-remote-libvirt-multi-z-z/2051658376382779392

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN timeout handling to ensure default and custom wait timeouts are properly applied to container operations when VPN configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->