### PR TITLE
resolve digest-only tags in ResolvePullSpec for PreserveOriginal imports

### DIFF
--- a/pkg/steps/release/import_release.go
+++ b/pkg/steps/release/import_release.go
@@ -241,6 +241,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 		for _, tag := range releaseIS.Spec.Tags {
 			existing.Insert(tag.Name)
 			tag.ReferencePolicy.Type = referencePolicy
+			tag.Reference = false
 			tag.ImportPolicy.ImportMode = imagev1.ImportModePreserveOriginal
 			tags = append(tags, tag)
 		}
@@ -250,6 +251,7 @@ oc create configmap release-%s --from-file=%s.yaml=${ARTIFACT_DIR}/%s
 			}
 			existing.Insert(tag.Name)
 			tag.ReferencePolicy.Type = referencePolicy
+			tag.Reference = false
 			tag.ImportPolicy.ImportMode = imagev1.ImportModePreserveOriginal
 			tags = append(tags, tag)
 		}

--- a/pkg/util/imagestream.go
+++ b/pkg/util/imagestream.go
@@ -56,6 +56,9 @@ func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (s
 				exists = true
 				break
 			}
+		} else if requireExact && strings.Contains(tags.Items[0].DockerImageReference, "@sha256:") {
+			pullSpec = tags.Items[0].DockerImageReference
+			exists = true
 		}
 		break
 	}


### PR DESCRIPTION
/cc @openshift/test-platform 
/hold 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Import Digest Resolution for PreserveOriginal Tags

This PR enhances the release import process to properly handle digest-only image references when using the `PreserveOriginal` import mode in the CI system's image streaming.

### Changes

**Image Resolution Enhancement** (`pkg/util/imagestream.go`)
The `ResolvePullSpec` function now includes a fallback mechanism for resolving tags that contain only a digest. When an exact pull spec is required (`requireExact=true`) and the tag's image reference is empty, the function will return the digest-qualified reference directly from the `DockerImageReference` field (e.g., `image@sha256:abc123...`). This ensures that digest-only references can be properly resolved without requiring a repository image field.

**Consistent Tag Reference Policy** (`pkg/steps/release/import_release.go`)
When updating the stable ImageStream to include tags from the extracted release payload, the code now explicitly sets `Reference = false` for all imported tags. This applies consistently to both newly imported tags from the release payload and tags preserved from the existing stable ImageStream. Combined with the `ImportModePreserveOriginal` setting, this ensures that original image references (including digest-only references) are preserved without being converted to local repository references.

### Impact

These changes improve the reliability of release imports when using `PreserveOriginal` import mode, allowing the CI system to properly handle and resolve digest-only image references that may not have traditional tag-based image identifiers. This is particularly important for release pipelines where images are referenced by their SHA256 digests rather than mutable tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->