### PR TITLE
validation: allow openshift-priv mirrors to inherit cluster profile/claim ownership

### DIFF
--- a/pkg/validation/test.go
+++ b/pkg/validation/test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/openshift/ci-tools/pkg/api"
+	"github.com/openshift/ci-tools/pkg/privateorg"
 	"github.com/openshift/ci-tools/pkg/util"
 )
 
@@ -466,6 +467,22 @@ func (v *Validator) validateClusterProfile(fieldRoot string, p api.ClusterProfil
 	return nil
 }
 
+var privateOrgFlattenedOrgs = sets.New[string](privateorg.DefaultFlattenOrgs...)
+
+// isPrivateMirrorOf returns true when openshift-priv/<privRepo> could be a
+// mirror of a repo owned by ownerOrg. For flattened orgs the repo name is
+// unchanged; for all others the mirror name is <ownerOrg>-<repo>.
+func isPrivateMirrorOf(privRepo string, ownerOrg string, ownerRepos []string) bool {
+	if privateOrgFlattenedOrgs.Has(ownerOrg) {
+		return ownerRepos == nil || util.Contains(ownerRepos, privRepo)
+	}
+	prefix := ownerOrg + "-"
+	if !strings.HasPrefix(privRepo, prefix) {
+		return false
+	}
+	return ownerRepos == nil || util.Contains(ownerRepos, strings.TrimPrefix(privRepo, prefix))
+}
+
 // verifyClusterProfileOwnership checks if metadata's org and repo match those in the profile,
 // verifying if it's one of the owners of the profile.
 func verifyClusterProfileOwnership(profile api.ClusterProfileDetails, m *api.Metadata) error {
@@ -481,6 +498,13 @@ func verifyClusterProfileOwnership(profile api.ClusterProfileDetails, m *api.Met
 		}
 		if owner.Repos == nil || util.Contains(owner.Repos, m.Repo) {
 			return nil
+		}
+	}
+	if m.Org == "openshift-priv" {
+		for _, owner := range profile.Owners {
+			if isPrivateMirrorOf(m.Repo, owner.Org, owner.Repos) {
+				return nil
+			}
 		}
 	}
 	return fmt.Errorf("%s/%s is not an owner of the cluster profile: %q", m.Org, m.Repo, profile.Name)
@@ -499,6 +523,13 @@ func verifyClusterClaimOwnership(claim api.ClusterClaimDetails, m *api.Metadata)
 		}
 		if owner.Repos == nil || util.Contains(owner.Repos, m.Repo) {
 			return nil
+		}
+	}
+	if m.Org == "openshift-priv" {
+		for _, owner := range claim.Owners {
+			if isPrivateMirrorOf(m.Repo, owner.Org, owner.Repos) {
+				return nil
+			}
 		}
 	}
 	return fmt.Errorf("%s/%s is not an owner of the cluster claim: %q", m.Org, m.Repo, claim.Claim)

--- a/pkg/validation/test_test.go
+++ b/pkg/validation/test_test.go
@@ -2016,6 +2016,44 @@ func TestVerifyClusterProfileOwnership(t *testing.T) {
 			Name:   "profile-with-no-owners-specified",
 			Owners: []api.ClusterProfileOwners{},
 		},
+		"profile-with-flattened-org-owner": api.ClusterProfileDetails{
+			Name: "profile-with-flattened-org-owner",
+			Owners: []api.ClusterProfileOwners{
+				{
+					Org:   "openshift",
+					Repos: []string{"csi-operator", "installer"},
+				},
+				{
+					Org:   "operator-framework",
+					Repos: []string{"operator-marketplace"},
+				},
+			},
+		},
+		"profile-with-non-flattened-org-owner": api.ClusterProfileDetails{
+			Name: "profile-with-non-flattened-org-owner",
+			Owners: []api.ClusterProfileOwners{
+				{
+					Org:   "stolostron",
+					Repos: []string{"acm-cli", "observatorium-operator"},
+				},
+			},
+		},
+		"profile-with-flattened-wildcard-owner": api.ClusterProfileDetails{
+			Name: "profile-with-flattened-wildcard-owner",
+			Owners: []api.ClusterProfileOwners{
+				{
+					Org: "openshift",
+				},
+			},
+		},
+		"profile-with-non-flattened-wildcard-owner": api.ClusterProfileDetails{
+			Name: "profile-with-non-flattened-wildcard-owner",
+			Owners: []api.ClusterProfileOwners{
+				{
+					Org: "stolostron",
+				},
+			},
+		},
 	}
 	v := NewValidator(cpMap, nil)
 
@@ -2090,6 +2128,82 @@ func TestVerifyClusterProfileOwnership(t *testing.T) {
 			metadata: nil,
 			expected: fmt.Errorf("can't do ownership check, metadata not defined"),
 		},
+		{
+			name:    "openshift-priv mirror of flattened org repo is allowed",
+			profile: v.validClusterProfiles["profile-with-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "csi-operator",
+			},
+		},
+		{
+			name:    "openshift-priv mirror of another flattened org repo is allowed",
+			profile: v.validClusterProfiles["profile-with-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "operator-marketplace",
+			},
+		},
+		{
+			name:    "openshift-priv mirror of non-flattened org repo is allowed with collapsed name",
+			profile: v.validClusterProfiles["profile-with-non-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "stolostron-acm-cli",
+			},
+		},
+		{
+			name:    "openshift-priv non-flattened org repo without collapsed name is rejected",
+			profile: v.validClusterProfiles["profile-with-non-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "acm-cli",
+			},
+			expected: fmt.Errorf("openshift-priv/acm-cli is not an owner of the cluster profile: \"profile-with-non-flattened-org-owner\""),
+		},
+		{
+			name:    "openshift-priv unknown repo is rejected",
+			profile: v.validClusterProfiles["profile-with-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "unknown-repo",
+			},
+			expected: fmt.Errorf("openshift-priv/unknown-repo is not an owner of the cluster profile: \"profile-with-flattened-org-owner\""),
+		},
+		{
+			name:    "openshift-priv non-matching prefix for non-flattened wildcard owner is rejected",
+			profile: v.validClusterProfiles["profile-with-one-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "any-repo",
+			},
+			expected: fmt.Errorf("openshift-priv/any-repo is not an owner of the cluster profile: \"profile-with-one-owner\""),
+		},
+		{
+			name:    "openshift-priv wildcard flattened org owner extends to mirrors",
+			profile: v.validClusterProfiles["profile-with-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "any-repo",
+			},
+		},
+		{
+			name:    "openshift-priv wildcard non-flattened org owner extends to prefixed mirrors",
+			profile: v.validClusterProfiles["profile-with-non-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "stolostron-some-repo",
+			},
+		},
+		{
+			name:    "openshift-priv wildcard non-flattened org owner rejects wrong prefix",
+			profile: v.validClusterProfiles["profile-with-non-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "other-org-some-repo",
+			},
+			expected: fmt.Errorf("openshift-priv/other-org-some-repo is not an owner of the cluster profile: \"profile-with-non-flattened-wildcard-owner\""),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			actual := verifyClusterProfileOwnership(tc.profile, tc.metadata)
@@ -2138,6 +2252,40 @@ func TestVerifyClusterClaimOwnership(t *testing.T) {
 		"claim-with-no-owners-specified": api.ClusterClaimDetails{
 			Claim:  "claim-with-no-owners-specified",
 			Owners: []api.ClusterClaimOwnerDetails{},
+		},
+		"claim-with-flattened-org-owner": api.ClusterClaimDetails{
+			Claim: "claim-with-flattened-org-owner",
+			Owners: []api.ClusterClaimOwnerDetails{
+				{
+					Org:   "openshift",
+					Repos: []string{"csi-operator", "installer"},
+				},
+			},
+		},
+		"claim-with-non-flattened-org-owner": api.ClusterClaimDetails{
+			Claim: "claim-with-non-flattened-org-owner",
+			Owners: []api.ClusterClaimOwnerDetails{
+				{
+					Org:   "stolostron",
+					Repos: []string{"acm-cli"},
+				},
+			},
+		},
+		"claim-with-flattened-wildcard-owner": api.ClusterClaimDetails{
+			Claim: "claim-with-flattened-wildcard-owner",
+			Owners: []api.ClusterClaimOwnerDetails{
+				{
+					Org: "openshift",
+				},
+			},
+		},
+		"claim-with-non-flattened-wildcard-owner": api.ClusterClaimDetails{
+			Claim: "claim-with-non-flattened-wildcard-owner",
+			Owners: []api.ClusterClaimOwnerDetails{
+				{
+					Org: "stolostron",
+				},
+			},
 		},
 	}
 	v := NewValidator(nil, clusterClaim)
@@ -2212,6 +2360,65 @@ func TestVerifyClusterClaimOwnership(t *testing.T) {
 			claim:    v.validClusterClaimOwners["claim-with-multiple-orgs-and-repos"],
 			metadata: nil,
 			expected: fmt.Errorf("can't do ownership check, metadata not defined"),
+		},
+		{
+			name:  "openshift-priv mirror of flattened org repo is allowed",
+			claim: v.validClusterClaimOwners["claim-with-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "csi-operator",
+			},
+		},
+		{
+			name:  "openshift-priv mirror of non-flattened org repo is allowed with collapsed name",
+			claim: v.validClusterClaimOwners["claim-with-non-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "stolostron-acm-cli",
+			},
+		},
+		{
+			name:  "openshift-priv non-flattened org repo without collapsed name is rejected",
+			claim: v.validClusterClaimOwners["claim-with-non-flattened-org-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "acm-cli",
+			},
+			expected: fmt.Errorf("openshift-priv/acm-cli is not an owner of the cluster claim: \"claim-with-non-flattened-org-owner\""),
+		},
+		{
+			name:  "openshift-priv non-matching prefix for non-flattened wildcard owner is rejected",
+			claim: v.validClusterClaimOwners["claim-with-one-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "any-repo",
+			},
+			expected: fmt.Errorf("openshift-priv/any-repo is not an owner of the cluster claim: \"claim-with-one-owner\""),
+		},
+		{
+			name:  "openshift-priv wildcard flattened org owner extends to mirrors",
+			claim: v.validClusterClaimOwners["claim-with-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "any-repo",
+			},
+		},
+		{
+			name:  "openshift-priv wildcard non-flattened org owner extends to prefixed mirrors",
+			claim: v.validClusterClaimOwners["claim-with-non-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "stolostron-some-repo",
+			},
+		},
+		{
+			name:  "openshift-priv wildcard non-flattened org owner rejects wrong prefix",
+			claim: v.validClusterClaimOwners["claim-with-non-flattened-wildcard-owner"],
+			metadata: &api.Metadata{
+				Org:  "openshift-priv",
+				Repo: "other-org-some-repo",
+			},
+			expected: fmt.Errorf("openshift-priv/other-org-some-repo is not an owner of the cluster claim: \"claim-with-non-flattened-wildcard-owner\""),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Repos mirrored to openshift-priv should implicitly inherit cluster profile and cluster claim ownership from their upstream counterparts. For flattened orgs (openshift, openshift-eng, operator-framework, etc.) the repo name is preserved; for all others it is collapsed to <org>-<repo>.

Uses the shared privateorg.DefaultFlattenOrgs constant as the single source of truth for the flatten-org list.

Made with Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Cluster Profile and Claim Ownership for openshift-priv Repository Mirrors

The validation component of ci-tools (pkg/validation) now treats repositories mirrored into the openshift-priv organization as implicit owners for cluster profiles and cluster claims when their upstream repositories are authorized owners. This removes the need to separately configure ownership for those private mirrors.

What changed
- Validation now recognizes openshift-priv repo naming conventions and maps them back to upstream owners:
  - Repos from "flattened" organizations (from privateorg.DefaultFlattenOrgs) keep their original repo name in the mirror (e.g., openshift/csi-operator → openshift-priv/csi-operator).
  - Repos from other organizations are mirrored with a collapsed name of the form <org>-<repo> (e.g., stolostron/acm-cli → openshift-priv/stolostron-acm-cli).
- A new helper (isPrivateMirrorOf) and use of privateorg.DefaultFlattenOrgs centralize the flatten-org list so naming logic is consistent across CI tooling.
- verifyClusterProfileOwnership and verifyClusterClaimOwnership now accept openshift-priv metadata as owned when the mirrored repo corresponds to any configured upstream owner (including wildcard owners), instead of requiring an exact org+repo match.

Affected component and behavior
- Component: validation code in ci-tools (pkg/validation).
- Behavior: ownership checks for cluster profiles and cluster claims now accept openshift-priv mirrored repositories that map to configured upstream owners, simplifying validation for private mirror-based CI jobs.

Impact for CI users/operators
- Operators maintaining private mirrors in openshift-priv no longer need duplicate ownership entries for cluster profiles or claims; ownership is automatically inherited from upstream repositories when the mirror name matches the upstream according to the flattening rules.
- The change reduces configuration duplication and prevents validation failures caused solely by mirrored repo naming.

Tests
- Unit tests in pkg/validation were extended to cover flattened and non-flattened mirror scenarios, wildcard ownership, and prefix/collapse edge cases to ensure the new mapping logic behaves as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->