### PR TITLE
replace dots in shared-dir volume names

### DIFF
--- a/pkg/steps/multi_stage/gen.go
+++ b/pkg/steps/multi_stage/gen.go
@@ -605,15 +605,20 @@ func addCliInjector(imagestream string, pod *coreapi.Pod) {
 	})
 }
 
+func sharedDirVolumeName(secret string) string {
+	return strings.ReplaceAll(secret, ".", "-")
+}
+
 func addSharedDirSecret(secret string, pod *coreapi.Pod) {
+	volName := sharedDirVolumeName(secret)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, coreapi.Volume{
-		Name: secret,
+		Name: volName,
 		VolumeSource: coreapi.VolumeSource{
 			Secret: &coreapi.SecretVolumeSource{SecretName: secret},
 		},
 	})
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, coreapi.VolumeMount{
-		Name:      secret,
+		Name:      volName,
 		MountPath: SecretMountPath,
 	})
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, coreapi.EnvVar{

--- a/pkg/steps/multi_stage/gen_test.go
+++ b/pkg/steps/multi_stage/gen_test.go
@@ -506,6 +506,68 @@ func TestAddCredentials(t *testing.T) {
 	}
 }
 
+func TestAddSharedDirSecret(t *testing.T) {
+	tests := []struct {
+		name           string
+		secret         string
+		wantVolumeName string
+		wantSecretName string
+	}{
+		{
+			name:           "valid label unchanged",
+			secret:         "multi-stage-test-alpha",
+			wantVolumeName: "multi-stage-test-alpha",
+			wantSecretName: "multi-stage-test-alpha",
+		},
+		{
+			name:           "valid label with version segment",
+			secret:         "multi-stage-test-beta-4-21",
+			wantVolumeName: "multi-stage-test-beta-4-21",
+			wantSecretName: "multi-stage-test-beta-4-21",
+		},
+		{
+			name:           "dots replaced",
+			secret:         "multi-stage-test-gamma-4.22",
+			wantVolumeName: "multi-stage-test-gamma-4-22",
+			wantSecretName: "multi-stage-test-gamma-4.22",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := coreapi.Pod{Spec: coreapi.PodSpec{
+				Containers: []coreapi.Container{{}},
+			}}
+			addSharedDirSecret(tt.secret, &pod)
+			if len(pod.Spec.Volumes) != 1 {
+				t.Fatalf("expected 1 volume, got %d", len(pod.Spec.Volumes))
+			}
+			vol := pod.Spec.Volumes[0]
+			if vol.Name != tt.wantVolumeName {
+				t.Errorf("volume name = %q, want %q", vol.Name, tt.wantVolumeName)
+			}
+			if vol.Secret == nil {
+				t.Fatalf("volume secret source is nil")
+			}
+			if vol.Secret.SecretName != tt.wantSecretName {
+				t.Errorf("secret name = %q, want %q", vol.Secret.SecretName, tt.wantSecretName)
+			}
+			if len(pod.Spec.Containers) == 0 {
+				t.Fatalf("expected at least 1 container, got 0")
+			}
+			if len(pod.Spec.Containers[0].VolumeMounts) == 0 {
+				t.Fatalf("expected at least 1 volume mount, got 0")
+			}
+			mount := pod.Spec.Containers[0].VolumeMounts[0]
+			if mount.Name != tt.wantVolumeName {
+				t.Errorf("volume mount name = %q, want %q", mount.Name, tt.wantVolumeName)
+			}
+			if mount.MountPath != SecretMountPath {
+				t.Errorf("mount path = %q, want %q", mount.MountPath, SecretMountPath)
+			}
+		})
+	}
+}
+
 // sortPodVolumesAndMounts sorts volumes and volume mounts in a pod for deterministic comparison
 func sortPodVolumesAndMounts(pod *coreapi.Pod) {
 	// Sort volumes by name


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/CBN38N3MW/p1779090578809989

/cc @openshift/test-platform 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Fix shared-dir volume naming for Kubernetes DNS compliance

This change makes multi-stage test pods generated by ci-operator produce Kubernetes-safe volume and mount names for Secret-backed shared directories when the secret name contains dots.

What changed
- Adds sharedDirVolumeName(secret) which normalizes a secret-derived volume/mount name by replacing '.' with '-' to make it DNS-1123 compliant (e.g., "test-4.22" → "test-4-22").
- Updates addSharedDirSecret to use the normalized name for the Pod volume Name and the container VolumeMount Name, while continuing to set SecretName to the original secret string (the referenced Secret resource is unchanged).
- Adds unit tests (TestAddSharedDirSecret) that verify volumes and mounts are created exactly once and validate naming behavior for names with and without dots and with existing dash-separated segments.

Component and behavioral impact
- Affects the multi-stage test executor (pkg/steps/multi_stage) used by ci-operator. Pods that mount Secret-backed shared directories will now always have valid volume and mount names, preventing Pod creation failures when secret names include dots (common in versioned names like "4.22").
- Backwards compatible: the Secret resource name used to look up the Secret is unchanged; only the in-Pod volume/mount identifiers are normalized.

Testing
- Table-driven unit tests cover cases ensuring:
  - Names without dots remain unchanged.
  - Names with dots are normalized by replacing dots with dashes.
  - SecretName and mount path remain correct.

This resolves pod creation errors caused by invalid volume names derived from dotted secret names while keeping Secret references intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->