### PR TITLE
NO-JIRA: remove release-release template

### DIFF
--- a/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
+++ b/pkg/jobrunaggregator/jobtableprimer/job_name_generator.go
@@ -38,11 +38,9 @@ type jobNameGenerator struct {
 }
 
 var (
-	templateException = []string{
-		"openshift-release-release-5.0-periodics.yaml",
-	}
+	// templateException is for cases where a particular release is known not to have a matching periodicURL definition
+	templateException    = []string{}
 	periodicURLTemplates = []string{
-		"https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/release/openshift-release-release-%s-periodics.yaml",
 		"https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-%s-periodics.yaml",
 	}
 	releaseConfigURLTemplates = []string{
@@ -103,7 +101,7 @@ func readConfigURL(url string, into interface{}, unmarshal func(data []byte, v a
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound && isTemplateException(url) {
-		logrus.WithField("url", url).Info("skipping pre-branch-cut config: URL 404 not found")
+		logrus.WithField("url", url).Info("skipping template exception config: URL 404 not found")
 		return true, nil
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {


### PR DESCRIPTION
openshift-release-release-%s-periodics.yaml look to only contain older multi release upgrade jobs that aren't monitored for signal.  

Those definitions have not been updated for 5.0.  Removing them from the periodicURLTemplates we monitor for job name updating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Job Run Aggregator: Removes monitoring of deprecated release-release periodic jobs

The **job run aggregator**'s job name generator component no longer fetches or monitors the `openshift-release-release-*-periodics.yaml` template from the OpenShift release repository.

### What Changed

The `periodicURLTemplates` list in `pkg/jobrunaggregator/jobtableprimer/job_name_generator.go` was updated to remove one template:
- **Removed**: `https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/release/openshift-release-release-%s-periodics.yaml`
- **Kept**: `https://raw.githubusercontent.com/openshift/release/main/ci-operator/jobs/openshift/hypershift/openshift-hypershift-release-%s-periodics.yaml`

The `templateException` list (which provided 404-handling exceptions for specific templates) was also cleared, as it only contained an exception for the removed `openshift-release-release-5.0-periodics.yaml` file.

### Why

The `openshift-release-release-*` template contains older multi-release upgrade jobs that are not actively monitored for disruption signal. Those job definitions have not been updated for version 5.0 and are no longer relevant to current CI monitoring requirements.

### Impact on CI Users and Operators

- The job run aggregator will no longer attempt to load or analyze periodic jobs from the deprecated release-release template
- Job name generation and aggregation logic will only process Hypershift and release controller job definitions
- This reduces unnecessary network requests and simplifies the set of jobs monitored for disruption analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->