### PR TITLE
Integrate BYOIP with Cluster Profile Sets

### DIFF
--- a/pkg/api/leases.go
+++ b/pkg/api/leases.go
@@ -27,19 +27,21 @@ func LeasesForTest(test *TestStepConfiguration) (ret []StepLease) {
 
 const maxAddressesRequired = 13
 
-func IPPoolLeaseForTest(s *MultiStageTestConfigurationLiteral, metadata Metadata) (ret StepLease) {
-	p := s.ClusterProfile
-	if p != "" {
-		if lt := p.IPPoolLeaseType(); lt != "" {
-			if !p.IPPoolLeaseShouldValidateBranch() || branchValidForIPPoolLease(metadata.Branch) {
-				ret = StepLease{
-					ResourceType: lt,
-					Env:          DefaultIPPoolLeaseEnv,
-					Count:        maxAddressesRequired,
-				}
+func IPPoolLeaseForTest(profile ClusterProfile, branch string) (ret StepLease) {
+	if profile == "" {
+		return
+	}
+
+	if lt := profile.IPPoolLeaseType(); lt != "" {
+		if !profile.IPPoolLeaseShouldValidateBranch() || branchValidForIPPoolLease(branch) {
+			ret = StepLease{
+				ResourceType: lt,
+				Env:          DefaultIPPoolLeaseEnv,
+				Count:        maxAddressesRequired,
 			}
 		}
 	}
+
 	return
 }
 

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -125,7 +125,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ret := IPPoolLeaseForTest(&tc.tests, tc.metadata)
+			ret := IPPoolLeaseForTest(tc.tests.ClusterProfile, tc.metadata.Branch)
 			if diff := cmp.Diff(tc.expected, ret); diff != "" {
 				t.Errorf("incorrect lease returned, diff: %s", diff)
 			}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2608,6 +2608,14 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 	}
 }
 
+func ClusterProfileFromParams(params Parameters) (ClusterProfile, error) {
+	if params == nil {
+		return "", nil
+	}
+	cp, err := params.Get(ClusterProfileParam)
+	return ClusterProfile(cp), err
+}
+
 // ClusterTestConfiguration describes a test that provisions
 // a cluster and runs a command in it.
 type ClusterTestConfiguration struct {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -356,19 +356,20 @@ func stepForTest(cfg *Config, inputImages inputImageSet, c *api.TestStepConfigur
 ) []api.Step {
 	if test := c.MultiStageTestConfigurationLiteral; test != nil {
 		params := cfg.params
+
 		leases := api.LeasesForTest(c)
-		ipPoolLease := api.IPPoolLeaseForTest(test, cfg.CIConfig.Metadata)
-		if len(leases) != 0 || ipPoolLease.ResourceType != "" {
+		if len(leases) != 0 {
 			params = api.NewDeferredParameters(params)
 		}
+
 		var ret []api.Step
 		step := multi_stage.MultiStageTestStep(*c, cfg.CIConfig, params, cfg.podClient, cfg.JobSpec, leases, cfg.NodeName, cfg.TargetAdditionalSuffix, nil, cfg.GSMConfig != nil, cfg.GSMConfig, isLeaseProxyServerAvailable(cfg), retry.DefaultRetry)
-		if ipPoolLease.ResourceType != "" {
-			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, ipPoolLease, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent)
-		}
+
 		if len(leases) != 0 {
+			step = steps.IPPoolStep(cfg.LeaseClient, cfg.podClient, step, params, cfg.JobSpec.Namespace, cfg.MetricsAgent, test.ClusterProfile, cfg.CIConfig.Metadata.Branch)
 			step = steps.LeaseStep(cfg.LeaseClient, leases, step, cfg.JobSpec.Namespace, cfg.MetricsAgent, cfg.kubeClient, cfg.ClusterProfileGetter)
 		}
+
 		if c.ClusterClaim != nil {
 			step = steps.ClusterClaimStep(c.As, c.ClusterClaim, cfg.hiveClient, cfg.kubeClient, cfg.JobSpec, step, cfg.Censor)
 			name := c.ClusterClaim.ClaimRelease(c.As).ReleaseName

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -33,19 +33,28 @@ type ipPoolStep struct {
 	metricsAgent *metrics.MetricsAgent
 
 	namespace func() string
+	// To ease unit testing
+	profile         api.ClusterProfile
+	branch          string
+	ipPoolLeaseFunc func(profile api.ClusterProfile, branch string) stepLease
 }
 
-func IPPoolStep(client *lease.Client, secretClient SecretClient, lease api.StepLease, wrapped api.Step, params api.Parameters, namespace func() string, metricsAgent *metrics.MetricsAgent) api.Step {
-	ret := ipPoolStep{
+// lease api.StepLease,
+func IPPoolStep(client *lease.Client, secretClient SecretClient, wrapped api.Step, params api.Parameters,
+	namespace func() string, metricsAgent *metrics.MetricsAgent, profile api.ClusterProfile, branch string) api.Step {
+	return &ipPoolStep{
 		client:       client,
 		secretClient: secretClient,
 		wrapped:      wrapped,
 		namespace:    namespace,
 		params:       params,
-		ipPoolLease:  stepLease{StepLease: lease},
 		metricsAgent: metricsAgent,
+		profile:      profile,
+		branch:       branch,
+		ipPoolLeaseFunc: func(profile api.ClusterProfile, branch string) stepLease {
+			return stepLease{StepLease: api.IPPoolLeaseForTest(profile, branch)}
+		},
 	}
-	return &ret
 }
 
 func (s *ipPoolStep) Inputs() (api.InputDefinition, error) {
@@ -70,12 +79,13 @@ func (s *ipPoolStep) Provides() api.ParameterMap {
 	if parameters == nil {
 		parameters = api.ParameterMap{}
 	}
-	l := &s.ipPoolLease
+
 	// Disable unparam lint as we need to confirm to this interface, but there will never be an error
 	//nolint:unparam
-	parameters[l.Env] = func() (string, error) {
-		return strconv.Itoa(len(l.resources)), nil
+	parameters[api.DefaultIPPoolLeaseEnv] = func() (string, error) {
+		return strconv.Itoa(len(s.ipPoolLease.resources)), nil
 	}
+
 	return parameters
 }
 
@@ -99,7 +109,21 @@ func (s *ipPoolStep) Run(ctx context.Context) error {
 
 // minute is provided as an argument to assist with unit testing
 func (s *ipPoolStep) run(ctx context.Context, minute time.Duration) error {
+	clusterProfile, err := api.ClusterProfileFromParams(s.params)
+	if err != nil {
+		return fmt.Errorf("get cluster profile from parameters: %w", err)
+	}
+	if clusterProfile != "" {
+		s.profile = clusterProfile
+	}
+
+	s.ipPoolLease = s.ipPoolLeaseFunc(s.profile, s.branch)
+	if !s.ipPoolLeaseAvailable() {
+		return results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
+	}
+
 	l := &s.ipPoolLease
+
 	region, err := s.params.Get(api.DefaultLeaseEnv)
 	if err != nil || region == "" {
 		return results.ForReason("acquiring_ip_pool_lease").WithError(err).Errorf("failed to determine region to acquire lease for %s", l.ResourceType)
@@ -144,6 +168,10 @@ func (s *ipPoolStep) run(ctx context.Context, minute time.Duration) error {
 	releaseErr := results.ForReason("releasing_ip_pool_lease").ForError(releaseLeases(client, s.metricsAgent, l))
 
 	return aggregateWrappedErrorAndReleaseError(wrappedErr, releaseErr)
+}
+
+func (s *ipPoolStep) ipPoolLeaseAvailable() bool {
+	return s.ipPoolLease.StepLease.ResourceType != ""
 }
 
 type SecretClient interface {

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/openshift/ci-tools/pkg/testhelper"
 )
 
+func ipPoolLeaseAdapter(lease stepLease) func(api.ClusterProfile, string) stepLease {
+	return func(api.ClusterProfile, string) stepLease { return lease }
+}
+
 func TestProvides(t *testing.T) {
 	testCases := []struct {
 		name     string
@@ -148,13 +152,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "leases available in region",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        2,
 					},
-				},
+				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 				namespace: func() string {
@@ -171,13 +175,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "requested to release unused",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        3,
 					},
-				},
+				}),
 				wrapped: &blockingStep{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 				namespace: func() string {
@@ -197,13 +201,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "requested to release too many unused",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        1,
 					},
-				},
+				}),
 				wrapped: &blockingStep{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 				namespace: func() string {
@@ -219,13 +223,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "leases unavailable in region, step should not error",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        1,
 					},
-				},
+				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 				namespace: func() string {
@@ -242,13 +246,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "region not provided, errors",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        2,
 					},
-				},
+				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{},
 			},
@@ -257,13 +261,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "unknown lease client error",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        1,
 					},
-				},
+				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
 			},
@@ -278,13 +282,13 @@ func TestRun(t *testing.T) {
 		{
 			name: "wrapped step fails",
 			step: ipPoolStep{
-				ipPoolLease: stepLease{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
 					StepLease: api.StepLease{
 						ResourceType: "aws-ip-pool",
 						Env:          api.DefaultIPPoolLeaseEnv,
 						Count:        1,
 					},
-				},
+				}),
 				namespace: func() string {
 					return ciOpNamespace
 				},
@@ -296,6 +300,18 @@ func TestRun(t *testing.T) {
 				"releaseone owner aws-ip-pool-us-east-1_0 free",
 			},
 			expectedError: errors.New("injected failure"),
+		},
+		{
+			name: "ip pool lease not available, run wrapped step",
+			step: ipPoolStep{
+				ipPoolLeaseFunc: ipPoolLeaseAdapter(stepLease{
+					StepLease: api.StepLease{},
+				}),
+				namespace: func() string {
+					return ciOpNamespace
+				},
+				wrapped: &stepNeedsLease{},
+			},
 		},
 	}
 	for _, tc := range testCases {
@@ -342,7 +358,7 @@ func TestRun(t *testing.T) {
 
 func TestIPPoolStepForward(t *testing.T) {
 	step := stepNeedsLease{}
-	withIPPool := IPPoolStep(nil, nil, api.StepLease{ResourceType: "aws-ip-pool", Env: api.DefaultIPPoolLeaseEnv}, &step, nil, emptyNamespace, nil)
+	withIPPool := IPPoolStep(nil, nil, &step, nil, emptyNamespace, nil, api.ClusterProfileAWS, "main")
 	t.Run("SubTests", func(t *testing.T) {
 		s, l := step.SubTests(), withIPPool.(SubtestReporter).SubTests()
 		if diff := cmp.Diff(s, l); diff != "" {

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -232,7 +232,7 @@ func (s *multiStageTestStep) Run(ctx context.Context) error {
 func (s *multiStageTestStep) run(ctx context.Context) error {
 	logrus.Infof("Running multi-stage test %s", s.name)
 
-	clusterProfile, err := getClusterProfileFromParams(s.params)
+	clusterProfile, err := api.ClusterProfileFromParams(s.params)
 	if err != nil {
 		return fmt.Errorf("get cluster profile from parameters: %w", err)
 	}
@@ -624,14 +624,6 @@ func getMountPath(secretName string) string {
 
 func volumeName(ns, name string) string {
 	return strings.ReplaceAll(fmt.Sprintf("%s-%s", ns, name), ".", "-")
-}
-
-func getClusterProfileFromParams(params api.Parameters) (api.ClusterProfile, error) {
-	if params == nil {
-		return "", nil
-	}
-	cp, err := params.Get(api.ClusterProfileParam)
-	return api.ClusterProfile(cp), err
 }
 
 // ensureScriptConfigMap copies the lease proxy scripts ConfigMap from src to dst.


### PR DESCRIPTION
The "Bring Your Own IP Pool" feature assumes a cluster profile to be defined at configuration time:
```yaml
tests:
- as: e2e
  steps:
    cluster_profile: aws
```
but it doesn't work as intended when a Cluster Profile Set is used.

The following depicts a scenario in which a test uses the Cluster Profile Set functionality that breaks BYOIP.

`ci-operator` test's configuration:
```yaml
tests:
- as: e2e
  steps:
    cluster_profile: openhishift-org-aws
```

1. `ci-operator` acquires a lease of type `openhishift-org-aws` and it gets `aws--us-east-1--quota-slice-001`
2. The lease name at (1) is parsed and the cluster profile `aws` is load
  a. The cluster profile `aws` is a legitimate profile for using BYOIP
3. `ci-operator` tries to acquire some leases for BYOIP but it considers the profile `openhishift-org-aws` (statically defined) rather than `aws`
4. No IP pool is claimed
5. Test fails

This PR addresses the issue above by taking into account the cluster profile defined at runtime `aws` rather than the static one `openshift-org-aws`.
If no Cluster Profile Set is in use, it falls back to the old behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## BYOIP Integration with Cluster Profile Sets

This PR fixes a BYOIP (Bring Your Own IP Pool) integration bug in ci-operator so IP pools are claimed using the runtime cluster profile when Cluster Profile Sets are used.

What changed, in practical terms
- Component affected: ci-operator (lease/IP-pool handling and multi-stage step wiring).
- Problem fixed: When ci-operator acquired a lease whose name encodes a runtime profile (e.g., lease "aws--us-east-1--quota-slice-001" ⇒ runtime profile "aws"), BYOIP continued to use the static cluster_profile from test config (e.g., "openshift-org-aws"). That mismatch prevented claiming the correct IP pool and caused tests to fail.
- Behavior change: BYOIP now uses the cluster profile determined at runtime (parsed from the acquired lease / present in job parameters) when Cluster Profile Sets are in use; when no Cluster Profile Set is involved it falls back to previous static behavior.

Key implementation points
- IPPoolLeaseForTest signature changed to accept an explicit ClusterProfile and branch so callers can pass either the static or the runtime profile.
- New helper ClusterProfileFromParams(params) extracts the runtime profile from job parameters so downstream steps can read the profile chosen when the lease was acquired.
- IPPoolStep now accepts profile and branch inputs and re-initializes its lease using the profile found in params at run-time; if no IP-pool lease is applicable it skips acquiring/releasing leases and simply runs the wrapped step.
- Multi-stage test setup and defaults were adjusted so IP-pool handling is applied based on actual leases present and the runtime profile is resolved inside multi-stage steps.
- Tests updated to exercise the new function shapes and the "no IP-pool available" path.

Impact
- CI users: Tests that use Cluster Profile Sets and require BYOIP will now successfully claim the correct IP pools and avoid failures caused by using the wrong (static) profile.
- CI operators: Runtime profile selection is now honored for IP-pool acquisition while keeping backward compatibility for jobs that use a static cluster_profile. The change is internal to ci-operator lease/step wiring and should be transparent to job authors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->