### PR TITLE
blocking-issue-creator: support GitHub App authentication

### DIFF
--- a/cmd/auto-config-brancher/main.go
+++ b/cmd/auto-config-brancher/main.go
@@ -18,7 +18,7 @@ import (
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
 
-	"github.com/openshift/ci-tools/pkg/github/prcreation"
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 	"github.com/openshift/ci-tools/pkg/promotion"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 )
@@ -271,7 +271,7 @@ func main() {
 		logrus.WithError(err).Fatalf("Error retrieving repository data: %v", err)
 	}
 	isAppAuth := o.GitHubOptions.TokenPath == ""
-	prClient := github.Client(&prcreation.OrgAwareClient{Client: gc, Org: githubOrg, IsAppAuth: isAppAuth})
+	prClient := github.Client(&orgclient.OrgAwareClient{Client: gc, Org: githubOrg, IsAppAuth: isAppAuth})
 	if err := bumper.UpdatePullRequestWithLabels(prClient, githubOrg, githubRepo, title, fmt.Sprintf("/cc @%s", o.assign), prHead, repo.DefaultBranch, remoteBranch, true, labelsToAdd, false); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}

--- a/cmd/blocking-issue-creator/main.go
+++ b/cmd/blocking-issue-creator/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 	"github.com/openshift/ci-tools/pkg/promotion"
 )
 
@@ -64,13 +65,21 @@ func main() {
 		logrus.Fatalf("Invalid options: %v", err)
 	}
 
-	if err := secret.Add(o.github.TokenPath); err != nil {
-		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	if o.github.TokenPath != "" {
+		if err := secret.Add(o.github.TokenPath); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
 	}
 
-	client, err := o.github.GitHubClient(o.dryRun)
+	ghClient, err := o.github.GitHubClient(o.dryRun)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating github client.")
+	}
+
+	client := &orgclient.OrgAwareClient{
+		Client:    ghClient,
+		Org:       "openshift",
+		IsAppAuth: o.github.AppID != "",
 	}
 
 	botUser, err := client.BotUser()
@@ -79,7 +88,7 @@ func main() {
 	}
 
 	failed := false
-	if err := client.Throttle(300, 300); err != nil {
+	if err := ghClient.Throttle(300, 300); err != nil {
 		logrus.WithError(err).Fatal("failed to throttle")
 	}
 

--- a/pkg/github/orgclient/orgclient.go
+++ b/pkg/github/orgclient/orgclient.go
@@ -1,4 +1,4 @@
-package prcreation
+package orgclient
 
 import (
 	"strings"
@@ -8,8 +8,8 @@ import (
 
 // OrgAwareClient wraps a github.Client so that FindIssues routes through
 // FindIssuesWithOrg. Prow's App auth round-tripper requires the org in
-// the request context to resolve the installation token, but
-// bumper.UpdatePullRequestWithLabels internally calls FindIssues which
+// the request context to resolve the installation token, but callers like
+// bumper.UpdatePullRequestWithLabels internally call FindIssues which
 // passes an empty org.
 //
 // When IsAppAuth is true, BotUser() appends "[bot]" to the login so that
@@ -27,9 +27,8 @@ func (c *OrgAwareClient) FindIssues(query, sort string, asc bool) ([]github.Issu
 // BotUser returns the bot user data. When the client is using GitHub App auth,
 // it appends the "[bot]" suffix to the login. GitHub Apps act as "slug[bot]"
 // users, but prow's getUserData only stores the bare slug. The search API's
-// author: qualifier requires the full "slug[bot]" form to match PRs created
-// by the App; using the bare slug results in a 422 because that user does not
-// exist on GitHub.
+// author: qualifier requires the full "slug[bot]" form to match issues created
+// by the App.
 func (c *OrgAwareClient) BotUser() (*github.UserData, error) {
 	user, err := c.Client.BotUser()
 	if err != nil {

--- a/pkg/github/prcreation/prcreation.go
+++ b/pkg/github/prcreation/prcreation.go
@@ -15,6 +15,8 @@ import (
 	"sigs.k8s.io/prow/pkg/flagutil"
 	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
+
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 )
 
 type PRCreationOptions struct {
@@ -340,7 +342,7 @@ func (o *PRCreationOptions) ensurePR(org, repo, branch, prTitle, head, headBranc
 
 	// Wrap the client so FindIssues routes through FindIssuesWithOrg,
 	// which is required for GitHub App auth.
-	prClient := github.Client(&OrgAwareClient{Client: o.GithubClient, Org: org, IsAppAuth: isAppAuth})
+	prClient := github.Client(&orgclient.OrgAwareClient{Client: o.GithubClient, Org: org, IsAppAuth: isAppAuth})
 
 	return bumper.UpdatePullRequestWithLabels(
 		prClient, org, repo, prTitle, prBody,


### PR DESCRIPTION
Extract OrgAwareClient from pkg/github/prcreation into a shared pkg/github/orgclient package so it can be reused by other binaries. The prcreation package keeps a type alias for backward compatibility.

Adapt blocking-issue-creator to use the OrgAwareClient wrapper, which routes FindIssues through FindIssuesWithOrg (required for App auth installation token resolution) and appends [bot] to the author login for search queries. Guard secret.Add for empty TokenPath when using App credentials instead of a PAT.

Co-authored-by Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds GitHub App authentication support for blocking-issue-creator and centralizes an org-aware GitHub client wrapper so multiple CI tools can resolve App installation tokens correctly.

### Key changes and practical effects

- Shared org-aware client
  - Extracts OrgAwareClient into pkg/github/orgclient and updates callers to use it.
  - OrgAwareClient routes FindIssues through FindIssuesWithOrg so Prow’s App auth can resolve installation tokens when searches require an org in context.
  - When using App auth, BotUser() returns the bot login with a trailing "[bot]" (if not already present) so author: search qualifiers match issues created by the GitHub App.

- blocking-issue-creator
  - Now supports GitHub App credentials as an alternative to a PAT.
  - The secrets agent is started only when github.TokenPath is provided, allowing runs that rely solely on App credentials (TokenPath empty) without adding a PAT.
  - Uses orgclient.OrgAwareClient to perform org-aware issue searches and to obtain the bot identity (including the "[bot]" suffix for App auth).
  - Keeps API rate-throttling on the underlying GitHub client.

- auto-config-brancher and prcreation usage
  - Updated to construct and use the new orgclient.OrgAwareClient wrapper so their internal FindIssues calls are org-aware and compatible with App auth.
  - prcreation retains compatibility through the move; exported method signatures are unchanged.

### Impact for CI operators
- Tools such as blocking-issue-creator and auto-config-brancher can now run using GitHub App credentials (improving credential management and security) without requiring a personal access token, and issue searches created/queried by the App will correctly match by author.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->