### PR TITLE
autoowners: support GitHub App authentication

### DIFF
--- a/cmd/autoowners/main.go
+++ b/cmd/autoowners/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -25,6 +26,7 @@ import (
 	"sigs.k8s.io/prow/pkg/plugins/ownersconfig"
 	"sigs.k8s.io/prow/pkg/repoowners"
 
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 	"github.com/openshift/ci-tools/pkg/rehearse"
 )
 
@@ -512,10 +514,20 @@ func main() {
 	remoteBranch := "autoowners"
 	matchTitle := "Sync OWNERS files"
 	title := getTitle(matchTitle, time.Now().Format(time.RFC1123))
-	if err := bumper.GitCommitSignoffAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin,
-		string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, o.githubRepo),
-		remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.gitSignoff, o.dryRun); err != nil {
-		logrus.WithError(err).Fatal("Failed to push changes.")
+
+	var prHead string
+	if o.GitHubOptions.TokenPath != "" {
+		if err := bumper.GitCommitSignoffAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin,
+			string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, o.githubRepo),
+			remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.gitSignoff, o.dryRun); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = o.githubLogin + ":" + remoteBranch
+	} else {
+		if err := pushWithAppAuth(&o, remoteBranch, o.gitName, o.gitEmail, title, o.gitSignoff, stdout, stderr, o.dryRun); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = remoteBranch
 	}
 
 	labelsToAdd := []string{
@@ -525,10 +537,59 @@ func main() {
 		logrus.Infof("Self-aproving PR by adding the %q and %q labels", labels.Approved, labels.LGTM)
 		labelsToAdd = append(labelsToAdd, labels.Approved, labels.LGTM)
 	}
-	if err := bumper.UpdatePullRequestWithLabels(gc, o.githubOrg, o.githubRepo, title,
-		getBody(directories, o.assign), o.githubLogin+":"+remoteBranch, o.prBaseBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
+	isAppAuth := o.GitHubOptions.TokenPath == ""
+	prClient := github.Client(&orgclient.OrgAwareClient{Client: gc, Org: o.githubOrg, IsAppAuth: isAppAuth})
+	if err := bumper.UpdatePullRequestWithLabels(prClient, o.githubOrg, o.githubRepo, title,
+		getBody(directories, o.assign), prHead, o.prBaseBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}
+}
+
+func pushWithAppAuth(o *options, branch, gitName, gitEmail, commitMsg string, signoff bool, stdout, stderr bumper.HideSecretsWriter, dryRun bool) error {
+	if err := bumper.Call(stdout, stderr, "git", []string{"add", "-A"}); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	commitArgs := []string{"commit", "-m", commitMsg}
+	if gitName != "" && gitEmail != "" {
+		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", gitName, gitEmail))
+	}
+	if signoff {
+		commitArgs = append(commitArgs, "--signoff")
+	}
+	if err := bumper.Call(stdout, stderr, "git", commitArgs); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	if dryRun {
+		logrus.Info("[Dryrun] Skip git push")
+		return nil
+	}
+
+	if out, err := exec.Command("git", "checkout", "-B", branch).CombinedOutput(); err != nil {
+		return fmt.Errorf("error creating local branch %s: %w\n%s", branch, err, string(out))
+	}
+
+	gcf, err := o.GitHubOptions.GitClientFactory("", nil, false, false)
+	if err != nil {
+		return fmt.Errorf("error creating git client factory: %w", err)
+	}
+	defer func() {
+		if err := gcf.Clean(); err != nil {
+			logrus.WithError(err).Warn("Failed to clean git client factory cache.")
+		}
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting working directory: %w", err)
+	}
+
+	repoClient, err := gcf.ClientFromDir(o.githubOrg, o.githubRepo, cwd)
+	if err != nil {
+		return fmt.Errorf("error creating repo client: %w", err)
+	}
+
+	return repoClient.PushToCentral(branch, true)
 }
 
 type ownersCleaner func([]string) []string


### PR DESCRIPTION
Add a dual-path push flow so autoowners can operate with either a PAT (legacy fork-based workflow) or GitHub App credentials (direct push via GitClientFactory/PushToCentral). The GitHub client is wrapped with OrgAwareClient so that bumper.UpdatePullRequestWithLabels correctly resolves installation tokens via FindIssuesWithOrg.

Made with Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends the `autoowners` utility to support GitHub App authentication in addition to the existing personal access token (PAT) workflow. The `autoowners` tool is responsible for syncing OWNERS and OWNERS_ALIASES files from upstream OpenShift repositories into the release repository, then creating a PR with the updated configuration.

### Key Changes

**Dual Authentication Paths:**
The tool now conditionally selects the push mechanism based on whether `--github-token-path` is provided:

1. **Token-based (legacy, fork workflow)**: When `TokenPath` is configured, autoowners continues to use the existing `bumper.GitCommitSignoffAndPush` to push commits via the fork-based workflow, setting the PR head to `username:branch`

2. **GitHub App auth (new, direct push)**: When `TokenPath` is empty (relying on `--github-app-id` and `--github-app-private-key-path` instead), a new `pushWithAppAuth` helper function performs local commits and pushes directly to the central repository using GitHub App credentials, setting the PR head to the bare branch name

**Enhanced PR Operations:**
The GitHub client used for PR creation and labeling is now wrapped with `OrgAwareClient`, which enables proper installation token resolution when using GitHub App authentication. An `isAppAuth` flag is passed to `OrgAwareClient` to distinguish between authentication modes, ensuring that `bumper.UpdatePullRequestWithLabels` correctly handles token scoping for organizations.

### Practical Impact

CI operators can now deploy `autoowners` with GitHub App authentication as a more secure alternative to PATs, while maintaining backward compatibility with existing token-based configurations. This supports modern GitHub security practices and eliminates the need for fork-based workflows when using GitHub Apps.

Lines changed: +67/-6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->