### PR TITLE
promoted-image-governor openshift mapping pullspec styles

### DIFF
--- a/cmd/promoted-image-governor/main.go
+++ b/cmd/promoted-image-governor/main.go
@@ -208,7 +208,7 @@ func mirroredTagsByReleaseController(ctx context.Context, client ctrlruntimeclie
 	for _, ref := range refs {
 		imageStream := &imagev1.ImageStream{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{Namespace: "ocp", Name: ref.Name}, imageStream); err != nil {
-			return nil, fmt.Errorf("could not get image stream %s in namespace ocp", ref.Name)
+			return nil, fmt.Errorf("could not get image stream %s in namespace ocp: %w", ref.Name, err)
 		}
 		excludedTags := sets.New[string](ref.ExcludeTags...)
 		for _, tag := range imageStream.Status.Tags {
@@ -256,7 +256,11 @@ func generateMappings(promotedTags []api.ImageStreamTagReference, mappingConfig 
 						if _, ok := mappings[filename]; !ok {
 							mappings[filename] = map[string]sets.Set[string]{}
 						}
-						src := fmt.Sprintf("%s/%s/%s:%s", mappingConfig.SourceRegistry, mappingConfig.SourceNamespace, tag.Name, tag.Tag)
+						src := api.QuayImageReference(api.ImageStreamTagReference{
+							Namespace: mappingConfig.SourceNamespace,
+							Name:      tag.Name,
+							Tag:       tag.Tag,
+						})
 						dst := fmt.Sprintf("%s/%s/%s-%s:%s", mappingConfig.TargetRegistry, mappingConfig.TargetNamespace, mappingConfig.SourceNamespace, tag.Tag, targetTag)
 						if _, ok = mappings[filename][src]; !ok {
 							mappings[filename][src] = sets.New[string]()

--- a/cmd/promoted-image-governor/main_test.go
+++ b/cmd/promoted-image-governor/main_test.go
@@ -220,20 +220,20 @@ func TestGenerateMappings(t *testing.T) {
 			},
 			expected: map[string]map[string]sets.Set[string]{
 				"mapping_origin_4_8": {
-					"registry.ci.openshift.org/origin/4.8:bar": sets.New[string]("quay.io/openshift/origin-bar:4.8", "quay.io/openshift/origin-bar:4.8.0"),
-					"registry.ci.openshift.org/origin/4.8:foo": sets.New[string]("quay.io/openshift/origin-foo:4.8", "quay.io/openshift/origin-foo:4.8.0"),
-					"registry.ci.openshift.org/origin/4.8:ocp-some": sets.New[string](
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_bar": sets.New[string]("quay.io/openshift/origin-bar:4.8", "quay.io/openshift/origin-bar:4.8.0"),
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_foo": sets.New[string]("quay.io/openshift/origin-foo:4.8", "quay.io/openshift/origin-foo:4.8.0"),
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.8_ocp-some": sets.New[string](
 						"quay.io/openshift/origin-ocp-some:4.8",
 						"quay.io/openshift/origin-ocp-some:4.8.0",
 					),
 				},
 				"mapping_origin_4_9": {
-					"registry.ci.openshift.org/origin/4.9:bar": sets.New[string](
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.9_bar": sets.New[string](
 						"quay.io/openshift/origin-bar:4.9",
 						"quay.io/openshift/origin-bar:4.9.0",
 						"quay.io/openshift/origin-bar:latest",
 					),
-					"registry.ci.openshift.org/origin/4.9:some": sets.New[string](
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.9_some": sets.New[string](
 						"quay.io/openshift/origin-some:4.9",
 						"quay.io/openshift/origin-some:4.9.0",
 						"quay.io/openshift/origin-some:latest",
@@ -271,8 +271,8 @@ func TestGenerateMappings(t *testing.T) {
 				},
 			},
 			expectedErr: utilerrors.NewAggregate([]error{
-				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6 more than once for the source registry.ci.openshift.org/origin/4.6:ovirt-installer in filename mapping_origin_4_6"),
-				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6.0 more than once for the source registry.ci.openshift.org/origin/4.6:ovirt-installer in filename mapping_origin_4_6"),
+				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6 more than once for the source quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
+				fmt.Errorf("cannot define the same mirroring destination quay.io/openshift/origin-ovirt-installer:4.6.0 more than once for the source quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer in filename mapping_origin_4_6"),
 			}),
 		},
 		{
@@ -307,7 +307,7 @@ func TestGenerateMappings(t *testing.T) {
 			},
 			expected: map[string]map[string]sets.Set[string]{
 				"mapping_origin_4_6": {
-					"registry.ci.openshift.org/origin/4.6:ovirt-installer": sets.New[string]("quay.io/openshift/origin-ovirt-installer:4.6", "quay.io/openshift/origin-ovirt-installer:4.6.0"),
+					"quay-proxy.ci.openshift.org/openshift/ci:origin_4.6_ovirt-installer": sets.New[string]("quay.io/openshift/origin-ovirt-installer:4.6", "quay.io/openshift/origin-ovirt-installer:4.6.0"),
 				},
 			},
 		},
@@ -323,12 +323,6 @@ func TestGenerateMappings(t *testing.T) {
 				t.Errorf("%s: actual does not match expected, diff: %s", tc.name, diff)
 			}
 		})
-	}
-}
-
-func init() {
-	if err := imagev1.AddToScheme(scheme.Scheme); err != nil {
-		panic(fmt.Sprintf("failed to register imagev1 scheme: %v", err))
 	}
 }
 


### PR DESCRIPTION
/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
promoted-image-governor: Use quay-proxy-style source pullspecs in mapping generation and tighten error wrapping

Component affected:
- promoted-image-governor — the CLI that generates OpenShift image mapping files used for mirroring images (used by CI and release workflows).

What changed (practical impact for CI users/operators):
- generateMappings now computes source pullspecs using the quay-proxy helper (api.QuayImageReference) instead of composing a legacy registry/path string. Generated mapping keys in tests now use quay-proxy.<source-registry-domain>/openshift/... as the "src" prefix. This means the mapping generator will emit source pullspecs that route through the CI quay-proxy/cache in the updated cases, aligning generated mappings with the proxied pull-through style used by CI.
- mirroredTagsByReleaseController now wraps client.Get errors with %w when returning errors, improving error propagation so callers can inspect underlying errors.
- No exported/public API surface changes were introduced.

Why this matters:
- Mapping files produced by this tool will reference source images via the quay-proxy style where applicable, which routes pulls through the CI pull-through cache — useful for environments that rely on the CI proxy/cache. Operators should expect generated mapping keys and source pullspecs to reflect the proxied format in the updated code paths/tests.
- Improved error wrapping makes diagnosing client.Get failures easier for callers of mirroredTagsByReleaseController.

Tests and validation:
- Tests were updated to expect the proxied quay-proxy source pullspec prefix in generated mappings.
- A redundant init() test registration block was removed.

Files with key changes:
- cmd/promoted-image-governor/main.go — mapping generation now uses quay-proxy helper for source pullspecs and improved error wrapping in mirroredTagsByReleaseController.
- cmd/promoted-image-governor/main_test.go — updated expected mappings to use quay-proxy source pullspecs and test cleanup.

No configuration schema additions (e.g., no new source_pullspec_style field) or other user-facing flags were added in this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->