### PR TITLE
auto-peribolos-sync: support GitHub App authentication

### DIFF
--- a/cmd/auto-peribolos-sync/main.go
+++ b/cmd/auto-peribolos-sync/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -14,7 +15,10 @@ import (
 	"sigs.k8s.io/prow/cmd/generic-autobumper/bumper"
 	"sigs.k8s.io/prow/pkg/config/secret"
 	"sigs.k8s.io/prow/pkg/flagutil"
+	"sigs.k8s.io/prow/pkg/github"
 	"sigs.k8s.io/prow/pkg/labels"
+
+	"github.com/openshift/ci-tools/pkg/github/orgclient"
 )
 
 const (
@@ -100,8 +104,10 @@ func main() {
 		logrus.WithError(err).Fatal("Invalid arguments.")
 	}
 
-	if err := secret.Add(o.GitHubOptions.TokenPath); err != nil {
-		logrus.WithError(err).Fatal("Failed to start secrets agent")
+	if o.GitHubOptions.TokenPath != "" {
+		if err := secret.Add(o.GitHubOptions.TokenPath); err != nil {
+			logrus.WithError(err).Fatal("Failed to start secrets agent")
+		}
 	}
 
 	gc, err := o.GitHubOptions.GitHubClient(o.dryRun)
@@ -114,7 +120,12 @@ func main() {
 		"--destination-org", destinationOrg,
 		"--peribolos-config", o.peribolosConfig,
 		"--release-repo-path", o.releaseRepoPath,
-		"--github-token-path", o.TokenPath,
+	}
+
+	if o.GitHubOptions.TokenPath != "" {
+		args = append(args, "--github-token-path", o.TokenPath)
+	} else {
+		args = append(args, "--github-app-id", o.AppID, "--github-app-private-key-path", o.AppPrivateKeyPath)
 	}
 
 	if o.whitelist != "" {
@@ -150,8 +161,18 @@ func main() {
 	}
 
 	title := fmt.Sprintf("%s %s", matchTitle, time.Now().Format(time.RFC1123))
-	if err := bumper.GitCommitAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin, string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {
-		logrus.WithError(err).Fatal("Failed to push changes.")
+
+	var prHead string
+	if o.GitHubOptions.TokenPath != "" {
+		if err := bumper.GitCommitAndPush(fmt.Sprintf("https://%s:%s@github.com/%s/%s.git", o.githubLogin, string(secret.GetTokenGenerator(o.GitHubOptions.TokenPath)()), o.githubLogin, githubRepo), remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = o.githubLogin + ":" + remoteBranch
+	} else {
+		if err := pushWithAppAuth(&o, remoteBranch, o.gitName, o.gitEmail, title, stdout, stderr, o.dryRun); err != nil {
+			logrus.WithError(err).Fatal("Failed to push changes.")
+		}
+		prHead = remoteBranch
 	}
 
 	var labelsToAdd []string
@@ -164,7 +185,53 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("Error retrieving repository data: %v", err)
 	}
-	if err := bumper.UpdatePullRequestWithLabels(gc, githubOrg, githubRepo, title, description, o.githubLogin+":"+remoteBranch, repo.DefaultBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
+	isAppAuth := o.GitHubOptions.TokenPath == ""
+	prClient := github.Client(&orgclient.OrgAwareClient{Client: gc, Org: githubOrg, IsAppAuth: isAppAuth})
+	if err := bumper.UpdatePullRequestWithLabels(prClient, githubOrg, githubRepo, title, description, prHead, repo.DefaultBranch, remoteBranch, true, labelsToAdd, o.dryRun); err != nil {
 		logrus.WithError(err).Fatalf("PR creation failed for '%s' branch", repo.DefaultBranch)
 	}
+}
+
+func pushWithAppAuth(o *options, branch, gitName, gitEmail, commitMsg string, stdout, stderr bumper.HideSecretsWriter, dryRun bool) error {
+	if err := bumper.Call(stdout, stderr, "git", []string{"add", "-A"}); err != nil {
+		return fmt.Errorf("git add: %w", err)
+	}
+	commitArgs := []string{"commit", "-m", commitMsg}
+	if gitName != "" && gitEmail != "" {
+		commitArgs = append(commitArgs, "--author", fmt.Sprintf("%s <%s>", gitName, gitEmail))
+	}
+	if err := bumper.Call(stdout, stderr, "git", commitArgs); err != nil {
+		return fmt.Errorf("git commit: %w", err)
+	}
+
+	if dryRun {
+		logrus.Info("[Dryrun] Skip git push")
+		return nil
+	}
+
+	if out, err := exec.Command("git", "checkout", "-B", branch).CombinedOutput(); err != nil {
+		return fmt.Errorf("error creating local branch %s: %w\n%s", branch, err, string(out))
+	}
+
+	gcf, err := o.GitHubOptions.GitClientFactory("", nil, false, false)
+	if err != nil {
+		return fmt.Errorf("error creating git client factory: %w", err)
+	}
+	defer func() {
+		if err := gcf.Clean(); err != nil {
+			logrus.WithError(err).Warn("Failed to clean git client factory cache.")
+		}
+	}()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting working directory: %w", err)
+	}
+
+	repoClient, err := gcf.ClientFromDir(githubOrg, githubRepo, cwd)
+	if err != nil {
+		return fmt.Errorf("error creating repo client: %w", err)
+	}
+
+	return repoClient.PushToCentral(branch, true)
 }

--- a/cmd/private-org-peribolos-sync/main.go
+++ b/cmd/private-org-peribolos-sync/main.go
@@ -104,8 +104,10 @@ func main() {
 		logger.WithError(err).Fatal("failed to unmarshal peribolos config")
 	}
 
-	if err := secret.Add(o.github.TokenPath); err != nil {
-		logrus.WithError(err).Fatal("Error starting secrets agent.")
+	if o.github.TokenPath != "" {
+		if err := secret.Add(o.github.TokenPath); err != nil {
+			logrus.WithError(err).Fatal("Error starting secrets agent.")
+		}
 	}
 	gc, err := o.github.GitHubClient(false)
 	if err != nil {


### PR DESCRIPTION
Add dual-path push flow so auto-peribolos-sync can operate with either a PAT (legacy fork-based workflow) or GitHub App credentials (direct push via GitClientFactory/PushToCentral). Forward the appropriate auth flags (--github-app-id/--github-app-private-key-path) to the sub-process private-org-peribolos-sync when using App auth. Guard secret.Add in both binaries for empty TokenPath. Wrap the GitHub client with OrgAwareClient so bumper.UpdatePullRequestWithLabels resolves installation tokens.

Made with Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## GitHub App Authentication Support for Peribolos Sync Tools

This change adds GitHub App authentication as an alternative to Personal Access Token (PAT) authentication for the peribolos synchronization tools used to manage repository configurations in the openshift-priv organization.

### What Changed

**auto-peribolos-sync** (the wrapper that generates and files PRs):
- Now supports a dual-path push flow: it can use either PAT-based authentication (legacy fork-based workflow) or GitHub App authentication (direct push to the main repo)
- Secrets agent is only initialized when a token path is provided, allowing the tool to run with App credentials alone
- When launching the `private-org-peribolos-sync` sub-process, it forwards either `--github-token-path` or GitHub App flags (`--github-app-id` and `--github-app-private-key-path`)
- Implemented new `pushWithAppAuth()` helper function that uses GitClientFactory to perform git operations with App credentials
- GitHub client is wrapped with `OrgAwareClient` to properly resolve installation tokens when using App authentication
- PR head reference differs by auth method: PAT uses fork-based reference ("username:branch"), App uses direct reference ("branch")

**private-org-peribolos-sync** (the tool that generates peribolos config):
- Secrets agent initialization is now conditional, only running when a token path is provided

### Practical Impact for CI Operators

CI operators can now deploy these synchronization tools using GitHub App authentication instead of requiring a Personal Access Token. This enables:
- More secure credential management using GitHub App private keys
- Direct pushes to the main repository instead of fork-based workflows
- Flexibility to use either authentication method based on their infrastructure setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->