### PR TITLE
allow digest-only resolution for Local reference tags

### DIFF
--- a/pkg/util/imagestream.go
+++ b/pkg/util/imagestream.go
@@ -29,6 +29,15 @@ func ParseImageStreamTagReference(s string) (api.ImageStreamTagReference, error)
 	return ret, nil
 }
 
+func isLocalReferenceTag(is *imageapi.ImageStream, tag string) bool {
+	for _, st := range is.Spec.Tags {
+		if st.Name == tag {
+			return st.Reference && st.ReferencePolicy.Type == imageapi.LocalTagReferencePolicy
+		}
+	}
+	return false
+}
+
 // ResolvePullSpec if a tag of an imagestream is resolved
 func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (string, bool, imageapi.TagEventCondition) {
 	var condition imageapi.TagEventCondition
@@ -56,6 +65,9 @@ func ResolvePullSpec(is *imageapi.ImageStream, tag string, requireExact bool) (s
 				exists = true
 				break
 			}
+		} else if requireExact && isLocalReferenceTag(is, tag) && strings.Contains(tags.Items[0].DockerImageReference, "@sha256:") {
+			pullSpec = tags.Items[0].DockerImageReference
+			exists = true
 		}
 		break
 	}


### PR DESCRIPTION
/cc @danilo-gemoli
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Image Reference Resolution

Modified the image stream pull spec resolution logic in `pkg/util/imagestream.go` to support digest-only resolution for local reference tags.

**What changed:**
- Added an internal helper function `isLocalReferenceTag()` to identify ImageStream tags that are configured as local tag references (those with `Reference=true` and `ReferencePolicy.Type=LocalTagReferencePolicy`)
- Updated `ResolvePullSpec()` to handle a new resolution path: when exact resolution is required (`requireExact=true`), the tag is a local reference tag, and the tag's `DockerImageReference` contains a digest (`@sha256:`), the function now returns that digest-based reference directly

**Practical impact for CI:**
This enables CI jobs to resolve local reference tags by their digest when an exact image reference is required, rather than falling back to generic tag-based paths. This is useful when working with local image stream tags that point to specific image digests, allowing more reliable and predictable image resolution in CI pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->