### PR TITLE
feat: add garbage collection for finished PullRequestPayloadQualificationRuns

### DIFF
--- a/cmd/job-trigger-controller-manager/main.go
+++ b/cmd/job-trigger-controller-manager/main.go
@@ -35,6 +35,7 @@ type options struct {
 	defaultMultiRefJobTimeoutInHour   int64
 	dispatcherAddress                 string
 	dryRun                            bool
+	maxPRPQRAge                       time.Duration
 }
 
 func gatherOptions() (*options, error) {
@@ -48,6 +49,7 @@ func gatherOptions() (*options, error) {
 	fs.Int64Var(&o.defaultAggregatorJobTimeoutInHour, "aggregator-job-timeout", 6, "Amount of hours to wait for job to timeout in order to update status")
 	fs.Int64Var(&o.defaultMultiRefJobTimeoutInHour, "multi-ref-job-timeout", 6, "Amount of hours to wait for job to timeout in order to update status")
 	fs.StringVar(&o.dispatcherAddress, "dispatcher-address", "http://prowjob-dispatcher.ci.svc.cluster.local:8080", "Address of prowjob-dispatcher server.")
+	fs.DurationVar(&o.maxPRPQRAge, "max-prpqr-age", 7*24*time.Hour, "Maximum age of finished PullRequestPayloadQualificationRuns before garbage collection. Set to 0 to disable.")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		return o, fmt.Errorf("failed to parse flags: %w", err)
@@ -104,7 +106,7 @@ func main() {
 	duration := time.Duration(o.jobTriggerWaitInSeconds) * time.Second
 	defaultAggregatorJobTimeout := time.Duration(o.defaultAggregatorJobTimeoutInHour) * time.Hour
 	defaultMultiRefJobTimeout := time.Duration(o.defaultMultiRefJobTimeoutInHour) * time.Hour
-	if err := prpqr_reconciler.AddToManager(mgr, o.namespace, server.NewResolverClient(configResolverAddress), agent, o.dispatcherAddress, duration, defaultAggregatorJobTimeout, defaultMultiRefJobTimeout); err != nil {
+	if err := prpqr_reconciler.AddToManager(mgr, o.namespace, server.NewResolverClient(configResolverAddress), agent, o.dispatcherAddress, duration, defaultAggregatorJobTimeout, defaultMultiRefJobTimeout, o.maxPRPQRAge); err != nil {
 		logrus.WithError(err).Fatal("Failed to add prpqr_reconciler to manager")
 	}
 

--- a/pkg/controller/prpqr_reconciler/gc.go
+++ b/pkg/controller/prpqr_reconciler/gc.go
@@ -1,0 +1,125 @@
+package prpqr_reconciler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+)
+
+const (
+	conditionAllJobsFinished = "AllJobsFinished"
+	gcInterval               = 30 * time.Minute
+)
+
+// prpqrGarbageCollector periodically deletes finished PRPQRs older than maxAge.
+type prpqrGarbageCollector struct {
+	logger    *logrus.Entry
+	client    ctrlruntimeclient.Client
+	namespace string
+	maxAge    time.Duration
+	now       func() time.Time
+}
+
+func (gc *prpqrGarbageCollector) Start(ctx context.Context) error {
+	gc.logger.WithField("max_age", gc.maxAge).WithField("interval", gcInterval).Info("Starting PRPQR garbage collector")
+	ticker := time.NewTicker(gcInterval)
+	defer ticker.Stop()
+
+	// Run immediately on startup, then on interval
+	gc.collect(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			gc.logger.Info("PRPQR garbage collector stopped")
+			return nil
+		case <-ticker.C:
+			gc.collect(ctx)
+		}
+	}
+}
+
+func (gc *prpqrGarbageCollector) collect(ctx context.Context) {
+	logger := gc.logger.WithField("action", "gc-cycle")
+	logger.Info("Starting PRPQR garbage collection cycle")
+
+	prpqrs := &v1.PullRequestPayloadQualificationRunList{}
+	if err := gc.client.List(ctx, prpqrs, ctrlruntimeclient.InNamespace(gc.namespace)); err != nil {
+		logger.WithError(err).Error("Failed to list PRPQRs for garbage collection")
+		return
+	}
+
+	cutoff := gc.now().Add(-gc.maxAge)
+	var deleted, skipped int
+	for i := range prpqrs.Items {
+		prpqr := &prpqrs.Items[i]
+
+		if prpqr.CreationTimestamp.Time.After(cutoff) {
+			continue
+		}
+
+		if !isFinished(prpqr) {
+			skipped++
+			continue
+		}
+
+		if err := gc.client.Delete(ctx, prpqr); err != nil {
+			logger.WithError(err).WithField("prpqr", prpqr.Name).Error("Failed to delete PRPQR")
+			continue
+		}
+		deleted++
+	}
+
+	logger.WithFields(logrus.Fields{
+		"total":   len(prpqrs.Items),
+		"deleted": deleted,
+		"skipped": skipped,
+		"cutoff":  cutoff.Format(time.RFC3339),
+	}).Info("PRPQR garbage collection cycle complete")
+}
+
+func isFinished(prpqr *v1.PullRequestPayloadQualificationRun) bool {
+	for _, c := range prpqr.Status.Conditions {
+		if c.Type == conditionAllJobsFinished && c.Status == metav1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable to ensure
+// only one replica runs GC at a time.
+func (gc *prpqrGarbageCollector) NeedLeaderElection() bool {
+	return true
+}
+
+func newGarbageCollector(client ctrlruntimeclient.Client, namespace string, maxAge time.Duration) *prpqrGarbageCollector {
+	return &prpqrGarbageCollector{
+		logger:    logrus.WithField("component", "prpqr-gc"),
+		client:    client,
+		namespace: namespace,
+		maxAge:    maxAge,
+		now:       time.Now,
+	}
+}
+
+// startGarbageCollector registers the GC runnable with the controller manager.
+// maxAge of 0 disables garbage collection.
+func startGarbageCollector(mgr manager.Manager, namespace string, maxAge time.Duration) error {
+	if maxAge <= 0 {
+		logrus.Info("PRPQR garbage collection disabled (max-prpqr-age <= 0)")
+		return nil
+	}
+	gc := newGarbageCollector(mgr.GetClient(), namespace, maxAge)
+	if err := mgr.Add(gc); err != nil {
+		return fmt.Errorf("failed to add PRPQR garbage collector to manager: %w", err)
+	}
+	return nil
+}

--- a/pkg/controller/prpqr_reconciler/gc_test.go
+++ b/pkg/controller/prpqr_reconciler/gc_test.go
@@ -1,0 +1,244 @@
+package prpqr_reconciler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1 "github.com/openshift/ci-tools/pkg/api/pullrequestpayloadqualification/v1"
+)
+
+func TestCollect(t *testing.T) {
+	now := time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC)
+	twoDaysAgo := metav1.NewTime(now.Add(-48 * time.Hour))
+	tenDaysAgo := metav1.NewTime(now.Add(-240 * time.Hour))
+	oneHourAgo := metav1.NewTime(now.Add(-1 * time.Hour))
+
+	finishedCondition := metav1.Condition{
+		Type:               conditionAllJobsFinished,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: twoDaysAgo,
+		Reason:             conditionAllJobsFinished,
+		Message:            "All jobs have finished.",
+	}
+	runningCondition := metav1.Condition{
+		Type:               conditionAllJobsFinished,
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: twoDaysAgo,
+		Reason:             conditionAllJobsFinished,
+		Message:            "jobs [some-job] still running",
+	}
+
+	tests := []struct {
+		name        string
+		maxAge      time.Duration
+		prpqrs      []ctrlruntimeclient.Object
+		wantDeleted []string
+		wantKept    []string
+	}{
+		{
+			name:   "deletes old finished PRPQRs",
+			maxAge: 24 * time.Hour,
+			prpqrs: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-finished",
+						Namespace:         "ci",
+						CreationTimestamp: tenDaysAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{finishedCondition},
+					},
+				},
+			},
+			wantDeleted: []string{"old-finished"},
+		},
+		{
+			name:   "keeps young finished PRPQRs",
+			maxAge: 24 * time.Hour,
+			prpqrs: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "young-finished",
+						Namespace:         "ci",
+						CreationTimestamp: oneHourAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{finishedCondition},
+					},
+				},
+			},
+			wantKept: []string{"young-finished"},
+		},
+		{
+			name:   "keeps old still-running PRPQRs",
+			maxAge: 24 * time.Hour,
+			prpqrs: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-running",
+						Namespace:         "ci",
+						CreationTimestamp: tenDaysAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{runningCondition},
+					},
+				},
+			},
+			wantKept: []string{"old-running"},
+		},
+		{
+			name:   "keeps old PRPQRs with no conditions",
+			maxAge: 24 * time.Hour,
+			prpqrs: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-no-conditions",
+						Namespace:         "ci",
+						CreationTimestamp: tenDaysAgo,
+					},
+				},
+			},
+			wantKept: []string{"old-no-conditions"},
+		},
+		{
+			name:   "mixed scenario",
+			maxAge: 24 * time.Hour,
+			prpqrs: []ctrlruntimeclient.Object{
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-finished-1",
+						Namespace:         "ci",
+						CreationTimestamp: tenDaysAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{finishedCondition},
+					},
+				},
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-finished-2",
+						Namespace:         "ci",
+						CreationTimestamp: twoDaysAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{finishedCondition},
+					},
+				},
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "young-finished",
+						Namespace:         "ci",
+						CreationTimestamp: oneHourAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{finishedCondition},
+					},
+				},
+				&v1.PullRequestPayloadQualificationRun{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "old-running",
+						Namespace:         "ci",
+						CreationTimestamp: tenDaysAgo,
+					},
+					Status: v1.PullRequestPayloadTestStatus{
+						Conditions: []metav1.Condition{runningCondition},
+					},
+				},
+			},
+			wantDeleted: []string{"old-finished-1", "old-finished-2"},
+			wantKept:    []string{"young-finished", "old-running"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fakectrlruntimeclient.NewClientBuilder().
+				WithObjects(tt.prpqrs...).
+				Build()
+
+			gc := &prpqrGarbageCollector{
+				logger:    logrus.WithField("test", tt.name),
+				client:    client,
+				namespace: "ci",
+				maxAge:    tt.maxAge,
+				now:       func() time.Time { return now },
+			}
+
+			gc.collect(context.Background())
+
+			for _, name := range tt.wantDeleted {
+				prpqr := &v1.PullRequestPayloadQualificationRun{}
+				err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: name}, prpqr)
+				if err == nil {
+					t.Errorf("expected PRPQR %s to be deleted, but it still exists", name)
+				}
+			}
+
+			for _, name := range tt.wantKept {
+				prpqr := &v1.PullRequestPayloadQualificationRun{}
+				err := client.Get(context.Background(), ctrlruntimeclient.ObjectKey{Namespace: "ci", Name: name}, prpqr)
+				if err != nil {
+					t.Errorf("expected PRPQR %s to be kept, but got error: %v", name, err)
+				}
+			}
+		})
+	}
+}
+
+func TestIsFinished(t *testing.T) {
+	tests := []struct {
+		name     string
+		prpqr    *v1.PullRequestPayloadQualificationRun
+		expected bool
+	}{
+		{
+			name: "finished",
+			prpqr: &v1.PullRequestPayloadQualificationRun{
+				Status: v1.PullRequestPayloadTestStatus{
+					Conditions: []metav1.Condition{
+						{Type: "AllJobsTriggered", Status: metav1.ConditionTrue},
+						{Type: conditionAllJobsFinished, Status: metav1.ConditionTrue},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "not finished - still running",
+			prpqr: &v1.PullRequestPayloadQualificationRun{
+				Status: v1.PullRequestPayloadTestStatus{
+					Conditions: []metav1.Condition{
+						{Type: conditionAllJobsFinished, Status: metav1.ConditionFalse},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "not finished - no conditions",
+			prpqr: &v1.PullRequestPayloadQualificationRun{
+				Status: v1.PullRequestPayloadTestStatus{},
+			},
+			expected: false,
+		},
+		{
+			name:     "not finished - empty status",
+			prpqr:    &v1.PullRequestPayloadQualificationRun{},
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFinished(tt.prpqr); got != tt.expected {
+				t.Errorf("isFinished() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
+++ b/pkg/controller/prpqr_reconciler/prpqr_reconciler.go
@@ -83,9 +83,13 @@ type jobClusterCache struct {
 	lastCleared   time.Time
 }
 
-func AddToManager(mgr manager.Manager, ns string, rc injectingResolverClient, prowConfigAgent *prowconfig.Agent, dispatcherAddress string, jobTriggerWaitDuration time.Duration, defaultAggregatorJobTimeout time.Duration, defaultMultiRefJobTimeout time.Duration) error {
+func AddToManager(mgr manager.Manager, ns string, rc injectingResolverClient, prowConfigAgent *prowconfig.Agent, dispatcherAddress string, jobTriggerWaitDuration time.Duration, defaultAggregatorJobTimeout time.Duration, defaultMultiRefJobTimeout time.Duration, maxPRPQRAge time.Duration) error {
 	if err := pjstatussyncer.AddToManager(mgr, ns); err != nil {
 		return fmt.Errorf("failed to construct pjstatussyncer: %w", err)
+	}
+
+	if err := startGarbageCollector(mgr, ns, maxPRPQRAge); err != nil {
+		return fmt.Errorf("failed to start PRPQR garbage collector: %w", err)
 	}
 
 	c, err := controller.New(controllerName, mgr, controller.Options{


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Garbage Collection for Finished PullRequestPayloadQualificationRuns

This PR adds automatic cleanup of finished PullRequestPayloadQualificationRun (PRPQR) objects to the job-trigger-controller-manager, reducing storage consumption and improving cluster health.

### What Changed

**job-trigger-controller-manager** now exposes a new CLI flag `--max-prpqr-age` (default: 7 days) that controls how long finished PRPQR objects are retained. The flag is passed to the PRPQR reconciler during initialization.

**PRPQR Reconciler** now launches a garbage collector when configured. The collector runs every 30 minutes and:
- Lists all PRPQR objects in the configured namespace
- Deletes PRPQRs that are older than the configured age AND have completed all their jobs (indicated by the `AllJobsFinished` condition being `True`)
- Uses Kubernetes leader election to ensure only one controller replica performs GC
- Logs deletion counts and skipped items for troubleshooting

Garbage collection can be disabled by setting `--max-prpqr-age=0`.

### For CI Operators

This feature automatically cleans up old PRPQR objects that have finished testing, preventing unbounded growth of these resources in the cluster. The 7-day default strikes a balance between retention for audit/debugging and resource efficiency. Operators can adjust this value or disable it entirely via the controller manager flags.

### Testing

Comprehensive unit tests verify that:
- PRPQRs are correctly identified as finished based on their status conditions
- Only PRPQRs older than the configured age are deleted
- Running PRPQRs are never deleted
- Deletion failures in one run don't prevent subsequent runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->