### PR TITLE
Remove obsolete cluster profiles

### DIFF
--- a/cmd/repo-init/main.go
+++ b/cmd/repo-init/main.go
@@ -100,9 +100,8 @@ var (
 	// This is supposed to be a simple, non-exhaustive list of profiles that are
 	// commonly used.  Advanced users can edit the configuration themselves.
 	clusterProfiles = map[api.ClusterProfile]string{
-		api.ClusterProfileAWS:   "ipi-aws",
-		api.ClusterProfileAzure: "ipi-azure",
-		api.ClusterProfileGCP:   "ipi-gcp",
+		api.ClusterProfileAWS: "ipi-aws",
+		api.ClusterProfileGCP: "ipi-gcp",
 	}
 	clusterProfileList = func() (ret []api.ClusterProfile) {
 		for k := range clusterProfiles {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1509,7 +1509,6 @@ const (
 	ClusterProfileOpenStackIBMOSP         ClusterProfile = "openstack-ibm-osp"
 	ClusterProfileOpenStackNFV            ClusterProfile = "openstack-nfv"
 	ClusterProfileOpenStackMechaCentral   ClusterProfile = "openstack-vh-mecha-central"
-	ClusterProfileOpenStackMechaAz0       ClusterProfile = "openstack-vh-mecha-az0"
 	ClusterProfileOpenStackOsuosl         ClusterProfile = "openstack-osuosl"
 	ClusterProfileOpenStackVexxhost       ClusterProfile = "openstack-vexxhost"
 	ClusterProfileOpenStackVexxhostRHOS   ClusterProfile = "openstack-vh-bm-rhos"
@@ -1725,7 +1724,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileOSDEphemeral,
 		ClusterProfileOpenStackHwoffload,
 		ClusterProfileOpenStackIBMOSP,
-		ClusterProfileOpenStackMechaAz0,
 		ClusterProfileOpenStackMechaCentral,
 		ClusterProfileOpenStackNFV,
 		ClusterProfileOpenStackOsuosl,
@@ -2012,8 +2010,6 @@ func (p ClusterProfile) ClusterType() string {
 		return "openstack-nfv"
 	case ClusterProfileOpenStackMechaCentral:
 		return "openstack-vh-mecha-central"
-	case ClusterProfileOpenStackMechaAz0:
-		return "openstack-vh-mecha-az0"
 	case ClusterProfileOpenStackOsuosl:
 		return "openstack-osuosl"
 	case ClusterProfileOpenStackVexxhost:
@@ -2351,8 +2347,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "openstack-nfv-quota-slice"
 	case ClusterProfileOpenStackMechaCentral:
 		return "openstack-vh-mecha-central-quota-slice"
-	case ClusterProfileOpenStackMechaAz0:
-		return "openstack-vh-mecha-az0-quota-slice"
 	case ClusterProfileOpenStackNercDev:
 		return "openstack-nerc-dev-quota-slice"
 	case ClusterProfileOpenStackRHOSO:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1426,7 +1426,6 @@ const (
 	ClusterProfileAWSTelco                ClusterProfile = "aws-telco"
 	ClusterProfileAWSOpendatahub          ClusterProfile = "aws-opendatahub"
 	ClusterProfileAWSDevfile              ClusterProfile = "aws-devfile"
-	ClusterProfileAWSSPLAT                ClusterProfile = "aws-splat"
 	ClusterProfileAWSSustAutoRel412       ClusterProfile = "aws-sustaining-autorelease-412"
 	ClusterProfileAWSKubeVirt             ClusterProfile = "aws-kubevirt"
 	ClusterProfileAWSOVNPerfScale         ClusterProfile = "aws-ovn-perfscale"
@@ -1645,7 +1644,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSTelco,
 		ClusterProfileAWSOpendatahub,
 		ClusterProfileAWSDevfile,
-		ClusterProfileAWSSPLAT,
 		ClusterProfileAWSSustAutoRel412,
 		ClusterProfileAWSKubeVirt,
 		ClusterProfileAWSOVNPerfScale,
@@ -1852,7 +1850,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSKonfluxQE,
 		ClusterProfileAWSRHTAPPerformance,
 		ClusterProfileAWSRHDHPerf,
-		ClusterProfileAWSSPLAT,
 		ClusterProfileAWSSustAutoRel412,
 		ClusterProfileAWSKubeVirt,
 		ClusterProfileAWSOVNPerfScale,
@@ -2204,8 +2201,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-opendatahub-quota-slice"
 	case ClusterProfileAWSDevfile:
 		return "aws-devfile-quota-slice"
-	case ClusterProfileAWSSPLAT:
-		return "aws-splat-quota-slice"
 	case ClusterProfileAWSKubeVirt:
 		return "aws-kubevirt-quota-slice"
 	case ClusterProfileAWSRHOAIQE:
@@ -2569,7 +2564,7 @@ func GetDefaultClusterProfileSecretName(profile ClusterProfile) string {
 func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
 	case
-		"aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub", "aws-splat",
+		"aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub",
 		"alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
 		"gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
 		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1560,7 +1560,6 @@ const (
 	ClusterProfileAWSEdgeInfra            ClusterProfile = "aws-edge-infra"
 	ClusterProfileRHOpenShiftEcosystem    ClusterProfile = "rh-openshift-ecosystem"
 	ClusterProfileODFAWS                  ClusterProfile = "odf-aws"
-	ClusterProfileKonfluxWorkspacesAWS    ClusterProfile = "konfluxworkspaces-aws"
 	ClusterProfileAWSObservabiltity       ClusterProfile = "aws-observability"
 	ClusterProfileAWSStackrox             ClusterProfile = "aws-stackrox"
 	ClusterProfileAroRH                   ClusterProfile = "aro-redhat-tenant"
@@ -1769,7 +1768,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSEdgeInfra,
 		ClusterProfileRHOpenShiftEcosystem,
 		ClusterProfileODFAWS,
-		ClusterProfileKonfluxWorkspacesAWS,
 		ClusterProfileAWSObservabiltity,
 		ClusterProfileAroRH,
 		ClusterProfileAWSRHOAIQE,
@@ -1859,7 +1857,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSEdgeInfra,
 		ClusterProfileODFAWS,
 		ClusterProfileAWSObservabiltity,
-		ClusterProfileKonfluxWorkspacesAWS,
 		ClusterProfileAWSRHOAIQE,
 		ClusterProfileAWSManagedRosaRHOAIQE,
 		ClusterProfileAWSQUAYQE,
@@ -2466,8 +2463,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "rh-openshift-ecosystem-quota-slice"
 	case ClusterProfileODFAWS:
 		return "odf-aws-quota-slice"
-	case ClusterProfileKonfluxWorkspacesAWS:
-		return "konfluxworkspaces-aws-quota-slice"
 	case ClusterProfileAWSObservabiltity:
 		return "aws-observability-quota-slice"
 	case ClusterProfileAroRH:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1499,7 +1499,6 @@ const (
 	ClusterProfileMetalPerfscaleOSP       ClusterProfile = "metal-perfscale-osp"
 	ClusterProfileMetalPerfscaleSelfSched ClusterProfile = "metal-perfscale-selfsched"
 	ClusterProfileMetalPerfscaleTelco     ClusterProfile = "metal-perfscale-telco"
-	ClusterProfileMetalTelco5GPTP         ClusterProfile = "metal-telco5g-ptp"
 	ClusterProfileNutanix                 ClusterProfile = "nutanix"
 	ClusterProfileNutanixQE               ClusterProfile = "nutanix-qe"
 	ClusterProfileNutanixQEDis            ClusterProfile = "nutanix-qe-dis"
@@ -1717,7 +1716,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileMetalPerfscaleOSP,
 		ClusterProfileMetalPerfscaleSelfSched,
 		ClusterProfileMetalPerfscaleTelco,
-		ClusterProfileMetalTelco5GPTP,
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
 		ClusterProfileNutanixQEDis,
@@ -1998,8 +1996,6 @@ func (p ClusterProfile) ClusterType() string {
 		return "metal-perfscale-selfsched"
 	case ClusterProfileMetalPerfscaleTelco:
 		return "metal-perfscale-telco"
-	case ClusterProfileMetalTelco5GPTP:
-		return "metal-telco5g-ptp"
 	case
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
@@ -2335,8 +2331,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "metal-perfscale-selfsched-quota-slice"
 	case ClusterProfileMetalPerfscaleTelco:
 		return "metal-perfscale-telco-quota-slice"
-	case ClusterProfileMetalTelco5GPTP:
-		return "metal-telco5g-ptp-quota-slice"
 	case ClusterProfileNutanix:
 		return "nutanix-quota-slice"
 	case ClusterProfileNutanixQE:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1565,7 +1565,6 @@ const (
 	ClusterProfileKonfluxWorkspacesAWS    ClusterProfile = "konfluxworkspaces-aws"
 	ClusterProfileAWSObservabiltity       ClusterProfile = "aws-observability"
 	ClusterProfileAWSStackrox             ClusterProfile = "aws-stackrox"
-	ClusterProfileAWSSDCICD               ClusterProfile = "aws-sd-cicd"
 	ClusterProfileGCPSDCICD               ClusterProfile = "gcp-sd-cicd"
 	ClusterProfileAroRH                   ClusterProfile = "aro-redhat-tenant"
 	ClusterProfileAWSRHOAIQE              ClusterProfile = "aws-rhoai-qe"
@@ -1778,7 +1777,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileODFAWS,
 		ClusterProfileKonfluxWorkspacesAWS,
 		ClusterProfileAWSObservabiltity,
-		ClusterProfileAWSSDCICD,
 		ClusterProfileGCPSDCICD,
 		ClusterProfileAroRH,
 		ClusterProfileAWSRHOAIQE,
@@ -1870,7 +1868,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAWSEdgeInfra,
 		ClusterProfileODFAWS,
 		ClusterProfileAWSObservabiltity,
-		ClusterProfileAWSSDCICD,
 		ClusterProfileKonfluxWorkspacesAWS,
 		ClusterProfileAWSRHOAIQE,
 		ClusterProfileAWSManagedRosaRHOAIQE,
@@ -2488,8 +2485,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "konfluxworkspaces-aws-quota-slice"
 	case ClusterProfileAWSObservabiltity:
 		return "aws-observability-quota-slice"
-	case ClusterProfileAWSSDCICD:
-		return "aws-sd-cicd-quota-slice"
 	case ClusterProfileGCPSDCICD:
 		return "gcp-sd-cicd-quota-slice"
 	case ClusterProfileAroRH:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1503,7 +1503,6 @@ const (
 	ClusterProfileMetalPerfscaleSelfSched ClusterProfile = "metal-perfscale-selfsched"
 	ClusterProfileMetalPerfscaleTelco     ClusterProfile = "metal-perfscale-telco"
 	ClusterProfileMetalTelco5G            ClusterProfile = "metal-telco5g"
-	ClusterProfileMetalTelcoV10N          ClusterProfile = "metal-telcov10n"
 	ClusterProfileMetalTelco5GPTP         ClusterProfile = "metal-telco5g-ptp"
 	ClusterProfileNutanix                 ClusterProfile = "nutanix"
 	ClusterProfileNutanixQE               ClusterProfile = "nutanix-qe"
@@ -1730,7 +1729,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileMetalPerfscaleSelfSched,
 		ClusterProfileMetalPerfscaleTelco,
 		ClusterProfileMetalTelco5G,
-		ClusterProfileMetalTelcoV10N,
 		ClusterProfileMetalTelco5GPTP,
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
@@ -2027,8 +2025,6 @@ func (p ClusterProfile) ClusterType() string {
 		return "metal-telco5g"
 	case ClusterProfileMetalTelco5GPTP:
 		return "metal-telco5g-ptp"
-	case ClusterProfileMetalTelcoV10N:
-		return "metal-telcov10n"
 	case
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
@@ -2372,8 +2368,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "metal-perfscale-telco-quota-slice"
 	case ClusterProfileMetalTelco5G:
 		return "metal-telco5g-quota-slice"
-	case ClusterProfileMetalTelcoV10N:
-		return "metal-telcov10n-quota-slice"
 	case ClusterProfileMetalTelco5GPTP:
 		return "metal-telco5g-ptp-quota-slice"
 	case ClusterProfileNutanix:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1435,7 +1435,6 @@ const (
 	ClusterProfileAlibabaCloudCNQE        ClusterProfile = "alibabacloud-cn-qe"
 	ClusterProfileAzure2                  ClusterProfile = "azure-2"
 	ClusterProfileAzure4                  ClusterProfile = "azure4"
-	ClusterProfileAzureArc                ClusterProfile = "azure-arc"
 	ClusterProfileAzureArm64              ClusterProfile = "azure-arm64"
 	ClusterProfileAzurePerfScale          ClusterProfile = "azure-perfscale"
 	ClusterProfileAzureStack              ClusterProfile = "azurestack"
@@ -1653,7 +1652,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAlibabaCloudCNQE,
 		ClusterProfileAzure2,
 		ClusterProfileAzure4,
-		ClusterProfileAzureArc,
 		ClusterProfileAzureArm64,
 		ClusterProfileAzureArm64QE,
 		ClusterProfileAzureMag,
@@ -1898,7 +1896,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileAzure2,
 		ClusterProfileAzure4,
 		ClusterProfileOpenshiftOrgAzure,
-		ClusterProfileAzureArc,
 		ClusterProfileAzureQE,
 		ClusterProfileAzureObservability,
 		ClusterProfileAzureHCPQE,
@@ -2219,8 +2216,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "azure4-quota-slice"
 	case ClusterProfileAzureArm64:
 		return "azure-arm64-quota-slice"
-	case ClusterProfileAzureArc:
-		return "azure-arc-quota-slice"
 	case ClusterProfileAzurePerfScale:
 		return "azure-perfscale-quota-slice"
 	case ClusterProfileAzureStack:
@@ -2565,7 +2560,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 	switch t {
 	case
 		"aws", "aws-c2s", "aws-china", "aws-usgov", "aws-sc2s", "aws-eusc", "aws-osd-msp", "aws-opendatahub",
-		"alibaba", "azure-2", "azure4", "azure-arc", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
+		"alibaba", "azure-2", "azure4", "azure-arm64", "azurestack", "azuremag", "equinix-ocp-metal",
 		"gcp", "gcp-arm64", "gcp-opendatahub", "libvirt-ppc64le", "libvirt-ppc64le-s2s", "libvirt-s390x",
 		"libvirt-s390x-1", "libvirt-s390x-2", "libvirt-s390x-amd64", "libvirt-s390x-vpn", "ibmcloud-multi-ppc64le",
 		"ibmcloud-multi-s390x", "nutanix", "nutanix-qe", "nutanix-qe-dis", "nutanix-qe-zone", "nutanix-qe-gpu",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1499,7 +1499,6 @@ const (
 	ClusterProfileMetalPerfscaleOSP       ClusterProfile = "metal-perfscale-osp"
 	ClusterProfileMetalPerfscaleSelfSched ClusterProfile = "metal-perfscale-selfsched"
 	ClusterProfileMetalPerfscaleTelco     ClusterProfile = "metal-perfscale-telco"
-	ClusterProfileMetalTelco5G            ClusterProfile = "metal-telco5g"
 	ClusterProfileMetalTelco5GPTP         ClusterProfile = "metal-telco5g-ptp"
 	ClusterProfileNutanix                 ClusterProfile = "nutanix"
 	ClusterProfileNutanixQE               ClusterProfile = "nutanix-qe"
@@ -1718,7 +1717,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileMetalPerfscaleOSP,
 		ClusterProfileMetalPerfscaleSelfSched,
 		ClusterProfileMetalPerfscaleTelco,
-		ClusterProfileMetalTelco5G,
 		ClusterProfileMetalTelco5GPTP,
 		ClusterProfileNutanix,
 		ClusterProfileNutanixQE,
@@ -2000,8 +1998,6 @@ func (p ClusterProfile) ClusterType() string {
 		return "metal-perfscale-selfsched"
 	case ClusterProfileMetalPerfscaleTelco:
 		return "metal-perfscale-telco"
-	case ClusterProfileMetalTelco5G:
-		return "metal-telco5g"
 	case ClusterProfileMetalTelco5GPTP:
 		return "metal-telco5g-ptp"
 	case
@@ -2339,8 +2335,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "metal-perfscale-selfsched-quota-slice"
 	case ClusterProfileMetalPerfscaleTelco:
 		return "metal-perfscale-telco-quota-slice"
-	case ClusterProfileMetalTelco5G:
-		return "metal-telco5g-quota-slice"
 	case ClusterProfileMetalTelco5GPTP:
 		return "metal-telco5g-ptp-quota-slice"
 	case ClusterProfileNutanix:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1397,7 +1397,6 @@ const (
 	ClusterProfileAWSChinaQE              ClusterProfile = "aws-china-qe"
 	ClusterProfileAWSGovCloudQE           ClusterProfile = "aws-usgov-qe"
 	ClusterProfileAWSSC2SQE               ClusterProfile = "aws-sc2s-qe"
-	ClusterProfileAWSSCPQE                ClusterProfile = "aws-scp-qe"
 	ClusterProfileAWS1QE                  ClusterProfile = "aws-1-qe"
 	ClusterProfileAWSAutoreleaseQE        ClusterProfile = "aws-autorelease-qe"
 	ClusterProfileAWSSdQE                 ClusterProfile = "aws-sd-qe"
@@ -1634,7 +1633,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileOEXAWSQE,
 		ClusterProfileHyperfleetE2E,
 		ClusterProfileAWSSC2SQE,
-		ClusterProfileAWSSCPQE,
 		ClusterProfileAWSOutpostQE,
 		ClusterProfileAWSINTEROPQE,
 		ClusterProfileAWSTerraformQE,
@@ -1900,8 +1898,6 @@ func (p ClusterProfile) ClusterType() string {
 		return "aws-sc2s"
 	case ClusterProfileAWSEUSC:
 		return "aws-eusc"
-	case ClusterProfileAWSSCPQE:
-		return "aws-scp"
 	case ClusterProfileAWSOSDMSP:
 		return "aws-osd-msp"
 	case
@@ -2183,8 +2179,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-usgov-qe-quota-slice"
 	case ClusterProfileAWSSC2SQE:
 		return "aws-sc2s-qe-quota-slice"
-	case ClusterProfileAWSSCPQE:
-		return "aws-scp-qe-quota-slice"
 	case ClusterProfileAWSSustAutoRel412:
 		return "aws-sustaining-autorelease-412-quota-slice"
 	case ClusterProfileAWSINTEROPQE:

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1576,7 +1576,6 @@ const (
 	ClusterProfileAWSMCOQE                ClusterProfile = "aws-mco-qe"
 	ClusterProfileAWSOADPQE               ClusterProfile = "aws-oadp-qe"
 	ClusterProfileAzureOADPQE             ClusterProfile = "azure-oadp-qe"
-	ClusterProfileGCPOADPQE               ClusterProfile = "gcp-oadp-qe"
 	ClusterProfileAWSlpChaos              ClusterProfile = "aws-lp-chaos"
 	ClusterProfileMetalRHgs               ClusterProfile = "metal-redhat-gs"
 	ClusterProfileAWSOSPQE                ClusterProfile = "aws-osp-qe"
@@ -1785,7 +1784,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileAWSMCOQE,
 		ClusterProfileAWSOADPQE,
 		ClusterProfileAzureOADPQE,
-		ClusterProfileGCPOADPQE,
 		ClusterProfileAWSlpChaos,
 		ClusterProfileMetalRHgs,
 		ClusterProfileAWSOSPQE,
@@ -2495,8 +2493,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "aws-oadp-qe-quota-slice"
 	case ClusterProfileAzureOADPQE:
 		return "azure-oadp-qe-quota-slice"
-	case ClusterProfileGCPOADPQE:
-		return "gcp-oadp-qe-quota-slice"
 	case ClusterProfileAWSlpChaos:
 		return "aws-lp-chaos-quota-slice"
 	case ClusterProfileMetalRHgs:
@@ -2570,7 +2566,7 @@ func LeaseTypeFromClusterType(t string) (string, error) {
 		"kubevirt", "aws-cpaas", "osd-ephemeral", "gcp-virtualization", "aws-virtualization",
 		"azure-virtualization", "hypershift-aws", "hypershift-aks", "hypershift-azure",
 		"hypershift-powervs", "hypershift-powervs-cb", "hypershift-gcp", "aws-mco-qe",
-		"equinix-edge-enablement", "aws-oadp-qe", "azure-oadp-qe", "gcp-oadp-qe", "aws-lp-chaos", "aws-osp-qe",
+		"equinix-edge-enablement", "aws-oadp-qe", "azure-oadp-qe", "aws-lp-chaos", "aws-osp-qe",
 		"metal-redhat-gs", "aro-hcp-int", "aro-hcp-stg", "aro-hcp-prod", "aro-hcp-dev", "rosa-regional-platform-int", "hyperfleet-e2e",
 		"aro-classic-int", "aro-classic-stg", "aro-classic-prod", "aro-classic-dev", "rosa-e2e-01", "rosa-e2e-02", "rosa-e2e-03":
 		return t + "-quota-slice", nil

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1435,7 +1435,6 @@ const (
 	ClusterProfileAlibabaCloud            ClusterProfile = "alibabacloud"
 	ClusterProfileAlibabaCloudQE          ClusterProfile = "alibabacloud-qe"
 	ClusterProfileAlibabaCloudCNQE        ClusterProfile = "alibabacloud-cn-qe"
-	ClusterProfileAzure                   ClusterProfile = "azure"
 	ClusterProfileAzure2                  ClusterProfile = "azure-2"
 	ClusterProfileAzure4                  ClusterProfile = "azure4"
 	ClusterProfileAzureArc                ClusterProfile = "azure-arc"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1563,7 +1563,6 @@ const (
 	ClusterProfileKonfluxWorkspacesAWS    ClusterProfile = "konfluxworkspaces-aws"
 	ClusterProfileAWSObservabiltity       ClusterProfile = "aws-observability"
 	ClusterProfileAWSStackrox             ClusterProfile = "aws-stackrox"
-	ClusterProfileGCPSDCICD               ClusterProfile = "gcp-sd-cicd"
 	ClusterProfileAroRH                   ClusterProfile = "aro-redhat-tenant"
 	ClusterProfileAWSRHOAIQE              ClusterProfile = "aws-rhoai-qe"
 	ClusterProfileAWSManagedRosaRHOAIQE   ClusterProfile = "aws-managed-rosa-rhoai-qe"
@@ -1772,7 +1771,6 @@ func ClusterProfiles() []ClusterProfile {
 		ClusterProfileODFAWS,
 		ClusterProfileKonfluxWorkspacesAWS,
 		ClusterProfileAWSObservabiltity,
-		ClusterProfileGCPSDCICD,
 		ClusterProfileAroRH,
 		ClusterProfileAWSRHOAIQE,
 		ClusterProfileAWSManagedRosaRHOAIQE,
@@ -1942,7 +1940,6 @@ func (p ClusterProfile) ClusterType() string {
 		ClusterProfileGCPChaos,
 		ClusterProfileGCPConfidentialQE,
 		ClusterProfileGCPPerfScaleQE,
-		ClusterProfileGCPSDCICD,
 		ClusterProfileGCPQUAYQE,
 		ClusterProfileOSLGCP,
 		ClusterProfileOpenshiftOrgGCP:
@@ -2473,8 +2470,6 @@ func (p ClusterProfile) LeaseType() string {
 		return "konfluxworkspaces-aws-quota-slice"
 	case ClusterProfileAWSObservabiltity:
 		return "aws-observability-quota-slice"
-	case ClusterProfileGCPSDCICD:
-		return "gcp-sd-cicd-quota-slice"
 	case ClusterProfileAroRH:
 		return "aro-redhat-tenant-quota-slice"
 	case ClusterProfileAWSManagedRosaRHOAIQE:


### PR DESCRIPTION
These profiles are not used in any tests or configs. Created a separate commit for each for easy revert, if we ever need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR removes a set of obsolete cluster profiles from the CI API and related CLI defaults so they can no longer be selected or resolved by ci-operator tooling or the repo-init CLI. The change is implemented as one separate commit per profile to make reversion straightforward.

What changed for CI users/operators
- The listed cluster profiles are no longer accepted in job/config definitions and will not be returned by API lookups: azure, azure-arc, aws-scp-qe, aws-sd-cicd, aws-splat, gcp-oadp-qe, gcp-sd-cicd, konfluxworkspaces-aws, metal-telcov10n, metal-telco5g, metal-telco5g-ptp, and openstack-vh-mecha-az0.
- Where code previously mapped those profiles to cluster types or quota-slice lease types, those mappings have been removed; code paths that converted ClusterProfile → ClusterType or ClusterProfile → LeaseType no longer include these profiles.
- The repo-init CLI’s selectable/default profiles no longer include Azure (the interactive/CLI init list was updated), so repo-init will not offer Azure as an option when bootstrapping repository configs.

Components affected
- Core API types (pkg/api/types.go): removed exported ClusterProfile constants, updated ClusterProfiles() registry, and removed the deleted profiles from ClusterType/LeaseType mapping logic.
- repo-init CLI (cmd/repo-init/main.go): updated clusterProfiles map used for interactive/default profile selection (Azure removed).

Practical impact
- Jobs, tests or configs referencing any of the removed profiles will fail validation or stop resolving to the previous cluster/lease semantics; operators must migrate configs to supported profiles.
- Reduction of unused API surface and lease-mapping cases reduces maintenance burden and potential confusion.
- Each profile removal is isolated in its own commit to enable easy rollback if a removal causes unexpected breakage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->