### PR TITLE
DPTP-4613: pod-scaler reserve 2 CPU cores for system overhead in measured pod capping

### DIFF
--- a/cmd/pod-scaler/admission.go
+++ b/cmd/pod-scaler/admission.go
@@ -37,7 +37,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/steps"
 )
 
-func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, reporter results.PodScalerReporter) {
+func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Interface, kubeClient kubernetes.Interface, loaders map[string][]*cacheReloader, mutateResourceLimits bool, cpuCap int64, memoryCap string, cpuPriorityScheduling int64, percentageMeasured float64, measuredPodCPUIncrease float64, systemReservedCPU int64, reporter results.PodScalerReporter) {
 	logger := logrus.WithField("component", "pod-scaler admission")
 	logger.Infof("Initializing admission webhook server with %d loaders.", len(loaders))
 	health := pjutil.NewHealthOnPort(healthPort)
@@ -45,7 +45,7 @@ func admit(port, healthPort int, certDir string, client buildclientv1.BuildV1Int
 	decoder := admission.NewDecoder(scheme.Scheme)
 
 	// Initialize node allocatable CPU cache
-	nodeCache := newNodeAllocatableCache(kubeClient)
+	nodeCache := newNodeAllocatableCache(kubeClient, systemReservedCPU)
 
 	server := webhook.NewServer(webhook.Options{
 		Port:    port,
@@ -603,18 +603,23 @@ func (m *podMutator) addMeasuredPodAntiaffinity(pod *corev1.Pod, logger *logrus.
 
 // nodeAllocatableCache caches node allocatable CPU information
 type nodeAllocatableCache struct {
-	client     kubernetes.Interface
-	lock       sync.RWMutex
-	cache      map[string]int64 // workload type -> max allocatable CPU (in cores)
-	lastUpdate time.Time
+	client            kubernetes.Interface
+	lock              sync.RWMutex
+	cache             map[string]int64
+	lastUpdate        time.Time
+	systemReservedCPU int64
 }
 
-const nodeCacheRefreshInterval = 15 * time.Minute
+const (
+	nodeCacheRefreshInterval = 15 * time.Minute
+	maxMeasuredCPUCores      = 10
+)
 
-func newNodeAllocatableCache(client kubernetes.Interface) *nodeAllocatableCache {
+func newNodeAllocatableCache(client kubernetes.Interface, systemReservedCPU int64) *nodeAllocatableCache {
 	cache := &nodeAllocatableCache{
-		client: client,
-		cache:  make(map[string]int64),
+		client:            client,
+		cache:             make(map[string]int64),
+		systemReservedCPU: systemReservedCPU,
 	}
 
 	// Initial load
@@ -650,13 +655,11 @@ func (c *nodeAllocatableCache) refresh() {
 		workloadNodes[workloadType] = append(workloadNodes[workloadType], node)
 	}
 
-	// Find minimum allocatable CPU for each workload type
-	// Note: Allocatable already accounts for system/kubelet reserved resources
+	// Find minimum allocatable CPU per workload type, minus system reserve, capped at maxMeasuredCPUCores.
 	for workloadType, nodeList := range workloadNodes {
 		minAllocatable := int64(0)
 		for _, node := range nodeList {
 			cpu := node.Status.Allocatable[corev1.ResourceCPU]
-			// AsApproximateFloat64() returns the value in cores
 			cpuCores := int64(cpu.AsApproximateFloat64())
 
 			if minAllocatable == 0 || cpuCores < minAllocatable {
@@ -664,15 +667,16 @@ func (c *nodeAllocatableCache) refresh() {
 			}
 		}
 
-		// Cap at 10 cores maximum
-		if minAllocatable > 10 {
-			minAllocatable = 10
+		minAllocatable -= c.systemReservedCPU
+		if minAllocatable < 0 {
+			minAllocatable = 0
+		}
+		if minAllocatable > maxMeasuredCPUCores {
+			minAllocatable = maxMeasuredCPUCores
 		}
 
-		if minAllocatable > 0 {
-			newCache[workloadType] = minAllocatable
-			logger.Debugf("Workload type %s: min allocatable CPU = %d cores", workloadType, minAllocatable)
-		}
+		newCache[workloadType] = minAllocatable
+		logger.Debugf("Workload type %s: min allocatable CPU = %d cores (after %d core system reserve)", workloadType, minAllocatable, c.systemReservedCPU)
 	}
 
 	c.lock.Lock()
@@ -692,6 +696,5 @@ func (c *nodeAllocatableCache) getMaxCPUForWorkload(workloadType string) int64 {
 		return maxCPU
 	}
 
-	// Default to 10 cores if workload type not found
-	return 10
+	return maxMeasuredCPUCores
 }

--- a/cmd/pod-scaler/main.go
+++ b/cmd/pod-scaler/main.go
@@ -70,6 +70,7 @@ type consumerOptions struct {
 	cpuPriorityScheduling  int64
 	percentageMeasured     float64
 	measuredPodCPUIncrease float64
+	systemReservedCPU      int64
 }
 
 func bindOptions(fs *flag.FlagSet) *options {
@@ -94,6 +95,7 @@ func bindOptions(fs *flag.FlagSet) *options {
 	fs.Int64Var(&o.cpuPriorityScheduling, "cpu-priority-scheduling", 8, "Pods with CPU requests at, or above, this value will be admitted with priority scheduling")
 	fs.Float64Var(&o.percentageMeasured, "percentage-measured", 0, "Percentage of pods to mark as measured (0-100). Measured pods get increased CPU requests and anti-affinity rules.")
 	fs.Float64Var(&o.measuredPodCPUIncrease, "measured-pod-cpu-increase", 50, "Percentage increase in CPU requests for measured pods (default: 50%).")
+	fs.Int64Var(&o.systemReservedCPU, "system-reserved-cpu", 2, "CPU cores to reserve for system overhead when capping measured pod CPU.")
 	o.resultsOptions.Bind(fs)
 	return &o
 }
@@ -283,7 +285,7 @@ func mainAdmission(opts *options, cache Cache) {
 		logrus.WithError(err).Fatal("Failed to create pod-scaler reporter.")
 	}
 
-	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, reporter)
+	go admit(opts.port, opts.instrumentationOptions.HealthPort, opts.certDir, client, kubeClient, loaders(cache), opts.mutateResourceLimits, opts.cpuCap, opts.memoryCap, opts.cpuPriorityScheduling, opts.percentageMeasured, opts.measuredPodCPUIncrease, opts.systemReservedCPU, reporter)
 }
 
 func loaders(cache Cache) map[string][]*cacheReloader {


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds a configurable system reserved CPU value to the pod-scaler admission webhook so measured-pod capping accounts for node/system overhead.

What changed for CI operators and the pod-scaler component
- New CLI flag: --system-reserved-cpu (consumer.admission), int64, default 2 — operators can lower/increase the number of CPU cores the pod-scaler will withhold for system use when computing measured-pod caps.
- The admission webhook (consumer.admission → pod-scaler) now initializes the node allocatable CPU cache with the configured reserve and uses it when computing per-workload caps.
- Behavior when computing caps:
  - For each ci-workload class the cache computes the minimum node allocatable CPU (in cores) across nodes, subtracts the configured system reserve, clamps the result to [0, maxMeasuredCPUCores], and stores that value (including explicit 0).
  - Debug logging now reports the post-reserve minimum and the reserve amount for each workload.
  - If a workload type is missing from the cache, getMaxCPUForWorkload falls back to the existing max measured CPU constant rather than a hard-coded literal.
- The new flag is bound in cmd/pod-scaler/main.go and passed into admit(...), which in turn constructs the nodeAllocatableCache with systemReservedCPU. No validation logic was added to validate() beyond existing checks.

Operational impact
- Operators can tune pod-scaler conservatism for measured pods by changing --system-reserved-cpu to better reflect cluster/system overhead (default remains 2 cores).
- Caps computed for measured pods will be reduced by the reserved amount across workload classes, and may be clamped to zero for very small node allocatable values — visible in debug logs.

Files/components affected (high level)
- cmd/pod-scaler/main.go: added option and flag binding for --system-reserved-cpu; passed to admission path.
- cmd/pod-scaler/admission.go: admission flow and nodeAllocatableCache updated to accept/use systemReservedCPU and to log the post-reserve values.

Security/validation
- No additional validation rules were introduced for the new flag; existing flag validation remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->