### PR TITLE
Cluster Profile Set: `tests_allowlist` supports regex patterns in test name

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -3151,7 +3151,7 @@ type ClusterProfileSetDetailsNew struct {
 	// regarding the cluster profile sets usage.
 	// This deeply nested type match the following pattern:
 	//  "org/repo": "branch": "variant": "test"
-	TestsAllowlist map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string `json:"tests_allowlist,omitempty"`
+	TestsAllowlist map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp `json:"tests_allowlist,omitempty"`
 }
 
 func (cps ClusterProfileSetDetailsNew) FindSetByProfile(profile ClusterProfile) (ClusterProfile, bool) {
@@ -3183,7 +3183,13 @@ func (cps ClusterProfileSetDetailsNew) IsTestAllowlisted(test string, metadata M
 		return false
 	}
 
-	return slices.Contains(tests, test)
+	for _, t := range tests {
+		if t.Pattern.MatchString(test) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type ClusterClaimDetails struct {

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -2276,24 +2276,24 @@ func TestValidateClusterProfiles(t *testing.T) {
 					ClusterProfileSets: map[api.ClusterProfile][]string{
 						"openshift-org-azure": {"azure-2"},
 					},
-					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string{
-						re("openshift/ci-tools"): {re("main"): {re(""): {"e2e-aws-ovn"}}},
+					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
+						re("openshift/ci-tools"): {re("main"): {re(""): {re("e2e-aws-ovn")}}},
 					},
 				},
 			},
 		},
 		{
 			name:           "Skip allowlisted test that matches a pattern",
-			metadata:       &api.Metadata{Org: "openshift-priv", Repo: "ci-tools", Branch: "main", Variant: "nightly"},
-			testName:       "e2e-aws-ovn",
+			metadata:       &api.Metadata{Org: "openshift-priv", Repo: "openshift-tests-private", Branch: "main", Variant: "nightly"},
+			testName:       "aws-ipi-public-ipv4-pool-byo-subnet-amd-f28-destructive",
 			clusterProfile: "azure-2",
 			cpsDetails: api.ClusterProfileSetDetails{
 				ClusterProfileSetDetailsNew: api.ClusterProfileSetDetailsNew{
 					ClusterProfileSets: map[api.ClusterProfile][]string{
 						"openshift-org-azure": {"azure-2"},
 					},
-					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]string{
-						re("openshift(-priv)?/ci-tools"): {re("main"): {re("daily|nightly"): {"e2e-aws-ovn"}}},
+					TestsAllowlist: map[utilregexp.Regexp]map[utilregexp.Regexp]map[utilregexp.Regexp][]utilregexp.Regexp{
+						re("openshift(-priv)?/openshift-tests-private"): {re("main"): {re("daily|nightly"): {re(".*-ipi-public-ipv4-pool-.*")}}},
 					},
 				},
 			},


### PR DESCRIPTION
Follow up of https://github.com/openshift/ci-tools/pull/5171 add regex pattern matching for test names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Cluster Profile Set test allowlist now supports regex patterns

This PR extends the Cluster Profile Set validation system to support regular expression patterns when allowlisting tests. Previously, the `tests_allowlist` required exact test name matches. Now CI configuration authors can specify regex patterns to match multiple test names with a single allowlist entry.

### Changes

**pkg/api/types.go**
- Updated the `TestsAllowlist` field in `ClusterProfileSetDetailsNew` to store regex patterns (`[]utilregexp.Regexp`) instead of literal test name strings (`[]string`)
- Modified the `IsTestAllowlisted()` function to match test names against regex patterns using `MatchString()` instead of checking for exact string membership

**pkg/validation/test_test.go**
- Updated test cases to demonstrate regex pattern usage in the allowlist, such as `re("e2e-aws-ovn")` for exact pattern matching and `re(".*-ipi-public-ipv4-pool-.*")` for wildcard matching

### Impact on CI users

The Cluster Profile Set system enforces policies about which tests can use specific cluster profiles. The allowlist mechanism exempts certain tests from these restrictions. With this change:
- Configuration authors can use regex patterns like `e2e-.*-ovn` to allowlist multiple related tests at once, rather than listing each test name individually
- This reduces configuration verbosity and makes allowlists more maintainable when dealing with similarly-named test variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->