### PR TITLE
ci-operator-checkconfig: Forbid some chars in multistage test name

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -43,6 +43,8 @@ const (
 	// more things from the name
 	maxClaimTestNameLength = 42
 	maxTestNameLength      = 61
+
+	multiStageTestNameForbiddenChars = "."
 )
 
 func (v *Validator) commandHasTrap(cmd string) bool {
@@ -131,6 +133,8 @@ func (v *Validator) validateTestStepConfiguration(
 	validationErrors = append(validationErrors, searchForTestDuplicates(input)...)
 	inputImagesSeen := make(testInputImages)
 	for num, test := range input {
+		hasCommands, hasSteps, hasLiteral := len(test.Commands) != 0, test.MultiStageTestConfiguration != nil, test.MultiStageTestConfigurationLiteral != nil
+
 		fieldRootN := fmt.Sprintf("%s[%d]", fieldRoot, num)
 		if len(test.As) == 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: is required", fieldRootN))
@@ -148,8 +152,11 @@ func (v *Validator) validateTestStepConfiguration(
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' is not a valid Kubernetes object name", fieldRootN, test.As))
 		} else if api.ShardSuffix.MatchString(test.As) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' ends with a shard suffix (e.g. -1of2) which is reserved for infrastructure use and will be stripped from the test name during rehearsals", fieldRootN, test.As))
+		} else if strings.ContainsAny(test.As, multiStageTestNameForbiddenChars) && (hasSteps || hasLiteral) {
+			validationErrors = append(validationErrors, fmt.Errorf("%s.as: '%s' is not a valid name, the following chars '%s' are forbidden", fieldRootN, test.As, multiStageTestNameForbiddenChars))
 		}
-		if hasCommands, hasSteps, hasLiteral := len(test.Commands) != 0, test.MultiStageTestConfiguration != nil, test.MultiStageTestConfigurationLiteral != nil; !hasCommands && !hasSteps && !hasLiteral {
+
+		if !hasCommands && !hasSteps && !hasLiteral {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: either `commands`, `steps`, or `literal_steps` should be set", fieldRootN))
 		} else if hasCommands && (hasSteps || hasLiteral) || (hasSteps && hasLiteral) {
 			validationErrors = append(validationErrors, fmt.Errorf("%s: `commands`, `steps`, and `literal_steps` are mutually exclusive", fieldRootN))

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -712,6 +712,17 @@ func TestValidateTests(t *testing.T) {
 				},
 			},
 		},
+		{
+			id: `test name contains forbidden chars`,
+			tests: []api.TestStepConfiguration{
+				{
+					As:                          "e2e-release-4.22",
+					Commands:                    "commands",
+					MultiStageTestConfiguration: &api.MultiStageTestConfiguration{},
+				},
+			},
+			expectedError: errors.New("tests[0].as: 'e2e-release-4.22' is not a valid name, the following chars '.' are forbidden"),
+		},
 	} {
 		t.Run(tc.id, func(t *testing.T) {
 			v := newSingleUseValidator()


### PR DESCRIPTION
This is an alternative solution to https://github.com/openshift/ci-tools/pull/5188