### PR TITLE
DPTP-2938: pod-scaler add --max-data-age flag to cap cache retention and query range

### DIFF
--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -56,6 +56,7 @@ type producerOptions struct {
 	kubernetesOptions prowflagutil.KubernetesOptions
 	once              bool
 	ignoreLatest      time.Duration
+	maxDataAge        time.Duration
 }
 
 type consumerOptions struct {
@@ -78,6 +79,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.StringVar(&o.mode, "mode", "", "Which mode to run in.")
 	o.producerOptions.kubernetesOptions.AddFlags(fs)
 	fs.DurationVar(&o.ignoreLatest, "ignore-latest", 0, "Duration of latest time series to ignore when querying Prometheus. For instance, 1h will ignore the latest hour of data.")
+	fs.DurationVar(&o.maxDataAge, "max-data-age", 90*24*time.Hour, "Maximum age of data to retain and query. Caps the Prometheus query range and prunes older cached data.")
 	fs.BoolVar(&o.once, "produce-once", false, "Query Prometheus and refresh cached data only once before exiting.")
 	fs.IntVar(&o.port, "port", 0, "Port to serve admission webhooks on.")
 	fs.IntVar(&o.uiPort, "ui-port", 0, "Port to serve frontend on.")
@@ -255,7 +257,7 @@ func mainProduce(opts *options, cache Cache) {
 		logger.Debugf("Loaded Prometheus client.")
 	}
 
-	produce(clients, cache, opts.ignoreLatest, opts.once)
+	produce(clients, cache, opts.ignoreLatest, opts.maxDataAge, opts.once)
 
 }
 

--- a/cmd/pod-scaler/producer.go
+++ b/cmd/pod-scaler/producer.go
@@ -70,7 +70,7 @@ func queriesByMetric() map[string]string {
 	return queries
 }
 
-func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest time.Duration, once bool) {
+func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest, maxDataAge time.Duration, once bool) {
 	var execute func(func())
 	if once {
 		execute = func(f func()) {
@@ -121,8 +121,9 @@ func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest
 			}
 			until := time.Now().Add(-ignoreLatest)
 			q := querier{
-				lock: &sync.RWMutex{},
-				data: cache,
+				lock:       &sync.RWMutex{},
+				data:       cache,
+				maxDataAge: maxDataAge,
 			}
 			wg := &sync.WaitGroup{}
 			for clusterName, client := range clients {
@@ -152,7 +153,7 @@ func produce(clients map[string]prometheusapi.API, dataCache Cache, ignoreLatest
 				}()
 			}
 			wg.Wait()
-			if err := storeCache(dataCache, name, cache, logger); err != nil {
+			if err := storeCache(dataCache, name, cache, maxDataAge, logger); err != nil {
 				logger.WithError(err).Error("Failed to write cached data.")
 			}
 		}
@@ -184,8 +185,9 @@ func rangeFrom(r prometheusapi.Range) podscaler.TimeRange {
 }
 
 type querier struct {
-	lock *sync.RWMutex
-	data *podscaler.CachedQuery
+	lock       *sync.RWMutex
+	data       *podscaler.CachedQuery
+	maxDataAge time.Duration
 }
 
 type clusterMetadata struct {
@@ -214,8 +216,15 @@ func (q *querier) execute(ctx context.Context, c *clusterMetadata, until time.Ti
 	if err != nil {
 		return fmt.Errorf("could not determine Prometheus retention duration: %w", err)
 	}
+	start := time.Now().Add(-time.Duration(retention))
+	if q.maxDataAge > 0 {
+		maxStart := time.Now().Add(-q.maxDataAge)
+		if maxStart.After(start) {
+			start = maxStart
+		}
+	}
 	r := prometheusapi.Range{
-		Start: time.Now().Add(-time.Duration(retention)),
+		Start: start,
 		End:   until,
 		Step:  1 * time.Minute,
 	}

--- a/cmd/pod-scaler/storage.go
+++ b/cmd/pod-scaler/storage.go
@@ -161,10 +161,10 @@ func loadFrom(loader loader, metricName string) ([]byte, error) {
 }
 
 // storeCache prunes and stores cached query data to the given storage storer.
-func storeCache(storer storer, metricName string, data *podscaler.CachedQuery, logger *logrus.Entry) error {
+func storeCache(storer storer, metricName string, data *podscaler.CachedQuery, maxDataAge time.Duration, logger *logrus.Entry) error {
 	pruneStart := time.Now()
 	logger.Debug("Pruning cached Prometheus data.")
-	data.Prune()
+	data.PruneWithMaxAge(maxDataAge)
 	logger.Debugf("Pruned cached Prometheus data after %s.", time.Since(pruneStart).Round(time.Second))
 
 	flushStart := time.Now()

--- a/pkg/pod-scaler/types.go
+++ b/pkg/pod-scaler/types.go
@@ -335,14 +335,9 @@ func coalesceOnce(input []TimeRange) []TimeRange {
 	return input
 }
 
-// Prune ensures that no identifying set of labels contains more than twenty-five entries,
-// as well as removing any data that was added more than 90 days ago.
-// We know that an entry fingerprint can only exist for one fully-qualified label set,
-// but if the label set contains a multi-stage step, it will also be referenced in
-// the additional per-step index.
-func (q *CachedQuery) Prune() {
-	ninetyDaysAgo := time.Now().Add(-90 * 24 * time.Hour)
-	q.prune(ninetyDaysAgo)
+// PruneWithMaxAge removes data older than maxAge and caps each label set to 25 entries.
+func (q *CachedQuery) PruneWithMaxAge(maxAge time.Duration) {
+	q.prune(time.Now().Add(-maxAge))
 }
 
 func (q *CachedQuery) prune(pruneBefore time.Time) {


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## pod-scaler: Add configurable --max-data-age to cap cache retention and query range

This PR adds a new --max-data-age flag to the pod-scaler producer so operators can cap how far back Prometheus is queried and how long cached Prometheus data is retained.

Practical changes for CI operators
- New flag: --max-data-age (type duration). Default is 90d (90*24*time.Hour) when not specified.
- Query behavior: When >0, Prometheus query ranges are clamped to not go further back than now - maxDataAge (i.e., the producer will not request data older than the configured age). If max-data-age is set to 0 (explicitly), the clamping code is skipped; the producer relies on Prometheus's native retention.
- Cache pruning: Cached results are pruned using the supplied max-data-age via a new PruneWithMaxAge(maxAge time.Duration) API on the cached query type; storeCache calls this method before persisting cache data.

Component and impact
- Affects the pod-scaler producer and its caching: controls both the Prometheus query range and the cache prune window.
- Default behavior unchanged for typical installs (90 days). Operators can reduce the data footprint and query/storage load by setting a smaller max-data-age, or keep longer history by increasing it.
- Note: the code paths do not implement a separate fallback when max-data-age <= 0 (the default prevents that). Operators setting max-data-age to 0 should be aware that query clamping is disabled and the prune call receives 0 (i.e., pruning behavior is determined entirely by the new PruneWithMaxAge implementation).

Why this matters
- Provides explicit, operator-controlled tradeoff between historical coverage and resource usage (query volume, cache size, and storage costs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->