### PR TITLE
🤖 TRT-2622: test result aggregation: properties

### DIFF
--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -496,14 +496,13 @@ func TestAggregateTestCasePropagatesProperties(t *testing.T) {
 	assert.Equal(t, 2, len(combined.Properties))
 	assert.Equal(t, "lifecycle", combined.Properties[0].Name)
 	assert.Equal(t, "informing", combined.Properties[0].Value)
-	assert.Equal(t, "owner", combined.Properties[1].Name)
-	assert.Equal(t, "team-platform", combined.Properties[1].Value)
 
-	// Second aggregation should not overwrite the properties
+	// A different second aggregation should not overwrite the properties
+	// (Usually the important properties would be the same anyway, but where properties differ, just one gets picked)
 	source2 := &junit.TestCase{
 		Name: "test-with-properties",
 		Properties: []*junit.Property{
-			{Name: "lifecycle", Value: "informing"},
+			{Name: "lifecycle", Value: "blocking"},
 		},
 	}
 	err = aggregateTestCase("suite", combined, "logs/job", "run2", source2)

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/analyzer_test.go
@@ -480,6 +480,40 @@ func TestAggregateTestCasePropagatesLifecycle(t *testing.T) {
 	assert.Equal(t, "informing", combined.Lifecycle)
 }
 
+func TestAggregateTestCasePropagatesProperties(t *testing.T) {
+	combined := &junit.TestCase{Name: "test-with-properties"}
+
+	source := &junit.TestCase{
+		Name: "test-with-properties",
+		Properties: []*junit.Property{
+			{Name: "lifecycle", Value: "informing"},
+			{Name: "owner", Value: "team-platform"},
+		},
+	}
+
+	err := aggregateTestCase("suite", combined, "logs/job", "run1", source)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(combined.Properties))
+	assert.Equal(t, "lifecycle", combined.Properties[0].Name)
+	assert.Equal(t, "informing", combined.Properties[0].Value)
+	assert.Equal(t, "owner", combined.Properties[1].Name)
+	assert.Equal(t, "team-platform", combined.Properties[1].Value)
+
+	// Second aggregation should not overwrite the properties
+	source2 := &junit.TestCase{
+		Name: "test-with-properties",
+		Properties: []*junit.Property{
+			{Name: "lifecycle", Value: "informing"},
+		},
+	}
+	err = aggregateTestCase("suite", combined, "logs/job", "run2", source2)
+	assert.NoError(t, err)
+	// Properties should remain unchanged from first aggregation
+	assert.Equal(t, 2, len(combined.Properties))
+	assert.Equal(t, "lifecycle", combined.Properties[0].Name)
+	assert.Equal(t, "informing", combined.Properties[0].Value)
+}
+
 func TestInformingTestFailureMessage(t *testing.T) {
 	suite := &junit.TestSuites{
 		Suites: []*junit.TestSuite{

--- a/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
+++ b/pkg/jobrunaggregator/jobrunaggregatoranalyzer/junit.go
@@ -235,5 +235,16 @@ func aggregateTestCase(testSuiteName string, combined *junit.TestCase, jobGCSBuc
 		combined.Lifecycle = toAdd.Lifecycle
 	}
 
+	// Propagate properties from source test case to the combined one
+	if len(combined.Properties) == 0 && len(toAdd.Properties) > 0 {
+		combined.Properties = make([]*junit.Property, len(toAdd.Properties))
+		for i, prop := range toAdd.Properties {
+			combined.Properties[i] = &junit.Property{
+				Name:  prop.Name,
+				Value: prop.Value,
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/junit/censor.go
+++ b/pkg/junit/censor.go
@@ -7,30 +7,35 @@ func CensorTestSuite(censor secretutil.Censorer, testSuite *TestSuite) {
 	if testSuite == nil {
 		return
 	}
-	testSuite.Name = censored(censor, testSuite.Name)
-	for i := range testSuite.Properties {
-		testSuite.Properties[i].Name = censored(censor, testSuite.Properties[i].Name)
-		testSuite.Properties[i].Value = censored(censor, testSuite.Properties[i].Value)
+	censorStr(censor, &testSuite.Name)
+	for i, prop := range testSuite.Properties {
+		censorStr(censor, &prop.Name, &prop.Value)
+		testSuite.Properties[i] = prop
 	}
-	for i := range testSuite.TestCases {
-		testSuite.TestCases[i].Name = censored(censor, testSuite.TestCases[i].Name)
-		if testSuite.TestCases[i].SkipMessage != nil {
-			testSuite.TestCases[i].SkipMessage.Message = censored(censor, testSuite.TestCases[i].SkipMessage.Message)
+	for i, testCase := range testSuite.TestCases {
+		censorStr(censor, &testCase.Name)
+		for j, prop := range testCase.Properties {
+			censorStr(censor, &prop.Name, &prop.Value)
+			testCase.Properties[j] = prop
 		}
-		if testSuite.TestCases[i].FailureOutput != nil {
-			testSuite.TestCases[i].FailureOutput.Output = censored(censor, testSuite.TestCases[i].FailureOutput.Output)
-			testSuite.TestCases[i].FailureOutput.Message = censored(censor, testSuite.TestCases[i].FailureOutput.Message)
+		if testCase.SkipMessage != nil {
+			censorStr(censor, &testCase.SkipMessage.Message)
 		}
-		testSuite.TestCases[i].SystemOut = censored(censor, testSuite.TestCases[i].SystemOut)
-		testSuite.TestCases[i].SystemErr = censored(censor, testSuite.TestCases[i].SystemErr)
+		if testCase.FailureOutput != nil {
+			censorStr(censor, &testCase.FailureOutput.Output, &testCase.FailureOutput.Message)
+		}
+		censorStr(censor, &testCase.SystemOut, &testCase.SystemErr)
+		testSuite.TestCases[i] = testCase
 	}
 	for i := range testSuite.Children {
 		CensorTestSuite(censor, testSuite.Children[i])
 	}
 }
 
-func censored(censor secretutil.Censorer, value string) string {
-	raw := []byte(value)
-	censor.Censor(&raw)
-	return string(raw)
+func censorStr(censor secretutil.Censorer, values ...*string) {
+	for _, val := range values {
+		raw := []byte(*val)
+		censor.Censor(&raw)
+		*val = string(raw)
+	}
 }

--- a/pkg/junit/censor_test.go
+++ b/pkg/junit/censor_test.go
@@ -19,7 +19,10 @@ func TestCensorTestSuite(t *testing.T) {
 		},
 		TestCases: []*TestCase{
 			{
-				Name:        "somehow secret",
+				Name: "somehow secret",
+				Properties: []*Property{
+					{Name: "lifecycle", Value: "secret value"},
+				},
 				SkipMessage: &SkipMessage{Message: "skipped due to secret"},
 				FailureOutput: &FailureOutput{
 					Message: "failed due to secret",
@@ -29,7 +32,10 @@ func TestCensorTestSuite(t *testing.T) {
 				SystemErr: "error containing secret",
 			},
 			{
-				Name:        "somehow also secret",
+				Name: "somehow also secret",
+				Properties: []*Property{
+					{Name: "owner", Value: "also secret value"},
+				},
 				SkipMessage: &SkipMessage{Message: "also skipped due to secret"},
 				FailureOutput: &FailureOutput{
 					Message: "also failed due to secret",
@@ -48,7 +54,10 @@ func TestCensorTestSuite(t *testing.T) {
 				},
 				TestCases: []*TestCase{
 					{
-						Name:        "somehow nested secret",
+						Name: "somehow nested secret",
+						Properties: []*Property{
+							{Name: "lifecycle", Value: "nested secret value"},
+						},
 						SkipMessage: &SkipMessage{Message: "skipped due to nested secret"},
 						FailureOutput: &FailureOutput{
 							Message: "failed due to nested secret",
@@ -58,7 +67,10 @@ func TestCensorTestSuite(t *testing.T) {
 						SystemErr: "error containing nested secret",
 					},
 					{
-						Name:        "somehow also nested secret",
+						Name: "somehow also nested secret",
+						Properties: []*Property{
+							{Name: "owner", Value: "also nested secret value"},
+						},
 						SkipMessage: &SkipMessage{Message: "also skipped due to nested secret"},
 						FailureOutput: &FailureOutput{
 							Message: "also failed due to nested secret",
@@ -77,7 +89,10 @@ func TestCensorTestSuite(t *testing.T) {
 						},
 						TestCases: []*TestCase{
 							{
-								Name:        "somehow very nested secret",
+								Name: "somehow very nested secret",
+								Properties: []*Property{
+									{Name: "lifecycle", Value: "very nested secret value"},
+								},
 								SkipMessage: &SkipMessage{Message: "skipped due to very nested secret"},
 								FailureOutput: &FailureOutput{
 									Message: "failed due to very nested secret",
@@ -87,7 +102,10 @@ func TestCensorTestSuite(t *testing.T) {
 								SystemErr: "error containing very nested secret",
 							},
 							{
-								Name:        "somehow also very nested secret",
+								Name: "somehow also very nested secret",
+								Properties: []*Property{
+									{Name: "owner", Value: "also very nested secret value"},
+								},
 								SkipMessage: &SkipMessage{Message: "also skipped due to very nested secret"},
 								FailureOutput: &FailureOutput{
 									Message: "also failed due to very nested secret",

--- a/pkg/junit/censor_test.go
+++ b/pkg/junit/censor_test.go
@@ -13,7 +13,7 @@ func TestCensorTestSuite(t *testing.T) {
 	censorer.Refresh("secret")
 	input := TestSuite{
 		Name: "some secret",
-		Properties: []*TestSuiteProperty{
+		Properties: []*Property{
 			{Name: "secret things", Value: "secret values"},
 			{Name: "also secret things", Value: "really secret values"},
 		},
@@ -42,7 +42,7 @@ func TestCensorTestSuite(t *testing.T) {
 		Children: []*TestSuite{
 			{
 				Name: "some nested secret",
-				Properties: []*TestSuiteProperty{
+				Properties: []*Property{
 					{Name: "nested secret things", Value: "nested secret values"},
 					{Name: "also nested secret things", Value: "really nested secret values"},
 				},
@@ -71,7 +71,7 @@ func TestCensorTestSuite(t *testing.T) {
 				Children: []*TestSuite{
 					{
 						Name: "some very nested secret",
-						Properties: []*TestSuiteProperty{
+						Properties: []*Property{
 							{Name: "very nested secret things", Value: "very nested secret values"},
 							{Name: "also very nested secret things", Value: "really very nested secret values"},
 						},

--- a/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
+++ b/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
@@ -28,7 +28,12 @@ Children:
           Space: ""
       Lifecycle: ""
       Name: somehow very nested XXXXXX
-      Properties: null
+      Properties:
+      - Name: lifecycle
+        Value: very nested XXXXXX value
+        XMLName:
+          Local: ""
+          Space: ""
       SkipMessage:
         Message: skipped due to very nested XXXXXX
         XMLName:
@@ -49,7 +54,12 @@ Children:
           Space: ""
       Lifecycle: ""
       Name: somehow also very nested XXXXXX
-      Properties: null
+      Properties:
+      - Name: owner
+        Value: also very nested XXXXXX value
+        XMLName:
+          Local: ""
+          Space: ""
       SkipMessage:
         Message: also skipped due to very nested XXXXXX
         XMLName:
@@ -90,7 +100,12 @@ Children:
         Space: ""
     Lifecycle: ""
     Name: somehow nested XXXXXX
-    Properties: null
+    Properties:
+    - Name: lifecycle
+      Value: nested XXXXXX value
+      XMLName:
+        Local: ""
+        Space: ""
     SkipMessage:
       Message: skipped due to nested XXXXXX
       XMLName:
@@ -111,7 +126,12 @@ Children:
         Space: ""
     Lifecycle: ""
     Name: somehow also nested XXXXXX
-    Properties: null
+    Properties:
+    - Name: owner
+      Value: also nested XXXXXX value
+      XMLName:
+        Local: ""
+        Space: ""
     SkipMessage:
       Message: also skipped due to nested XXXXXX
       XMLName:
@@ -152,7 +172,12 @@ TestCases:
       Space: ""
   Lifecycle: ""
   Name: somehow XXXXXX
-  Properties: null
+  Properties:
+  - Name: lifecycle
+    Value: XXXXXX value
+    XMLName:
+      Local: ""
+      Space: ""
   SkipMessage:
     Message: skipped due to XXXXXX
     XMLName:
@@ -173,7 +198,12 @@ TestCases:
       Space: ""
   Lifecycle: ""
   Name: somehow also XXXXXX
-  Properties: null
+  Properties:
+  - Name: owner
+    Value: also XXXXXX value
+    XMLName:
+      Local: ""
+      Space: ""
   SkipMessage:
     Message: also skipped due to XXXXXX
     XMLName:

--- a/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
+++ b/pkg/junit/testdata/zz_fixture_TestCensorTestSuite.yaml
@@ -28,6 +28,7 @@ Children:
           Space: ""
       Lifecycle: ""
       Name: somehow very nested XXXXXX
+      Properties: null
       SkipMessage:
         Message: skipped due to very nested XXXXXX
         XMLName:
@@ -48,6 +49,7 @@ Children:
           Space: ""
       Lifecycle: ""
       Name: somehow also very nested XXXXXX
+      Properties: null
       SkipMessage:
         Message: also skipped due to very nested XXXXXX
         XMLName:
@@ -88,6 +90,7 @@ Children:
         Space: ""
     Lifecycle: ""
     Name: somehow nested XXXXXX
+    Properties: null
     SkipMessage:
       Message: skipped due to nested XXXXXX
       XMLName:
@@ -108,6 +111,7 @@ Children:
         Space: ""
     Lifecycle: ""
     Name: somehow also nested XXXXXX
+    Properties: null
     SkipMessage:
       Message: also skipped due to nested XXXXXX
       XMLName:
@@ -148,6 +152,7 @@ TestCases:
       Space: ""
   Lifecycle: ""
   Name: somehow XXXXXX
+  Properties: null
   SkipMessage:
     Message: skipped due to XXXXXX
     XMLName:
@@ -168,6 +173,7 @@ TestCases:
       Space: ""
   Lifecycle: ""
   Name: somehow also XXXXXX
+  Properties: null
   SkipMessage:
     Message: also skipped due to XXXXXX
     XMLName:

--- a/pkg/junit/types.go
+++ b/pkg/junit/types.go
@@ -38,7 +38,7 @@ type TestSuite struct {
 	Duration float64 `xml:"time,attr"`
 
 	// Properties holds other properties of the test suite as a mapping of name to value
-	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
+	Properties []*Property `xml:"properties>property,omitempty"`
 
 	// TestCases are the test cases contained in the test suite
 	TestCases []*TestCase `xml:"testcase"`
@@ -47,8 +47,8 @@ type TestSuite struct {
 	Children []*TestSuite `xml:"testsuite"`
 }
 
-// TestSuiteProperty contains a mapping of a property name to a value
-type TestSuiteProperty struct {
+// Property contains a mapping of a property name to a value
+type Property struct {
 	XMLName xml.Name `xml:"property"`
 
 	Name  string `xml:"name,attr"`
@@ -70,6 +70,9 @@ type TestCase struct {
 
 	// Lifecycle indicates the test lifecycle phase (e.g. "informing" or "blocking")
 	Lifecycle string `xml:"lifecycle,attr,omitempty"`
+
+	// Properties holds other properties of the test case as a mapping of name to value
+	Properties []*Property `xml:"properties>property,omitempty"`
 
 	// SkipMessage holds the reason why the test was skipped
 	SkipMessage *SkipMessage `xml:"skipped"`

--- a/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
+++ b/test/e2e/observer/artifacts/multi-observers-junit_operator.xml
@@ -1,21 +1,35 @@
 <testsuites>
   <testsuite name="step graph" tests="9" skipped="0" failures="1" time="whatever">
     <properties></properties>
-    <testcase name="Find the input image os and tag it into the pipeline" time="whatever"></testcase>
-    <testcase name="Run multi-stage test multi-observers - multi-observers-check-shared-dir container test" time="whatever"></testcase>
-    <testcase name="Run multi-stage test multi-observers - multi-observers-create-kubeconfig container test" time="whatever"></testcase>
+    <testcase name="Find the input image os and tag it into the pipeline" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage test multi-observers - multi-observers-check-shared-dir container test" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage test multi-observers - multi-observers-create-kubeconfig container test" time="whatever">
+      <properties></properties>
+    </testcase>
     <testcase name="Run multi-stage test multi-observers - multi-observers-failing-observer container test" time="whatever">
+      <properties></properties>
       <failure message="">+ echo &#39;this is going to fail&#39;&#xA;this is going to fail&#xA;+ exit 1&#xA;{&#34;component&#34;:&#34;entrypoint&#34;,&#34;error&#34;:&#34;wrapped process failed: exit status 1&#34;,&#34;file&#34;:&#34;sigs.k8s.io/prow/pkg/entrypoint/run.go&#34;,&#34;func&#34;:&#34;sigs.k8s.io/prow/pkg/entrypoint.Options.internalRun&#34;,&#34;level&#34;:&#34;error&#34;,&#34;msg&#34;:&#34;Error executing test process&#34;,&#34;severity&#34;:&#34;error&#34;,&#34;time&#34;:&#34;whatever&#34;}&#xA;error: failed to execute wrapped command: exit status 1&#xA;</failure>
     </testcase>
-    <testcase name="Run multi-stage test multi-observers - multi-observers-inject-observer container test" time="whatever"></testcase>
-    <testcase name="Run multi-stage test multi-observers - multi-observers-observer container test" time="whatever"></testcase>
+    <testcase name="Run multi-stage test multi-observers - multi-observers-inject-observer container test" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage test multi-observers - multi-observers-observer container test" time="whatever">
+      <properties></properties>
+    </testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase post.</system-out>
     </testcase>
     <testcase name="Run multi-stage test pre phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase pre.</system-out>
     </testcase>
     <testcase name="Run multi-stage test test phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase test.</system-out>
     </testcase>
   </testsuite>

--- a/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
+++ b/test/e2e/observer/artifacts/simple-observer-junit_operator.xml
@@ -1,18 +1,29 @@
 <testsuites>
   <testsuite name="step graph" tests="7" skipped="0" failures="0" time="whatever">
     <properties></properties>
-    <testcase name="Find the input image os and tag it into the pipeline" time="whatever"></testcase>
+    <testcase name="Find the input image os and tag it into the pipeline" time="whatever">
+      <properties></properties>
+    </testcase>
     <testcase name="Run multi-stage test post phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase post.</system-out>
     </testcase>
     <testcase name="Run multi-stage test pre phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase pre.</system-out>
     </testcase>
     <testcase name="Run multi-stage test test phase" time="whatever">
+      <properties></properties>
       <system-out>The collected steps of multi-stage phase test.</system-out>
     </testcase>
-    <testcase name="Run multi-stage test with-observer - with-observer-check-shared-dir container test" time="whatever"></testcase>
-    <testcase name="Run multi-stage test with-observer - with-observer-create-kubeconfig container test" time="whatever"></testcase>
-    <testcase name="Run multi-stage test with-observer - with-observer-observer container test" time="whatever"></testcase>
+    <testcase name="Run multi-stage test with-observer - with-observer-check-shared-dir container test" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage test with-observer - with-observer-create-kubeconfig container test" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Run multi-stage test with-observer - with-observer-observer container test" time="whatever">
+      <properties></properties>
+    </testcase>
   </testsuite>
 </testsuites>

--- a/test/e2e/simple/artifacts/junit_operator.xml
+++ b/test/e2e/simple/artifacts/junit_operator.xml
@@ -1,10 +1,20 @@
 <testsuites>
   <testsuite name="step graph" tests="8" skipped="0" failures="0" time="whatever">
     <properties></properties>
-    <testcase name="All images are built and tagged into stable" time="whatever"></testcase>
-    <testcase name="Clone the correct source code into an image and tag it as src" time="whatever"></testcase>
-    <testcase name="Create the release image &#34;latest&#34; containing all images built by this job" time="whatever"></testcase>
-    <testcase name="Find all of the input images from ocp/4.10:${component} and tag them into the output image stream" time="whatever"></testcase>
-    <testcase name="Find the input image root and tag it into the pipeline" time="whatever"></testcase>
+    <testcase name="All images are built and tagged into stable" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Clone the correct source code into an image and tag it as src" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Create the release image &#34;latest&#34; containing all images built by this job" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Find all of the input images from ocp/4.10:${component} and tag them into the output image stream" time="whatever">
+      <properties></properties>
+    </testcase>
+    <testcase name="Find the input image root and tag it into the pipeline" time="whatever">
+      <properties></properties>
+    </testcase>
   </testsuite>
 </testsuites>


### PR DESCRIPTION
The aggregator now propagates properties of the testcases aggregated, choosing the properties of the first testcase instance as representative in the aggregated testcase.

🤖 Assisted by Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- What changed (practical effect): The test-result aggregator now preserves testcase-level metadata when combining multiple JUnit test runs. For each aggregated testcase it will adopt the lifecycle attribute and the Properties list from the first observed testcase instance and will not overwrite them on subsequent aggregations. Censoring was extended so property names and values are redacted alongside suite/case names, messages and stdout/stderr.

- Component(s) affected: jobrunaggregator (jobrunaggregatoranalyzer) and the junit package used to parse/manipulate JUnit XML.

- Behavioral impact for CI users/operators:
  - Aggregated JUnit emitted by the aggregator will now include testcase-level lifecycle attributes and properties (e.g., lifecycle, owner) taken from the first seen testcase. This metadata becomes visible to downstream consumers (reporting, BigQuery, dashboards).
  - Property values are subject to the same secret-censoring as other fields, so secrets in property names/values will be redacted when CensorTestSuite is applied.
  - Because the aggregator treats the first-seen testcase as authoritative for lifecycle and properties, differing property values across runs will not be merged — later values are ignored. Operators whose tooling expects merged or last-seen property semantics should update their consumers or aggregation workflow.

- Key implementation notes (what changed in code/tests):
  - Introduced junit.Property and added TestCase.Properties ([]*Property) and TestCase.Lifecycle fields; TestSuite.Properties now uses []*Property.
  - aggregateTestCase updated to copy Lifecycle into combined if combined.Lifecycle is empty and to copy Properties into combined if combined has no properties yet.
  - CensorTestSuite updated to censor Property.Name and Property.Value and replaced the previous per-value helper with censorStr to redact multiple string pointers in-place.
  - Unit tests and fixtures updated: new test TestAggregateTestCasePropagatesProperties verifies propagation and non-overwrite behavior; junit censor tests and YAML fixtures updated to include case-level properties; example e2e JUnit artifacts were adjusted to include explicit <properties> blocks.

- Operator considerations:
  - Expect testcase <properties> elements and lifecycle attributes to appear in aggregated JUnit outputs. Update any downstream parsing or dashboards that assume properties are absent or that properties should be merged/updated across runs.
  - The change introduced a new exported type name (Property); downstream consumers importing junit types should review compatibility if they relied on the prior TestSuiteProperty type name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->