### PR TITLE
autopublicizeconfig: support GitHub App authentication

### DIFF
--- a/cmd/autopublicizeconfig/main.go
+++ b/cmd/autopublicizeconfig/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"time"
@@ -16,10 +17,12 @@ import (
 	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
 
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/config"
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 	"github.com/openshift/ci-tools/pkg/privateorg"
 )
 
@@ -100,8 +103,10 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid arguments.")
 	}
 
-	if err := secret.Add(o.GitHubOptions.TokenPath); err != nil {
-		logrus.WithError(err).Fatal("Failed to start secrets agent")
+	if o.GitHubOptions.TokenPath != "" {
+		if err := secret.Add(o.GitHubOptions.TokenPath); err != nil {
+			logrus.WithError(err).Fatal("Failed to start secrets agent")
+		}
 	}
 
 	gc, err := o.GitHubOptions.GitHubClient(o.dryRun)
@@ -127,10 +132,10 @@ func main() {
 		}
 	}
 
-	config := &Config{}
-	config.Repositories = publicizeRepos
+	cfg := &Config{}
+	cfg.Repositories = publicizeRepos
 
-	b, err := yaml.Marshal(&config)
+	b, err := yaml.Marshal(&cfg)
 	if err != nil {
 		logrus.WithError(err).Fatal("couldn't marshal the publicize configuration")
 	}
@@ -163,8 +168,18 @@ func main() {
 
 	logrus.Info("Preparing pull request")
 	title := fmt.Sprintf("%s %s", matchTitle, time.Now().Format(time.RFC1123))
-	if err := bumper.GitCommitAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin, string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {
-		logrus.WithError(err).Fatal("Failed to push changes.")
+
+	var prHead string
+	if o.GitHubOptions.TokenPath != "" {
+		if err := bumper.GitCommitAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin, string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = fmt.Sprintf("%s:%s", o.githubLogin, remoteBranch)
+	} else {
+		if err := pushWithAppAuth(&o, remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = remoteBranch
 	}
 
 	var labelsToAdd []string
@@ -177,10 +192,50 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("Error retrieving repository data: %v", err)
 	}
-	source := fmt.Sprintf("%s:%s", o.githubLogin, remoteBranch)
-	if err := bumper.UpdatePullRequestWithLabels(gc, githubOrg, githubRepo, title, description, source, repo.DefaultBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
+	isAppAuth := o.GitHubOptions.TokenPath == ""
+	prClient := github.Client(&orgclient.OrgAwareClient{Client: gc, Org: githubOrg, IsAppAuth: isAppAuth})
+	if err := bumper.UpdatePullRequestWithLabels(prClient, githubOrg, githubRepo, title, description, prHead, repo.DefaultBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}
+}
+
+func pushWithAppAuth(o *options, branch, gitName, gitEmail, commitMsg string, stdout, stderr bumper.HideSecretsWriter) error {
+	if err := bumper.Call(stdout, stderr, "git", []string{"add", "-A"}); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	commitArgs := []string{"commit", "-m", commitMsg}
+	if gitName != "" && gitEmail != "" {
+		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", gitName, gitEmail))
+	}
+	if err := bumper.Call(stdout, stderr, "git", commitArgs); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	if out, err := exec.Command("git", "checkout", "-B", branch).CombinedOutput(); err != nil {
+		return fmt.Errorf("error creating local branch %s: %w\n%s", branch, err, string(out))
+	}
+
+	gcf, err := o.GitHubOptions.GitClientFactory("", nil, false, false)
+	if err != nil {
+		return fmt.Errorf("error creating git client factory: %w", err)
+	}
+	defer func() {
+		if err := gcf.Clean(); err != nil {
+			logrus.WithError(err).Warn("Failed to clean git client factory cache.")
+		}
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting working directory: %w", err)
+	}
+
+	repoClient, err := gcf.ClientFromDir(githubOrg, githubRepo, cwd)
+	if err != nil {
+		return fmt.Errorf("error creating repo client: %w", err)
+	}
+
+	return repoClient.PushToCentral(branch, true)
 }
 
 func getReposForPrivateOrg(releaseRepoPath string, allowlist map[string][]string) (map[string]sets.Set[string], error) {


### PR DESCRIPTION
Add a dual-path push flow: when a token path is provided, the legacy PAT+fork workflow is used unchanged. When App credentials are provided instead (--github-app-id + --github-app-private-key-path), the tool pushes directly to the upstream repo via GitClientFactory/PushToCentral and creates a same-repo PR.

Wrap the GitHub client with OrgAwareClient so that UpdatePullRequestWithLabels correctly routes FindIssues through FindIssuesWithOrg (required for App auth token resolution) and appends [bot] to the author login for search queries.

Guard secret.Add for empty TokenPath to prevent crashes when using App credentials.

Made with Cursor