### PR TITLE
Remove cluster-init from `check-breaking-changes`

### DIFF
--- a/test/validate-generation-breaking-changes.sh
+++ b/test/validate-generation-breaking-changes.sh
@@ -65,25 +65,6 @@ for org in openshift; do
     fi
   fi
 
-  # Skip cluster-init update if kubeconfig directory is not set, as we won't have access to real clusters
-  if [[ -n "${KUBECONFIG_DIR:-}" && -d "${KUBECONFIG_DIR}" ]]; then
-    echo >&2 "$(date -u +'%Y-%m-%dT%H:%M:%S%z') Executing cluster-init update"
-    cluster-init onboard config update --release-repo="$clonedir" --kubeconfig-dir="${KUBECONFIG_DIR}" --kubeconfig-suffix="${KUBECONFIG_SUFFIX:-}"
-    out="$(git status --porcelain)"
-    if [[ -n "$out" ]]; then
-      echo "ERROR: Changes in $org/release:"
-      git diff
-      echo "ERROR: Running cluster-init in update mode in $org/release results in changes ^^^"
-      echo "ERROR: To avoid breaking $org/release for everyone you should regenerate the build clusters"
-      echo "ERROR: there and merge the changes ASAP after this change to cluster-init"
-      failure=1
-    else
-      echo "Running cluster-init in update mode in $org/release does not result in changes, no followups needed"
-    fi
-  else
-    echo "Skipping cluster-init update mode check as KUBECONFIG_DIR is not set or does not exist"
-  fi
-
   popd
 done
 


### PR DESCRIPTION
Since it is permafailing and we are struggling to keep it up to date with the changes we make in `o/release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Removed cluster-init validation from breaking changes check

This PR removes the `cluster-init onboard config update` validation step from the `test/validate-generation-breaking-changes.sh` script (19 lines removed).

The breaking changes validation script tests whether changes to ci-tools would break the openshift/release repository by running tools like `ci-operator-prowgen`, `sanitize-prow-jobs`, and `determinize-prow-config` and checking for unexpected changes. Previously, it also included a `cluster-init onboard config update` validation step.

This `cluster-init` check is being removed because it is consistently failing and difficult to keep in sync with changes made in the openshift/release repository. The rest of the validation (prowgen, sanitize-prow-jobs, and determinize-prow-config checks) remains intact and will continue to detect if changes to ci-tools break the release repo configuration.

This change improves CI reliability by removing a persistent failure point from the breaking changes validation pipeline while maintaining validation for the tools that are actively maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->