### PR TITLE
Update naming rules

### DIFF
--- a/pkg/gsm-validation/gsm.go
+++ b/pkg/gsm-validation/gsm.go
@@ -17,7 +17,7 @@ const (
 	UnderscoreSuffix = "--"
 
 	CollectionRegex = "^([a-z0-9_-]*[a-z0-9])?$"
-	GroupRegex      = `^[a-z0-9]+([a-z0-9_-]*[a-z0-9]+)?(/[a-z0-9]+([a-z0-9_-]*[a-z0-9]+)?)*$`
+	GroupRegex      = `^(--dot--)?[a-zA-Z0-9]+([a-zA-Z0-9_-]*[a-zA-Z0-9]+)?(/[a-zA-Z0-9]+([a-zA-Z0-9_-]*[a-zA-Z0-9]+)?)*$`
 	SecretNameRegex = "^[A-Za-z0-9_-]+$"
 
 	// MaxCollectionLength is the maximum length of a collection name
@@ -46,7 +46,10 @@ func ValidateCollectionName(collection string) bool {
 		return false
 	}
 
-	// Cannot end with underscore (would create collection___secret)
+	// Cannot start or end with underscore
+	if strings.HasPrefix(collection, "_") {
+		return false
+	}
 	if strings.HasSuffix(collection, "_") {
 		return false
 	}
@@ -85,8 +88,11 @@ func ValidateSecretName(secretName string) bool {
 		return false
 	}
 
-	// Cannot start with underscore (would create collection___secret)
+	// Cannot start or end with underscore
 	if strings.HasPrefix(secretName, "_") {
+		return false
+	}
+	if strings.HasSuffix(secretName, "_") {
 		return false
 	}
 

--- a/pkg/gsm-validation/gsm_test.go
+++ b/pkg/gsm-validation/gsm_test.go
@@ -43,9 +43,9 @@ func TestValidateCollectionName(t *testing.T) {
 			expectedValid: true,
 		},
 		{
-			name:          "valid collection name: underscore at the beginning",
+			name:          "invalid collection name: underscore at the beginning",
 			collection:    "_name",
-			expectedValid: true,
+			expectedValid: false,
 		},
 		{
 			name:          "valid collection name: multiple underscores",
@@ -588,6 +588,31 @@ func TestValidateGroupName(t *testing.T) {
 		{
 			name:          "invalid group: ends with underscore",
 			group:         "group_",
+			expectedValid: false,
+		},
+		{
+			name:          "valid group: uppercase letters",
+			group:         "MY_UPPERCASE_GROUP",
+			expectedValid: true,
+		},
+		{
+			name:          "valid group: mixed case",
+			group:         "scalingPipelines",
+			expectedValid: true,
+		},
+		{
+			name:          "valid group: --dot-- prefix", // sadly we have to have this, because of backwards compatibility
+			group:         "--dot--awscred",
+			expectedValid: true,
+		},
+		{
+			name:          "valid group: uppercase in nested path",
+			group:         "teams/slcm/BOS2-Nokia-bastion",
+			expectedValid: true,
+		},
+		{
+			name:          "invalid group: arbitrary leading hyphen",
+			group:         "--awscred",
 			expectedValid: false,
 		},
 	}


### PR DESCRIPTION
- Relax group name validation to allow uppercase letters and `--dot--` prefix for backwards compatibility with Vault secrets containing uppercase names or leading dots. 
- Add leading underscore check to collection and trailing underscore check to secret name validation for consistency with the CLI. 
- Making these rules compatible with the secret manager CLI https://github.com/openshift/ci-tools-standalone/pull/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## GSM Validation Rules Update for Secret Manager CLI Compatibility

This PR updates the Google Secret Manager (GSM) validation rules in the CI tooling's secrets handling component to align with the secret manager CLI and ensure backward compatibility with existing Vault secrets.

### Key Changes

**Group Name Validation** (`GroupRegex`):
- Now accepts uppercase letters and mixed case in group names (previously lowercase-only)
- Supports optional `--dot--` prefix for backward compatibility with existing Vault secrets that may have been migrated with dots in their names converted to this prefix
- Allows uppercase letters in nested path segments (e.g., `teams/slcm/BOS2-Nokia-bastion`)

**Collection Name Validation**:
- Added validation to reject collection names starting with underscore (in addition to existing trailing underscore check)
- This prevents invalid names like `_name` from being accepted

**Secret Name Validation**:
- Added validation to reject secret names ending with underscore (in addition to existing leading underscore check)
- Now enforces symmetric rules: cannot start OR end with underscore

### Impact

These changes ensure that:
1. Existing Vault secrets with uppercase characters or special prefixes can be properly validated when migrating to GSM
2. Validation behavior is consistent with the secret manager CLI, preventing compatibility issues
3. The naming rules better prevent accidental creation of invalid secret identifiers that could conflict with the collection/secret delimiter (`__`)

The changes maintain all existing public function signatures and don't affect the name normalization/denormalization logic used for character encoding in secret fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->