### PR TITLE
sparse checkout: fix test pods and periodic rehearsals

### DIFF
--- a/pkg/rehearse/jobs.go
+++ b/pkg/rehearse/jobs.go
@@ -577,6 +577,10 @@ func (jc *JobConfigurer) ConvertPeriodicsToPresubmits(periodics []prowconfig.Per
 			return nil, fmt.Errorf("makeRehearsalPresubmit failed: %w", err)
 		}
 
+		if p.DecorationConfig != nil {
+			p.DecorationConfig.SparseCheckoutFiles = nil
+		}
+
 		if len(p.ExtraRefs) > 0 {
 			// we aren't injecting this as we do for presubmits, but we need it to be set
 			p.ExtraRefs[0].WorkDir = true

--- a/pkg/steps/artifacts.go
+++ b/pkg/steps/artifacts.go
@@ -305,9 +305,22 @@ func addPodUtils(
 		// disabled.
 		decorationConfig := *decorationConfig
 		decorationConfig.SkipCloning = nil
+		decorationConfig.SparseCheckoutFiles = nil
+
+		var cloneRefs *prowv1.Refs
+		if jobSpec.Refs != nil {
+			r := *jobSpec.Refs
+			r.SparseCheckoutFiles = nil
+			cloneRefs = &r
+		}
+		var cloneExtraRefs []prowv1.Refs
+		for _, r := range jobSpec.ExtraRefs {
+			r.SparseCheckoutFiles = nil
+			cloneExtraRefs = append(cloneExtraRefs, r)
+		}
 
 		codeMount, codeVolume := decorate.CodeMountAndVolume()
-		cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Refs: jobSpec.Refs, ExtraRefs: jobSpec.ExtraRefs, DecorationConfig: &decorationConfig}}, codeMount, logMount)
+		cloneRefsContainer, refs, cloneRefsVolumes, err := decorate.CloneRefs(prowv1.ProwJob{Spec: prowv1.ProwJobSpec{Refs: cloneRefs, ExtraRefs: cloneExtraRefs, DecorationConfig: &decorationConfig}}, codeMount, logMount)
 		if err != nil {
 			return fmt.Errorf("failed to construct clonerefs: %w", err)
 		}

--- a/test/integration/pj-rehearse/expected.yaml
+++ b/test/integration/pj-rehearse/expected.yaml
@@ -483,8 +483,6 @@
         path_strategy: single
       gcs_credentials_secret: gce-sa-credentials-gcs-publisher
       grace_period: 15s
-      sparse_checkout_files:
-      - Dockerfile
       timeout: 4h0m0s
       utility_images:
         clonerefs: gcr.io/k8s-prow/clonerefs:v20190129-0a3c54c
@@ -570,8 +568,6 @@
         number: 1234
         sha: test_sha
       repo: release
-      sparse_checkout_files:
-      - Dockerfile
     report: true
     rerun_command: /pj-rehearse periodic-ci-super-trooper-master-changed-periodic
     type: presubmit


### PR DESCRIPTION
## Summary
- **Test pods get full clone**: ci-operator's `addPodUtils` clears `SparseCheckoutFiles` from the decoration config when setting up test pod clonerefs, so tests always get a full repo clone (e.g., `hack/lint.sh` is available). The outer prow clonerefs still uses sparse checkout for ci-operator itself.
- **Periodic rehearsals don't leak sparse checkout**: `ConvertPeriodicsToPresubmits` clears `DecorationConfig.SparseCheckoutFiles` after conversion, preventing sparse checkout files from leaking to the `openshift/release` primary ref via `pjutil.CompletePrimaryRefs`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes two sparse-checkout leaks that caused rehearsal jobs and test pods to receive incorrect repository clones.

### Components affected
- pj-rehearse (rehearsal conversion and presubmit generation)
- ci-operator pod setup (pod utility that prepares clonerefs/clone container)

### Practical change / behavior
- ConvertPeriodicsToPresubmits (pj-rehearse): when converting periodic jobs into rehearsal presubmits, the rehearsal presubmit's primary DecorationConfig.SparseCheckoutFiles is explicitly cleared (if DecorationConfig is set). This prevents sparse-checkout entries from being carried onto the primary openshift/release ref via pjutil.CompletePrimaryRefs during rehearsals.
- addPodUtils (ci-operator pod setup): when generatePodOptions.Clone is enabled, the decoration config and all Refs/ExtraRefs passed into the clone-refs container have SparseCheckoutFiles cleared. This ensures test pods receive a full repository clone (so files like hack/lint.sh are available during tests), while the outer prow clonerefs used for ci-operator itself can continue to use sparse checkout.

### Impact for CI users/operators
- Rehearsal ProwJobs will no longer accidentally filter the primary openshift/release ref via sparse-checkout settings. Rehearsals will reflect actual execution semantics.
- Test pods spawned for CI jobs will get a full clone of repositories when cloning is requested, avoiding missing files during test execution.
- Sparse-checkout entries remain available on ExtraRefs where intended (target repositories).

### Tests
- Added unit test TestConvertPeriodicsToPresubmitsClearsSparseCheckout to verify the primary ref’s SparseCheckoutFiles is cleared while preserving ExtraRefs’ sparse checkout entries.
- Updated integration test expectation YAML for pj-rehearse to remove extra_refs.sparse_checkout_files from affected job specs.
- Existing rehearse tests pass per the PR description.

### Public API
- No changes to exported/public function or type signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->