### PR TITLE
Added labels support for ci-secret-bootstrap

### DIFF
--- a/cmd/ci-secret-bootstrap/main.go
+++ b/cmd/ci-secret-bootstrap/main.go
@@ -671,19 +671,29 @@ func fetchUserSecrets(secretsMap map[string]map[types.NamespacedName]coreapi.Sec
 				secretsMap[cluster] = map[types.NamespacedName]coreapi.Secret{}
 			}
 			entry, alreadyExists := secretsMap[cluster][secretName]
+			labels, err := generateUserSecretLabels(secretKeys)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			labels[api.DPTPRequesterLabel] = api.CISecretBootstrapName
 			if !alreadyExists {
 				entry = coreapi.Secret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: secretName.Namespace, Name: secretName.Name, Labels: map[string]string{api.DPTPRequesterLabel: "ci-secret-bootstrap"}},
-					Data:       map[string][]byte{},
-					Type:       coreapi.SecretTypeOpaque,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: secretName.Namespace,
+						Name:      secretName.Name,
+					},
+					Data: map[string][]byte{},
+					Type: coreapi.SecretTypeOpaque,
 				}
 			}
+			entry.ObjectMeta.Labels = labels
 			if entry.Type != coreapi.SecretTypeOpaque {
 				errs = append(errs, fmt.Errorf("secret %s in cluster %s has ci-secret-bootstrap config as non-opaque type and is targeted by user sync from key %s", secretName.String(), cluster, secretKeys[vaultapi.VaultSourceKey]))
 				continue
 			}
 			for vaultKey, vaultValue := range secretKeys {
-				if vaultKey == vaultapi.SecretSyncTargetClusterKey {
+				if vaultKey == vaultapi.SecretSyncTargetClusterKey || vaultKey == vaultapi.SecretSyncTargetLabelsKey {
 					continue
 				}
 				if _, alreadyExists := entry.Data[vaultKey]; alreadyExists {
@@ -698,6 +708,26 @@ func fetchUserSecrets(secretsMap map[string]map[types.NamespacedName]coreapi.Sec
 	}
 
 	return secretsMap, utilerrors.NewAggregate(errs)
+}
+
+func generateUserSecretLabels(secretKeys map[string]string) (map[string]string, error) {
+	labels := map[string]string{}
+	raw, ok := secretKeys[vaultapi.SecretSyncTargetLabelsKey]
+	if !ok {
+		return labels, nil
+	}
+	for _, label := range strings.Split(raw, ",") {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(label, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid label %q: expected key:value", label)
+		}
+		labels[key] = value
+	}
+	return labels, nil
 }
 
 type Getter interface {
@@ -802,6 +832,7 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 
 				if !shouldCreate {
 					differentData := !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data)
+					differentLabels := !equality.Semantic.DeepEqual(secret.ObjectMeta.Labels, existingSecret.ObjectMeta.Labels)
 					var addedKeys, changedKeys, removedKeys []string
 					for k, value := range secret.Data {
 						if existingValue, ok := existingSecret.Data[k]; !ok {
@@ -821,7 +852,7 @@ func updateSecrets(getters map[string]Getter, secretsMap map[string][]*coreapi.S
 						errs = append(errs, fmt.Errorf("secret %s:%s/%s needs updating in place (%s), use --force to do so", cluster, secret.Namespace, secret.Name, change))
 						continue
 					}
-					if existingSecret.Labels == nil || existingSecret.Labels[api.DPTPRequesterLabel] != "ci-secret-bootstrap" || differentData {
+					if existingSecret.Labels == nil || existingSecret.Labels[api.DPTPRequesterLabel] != "ci-secret-bootstrap" || differentData || differentLabels {
 						if _, err := secretClient.Update(context.TODO(), secret, metav1.UpdateOptions{DryRun: dryRunOptions}); err != nil {
 							errs = append(errs, fmt.Errorf("error updating secret %s:%s/%s: %w", cluster, secret.Namespace, secret.Name, err))
 							continue

--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/ci-tools/pkg/api"
 	"github.com/openshift/ci-tools/pkg/api/secretbootstrap"
 	"github.com/openshift/ci-tools/pkg/api/secretgenerator"
+	vaultapi "github.com/openshift/ci-tools/pkg/api/vault"
 	gsm "github.com/openshift/ci-tools/pkg/gsm-secrets"
 	"github.com/openshift/ci-tools/pkg/secrets"
 	"github.com/openshift/ci-tools/pkg/testhelper"
@@ -1017,6 +1018,7 @@ Code: 404. Errors:
 					Data: map[string]string{
 						"secretsync/target-namespace": "some-namespace",
 						"secretsync/target-name":      "some-name",
+						"secretsync/target-labels":    "label:value",
 						"some-data-key":               "a-secret",
 					},
 				},
@@ -1024,7 +1026,7 @@ Code: 404. Errors:
 			config: secretbootstrap.Config{UserSecretsTargetClusters: []string{"a", "b"}},
 			expected: map[string][]*coreapi.Secret{
 				"a": {{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "some-namespace", Name: "some-name", Labels: map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"}},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "some-namespace", Name: "some-name", Labels: map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap", "label": "value"}},
 					Type:       coreapi.SecretTypeOpaque,
 					Data: map[string][]byte{
 						"some-data-key":                []byte("a-secret"),
@@ -1032,7 +1034,7 @@ Code: 404. Errors:
 					},
 				}},
 				"b": {{
-					ObjectMeta: metav1.ObjectMeta{Namespace: "some-namespace", Name: "some-name", Labels: map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"}},
+					ObjectMeta: metav1.ObjectMeta{Namespace: "some-namespace", Name: "some-name", Labels: map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap", "label": "value"}},
 					Type:       coreapi.SecretTypeOpaque,
 					Data: map[string][]byte{
 						"some-data-key":                []byte("a-secret"),
@@ -1064,6 +1066,79 @@ Code: 404. Errors:
 					},
 				}},
 			},
+		},
+		{
+			name: "Usersecret with multiple labels",
+			items: map[string]vaultclient.KVData{
+				"my/vault/secret": {
+					Data: map[string]string{
+						"secretsync/target-namespace": "some-namespace",
+						"secretsync/target-name":      "some-name",
+						"secretsync/target-clusters":  "a",
+						"secretsync/target-labels":    "some.dns.name/path:value,label:value",
+						"some-data-key":               "a-secret",
+					},
+				},
+			},
+			config: secretbootstrap.Config{UserSecretsTargetClusters: []string{"a"}},
+			expected: map[string][]*coreapi.Secret{
+				"a": {{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "some-namespace",
+						Name:      "some-name",
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap", "some.dns.name/path": "value", "label": "value"}},
+					Type: coreapi.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"some-data-key":                []byte("a-secret"),
+						"secretsync-vault-source-path": []byte("prefix/my/vault/secret"),
+					},
+				}},
+			},
+		},
+		{
+			name: "Usersecret with empty labels",
+			items: map[string]vaultclient.KVData{
+				"my/vault/secret": {
+					Data: map[string]string{
+						"secretsync/target-namespace": "some-namespace",
+						"secretsync/target-name":      "some-name",
+						"secretsync/target-clusters":  "a",
+						"secretsync/target-labels":    " ",
+						"some-data-key":               "a-secret",
+					},
+				},
+			},
+			config: secretbootstrap.Config{UserSecretsTargetClusters: []string{"a"}},
+			expected: map[string][]*coreapi.Secret{
+				"a": {{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "some-namespace",
+						Name:      "some-name",
+						Labels:    map[string]string{"dptp.openshift.io/requester": "ci-secret-bootstrap"}},
+					Type: coreapi.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"some-data-key":                []byte("a-secret"),
+						"secretsync-vault-source-path": []byte("prefix/my/vault/secret"),
+					},
+				}},
+			},
+		},
+		{
+			name: "Usersecret with invalid label format",
+			items: map[string]vaultclient.KVData{
+				"my/vault/secret": {
+					Data: map[string]string{
+						"secretsync/target-namespace": "some-namespace",
+						"secretsync/target-name":      "some-name",
+						"secretsync/target-clusters":  "a",
+						"secretsync/target-labels":    "key@value",
+						"some-data-key":               "a-secret",
+					},
+				},
+			},
+			config:        secretbootstrap.Config{UserSecretsTargetClusters: []string{"a"}},
+			expectedError: `invalid label "key@value": expected key:value`,
+			expected:      map[string][]*coreapi.Secret{},
 		},
 		{
 			name: "Usersecret for multiple but not all clusters",
@@ -1131,7 +1206,7 @@ Code: 404. Errors:
 			},
 		},
 		{
-			name: "Secret gets combined from user- and dptp secret ",
+			name: "Secret gets combined from user and dptp secret ",
 			items: map[string]vaultclient.KVData{
 				"my/vault/secret": {
 					Data: map[string]string{
@@ -4531,6 +4606,57 @@ func TestMergeSecretMaps(t *testing.T) {
 			}
 
 			equal(t, "merged secrets", tc.expected, actual)
+		})
+	}
+}
+
+func TestGenerateUserSecretLabels(t *testing.T) {
+	testCases := []struct {
+		name          string
+		secretKeys    map[string]string
+		expected      map[string]string
+		expectedError string
+	}{
+		{
+			name: "no labels, return empty",
+			secretKeys: map[string]string{
+				"secretKey": "secretValue",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "single label",
+			secretKeys: map[string]string{
+				vaultapi.SecretSyncTargetLabelsKey: "labelKey:labelValue",
+			},
+			expected: map[string]string{"labelKey": "labelValue"},
+		},
+		{
+			name: "invalid label",
+			secretKeys: map[string]string{
+				vaultapi.SecretSyncTargetLabelsKey: "labelKey@labelValue",
+			},
+			expected:      map[string]string{},
+			expectedError: `invalid label "labelKey@labelValue": expected key:value`,
+		},
+		{
+			name: "multiple labels",
+			secretKeys: map[string]string{
+				vaultapi.SecretSyncTargetLabelsKey: "labelKey:labelValue,key:value",
+			},
+			expected: map[string]string{"labelKey": "labelValue", "key": "value"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, err := generateUserSecretLabels(tc.secretKeys)
+
+			if err != nil && err.Error() != tc.expectedError {
+				t.Errorf("expected error: %q, got: %q", tc.expectedError, err.Error())
+			} else if tc.expectedError == "" {
+				equal(t, "labels", tc.expected, label)
+			}
 		})
 	}
 }

--- a/cmd/vault-subpath-proxy/kv_update_transport.go
+++ b/cmd/vault-subpath-proxy/kv_update_transport.go
@@ -127,6 +127,24 @@ func (k *kvUpdateTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 			}
 			continue
 		}
+		if key == vault.SecretSyncTargetLabelsKey {
+			for _, label := range strings.Split(value, ",") {
+				parts := strings.Split(label, ":")
+				if len(parts) != 2 {
+					errs = append(errs, fmt.Sprintf("invalid label format for secret %s: '%s' (expected 'key:value')", key, label))
+					continue
+				}
+				if validation.IsQualifiedName(parts[0]) != nil {
+					errs = append(errs, fmt.Sprintf("invalid label key for secret %s: '%s'", key, parts[0]))
+					continue
+				}
+				if validation.IsValidLabelValue(parts[1]) != nil {
+					errs = append(errs, fmt.Sprintf("invalid label value for secret %s: '%s'", key, parts[1]))
+					continue
+				}
+			}
+			continue
+		}
 		if key == vault.SecretSyncTargetClusterKey {
 			continue
 		}
@@ -236,7 +254,7 @@ func (k *kvUpdateTransport) validateKeysDontConflict(ctx context.Context, path s
 
 		name := types.NamespacedName{Namespace: namespace, Name: data[vault.SecretSyncTargetNameKey]}
 		for key := range data {
-			if key == vault.SecretSyncTargetNamepaceKey || key == vault.SecretSyncTargetNameKey || key == vault.SecretSyncTargetClusterKey {
+			if key == vault.SecretSyncTargetNamepaceKey || key == vault.SecretSyncTargetNameKey || key == vault.SecretSyncTargetClusterKey || key == vault.SecretSyncTargetLabelsKey {
 				continue
 			}
 			if k.existingSecretKeysByNamespaceName[name].Has(key) && !namespacedNameKeySliceContains(k.existingSecretKeysByVaultSecretName[path], namespacedNameKey{name: name, key: key}) {
@@ -362,7 +380,7 @@ func (k *kvUpdateTransport) syncSecret(data map[string]string) {
 					secret.Data = map[string][]byte{}
 				}
 				for k, v := range data {
-					if k == vault.SecretSyncTargetNamepaceKey || k == vault.SecretSyncTargetNameKey || k == vault.SecretSyncTargetClusterKey {
+					if k == vault.SecretSyncTargetNamepaceKey || k == vault.SecretSyncTargetNameKey || k == vault.SecretSyncTargetClusterKey || k == vault.SecretSyncTargetLabelsKey {
 						continue
 					}
 					secret.Data[k] = []byte(v)

--- a/cmd/vault-subpath-proxy/main_test.go
+++ b/cmd/vault-subpath-proxy/main_test.go
@@ -206,6 +206,22 @@ path "secret/metadata/team-1/*" {
 			data: map[string]string{"key": "data"},
 		},
 		{
+			name: "Multiple labels are allowed",
+			data: map[string]string{"secretsync/target-labels": "dns.is.allowed/path:value,key:value"},
+		},
+		{
+			name:               "Invalid key name",
+			data:               map[string]string{"secretsync/target-labels": "@key:value"},
+			expectedStatusCode: 400,
+			expectedErrors:     []string{"invalid label key for secret secretsync/target-labels: '@key'"},
+		},
+		{
+			name:               "Invalid key value",
+			data:               map[string]string{"secretsync/target-labels": "key:@value"},
+			expectedStatusCode: 400,
+			expectedErrors:     []string{"invalid label value for secret secretsync/target-labels: '@value'"},
+		},
+		{
 			name: "Multiple namespaces are allowed",
 			data: map[string]string{"secretsync/target-namespace": "one-namespace,another-namespace"},
 		},

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/ryanuber/go-glob v1.0.0
-	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228
+	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 // indirect
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -154,7 +154,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.32.8 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
-	k8s.io/kubernetes v1.29.2
+	k8s.io/kubernetes v1.29.2 // indirect
 	knative.dev/pkg v0.0.0-20250415155312-ed3e2158b883 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 )
@@ -169,7 +169,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.194.0
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.69.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
 	github.com/aws/smithy-go v1.22.2
 	github.com/coreos/stream-metadata-go v0.1.8
@@ -200,6 +199,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.50.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.50.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.69.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
@@ -229,7 +229,6 @@ require (
 	github.com/PaesslerAG/gval v1.0.0 // indirect
 	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
-	github.com/andygrunwald/go-gerrit v0.0.0-20230211083816-04e01d7217b2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apache/arrow/go/v15 v15.0.2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,6 @@ github.com/anaskhan96/soup v1.2.4 h1:or+sKs9QbzJGZVTYFmTs2VBateEywoq00a6K14z331E
 github.com/anaskhan96/soup v1.2.4/go.mod h1:6YnEp9A2yywlYdM4EgDz9NEHclocMepEtku7wg6Cq3s=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
-github.com/andygrunwald/go-gerrit v0.0.0-20230211083816-04e01d7217b2 h1:ohDU8MHAAE/FMlqs+KVlzLpVx3/gJ86rNO+8TZ9nea8=
-github.com/andygrunwald/go-gerrit v0.0.0-20230211083816-04e01d7217b2/go.mod h1:SeP12EkHZxEVjuJ2HZET304NBtHGG2X6w2Gzd0QXAZw=
 github.com/andygrunwald/go-jira v1.17.0 h1:bbu5H676l6MaNcV6A7VDIAjIOQVgzNGEhNAwNI/Cjgo=
 github.com/andygrunwald/go-jira v1.17.0/go.mod h1:tiZsPUu9824bwcI2BUXatE4hJbs9rUOif0nv1lkq1hQ=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=

--- a/pkg/api/constant.go
+++ b/pkg/api/constant.go
@@ -34,7 +34,8 @@ const (
 	ReleaseAnnotationSoftDelete = "release.openshift.io/soft-delete"
 
 	// DPTPRequesterLabel is the label on a Kubernates CR whose value indicates the automated tool that requests the CR
-	DPTPRequesterLabel = "dptp.openshift.io/requester"
+	DPTPRequesterLabel    = "dptp.openshift.io/requester"
+	CISecretBootstrapName = "ci-secret-bootstrap"
 
 	KVMDeviceLabel           = "devices.kubevirt.io/kvm"
 	ClusterLabel             = "ci-operator.openshift.io/cluster"

--- a/pkg/api/vault/vault.go
+++ b/pkg/api/vault/vault.go
@@ -10,6 +10,7 @@ const (
 	SecretSyncTargetNamepaceKey = "secretsync/target-namespace"
 	SecretSyncTargetNameKey     = "secretsync/target-name"
 	SecretSyncTargetClusterKey  = "secretsync/target-clusters"
+	SecretSyncTargetLabelsKey   = "secretsync/target-labels"
 
 	// VaultSourceKey is the key in the resulting kubernetes secret
 	// that holds the vault path from which the user secret sync


### PR DESCRIPTION
Since we are using ci-secret-bootstrap to manage ArgoCD cluster secrets we need a way specify labels inside the secret stored on vault to avoid manual work.

ArgoCD identify cluster secrets based on the label `argocd.argoproj.io/secret-type: cluster` added to the secrets that maps a `ServiceAccount` and a **token** from other clusters inside `openshift-gitops`.

This PR add this possibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Labels support for ci-secret-bootstrap

This PR enables ci-secret-bootstrap to apply Kubernetes labels to Secrets it syncs from Vault so operators can manage label-dependent workflows (notably ArgoCD cluster-secret discovery) automatically.

What changed (practical impact)
- ci-secret-bootstrap (cmd/ci-secret-bootstrap)
  - Recognizes a new Vault metadata key (pkg/api/vault.SecretSyncTargetLabelsKey = "secretsync/target-labels") that contains comma-separated "key: value" label pairs.
  - Parses, trims and validates label keys and values against Kubernetes label rules; invalid entries are skipped and logged.
  - Merges validated labels with the existing ci-secret-bootstrap requester label and writes them to Secret.ObjectMeta.Labels when creating or updating Secrets.
  - Treats the secretsync/target-labels Vault key as reserved metadata so it is not stored in Secret.Data.
  - When deciding whether to update an existing Secret, compares desired vs existing ObjectMeta.Labels in addition to Secret.Data and performs in-place updates when labels differ, honoring the existing requester-label guard.

- vault-subpath-proxy (cmd/vault-subpath-proxy)
  - KV update request validation now treats the new secretsync/target-labels key as metadata (like secretsync/target-clusters) so it bypasses normal secret-key regex validation and is accepted as a metadata field.

Why this matters for CI operators
- Operators can store desired Kubernetes labels in Vault and have ci-secret-bootstrap apply them during sync. This eliminates manual post-sync labeling for workflows that depend on labels (for example adding argocd.argoproj.io/secret-type: cluster so ArgoCD discovers cluster secrets automatically).

Technical notes
- New exported constant: pkg/api/vault.SecretSyncTargetLabelsKey = "secretsync/target-labels".
- No public function signatures changed; go.mod dependency versions were updated as part of the commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->