### PR TITLE
ci-operator: Expose `IP_POOL_AVAILABLE` only when the step `ip_pool` has run

### DIFF
--- a/pkg/api/clusterprofile.go
+++ b/pkg/api/clusterprofile.go
@@ -1136,7 +1136,6 @@ func (p ClusterProfile) LeaseType() string {
 func (p ClusterProfile) IPPoolLeaseType() string {
 	switch p {
 	case
-		ClusterProfileAWS,
 		ClusterProfileAWSUSEast1:
 		return "aws-ip-pools"
 	default:

--- a/pkg/api/leases_test.go
+++ b/pkg/api/leases_test.go
@@ -65,7 +65,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 	}{
 		{
 			name:     "aws",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "master"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",
@@ -79,7 +79,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 		},
 		{
 			name:     "aws, with 4.16 branch",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "release-4.16"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",
@@ -89,12 +89,12 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 		},
 		{
 			name:     "aws, but older release branch",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "release-4.10"},
 		},
 		{
 			name:     "aws, with 5.0 branch (should be valid)",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "release-5.0"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",
@@ -104,7 +104,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 		},
 		{
 			name:     "aws, with openshift-5.0 branch (should be valid)",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "openshift-5.0"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",
@@ -114,7 +114,7 @@ func TestIPPoolLeaseForTest(t *testing.T) {
 		},
 		{
 			name:     "aws, with 5.1 branch (should be valid)",
-			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWS},
+			tests:    MultiStageTestConfigurationLiteral{ClusterProfile: ClusterProfileAWSUSEast1},
 			metadata: Metadata{Branch: "release-5.1"},
 			expected: StepLease{
 				ResourceType: "aws-ip-pools",

--- a/pkg/steps/ip_pool.go
+++ b/pkg/steps/ip_pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -37,6 +38,9 @@ type ipPoolStep struct {
 	profile         api.ClusterProfile
 	branch          string
 	ipPoolLeaseFunc func(profile api.ClusterProfile, branch string) stepLease
+
+	// Reports whether this step has run or not
+	stepRun *atomic.Bool
 }
 
 // lease api.StepLease,
@@ -54,6 +58,7 @@ func IPPoolStep(client *lease.Client, secretClient SecretClient, wrapped api.Ste
 		ipPoolLeaseFunc: func(profile api.ClusterProfile, branch string) stepLease {
 			return stepLease{StepLease: api.IPPoolLeaseForTest(profile, branch)}
 		},
+		stepRun: &atomic.Bool{},
 	}
 }
 
@@ -83,6 +88,9 @@ func (s *ipPoolStep) Provides() api.ParameterMap {
 	// Disable unparam lint as we need to confirm to this interface, but there will never be an error
 	//nolint:unparam
 	parameters[api.DefaultIPPoolLeaseEnv] = func() (string, error) {
+		if !s.stepRun.Load() {
+			return "", nil
+		}
 		return strconv.Itoa(len(s.ipPoolLease.resources)), nil
 	}
 
@@ -122,6 +130,7 @@ func (s *ipPoolStep) run(ctx context.Context, minute time.Duration) error {
 		return results.ForReason("executing_test").ForError(s.wrapped.Run(ctx))
 	}
 
+	s.stepRun.Store(true)
 	l := &s.ipPoolLease
 
 	region, err := s.params.Get(api.DefaultLeaseEnv)

--- a/pkg/steps/ip_pool_test.go
+++ b/pkg/steps/ip_pool_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,12 @@ import (
 
 func ipPoolLeaseAdapter(lease stepLease) func(api.ClusterProfile, string) stepLease {
 	return func(api.ClusterProfile, string) stepLease { return lease }
+}
+
+func atomicBool(v bool) *atomic.Bool {
+	b := &atomic.Bool{}
+	b.Store(v)
+	return b
 }
 
 func TestProvides(t *testing.T) {
@@ -40,6 +47,7 @@ func TestProvides(t *testing.T) {
 					resources: []string{"some-resource", "some-other-resource"},
 				},
 				wrapped: &stepNeedsLease{},
+				stepRun: atomicBool(true),
 			},
 			expected: map[string]string{
 				"parameter":               "map",
@@ -58,10 +66,30 @@ func TestProvides(t *testing.T) {
 					resources: []string{},
 				},
 				wrapped: &stepNeedsLease{},
+				stepRun: atomicBool(true),
 			},
 			expected: map[string]string{
 				"parameter":               "map",
 				api.DefaultIPPoolLeaseEnv: "0",
+			},
+		},
+		{
+			name: "step did not run, ip pool env var is empty",
+			step: ipPoolStep{
+				ipPoolLease: stepLease{
+					StepLease: api.StepLease{
+						ResourceType: "aws-ip-pool",
+						Env:          api.DefaultIPPoolLeaseEnv,
+						Count:        2,
+					},
+					resources: []string{},
+				},
+				wrapped: &stepNeedsLease{},
+				stepRun: atomicBool(false),
+			},
+			expected: map[string]string{
+				"parameter":               "map",
+				api.DefaultIPPoolLeaseEnv: "",
 			},
 		},
 	}
@@ -164,6 +192,7 @@ func TestRun(t *testing.T) {
 				namespace: func() string {
 					return ciOpNamespace
 				},
+				stepRun: &atomic.Bool{},
 			},
 			expected: []string{
 				"acquire owner aws-ip-pool-us-east-1 free leased",
@@ -187,6 +216,7 @@ func TestRun(t *testing.T) {
 				namespace: func() string {
 					return ciOpNamespace
 				},
+				stepRun: &atomic.Bool{},
 			},
 			expected: []string{
 				"acquire owner aws-ip-pool-us-east-1 free leased",
@@ -213,6 +243,7 @@ func TestRun(t *testing.T) {
 				namespace: func() string {
 					return ciOpNamespace
 				},
+				stepRun: &atomic.Bool{},
 			},
 			expected: []string{
 				"acquire owner aws-ip-pool-us-east-1 free leased",
@@ -235,6 +266,7 @@ func TestRun(t *testing.T) {
 				namespace: func() string {
 					return ciOpNamespace
 				},
+				stepRun: &atomic.Bool{},
 			},
 			injectFailures: map[string]error{
 				"acquire owner aws-ip-pool-us-east-1 free leased": lease.ErrNotFound,
@@ -255,6 +287,7 @@ func TestRun(t *testing.T) {
 				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{},
+				stepRun: &atomic.Bool{},
 			},
 			expectedError: errors.New("failed to determine region to acquire lease for aws-ip-pool"),
 		},
@@ -270,6 +303,7 @@ func TestRun(t *testing.T) {
 				}),
 				wrapped: &stepNeedsLease{},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				stepRun: &atomic.Bool{},
 			},
 			injectFailures: map[string]error{
 				"acquire owner aws-ip-pool-us-east-1 free leased": errors.New("some client error"),
@@ -294,6 +328,7 @@ func TestRun(t *testing.T) {
 				},
 				wrapped: &stepNeedsLease{fail: true},
 				params:  fakeStepParams{api.DefaultLeaseEnv: "us-east-1"},
+				stepRun: &atomic.Bool{},
 			},
 			expected: []string{
 				"acquire owner aws-ip-pool-us-east-1 free leased",
@@ -311,6 +346,7 @@ func TestRun(t *testing.T) {
 					return ciOpNamespace
 				},
 				wrapped: &stepNeedsLease{},
+				stepRun: &atomic.Bool{},
 			},
 		},
 	}

--- a/pkg/steps/multi_stage/multi_stage.go
+++ b/pkg/steps/multi_stage/multi_stage.go
@@ -548,11 +548,12 @@ func (s *multiStageTestStep) environment() ([]coreapi.EnvVar, error) {
 			}
 			ret = append(ret, coreapi.EnvVar{Name: e, Value: val})
 		}
-		if s.profile == "aws" { //TODO(sgoeddel): only enabled for aws for now, later this will be configurable
-			val, err := s.params.Get(api.DefaultIPPoolLeaseEnv)
-			if err != nil {
-				return nil, err
-			}
+
+		val, err := s.params.Get(api.DefaultIPPoolLeaseEnv)
+		if err != nil {
+			return nil, err
+		}
+		if val != "" {
 			ret = append(ret, coreapi.EnvVar{Name: api.DefaultIPPoolLeaseEnv, Value: val})
 		}
 	}


### PR DESCRIPTION
Up until now, the `IP_POOL_AVAILABLE` env var has been exposed only for the tests that uses the `aws` cluster profile.
This logic is fragile and problematic when someone (like me) add a new cluster profile that supports the `BYOIP` feature and forget to update the code that exposes the variable.

This PR changes the code such that the env variable only when the `ip_pool` step run, regardless of the cluster profile in use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ci-operator: Expose `IP_POOL_AVAILABLE` only when the `ip_pool` step has run

This PR changes ci-operator so the IP_POOL_AVAILABLE environment variable is published based on whether the ip_pool step actually ran, instead of being tied to specific cluster profiles.

What changed and why:
- ip_pool step:
  - IPPoolStep now tracks if the wrapped step has started using an atomic flag. Provides() only returns the IP pool lease value after the step has run and confirmed a lease is being managed.
  - This prevents exposing IP_POOL_AVAILABLE prematurely when the ip_pool step never executed.
- Cluster profile logic:
  - ClusterProfile.IPPoolLeaseType was narrowed so only ClusterProfileAWSUSEast1 returns the aws-ip-pools lease type; ClusterProfileAWS no longer reports that type. This reduces fragile profile-based assumptions.
- multi_stage executor:
  - The environment assembly now attempts to include DEFAULT_IP_POOL_LEASE for any non-empty profile value, but only appends it when the ip_pool-provided value is non-empty — effectively making exposure runtime-driven rather than profile-driven.
- Tests:
  - Unit tests updated to exercise the new atomic step-run flag: they assert the env var is empty when the wrapped step never ran and contains lease information only after the step runs.

Practical impact for CI users/operators:
- IP_POOL_AVAILABLE will only appear in test jobs when the ip_pool step actually acquired or managed a lease, avoiding incorrect environment exposure for profiles that don't execute ip_pool.
- Adding new cluster profiles that support BYOIP will no longer require code changes to environment-exposure logic; behavior is determined at runtime by whether ip_pool runs.
- Safer, less fragile behavior across different cluster profiles and multi-stage executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->