### PR TITLE
Add destroy previous secret versions functionality when updating a secret

### DIFF
--- a/cmd/ci-secret-bootstrap/main_test.go
+++ b/cmd/ci-secret-bootstrap/main_test.go
@@ -2323,6 +2323,14 @@ func (f *fakeGSMClient) AddSecretVersion(ctx context.Context, req *secretmanager
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (f *fakeGSMClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator {
+	return nil
+}
+
+func (f *fakeGSMClient) DestroySecretVersion(ctx context.Context, req *secretmanagerpb.DestroySecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
 func TestIntegration(t *testing.T) {
 	testCases := []struct {
 		id               string

--- a/pkg/gsm-secrets/execution.go
+++ b/pkg/gsm-secrets/execution.go
@@ -28,8 +28,7 @@ import (
 
 // CreateOrUpdateSecret creates a new secret in Google Secret Manager or updates an existing one with a new version.
 // If labels or annotations are nil, they won't be set on the secret.
-// destroyPreviousVersions controls whether old enabled versions are cleaned up after adding the new one.
-func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, projectIdNumber, secretName string, payload []byte, labels, annotations map[string]string, destroyPreviousVersions bool) error {
+func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, projectIdNumber, secretName string, payload []byte, labels, annotations map[string]string) error {
 	parent := GetProjectResourceIdNumber(projectIdNumber)
 	secretPath := fmt.Sprintf("%s/secrets/%s", parent, secretName)
 
@@ -53,25 +52,31 @@ func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, proje
 		}
 	}
 
-	newVersion, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+	_, err = client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
 		Parent:  secretPath,
 		Payload: &secretmanagerpb.SecretPayload{Data: payload},
 	})
 	if err != nil {
 		return fmt.Errorf("failed to add version to secret %s: %w", secretName, err)
 	}
-
-	if destroyPreviousVersions {
-		if err := destroyPreviousSecretVersions(ctx, client, secretPath, newVersion.Name); err != nil {
-			return fmt.Errorf("failed to destroy previous versions of %s: %w", secretName, err)
-		}
-	}
 	return nil
 }
 
-// destroyPreviousSecretVersions destroys all enabled secret versions except the current one
+// CreateOrUpdateSecretDestroyingPreviousVersions creates or updates a secret and then destroys
+// all previously enabled versions to prevent version accumulation and cost growth.
+// Use this for periodic updates (e.g. ci-secret-generator). For initial creation where there
+// are no previous versions, use CreateOrUpdateSecret instead.
+func CreateOrUpdateSecretDestroyingPreviousVersions(ctx context.Context, client SecretManagerClient, projectIdNumber, secretName string, payload []byte, labels, annotations map[string]string) error {
+	if err := CreateOrUpdateSecret(ctx, client, projectIdNumber, secretName, payload, labels, annotations); err != nil {
+		return err
+	}
+	secretPath := fmt.Sprintf("%s/secrets/%s", GetProjectResourceIdNumber(projectIdNumber), secretName)
+	return destroyPreviousSecretVersions(ctx, client, secretPath)
+}
+
+// destroyPreviousSecretVersions destroys all enabled secret versions except the latest one,
 // to avoid accumulating billable versions in GSM.
-func destroyPreviousSecretVersions(ctx context.Context, client SecretManagerClient, secretPath, currentVersionName string) error {
+func destroyPreviousSecretVersions(ctx context.Context, client SecretManagerClient, secretPath string) error {
 	it := client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
 		Parent: secretPath,
 		Filter: "state:ENABLED",
@@ -79,6 +84,8 @@ func destroyPreviousSecretVersions(ctx context.Context, client SecretManagerClie
 	if it == nil {
 		return nil
 	}
+
+	var versions []*secretmanagerpb.SecretVersion
 	for {
 		v, err := it.Next()
 		if errors.Is(err, iterator.Done) {
@@ -87,7 +94,28 @@ func destroyPreviousSecretVersions(ctx context.Context, client SecretManagerClie
 		if err != nil {
 			return fmt.Errorf("failed to list versions for secret %s: %w", secretPath, err)
 		}
-		if v.Name == currentVersionName {
+		versions = append(versions, v)
+	}
+
+	if len(versions) <= 1 {
+		return nil
+	}
+
+	var latest *secretmanagerpb.SecretVersion
+	for _, v := range versions {
+		if v.CreateTime == nil {
+			continue
+		}
+		if latest == nil || v.CreateTime.AsTime().After(latest.CreateTime.AsTime()) {
+			latest = v
+		}
+	}
+	if latest == nil {
+		return fmt.Errorf("cannot determine latest version for %s: no versions have CreateTime set", secretPath)
+	}
+
+	for _, v := range versions {
+		if v.Name == latest.Name {
 			continue
 		}
 		if _, err := client.DestroySecretVersion(ctx, &secretmanagerpb.DestroySecretVersionRequest{
@@ -298,7 +326,7 @@ func (a *Actions) CreateSecrets(ctx context.Context, secretsClient SecretManager
 		}
 
 		logrus.Infof("Creating secret: %s (type: %v, collection: %s)", s.Name, s.Type, s.Collection)
-		if err := CreateOrUpdateSecret(ctx, secretsClient, a.Config.ProjectIdNumber, s.Name, s.Payload, s.Labels, s.Annotations, false); err != nil {
+		if err := CreateOrUpdateSecret(ctx, secretsClient, a.Config.ProjectIdNumber, s.Name, s.Payload, s.Labels, s.Annotations); err != nil {
 			logrus.WithError(err).Errorf("Failed to create secret: %s", s.Name)
 			continue
 		}

--- a/pkg/gsm-secrets/execution.go
+++ b/pkg/gsm-secrets/execution.go
@@ -28,7 +28,8 @@ import (
 
 // CreateOrUpdateSecret creates a new secret in Google Secret Manager or updates an existing one with a new version.
 // If labels or annotations are nil, they won't be set on the secret.
-func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, projectIdNumber, secretName string, payload []byte, labels, annotations map[string]string) error {
+// destroyPreviousVersions controls whether old enabled versions are cleaned up after adding the new one.
+func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, projectIdNumber, secretName string, payload []byte, labels, annotations map[string]string, destroyPreviousVersions bool) error {
 	parent := GetProjectResourceIdNumber(projectIdNumber)
 	secretPath := fmt.Sprintf("%s/secrets/%s", parent, secretName)
 
@@ -52,7 +53,7 @@ func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, proje
 		}
 	}
 
-	_, err = client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
+	newVersion, err := client.AddSecretVersion(ctx, &secretmanagerpb.AddSecretVersionRequest{
 		Parent:  secretPath,
 		Payload: &secretmanagerpb.SecretPayload{Data: payload},
 	})
@@ -60,16 +61,53 @@ func CreateOrUpdateSecret(ctx context.Context, client SecretManagerClient, proje
 		return fmt.Errorf("failed to add version to secret %s: %w", secretName, err)
 	}
 
+	if destroyPreviousVersions {
+		if err := destroyPreviousSecretVersions(ctx, client, secretPath, newVersion.Name); err != nil {
+			return fmt.Errorf("failed to destroy previous versions of %s: %w", secretName, err)
+		}
+	}
+	return nil
+}
+
+// destroyPreviousSecretVersions destroys all enabled secret versions except the current one
+// to avoid accumulating billable versions in GSM.
+func destroyPreviousSecretVersions(ctx context.Context, client SecretManagerClient, secretPath, currentVersionName string) error {
+	it := client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
+		Parent: secretPath,
+		Filter: "state:ENABLED",
+	})
+	if it == nil {
+		return nil
+	}
+	for {
+		v, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to list versions for secret %s: %w", secretPath, err)
+		}
+		if v.Name == currentVersionName {
+			continue
+		}
+		if _, err := client.DestroySecretVersion(ctx, &secretmanagerpb.DestroySecretVersionRequest{
+			Name: v.Name,
+		}); err != nil {
+			return fmt.Errorf("failed to destroy version %s: %w", v.Name, err)
+		}
+	}
 	return nil
 }
 
 // SecretManagerClient interface defines methods for interacting with Google Secret Manager
 type SecretManagerClient interface {
 	ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest, opts ...gax.CallOption) *secretmanager.SecretIterator
+	ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator
 	GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	DeleteSecret(ctx context.Context, req *secretmanagerpb.DeleteSecretRequest, opts ...gax.CallOption) error
 	CreateSecret(ctx context.Context, req *secretmanagerpb.CreateSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error)
 	AddSecretVersion(ctx context.Context, req *secretmanagerpb.AddSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error)
+	DestroySecretVersion(ctx context.Context, req *secretmanagerpb.DestroySecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error)
 	AccessSecretVersion(ctx context.Context, req *secretmanagerpb.AccessSecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.AccessSecretVersionResponse, error)
 }
 
@@ -260,7 +298,7 @@ func (a *Actions) CreateSecrets(ctx context.Context, secretsClient SecretManager
 		}
 
 		logrus.Infof("Creating secret: %s (type: %v, collection: %s)", s.Name, s.Type, s.Collection)
-		if err := CreateOrUpdateSecret(ctx, secretsClient, a.Config.ProjectIdNumber, s.Name, s.Payload, s.Labels, s.Annotations); err != nil {
+		if err := CreateOrUpdateSecret(ctx, secretsClient, a.Config.ProjectIdNumber, s.Name, s.Payload, s.Labels, s.Annotations, false); err != nil {
 			logrus.WithError(err).Errorf("Failed to create secret: %s", s.Name)
 			continue
 		}

--- a/pkg/gsm-secrets/execution_mock.go
+++ b/pkg/gsm-secrets/execution_mock.go
@@ -125,6 +125,26 @@ func (mr *MockSecretManagerClientMockRecorder) DeleteSecret(ctx, req any, opts .
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockSecretManagerClient)(nil).DeleteSecret), varargs...)
 }
 
+// DestroySecretVersion mocks base method.
+func (m *MockSecretManagerClient) DestroySecretVersion(ctx context.Context, req *secretmanagerpb.DestroySecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, req}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DestroySecretVersion", varargs...)
+	ret0, _ := ret[0].(*secretmanagerpb.SecretVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DestroySecretVersion indicates an expected call of DestroySecretVersion.
+func (mr *MockSecretManagerClientMockRecorder) DestroySecretVersion(ctx, req any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, req}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroySecretVersion", reflect.TypeOf((*MockSecretManagerClient)(nil).DestroySecretVersion), varargs...)
+}
+
 // GetSecret mocks base method.
 func (m *MockSecretManagerClient) GetSecret(ctx context.Context, req *secretmanagerpb.GetSecretRequest, opts ...gax.CallOption) (*secretmanagerpb.Secret, error) {
 	m.ctrl.T.Helper()
@@ -143,6 +163,25 @@ func (mr *MockSecretManagerClientMockRecorder) GetSecret(ctx, req any, opts ...a
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, req}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockSecretManagerClient)(nil).GetSecret), varargs...)
+}
+
+// ListSecretVersions mocks base method.
+func (m *MockSecretManagerClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, req}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListSecretVersions", varargs...)
+	ret0, _ := ret[0].(*secretmanager.SecretVersionIterator)
+	return ret0
+}
+
+// ListSecretVersions indicates an expected call of ListSecretVersions.
+func (mr *MockSecretManagerClientMockRecorder) ListSecretVersions(ctx, req any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, req}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecretVersions", reflect.TypeOf((*MockSecretManagerClient)(nil).ListSecretVersions), varargs...)
 }
 
 // ListSecrets mocks base method.

--- a/pkg/secrets/gsm.go
+++ b/pkg/secrets/gsm.go
@@ -65,7 +65,7 @@ func (g *gsmSyncDecorator) SetFieldOnItem(itemName, fieldName string, fieldValue
 	annotations := make(map[string]string)
 	annotations["request-information"] = "Created by periodic-ci-secret-generator."
 
-	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, secretName, fieldValue, labels, annotations); err != nil {
+	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, secretName, fieldValue, labels, annotations, true); err != nil {
 		logrus.WithError(err).Errorf("Failed to sync to GSM: %s", secretName)
 		// Don't fail the Vault write
 	} else {
@@ -78,7 +78,7 @@ func (g *gsmSyncDecorator) SetFieldOnItem(itemName, fieldName string, fieldValue
 func (g *gsmSyncDecorator) UpdateIndexSecret(itemName string, payload []byte) error {
 	annotations := make(map[string]string)
 	annotations["request-information"] = "Created by periodic-ci-secret-generator."
-	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, gsm.GetIndexSecretName(itemName), payload, nil, annotations); err != nil {
+	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, gsm.GetIndexSecretName(itemName), payload, nil, annotations, true); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/secrets/gsm.go
+++ b/pkg/secrets/gsm.go
@@ -65,7 +65,7 @@ func (g *gsmSyncDecorator) SetFieldOnItem(itemName, fieldName string, fieldValue
 	annotations := make(map[string]string)
 	annotations["request-information"] = "Created by periodic-ci-secret-generator."
 
-	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, secretName, fieldValue, labels, annotations, true); err != nil {
+	if err := gsm.CreateOrUpdateSecretDestroyingPreviousVersions(g.ctx, g.gsmClient, g.config.ProjectIdNumber, secretName, fieldValue, labels, annotations); err != nil {
 		logrus.WithError(err).Errorf("Failed to sync to GSM: %s", secretName)
 		// Don't fail the Vault write
 	} else {
@@ -78,7 +78,7 @@ func (g *gsmSyncDecorator) SetFieldOnItem(itemName, fieldName string, fieldValue
 func (g *gsmSyncDecorator) UpdateIndexSecret(itemName string, payload []byte) error {
 	annotations := make(map[string]string)
 	annotations["request-information"] = "Created by periodic-ci-secret-generator."
-	if err := gsm.CreateOrUpdateSecret(g.ctx, g.gsmClient, g.config.ProjectIdNumber, gsm.GetIndexSecretName(itemName), payload, nil, annotations, true); err != nil {
+	if err := gsm.CreateOrUpdateSecretDestroyingPreviousVersions(g.ctx, g.gsmClient, g.config.ProjectIdNumber, gsm.GetIndexSecretName(itemName), payload, nil, annotations); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/steps/multi_stage/gsm_bundle_resolver_test.go
+++ b/pkg/steps/multi_stage/gsm_bundle_resolver_test.go
@@ -45,6 +45,14 @@ func (f *fakeGSMClient) AddSecretVersion(ctx context.Context, req *secretmanager
 	panic("AddSecretVersion not implemented in test")
 }
 
+func (f *fakeGSMClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest, opts ...gax.CallOption) *secretmanager.SecretVersionIterator {
+	return nil
+}
+
+func (f *fakeGSMClient) DestroySecretVersion(ctx context.Context, req *secretmanagerpb.DestroySecretVersionRequest, opts ...gax.CallOption) (*secretmanagerpb.SecretVersion, error) {
+	panic("DestroySecretVersion not implemented in test")
+}
+
 func TestResolveCredentialReferences(t *testing.T) {
 	client := &fakeGSMClient{}
 


### PR DESCRIPTION
I identified that GSM costs were getting high by accumulating secret versions (~150 per secret across ~550 secrets in the `test-platform-infra` collection), all using automatic replication. I ran a one-time cleanup script to destroy all non-latest versions, and modified CreateOrUpdateSecret to accept a destroyPreviousVersions flag — enabled for ci-secret-generator — so old versions are automatically destroyed after each update, preventing future cost buildup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds an opt-in GSM secret-update path that destroys previous secret versions after a successful update and enables that path for the ci-secret-generator so old versions will not re-accumulate.

What it does (practical terms)
- New helper: CreateOrUpdateSecretDestroyingPreviousVersions
  - Performs the same create-or-update work as CreateOrUpdateSecret, then lists ENABLED secret versions for the secret, keeps the newest version (by CreateTime) and destroys every other enabled version via DestroySecretVersion.
  - Errors from listing or destroying are returned (cleanup is not best-effort).
  - Requires the GSM client to implement ListSecretVersions and DestroySecretVersion.

- Where it's used
  - The ci-secret-generator code path now calls CreateOrUpdateSecretDestroyingPreviousVersions from pkg/secrets/gsm.go (SetFieldOnItem and UpdateIndexSecret). As a result, routine periodic updates performed by ci-secret-generator will automatically remove prior enabled secret versions after each update.
  - Existing callers that still call CreateOrUpdateSecret are unaffected.

- Tests & mocks
  - Test fakes and GoMock-generated mocks were extended with ListSecretVersions and DestroySecretVersion so unit tests compile and can exercise the new behavior.
  - Some test fakes return nil iterators or a not-implemented error consistent with other test stubs.

Operational impact
- Prevents future accumulation of enabled GSM secret versions for secrets managed by ci-secret-generator, reducing GSM storage usage and cost (the author ran a one-time cleanup to remove existing non-latest versions).
- Because listing or destruction failures are surfaced as errors, callers that opt into this destructive cleanup (currently ci-secret-generator) may see failed GSM updates when cleanup fails and should handle those errors accordingly.

Compatibility
- Backwards-compatible for callers that do not opt in; CreateOrUpdateSecret remains available and unchanged for non-destructive updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->