### PR TITLE
pj-rehearse: add concurrency control, changed-files prefilter, and drop notifications

### DIFF
--- a/cmd/pj-rehearse/main.go
+++ b/cmd/pj-rehearse/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,23 +36,126 @@ var concurrentHandlersInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "Current number of concurrent webhook handler goroutines running in pj-rehearse.",
 })
 
+var queuedHandlers = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "pj_rehearse_handlers_queued",
+	Help: "Current number of webhook handler requests queued in pj-rehearse.",
+})
+
+var droppedHandlerRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "pj_rehearse_handler_requests_dropped_total",
+	Help: "Total number of webhook handler requests dropped by pj-rehearse admission control.",
+}, []string{"reason"})
+
+var timedOutHandlers = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "pj_rehearse_handler_timeouts_total",
+	Help: "Total number of webhook handler requests that exceeded execution timeout in pj-rehearse.",
+})
+
 func init() {
 	prometheus.MustRegister(concurrentHandlersInFlight)
+	prometheus.MustRegister(queuedHandlers)
+	prometheus.MustRegister(droppedHandlerRequests)
+	prometheus.MustRegister(timedOutHandlers)
 }
 
-func trackPullRequestHandler(handler githubeventserver.PullRequestHandler) githubeventserver.PullRequestHandler {
-	return func(l *logrus.Entry, event github.PullRequestEvent) {
-		concurrentHandlersInFlight.Inc()
-		defer concurrentHandlersInFlight.Dec()
-		handler(l, event)
+type handlerDispatcher struct {
+	executionSlots   chan struct{}
+	queueSlots       chan struct{}
+	queueTimeout     time.Duration
+	executionTimeout time.Duration
+}
+
+func newHandlerDispatcher(maxConcurrent, maxQueued int, queueTimeout, executionTimeout time.Duration) *handlerDispatcher {
+	return &handlerDispatcher{
+		executionSlots:   make(chan struct{}, maxConcurrent),
+		queueSlots:       make(chan struct{}, maxQueued),
+		queueTimeout:     queueTimeout,
+		executionTimeout: executionTimeout,
 	}
 }
 
-func trackIssueCommentHandler(handler githubeventserver.IssueCommentEventHandler) githubeventserver.IssueCommentEventHandler {
-	return func(l *logrus.Entry, event github.IssueCommentEvent) {
+func (d *handlerDispatcher) dispatch(logger *logrus.Entry, handler func(), onDrop func(string)) {
+	if d.tryAcquireExecutionSlot() {
+		d.run(logger, handler)
+		return
+	}
+
+	if !d.tryQueue() {
+		droppedHandlerRequests.WithLabelValues("queue_full").Inc()
+		logger.WithField("max_queue", cap(d.queueSlots)).Warn("Dropping webhook request because handler queue is full")
+		if onDrop != nil {
+			onDrop("queue_full")
+		}
+		return
+	}
+	select {
+	case d.executionSlots <- struct{}{}:
+		d.dequeue()
+		d.run(logger, handler)
+	case <-time.After(d.queueTimeout):
+		d.dequeue()
+		droppedHandlerRequests.WithLabelValues("queue_timeout").Inc()
+		logger.WithField("timeout", d.queueTimeout).Warn("Dropping webhook request because it waited too long in queue")
+		if onDrop != nil {
+			onDrop("queue_timeout")
+		}
+	}
+}
+
+// run executes the handler in a goroutine and waits for completion or timeout.
+// On timeout, the goroutine keeps running (and holding its execution slot) until
+// the handler returns naturally. True cancellation would require context propagation
+// through all downstream operations (git, GitHub API, config loading).
+func (d *handlerDispatcher) run(logger *logrus.Entry, handler func()) {
+	done := make(chan struct{})
+	go func() {
 		concurrentHandlersInFlight.Inc()
 		defer concurrentHandlersInFlight.Dec()
-		handler(l, event)
+		defer func() { <-d.executionSlots }()
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				stack := make([]byte, 8192)
+				stack = stack[:runtime.Stack(stack, false)]
+				logger.WithField("panic", r).Errorf("Webhook handler panicked: %v\n%s", r, stack)
+			}
+		}()
+		handler()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d.executionTimeout):
+		timedOutHandlers.Inc()
+		logger.WithField("timeout", d.executionTimeout).Warn("Webhook handler exceeded execution timeout and is still running in background")
+	}
+}
+
+func (d *handlerDispatcher) tryAcquireExecutionSlot() bool {
+	select {
+	case d.executionSlots <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *handlerDispatcher) tryQueue() bool {
+	select {
+	case d.queueSlots <- struct{}{}:
+		queuedHandlers.Inc()
+		return true
+	default:
+		return false
+	}
+}
+
+func (d *handlerDispatcher) dequeue() {
+	select {
+	case <-d.queueSlots:
+		queuedHandlers.Dec()
+	default:
+		logrus.Warn("dequeue called but queue slot channel was empty; gauge may drift")
 	}
 }
 
@@ -64,9 +168,13 @@ type options struct {
 	noTemplates       bool
 	noRegistry        bool
 
-	normalLimit int
-	moreLimit   int
-	maxLimit    int
+	normalLimit           int
+	moreLimit             int
+	maxLimit              int
+	maxConcurrentHandlers int
+	maxQueuedHandlers     int
+	queueTimeoutMinutes   int
+	handlerTimeoutMinutes int
 
 	gcsBucket          string
 	gcsCredentialsFile string
@@ -101,6 +209,10 @@ func gatherOptions() (options, error) {
 	fs.IntVar(&o.normalLimit, "normal-limit", 10, "Upper limit of jobs attempted to rehearse with normal command (if more jobs are being touched, only this many will be rehearsed)")
 	fs.IntVar(&o.moreLimit, "more-limit", 20, "Upper limit of jobs attempted to rehearse with more command (if more jobs are being touched, only this many will be rehearsed)")
 	fs.IntVar(&o.maxLimit, "max-limit", 35, "Upper limit of jobs attempted to rehearse with max command (if more jobs are being touched, only this many will be rehearsed)")
+	fs.IntVar(&o.maxConcurrentHandlers, "max-concurrent-handlers", 5, "Maximum number of webhook handlers that may run concurrently.")
+	fs.IntVar(&o.maxQueuedHandlers, "max-queued-handlers", 50, "Maximum number of webhook handler requests queued while all handler slots are busy.")
+	fs.IntVar(&o.queueTimeoutMinutes, "queue-timeout-minutes", 5, "Maximum time in minutes a request can wait in the queue before being dropped.")
+	fs.IntVar(&o.handlerTimeoutMinutes, "handler-timeout-minutes", 15, "Maximum time in minutes a handler can execute before being considered timed out.")
 
 	fs.Var(&o.stickyLabelAuthors, "sticky-label-author", "PR Author for which the 'rehearsals-ack' label will not be removed upon a new push. Can be passed multiple times.")
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
@@ -126,6 +238,18 @@ func (o *options) validate() error {
 		errs = append(errs, fmt.Errorf("invalid log level specified: %w", err))
 	}
 	logrus.SetLevel(level)
+	if o.maxConcurrentHandlers < 1 {
+		errs = append(errs, errors.New("max-concurrent-handlers must be greater than zero"))
+	}
+	if o.maxQueuedHandlers < 1 {
+		errs = append(errs, errors.New("max-queued-handlers must be greater than zero"))
+	}
+	if o.queueTimeoutMinutes < 1 {
+		errs = append(errs, errors.New("queue-timeout-minutes must be greater than zero"))
+	}
+	if o.handlerTimeoutMinutes < 1 {
+		errs = append(errs, errors.New("handler-timeout-minutes must be greater than zero"))
+	}
 
 	if o.dryRun {
 		errs = append(errs, o.dryRunOptions.validate())
@@ -137,6 +261,22 @@ func (o *options) validate() error {
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+func notifyDroppedRequest(ghc githubClient, org, repo string, number int, user, reason string, queueTimeoutMinutes int, userTriggered bool, logger *logrus.Entry) {
+	reasonText := "the request queue is currently full"
+	if reason == "queue_timeout" {
+		reasonText = fmt.Sprintf("the request waited in queue for longer than %d minutes", queueTimeoutMinutes)
+	}
+	var comment string
+	if userTriggered {
+		comment = fmt.Sprintf("@%s: your `/pj-rehearse` request was not processed because %s. Please retry in a few minutes.", user, reasonText)
+	} else {
+		comment = fmt.Sprintf("@%s: `pj-rehearse` could not automatically process this event because %s. Use `/pj-rehearse` to trigger rehearsals manually.", user, reasonText)
+	}
+	if err := ghc.CreateComment(org, repo, number, comment); err != nil {
+		logger.WithError(err).Warn("failed to create dropped-request notification comment")
+	}
 }
 
 type dryRunOptions struct {
@@ -252,9 +392,30 @@ func main() {
 
 		logger.Debug("starting eventServer")
 		eventServer := githubeventserver.New(o.githubEventServerOptions, webhookTokenGenerator, logger)
-		eventServer.RegisterHandlePullRequestEvent(trackPullRequestHandler(s.handlePullRequestCreation))
-		eventServer.RegisterHandlePullRequestEvent(trackPullRequestHandler(s.handleNewPush))
-		eventServer.RegisterHandleIssueCommentEvent(trackIssueCommentHandler(s.handleIssueComment))
+		queueTimeout := time.Duration(o.queueTimeoutMinutes) * time.Minute
+		executionTimeout := time.Duration(o.handlerTimeoutMinutes) * time.Minute
+		dispatcher := newHandlerDispatcher(o.maxConcurrentHandlers, o.maxQueuedHandlers, queueTimeout, executionTimeout)
+		eventServer.RegisterHandlePullRequestEvent(func(l *logrus.Entry, event github.PullRequestEvent) {
+			if event.Action != github.PullRequestActionOpened && event.Action != github.PullRequestActionSynchronize {
+				return
+			}
+			dispatcher.dispatch(l, func() {
+				s.handlePullRequestCreation(l, event)
+				s.handleNewPush(l, event)
+			}, func(reason string) {
+				notifyDroppedRequest(s.ghc, event.Repo.Owner.Login, event.Repo.Name, event.Number, event.PullRequest.User.Login, reason, o.queueTimeoutMinutes, false, l)
+			})
+		})
+		eventServer.RegisterHandleIssueCommentEvent(func(l *logrus.Entry, event github.IssueCommentEvent) {
+			if !event.Issue.IsPullRequest() || event.Action != github.IssueCommentActionCreated {
+				return
+			}
+			dispatcher.dispatch(l, func() {
+				s.handleIssueComment(l, event)
+			}, func(reason string) {
+				notifyDroppedRequest(s.ghc, event.Repo.Owner.Login, event.Repo.Name, event.Issue.Number, event.Comment.User.Login, reason, o.queueTimeoutMinutes, true, l)
+			})
+		})
 		eventServer.RegisterHelpProvider(s.helpProvider, logger)
 
 		interrupts.OnInterrupt(func() {

--- a/cmd/pj-rehearse/server.go
+++ b/cmd/pj-rehearse/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -399,7 +400,12 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					continue
 				}
 
-				//TODO(DPTP-2888): this is the point at which we can use repoClient.RevParse() to see if we even need to load the configs at all, and also prune the set of loaded configs to only the changed files
+				shouldAnalyze, err := shouldAnalyzeRehearsals(repoClient, pullRequest.Base.Ref, !rc.NoRegistry, logger)
+				if err != nil {
+					logger.WithError(err).Error("couldn't determine changed files")
+					s.reportFailure("unable to determine changed files", err, org, repo, user, number, true, false, logger)
+					continue
+				}
 
 				allowedLabel := false
 				approved := false
@@ -411,6 +417,15 @@ func (s *server) handlePotentialCommands(pullRequest *github.PullRequest, commen
 					}
 				}
 				networkAccessRehearsalsAllowed := allowedLabel && approved
+
+				if !shouldAnalyze {
+					logger.Debug("Skipping affected job analysis because no rehearsal-relevant paths changed")
+					s.acknowledgeRehearsals(org, repo, number, logger)
+					if err := s.ghc.CreateComment(org, repo, number, fmt.Sprintf("@%s: no rehearsal-relevant files were changed in this PR", user)); err != nil {
+						logger.WithError(err).Error("failed to create comment")
+					}
+					continue
+				}
 
 				candidatePath := repoClient.Directory()
 				prConfig, presubmits, periodics, _, err := rc.DetermineAffectedJobs(candidate, candidatePath, networkAccessRehearsalsAllowed, logger)
@@ -498,11 +513,50 @@ func (s *server) getAffectedJobs(pullRequest *github.PullRequest, logger *logrus
 		return nil, nil, nil, fmt.Errorf("couldn't prepare candidate: %w", err)
 	}
 
-	//TODO(DPTP-2888): this is the point at which we can use repoClient.RevParse() to see if we even need to load the configs at all, and also prune the set of loaded configs to only the changed files
+	shouldAnalyze, err := shouldAnalyzeRehearsals(repoClient, pullRequest.Base.Ref, !rc.NoRegistry, logger)
+	if err != nil {
+		logger.WithError(err).Error("couldn't determine changed files")
+		return nil, nil, nil, fmt.Errorf("couldn't determine changed files: %w", err)
+	}
+	if !shouldAnalyze {
+		logger.Debug("Skipping affected job analysis because no rehearsal-relevant paths changed")
+		return config.Presubmits{}, config.Periodics{}, nil, nil
+	}
 
 	candidatePath := repoClient.Directory()
 	_, presubmits, periodics, disabledDueToNetworkAccessToggle, err := rc.DetermineAffectedJobs(candidate, candidatePath, false, logger)
 	return presubmits, periodics, disabledDueToNetworkAccessToggle, err
+}
+
+func shouldAnalyzeRehearsals(repoClient git.RepoClient, baseRef string, includeRegistryChanges bool, logger *logrus.Entry) (bool, error) {
+	changedFiles, err := repoClient.Diff(baseRef, "HEAD")
+	if err != nil {
+		return false, fmt.Errorf("failed to diff changed files from base ref %s: %w", baseRef, err)
+	}
+	logger.WithField("changed-files", len(changedFiles)).Debug("Computed changed files for rehearsal prefilter")
+	for _, changedPath := range changedFiles {
+		if isRehearsalRelevantPath(changedPath, includeRegistryChanges) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isRehearsalRelevantPath(changedPath string, includeRegistryChanges bool) bool {
+	if hasPathPrefix(changedPath, config.CiopConfigInRepoPath) {
+		return true
+	}
+	if hasPathPrefix(changedPath, config.JobConfigInRepoPath) {
+		return true
+	}
+	if hasPathPrefix(changedPath, filepath.Dir(config.ConfigInRepoPath)) {
+		return true
+	}
+	return includeRegistryChanges && hasPathPrefix(changedPath, config.RegistryPath)
+}
+
+func hasPathPrefix(path, prefix string) bool {
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
 }
 
 func (s *server) reportFailure(message string, err error, org, repo, user string, number int, addContact, addUsageDetails bool, l *logrus.Entry) {

--- a/cmd/pj-rehearse/server_test.go
+++ b/cmd/pj-rehearse/server_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -185,5 +187,260 @@ func TestPrepareCandidateRebaseDirection(t *testing.T) {
 	}
 	if len(changes) != 1 || changes[0] != "pr.txt" {
 		t.Errorf("expected diff main..HEAD to show only [pr.txt], got %v", changes)
+	}
+}
+
+func TestHasPathPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		prefix string
+		want   bool
+	}{
+		{name: "exact match", path: "ci-operator/config", prefix: "ci-operator/config", want: true},
+		{name: "child path", path: "ci-operator/config/org/repo.yaml", prefix: "ci-operator/config", want: true},
+		{name: "partial name match should not match", path: "ci-operator/configs/foo", prefix: "ci-operator/config", want: false},
+		{name: "completely different path", path: "docs/readme.md", prefix: "ci-operator/config", want: false},
+		{name: "prefix is longer than path", path: "ci-operator", prefix: "ci-operator/config", want: false},
+		{name: "empty path", path: "", prefix: "ci-operator/config", want: false},
+		{name: "empty prefix matches exact empty", path: "", prefix: "", want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasPathPrefix(tc.path, tc.prefix)
+			if got != tc.want {
+				t.Errorf("hasPathPrefix(%q, %q) = %v, want %v", tc.path, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRehearsalRelevantPath(t *testing.T) {
+	tests := []struct {
+		name                   string
+		path                   string
+		includeRegistryChanges bool
+		want                   bool
+	}{
+		{name: "ci-operator config", path: "ci-operator/config/org/repo.yaml", includeRegistryChanges: false, want: true},
+		{name: "ci-operator jobs", path: "ci-operator/jobs/org/repo/job.yaml", includeRegistryChanges: false, want: true},
+		{name: "prow config dir", path: "core-services/prow/02_config/something.yaml", includeRegistryChanges: false, want: true},
+		{name: "registry with flag on", path: "ci-operator/step-registry/ipi/install/install.yaml", includeRegistryChanges: true, want: true},
+		{name: "registry with flag off", path: "ci-operator/step-registry/ipi/install/install.yaml", includeRegistryChanges: false, want: false},
+		{name: "unrelated file", path: "hack/build.sh", includeRegistryChanges: true, want: false},
+		{name: "README at root", path: "README.md", includeRegistryChanges: true, want: false},
+		{name: "ci-operator root file", path: "ci-operator/OWNERS", includeRegistryChanges: false, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isRehearsalRelevantPath(tc.path, tc.includeRegistryChanges)
+			if got != tc.want {
+				t.Errorf("isRehearsalRelevantPath(%q, %v) = %v, want %v", tc.path, tc.includeRegistryChanges, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDispatcherImmediateExecution(t *testing.T) {
+	d := newHandlerDispatcher(2, 5, time.Minute, 5*time.Second)
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	executed := make(chan struct{})
+	d.dispatch(logger, func() {
+		close(executed)
+	}, nil)
+
+	select {
+	case <-executed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler was not executed within timeout")
+	}
+}
+
+func TestDispatcherQueuesThenExecutes(t *testing.T) {
+	d := newHandlerDispatcher(1, 5, 10*time.Second, 30*time.Second)
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	blocker := make(chan struct{})
+	firstStarted := make(chan struct{})
+
+	go d.dispatch(logger, func() {
+		close(firstStarted)
+		<-blocker
+	}, nil)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first handler did not start")
+	}
+
+	secondDone := make(chan struct{})
+	go d.dispatch(logger, func() {
+		close(secondDone)
+	}, nil)
+
+	select {
+	case <-secondDone:
+		t.Fatal("second handler should not have run while first is blocking")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	close(blocker)
+	select {
+	case <-secondDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second handler was not executed after first completed")
+	}
+}
+
+func TestDispatcherDropsWhenQueueFull(t *testing.T) {
+	d := newHandlerDispatcher(1, 1, 10*time.Second, 30*time.Second)
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	blocker := make(chan struct{})
+	firstStarted := make(chan struct{})
+	go d.dispatch(logger, func() {
+		close(firstStarted)
+		<-blocker
+	}, nil)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first handler did not start")
+	}
+
+	// Fill the single queue slot; this dispatch will block in the select
+	// waiting for an execution slot, which holds the queue slot occupied.
+	secondStarted := make(chan struct{})
+	go d.dispatch(logger, func() {
+		close(secondStarted)
+	}, nil)
+
+	// We can't directly observe the second handler entering the queue, but
+	// we know it can't start (slot is full) and can't be dropped (queue has
+	// room). Give the scheduler a moment to let it enter the select.
+	time.Sleep(50 * time.Millisecond)
+
+	dropped := make(chan string, 1)
+	d.dispatch(logger, func() {}, func(reason string) {
+		dropped <- reason
+	})
+
+	select {
+	case reason := <-dropped:
+		if reason != "queue_full" {
+			t.Errorf("expected reason 'queue_full', got %q", reason)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("third handler was not dropped")
+	}
+
+	close(blocker)
+
+	select {
+	case <-secondStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second handler did not start after blocker released")
+	}
+}
+
+func TestDispatcherQueueTimeout(t *testing.T) {
+	d := newHandlerDispatcher(1, 5, 200*time.Millisecond, 30*time.Second)
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	blocker := make(chan struct{})
+	firstStarted := make(chan struct{})
+	go d.dispatch(logger, func() {
+		close(firstStarted)
+		<-blocker
+	}, nil)
+
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first handler did not start")
+	}
+
+	dropped := make(chan string, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		d.dispatch(logger, func() {
+			t.Error("handler should not have run after queue timeout")
+		}, func(reason string) {
+			dropped <- reason
+		})
+	}()
+
+	select {
+	case reason := <-dropped:
+		if reason != "queue_timeout" {
+			t.Errorf("expected reason 'queue_timeout', got %q", reason)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler was not dropped after queue timeout")
+	}
+
+	close(blocker)
+	wg.Wait()
+}
+
+type commentRecorder struct {
+	fakeGHC
+	mu       sync.Mutex
+	comments []string
+}
+
+func (c *commentRecorder) CreateComment(_, _ string, _ int, comment string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.comments = append(c.comments, comment)
+	return nil
+}
+
+func (c *commentRecorder) getComments() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.comments))
+	copy(out, c.comments)
+	return out
+}
+
+func TestNotifyDroppedRequestUserTriggered(t *testing.T) {
+	ghc := &commentRecorder{}
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	notifyDroppedRequest(ghc, "org", "repo", 1, "alice", "queue_full", 5, true, logger)
+
+	comments := ghc.getComments()
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if !strings.Contains(comments[0], "@alice") {
+		t.Errorf("expected comment to mention user, got: %s", comments[0])
+	}
+	if !strings.Contains(comments[0], "/pj-rehearse") {
+		t.Errorf("expected comment to mention /pj-rehearse command for user-triggered, got: %s", comments[0])
+	}
+}
+
+func TestNotifyDroppedRequestAutomatic(t *testing.T) {
+	ghc := &commentRecorder{}
+	logger := logrus.NewEntry(logrus.StandardLogger())
+
+	notifyDroppedRequest(ghc, "org", "repo", 1, "alice", "queue_timeout", 5, false, logger)
+
+	comments := ghc.getComments()
+	if len(comments) != 1 {
+		t.Fatalf("expected 1 comment, got %d", len(comments))
+	}
+	if !strings.Contains(comments[0], "could not automatically process") {
+		t.Errorf("expected automatic event message, got: %s", comments[0])
+	}
+	if !strings.Contains(comments[0], "5 minutes") {
+		t.Errorf("expected timeout duration in message, got: %s", comments[0])
 	}
 }


### PR DESCRIPTION


pj-rehearse was vulnerable to memory spikes (50+ GB) under load because it handled an unlimited number of webhook requests concurrently, each loading full CI/Prow configurations.

This commit introduces three features to mitigate the problem:

1. Handler dispatcher with bounded concurrency and queuing:
   - Configurable max concurrent handlers (default 5), max queued (50), queue timeout (5m), and execution timeout (15m) via CLI flags.
   - Requests that exceed the queue capacity or wait too long are dropped with a GitHub comment notifying the user.
   - Separate Prometheus metrics for in-flight handlers, queued requests, drops (by reason), and execution timeouts.

2. Changed-files prefilter (implements [DPTP-2888](https://redhat.atlassian.net/browse/DPTP-2888)):
   - Before loading full configs, diffs the PR against the base branch to check if any changed files fall under ci-operator/config, ci-operator/jobs, core-services/prow/02_config, or ci-operator/step-registry.
   - If no rehearsal-relevant paths changed, skips DetermineAffectedJobs entirely, avoiding the expensive config load.

3. Merged PR event handlers into a single registration:
   - handlePullRequestCreation and handleNewPush are now dispatched as one unit, preventing a single PR event from consuming two dispatcher slots.

Co-authored-by Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook admission control with concurrency limits, bounded queueing, queue timeouts, metrics for queued/dropped requests (with drop reasons), execution-timeout tracking, and user-facing notifications when requests are dropped.

* **Improvements**
  * Rehearsal analysis now prefilters changes and skips work when no relevant config paths changed; clearer messages when diffs cannot be determined.

* **Tests**
  * Added unit and concurrency tests for dispatch/queue behavior, path-matching logic, and drop-notification content/timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->