### PR TITLE
ci-operator-checkconfig: Add cluster profile sets allowlist

### DIFF
--- a/cmd/ci-operator-checkconfig/main.go
+++ b/cmd/ci-operator-checkconfig/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -35,7 +34,7 @@ type options struct {
 	ciOPConfigAgent          agents.ConfigAgent
 	clusterProfiles          api.ClusterProfilesMap
 	clusterClaimOwners       api.ClusterClaimOwnersMap
-	clusterProfileSetDetails validation.ClusterProfileSetDetails
+	clusterProfileSetDetails api.ClusterProfileSetDetails
 }
 
 func (o *options) parse() error {
@@ -79,9 +78,11 @@ func (o *options) parse() error {
 	o.ciOPConfigAgent = ciOPConfigAgent
 
 	if clusterProfileSetDetailsPath != "" {
-		if err := o.loadClusterProfileDetails(clusterProfileSetDetailsPath); err != nil {
+		cpsd, err := load.ClusterProfileSetDetails(clusterProfileSetDetailsPath)
+		if err != nil {
 			return fmt.Errorf("load cluster profile set details: %w", err)
 		}
+		o.clusterProfileSetDetails = cpsd
 	}
 
 	if err := o.Options.Validate(); err != nil {
@@ -130,20 +131,6 @@ func (o *options) validate() (ret []error) {
 		ret = append(ret, err)
 	}
 	return append(ret, validateTags(seen)...)
-}
-
-func (o *options) loadClusterProfileDetails(p string) error {
-	cpsDetailsBytes, err := os.ReadFile(p)
-	if err != nil {
-		return fmt.Errorf("read file %s: %w", p, err)
-	}
-
-	o.clusterProfileSetDetails = make(map[api.ClusterProfile][]string)
-	if err := json.Unmarshal(cpsDetailsBytes, &o.clusterProfileSetDetails); err != nil {
-		return fmt.Errorf("unmarshal cluster profile set details: %w", err)
-	}
-
-	return nil
 }
 
 func (o *options) loadResolver(path string) error {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	"sigs.k8s.io/prow/pkg/repoowners"
 
 	imagev1 "github.com/openshift/api/image/v1"
+
+	utilregexp "github.com/openshift/ci-tools/pkg/util/regexp"
 )
 
 const (
@@ -3112,6 +3115,74 @@ type ClusterProfileOwners struct {
 	Konflux *ClusterProfileKonfluxOwner `yaml:"konflux,omitempty" json:"konflux,omitempty"`
 }
 type ClusterClaimOwnersMap map[string]ClusterClaimDetails
+
+// +kubebuilder:object:generate=false
+type ClusterProfileSetDetails struct {
+	ClusterProfileSetDetailsNew
+}
+
+func (cps *ClusterProfileSetDetails) UnmarshalJSON(data []byte) error {
+	cpsDetails := make(map[ClusterProfile][]string)
+
+	if strings.Contains(string(data), `"cluster_profile_sets"`) {
+		newCPSDetails := ClusterProfileSetDetailsNew{}
+		if err := json.Unmarshal(data, &newCPSDetails); err != nil {
+			return fmt.Errorf("new ClusterProfileSetDetails schema: %w", err)
+		}
+		cps.ClusterProfileSetDetailsNew = newCPSDetails
+	} else {
+		if err := json.Unmarshal(data, &cpsDetails); err != nil {
+			return fmt.Errorf("old ClusterProfileSetDetails schema: %w", err)
+		}
+		cps.ClusterProfileSets = cpsDetails
+	}
+
+	return nil
+}
+
+// TODO: This will replace `ClusterProfileSetDetails` once the migration is complete.
+// +kubebuilder:object:generate=false
+type ClusterProfileSetDetailsNew struct {
+	ClusterProfileSets map[ClusterProfile][]string `json:"cluster_profile_sets,omitempty"`
+
+	// TestsAllowlist holds a list of tests for which we do not enfoce policy
+	// regarding the cluster profile sets usage.
+	// This deeply nested type match the following pattern:
+	//  "org/repo": "branch": "variant": "test"
+	TestsAllowlist map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string `json:"tests_allowlist,omitempty"`
+}
+
+func (cps ClusterProfileSetDetailsNew) FindSetByProfile(profile ClusterProfile) (ClusterProfile, bool) {
+	for cpsName, cpDetails := range cps.ClusterProfileSets {
+		if slices.Contains(cpDetails, string(profile)) {
+			return cpsName, true
+		}
+	}
+	return "", false
+}
+
+func (cps ClusterProfileSetDetailsNew) IsTestAllowlisted(test string, metadata Metadata) bool {
+	if cps.TestsAllowlist == nil {
+		return false
+	}
+
+	orgRepo, ok := utilregexp.LookupByMatch(cps.TestsAllowlist, metadata.Org+"/"+metadata.Repo)
+	if !ok {
+		return false
+	}
+
+	branch, ok := utilregexp.LookupByMatch(orgRepo, metadata.Branch)
+	if !ok {
+		return false
+	}
+
+	tests, ok := utilregexp.LookupByMatch(branch, metadata.Variant)
+	if !ok {
+		return false
+	}
+
+	return slices.Contains(tests, test)
+}
 
 type ClusterClaimDetails struct {
 	Claim  string                     `yaml:"claim"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -445,6 +446,70 @@ func TestResolveClusterProfileList(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantProfiles, tc.profiles); diff != "" {
 				t.Errorf("unexpected profiles: %s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalClusterProfileSetDetails(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name                         string
+		data                         string
+		wantClusterProfileSetDetails ClusterProfileSetDetails
+	}{
+		{
+			name: "Old schema",
+			data: `{
+		"openshift-org-aws": [
+			"aws",
+			"aws-2",
+			"aws-3",
+			"aws-4",
+			"aws-5"
+			]
+		}`,
+			wantClusterProfileSetDetails: ClusterProfileSetDetails{
+				ClusterProfileSetDetailsNew: ClusterProfileSetDetailsNew{
+					ClusterProfileSets: map[ClusterProfile][]string{
+						"openshift-org-aws": {"aws", "aws-2", "aws-3", "aws-4", "aws-5"},
+					},
+				},
+			},
+		},
+		{
+			name: "New schema",
+			data: `{
+"cluster_profile_sets": {
+	"openshift-org-aws": [
+			"aws",
+			"aws-2",
+			"aws-3",
+			"aws-4",
+			"aws-5"
+		]
+	}
+}`,
+			wantClusterProfileSetDetails: ClusterProfileSetDetails{
+				ClusterProfileSetDetailsNew: ClusterProfileSetDetailsNew{
+					ClusterProfileSets: map[ClusterProfile][]string{
+						"openshift-org-aws": {"aws", "aws-2", "aws-3", "aws-4", "aws-5"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotClusterProfileSetDetails := ClusterProfileSetDetails{}
+			if err := json.Unmarshal([]byte(tc.data), &gotClusterProfileSetDetails); err != nil {
+				t.Errorf("fail to unmarshal cluster profile set details: %s", err.Error())
+				return
+			}
+
+			if diff := cmp.Diff(&tc.wantClusterProfileSetDetails, &gotClusterProfileSetDetails); diff != "" {
+				t.Errorf("unexpected cluster profile set details:\n %s", diff)
 			}
 		})
 	}

--- a/pkg/load/load.go
+++ b/pkg/load/load.go
@@ -306,6 +306,21 @@ func ClusterProfilesConfig(configPath string) (api.ClusterProfilesMap, error) {
 	return mergedMap, nil
 }
 
+func ClusterProfileSetDetails(path string) (api.ClusterProfileSetDetails, error) {
+	cpsd := api.ClusterProfileSetDetails{}
+
+	cpsDetailsBytes, err := os.ReadFile(path)
+	if err != nil {
+		return cpsd, fmt.Errorf("read file %s: %w", path, err)
+	}
+
+	if err := json.Unmarshal(cpsDetailsBytes, &cpsd); err != nil {
+		return cpsd, fmt.Errorf("unmarshal file %s: %w", path, err)
+	}
+
+	return cpsd, nil
+}
+
 // ClusterClaimOwnersConfig loads cluster claim owners information from its config in the release repository
 func ClusterClaimOwnersConfig(configPath string) (api.ClusterClaimOwnersMap, error) {
 	configContents, err := os.ReadFile(configPath)

--- a/pkg/util/regexp/regexp.go
+++ b/pkg/util/regexp/regexp.go
@@ -1,0 +1,53 @@
+package regexp
+
+import "regexp"
+
+// Regexp is a wrapper for regexp.Regexp that is also comparable.
+// This type can be used as a key in maps: `map[Regexp]T`.
+type Regexp struct {
+	expr    string
+	Pattern *regexp.Regexp
+}
+
+// AppendText implements [encoding.TextAppender].
+func (re *Regexp) AppendText(b []byte) ([]byte, error) {
+	return append(b, re.Pattern.String()...), nil
+}
+
+// MarshalText implements [encoding.TextMarshaler].
+func (re *Regexp) MarshalText() ([]byte, error) {
+	return re.Pattern.AppendText(nil)
+}
+
+// UnmarshalText implements [encoding.UnmarshalText].
+func (re *Regexp) UnmarshalText(text []byte) error {
+	re.expr = string(text)
+	compiled, err := regexp.Compile(re.expr)
+	if err != nil {
+		return err
+	}
+	re.Pattern = compiled
+	return nil
+
+}
+
+func Compile(expr string) (*Regexp, error) {
+	compiled, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	return &Regexp{expr: expr, Pattern: compiled}, nil
+}
+
+// LookupByMatch scans <key, value> tuples `patterns` and returns the value
+// whose key matches `s`.
+func LookupByMatch[T any](patterns map[Regexp]T, s string) (T, bool) {
+	for re, val := range patterns {
+		if re.Pattern.Match([]byte(s)) {
+			return val, true
+		}
+	}
+
+	var zero T
+	return zero, false
+}

--- a/pkg/util/regexp/regexp_test.go
+++ b/pkg/util/regexp/regexp_test.go
@@ -1,0 +1,222 @@
+package regexp
+
+import (
+	"testing"
+)
+
+func TestRegexp_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		wantErr bool
+	}{
+		{
+			name:    "valid pattern",
+			text:    "^test.*$",
+			wantErr: false,
+		},
+		{
+			name:    "invalid pattern",
+			text:    "[unclosed",
+			wantErr: true,
+		},
+		{
+			name:    "empty pattern",
+			text:    "",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var re Regexp
+			err := re.UnmarshalText([]byte(tt.text))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalText() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if re.expr != tt.text {
+					t.Errorf("UnmarshalText() expr = %v, want %v", re.expr, tt.text)
+				}
+				if re.Pattern == nil {
+					t.Error("UnmarshalText() Pattern is nil")
+				}
+			}
+		})
+	}
+}
+
+func TestLookupByMatch(t *testing.T) {
+	type Config struct {
+		Name  string
+		Value int
+	}
+
+	tests := []struct {
+		name           string
+		patternPairs   map[string]string
+		input          string
+		wantValue      string
+		wantFound      bool
+		skipValueCheck bool
+	}{
+		{
+			name: "match first pattern",
+			patternPairs: map[string]string{
+				"^test-.*": "test-env",
+				"^prod-.*": "prod-env",
+				"^dev-.*":  "dev-env",
+			},
+			input:     "test-cluster",
+			wantValue: "test-env",
+			wantFound: true,
+		},
+		{
+			name: "match second pattern",
+			patternPairs: map[string]string{
+				"^test-.*": "test-env",
+				"^prod-.*": "prod-env",
+				"^dev-.*":  "dev-env",
+			},
+			input:     "prod-cluster",
+			wantValue: "prod-env",
+			wantFound: true,
+		},
+		{
+			name: "match third pattern",
+			patternPairs: map[string]string{
+				"^test-.*": "test-env",
+				"^prod-.*": "prod-env",
+				"^dev-.*":  "dev-env",
+			},
+			input:     "dev-cluster",
+			wantValue: "dev-env",
+			wantFound: true,
+		},
+		{
+			name: "no match",
+			patternPairs: map[string]string{
+				"^test-.*": "test-env",
+				"^prod-.*": "prod-env",
+			},
+			input:     "staging-cluster",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name: "empty string input",
+			patternPairs: map[string]string{
+				"^test-.*": "test-env",
+			},
+			input:     "",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name:         "empty map",
+			patternPairs: map[string]string{},
+			input:        "any-string",
+			wantValue:    "",
+			wantFound:    false,
+		},
+		{
+			name: "match with special characters",
+			patternPairs: map[string]string{
+				`^v\d+\.\d+\.\d+$`: "version",
+			},
+			input:     "v1.2.3",
+			wantValue: "version",
+			wantFound: true,
+		},
+		{
+			name: "partial match not allowed",
+			patternPairs: map[string]string{
+				"^test$": "exact",
+			},
+			input:     "test-extra",
+			wantValue: "",
+			wantFound: false,
+		},
+		{
+			name: "multiple patterns could match - first wins",
+			patternPairs: map[string]string{
+				".*":       "wildcard",
+				"^test-.*": "specific",
+			},
+			input:          "test-cluster",
+			wantFound:      true,
+			skipValueCheck: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patterns := make(map[Regexp]string)
+			for expr, value := range tt.patternPairs {
+				patterns[re(expr, t)] = value
+			}
+
+			gotValue, gotFound := LookupByMatch(patterns, tt.input)
+			if gotFound != tt.wantFound {
+				t.Errorf("LookupByMatch() found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if !tt.skipValueCheck && gotValue != tt.wantValue {
+				t.Errorf("LookupByMatch() value = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+
+	t.Run("complex types", func(t *testing.T) {
+		patterns := map[Regexp]Config{
+			re("^app-.*", t): {Name: "application", Value: 100},
+			re("^db-.*", t):  {Name: "database", Value: 200},
+		}
+
+		tests := []struct {
+			name      string
+			input     string
+			wantValue Config
+			wantFound bool
+		}{
+			{
+				name:      "match app pattern",
+				input:     "app-server",
+				wantValue: Config{Name: "application", Value: 100},
+				wantFound: true,
+			},
+			{
+				name:      "match db pattern",
+				input:     "db-postgres",
+				wantValue: Config{Name: "database", Value: 200},
+				wantFound: true,
+			},
+			{
+				name:      "no match returns zero value",
+				input:     "cache-redis",
+				wantValue: Config{},
+				wantFound: false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gotValue, gotFound := LookupByMatch(patterns, tt.input)
+				if gotFound != tt.wantFound {
+					t.Errorf("LookupByMatch() found = %v, want %v", gotFound, tt.wantFound)
+				}
+				if gotValue != tt.wantValue {
+					t.Errorf("LookupByMatch() value = %v, want %v", gotValue, tt.wantValue)
+				}
+			})
+		}
+	})
+}
+
+func re(expr string, t *testing.T) Regexp {
+	compiled, err := Compile(expr)
+	if err != nil {
+		t.Fatalf("failed to compile regexp %q: %v", expr, err)
+	}
+	return *compiled
+}

--- a/pkg/validation/config.go
+++ b/pkg/validation/config.go
@@ -13,24 +13,18 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 )
 
-type ClusterProfileDetails struct {
-	Name string `json:"name"`
-}
-
-type ClusterProfileSetDetails map[api.ClusterProfile][]string
-
 // Validator holds data used across validations.
 type Validator struct {
 	validClusterProfiles    api.ClusterProfilesMap
 	validClusterClaimOwners api.ClusterClaimOwnersMap
 	// hasTrapCache avoids redundant regexp searches on step commands.
 	hasTrapCache map[string]bool
-	cpsDetails   ClusterProfileSetDetails
+	cpsDetails   api.ClusterProfileSetDetails
 }
 
 type ValidatorOption func(*Validator)
 
-func WithClusterProfileSetDetails(cpsDetails ClusterProfileSetDetails) func(*Validator) {
+func WithClusterProfileSetDetails(cpsDetails api.ClusterProfileSetDetails) func(*Validator) {
 	return func(v *Validator) { v.cpsDetails = cpsDetails }
 }
 
@@ -38,7 +32,7 @@ func WithClusterProfileSetDetails(cpsDetails ClusterProfileSetDetails) func(*Val
 func NewValidator(profiles api.ClusterProfilesMap, clusterClaimOwners api.ClusterClaimOwnersMap, opts ...ValidatorOption) Validator {
 	v := Validator{
 		hasTrapCache: make(map[string]bool),
-		cpsDetails:   make(map[api.ClusterProfile][]string),
+		cpsDetails:   api.ClusterProfileSetDetails{},
 	}
 	for _, f := range opts {
 		f(&v)

--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -440,24 +440,26 @@ func validateTestStepDependencies(config *api.ReleaseBuildConfiguration) []error
 	return errs
 }
 
-func (v *Validator) validateClusterProfile(fieldRoot string, p api.ClusterProfile, metadata *api.Metadata) []error {
+func (v *Validator) validateClusterProfile(fieldRoot string, p api.ClusterProfile, test string, metadata *api.Metadata) []error {
 	if v.validClusterProfiles != nil {
 		if _, ok := v.validClusterProfiles[p]; ok {
 			if err := verifyClusterProfileOwnership(v.validClusterProfiles[p], metadata); err != nil {
 				return []error{err}
 			}
 		}
-	} else {
-		if !slices.Contains(api.ClusterProfiles(), p) {
-			return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}
-		}
 	}
 
-	for cpsName, cpDetails := range v.cpsDetails {
-		for _, cpDetail := range cpDetails {
-			if string(p) == cpDetail {
-				return []error{fmt.Errorf("%s: invalid cluster profile %q, use the cluster profile set %q instead", fieldRoot, p, cpsName)}
-			}
+	if !slices.Contains(api.ClusterProfiles(), p) {
+		return []error{fmt.Errorf("%s: invalid cluster profile %q", fieldRoot, p)}
+	}
+
+	if metadata == nil {
+		return []error{fmt.Errorf("can't validate cluster profile, metadata not defined")}
+	}
+
+	if !v.cpsDetails.IsTestAllowlisted(test, *metadata) {
+		if set, ok := v.cpsDetails.FindSetByProfile(p); ok {
+			return []error{fmt.Errorf("%s: invalid cluster profile %q, use the cluster profile set %q instead", fieldRoot, p, set)}
 		}
 	}
 
@@ -582,7 +584,7 @@ func (v *Validator) validateTestConfigurationType(
 		typeCount++
 		if testConfig.ClusterProfile != "" {
 			clusterCount++
-			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfile, metadata)...)
+			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfile, test.As, metadata)...)
 		}
 		context := newContext(fieldPath(fieldRoot), testConfig.Environment, releases, inputImagesSeen)
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
@@ -598,7 +600,7 @@ func (v *Validator) validateTestConfigurationType(
 		context := newContext(fieldPath(fieldRoot).addField("steps"), testConfig.Environment, releases, inputImagesSeen)
 		if testConfig.ClusterProfile != "" {
 			clusterCount++
-			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfile, metadata)...)
+			validationErrors = append(validationErrors, v.validateClusterProfile(fieldRoot, testConfig.ClusterProfile, test.As, metadata)...)
 		}
 		validationErrors = append(validationErrors, validateLeases(context.addField("leases"), testConfig.Leases)...)
 		for i, s := range testConfig.Pre {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/testhelper"
+	utilregexp "github.com/openshift/ci-tools/pkg/util/regexp"
 )
 
 func TestValidateTests(t *testing.T) {
@@ -714,7 +715,7 @@ func TestValidateTests(t *testing.T) {
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()
-			errs := v.validateTestStepConfiguration(NewConfigContext(), "tests", tc.tests, tc.release, nil, tc.releases, sets.New[string](), tc.resolved)
+			errs := v.validateTestStepConfiguration(NewConfigContext(), "tests", tc.tests, tc.release, &api.Metadata{}, tc.releases, sets.New[string](), tc.resolved)
 			if tc.expectedError == nil && len(errs) > 0 {
 				t.Errorf("expected to be valid, got: %v", errs)
 			}
@@ -1968,7 +1969,7 @@ func TestValidateTestConfigurationType(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			v := NewValidator(nil, nil)
-			actual := v.validateTestConfigurationType("test", tc.test, nil, nil, nil, make(testInputImages), false)
+			actual := v.validateTestConfigurationType("test", tc.test, &api.Metadata{}, nil, nil, make(testInputImages), false)
 			if diff := cmp.Diff(tc.expected, actual, testhelper.EquateErrorMessage); diff != "" {
 				t.Errorf("expected differs from actual: %s", diff)
 			}
@@ -2223,38 +2224,86 @@ func TestVerifyClusterClaimOwnership(t *testing.T) {
 }
 
 func TestValidateClusterProfiles(t *testing.T) {
+	re := func(expr string) utilregexp.Regexp {
+		re, err := utilregexp.Compile(expr)
+		if err != nil {
+			t.Fatalf("compile regexp %s: %s", expr, err.Error())
+		}
+		return *re
+	}
+
 	t.Parallel()
 	for _, tc := range []struct {
 		name               string
 		clusterProfile     api.ClusterProfile
+		testName           string
 		metadata           *api.Metadata
 		clusterProfilesMap api.ClusterProfilesMap
-		cpsDetails         ClusterProfileSetDetails
+		cpsDetails         api.ClusterProfileSetDetails
 		wantErrs           []error
 	}{
 		{
 			name:           "Valid cluster profile",
+			metadata:       &api.Metadata{},
 			clusterProfile: api.ClusterProfileAROHCPDev,
 		},
 		{
 			name:           "invalid cluster profile",
+			metadata:       &api.Metadata{},
 			clusterProfile: "foobar",
 			wantErrs:       []error{errors.New(`foo: invalid cluster profile "foobar"`)},
 		},
 		{
 			name:           "Use cluster profile set",
+			metadata:       &api.Metadata{},
 			clusterProfile: "azure-2",
-			cpsDetails: ClusterProfileSetDetails{
-				"openshift-org-azure": []string{"azure-2"},
+			cpsDetails: api.ClusterProfileSetDetails{
+				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
+					ClusterProfileSets: map[api.ClusterProfile][]string{
+						"openshift-org-azure": {"azure-2"},
+					},
+				},
 			},
 			wantErrs: []error{errors.New(`foo: invalid cluster profile "azure-2", use the cluster profile set "openshift-org-azure" instead`)},
+		},
+		{
+			name:           "Skip allowlisted test",
+			metadata:       &api.Metadata{Org: "openshift", Repo: "ci-tools", Branch: "main"},
+			testName:       "e2e-aws-ovn",
+			clusterProfile: "azure-2",
+			cpsDetails: api.ClusterProfileSetDetails{
+				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
+					ClusterProfileSets: map[api.ClusterProfile][]string{
+						"openshift-org-azure": {"azure-2"},
+					},
+					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string{
+						re("openshift/ci-tools"): {re("main"): {re(""): {"e2e-aws-ovn"}}},
+					},
+				},
+			},
+		},
+		{
+			name:           "Skip allowlisted test that matches a pattern",
+			metadata:       &api.Metadata{Org: "openshift-priv", Repo: "ci-tools", Branch: "main", Variant: "nightly"},
+			testName:       "e2e-aws-ovn",
+			clusterProfile: "azure-2",
+			cpsDetails: api.ClusterProfileSetDetails{
+				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
+					ClusterProfileSets: map[api.ClusterProfile][]string{
+						"openshift-org-azure": {"azure-2"},
+					},
+					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string{
+						re("openshift(-priv)?/ci-tools"): {re("main"): {re("daily|nightly"): {"e2e-aws-ovn"}}},
+					},
+				},
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			v := NewValidator(tc.clusterProfilesMap, nil, WithClusterProfileSetDetails(tc.cpsDetails))
-			gotErrs := v.validateClusterProfile("foo", tc.clusterProfile, tc.metadata)
+			gotErrs := v.validateClusterProfile("foo", tc.clusterProfile, tc.testName, tc.metadata)
 
 			wantErrMsg := "<nil>"
 			if tc.wantErrs != nil {


### PR DESCRIPTION
Revisit the Cluster Profile Sets policy that has been introduced with https://github.com/openshift/ci-tools/pull/5087 by adding a whitelist that allows some tests to use the underlying cluster profile rather than the cluster profile set.

With the actual policy, the following test in `ci-operator/config/openshift/openshift-tests-private/openshift-openshift-tests-private-release-4.22__multi-nightly.yaml` doesn't pass the validation since it is using `aws` rather than `openshift-org-aws`:
```yaml
tests:
- as: aws-ipi-public-ipv4-pool-byo-subnet-mini-perm-arm-f14
  cron: 33 8 4,18 * *
  steps:
    cluster_profile: aws
```

After we merge this PR along with another one in `openshift/release` that would produce an allowlist like the following one, the test will pass the validation:
```json
{
  "cluster_profile_sets": {
    "openshift-org-aws": [
      "aws",
      "aws-2",
      "aws-3",
      "aws-4",
      "aws-5"
    ],
  "tests_allowlist": {
    "openshift/openshift-tests-private": {
      "release-4.22": {
        "multi-nightly": [
          "aws-ipi-public-ipv4-pool-byo-subnet-mini-perm-arm-f14"
        ]
      }
    }
  }
}
```

The `tests_allowlist` consists of:
```json
{
  "tests_allowlist" : {
     "${ORG}/${REPO}": {   // Regex allowed
       "${BRANCH}": {      // Regex allowed
         "${VARIANT}": [   // Regex allowed
           "${TEST_NAME}"  // Plain text, NO regex allowed
         ]
       }
     }
  }
}
```

The type `ClusterProfileSetDetailsNew` is temporary and will be deleted once we merge a PR in `openshift/release` that will modify the `cluster-profile-set-details.json` schema to accomodate the new `tests_whitelist` stanza.
The combination of both `ClusterProfileSetDetails` and `ClusterProfileSetDetailsNew` makes sure we are backward compatible until the migration is complete.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a regex-based allowlist for cluster profile set usage so specific tests can continue using legacy cluster profiles.
  * Backwards-compatible loading of both legacy and new allowlist JSON shapes.
* **Validation**
  * Validation now enforces per-test allowlisting, suggests appropriate cluster profile sets, and skips allowlisted tests.
* **Tests**
  * Expanded unit tests covering legacy/new schemas, allowlist behavior, and regexp utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->