### PR TITLE
Ignore non-created issue comment events in prow plugins

### DIFF
--- a/cmd/backport-verifier/server.go
+++ b/cmd/backport-verifier/server.go
@@ -54,6 +54,9 @@ type server struct {
 }
 
 func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) {
+	if ic.Action != github.IssueCommentActionCreated {
+		return
+	}
 	if !commandRe.MatchString(ic.Comment.Body) {
 		return
 	}

--- a/cmd/backport-verifier/server_test.go
+++ b/cmd/backport-verifier/server_test.go
@@ -76,6 +76,37 @@ func (c *fakeClient) RemoveLabel(org, repo string, number int, label string) err
 	return nil
 }
 
+func TestHandleIssueCommentIgnoresNonCreatedActions(t *testing.T) {
+	for _, action := range []github.IssueCommentEventAction{github.IssueCommentActionEdited, github.IssueCommentActionDeleted} {
+		t.Run(string(action), func(t *testing.T) {
+			orp := orgrepopr{org: "org", repo: "repo", pr: 1}
+			client := &fakeClient{
+				comments: map[orgrepopr][]string{orp: {}},
+				labels:   map[orgrepopr][]string{orp: {}},
+			}
+			s := &server{
+				config: func() *Config { return &Config{} },
+				ghc:    client,
+			}
+			s.handleIssueComment(logrus.WithField("test", t.Name()), github.IssueCommentEvent{
+				Action: action,
+				Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+				Issue: github.Issue{
+					Number:      1,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/validate-backports",
+					User: github.User{Login: "author"},
+				},
+			})
+			if len(client.comments[orp]) > 0 {
+				t.Errorf("expected no comments for %s action, got: %v", action, client.comments[orp])
+			}
+		})
+	}
+}
+
 func TestHandle(t *testing.T) {
 	var testCases = []struct {
 		name             string

--- a/cmd/multi-pr-prow-plugin/server.go
+++ b/cmd/multi-pr-prow-plugin/server.go
@@ -153,6 +153,9 @@ func newServer(ctx context.Context,
 }
 
 func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) {
+	if ic.Action != github.IssueCommentActionCreated {
+		return
+	}
 	if strings.HasPrefix(ic.Comment.Body, testwithPrefix) {
 		l.Infof("handling comment: %s", ic.Comment.Body)
 		_, err := s.handle(l, ic)

--- a/cmd/multi-pr-prow-plugin/server_test.go
+++ b/cmd/multi-pr-prow-plugin/server_test.go
@@ -396,6 +396,37 @@ func TestHandle(t *testing.T) {
 	}
 }
 
+func TestHandleIssueCommentIgnoresNonCreatedActions(t *testing.T) {
+	ghc := fakeGithubClient{}
+	reporter := &fakeReporter{}
+	s := server{
+		ghc:            ghc,
+		trustedChecker: &fakeTrustedChecker{},
+		reporter:       reporter,
+		kubeClient:     fakectrlruntimeclient.NewFakeClient(),
+		namespace:      "ci",
+	}
+	for _, action := range []github.IssueCommentEventAction{github.IssueCommentActionEdited, github.IssueCommentActionDeleted} {
+		t.Run(string(action), func(t *testing.T) {
+			s.handleIssueComment(logrus.WithField("test", t.Name()), github.IssueCommentEvent{
+				Action: action,
+				Repo:   github.Repo{Owner: github.User{Login: "openshift"}, Name: "ci-tools"},
+				Issue: github.Issue{
+					Number:      999,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/testwith openshift/ci-tools/main/unit openshift/ci-tools#123",
+					User: github.User{Login: "developer"},
+				},
+			})
+			if got := len(reporter.reported); got != 0 {
+				t.Errorf("expected no reported prow jobs for %s action, got %d", action, got)
+			}
+		})
+	}
+}
+
 func TestDetermineJobRuns(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/cmd/payload-testing-prow-plugin/server.go
+++ b/cmd/payload-testing-prow-plugin/server.go
@@ -285,6 +285,9 @@ const (
 )
 
 func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent) {
+	if ic.Action != github.IssueCommentActionCreated {
+		return
+	}
 	if comment, additionalPRs := s.handle(l, ic); comment != "" {
 		org := ic.Repo.Owner.Login
 		repo := ic.Repo.Name

--- a/cmd/payload-testing-prow-plugin/server_test.go
+++ b/cmd/payload-testing-prow-plugin/server_test.go
@@ -1397,6 +1397,41 @@ func TestGithubTrustedChecker_trustedUser_AllowsTrustedApp(t *testing.T) {
 	}
 }
 
+func TestHandleIssueCommentIgnoresNonCreatedActions(t *testing.T) {
+	ghc := fakegithub.NewFakeClient()
+	s := &server{
+		ghc:        ghc,
+		ctx:        context.TODO(),
+		kubeClient: fakeclient.NewClientBuilder().Build(),
+		namespace:  "ci",
+		jobResolver: newFakeJobResolver(map[string][]config.Job{"4.10": {
+			{Name: "periodic-ci-openshift-release-master-nightly-4.10-e2e-aws-serial"},
+		}}),
+		testResolver:       newFakeTestResolver(),
+		trustedChecker:     &fakeTrustedChecker{},
+		ciOpConfigResolver: &fakeCIOpConfigResolver{},
+	}
+	for _, action := range []github.IssueCommentEventAction{github.IssueCommentActionEdited, github.IssueCommentActionDeleted} {
+		t.Run(string(action), func(t *testing.T) {
+			ghc.IssueCommentsAdded = nil
+			s.handleIssueComment(logrus.WithField("test", t.Name()), github.IssueCommentEvent{
+				Action: action,
+				Repo:   github.Repo{Owner: github.User{Login: "openshift"}},
+				Issue: github.Issue{
+					Number:      123,
+					PullRequest: &struct{}{},
+				},
+				Comment: github.IssueComment{
+					Body: "/payload 4.10 nightly informing",
+				},
+			})
+			if len(ghc.IssueCommentsAdded) > 0 {
+				t.Errorf("expected no comments for %s action, got: %v", action, ghc.IssueCommentsAdded)
+			}
+		})
+	}
+}
+
 func TestGithubTrustedChecker_trustedUser_UntrustedAppFallsBackToHumanCheck(t *testing.T) {
 	c := &githubTrustedChecker{
 		githubClient: nil,

--- a/cmd/pipeline-controller/main.go
+++ b/cmd/pipeline-controller/main.go
@@ -359,6 +359,10 @@ func (cw *clientWrapper) handleLabelAddition(l *logrus.Entry, event github.PullR
 }
 
 func (cw *clientWrapper) handleIssueComment(l *logrus.Entry, event github.IssueCommentEvent) {
+	if event.Action != github.IssueCommentActionCreated {
+		return
+	}
+
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
 

--- a/cmd/pipeline-controller/main_test.go
+++ b/cmd/pipeline-controller/main_test.go
@@ -238,8 +238,35 @@ func TestHandleIssueComment(t *testing.T) {
 		expectedComment   string
 	}{
 		{
+			name: "edited comment: do nothing",
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionEdited,
+				Comment: github.IssueComment{
+					Body: "/pipeline required",
+				},
+				Issue: github.Issue{
+					PullRequest: &struct{}{},
+				},
+			},
+			expectCommentCall: false,
+		},
+		{
+			name: "deleted comment: do nothing",
+			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionDeleted,
+				Comment: github.IssueComment{
+					Body: "/pipeline required",
+				},
+				Issue: github.Issue{
+					PullRequest: &struct{}{},
+				},
+			},
+			expectCommentCall: false,
+		},
+		{
 			name: "not a PR: do nothing",
 			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
 				Issue: github.Issue{
 					PullRequest: nil,
 				},
@@ -249,6 +276,7 @@ func TestHandleIssueComment(t *testing.T) {
 		{
 			name: "comment doesn't contain /pipeline required: do nothing",
 			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
 				Comment: github.IssueComment{
 					Body: "This is just a regular comment",
 				},
@@ -261,6 +289,7 @@ func TestHandleIssueComment(t *testing.T) {
 		{
 			name: "comment contains /pipeline required in middle of text: do nothing",
 			event: github.IssueCommentEvent{
+				Action: github.IssueCommentActionCreated,
 				Comment: github.IssueComment{
 					Body: "Comment `/pipeline required` to trigger all required & necessary jobs.",
 				},


### PR DESCRIPTION
## Summary

Several custom prow plugins (`payload-testing`, `multi-pr-prow-plugin`, `backport-verifier`, `pipeline-controller`) process all `IssueCommentEvent` actions, including `edited` and `deleted`. This means editing a comment containing a slash command (e.g. `/payload-job`) unintentionally re-triggers the action.

Add an early return for non-`created` actions in each plugin's `handleIssueComment`, matching what `pj-rehearse` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR makes four custom Prow plugins ignore IssueCommentEvent actions other than "created", preventing edited or deleted comments from re-triggering slash-command processing.

What changed in practice
- Each plugin's issue-comment handler now returns early unless ic.Action == github.IssueCommentActionCreated. Only newly created comments containing slash commands will be parsed and acted on.
- Unit tests were added/expanded for each plugin to assert that edited and deleted comment events do not trigger actions (no comments posted, no prow jobs scheduled, etc.).

Components affected and behavior changes
- payload-testing-prow-plugin: Only newly created comments will trigger /payload, /payload-job, /payload-with-prs, /payload-job-with-prs, /payload-aggregate, /payload-aggregate-with-prs and /payload-abort handling. Editing or deleting a comment with a payload command will no longer re-run or re-schedule payload jobs.
- multi-pr-prow-plugin: Only newly created comments will trigger /testwith and /testwith abort flows; edits/deletes will be ignored and will not schedule or abort multi-PR ProwJobs.
- backport-verifier: Only newly created comments will trigger /validate-backports. Edited or deleted comments will not re-run backport validation or post validation comments/labels.
- pipeline-controller: Only newly created comments will trigger /pipeline commands (e.g., /pipeline required, /pipeline auto). As a minor efficiency improvement, ignored events now return before acquiring the controller’s mutex, reducing unnecessary lock contention.

Impact for CI users and operators
- Editing or deleting a comment that contains a slash command will no longer accidentally re-trigger CI actions or create redundant noise.
- Reduces unnecessary job runs and spurious comments; improves predictability of slash-command-triggered behavior.
- New unit tests across the plugins help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->