### PR TITLE
Add new profile: azure-perfscale-qe

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1455,6 +1455,7 @@ const (
 	ClusterProfileAzureMagQE              ClusterProfile = "azuremag-qe"
 	ClusterProfileAzureSustAutoRel412     ClusterProfile = "azure-sustaining-autorelease-412"
 	ClusterProfileAzureConfidentialQE     ClusterProfile = "azure-confidential-qe"
+	ClusterProfileAzurePerfScaleQE        ClusterProfile = "azure-perfscale-qe"
 	ClusterProfileAzureCNVDevOps          ClusterProfile = "azure-cnv-devops"
 	ClusterProfileEquinixOcpMetal         ClusterProfile = "equinix-ocp-metal"
 	ClusterProfileEquinixOcpMetalQE       ClusterProfile = "equinix-ocp-metal-qe"
@@ -1676,6 +1677,7 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAzureStackQE,
 		ClusterProfileAzureSustAutoRel412,
 		ClusterProfileAzureConfidentialQE,
+		ClusterProfileAzurePerfScaleQE,
 		ClusterProfileAzureCNVDevOps,
 		ClusterProfileEquinixOcpMetal,
 		ClusterProfileEquinixOcpMetalQE,
@@ -1920,6 +1922,7 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAzureSustAutoRel412,
 		ClusterProfileAzureQUAYQE,
 		ClusterProfileAzureConfidentialQE,
+		ClusterProfileAzurePerfScaleQE,
 		ClusterProfileAzureCNVDevOps,
 		ClusterProfileAzureVirtualization,
 		ClusterProfileAzureOADPQE:
@@ -2270,6 +2273,8 @@ func (p ClusterProfile) LeaseType() string {
 		return "azure-sustaining-autorelease-412-quota-slice"
 	case ClusterProfileAzureConfidentialQE:
 		return "azure-confidential-qe-quota-slice"
+	case ClusterProfileAzurePerfScaleQE:
+		return "azure-perfscale-qe-quota-slice"
 	case ClusterProfileAzureCNVDevOps:
 		return "azure-cnv-devops-quota-slice"
 	case ClusterProfileEquinixOcpMetal:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CNTRLPLANE-3394

Ref: https://redhat-internal.slack.com/archives/C0780C0J6HJ/p1776870549694489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds support for a new Azure performance testing cluster profile (`azure-perfscale-qe`) to the ci-tools codebase. This profile enables tests to run against Azure 4-based infrastructure with dedicated quota slices for performance and scale quality engineering testing.

## Changes

The new profile is registered in `pkg/api/types.go` with the following configuration:
- **Profile Name**: `azure-perfscale-qe`
- **Cluster Type**: Maps to `"azure4"` (Azure 4 infrastructure)
- **Lease Type**: Uses `"azure-perfscale-qe-quota-slice"` for resource quota management

## Practical Impact

CI operators and test authors can now:
- Reference the `azure-perfscale-qe` cluster profile in test configurations
- Run performance and scale tests on dedicated Azure infrastructure with predictable quota isolation
- Integrate with the existing lease management system for quota allocation

The addition follows the established pattern of other QE profiles (e.g., `aws-perfscale-qe`, `gcp-perfscale-qe`) and enables Azure-based performance testing workflows that were previously unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->